### PR TITLE
Make [store_reachable_locations]range=vision calculate vision

### DIFF
--- a/data/lua/wml/store_reachable_locations.lua
+++ b/data/lua/wml/store_reachable_locations.lua
@@ -14,33 +14,36 @@ function wesnoth.wml_actions.store_reachable_locations(cfg)
 	elseif cfg.viewing_side == nil then
 		reach_param.ignore_visibility = true
 	end
-	if range == "vision" then
-		moves = "max"
-		reach_param.ignore_units = true
-	end
 
 	local reach = location_set.create()
 
-	for i,unit in ipairs(wesnoth.units.find_on_map(unit_filter)) do
-		local unit_reach
-		if moves == "max" then
-			local saved_moves = unit.moves
-			unit.moves = unit.max_moves
-			unit_reach = location_set.of_pairs(wesnoth.find_reach(unit, reach_param))
-			unit.moves = saved_moves
-		else
-			unit_reach = location_set.of_pairs(wesnoth.find_reach(unit, reach_param))
-		end
-
-		if range == "vision" or range == "attack" then
-			unit_reach:iter(function(x, y)
-				reach:insert(x, y)
-				for u,v in helper.adjacent_tiles(x, y) do
-					reach:insert(u, v)
-				end
-			end)
-		else
+	if range == "vision" then
+		for i,unit in ipairs(wesnoth.units.find_on_map(unit_filter)) do
+			local unit_reach = location_set.of_pairs(wesnoth.find_vision_range(unit))
 			reach:union(unit_reach)
+		end
+	else
+		for i,unit in ipairs(wesnoth.units.find_on_map(unit_filter)) do
+			local unit_reach
+			if moves == "max" then
+				local saved_moves = unit.moves
+				unit.moves = unit.max_moves
+				unit_reach = location_set.of_pairs(wesnoth.find_reach(unit, reach_param))
+				unit.moves = saved_moves
+			else
+				unit_reach = location_set.of_pairs(wesnoth.find_reach(unit, reach_param))
+			end
+
+			if range == "attack" then
+				unit_reach:iter(function(x, y)
+					reach:insert(x, y)
+					for u,v in helper.adjacent_tiles(x, y) do
+						reach:insert(u, v)
+					end
+				end)
+			else
+				reach:union(unit_reach)
+			end
 		end
 	end
 

--- a/data/lua/wml/store_reachable_locations.lua
+++ b/data/lua/wml/store_reachable_locations.lua
@@ -1,0 +1,53 @@
+local helper = wesnoth.require "helper"
+local location_set = wesnoth.require "location_set"
+
+function wesnoth.wml_actions.store_reachable_locations(cfg)
+	local unit_filter = wml.get_child(cfg, "filter") or
+		wml.error "[store_reachable_locations] missing required [filter] tag"
+	local location_filter = wml.get_child(cfg, "filter_location")
+	local range = cfg.range or "movement"
+	local moves = cfg.moves or "current"
+	local variable = cfg.variable or wml.error "[store_reachable_locations] missing required variable= key"
+	local reach_param = { viewing_side = cfg.viewing_side }
+	if cfg.viewing_side == 0 then
+		wml.error "[store_reachable_locations] invalid viewing_side"
+	elseif cfg.viewing_side == nil then
+		reach_param.ignore_visibility = true
+	end
+	if range == "vision" then
+		moves = "max"
+		reach_param.ignore_units = true
+	end
+
+	local reach = location_set.create()
+
+	for i,unit in ipairs(wesnoth.units.find_on_map(unit_filter)) do
+		local unit_reach
+		if moves == "max" then
+			local saved_moves = unit.moves
+			unit.moves = unit.max_moves
+			unit_reach = location_set.of_pairs(wesnoth.find_reach(unit, reach_param))
+			unit.moves = saved_moves
+		else
+			unit_reach = location_set.of_pairs(wesnoth.find_reach(unit, reach_param))
+		end
+
+		if range == "vision" or range == "attack" then
+			unit_reach:iter(function(x, y)
+				reach:insert(x, y)
+				for u,v in helper.adjacent_tiles(x, y) do
+					reach:insert(u, v)
+				end
+			end)
+		else
+			reach:union(unit_reach)
+		end
+	end
+
+	if location_filter then
+		reach = reach:filter(function(x, y)
+			return wesnoth.map.matches(x, y, location_filter)
+		end)
+	end
+	reach:to_wml_var(variable)
+end

--- a/data/test/scenarios/store_reachable_locations_vision.cfg
+++ b/data/test/scenarios/store_reachable_locations_vision.cfg
@@ -1,0 +1,114 @@
+# wmllint: no translatables
+
+#define ASSERT_ALICE_VISION COUNT
+    [store_reachable_locations]
+        [filter]
+            id=alice
+        [/filter]
+        range=vision
+        variable=locs
+    [/store_reachable_locations]
+
+    {ASSERT {VARIABLE_CONDITIONAL locs.length equals {COUNT}}}
+    {CLEAR_VARIABLE locs}
+#enddef
+
+# Just to test that setting up vision hasn't affected movement
+#define ASSERT_ALICE_MOVEMENT COUNT
+    [store_reachable_locations]
+        [filter]
+            id=alice
+        [/filter]
+        variable=locs
+    [/store_reachable_locations]
+
+    {ASSERT {VARIABLE_CONDITIONAL locs.length equals {COUNT}}}
+    {CLEAR_VARIABLE locs}
+#enddef
+
+# For these tests, note that the visible hexes include Xv impassible void tiles. Cutting and pasting the
+# show_vision_range menu item from scenario-test.cfg is a huge help when working out the expected values.
+#
+# This test uses the same map test_elf_movement, test_orc_movement, test_elf_longsighted_movement, etc,
+# where the paths from Alice and Bob are:
+#     Flat
+#     Forest (Alice and Bob's paths merge)
+#     Forest Hills
+#     Hills
+#     Cave Hills
+#     a few others that aren't reached during this test
+[test]
+    name = "Unit Test store_reachable_locations_vision"
+    map_file=test/maps/test_movetype.map
+    turns = 1
+    id = store_reachable_locations_vision
+    random_start_time = no
+    is_unit_test = yes
+
+    {DEFAULT_SCHEDULE}
+
+    [side]
+        side=1
+        controller=human
+        name = "Alice"
+        type = Elvish Archer
+        id=alice
+        fog=no
+        shroud=no
+        share_view=no
+    [/side]
+    [side]
+        side=2
+        controller=human
+        name = "Bob"
+        type = Orcish Grunt
+        id=bob
+        fog=no
+        shroud=no
+        share_view=no
+    [/side]
+
+    [event]
+        name = side 1 turn 1
+
+        # An elf with 6 mp should be able to see Bob's two hexes, her own hex, Flat, Forest, Forest Hills, Hills, and all surrounding hexes, including the void ones.
+        {ASSERT_ALICE_VISION 24}
+
+        # She can move to next to Bob, stay on her own hex, or move to Flat, Forest, Forest Hills, Hills
+        {ASSERT_ALICE_MOVEMENT 6}
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=vision_costs
+                replace=yes
+                [vision_costs]
+                    hills=50
+                [/vision_costs]
+            [/effect]
+        [/modify_unit]
+
+        # Bob's two hexes, her own hex, Flat, Forest, and surroundings
+        {ASSERT_ALICE_VISION 18}
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=jamming
+                set=4
+            [/effect]
+        [/modify_unit]
+
+        # Bob's her own hex, Flat, Forest, and surroundings
+        {ASSERT_ALICE_VISION 13}
+
+        {SUCCEED}
+    [/event]
+[/test]
+
+#undef ASSERT_ALICE_MOVEMENT
+#undef ASSERT_ALICE_VISION

--- a/src/actions/vision.cpp
+++ b/src/actions/vision.cpp
@@ -45,10 +45,7 @@ static lg::log_domain log_engine("engine");
 static const std::string sighted_str("sighted");
 
 
-/**
- * Sets @a jamming to the (newly calculated) "jamming" map for @a view_team.
- */
-static void create_jamming_map(std::map<map_location, int> & jamming,
+void actions::create_jamming_map(std::map<map_location, int> & jamming,
                                const team & view_team)
 {
 	// Reset the map.
@@ -82,7 +79,7 @@ static bool can_see(const unit & viewer, const map_location & loc,
 	// Make sure we have a "jamming" map.
 	std::map<map_location, int> local_jamming;
 	if ( jamming == nullptr ) {
-		create_jamming_map(local_jamming, resources::gameboard->get_team(viewer.side()));
+		actions::create_jamming_map(local_jamming, resources::gameboard->get_team(viewer.side()));
 		jamming = &local_jamming;
 	}
 

--- a/src/actions/vision.hpp
+++ b/src/actions/vision.hpp
@@ -36,6 +36,15 @@ namespace actions {
 	class  move_unit_spectator;
 
 /**
+ * Helper function that creates the map of enemy anti-vision that's needed when
+ * creating a pathfinding::vision_path.
+ *
+ * Sets @a jamming to the (newly calculated) "jamming" map that reduces @a view_team's vision.
+ */
+void create_jamming_map(std::map<map_location, int> & jamming,
+	const team & view_team);
+
+/**
  * Class that stores the part of a unit's data that is needed for fog clearing.
  * (Used by the undo stack as that cannot rely on a unit sticking around, and
  * we do not really need to copy the entire unit.)

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -108,9 +108,10 @@ class game_lua_kernel : public lua_kernel_base
 	int impl_end_level_data_set(lua_State*);
 	int intf_get_end_level_data(lua_State*);
 	int intf_end_turn(lua_State*);
+	int intf_find_cost_map(lua_State *L);
 	int intf_find_path(lua_State *L);
 	int intf_find_reach(lua_State *L);
-	int intf_find_cost_map(lua_State *L);
+	int intf_find_vision_range(lua_State *L);
 	int intf_heal_unit(lua_State *L);
 	int intf_message(lua_State *L);
 	int intf_open_help(lua_State *L);

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -187,6 +187,8 @@
 0 effect_move_affects_vision
 0 effect_move_ignores_vision
 0 effect_vision
+# [store_locations]
+0 store_reachable_locations_vision
 #
 # Attack calculations & codepath tests
 #


### PR DESCRIPTION
Previously it calculated max movement, and then added the adjacent hexes. This
version should correctly handle:
* units with vp different to max mp
* units with vision costs different to movement costs
* jamming by enemy units

An interactive test showing the before and after results is in #5704
Fixes #4179