### PR TITLE
Make the debug clock look right

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
    * Added logs folder path to the Game Version dialog on Windows.
    * Made Accelerated Speed toggle announcement not stackable over itself or other announcements.
    * Minor adjustments to the sidebar's minimap area in the default game theme to reclaim empty and uneven space back. Note that this WILL break custom WML themes that use the same sidebar graphics as the default theme.
+   * Minor adjustment to the placement of numerals on the debug clock.
  ### WML Engine
  ### Miscellaneous and Bug Fixes
    * Fixed units with max movement set to zero being given one max movement point by `[unstore_unit]` or when loading a saved game

--- a/data/gui/window/debug_clock.cfg
+++ b/data/gui/window/debug_clock.cfg
@@ -7,8 +7,8 @@
 
 #define _GUI_TICK_MARK ANGLE TEXT
 [text]
-	x = "(round(125 + (100.0 * sin({ANGLE}))))"
-	y = "(round(125 - (100.0 * cos({ANGLE}))))"
+	x = "(round(125 + (100.0 * sin({ANGLE})) - (text_width / 2)))"
+	y = "(round(125 - (100.0 * cos({ANGLE})) - (text_height / 2)))"
 	h = 20
 	w = 30
 	font_size = 10
@@ -249,32 +249,35 @@
 						height = 280
 
 						[draw]
-							# Add hour ticks.
+							# Add hour ticks, positioned at radius 100 from the center. The leading spaces on 1-9 are
+							# because the gap between the text and the outer [circle]radius=115 is more obvious than the
+							# placement on the radius 100 circle itself - without the leading space, aligning the center
+							# of the single-digit texts correctly looks wrong.
 
-							{_GUI_TICK_MARK  15.0 1 }
-							{_GUI_TICK_MARK  30.0 2 }
-							{_GUI_TICK_MARK  45.0 3 }
-							{_GUI_TICK_MARK  60.0 4 }
-							{_GUI_TICK_MARK  75.0 5 }
-							{_GUI_TICK_MARK  90.0 6 }
-							{_GUI_TICK_MARK 105.0 7 }
-							{_GUI_TICK_MARK 120.0 8 }
-							{_GUI_TICK_MARK 135.0 9 }
-							{_GUI_TICK_MARK 150.0 10}
-							{_GUI_TICK_MARK 165.0 11}
-							{_GUI_TICK_MARK 180.0 12}
-							{_GUI_TICK_MARK 195.0 13}
-							{_GUI_TICK_MARK 210.0 14}
-							{_GUI_TICK_MARK 225.0 15}
-							{_GUI_TICK_MARK 240.0 16}
-							{_GUI_TICK_MARK 255.0 17}
-							{_GUI_TICK_MARK 270.0 18}
-							{_GUI_TICK_MARK 285.0 19}
-							{_GUI_TICK_MARK 300.0 20}
-							{_GUI_TICK_MARK 315.0 21}
-							{_GUI_TICK_MARK 330.0 22}
-							{_GUI_TICK_MARK 345.0 23}
-							{_GUI_TICK_MARK 360.0 24}
+							{_GUI_TICK_MARK  15.0 ( 1)}
+							{_GUI_TICK_MARK  30.0 ( 2)}
+							{_GUI_TICK_MARK  45.0 ( 3)}
+							{_GUI_TICK_MARK  60.0 ( 4)}
+							{_GUI_TICK_MARK  75.0 ( 5)}
+							{_GUI_TICK_MARK  90.0 ( 6)}
+							{_GUI_TICK_MARK 105.0 ( 7)}
+							{_GUI_TICK_MARK 120.0 ( 8)}
+							{_GUI_TICK_MARK 135.0 ( 9)}
+							{_GUI_TICK_MARK 150.0 (10)}
+							{_GUI_TICK_MARK 165.0 (11)}
+							{_GUI_TICK_MARK 180.0 (12)}
+							{_GUI_TICK_MARK 195.0 (13)}
+							{_GUI_TICK_MARK 210.0 (14)}
+							{_GUI_TICK_MARK 225.0 (15)}
+							{_GUI_TICK_MARK 240.0 (16)}
+							{_GUI_TICK_MARK 255.0 (17)}
+							{_GUI_TICK_MARK 270.0 (18)}
+							{_GUI_TICK_MARK 285.0 (19)}
+							{_GUI_TICK_MARK 300.0 (20)}
+							{_GUI_TICK_MARK 315.0 (21)}
+							{_GUI_TICK_MARK 330.0 (22)}
+							{_GUI_TICK_MARK 345.0 (23)}
+							{_GUI_TICK_MARK 360.0 (24)}
 
 							# Add outer circle.
 


### PR DESCRIPTION
This is the only widget in mainline using GUI2's `[draw][circle]` tag. I'm
currently working on a change to the C++ `text_shape` class, and want to
be able to regression-test the placement of `[circle]`s after that change.

I'd be okay with deprecating both `[circle]` and `[round_rectangle]` as neither
seems to be used elsewhere, but this close to feature-freeze I'd prefer to keep
them in 1.16 rather than suggest removing them now.

To see the widget, start the game with `wesnoth --clock`, and then click the
button underneath "Quit" on the main menu.

Before and after:
![wesnoth_debug_clock_alignment](https://user-images.githubusercontent.com/101462/113567125-4f5aee80-960e-11eb-8f0f-5657ce4e7c2b.png)