### PR TITLE
scenario-test: Add a right-click "show vision range" option

### DIFF
--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -620,6 +620,13 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
     [/side]
 
     [label]
+        x,y=12,13
+        text="Jamming Orc"
+        tooltip="This unit’s ability reduces vision, that’s why 13,13 is shrouded at the start."
+        visible_in_shroud=yes
+    [/label]
+
+    [label]
         x,y=20,12
         text="Enhance Vision"
         tooltip="Set the unit's vision to 15."
@@ -1642,14 +1649,14 @@ My best advancement costs $next_cost gold and I’m $experience|% there."
                     [/filter]
 
                     range=attack
-                    variable=unit_reach
+                    variable=unit_attack_reach
                 [/store_reachable_locations]
 
                 [lua]
                     code=<<
                         local location_set = wesnoth.require 'location_set'
                         local items = wesnoth.require 'wml/items'
-                        local locs = location_set.of_wml_var 'unit_reach'
+                        local locs = location_set.of_wml_var 'unit_attack_reach'
                         locs:iter(function(x, y)
                             items.place_image(x, y, 'misc/waypoint.png~CS(255,-127,-127)')
                         end)
@@ -1660,7 +1667,7 @@ My best advancement costs $next_cost gold and I’m $experience|% there."
                     name=select,side turn,moveto
 
                     [foreach]
-                        array=unit_reach
+                        array=unit_attack_reach
                         [do]
                             [remove_item]
                                 x,y=$this_item.x,$this_item.y
@@ -1672,7 +1679,56 @@ My best advancement costs $next_cost gold and I’m $experience|% there."
                     [redraw]
                     [/redraw]
 
-                    {CLEAR_VARIABLE unit_reach}
+                    {CLEAR_VARIABLE unit_attack_reach}
+                [/event]
+            [/command]
+        [/set_menu_item]
+
+        [set_menu_item]
+            description="Show vision range"
+            id=show_vision_range
+            [filter_location]
+                [filter]
+                [/filter]
+            [/filter_location]
+            [command]
+                [store_reachable_locations]
+                    [filter]
+                        x,y=$x1,$y1
+                    [/filter]
+
+                    range=vision
+                    variable=unit_vision_reach
+                [/store_reachable_locations]
+
+                [lua]
+                    code=<<
+                        local location_set = wesnoth.require 'location_set'
+                        local items = wesnoth.require 'wml/items'
+                        local locs = location_set.of_wml_var 'unit_vision_reach'
+                        locs:iter(function(x, y)
+                            items.place_image(x, y, 'misc/waypoint.png~CS(-127,-127,255)')
+                        end)
+                    >>
+                [/lua]
+
+                [event]
+                    name=select,side turn,moveto
+
+                    [foreach]
+                        array=unit_vision_reach
+                        [do]
+                            [remove_item]
+                                x,y=$this_item.x,$this_item.y
+                                image="misc/waypoint.png~CS(-127,-127,255)"
+                            [/remove_item]
+                        [/do]
+                    [/foreach]
+
+                    [redraw]
+                    [/redraw]
+
+                    {CLEAR_VARIABLE unit_vision_reach}
                 [/event]
             [/command]
         [/set_menu_item]


### PR DESCRIPTION
Make "show attack range" not overwrite the array for cleaning up
the "show movement range" command's display.

Add a label and tooltip about the enemy unit with jamming.

The new option shows the result of [store_reachable_locations]range=vision.
There are known issues (in #4179) with that for:
* units with vp different to mp
* units with vision costs different to movement costs
* jamming by enemy units