### PR TITLE
Fix for Giant Scorpion having an empty variation name.

### DIFF
--- a/data/core/units/monsters/Giant_Scorpion.cfg
+++ b/data/core/units/monsters/Giant_Scorpion.cfg
@@ -109,6 +109,7 @@
     [/attack_anim]
     [variation]
         variation_id=scuttler
+        variation_name= _ "scuttler"
         name= _ "Sand Scuttler"
         inherit=yes
         small_profile="portraits/monsters/scuttler.png~FL()"


### PR DESCRIPTION
This PR restores the broken Help entry links for the unit and its sand scuttler variation.

Fixes #5676 