### PR TITLE
Refactor the game event system to be based on Lua at the core

### DIFF
--- a/data/campaigns/World_Conquest/lua/campaign_main.lua
+++ b/data/campaigns/World_Conquest/lua/campaign_main.lua
@@ -1,7 +1,7 @@
 -- the main file for the WC2 mp campaign
 
 T = wml.tag
-on_event = wesnoth.require("on_event")
+on_event = wesnoth.game_events.add_repeating
 
 
 wesnoth.dofile("./game_mechanics/_load.lua")

--- a/data/lua/core/interface.lua
+++ b/data/lua/core/interface.lua
@@ -64,7 +64,14 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	wesnoth.print = wesnoth.deprecate_api('wesnoth.print', 'wesnoth.interface.add_overlay_text', 1, nil, function(cfg)
 		wesnoth.wml_actions.print(cfg)
 	end)
-	-- No deprecation for these since since they're not actually public API yet
-	wesnoth.set_menu_item = wesnoth.interface.set_menu_item
+	wesnoth.set_menu_item = wesnoth.deprecate_api('wesnoth.set_menu_item', 'wesnoth.interface.set_menu_item', 1, nil, function(id, cfg)
+		-- wesnoth.set_menu_item added both the menu item and the event that it triggers
+		-- wesnoth.interface.set_menu_item only adds the menu item
+		wesnoth.interface.set_menu_item(id, cfg)
+		wesnoth.game_events.add(cfg.id, wesnoth.wml_actions.command, true)
+	end)
 	wesnoth.clear_menu_item = wesnoth.interface.clear_menu_item
+	-- Event handlers don't have a separate module Lua file so dump those here
+	wesnoth.add_event_handler = wesnoth.deprecate_api('wesnoth.add_event_hander', 'wesnoth.game_events.add', 1, nil, function(cfg) wesnoth.wml_actions.event(cfg) end)
+	wesnoth.remove_event_handler = wesnoth.deprecate_api('wesnoth.remove_event_handler', 'wesnoth.game_events.remove', 1, nil, wesnoth.game_events.remove)
 end

--- a/data/lua/core/interface.lua
+++ b/data/lua/core/interface.lua
@@ -74,4 +74,31 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	-- Event handlers don't have a separate module Lua file so dump those here
 	wesnoth.add_event_handler = wesnoth.deprecate_api('wesnoth.add_event_hander', 'wesnoth.game_events.add', 1, nil, function(cfg) wesnoth.wml_actions.event(cfg) end)
 	wesnoth.remove_event_handler = wesnoth.deprecate_api('wesnoth.remove_event_handler', 'wesnoth.game_events.remove', 1, nil, wesnoth.game_events.remove)
+
+	local function old_fire_event(fcn)
+		return function(...)
+			local id = select(1, ...)
+			local loc1, n1 = wesnoth.map.read_location(select(2, ...))
+			local loc2, n2 = wesnoth.map.read_location(select(2 + n1, ...))
+			local weap1, weap2 = select(2 + n1 + n2)
+			local data = {}
+			if weap1 ~= nil then
+				table.insert(data, wml.tag.first(weap1))
+			end
+			if weap2 ~= nil then
+				table.insert(data, wml.tag.second(weap2))
+			end
+			if n1 > 0 then
+				if n2 > 0 then
+					fcn(id, loc1, loc2, data)
+				else
+					fcn(id, loc1, data)
+				end
+			else
+				fcn(id, data)
+			end
+		end
+	end
+	wesnoth.fire_event = wesnoth.deprecate_api('wesnoth.fire_event', 'wesnoth.game_events.fire', 1, nil, old_fire_event(wesnoth.game_events.fire))
+	wesnoth.fire_event_by_id = wesnoth.deprecate_api('wesnoth.fire_event_by_id', 'wesnoth.game_events.fire_by_id', 1, nil, old_fire_event(wesnoth.game_events.fire_by_id))
 end

--- a/data/lua/core/interface.lua
+++ b/data/lua/core/interface.lua
@@ -68,7 +68,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 		-- wesnoth.set_menu_item added both the menu item and the event that it triggers
 		-- wesnoth.interface.set_menu_item only adds the menu item
 		wesnoth.interface.set_menu_item(id, cfg)
-		wesnoth.game_events.add(cfg.id, wesnoth.wml_actions.command, true)
+		wesnoth.game_events.add_menu(cfg.id, wesnoth.wml_actions.command)
 	end)
 	wesnoth.clear_menu_item = wesnoth.interface.clear_menu_item
 	-- Event handlers don't have a separate module Lua file so dump those here

--- a/data/lua/diversion.lua
+++ b/data/lua/diversion.lua
@@ -1,7 +1,6 @@
 
 local _ = wesnoth.textdomain 'wesnoth-help'
 local T = wml.tag
-local on_event = wesnoth.require("on_event")
 
 local u_pos_filter = function(u_id)
 
@@ -100,7 +99,7 @@ function wesnoth.wml_actions.on_undo_diversion(cfg)
 	status_anim_update(true)
 end
 
-on_event("moveto, die, recruit, recall", function()
+wesnoth.game_events.add_repeating("moveto, die, recruit, recall", function()
         status_anim_update()
 
 end)

--- a/data/lua/feeding.lua
+++ b/data/lua/feeding.lua
@@ -1,10 +1,9 @@
 
 local _ = wesnoth.textdomain 'wesnoth-help'
 local T = wml.tag
-local on_event = wesnoth.require("on_event")
 
 -- The feeding event code
-on_event("die", function()
+wesnoth.game_events.add_repeating("die", function()
 	local ec = wesnoth.current.event_context
 
 	if not ec.x1 or not ec.y1 or not ec.x2 or not ec.y2 then

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -51,5 +51,5 @@ local function on_event(eventname, priority, fcn)
 	end
 end
 
-core_on_event = on_event
-return on_event
+core_on_event = wesnoth.deprecate_api("on_event", "wesnoth.game_events.add", 1, nil, on_event)
+return core_on_event

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -51,5 +51,5 @@ local function on_event(eventname, priority, fcn)
 	end
 end
 
-core_on_event = wesnoth.deprecate_api("on_event", "wesnoth.game_events.add", 1, nil, on_event)
+core_on_event = wesnoth.deprecate_api("on_event", "wesnoth.game_events.add_repeating", 1, nil, on_event)
 return core_on_event

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -146,10 +146,12 @@ function wml_actions.fire_event(cfg)
 
 	local w1 = wml.get_child(cfg, "primary_attack")
 	local w2 = wml.get_child(cfg, "secondary_attack")
-	if w2 then w1 = w1 or {} end
+	local data = wml.get_child(cfg, "data") or {}
+	if w1 then table.insert(data, wml.tag.first(w1)) end
+	if w2 then table.insert(data, wml.tag.second(w2)) end
 
-	if cfg.id and cfg.id ~= "" then wesnoth.fire_event_by_id(cfg.id, x1, y1, x2, y2, w1, w2)
-	elseif cfg.name and cfg.name ~= "" then wesnoth.fire_event(cfg.name, x1, y1, x2, y2, w1, w2)
+	if cfg.id and cfg.id ~= "" then wesnoth.game_events.fire_by_id(cfg.id, x1, y1, x2, y2, data)
+	elseif cfg.name and cfg.name ~= "" then wesnoth.game_events.fire(cfg.name, x1, y1, x2, y2, data)
 	end
 end
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -665,7 +665,7 @@ end
 
 function wml_actions.set_menu_item(cfg)
 	wesnoth.interface.set_menu_item(cfg.id, cfg)
-	wesnoth.game_events.add(cfg.id, wml_actions.command, true)
+	wesnoth.game_events.add_menu(cfg.id, wml_actions.command)
 end
 
 function wml_actions.place_shroud(cfg)
@@ -730,9 +730,7 @@ function wml_actions.event(cfg)
 		wesnoth.deprecated_message("[event]remove=yes", 2, "1.17.0", "Use [remove_event] instead of [event]remove=yes")
 		wml_actions.remove_event(cfg)
 	else
-		local delay = cfg.delayed_variable_substitution
-		if delay == nil then delay = true end
-		wesnoth.game_events.add(delay, cfg)
+		wesnoth.game_events.add_wml(cfg)
 	end
 end
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -663,6 +663,7 @@ end
 
 function wml_actions.set_menu_item(cfg)
 	wesnoth.interface.set_menu_item(cfg.id, cfg)
+	wesnoth.game_events.add(cfg.id, wml_actions.command, true)
 end
 
 function wml_actions.place_shroud(cfg)
@@ -727,7 +728,9 @@ function wml_actions.event(cfg)
 		wesnoth.deprecated_message("[event]remove=yes", 2, "1.17.0", "Use [remove_event] instead of [event]remove=yes")
 		wml_actions.remove_event(cfg)
 	else
-		wesnoth.add_event_handler(cfg)
+		local delay = cfg.delayed_variable_substitution
+		if delay == nil then delay = true end
+		wesnoth.game_events.add(delay, cfg)
 	end
 end
 

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -740,7 +740,7 @@ function wml_actions.remove_event(cfg)
 	local id = cfg.id or wml.error("[remove_event] missing required id= key")
 
 	for _,w in ipairs(id:split()) do
-		wesnoth.remove_event_handler(w)
+		wesnoth.game_events.remove(w)
 	end
 end
 

--- a/data/modifications/pick_advance/main.lua
+++ b/data/modifications/pick_advance/main.lua
@@ -1,6 +1,6 @@
 -- << pick_advance/main.lua
 
-local on_event = wesnoth.require "on_event"
+local on_event = wesnoth.game_events.add_repeating
 local F = wesnoth.require "functional"
 local T = wml.tag
 local _ = wesnoth.textdomain "wesnoth"

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -1,7 +1,7 @@
 
 local _ = wesnoth.textdomain 'wesnoth-multiplayer'
 local T = wml.tag
-local on_event = wesnoth.require("on_event")
+local on_event = wesnoth.game_events.add_repeating
 
 local random_spawns = {
 	{

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -1,6 +1,6 @@
 local _ = wesnoth.textdomain 'wesnoth-multiplayer'
 local T = wml.tag
-local on_event = wesnoth.require("on_event")
+local on_event = wesnoth.game_events.add_repeating
 
 local random_spawns = {
 	{

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -124,6 +124,7 @@
 	super="$action_wml"
 	{SIMPLE_KEY name string}
 	{SIMPLE_KEY id string}
+	{SIMPLE_KEY filter_formula string}
 	{DEFAULT_KEY first_time_only bool yes}
 	{DEFAULT_KEY delayed_variable_substitution bool no}
 

--- a/data/test/scenarios/events-test_actions.cfg
+++ b/data/test/scenarios/events-test_actions.cfg
@@ -8,13 +8,13 @@
 )}
 
 # Test that dynamically adding an event from Lua works
-# There's two different ways of calling game_events.add, so test both
+# There's two different ways of adding events, so test both
 {GENERIC_UNIT_TEST "event_test_lua" (
     [event]
         name=preload
         [lua]
             code=<<
-                wesnoth.game_events.add('new turn', function()
+                wesnoth.game_events.add_repeating('new turn', function()
                     unit_test.succeed()
                 end)
             >>

--- a/data/test/scenarios/events-test_actions.cfg
+++ b/data/test/scenarios/events-test_actions.cfg
@@ -1,0 +1,99 @@
+
+# This is kinda a duplicate of a basic unit test system sanity test, but... it seems to fit here as well...
+{GENERIC_UNIT_TEST "event_test_action_wml" (
+    [event]
+        name=start
+        {SUCCEED}
+    [/event]
+)}
+
+# Test that dynamically adding an event from Lua works
+# There's two different ways of calling game_events.add, so test both
+{GENERIC_UNIT_TEST "event_test_lua" (
+    [event]
+        name=preload
+        [lua]
+            code=<<
+                wesnoth.game_events.add('new turn', function()
+                    unit_test.succeed()
+                end)
+            >>
+        [/lua]
+    [/event]
+)}
+{GENERIC_UNIT_TEST "event_test_lua_advanced" (
+    [event]
+        name=preload
+        [lua]
+            code=<<
+                wesnoth.game_events.add{
+                    name = 'new turn',
+                    action = function()
+                        unit_test.succeed()
+                    end
+                }
+            >>
+        [/lua]
+    [/event]
+)}
+
+# Test that first_time_only works correctly in Lua events
+{GENERIC_UNIT_TEST "event_test_lua_repeat" (
+    [event]
+        name=preload
+        [lua]
+            code=<<
+                wml.variables.only_once = 0
+                wml.variables.should_repeat = 0
+                wesnoth.game_events.add{
+                    name = 'new turn',
+                    first_time_only = true,
+                    action = function()
+                        wml.variables.only_once = wml.variables.only_once + 1
+                    end
+                }
+                wesnoth.game_events.add{
+                    name = 'new turn',
+                    first_time_only = false,
+                    action = function()
+                        wml.variables.should_repeat = wml.variables.should_repeat + 1
+                    end
+                }
+            >>
+        [/lua]
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn 1
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 1 turn 2
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL only_once equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL should_repeat equals 2})}
+        {SUCCEED}
+    [/event]
+)}
+
+# Verify that a warning is produced if adding an event that would break saved games
+{GENERIC_UNIT_TEST "event_test_lua_break_save" (
+    [event]
+        name=start
+        [lua]
+            code=<<
+                wesnoth.game_events.add{
+                    name = 'new turn',
+                    action = function() end
+                }
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/data/test/scenarios/events-test_filters.cfg
+++ b/data/test/scenarios/events-test_filters.cfg
@@ -230,3 +230,119 @@
         {RETURN ({VARIABLE_CONDITIONAL triggers equals 4})}
     [/event]
 )}
+
+{GENERIC_UNIT_TEST event_test_filter_wfl (
+    [event]
+        name=start
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side turn
+        first_time_only=no
+        filter_formula="turn_number = side_number"
+        {VARIABLE_OP triggers add 1}
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals $turn_number})}
+    [/event]
+    [event]
+        name=turn 3
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 2})}
+    [/event]
+    [event]
+        name=side turn
+        first_time_only=no
+        [end_turn][/end_turn]
+    [/event]
+)}
+
+{GENERIC_UNIT_TEST event_test_filter_wfl2 (
+    [event]
+        name=start
+        {VARIABLE triggers 0}
+        [do_command]
+            [move]
+                x=7,7,6,5,4,3,3,3
+                y=3,4,4,5,4,4,3,2
+            [/move]
+        [/do_command]
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 3})}
+    [/event]
+    [event]
+        name=enter hex
+        first_time_only=no
+        filter_formula="loc.x = loc.y"
+        {VARIABLE_OP triggers add 1}
+    [/event]
+)}
+
+{GENERIC_UNIT_TEST event_test_filter_lua_serializable (
+    [event]
+        name=start
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side turn
+        first_time_only=no
+        [filter_condition]
+            [lua]
+                code=<<return wesnoth.current.turn == wesnoth.current.side>>
+            [/lua]
+        [/filter_condition]
+        {VARIABLE_OP triggers add 1}
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals $turn_number})}
+    [/event]
+    [event]
+        name=turn 3
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 2})}
+    [/event]
+    [event]
+        name=side turn
+        first_time_only=no
+        [end_turn][/end_turn]
+    [/event]
+)}
+
+{GENERIC_UNIT_TEST event_test_filter_lua_dynamic (
+    [event]
+        name=preload
+        [lua]
+            code=<<
+                wml.variables.triggers = 0
+                wesnoth.game_events.add{
+                    name = 'side turn',
+                    first_time_only = false,
+                    filter = function()
+                        return wesnoth.current.turn == wesnoth.current.side
+                    end,
+                    action = function()
+                        wml.variables.triggers = wml.variables.triggers + 1
+                        unit_test.assert_equal(wesnoth.current.turn, wesnoth.current.side, 'filter correctly passed')
+                    end
+                }
+            >>
+        [/lua]
+    [/event]
+    [event]
+        name=side 2 turn 3
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 2})}
+    [/event]
+    [event]
+        name=side turn
+        first_time_only=no
+        [end_turn][/end_turn]
+    [/event]
+)}
+
+{GENERIC_UNIT_TEST event_test_filter_lua_dynamic_break_save (
+    [event]
+        name=start
+        [lua]
+            code=<<
+                wesnoth.game_events.add{
+                    name = 'new turn',
+                    filter = function() end
+                }
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/src/ai/formula/ai.cpp
+++ b/src/ai/formula/ai.cpp
@@ -580,6 +580,9 @@ variant formula_ai::get_value(const std::string& key) const
 	{
 		return villages_from_set(resources::gameboard->map().villages(), &current_team().villages());
 	}
+	else if(key == "world") {
+		return variant(std::make_shared<gamestate_callable>());
+	}
 
 	return variant();
 }
@@ -613,6 +616,7 @@ void formula_ai::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "my_villages");
 	add_input(inputs, "villages_of_side");
 	add_input(inputs, "enemy_and_unowned_villages");
+	add_input(inputs, "world");
 }
 
 void formula_ai::set_value(const std::string& key, const variant& value) {

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -30,6 +30,9 @@
 #include "game_board.hpp"
 #include "game_version.hpp"
 #include "resources.hpp"
+#include "tod_manager.hpp"
+#include "play_controller.hpp"
+#include "game_events/pump.hpp"
 
 static lg::log_domain log_scripting_formula("scripting/formula");
 #define LOG_SF LOG_STREAM(info, log_scripting_formula)
@@ -890,6 +893,89 @@ void safe_call_result::get_inputs(formula_input_vector& inputs) const
 	if(current_unit_location_ != map_location()) {
 		add_input(inputs, "current_loc");
 	}
+}
+
+void gamestate_callable::get_inputs(formula_input_vector &inputs) const
+{
+	add_input(inputs, "turn_number");
+	add_input(inputs, "time_of_day");
+	add_input(inputs, "side_number");
+	add_input(inputs, "sides");
+	add_input(inputs, "units");
+	add_input(inputs, "map");
+}
+
+variant gamestate_callable::get_value(const std::string &key) const
+{
+	if(key == "turn_number") {
+		return variant(resources::tod_manager->turn());
+	} else if(key == "time_of_day") {
+		return variant(resources::tod_manager->get_time_of_day().id);
+	} else if(key == "side_number") {
+		return variant(resources::controller->current_side());
+	} else if(key == "sides") {
+		std::vector<variant> vars;
+		for(const auto& team : resources::gameboard->teams()) {
+			vars.emplace_back(std::make_shared<team_callable>(team));
+		}
+		return variant(vars);
+	} else if(key == "units") {
+		std::vector<variant> vars;
+		for(const auto& unit : resources::gameboard->units()) {
+			vars.emplace_back(std::make_shared<unit_callable>(unit));
+		}
+		return variant(vars);
+	} else if(key == "map") {
+		return variant(std::make_shared<gamemap_callable>(*resources::gameboard));
+	}
+
+	return variant();
+}
+
+void event_callable::get_inputs(formula_input_vector &inputs) const
+{
+	add_input(inputs, "event");
+	add_input(inputs, "event_id");
+	add_input(inputs, "event_data");
+	add_input(inputs, "loc");
+	add_input(inputs, "unit");
+	add_input(inputs, "weapon");
+	add_input(inputs, "second_loc");
+	add_input(inputs, "second_unit");
+	add_input(inputs, "second_weapon");
+}
+
+variant event_callable::get_value(const std::string &key) const
+{
+	if(key == "event") {
+		return variant(event_info.name);
+	} else if(key == "event_id") {
+		return variant(event_info.id);
+	} else if(key == "loc") {
+		return variant(std::make_shared<location_callable>(event_info.loc1));
+	} else if(key == "second_loc") {
+		return variant(std::make_shared<location_callable>(event_info.loc2));
+	} else if(key == "event_data") {
+		return variant(std::make_shared<config_callable>(event_info.data));
+	} else if(key == "unit") {
+		if(auto u1 = event_info.loc1.get_unit()) {
+			return variant(std::make_shared<unit_callable>(*u1));
+		}
+	} else if(key == "second_unit") {
+		if(auto u2 = event_info.loc2.get_unit()) {
+			return variant(std::make_shared<unit_callable>(*u2));
+		}
+	} else if(key == "weapon") {
+		if(event_info.data.has_child("first")) {
+			return variant(std::make_shared<attack_type_callable>(attack_type(event_info.data.child("first"))));
+		}
+	} else if(key == "second_weapon") {
+		if(event_info.data.has_child("second")) {
+			return variant(std::make_shared<attack_type_callable>(attack_type(event_info.data.child("second"))));
+		}
+	}
+
+	return variant();
 }
 
 } // namespace wfl

--- a/src/formula/callable_objects.hpp
+++ b/src/formula/callable_objects.hpp
@@ -26,9 +26,32 @@ class team;
 class terrain_type;
 class unit;
 class unit_type;
+namespace game_events {struct queued_event;}
 
 namespace wfl
 {
+
+/** An object representing the state of the game, providing access to the map and basic information */
+class gamestate_callable : public formula_callable
+{
+public:
+	// Currently it accesses all its state through the resources namespace, so nothing is passed into it.
+
+	void get_inputs(formula_input_vector& inputs) const override;
+	variant get_value(const std::string& key) const override;
+};
+
+/** An object representing the state of the current event; equivalent to Lua's wesnoth.current.event_context */
+class event_callable : public formula_callable
+{
+public:
+	event_callable(const game_events::queued_event& event) : event_info(event) {}
+
+	void get_inputs(formula_input_vector& inputs) const override;
+	variant get_value(const std::string& key) const override;
+private:
+	const game_events::queued_event& event_info;
+};
 
 class terrain_callable : public formula_callable
 {

--- a/src/game_events/entity_location.cpp
+++ b/src/game_events/entity_location.cpp
@@ -89,8 +89,7 @@ bool entity_location::matches_unit(const unit_map::const_iterator & un_it) const
  * the unit is required to additionally match the unit that was supplied
  * when this was constructed.
  */
-bool entity_location::matches_unit_filter(const unit_map::const_iterator & un_it,
-                                          const vconfig & filter) const
+bool entity_location::matches_unit_filter(const unit_map::const_iterator & un_it, const unit_filter& filter) const
 {
 	if ( !un_it.valid() )
 		return false;
@@ -101,7 +100,7 @@ bool entity_location::matches_unit_filter(const unit_map::const_iterator & un_it
 
 	// Filter the unit at the filter location (should be the unit's
 	// location if no special filter location was specified).
-	return unit_filter(filter).matches(*un_it, filter_loc_)  &&
+	return filter.matches(*un_it, filter_loc_)  &&
 	       matches_unit(un_it);
 }
 

--- a/src/game_events/entity_location.hpp
+++ b/src/game_events/entity_location.hpp
@@ -25,7 +25,7 @@
 
 class unit;
 class vconfig;
-
+class unit_filter;
 
 namespace game_events
 {
@@ -39,7 +39,7 @@ namespace game_events
 		const map_location& filter_loc() const { return filter_loc_;  }
 		bool matches_unit(const unit_map::const_iterator & un_it) const;
 		bool matches_unit_filter(const unit_map::const_iterator & un_it,
-		                         const vconfig & filter) const;
+		                         const unit_filter& filter) const;
 		unit_const_ptr get_unit() const;
 
 		static const entity_location null_entity;

--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -40,13 +40,14 @@ namespace game_events
 {
 /* ** event_handler ** */
 
-event_handler::event_handler(config&& cfg, bool imi, const std::vector<std::string>& types)
+event_handler::event_handler(config&& cfg, bool imi, const std::vector<std::string>& types, game_lua_kernel& lk)
 	: first_time_only_(cfg["first_time_only"].to_bool(true))
 	, is_menu_item_(imi)
 	, disabled_(false)
 	, cfg_(cfg)
 	, types_(types)
 {
+	event_ref_ = lk.save_wml_event(cfg);
 }
 
 void event_handler::disable()
@@ -69,7 +70,7 @@ void event_handler::handle_event(const queued_event& event_info, game_lua_kernel
 		disable();
 	}
 
-	lk.run_wml_action("command", vconfig(cfg_, false), event_info);
+	lk.run_wml_event(event_ref_, vconfig(cfg_, false), event_info);
 	sound::commit_music_changes();
 }
 

--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -24,6 +24,8 @@
 #include "game_events/pump.hpp"
 #include "game_events/manager_impl.hpp" // for standardize_name
 
+#include "formula/callable_objects.hpp"
+#include "formula/formula.hpp"
 #include "formula/string_utils.hpp"
 #include "game_board.hpp"
 #include "game_data.hpp"
@@ -211,6 +213,28 @@ private:
 	bool first_;
 };
 
+struct filter_formula : public event_filter {
+	filter_formula(const std::string& formula) : formula_(formula) {}
+	bool operator()(const queued_event& event_info) const override
+	{
+		wfl::gamestate_callable gs;
+		wfl::event_callable evt(event_info);
+		wfl::formula_callable_with_backup data(evt, gs);
+		return formula_.evaluate(data).as_bool();
+	}
+	void serialize(config& cfg) const override
+	{
+		std::string code = formula_.str();
+		if(cfg.has_attribute("filter_formula")) {
+			// This will probably never happen in practice, but handle it just in case it somehow can
+			code = "(" + cfg["filter_formula"].str() + ") and (" + code + ")";
+		}
+		cfg["filter_formula"] = code;
+	}
+private:
+	wfl::formula formula_;
+};
+
 void event_handler::read_filters(const config &cfg)
 {
 	for(auto filter : cfg.all_children_range()) {
@@ -228,6 +252,9 @@ void event_handler::read_filters(const config &cfg)
 		} else if(filter.key == "filter_second_attack") {
 			add_filter(std::make_unique<filter_attack>(vcfg, false));
 		}
+	}
+	if(cfg.has_attribute("filter_formula")) {
+		add_filter(std::make_unique<filter_formula>(cfg["filter_formula"]));
 	}
 }
 

--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -20,11 +20,20 @@
  */
 
 #include "game_events/handlers.hpp"
+#include "game_events/conditional_wml.hpp"
+#include "game_events/pump.hpp"
+#include "game_events/manager_impl.hpp" // for standardize_name
 
+#include "formula/string_utils.hpp"
+#include "game_board.hpp"
 #include "game_data.hpp"
 #include "log.hpp"
+#include "play_controller.hpp"
+#include "resources.hpp"
 #include "scripting/game_lua_kernel.hpp"
+#include "side_filter.hpp"
 #include "sound.hpp"
+#include "units/filter.hpp"
 #include "variable.hpp"
 
 static lg::log_domain log_engine("engine");
@@ -40,14 +49,44 @@ namespace game_events
 {
 /* ** event_handler ** */
 
-event_handler::event_handler(config&& cfg, bool imi, const std::vector<std::string>& types, game_lua_kernel& lk)
-	: first_time_only_(cfg["first_time_only"].to_bool(true))
-	, is_menu_item_(imi)
+event_handler::event_handler(const std::string& types, const std::string& id)
+	: first_time_only_(true)
+	, is_menu_item_(false)
 	, disabled_(false)
-	, cfg_(cfg)
+	, is_lua_(false)
+	, id_(id)
 	, types_(types)
+{}
+
+std::vector<std::string> event_handler::names(const variable_set* vars) const
 {
-	event_ref_ = lk.save_wml_event(cfg);
+	std::string names = types_;
+
+	// Do some standardization on the name field.
+	// Split the name field and standardize each one individually.
+	// This ensures they're all valid for by-name lookup.
+	std::vector<std::string> standardized_names;
+	for(std::string single_name : utils::split(names)) {
+		if(utils::might_contain_variables(single_name)) {
+			if(!vars) {
+				// If we don't have gamedata, we can't interpolate variables, so there's
+				// no way the name will match. Move on to the next one in that case.
+				continue;
+			}
+			single_name = utils::interpolate_variables_into_string(single_name, *vars);
+		}
+		// Variable interpolation could've introduced additional commas, so split again.
+		for(const std::string& subname : utils::split(single_name)) {
+			standardized_names.emplace_back(event_handlers::standardize_name(subname));
+		}
+	}
+
+	return standardized_names;
+}
+
+bool event_handler::empty() const
+{
+	return args_.empty();
 }
 
 void event_handler::disable()
@@ -63,15 +102,150 @@ void event_handler::handle_event(const queued_event& event_info, game_lua_kernel
 	}
 
 	if(is_menu_item_) {
-		DBG_NG << cfg_["name"] << " will now invoke the following command(s):\n" << cfg_;
+		DBG_NG << "menu item " << id_ << " will now invoke the following command(s):\n" << args_;
 	}
 
 	if(first_time_only_) {
 		disable();
 	}
 
-	lk.run_wml_event(event_ref_, vconfig(cfg_, false), event_info);
+	lk.run_wml_event(event_ref_, vconfig(args_, false), event_info);
 	sound::commit_music_changes();
 }
+
+bool event_handler::filter_event(const queued_event& ev) const
+{
+	return std::all_of(filters_.begin(), filters_.end(), [&ev](const auto& filter) {
+		return (*filter)(ev);
+	});
+}
+
+void event_handler::write_config(config &cfg) const
+{
+	if(disabled_) {
+		WRN_NG << "Tried to serialize disabled event, skipping";
+		return;
+	}
+	if(is_lua_) {
+		WRN_NG << "Skipping serialization of an event bound to Lua code";
+		return;
+	}
+	if(!types_.empty()) cfg["name"] = types_;
+	if(!id_.empty()) cfg["id"] = id_;
+	cfg["first_time_only"] = first_time_only_;
+	for(const auto& filter : filters_) {
+		filter->serialize(cfg);
+	}
+	cfg.append(args_);
+}
+
+void event_filter::serialize(config&) const
+{
+	WRN_NG << "Tried to serialize an event with a filter that cannot be serialized!";
+}
+
+struct filter_condition : public event_filter {
+	filter_condition(const vconfig& cfg) : cfg_(cfg.make_safe()) {}
+	bool operator()(const queued_event&) const override
+	{
+		return conditional_passed(cfg_);
+	}
+	void serialize(config& cfg) const override
+	{
+		cfg.add_child("filter_condition", cfg_.get_config());
+	}
+private:
+	vconfig cfg_;
+};
+
+struct filter_side : public event_filter {
+	filter_side(const vconfig& cfg) : ssf_(cfg.make_safe(), &resources::controller->gamestate()) {}
+	bool operator()(const queued_event&) const override
+	{
+		return ssf_.match(resources::controller->current_side());
+	}
+	void serialize(config& cfg) const override
+	{
+		cfg.add_child("filter_side", ssf_.get_config());
+	}
+private:
+	side_filter ssf_;
+};
+
+struct filter_unit : public event_filter {
+	filter_unit(const vconfig& cfg, bool first) : suf_(cfg.make_safe()), first_(first) {}
+	bool operator()(const queued_event& event_info) const override
+	{
+		const auto& loc = first_ ? event_info.loc1 : event_info.loc2;
+		auto unit = resources::gameboard->units().find(loc);
+		return loc.matches_unit_filter(unit, suf_);
+	}
+	void serialize(config& cfg) const override
+	{
+		cfg.add_child(first_ ? "filter" : "filter_second", suf_.to_config());
+	}
+private:
+	unit_filter suf_;
+	bool first_;
+};
+
+struct filter_attack : public event_filter {
+	filter_attack(const vconfig& cfg, bool first) : swf_(cfg.make_safe()), first_(first) {}
+	bool operator()(const queued_event& event_info) const override
+	{
+		const unit_map& units = resources::gameboard->units();
+		const auto& loc = first_ ? event_info.loc1 : event_info.loc2;
+		auto unit = units.find(loc);
+		if(unit != units.end() && loc.matches_unit(unit)) {
+			const config& attack = event_info.data.child(first_ ? "first" : "second");
+			return swf_.empty() || matches_special_filter(attack, swf_);
+		}
+		return false;
+	}
+	void serialize(config& cfg) const override
+	{
+		cfg.add_child(first_ ? "filter_attack" : "filter_second_attack", swf_.get_config());
+	}
+private:
+	vconfig swf_;
+	bool first_;
+};
+
+void event_handler::read_filters(const config &cfg)
+{
+	for(auto filter : cfg.all_children_range()) {
+		vconfig vcfg(filter.cfg);
+		if(filter.key == "filter_condition") {
+			add_filter(std::make_unique<filter_condition>(vcfg));
+		} else if(filter.key == "filter_side") {
+			add_filter(std::make_unique<filter_side>(vcfg));
+		} else if(filter.key == "filter") {
+			add_filter(std::make_unique<filter_unit>(vcfg, true));
+		} else if(filter.key == "filter_attack") {
+			add_filter(std::make_unique<filter_attack>(vcfg, true));
+		} else if(filter.key == "filter_second") {
+			add_filter(std::make_unique<filter_unit>(vcfg, false));
+		} else if(filter.key == "filter_second_attack") {
+			add_filter(std::make_unique<filter_attack>(vcfg, false));
+		}
+	}
+}
+
+void event_handler::add_filter(std::unique_ptr<event_filter>&& filter)
+{
+	filters_.push_back(std::move(filter));
+}
+
+void event_handler::register_wml_event(game_lua_kernel &lk)
+{
+	event_ref_ = lk.save_wml_event();
+}
+
+void event_handler::set_event_ref(int idx)
+{
+	event_ref_ = idx;
+	is_lua_ = true;
+}
+
 
 } // end namespace game_events

--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -128,8 +128,26 @@ void event_handler::write_config(config &cfg) const
 		WRN_NG << "Tried to serialize disabled event, skipping";
 		return;
 	}
+	static const char* log_append_preload = " - this will not break saves since it was registered during or before preload\n";
+	static const char* log_append_postload = " - this will break saves because it was registered after preload\n";
 	if(is_lua_) {
-		WRN_NG << "Skipping serialization of an event bound to Lua code";
+		static const char* log = "Skipping serialization of an event with action bound to Lua code";
+		if(has_preloaded_){
+			WRN_NG << log << log_append_postload;
+			lg::log_to_chat() << log << log_append_postload;
+		} else {
+			LOG_NG << log << log_append_preload;
+		}
+		return;
+	}
+	if(!std::all_of(filters_.begin(), filters_.end(), std::mem_fn(&event_filter::can_serialize))) {
+		static const char* log = "Skipping serialization of an event with filter bound to Lua code";
+		if(has_preloaded_) {
+			WRN_NG << log << log_append_postload;
+			lg::log_to_chat() << log << log_append_postload;
+		} else {
+			LOG_NG << log << log_append_preload;
+		}
 		return;
 	}
 	if(!types_.empty()) cfg["name"] = types_;
@@ -146,6 +164,11 @@ void event_filter::serialize(config&) const
 	WRN_NG << "Tried to serialize an event with a filter that cannot be serialized!";
 }
 
+bool event_filter::can_serialize() const
+{
+	return false;
+}
+
 struct filter_condition : public event_filter {
 	filter_condition(const vconfig& cfg) : cfg_(cfg.make_safe()) {}
 	bool operator()(const queued_event&) const override
@@ -155,6 +178,10 @@ struct filter_condition : public event_filter {
 	void serialize(config& cfg) const override
 	{
 		cfg.add_child("filter_condition", cfg_.get_config());
+	}
+	bool can_serialize() const override
+	{
+		return true;
 	}
 private:
 	vconfig cfg_;
@@ -169,6 +196,10 @@ struct filter_side : public event_filter {
 	void serialize(config& cfg) const override
 	{
 		cfg.add_child("filter_side", ssf_.get_config());
+	}
+	bool can_serialize() const override
+	{
+		return true;
 	}
 private:
 	side_filter ssf_;
@@ -185,6 +216,10 @@ struct filter_unit : public event_filter {
 	void serialize(config& cfg) const override
 	{
 		cfg.add_child(first_ ? "filter" : "filter_second", suf_.to_config());
+	}
+	bool can_serialize() const override
+	{
+		return true;
 	}
 private:
 	unit_filter suf_;
@@ -208,6 +243,10 @@ struct filter_attack : public event_filter {
 	{
 		cfg.add_child(first_ ? "filter_attack" : "filter_second_attack", swf_.get_config());
 	}
+	bool can_serialize() const override
+	{
+		return true;
+	}
 private:
 	vconfig swf_;
 	bool first_;
@@ -230,6 +269,10 @@ struct filter_formula : public event_filter {
 			code = "(" + cfg["filter_formula"].str() + ") and (" + code + ")";
 		}
 		cfg["filter_formula"] = code;
+	}
+	bool can_serialize() const override
+	{
+		return true;
 	}
 private:
 	wfl::formula formula_;
@@ -268,10 +311,11 @@ void event_handler::register_wml_event(game_lua_kernel &lk)
 	event_ref_ = lk.save_wml_event();
 }
 
-void event_handler::set_event_ref(int idx)
+void event_handler::set_event_ref(int idx, bool has_preloaded)
 {
 	event_ref_ = idx;
 	is_lua_ = true;
+	has_preloaded_ = has_preloaded;
 }
 
 

--- a/src/game_events/handlers.hpp
+++ b/src/game_events/handlers.hpp
@@ -101,7 +101,10 @@ public:
 		return !first_time_only_;
 	}
 
-	void write_config(config& cfg) const;
+	// Normally non-serializable events are skipped when serializing (with a warning).
+	// If include_nonserializable is true, the game attempts to serialize them anyway.
+	// This will produce output that kind of looks like the event but would not deserialize to the same event.
+	void write_config(config& cfg, bool include_nonserializable = false) const;
 
 	void set_repeatable(bool repeat = true)
 	{

--- a/src/game_events/handlers.hpp
+++ b/src/game_events/handlers.hpp
@@ -38,7 +38,7 @@ struct queued_event;
 class event_handler
 {
 public:
-	event_handler(config&& cfg, bool is_menu_item, const std::vector<std::string>& types);
+	event_handler(config&& cfg, bool is_menu_item, const std::vector<std::string>& types, game_lua_kernel& lk);
 
 	const std::vector<std::string>& names() const
 	{
@@ -76,6 +76,7 @@ private:
 	bool is_menu_item_;
 	bool disabled_;
 	config cfg_;
+	int event_ref_;
 	std::vector<std::string> types_;
 };
 

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -184,7 +184,11 @@ void manager::write_events(config& cfg, bool include_nonserializable) const
 			assert(!eh->disabled());
 		}
 
-		eh->write_config(cfg.add_child("event"), include_nonserializable);
+		config event_cfg;
+		eh->write_config(event_cfg, include_nonserializable);
+		if(!event_cfg.empty()) {
+			cfg.add_child("event", std::move(event_cfg));
+		}
 	}
 
 	cfg["unit_wml_ids"] = utils::join(unit_wml_ids_);

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -72,7 +72,7 @@ void manager::add_event_handler_from_wml(const config& handler, game_lua_kernel&
 		new_handler->read_filters(handler);
 
 		// Strip out anything that's used by the event system itself.
-		// TODO: "filter" and "formula" are stubs intended for Lua and WFL code respectively.
+		// TODO: "filter" is a stub intended for Lua code.
 		config args;
 		for(const auto& [attr, val] : handler.attribute_range()) {
 			if(attr == "id" || attr == "name" || attr == "first_time_only" || attr.compare(0, 6, "filter") == 0) {

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -64,9 +64,9 @@ namespace
 namespace game_events
 {
 /** Create an event handler. */
-void manager::add_event_handler(const config& handler, bool is_menu_item)
+void manager::add_event_handler(const config& handler, game_lua_kernel& lk, bool is_menu_item)
 {
-	event_handlers_->add_event_handler(handler, is_menu_item);
+	event_handlers_->add_event_handler(handler, lk, is_menu_item);
 }
 
 /** Removes an event handler. */
@@ -91,10 +91,10 @@ manager::manager()
 {
 }
 
-void manager::read_scenario(const config& scenario_cfg)
+void manager::read_scenario(const config& scenario_cfg, game_lua_kernel& lk)
 {
 	for(const config& ev : scenario_cfg.child_range("event")) {
-		add_event_handler(ev);
+		add_event_handler(ev, lk);
 	}
 
 	for(const std::string& id : utils::split(scenario_cfg["unit_wml_ids"])) {
@@ -104,14 +104,14 @@ void manager::read_scenario(const config& scenario_cfg)
 	wml_menu_items_.set_menu_items(scenario_cfg);
 
 	// Create the event handlers for menu items.
-	wml_menu_items_.init_handlers();
+	wml_menu_items_.init_handlers(lk);
 }
 
 manager::~manager()
 {
 }
 
-void manager::add_events(const config::const_child_itors& cfgs, const std::string& type)
+void manager::add_events(const config::const_child_itors& cfgs, game_lua_kernel& lk, const std::string& type)
 {
 	if(!type.empty()) {
 		if(std::find(unit_wml_ids_.begin(), unit_wml_ids_.end(), type) != unit_wml_ids_.end()) {
@@ -127,7 +127,7 @@ void manager::add_events(const config::const_child_itors& cfgs, const std::strin
 			continue;
 		}
 
-		add_event_handler(new_ev);
+		add_event_handler(new_ev, lk);
 	}
 }
 

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -72,7 +72,6 @@ void manager::add_event_handler_from_wml(const config& handler, game_lua_kernel&
 		new_handler->read_filters(handler);
 
 		// Strip out anything that's used by the event system itself.
-		// TODO: "filter" is a stub intended for Lua code.
 		config args;
 		for(const auto& [attr, val] : handler.attribute_range()) {
 			if(attr == "id" || attr == "name" || attr == "first_time_only" || attr.compare(0, 6, "filter") == 0) {

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -165,7 +165,7 @@ void manager::add_events(const config::const_child_itors& cfgs, game_lua_kernel&
 	}
 }
 
-void manager::write_events(config& cfg) const
+void manager::write_events(config& cfg, bool include_nonserializable) const
 {
 	for(const handler_ptr& eh : event_handlers_->get_active()) {
 		if(!eh || eh->is_menu_item()) {
@@ -184,7 +184,7 @@ void manager::write_events(config& cfg) const
 			assert(!eh->disabled());
 		}
 
-		eh->write_config(cfg.add_child("event"));
+		eh->write_config(cfg.add_child("event"), include_nonserializable);
 	}
 
 	cfg["unit_wml_ids"] = utils::join(unit_wml_ids_);

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -25,6 +25,7 @@
 
 class filter_context;
 class game_data;
+class game_lua_kernel;
 
 namespace game_events
 {
@@ -55,11 +56,11 @@ public:
 	manager& operator=(const manager&) = delete;
 
 	explicit manager();
-	void read_scenario(const config& scenario_cfg);
+	void read_scenario(const config& scenario_cfg, game_lua_kernel& lk);
 	~manager();
 
 	/** Create an event handler. */
-	void add_event_handler(const config& handler, bool is_menu_item = false);
+	void add_event_handler(const config& handler, game_lua_kernel& lk, bool is_menu_item = false);
 
 	/** Removes an event handler. */
 	void remove_event_handler(const std::string& id);
@@ -67,7 +68,7 @@ public:
 	/** Gets an event handler by ID */
 	const handler_ptr get_event_handler_by_id(const std::string& id);
 
-	void add_events(const config::const_child_itors& cfgs, const std::string& type = std::string());
+	void add_events(const config::const_child_itors& cfgs, game_lua_kernel& lk, const std::string& type = std::string());
 
 	void write_events(config& cfg) const;
 

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -31,6 +31,7 @@ namespace game_events
 {
 class wml_event_pump;
 class event_handlers;
+class pending_event_handler;
 
 /**
  * The game event manager loads the scenario configuration object,
@@ -59,8 +60,10 @@ public:
 	void read_scenario(const config& scenario_cfg, game_lua_kernel& lk);
 	~manager();
 
-	/** Create an event handler. */
-	void add_event_handler(const config& handler, game_lua_kernel& lk, bool is_menu_item = false);
+	/** Create an event handler from an [event] tag. */
+	void add_event_handler_from_wml(const config& handler, game_lua_kernel& lk, bool is_menu_item = false);
+	/** Create an empty event handler. Expects the caller to finish setting up the event. */
+	pending_event_handler add_event_handler_from_lua(const std::string& name, const std::string& id, bool repeat = false, bool is_menu_item = false);
 
 	/** Removes an event handler. */
 	void remove_event_handler(const std::string& id);

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -73,7 +73,7 @@ public:
 
 	void add_events(const config::const_child_itors& cfgs, game_lua_kernel& lk, const std::string& type = std::string());
 
-	void write_events(config& cfg) const;
+	void write_events(config& cfg, bool include_nonserializable=false) const;
 
 	using event_func_t = std::function<void(game_events::manager&, handler_ptr&)>;
 	void execute_on_events(const std::string& event_id, event_func_t func);

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -73,6 +73,9 @@ public:
 
 	void add_events(const config::const_child_itors& cfgs, game_lua_kernel& lk, const std::string& type = std::string());
 
+	// Normally non-serializable events are skipped when serializing (with a warning).
+	// If include_nonserializable is true, the game attempts to serialize them anyway.
+	// This will produce output that kind of looks like the event but would not deserialize to the same event.
 	void write_events(config& cfg, bool include_nonserializable=false) const;
 
 	using event_func_t = std::function<void(game_events::manager&, handler_ptr&)>;

--- a/src/game_events/manager_impl.cpp
+++ b/src/game_events/manager_impl.cpp
@@ -28,6 +28,8 @@ static lg::log_domain log_engine("engine");
 #define WRN_NG LOG_STREAM(warn, log_engine)
 
 static lg::log_domain log_event_handler("event_handler");
+#define ERR_EH LOG_STREAM(err, log_event_handler)
+#define LOG_EH LOG_STREAM(info, log_event_handler)
 #define DBG_EH LOG_STREAM(debug, log_event_handler)
 
 static lg::log_domain log_wml("wml");
@@ -49,8 +51,7 @@ void event_handlers::log_handlers()
 			continue;
 		}
 
-		const config& cfg = h->get_config();
-		ss << "name=" << cfg["name"] << ", with id=" << cfg["id"] << "; ";
+		ss << "name=" << h->names_raw() << ", with id=" << h->id() << "; ";
 	}
 
 	DBG_EH << "active handlers are now " << ss.str() << "\n";
@@ -92,70 +93,57 @@ handler_list& event_handlers::get(const std::string& name)
  * An event with a nonempty ID will not be added if an event with that
  * ID already exists.
  */
-void event_handlers::add_event_handler(const config& cfg, game_lua_kernel& lk, bool is_menu_item)
+pending_event_handler event_handlers::add_event_handler(const std::string& name, const std::string& id, bool repeat, bool is_menu_item)
 {
-	// Someone decided to register an empty event... bail.
-	if(cfg.empty()) {
-		return;
-	}
-
-	std::string name = cfg["name"];
-	std::string id = cfg["id"];
-
 	if(!id.empty()) {
 		// Ignore this handler if there is already one with this ID.
 		auto find_it = id_map_.find(id);
 
 		if(find_it != id_map_.end() && !find_it->second.expired()) {
-			DBG_EH << "ignoring event handler for name='" << name << "' with id '" << id << "'\n";
-			return;
+			LOG_EH << "ignoring event handler for name='" << name << "' with id '" << id << "' because an event with that id already exists\n";
+			return {*this, nullptr};
 		}
 	}
 
 	if(name.empty() && id.empty()) {
-		lg::log_to_chat() << "[event] is missing name or id field\n";
-		ERR_WML << "[event] is missing name or id field\n";
-		DBG_WML << "Content of that event:\n" << cfg.debug() << "\n";
-		return;
-	}
-
-	// Make a copy of the event cfg here in order to do some standardization on the
-	// name field. Will be moved into the handler.
-	config event_cfg = cfg;
-
-	// Split the name field...
-	std::vector<std::string> standardized_names = utils::split(name);
-
-	if(!name.empty()) {
-		// ...and standardize each one individually. This ensures they're all valid for by-name lookup.
-		for(std::string& single_name : standardized_names) {
-			if(!utils::might_contain_variables(single_name)) {
-				single_name = standardize_name(single_name);
-			}
+		static const char* msg = "[event] is missing name or id field";
+		lg::log_to_chat() << msg << "\n";
+		if(lg::info().dont_log(log_event_handler)) {
+			ERR_EH << msg << " (run with --log-info=event_handler for more info)\n";
+		} else {
+			ERR_EH << msg << "\n";
 		}
-
-		assert(!standardized_names.empty());
-
-		// Write the new name back to the config.
-		name = utils::join(standardized_names);
-		event_cfg["name"] = name;
+		return {*this, nullptr};
 	}
 
 	// Create a new handler.
+	auto handler = std::make_shared<event_handler>(name, id);
+	handler->set_menu_item(is_menu_item);
+	handler->set_repeatable(repeat);
+	return {*this, handler};
+}
+
+void event_handlers::finish_adding_event_handler(handler_ptr handler)
+{
+	// Someone decided to register an empty event... bail.
+	if(handler->empty()) {
+		return;
+	}
+
+	const std::string& names = handler->names_raw();
+	const std::string& id = handler->id();
+
+	// Register the new handler.
 	// Do note active_ holds the main shared_ptr, and the other three containers
 	// construct weak_ptrs from the shared one.
-	DBG_EH << "inserting event handler for name=" << name << " with id=" << id << "\n";
-	active_.emplace_back(new event_handler(std::move(event_cfg), is_menu_item, standardized_names, lk));
-
-	//
-	//  !! event_cfg is invalid past this point! DO NOT USE!
-	//
+	DBG_EH << "inserting event handler for name=" << names << " with id=" << id << "\n";
+	active_.emplace_back(handler);
 
 	// File by name.
-	if(utils::might_contain_variables(name)) {
+	if(utils::might_contain_variables(names)) {
 		dynamic_.emplace_back(active_.back());
 	} else {
-		for(const std::string& single_name : standardized_names) {
+		for(const std::string& single_name : handler->names(nullptr)) {
 			by_name_[single_name].emplace_back(active_.back());
 		}
 	}
@@ -166,6 +154,11 @@ void event_handlers::add_event_handler(const config& cfg, game_lua_kernel& lk, b
 	}
 
 	log_handlers();
+}
+
+pending_event_handler::~pending_event_handler()
+{
+	if(valid()) list_.finish_adding_event_handler(handler_);
 }
 
 /**

--- a/src/game_events/manager_impl.cpp
+++ b/src/game_events/manager_impl.cpp
@@ -92,7 +92,7 @@ handler_list& event_handlers::get(const std::string& name)
  * An event with a nonempty ID will not be added if an event with that
  * ID already exists.
  */
-void event_handlers::add_event_handler(const config& cfg, bool is_menu_item)
+void event_handlers::add_event_handler(const config& cfg, game_lua_kernel& lk, bool is_menu_item)
 {
 	// Someone decided to register an empty event... bail.
 	if(cfg.empty()) {
@@ -145,7 +145,7 @@ void event_handlers::add_event_handler(const config& cfg, bool is_menu_item)
 	// Do note active_ holds the main shared_ptr, and the other three containers
 	// construct weak_ptrs from the shared one.
 	DBG_EH << "inserting event handler for name=" << name << " with id=" << id << "\n";
-	active_.emplace_back(new event_handler(std::move(event_cfg), is_menu_item, standardized_names));
+	active_.emplace_back(new event_handler(std::move(event_cfg), is_menu_item, standardized_names, lk));
 
 	//
 	//  !! event_cfg is invalid past this point! DO NOT USE!

--- a/src/game_events/manager_impl.hpp
+++ b/src/game_events/manager_impl.hpp
@@ -21,6 +21,8 @@
 #include <deque>
 #include <unordered_map>
 
+class game_lua_kernel;
+
 namespace game_events
 {
 // event_handlers is essentially the implementation details of the manager
@@ -82,7 +84,7 @@ public:
 	handler_list& get(const std::string& name);
 
 	/** Adds an event handler. */
-	void add_event_handler(const config& cfg, bool is_menu_item = false);
+	void add_event_handler(const config& cfg, game_lua_kernel& lk, bool is_menu_item = false);
 
 	/** Removes an event handler, identified by its ID. */
 	void remove_event_handler(const std::string& id);

--- a/src/game_events/menu_item.cpp
+++ b/src/game_events/menu_item.cpp
@@ -204,12 +204,12 @@ void wml_menu_item::finish_handler()
 	}
 }
 
-void wml_menu_item::init_handler()
+void wml_menu_item::init_handler(game_lua_kernel& lk)
 {
 	// If this menu item has a [command], add a handler for it.
 	if(!command_.empty()) {
 		assert(resources::game_events);
-		resources::game_events->add_event_handler(command_, true);
+		resources::game_events->add_event_handler(command_, lk, true);
 	}
 
 	// Hotkey support
@@ -367,7 +367,8 @@ void wml_menu_item::update_command(const config& new_command)
 		// Register the event.
 		LOG_NG << "Setting command for " << event_name_ << " to:\n" << command_;
 		assert(resources::game_events);
-		resources::game_events->add_event_handler(command_, true);
+		assert(resources::lua_kernel);
+		resources::game_events->add_event_handler(command_, *resources::lua_kernel, true);
 	}
 }
 

--- a/src/game_events/menu_item.cpp
+++ b/src/game_events/menu_item.cpp
@@ -209,7 +209,7 @@ void wml_menu_item::init_handler(game_lua_kernel& lk)
 	// If this menu item has a [command], add a handler for it.
 	if(!command_.empty()) {
 		assert(resources::game_events);
-		resources::game_events->add_event_handler(command_, lk, true);
+		resources::game_events->add_event_handler_from_wml(command_, lk, true);
 	}
 
 	// Hotkey support
@@ -338,16 +338,14 @@ void wml_menu_item::update(const vconfig& vcfg)
 void wml_menu_item::update_command(const config& new_command)
 {
 	// If there is an old command, remove it from the event handlers.
-	if(!command_.empty()) {
-		assert(resources::game_events);
+	assert(resources::game_events);
 
-		resources::game_events->execute_on_events(event_name_, [&](game_events::manager& man, handler_ptr& ptr) {
-			if(ptr->is_menu_item()) {
-				LOG_NG << "Removing command for " << event_name_ << ".\n";
-				man.remove_event_handler(command_["id"].str());
-			}
-		});
-	}
+	resources::game_events->execute_on_events(event_name_, [&](game_events::manager& man, handler_ptr& ptr) {
+		if(ptr->is_menu_item()) {
+			LOG_NG << "Removing command for " << event_name_ << ".\n";
+			man.remove_event_handler(command_["id"].str());
+		}
+	});
 
 	// Update our stored command.
 	if(new_command.empty()) {
@@ -368,7 +366,7 @@ void wml_menu_item::update_command(const config& new_command)
 		LOG_NG << "Setting command for " << event_name_ << " to:\n" << command_;
 		assert(resources::game_events);
 		assert(resources::lua_kernel);
-		resources::game_events->add_event_handler(command_, *resources::lua_kernel, true);
+		resources::game_events->add_event_handler_from_wml(command_, *resources::lua_kernel, true);
 	}
 }
 

--- a/src/game_events/menu_item.hpp
+++ b/src/game_events/menu_item.hpp
@@ -28,6 +28,7 @@
 
 class filter_context;
 class game_data;
+class game_lua_kernel;
 struct map_location;
 
 namespace game_events
@@ -109,7 +110,7 @@ public:
 	void finish_handler();
 
 	/** Initializes the implicit event handler for an inlined [command]. */
-	void init_handler();
+	void init_handler(game_lua_kernel& lk);
 
 	/**
 	 * The text to put in a menu for this item.

--- a/src/game_events/pump.hpp
+++ b/src/game_events/pump.hpp
@@ -143,8 +143,6 @@ public:
 	void flush_messages();
 
 private:
-	bool filter_event(const event_handler& handler, const queued_event& ev);
-
 	void process_event(handler_ptr& handler_p, const queued_event& ev);
 
 	void fill_wml_messages_map(std::map<std::string, int>& msg_map, std::stringstream& source);

--- a/src/game_events/wmi_manager.cpp
+++ b/src/game_events/wmi_manager.cpp
@@ -163,7 +163,7 @@ wmi_manager::item_ptr wmi_manager::get_item(const std::string& id) const
 /**
  * Initializes the implicit event handlers for inlined [command]s.
  */
-void wmi_manager::init_handlers() const
+void wmi_manager::init_handlers(game_lua_kernel& lk) const
 {
 	// Applying default hotkeys here currently does not work because
 	// the hotkeys are reset by play_controler::init_managers() ->
@@ -179,7 +179,7 @@ void wmi_manager::init_handlers() const
 	// Loop through each menu item.
 	for(const auto& item : wml_menu_items_) {
 		// If this menu item has a [command], add a handler for it.
-		item.second->init_handler();
+		item.second->init_handler(lk);
 
 		// Count the menu items (for the diagnostic message).
 		++wmi_count;

--- a/src/game_events/wmi_manager.hpp
+++ b/src/game_events/wmi_manager.hpp
@@ -28,6 +28,7 @@
 class config;
 class filter_context;
 class game_data;
+class game_lua_kernel;
 struct map_location;
 class unit_map;
 class vconfig;
@@ -79,7 +80,7 @@ public:
 			unit_map& units) const;
 
 	/** Initializes the implicit event handlers for inlined [command]s. */
-	void init_handlers() const;
+	void init_handlers(game_lua_kernel& lk) const;
 
 	void to_config(config& cfg) const;
 

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -94,7 +94,7 @@ game_state::game_state(const config& level, play_controller& pc, game_board& boa
 	, first_human_team_(-1)
 {
 	lua_kernel_->load_core();
-	events_manager_->read_scenario(level);
+	events_manager_->read_scenario(level, *lua_kernel_);
 	if(const config& endlevel_cfg = level.child("end_level_data")) {
 		end_level_data el_data;
 		el_data.read(endlevel_cfg);
@@ -178,7 +178,7 @@ void game_state::place_sides_in_preferred_locations(const config& level)
 
 void game_state::init(const config& level, play_controller & pc)
 {
-	events_manager_->read_scenario(level);
+	events_manager_->read_scenario(level, *lua_kernel_);
 	gui2::dialogs::loading_screen::progress(loading_stage::init_teams);
 	if (level["modify_placing"].to_bool()) {
 		LOG_NG << "modifying placing..." << std::endl;

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -490,7 +490,7 @@ const display_context& single_mode_controller::dc() const {
 event_mode_controller::event_mode_controller(gamestate_inspector::controller& c)
 	: single_mode_controller(c)
 {
-	single_mode_controller::events().write_events(events);
+	single_mode_controller::events().write_events(events, true);
 }
 
 void variable_mode_controller::show_list(tree_view_node& node)

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -348,6 +348,7 @@ void play_controller::fire_preload()
 	// Run initialization scripts, even if loading from a snapshot.
 	gamestate().gamedata_.get_variable("turn_number") = static_cast<int>(turn());
 	pump().fire("preload");
+	gamestate().lua_kernel_->preload_finished();
 }
 
 void play_controller::fire_prestart()

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3701,6 +3701,9 @@ struct lua_event_filter : public game_events::event_filter
 	{
 		lk.clear_wml_event(ref_);
 	}
+	void serialize(config& cfg) const override {
+		cfg.add_child("filter_lua")["code"] = "<function>";
+	}
 private:
 	game_lua_kernel& lk;
 	int ref_;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3762,24 +3762,26 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 					new_handler->add_filter(std::make_unique<lua_event_filter>(*this, fcnIdx, luaW_table_get_def(L, 1, "filter_args", config())));
 					has_lua_filter = true;
 				} else {
-					if(luaW_tableget(L, filterIdx, "condition")) {
-						filters.add_child("filter_condition", luaW_checkconfig(L, -1));
-					}
-					if(luaW_tableget(L, filterIdx, "side")) {
-						filters.add_child("filter_side", luaW_checkconfig(L, -1));
-					}
-					if(luaW_tableget(L, filterIdx, "unit")) {
-						filters.add_child("filter", luaW_checkconfig(L, -1));
-					}
-					if(luaW_tableget(L, filterIdx, "attack")) {
-						filters.add_child("filter_attack", luaW_checkconfig(L, -1));
-					}
-					if(luaW_tableget(L, filterIdx, "second_unit")) {
-						filters.add_child("filter_second", luaW_checkconfig(L, -1));
-					}
-					if(luaW_tableget(L, filterIdx, "second_attack")) {
-						filters.add_child("filter_second_attack", luaW_checkconfig(L, -1));
-					}
+#define READ_ONE_FILTER(key) \
+					do { \
+						if(luaW_tableget(L, filterIdx, key)) { \
+							if(lua_isstring(L, -1)) { \
+								filters.add_child("insert_tag", config{ \
+									"name", "filter_" key, \
+									"variable", luaL_checkstring(L, -1) \
+								}); \
+							} else { \
+								filters.add_child("filter_" key, luaW_checkconfig(L, -1)); \
+							} \
+						} \
+					} while(false);
+					READ_ONE_FILTER("condition");
+					READ_ONE_FILTER("side");
+					READ_ONE_FILTER("unit");
+					READ_ONE_FILTER("attack");
+					READ_ONE_FILTER("second_unit");
+					READ_ONE_FILTER("second_attack");
+#undef READ_ONE_FILTER
 					if(luaW_tableget(L, filterIdx, "formula")) {
 						filters["filter_formula"] = luaL_checkstring(L, -1);
 					}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -103,6 +103,7 @@
 #include "units/map.hpp"  // for unit_map, etc
 #include "units/ptr.hpp"                 // for unit_const_ptr, unit_ptr
 #include "units/types.hpp"    // for unit_type_data, unit_types, etc
+#include "utils/scope_exit.hpp"
 #include "variable.hpp"                 // for vconfig, etc
 #include "variable_info.hpp"
 #include "whiteboard/manager.hpp"       // for whiteboard
@@ -3695,9 +3696,9 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 	game_events::manager & man = *game_state_.events_manager_;
 
 	if (!cfg["delayed_variable_substitution"].to_bool(true)) {
-		man.add_event_handler(cfg.get_parsed_config());
+		man.add_event_handler(cfg.get_parsed_config(), *this);
 	} else {
-		man.add_event_handler(cfg.get_config());
+		man.add_event_handler(cfg.get_config(), *this);
 	}
 	return 0;
 }
@@ -4468,6 +4469,7 @@ game_lua_kernel::game_lua_kernel(game_state & gs, play_controller & pc, reports 
 	, play_controller_(pc)
 	, reports_(reports_object)
 	, level_lua_()
+	, EVENT_TABLE(LUA_NOREF)
 	, queued_events_()
 	, map_locked_(0)
 {
@@ -5209,6 +5211,73 @@ bool game_lua_kernel::run_wml_conditional(const std::string& cmd, const vconfig&
 
 	lua_pop(L, 1);
 	return b;
+}
+
+static int intf_run_event_wml(lua_State* L)
+{
+	int argIdx = lua_gettop(L);
+	if(!luaW_getglobal(L, "wesnoth", "wml_actions", "command")) {
+		return luaL_error(L, "wesnoth.wml_actions.command is missing");
+	}
+	lua_pushvalue(L, argIdx);
+	lua_call(L, 1, 0);
+	return 0;
+}
+
+int game_lua_kernel::save_wml_event(const config& evt)
+{
+	lua_State* L = mState;
+	if(EVENT_TABLE == LUA_NOREF) {
+		lua_newtable(L);
+		EVENT_TABLE = luaL_ref(L, LUA_REGISTRYINDEX);
+	}
+	lua_geti(L, LUA_REGISTRYINDEX, EVENT_TABLE);
+	int evtIdx = lua_gettop(L);
+	ON_SCOPE_EXIT(L) {
+		lua_pop(L, 1);
+	};
+	if(evt.has_attribute("code")) {
+		std::ostringstream name;
+		name << "event ";
+		if(evt.has_attribute("name")) {
+			name << evt["name"];
+		} else {
+			name << "<anon>";
+		}
+		if(evt.has_attribute("id")) {
+			name << "[id=" << evt["id"] << "]";
+		}
+		if(!load_string(evt["code"].str().c_str(), name.str())) {
+			ERR_LUA << "Failed to register WML event: " << name.str();
+			return LUA_NOREF;
+		}
+	} else {
+		lua_pushcfunction(L, intf_run_event_wml);
+	}
+	int ref = luaL_ref(L, evtIdx);
+	return ref;
+}
+
+void game_lua_kernel::clear_wml_event(int ref)
+{
+	lua_State* L = mState;
+	lua_geti(L, LUA_REGISTRYINDEX, EVENT_TABLE);
+	luaL_unref(L, -1, ref);
+	lua_pop(L, 1);
+}
+
+bool game_lua_kernel::run_wml_event(int ref, const vconfig& args, const game_events::queued_event& ev)
+{
+	lua_State* L = mState;
+	lua_geti(L, LUA_REGISTRYINDEX, EVENT_TABLE);
+	ON_SCOPE_EXIT(L) {
+		lua_pop(L, 1);
+	};
+	lua_geti(L, -1, ref);
+	if(lua_isnil(L, -1)) return false;
+	luaW_pushvconfig(L, args);
+	queued_event_context dummy(&ev, queued_events_);
+	return protected_call(1, 0);
 }
 
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3780,6 +3780,9 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 					if(luaW_tableget(L, filterIdx, "second_attack")) {
 						filters.add_child("filter_second_attack", luaW_checkconfig(L, -1));
 					}
+					if(luaW_tableget(L, filterIdx, "formula")) {
+						filters["filter_formula"] = luaL_checkstring(L, -1);
+					}
 				}
 			}
 			new_handler->read_filters(filters);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3746,7 +3746,7 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 			man.add_event_handler_from_wml(cfg.get_parsed_config(), *this);
 		}
 	} else if(lua_isstring(L, 1)) {
-		bool is_menu_item = luaW_toboolean(L, 3), repeat = false;
+		bool is_menu_item = luaW_toboolean(L, 3), repeat = true;
 		std::string name = read_event_name(L, 1), id;
 		if(is_menu_item) {
 			id = name;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -5438,7 +5438,7 @@ bool game_lua_kernel::run_wml_event(int ref, const vconfig& args, const game_eve
 	if(lua_isnil(L, -1)) return false;
 	luaW_pushvconfig(L, args);
 	queued_event_context dummy(&ev, queued_events_);
-	if(protected_call(1, out ? 1 : 0)) {
+	if(luaW_pcall(L, 1, out ? 1 : 0, true)) {
 		if(out) {
 			*out = luaW_toboolean(L, -1);
 			lua_pop(L, 1);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3756,7 +3756,7 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 		if(new_handler.valid()) {
 			// An event with empty arguments is not added, so set some dummy arguments
 			new_handler->set_arguments(config{"__quick_lua_event", true});
-			new_handler->set_event_ref(save_wml_event(2));
+			new_handler->set_event_ref(save_wml_event(2), has_preloaded_);
 		}
 	} else if(lua_istable(L, 1)) {
 		using namespace std::literals;
@@ -3803,12 +3803,12 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 			}
 
 			if(luaW_tableget(L, 1, "action")) {
-				new_handler->set_event_ref(save_wml_event(-1));
+				new_handler->set_event_ref(save_wml_event(-1), has_preloaded_);
 			} else {
 				if(has_lua_filter) {
 					// This just sets the appropriate flags so the engine knows it cannot be serialized.
 					// The register_wml_event call will override the actual event_ref so just pass LUA_NOREF here.
-					new_handler->set_event_ref(LUA_NOREF);
+					new_handler->set_event_ref(LUA_NOREF, has_preloaded_);
 				}
 				new_handler->register_wml_event(*this);
 			}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3747,6 +3747,14 @@ int game_lua_kernel::intf_add_event(lua_State *L)
 	bool repeat = !luaW_table_get_def(L, 1, "first_time_only", true), is_menu_item = luaW_table_get_def(L, 1, "menu_item", false);
 	if(luaW_tableget(L, 1, "name")) {
 		name = read_event_name(L, -1);
+	} else if(is_menu_item) {
+		if(id.empty()) {
+			return luaL_argerror(L, 1, "non-empty id is required for a menu item");
+		}
+		name = "menu item " + id;
+	}
+	if(id.empty() && name.empty()) {
+		return luaL_argerror(L, 1, "either a name or id is required");
 	}
 	auto new_handler = man.add_event_handler_from_lua(name, id, repeat, is_menu_item);
 	if(new_handler.valid()) {
@@ -3814,6 +3822,9 @@ int game_lua_kernel::intf_add_event_simple(lua_State *L)
 	game_events::manager & man = *game_state_.events_manager_;
 	bool repeat = true;
 	std::string name = read_event_name(L, 1), id;
+	if(name.empty()) {
+		return luaL_argerror(L, 1, "must not be empty");
+	}
 	if(is_menu_item) {
 		id = name;
 		name = "menu item " + name;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3725,96 +3725,102 @@ static std::string read_event_name(lua_State* L, int idx)
  * filter: Event filters as a config with filter tags, a table of the form {filter_type = filter_contents}, or a function
  * content: The content of the event. This is a WML table passed verbatim into the event when it fires. If no function is specified, it will be interpreted as ActionWML.
  * action: The function to call when the event triggers. Defaults to wesnoth.wml_actions.command.
- * OR
- * Arg 1: Event to handle, as a string or list of strings; or menu item ID if this is a menu item
- * Arg 2: The function to call when the event triggers
- * Arg 3: True if this is a menu item
- * OR
- * Arg 1: A boolean - whether to delay variable substitution
- * Arg 2: A full event specification as a WML config
  */
 int game_lua_kernel::intf_add_event(lua_State *L)
 {
 	game_events::manager & man = *game_state_.events_manager_;
+	using namespace std::literals;
+	std::string name, id = luaW_table_get_def(L, 1, "id", ""s);
+	bool repeat = !luaW_table_get_def(L, 1, "first_time_only", true), is_menu_item = luaW_table_get_def(L, 1, "menu_item", false);
+	if(luaW_tableget(L, 1, "name")) {
+		name = read_event_name(L, -1);
+	}
+	auto new_handler = man.add_event_handler_from_lua(name, id, repeat, is_menu_item);
+	if(new_handler.valid()) {
+		bool has_lua_filter = false;
+		new_handler->set_arguments(luaW_table_get_def(L, 1, "content", config{"__empty_lua_event", true}));
 
-	if(lua_isboolean(L, 1)) {
-		bool delayed_variable_substitution = luaW_toboolean(L, 1);
-		vconfig cfg(luaW_checkvconfig(L, 2));
-		if(delayed_variable_substitution) {
-			man.add_event_handler_from_wml(cfg.get_config(), *this);
-		} else {
-			man.add_event_handler_from_wml(cfg.get_parsed_config(), *this);
-		}
-	} else if(lua_isstring(L, 1)) {
-		bool is_menu_item = luaW_toboolean(L, 3), repeat = true;
-		std::string name = read_event_name(L, 1), id;
-		if(is_menu_item) {
-			id = name;
-			name = "menu item " + name;
-		}
-		auto new_handler = man.add_event_handler_from_lua(name, id, repeat, is_menu_item);
-		if(new_handler.valid()) {
-			// An event with empty arguments is not added, so set some dummy arguments
-			new_handler->set_arguments(config{"__quick_lua_event", true});
-			new_handler->set_event_ref(save_wml_event(2), has_preloaded_);
-		}
-	} else if(lua_istable(L, 1)) {
-		using namespace std::literals;
-		std::string name, id = luaW_table_get_def(L, 1, "id", ""s);
-		bool repeat = !luaW_table_get_def(L, 1, "first_time_only", true), is_menu_item = luaW_table_get_def(L, 1, "menu_item", false);
-		if(luaW_tableget(L, 1, "name")) {
-			name = read_event_name(L, -1);
-		}
-		auto new_handler = man.add_event_handler_from_lua(name, id, repeat, is_menu_item);
-		if(new_handler.valid()) {
-			bool has_lua_filter = false;
-			new_handler->set_arguments(luaW_table_get_def(L, 1, "content", config{"__empty_lua_event", true}));
-
-			if(luaW_tableget(L, 1, "filter")) {
-				int filterIdx = lua_gettop(L);
-				config filters;
-				if(!luaW_toconfig(L, filterIdx, filters)) {
-					if(lua_isfunction(L, filterIdx)) {
-						int fcnIdx = lua_absindex(L, -1);
-						new_handler->add_filter(std::make_unique<lua_event_filter>(*this, fcnIdx, luaW_table_get_def(L, 1, "filter_args", config())));
-						has_lua_filter = true;
-					} else {
-						if(luaW_tableget(L, filterIdx, "condition")) {
-							filters.add_child("filter_condition", luaW_checkconfig(L, -1));
-						}
-						if(luaW_tableget(L, filterIdx, "side")) {
-							filters.add_child("filter_side", luaW_checkconfig(L, -1));
-						}
-						if(luaW_tableget(L, filterIdx, "unit")) {
-							filters.add_child("filter", luaW_checkconfig(L, -1));
-						}
-						if(luaW_tableget(L, filterIdx, "attack")) {
-							filters.add_child("filter_attack", luaW_checkconfig(L, -1));
-						}
-						if(luaW_tableget(L, filterIdx, "second_unit")) {
-							filters.add_child("filter_second", luaW_checkconfig(L, -1));
-						}
-						if(luaW_tableget(L, filterIdx, "second_attack")) {
-							filters.add_child("filter_second_attack", luaW_checkconfig(L, -1));
-						}
+		if(luaW_tableget(L, 1, "filter")) {
+			int filterIdx = lua_gettop(L);
+			config filters;
+			if(!luaW_toconfig(L, filterIdx, filters)) {
+				if(lua_isfunction(L, filterIdx)) {
+					int fcnIdx = lua_absindex(L, -1);
+					new_handler->add_filter(std::make_unique<lua_event_filter>(*this, fcnIdx, luaW_table_get_def(L, 1, "filter_args", config())));
+					has_lua_filter = true;
+				} else {
+					if(luaW_tableget(L, filterIdx, "condition")) {
+						filters.add_child("filter_condition", luaW_checkconfig(L, -1));
+					}
+					if(luaW_tableget(L, filterIdx, "side")) {
+						filters.add_child("filter_side", luaW_checkconfig(L, -1));
+					}
+					if(luaW_tableget(L, filterIdx, "unit")) {
+						filters.add_child("filter", luaW_checkconfig(L, -1));
+					}
+					if(luaW_tableget(L, filterIdx, "attack")) {
+						filters.add_child("filter_attack", luaW_checkconfig(L, -1));
+					}
+					if(luaW_tableget(L, filterIdx, "second_unit")) {
+						filters.add_child("filter_second", luaW_checkconfig(L, -1));
+					}
+					if(luaW_tableget(L, filterIdx, "second_attack")) {
+						filters.add_child("filter_second_attack", luaW_checkconfig(L, -1));
 					}
 				}
-				new_handler->read_filters(filters);
 			}
-
-			if(luaW_tableget(L, 1, "action")) {
-				new_handler->set_event_ref(save_wml_event(-1), has_preloaded_);
-			} else {
-				if(has_lua_filter) {
-					// This just sets the appropriate flags so the engine knows it cannot be serialized.
-					// The register_wml_event call will override the actual event_ref so just pass LUA_NOREF here.
-					new_handler->set_event_ref(LUA_NOREF, has_preloaded_);
-				}
-				new_handler->register_wml_event(*this);
-			}
+			new_handler->read_filters(filters);
 		}
+
+		if(luaW_tableget(L, 1, "action")) {
+			new_handler->set_event_ref(save_wml_event(-1), has_preloaded_);
+		} else {
+			if(has_lua_filter) {
+				// This just sets the appropriate flags so the engine knows it cannot be serialized.
+				// The register_wml_event call will override the actual event_ref so just pass LUA_NOREF here.
+				new_handler->set_event_ref(LUA_NOREF, has_preloaded_);
+			}
+			new_handler->register_wml_event(*this);
+		}
+	}
+	return 0;
+}
+
+/** Add a new event handler
+ * Arg 1: Event to handle, as a string or list of strings; or menu item ID if this is a menu item
+ * Arg 2: The function to call when the event triggers
+ */
+template<bool is_menu_item>
+int game_lua_kernel::intf_add_event_simple(lua_State *L)
+{
+	game_events::manager & man = *game_state_.events_manager_;
+	bool repeat = true;
+	std::string name = read_event_name(L, 1), id;
+	if(is_menu_item) {
+		id = name;
+		name = "menu item " + name;
+	}
+	auto new_handler = man.add_event_handler_from_lua(name, id, repeat, is_menu_item);
+	if(new_handler.valid()) {
+		// An event with empty arguments is not added, so set some dummy arguments
+		new_handler->set_arguments(config{"__quick_lua_event", true});
+		new_handler->set_event_ref(save_wml_event(2), has_preloaded_);
+	}
+	return 0;
+}
+
+/** Add a new event handler
+ * Arg: A full event specification as a WML config
+ */
+int game_lua_kernel::intf_add_event_wml(lua_State *L)
+{
+	game_events::manager & man = *game_state_.events_manager_;
+	vconfig cfg(luaW_checkvconfig(L, 1));
+	bool delayed_variable_substitution = cfg["delayed_variable_substitution"].to_bool(true);
+	if(delayed_variable_substitution) {
+		man.add_event_handler_from_wml(cfg.get_config(), *this);
 	} else {
-		return luaW_type_error(L, 1, "boolean, string, or table");
+		man.add_event_handler_from_wml(cfg.get_parsed_config(), *this);
 	}
 	return 0;
 }
@@ -4946,6 +4952,9 @@ game_lua_kernel::game_lua_kernel(game_state & gs, play_controller & pc, reports 
 	cmd_log_ << "Adding game_events module...\n";
 	static luaL_Reg const event_callbacks[] {
 		{ "add", &dispatch<&game_lua_kernel::intf_add_event> },
+		{ "add_repeating", &dispatch<&game_lua_kernel::intf_add_event_simple<false>> },
+		{ "add_menu", &dispatch<&game_lua_kernel::intf_add_event_simple<true>> },
+		{ "add_wml", &dispatch<&game_lua_kernel::intf_add_event_wml> },
 		{ "remove", &dispatch<&game_lua_kernel::intf_remove_event> },
 		{ "fire", &dispatch2<&game_lua_kernel::intf_fire_event, false> },
 		{ "fire_by_id", &dispatch2<&game_lua_kernel::intf_fire_event, true> },

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -633,6 +633,16 @@ int game_lua_kernel::intf_fire_event(lua_State *L, const bool by_id)
 
 	luaW_toconfig(L, pos, data);
 
+	// Support WML names for some common data
+	if(data.has_child("primary_attack")) {
+		data.add_child("first", data.child("primary_attack"));
+		data.remove_children("primary_attack");
+	}
+	if(data.has_child("secondary_attack")) {
+		data.add_child("second", data.child("secondary_attack"));
+		data.remove_children("secondary_attack");
+	}
+
 	bool b = false;
 
 	if (by_id) {

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -218,11 +218,40 @@ public:
 	bool run_filter(char const *name, const team& t);
 	bool run_filter(char const *name, int nArgs);
 	bool run_wml_conditional(const std::string&, const vconfig&);
-	/** Store a WML event in the Lua registry, as a function */
-	int save_wml_event(const config& evt);
-	/** Clear a WML event store in the Lua registry */
+	/**
+	 * Store a WML event in the Lua registry, as a function.
+	 * Uses a default function that interprets ActionWML.
+	 * @return A unique index into the EVENT_TABLE within the Lua registry
+	 */
+	int save_wml_event();
+	/**
+	 * Store a WML event in the Lua registry, as a function.
+	 * Compiles the function from the given code.
+	 * @param name The event name, used to generate a chunk name for the compiled function
+	 * @param id The event id, used to generate a chunk name for the compiled function
+	 * @param code The actual code of the function
+	 * @return A unique index into the EVENT_TABLE within the Lua registry
+	 */
+	int save_wml_event(const std::string& name, const std::string& id, const std::string& code);
+	/**
+	 * Store a WML event in the Lua registry, as a function.
+	 * Uses the function at the specified Lua stack index.
+	 * @param idx The Lua stack index of the function to store
+	 * @return A unique index into the EVENT_TABLE within the Lua registry
+	 */
+	int save_wml_event(int idx);
+	/**
+	 * Clear a WML event store in the Lua registry.
+	 * @param ref The unique index into the EVENT_TABLE within the Lua registry
+	 */
 	void clear_wml_event(int ref);
-	/** Run a WML store in the Lua registry */
+	/**
+	 * Run a WML stored in the Lua registry.
+	 * @param ref The unique index into the EVENT_TABLE within the Lua registry
+	 * @param args Arguments to pass to the event function, as a config
+	 * @param ev The event data for the event being fired
+	 * @return Whether the function was successfully called; could be false if @a ref was invalid or if the function raised an error
+	 */
 	bool run_wml_event(int ref, const vconfig& args, const game_events::queued_event& ev);
 
 	virtual void log_error(char const* msg, char const* context = "Lua error") override;

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -59,6 +59,7 @@ class game_lua_kernel : public lua_kernel_base
 
 	config level_lua_;
 	int EVENT_TABLE;
+	bool has_preloaded_ = false;
 
 	std::stack<game_events::queued_event const * > queued_events_;
 
@@ -262,4 +263,5 @@ public:
 
 	void mouse_over_hex_callback(const map_location& loc);
 	void select_hex_callback(const map_location& loc);
+	void preload_finished() {has_preloaded_ = true;}
 };

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -151,6 +151,9 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_get_side(lua_State* L);
 	int intf_add_tile_overlay(lua_State *L);
 	int intf_remove_tile_overlay(lua_State *L);
+	template<bool is_menu_item>
+	int intf_add_event_simple(lua_State* L);
+	int intf_add_event_wml(lua_State* L);
 	int intf_add_event(lua_State *L);
 	int intf_remove_event(lua_State *L);
 	int intf_color_adjust(lua_State *L);

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -58,6 +58,7 @@ class game_lua_kernel : public lua_kernel_base
 	tod_manager & tod_man();
 
 	config level_lua_;
+	int EVENT_TABLE;
 
 	std::stack<game_events::queued_event const * > queued_events_;
 
@@ -217,6 +218,12 @@ public:
 	bool run_filter(char const *name, const team& t);
 	bool run_filter(char const *name, int nArgs);
 	bool run_wml_conditional(const std::string&, const vconfig&);
+	/** Store a WML event in the Lua registry, as a function */
+	int save_wml_event(const config& evt);
+	/** Clear a WML event store in the Lua registry */
+	void clear_wml_event(int ref);
+	/** Run a WML store in the Lua registry */
+	bool run_wml_event(int ref, const vconfig& args, const game_events::queued_event& ev);
 
 	virtual void log_error(char const* msg, char const* context = "Lua error") override;
 

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -250,9 +250,10 @@ public:
 	 * @param ref The unique index into the EVENT_TABLE within the Lua registry
 	 * @param args Arguments to pass to the event function, as a config
 	 * @param ev The event data for the event being fired
+	 * @param out If non-null, receives the result of the called function (provided it is a boolean value)
 	 * @return Whether the function was successfully called; could be false if @a ref was invalid or if the function raised an error
 	 */
-	bool run_wml_event(int ref, const vconfig& args, const game_events::queued_event& ev);
+	bool run_wml_event(int ref, const vconfig& args, const game_events::queued_event& ev, bool* out = nullptr);
 
 	virtual void log_error(char const* msg, char const* context = "Lua error") override;
 

--- a/src/scripting/push_check.hpp
+++ b/src/scripting/push_check.hpp
@@ -82,6 +82,12 @@ namespace lua_check_impl
 		return luaL_checkstring(L, n);
 	}
 	template<typename T>
+	std::enable_if_t<std::is_same_v<T, std::string>, std::string>
+	lua_to_or_default(lua_State *L, int n, const T& def)
+	{
+		return luaL_optstring(L, n, def.c_str());
+	}
+	template<typename T>
 	std::enable_if_t<std::is_same_v<T, std::string>, void>
 	lua_push(lua_State *L, const T& val)
 	{
@@ -114,6 +120,13 @@ namespace lua_check_impl
 	lua_check(lua_State *L, int n)
 	{
 		return luaW_checkconfig(L, n);
+	}
+	template<typename T>
+	std::enable_if_t<std::is_same_v<T, config>, config>
+	lua_to_or_default(lua_State *L, int n, const T& def)
+	{
+		config cfg;
+		return luaW_toconfig(L, n, cfg) ? cfg : def;
 	}
 	template<typename T>
 	std::enable_if_t<std::is_same_v<T, config>, void>

--- a/src/side_filter.hpp
+++ b/src/side_filter.hpp
@@ -40,6 +40,7 @@ public:
 	bool match(const team& t) const;
 	bool match(const int side) const;
 	std::vector<int> get_teams() const;
+	const config& get_config() const {return cfg_.get_config();}
 
 private:
 	side_filter(const side_filter &other);

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -421,8 +421,8 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 		}
 	}
 
-	if(resources::game_events) {
-		resources::game_events->add_events(events_.child_range("event"));
+	if(resources::game_events && resources::lua_kernel) {
+		resources::game_events->add_events(events_.child_range("event"), *resources::lua_kernel);
 	}
 
 	random_traits_ = cfg["random_traits"].to_bool(true);
@@ -997,8 +997,8 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	}
 
 	// In case the unit carries EventWML, apply it now
-	if(resources::game_events) {
-		resources::game_events->add_events(new_type.events(), new_type.id());
+	if(resources::game_events && resources::lua_kernel) {
+		resources::game_events->add_events(new_type.events(), *resources::lua_kernel, new_type.id());
 	}
 	bool bool_small_profile = get_attr_changed(UA_SMALL_PROFILE);
 	bool bool_profile = get_attr_changed(UA_PROFILE);

--- a/utils/emmylua/wesnoth/game_events.lua
+++ b/utils/emmylua/wesnoth/game_events.lua
@@ -24,3 +24,58 @@ function wesnoth.game_events.on_mouse_action(x, y) end
 ---@param x integer
 ---@param y integer
 function wesnoth.game_events.on_mouse_move(x, y) end
+
+---@class event_filter
+---@field condition WML
+---@field side WML
+---@field unit WML
+---@field attack WML
+---@field second_unit WML
+---@field second_attack WML
+
+---@class game_event_options
+---@field name string|string[] Event to handle, as a string or list of strings
+---@field id string Event ID
+---@field menu_item boolean True if this is a menu item (an ID is required); this means removing the menu item will automatically remove this event. Default false.
+---@field first_time_only boolean Whether this event should fire again after the first time; default true.
+---@field filter WML|event_filter|fun(cfg:WML):boolean Event filters as a config with filter tags, a table of the form {filter_type = filter_contents}, or a function
+---@field content WML The content of the event. This is a WML table passed verbatim into the event when it fires. If no function is specified, it will be interpreted as ActionWML.
+---@field action fun(cfg:WML) The function to call when the event triggers. Defaults to wesnoth.wml_actions.command.
+
+---Add a game event handler
+---@param opts game_event_options
+function wesnoth.game_events.add(opts) end
+
+---Add a repeating game event handler bound directly to a Lua function
+---@param name string|string[] The event or events to handle
+---@param action fun(WML) The function called when the event triggers
+function wesnoth.game_events.add_repeating(name, action) end
+
+---Add a game event handler triggered from a menu item, bound directly to a Lua function
+---@param id string
+---@param action fun(WML)
+function wesnoth.game_events.add_menu(id, action) end
+
+---Add a game event that runs ActionWML when triggered
+---@param event WML Event definition as WML, containing name, ID, filters, and ActionWML to run
+function wesnoth.game_events.add_wml(event) end
+
+---Fire an event by name
+---@param name string The event to fire
+---@param first? location|unit The primary location or unit of the event
+---@param second? location|unit The secondary location or unit of the event
+---@param data? WMLTable Additional data to pass to the event
+---@return boolean #Indicates whether the event was handled or not
+function wesnoth.game_events.fire(name, first, second, data) end
+
+---Fire an event by ID
+---@param id string The event to fire
+---@param first? location|unit The primary location or unit of the event
+---@param second? location|unit The secondary location or unit of the event
+---@param data? WMLTable Additional data to pass to the event
+---@return boolean #Indicates whether the event was handled or not
+function wesnoth.game_events.fire_by_id(id, first, second, data) end
+
+---Remove an event handler by ID
+---@param id string The event to remove
+function wesnoth.game_events.remove(id) end

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -139,6 +139,11 @@
 0 test_ability_id_active
 0 test_ability_id_not_active
 0 event_test_filter_attack
+0 event_test_action_wml
+0 event_test_lua
+0 event_test_lua_advanced
+0 event_test_lua_repeat
+9 event_test_lua_break_save
 0 test_lua_name
 0 filter_vision
 0 test_shroud_init

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -139,6 +139,11 @@
 0 test_ability_id_active
 0 test_ability_id_not_active
 0 event_test_filter_attack
+0 event_test_filter_wfl
+0 event_test_filter_wfl2
+0 event_test_filter_lua_serializable
+0 event_test_filter_lua_dynamic
+9 event_test_filter_lua_dynamic_break_save
 0 event_test_action_wml
 0 event_test_lua
 0 event_test_lua_advanced


### PR DESCRIPTION
All events are now just a Lua function and a package of arguments that are passed to the function. A typical event added via WML (ie, with the `[event]` tag) is the function `wesnoth.wml_actions.command` with the contained ActionWML tags passed as the argument, so they work just the same as before. However, you can now add events in two other ways:

* ~Instead of using ActionWML, you can write the entire event inline as Lua code using `[event]code=`. Although this is similar to just using an event containing a single `[lua]` tag, there are some differences. The code is compiled when the event is added, rather than when it is executed, and the argument passed to the event code is a copy of the `[event]` tag with filter data and event name and ID stripped out.~
* You can now register an event directly from Lua using the new `wesnoth.game_events.add` function, which supercedes the `on_event()` system that World Conquest and a few other things depend on. Unlike `on_event()`, this interface supports everything that `[event]` does, such as `first_time_only=true` or giving the event an ID that will allow other events to remove it. It also supports some things that `[event]` doesn't, such as using an arbitrary Lua function to handle the event (although if you do this, the event becomes unserializable, just the same as if you used `on_event()`) or marking the event as a menu item event (meaning it will be removed if the menu item with the same ID is removed).

The other significant change in this PR is a refactor of the event filtering system, which would make it very easy to add a new type of filter if we wanted to in the future (although I'm not anticipating any new types). As part of that, two new ways of filtering in events have been added:

* The `filter_formula` key in `[event]` takes a WFL formula that determines whether the event should trigger. It can access all the event context info (like `loc1`, `event_id`, `unit1`, etc) as well as the game state (such as `map`, `units`, `turn`, and `time_of_day`). In particular, it exposes event context info that nothing else does in `event_data`, although there may not be any way to actually set that data yet in `[fire_event]`.
* ~The `filter` key in `[event]` takes Lua code that determines whether the event should trigger. If there is a `[filter_args]` tag, its contents is passed to this function.~
* In addition, when adding an event from Lua, you can pass an arbitrary Lua function as the filter. Doing this makes the event unserializable, of course.

One other thing I've done here is to divorce menu items from events at the Lua level. This was already the case in C++, and it seemed to make for a cleaner API. The relevant functions were never documented, so this is probably a minor thing, but basically: `wesnoth.interface.set_menu_item` adds or updates a menu item but does not make it do anything - the `[command]` tag is ignored. To make it do something, you need to use `wesnoth.game_events.add` to create the event that the menu item will trigger. Of course, `[set_menu_item]` still does both for you.