### PR TITLE
[MP] [2p - Dark Forecast] Make Survival scenario at least winnable in 2-player mode.

### DIFF
--- a/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
@@ -117,6 +117,12 @@ Note: You need to use the default map settings for the scenario to work right."
             [else]
                 {VARIABLE lose_condition_string ( _ "Death of both of your team’s leaders")}
                 {VARIABLE notes ( _ "Since your team has two leaders, the enemy waves will be at full strength.")}
+                # each village will now support an upkeep of 2 instead of 1
+                # this makes the scenario somewhat passable now.
+                [modify_side]
+                    side=3,4
+                    village_support=2
+                [/modify_side]
             [/else]
         [/if]
         {CLEAR_VARIABLE leader}

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -157,8 +157,8 @@ end
 -- creates the 'timed_spawn' wml array.
 -- @a num_spawns: the total number of times units get spawned
 -- @a interval: the number of turns between 2 spawns
--- @a base_gold_amount, gold_increment: used to cauculate the amount of gold available for each timed spawn
--- @a units_amount, gold_per_unit_amount: used to cauculate the number of units spawned in each timed spawn
+-- @a base_gold_amount, gold_increment: used to calculate the amount of gold available for each timed spawn
+-- @a units_amount, gold_per_unit_amount: used to calculate the number of units spawned in each timed spawn
 local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
 	local configure_gold_factor = ((wml.variables["enemey_gold_factor"] or 0) + 100)/100
 	local random_spawn_numbers = {}

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -159,11 +159,7 @@ end
 -- @a interval: the number of turns between 2 spawns
 -- @a base_gold_amount, gold_increment: used to calculate the amount of gold available for each timed spawn
 -- @a units_amount, gold_per_unit_amount: used to calculate the number of units spawned in each timed spawn
-<<<<<<< HEAD
-local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
-=======
 local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
->>>>>>> upstream/master
 	local configure_gold_factor = ((wml.variables["enemey_gold_factor"] or 0) + 100)/100
 	local random_spawn_numbers = {}
 	for i = 1, #random_spawns do

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -159,11 +159,7 @@ end
 -- @a interval: the number of turns between 2 spawns
 -- @a base_gold_amount, gold_increment: used to calculate the amount of gold available for each timed spawn
 -- @a units_amount, gold_per_unit_amount: used to calculate the number of units spawned in each timed spawn
-<<<<<<< HEAD
 local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
-=======
-local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
->>>>>>> upstream/master
 	local configure_gold_factor = ((wml.variables["enemey_gold_factor"] or 0) + 100)/100
 	local random_spawn_numbers = {}
 	for i = 1, #random_spawns do

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -159,7 +159,11 @@ end
 -- @a interval: the number of turns between 2 spawns
 -- @a base_gold_amount, gold_increment: used to calculate the amount of gold available for each timed spawn
 -- @a units_amount, gold_per_unit_amount: used to calculate the number of units spawned in each timed spawn
+<<<<<<< HEAD
 local function create_timed_spaws(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
+=======
+local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
+>>>>>>> upstream/master
 	local configure_gold_factor = ((wml.variables["enemey_gold_factor"] or 0) + 100)/100
 	local random_spawn_numbers = {}
 	for i = 1, #random_spawns do


### PR DESCRIPTION
This PR makes Dark Forecast "passable" at default difficulty for 2 player mode. Initially, it was only passable if it was one-player-mode as one player could have 11 villages active and could get a good army built prior to the final wave.
2 player mode suffers from lack of resources to replace losses and would be unwinnable in some cases.

The change which has been made is that in 2-player-mode, the `village_support` has been set to 2.

The only 2 cases where it was won in 2 player mode was when the players were of _exceptionally high skill level_ but average skill-levelled players have yet to even win.

This PR fixes #5651 

Video Replays:
https://www.youtube.com/watch?v=w3VrWuS-IoU (Default Era)
https://youtu.be/zI3QCZr-1bg (UMC era)

[2p — Dark Forecast (Survival) replay 20210405-173408.gz](https://github.com/wesnoth/wesnoth/files/6258043/2p.Dark.Forecast.Survival.replay.20210405-173408.gz)
