### PR TITLE
Only render the visible area in canvas.cpp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
  ### User interface
  ### WML Engine
  ### Miscellaneous and Bug Fixes
+   * More optimizations in the UI drawing code, these shouldn't have visible effects (PR #5681).
    * Made GUI.pyw compatible with Python 3.9 (issue #5719).
 
 ## Version 1.15.12


### PR DESCRIPTION
If a widget is partially hidden or off-screen, this commit makes canvas.cpp
optimise and only draw the visible part.

Many of the asserts in canvas.cpp are removed, as the surface is no longer the
full canvas. The SDL_Render* functions do support the out-of-bounds and
negative values for x and y that are now passed to them, these are tested by
SDL2's testviewport.c.

Scrolling by a single pixel will force canvas::draw to do the full work of
redrawing the canvas. I had considered rendering a few of the off-screen lines
too, however it seems this isn't optimisable because the dirty flag is already
set on each redraw - that can be traced to window.cpp's push_draw_event()
causing canvas::set_is_dirty(true) to be called.

Refactor handling of the x, y, w, h variables with a common rect_bounded_shape
class, so that there are less code paths that might have unnoticed bugs.