### PR TITLE
Use the database to store and retrieve login history for the searchlog command.

### DIFF
--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -735,6 +735,20 @@ bool wildcard_string_match(const std::string& str, const std::string& match) {
 	return matches;
 }
 
+void to_sql_wildcards(std::string& str, bool underscores)
+{
+	std::replace(str.begin(), str.end(), '*', '%');
+	if(underscores)
+	{
+		std::size_t n = 0;
+		while((n = str.find("_", n)) != std::string::npos)
+		{
+			str.replace(n, 1, "\\_");
+			n += 2;
+		}
+	}
+}
+
 std::string indent(const std::string& string, std::size_t indent_size)
 {
 	if(indent_size == 0) {

--- a/src/serialization/string_utils.hpp
+++ b/src/serialization/string_utils.hpp
@@ -353,6 +353,14 @@ bool word_match(const std::string& message, const std::string& word);
 bool wildcard_string_match(const std::string& str, const std::string& match);
 
 /**
+ * Converts '*' to '%' and optionally escapes '_'.
+ * 
+ * @param str The original string.
+ * @param underscores Whether to escape underscore characters as well.
+ */
+void to_sql_wildcards(std::string& str, bool underscores = true);
+
+/**
  * Check if the username contains only valid characters.
  *
  * (all alpha-numeric characters plus underscore and hyphen)

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -153,6 +153,26 @@ class dbconn
 		 */
 		void insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id);
 
+		/**
+		 * @see forum_user_handler::db_insert_login().
+		 */
+		unsigned long long insert_login(const std::string& username, const std::string& ip);
+
+		/**
+		 * @see forum_user_handler::db_update_logout().
+		 */
+		void update_logout(unsigned long long login_id);
+
+		/**
+		 * @see forum_user_handler::get_users_for_ip().
+		 */
+		void get_users_for_ip(const std::string& ip, std::ostringstream* out);
+
+		/**
+		 * @see forum_user_handler::get_ips_for_users().
+		 */
+		void get_ips_for_user(const std::string& username, std::ostringstream* out);
+
 	private:
 		/**
 		 * The account used to connect to the database.
@@ -183,6 +203,8 @@ class dbconn
 		std::string db_topics_table_;
 		/** The name of the table that contains add-on information. */
 		std::string db_addon_info_table_;
+		/** The name of the table that contains user connection history. */
+		std::string db_connection_history_table_;
 
 		/**
 		 * This is used to write out error text when an SQL-related exception occurs.
@@ -258,7 +280,7 @@ class dbconn
 		 * @return The number of rows modified.
 		 */
 		template<typename... Args>
-		int modify(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
+		unsigned long long modify(mariadb::connection_ref connection, const std::string& sql, Args&&... args);
 
 		/**
 		 * Begins recursively unpacking of the parameter pack in order to be able to call the correct parameterized setters on the query.

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -251,4 +251,20 @@ void fuh::db_insert_addon_info(const std::string& instance_version, const std::s
 	conn_.insert_addon_info(instance_version, id, name, type, version, forum_auth, topic_id);
 }
 
+unsigned long long fuh::db_insert_login(const std::string& username, const std::string& ip) {
+	return conn_.insert_login(username, ip);
+}
+
+void fuh::db_update_logout(unsigned long long login_id) {
+	conn_.update_logout(login_id);
+}
+
+void fuh::get_users_for_ip(const std::string& ip, std::ostringstream* out) {
+	conn_.get_users_for_ip(ip, out);
+}
+
+void fuh::get_ips_for_user(const std::string& username, std::ostringstream* out) {
+	conn_.get_ips_for_user(username, out);
+}
+
 #endif //HAVE_MYSQLPP

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -221,6 +221,40 @@ public:
 	 */
 	void db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id);
 
+	/**
+	 * Inserts into the database for when a player logs in.
+	 * 
+	 * @param username The username of who logged in. The username is converted to lower case when inserting in order to allow index usage when querying.
+	 * @param ip The ip address of who logged in.
+	 */
+	unsigned long long db_insert_login(const std::string& username, const std::string& ip);
+
+	/**
+	 * Updates the database for when a player logs out.
+	 * 
+	 * @param login_id The generated ID that uniquely identifies the row to be updated.
+	 */
+	void db_update_logout(unsigned long long login_id);
+
+	/**
+	 * Searches for all players that logged in using the ip address.
+	 * The '%' wildcard can be used to search for partial ip addresses.
+	 * 
+	 * @param ip The ip address to search for.
+	 * @param out Where to output the results.
+	 */
+	void get_users_for_ip(const std::string& ip, std::ostringstream* out);
+
+	/**
+	 * Searches for all ip addresses used by the player.
+	 * The username is converted to lower case to allow a case insensitive select query to be executed while still using an index.
+	 * The '%' wildcard can be used to search for partial usernames.
+	 * 
+	 * @param username The username to search for.
+	 * @param out Where to output the results.
+	 */
+	void get_ips_for_user(const std::string& username, std::ostringstream* out);
+
 private:
 	/** An instance of the class responsible for executing the queries and handling the database connection. */
 	dbconn conn_;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -144,4 +144,8 @@ public:
 	virtual void async_test_query(boost::asio::io_service& io_service, int limit) = 0;
 	virtual bool db_topic_id_exists(int topic_id) = 0;
 	virtual void db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id) = 0;
+	virtual unsigned long long db_insert_login(const std::string& username, const std::string& ip) = 0;
+	virtual void db_update_logout(unsigned long long login_id) = 0;
+	virtual void get_users_for_ip(const std::string& ip, std::ostringstream* out) = 0;
+	virtual void get_ips_for_user(const std::string& username, std::ostringstream* out) = 0;
 };

--- a/src/server/wesnothd/player.cpp
+++ b/src/server/wesnothd/player.cpp
@@ -15,7 +15,7 @@
 #include "server/wesnothd/player.hpp"
 
 wesnothd::player::player(const std::string& n, simple_wml::node& cfg, int id,
-                         bool registered, const std::string& version, const std::string& source, const std::size_t max_messages,
+                         bool registered, const std::string& version, const std::string& source, unsigned long long login_id, const std::size_t max_messages,
                          const std::size_t time_period,
                          const bool moderator)
   : name_(n)
@@ -29,6 +29,7 @@ wesnothd::player::player(const std::string& n, simple_wml::node& cfg, int id,
   , TimePeriod(time_period)
   , status_(LOBBY)
   , moderator_(moderator)
+  , login_id_(login_id)
 {
 	cfg_.set_attr_dup("name", n.c_str());
 	cfg_.set_attr("registered", registered ? "yes" : "no");

--- a/src/server/wesnothd/player.hpp
+++ b/src/server/wesnothd/player.hpp
@@ -31,7 +31,7 @@ public:
 	};
 
 	player(const std::string& n, simple_wml::node& cfg, int id, bool registered, const std::string& version, const std::string& source,
-	       const std::size_t max_messages=4, const std::size_t time_period=10,
+	       unsigned long long login_id, const std::size_t max_messages=4, const std::size_t time_period=10,
 	       const bool moderator=false);
 
 	void set_status(STATUS status);
@@ -54,6 +54,8 @@ public:
 	void set_moderator(bool moderator) { moderator_ = moderator; }
 	bool is_moderator() const { return moderator_; }
 
+	unsigned long long get_login_id() const { return login_id_; };
+
 private:
 	const std::string name_;
 	std::string version_;
@@ -68,6 +70,7 @@ private:
 	const std::time_t TimePeriod;
 	STATUS status_;
 	bool moderator_;
+	unsigned long long login_id_;
 };
 
 } //namespace wesnothd

--- a/utils/mp-server/table_definitions.sql
+++ b/utils/mp-server/table_definitions.sql
@@ -91,6 +91,7 @@ CREATE INDEX START_TIME_IDX ON game_info(START_TIME);
 -- FACTION: the faction being played by this side
 -- CLIENT_VERSION: the version of the wesnoth client used to connect
 -- CLIENT_SOURCE: where the wesnoth client was downloaded from - SourceForge, Steam, etc
+-- USER_NAME: the username logged in with
 create table game_player_info
 (
     INSTANCE_UUID  CHAR(36) NOT NULL,
@@ -145,3 +146,21 @@ create table addon_info
     FEEDBACK_TOPIC   INT UNSIGNED NOT NULL,
     PRIMARY KEY (INSTANCE_VERSION, ADDON_ID, VERSION)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- history of user sessions
+-- LOGIN_ID: auto generated ID to use as a primary key
+-- USER_NAME: the username logged in with
+-- IP: the IP address the login originated from
+-- LOGIN_TIME: when the user logged in
+-- LOGOUT_TIME: when the user logged out
+create table connection_history
+(
+    LOGIN_ID    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    USER_NAME   VARCHAR(255) NOT NULL,
+    IP          VARCHAR(255) NOT NULL,
+    LOGIN_TIME  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LOGOUT_TIME TIMESTAMP NULL DEFAULT NULL,
+    PRIMARY KEY (LOGIN_ID)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE INDEX CONNECTION_IP_IDX ON connection_history(IP);
+CREATE INDEX CONNECTION_USERNAME_IDX ON connection_history(USER_NAME);


### PR DESCRIPTION
This allows the history to be persisted across restarts, whereas right now it's lost.