### PR TITLE
Balance changes for version 1.15.12

### DIFF
--- a/data/core/units/dunefolk/Blademaster.cfg
+++ b/data/core/units/dunefolk/Blademaster.cfg
@@ -16,7 +16,7 @@ units/dunefolk/soldier/#enddef
     experience=150
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=57
     usage=fighter
     description= _ "Dunefolk swordsmen are known for playing a game called the ‘Laeqad Challenge’, in which Laeqads—thick, sturdy reeds that are several sword lengths in height—are hurled at them like javelins and they attempt to split the reed length-wise in midair. The trick to the game is that the reed is not circularly symmetric: most of the stalk is quite hard, but there is a thin line across the cross section that is softer and easier to cut. For even an experienced swordsman, splitting an entire Laeqad down its length would be an extraordinary achievement, given the precise aim required to line up the blade with the reed’s soft spot. However, for a true master of the blade, splitting several Laeqads in quick succession is quite ordinary, and some are even able to cut through two or three reeds simultaneously with a single sword swish.
 

--- a/data/core/units/dunefolk/Captain.cfg
+++ b/data/core/units/dunefolk/Captain.cfg
@@ -13,7 +13,7 @@ units/dunefolk/soldier/#enddef
     movement=5
     experience=86
     level=2
-    alignment=liminal
+    alignment=lawful
     advances_to=Dune Warmaster
     cost=30
     usage=fighter

--- a/data/core/units/dunefolk/Cataphract.cfg
+++ b/data/core/units/dunefolk/Cataphract.cfg
@@ -17,7 +17,7 @@ units/dunefolk/rider/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=61
+    cost=62
     usage=fighter
     undead_variation=mounted
     description= _ "Cataphracts are eminent horsemen, riders of mounts that are possessed less of speed or endurance but tremendous power instead. Bearing a lance along with their signature maces, these warriors are most often the secondary strike force after a primary assault. After enemy forces are already occupied and weakened by a flank of swordsmen, a terrifying sight is a group of cataphracts lining up, lances pitched at the ready. A gap is made amongst the Dunefolk ranks, and in a single charge, these mighty horsemen pierce straight through enemy formations, dealing a lethal blow in a single stroke. Those who try to flee swiftly discover that neither sand nor hills deter these riders in the slightest, and the displaced air of a descending mace is the last sound they hear."

--- a/data/core/units/dunefolk/Firetrooper.cfg
+++ b/data/core/units/dunefolk/Firetrooper.cfg
@@ -17,7 +17,7 @@ units/dunefolk/burner/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=41
     usage=mixed fighter
     description= _ "By refining Sanbaar sap through a very specific distillation process, it becomes possible to produce exceedingly flammable naphtha, which burns even more violently than the sap it was derived from. Of course, such a substance is extremely dangerous due to its highly combustible nature. Most shy away from its use since the potential for self injury is very high, but a few daring souls take up flamethrowers fueled by pure naphtha as their weapons of choice. The resulting destruction is more than enough to justify the use of such a hazardous chemical."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/dunefolk/Harrier.cfg
+++ b/data/core/units/dunefolk/Harrier.cfg
@@ -17,7 +17,7 @@ units/dunefolk/skirmisher/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=46
+    cost=47
     usage=mixed fighter
     [abilities]
         {ABILITY_SKIRMISHER}

--- a/data/core/units/dunefolk/Luminary.cfg
+++ b/data/core/units/dunefolk/Luminary.cfg
@@ -20,7 +20,7 @@ units/dunefolk/herbalist/#enddef
     level=3
     alignment=liminal
     {AMLA_DEFAULT}
-    cost=53
+    cost=38
     usage=healer
     description= _ "On the surface, it is not entirely clear what distinguishes a Luminary from other healers among the Dunefolk. Certainly, a Luminary may be marginally more knowledgeable, well-traveled, or skilled in combat compared to normal herbalists or apothecaries, but the difference is usually modest at best. Nevertheless, ‘Luminary’ is a formal title granted to the highest order of Dunefolk healers and bestows these men both the greatest esteem and the greatest envy.
 

--- a/data/core/units/dunefolk/Marauder.cfg
+++ b/data/core/units/dunefolk/Marauder.cfg
@@ -25,7 +25,7 @@ units/dunefolk/rider/#enddef
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=60
     undead_variation=mounted
     usage=scout
     description= _ "Some find themselves well suited to the life of a raider and may even form their own clans with like-minded individuals. Ever roaming the deserts for unwary travelers or vulnerable caravans, these horsemen make their livelihood off scavenging and pilfering. Having no particular specialty, marauders are neither the strongest warriors, nor the most dextrous archers, but are nevertheless among the most dangerous enemies out in the desert due to their sheer maneuverability. A coordinated marauder attack can wipe out medium-sized camps before any response is possible, and guerrilla tactics may allow them to prevail against stronger foes where brute force does not. For this reason, they are sometimes hired by small armies or wealthier caravans as a deterrent to unwanted raids."

--- a/data/core/units/dunefolk/Sky_Hunter.cfg
+++ b/data/core/units/dunefolk/Sky_Hunter.cfg
@@ -33,7 +33,7 @@ units/dunefolk/skirmisher/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=47
+    cost=51
     usage=mixed fighter
     description= _ "Often mistaken for young Rocs, desert eagles are large, majestic birds of prey who are notoriously aggressive and nearly impossible to tame. In the wild, the eagles feed on larger prey such as wolves, small horses, and, it is said, naughty young children. The power of these creatures makes them tremendously difficult to engage, with only the most skilled of falconers even daring to approach them. In the event that the bird tamer is actually successful, the relationship between bird and hunter becomes less of master and pet, and more a mutual bond between two equals. Serving not only as tools for combat, the eagles can live for up to a few decades and are often precious companions to their dunefolk partners."
     {NOTE_SKIRMISHER}

--- a/data/core/units/dunefolk/Spearmaster.cfg
+++ b/data/core/units/dunefolk/Spearmaster.cfg
@@ -16,7 +16,7 @@ units/dunefolk/soldier/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=51
+    cost=57
     usage=fighter
     description= _ "Among Dunefolk armies, the highest prestige goes to the master swordsmen leading every assault. Though honored for their service in battle, those who wield the spear and shield are largely forgotten beyond that, usually fulfilling the least desirable role in combat without glory or recognition. When a Dunefolk assault fails and a retreat must be had, a rank of spearguards is usually left behind to hold back the counterassault. Though providing a formidable defense, the shield line is inevitably overwhelmed and most of the defenders lost to the maw of war. On the off chance that one manages to survive and find his way back to the recuperating army, he is often reprimanded for failing to stand his ground and die with the rest of his unnamed brethren. Nevertheless, after a minor scolding, the warrior is accepted back and carries his hard won experience into the next battle.
 

--- a/data/core/units/dunefolk/Warmaster.cfg
+++ b/data/core/units/dunefolk/Warmaster.cfg
@@ -8,15 +8,15 @@ units/dunefolk/soldier/#enddef
     name= _ "Dune Warmaster"
     race=dunefolk
     image="{PATH_TEMP}warmaster.png"
-    hitpoints=57
+    hitpoints=59
     movement_type=dunearmoredfoot
     movement=5
     experience=150
     level=3
-    alignment=liminal
+    alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=56
+    cost=57
     usage=fighter
     [abilities]
         {ABILITY_LEADERSHIP}

--- a/data/core/units/dunefolk/Wayfarer.cfg
+++ b/data/core/units/dunefolk/Wayfarer.cfg
@@ -16,7 +16,7 @@ units/dunefolk/rover/#enddef
     alignment=liminal
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=55
     usage=mixed fighter
     description= _ "From the journal of Balah, the Dune Watcher:
 

--- a/data/core/units/dunefolk/Windbolt.cfg
+++ b/data/core/units/dunefolk/Windbolt.cfg
@@ -16,7 +16,7 @@ units/dunefolk/rider/#enddef
     alignment=liminal
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=49
     usage=archer
     undead_variation=mounted
     description= _ "Archery on horseback presents a number of additional challenges that very few are able to overcome. What separates the renowned windbolts from other bowmen is their ability to not only master these difficulties, but turn them into advantages instead. Making use of their steeds’ great speed, a windbolt is actually a better archer when mounted as compared to on land. The extra momentum from riding on horseback provides additional force to their already potent shots, and by riding in meandering patterns, these bowmen are able to curve the trajectories of their arrows, reaching targets they might not be able to otherwise. Having honed their craft to its apex, windbolts are the undisputed masters of ranged combat among the Dunefolk."

--- a/data/core/units/monsters/Rock_Scorpion.cfg
+++ b/data/core/units/monsters/Rock_Scorpion.cfg
@@ -24,11 +24,11 @@
     [/standing_anim]
 #endif
     hitpoints=35
-    movement_type=mountainfoot
+    movement_type=scuttlefoot
     [resistance]
         blade=70
-        pierce=80
-        impact=80
+        pierce=60
+        impact=90
         fire=90
         cold=110
         arcane=100
@@ -48,6 +48,14 @@
     {DEFENSE_ANIM "units/monsters/scorpion/rock-scorpion-defend2.png" "units/monsters/scorpion/rock-scorpion-defend1.png" hiss.wav }
     # {DEFENSE_ANIM_DIRECTIONAL "units/monsters/scorpion/rock-scorpion-defend2.png" "units/monsters/scorpion/rock-scorpion-defend1.png" "units/monsters/scorpion/rock-scorpion-ne-defend2.png" "units/monsters/scorpion/rock-scorpion-ne-defend1.png" hiss.wav }
     [attack]
+        name=pincers
+        description=_"pincers"
+        type=blade
+        range=melee
+        damage=6
+        number=4
+    [/attack]
+    [attack]
         name=spray
         description=_"spray"
         type=impact
@@ -59,14 +67,6 @@
         damage=4
         # defense_weight=10.0
         number=1
-    [/attack]
-    [attack]
-        name=pincers
-        description=_"pincers"
-        type=blade
-        range=melee
-        damage=5
-        number=4
     [/attack]
     [attack_anim]
         [filter_attack]

--- a/data/core/units/monsters/Scarab.cfg
+++ b/data/core/units/monsters/Scarab.cfg
@@ -20,7 +20,7 @@
     [special_note]
         note= _ "This unit can burrow under loose dirt, sand, or leaves, concealing itself if it does not change location."
     [/special_note]
-    cost=12
+    cost=11
     usage=fighter
     description= _ "Horned Scarabs are large, rugged insects that can grow to be quite large, making them a threat when they decide to be aggressive. Their primary means of attack is the large, sharp horn growing from their head. Because of their large size, armor, and horn, they cannot fly."
     die_sound=hiss-die.wav

--- a/data/core/units/nagas/Ophidian.cfg
+++ b/data/core/units/nagas/Ophidian.cfg
@@ -13,7 +13,7 @@
     level=2
     alignment=neutral
     advances_to=Naga Sicarius
-    cost=24
+    cost=22
     usage=fighter
     description= _ "Experienced warriors of the Southern Naga often find work as mercenaries, usually hired by neighboring Dunefolk to control key waterways near the coastline. Due to their constant confrontations with enemy horsemen, Ophidians have retired the ringed blades of their youth and picked up the piercing bow. Though generally amicable with their wealthy employers, this friendliness should not be mistaken for loyalty, for the Ophidian are known for readily switching between rival city-state factions at the start of each shipping season, when demand for water-based protection is the highest. As a group, these nagas encourage a healthy amount of competition among the surface factions, ensuring their services are valued by one tribe or another."
     die_sound=naga-die.ogg
@@ -28,7 +28,7 @@
         description=_"curved blade"
         type=blade
         range=melee
-        damage=7
+        damage=6
         number=3
         icon=attacks/blade-curved.png
     [/attack]
@@ -37,7 +37,7 @@
         description= _"bow"
         type=pierce
         range=ranged
-        damage=10
+        damage=12
         number=2
         icon=attacks/bow-orcish.png
     [/attack]

--- a/data/core/units/nagas/Ringcaster.cfg
+++ b/data/core/units/nagas/Ringcaster.cfg
@@ -12,7 +12,7 @@
     level=2
     alignment=neutral
     advances_to=Naga Zephyr
-    cost=24
+    cost=22
     usage=mixed fighter
     description= _ "The chakram, a greater blade ring than the chakri, is the signature weapon of the southern Naga and their renowned Ringcasters. Well balanced chakrams are useful for throwing, but the rejected blades make a good fist-load weapon, similar to a sharp-bladed tekko or knuckleduster."
     die_sound=naga-die.ogg

--- a/data/core/units/nagas/Sicarius.cfg
+++ b/data/core/units/nagas/Sicarius.cfg
@@ -14,7 +14,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=48
+    cost=46
     usage=fighter
     description= _ "While they sometimes still stand in as sellswords for potential Dunefolk allies, Naga Sicarii are more often the keepers of trade routes and resource beds close to waterways. For the right fee or exchange of goods, a Sicarius will guarantee safe travel or free access to valuable supplies in his territory. Rubbed the wrong way and a Sicarius becomes a fearsome foe, not because of their personal strength in combat, but instead due to the numerous allies that he can call upon to quash any potential nuisance. Though perfectly capable warriors when the time is necessary, these experienced mercenaries know perfectly well that the best methods for generating money are those that do not place themselves in danger."
     die_sound=naga-die.ogg
@@ -30,7 +30,7 @@
         description=_"curved blade"
         type=blade
         range=melee
-        damage=10
+        damage=11
         number=3
         icon=attacks/blade-curved.png
     [/attack]
@@ -39,7 +39,7 @@
         description= _"bow"
         type=pierce
         range=ranged
-        damage=12
+        damage=13
         number=3
         icon=attacks/bow.png
     [/attack]

--- a/data/core/units/nagas/Zephyr.cfg
+++ b/data/core/units/nagas/Zephyr.cfg
@@ -13,7 +13,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=46
     usage=mixed fighter
     description= _ "The Southern Naga commonly recount a curious story about the Wind Spirit, Zefra and the aetherial chakram:
 

--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -283,9 +283,11 @@
             forest=4
             hills=4
             sand=1
+            deep_water=1
         [/movement_costs]
         [defense]
             sand=60
+            deep_water=50
         [/defense]
     [/variation]
 

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -282,9 +282,11 @@
             forest=4
             hills=4
             sand=1
+            deep_water=1
         [/movement_costs]
         [defense]
             sand=60
+            deep_water=50
         [/defense]
     [/variation]
 

--- a/data/core/units/wose/Wose_Sapling.cfg
+++ b/data/core/units/wose/Wose_Sapling.cfg
@@ -13,7 +13,7 @@
     level=0
     alignment=lawful
     advances_to=Wose
-    cost=10
+    cost=11
     description= _ "Rarely seen even by elves, the Wose is an order of creature about which little is known. The elves are the source of most of this knowledge; they know that these beings are not descended from trees, despite the similarity in form, and they know that a wose is more closely tied to the faerie world than the elves themselves, though in a different way. The motives and workings of their kind are unknown, though most subscribe to the obvious theory that woses are dedicated wardens of the natural world.
 
 Woses are utterly unwarlike, but possess a great strength. They are, however, neither used to, nor quick at moving around."

--- a/data/core/units/wose/Wose_Shaman.cfg
+++ b/data/core/units/wose/Wose_Shaman.cfg
@@ -8,15 +8,15 @@
         {ABILITY_AMBUSH}
         {ABILITY_REGENERATES}
     [/abilities]
-    hitpoints=50
+    hitpoints=56
     movement_type=treefolk
-    movement=3
+    movement=4
     experience=100
     level=2
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=40
+    cost=27
     usage=mixed fighter
     description=_"These woses are able to command forest plants such as vines and creepers to hinder their enemies."
     {NOTE_AMBUSH}
@@ -37,7 +37,7 @@
         description=_"crush"
         type=impact
         range=melee
-        damage=9
+        damage=12
         number=2
         icon=attacks/crush-wose.png
     [/attack]
@@ -48,7 +48,7 @@
         [specials]
             {WEAPON_SPECIAL_SLOW}
         [/specials]
-        damage=10
+        damage=11
         number=2
         range=ranged
     [/attack]


### PR DESCRIPTION
Dunefolk:
Dune Blademaster gold cost changed from 52 to 57.
Dune Captain alignment changed from liminal to lawful.
Dune Cataphract gold cost changed from 61 to 62.
Dune Firetrooper gold cost changed from 50 to 41.
Dune Harrier gold cost changed from 46 to 47.
Dune Luminary gold cost changed from 53 to 38.
Dune Maruder gold cost changed from 52 to 60.
Dune Sky Hunter gold cost changed from 47 to 51.
Dune Spearmaster gold cost changed from 51 to 57.
Dune Wayfarer gold cost changed from 52 to 55.
Dune Windbolt gold cost changed from 50 to 49.
Dune Warmaster gold cost changed from 56 to 57, hp changed from 57 to 59, alignment changed from liminal to lawful.
Naga Ophidian gold cost changed from 24 to 22, melee damage changed from 7 to 6, ranged damage changed from 10 to 12.
Naga Ringcaster gold cost changed from 24 to 22.
Naga Sicarus gold cost changed from 46g, melee damage changed from 10 to 9, ranged damage changed from 12 to 13.
Naga Zephyr gold cost changed from 46g.

Woses:
Wose Sapling gold cost changed from 10 to 11.
Wose Shaman gold cost changed from 40 to 27, movement points changed from 3 to 4, melee damage changed from 9 to 12, ranged damage changed from 10 to 11, hp changed from 50 to 56.

Monsters:
Horned scarab gold cost changed from 12 to 11.
Update Rock Scorpion. 

Fix for #5701.