### PR TITLE
Simplify canvas: renderer lifetime and only one list of shapes

### DIFF
--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -91,8 +91,6 @@ public:
 	canvas(const canvas&) = delete;
 	canvas(canvas&& c) noexcept;
 
-	~canvas();
-
 	/**
 	 * Draws the canvas.
 	 *
@@ -204,8 +202,6 @@ private:
 
 	/** The surface we draw all items on. */
 	surface canvas_;
-
-	SDL_Renderer* renderer_;
 
 	/** The variables of the canvas. */
 	wfl::map_formula_callable variables_;

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -84,9 +84,6 @@ public:
 		bool immutable_;
 	};
 
-	typedef std::shared_ptr<shape> shape_ptr;
-	typedef std::shared_ptr<const shape> const_shape_ptr;
-
 	canvas();
 	canvas(const canvas&) = delete;
 	canvas(canvas&& c) noexcept;
@@ -178,11 +175,7 @@ public:
 
 private:
 	/** Vector with the shapes to draw. */
-	std::vector<shape_ptr> shapes_;
-
-	/** All shapes which have been already drawn. Kept around in case
-	 * the cache needs to be invalidated. */
-	std::vector<shape_ptr> drawn_shapes_;
+	std::vector<std::unique_ptr<shape>> shapes_;
 
 	/**
 	 * The depth of the blur to use in the pre committing.


### PR DESCRIPTION
The renderer only needs to exist during draw(). The old implementation kept the
old renderer until the next call to draw(), but would then usually destroy the
old one and create a new one.

Canvas kept separate lists of what had already been drawn and what needed to be
drawn, but whenever changes happened all of the drawn_shapes_ were put back
into shapes_. No point in having two separate lists.

The list of shape needs pointers to support polymorphism, but doesn't need
shared_ptrs.

This is some cleanup to make #5681 slightly smaller.