### PR TITLE
Fix the indentation in test_lua_wml

### DIFF
--- a/data/test/scenarios/test_lua_wml.cfg
+++ b/data/test/scenarios/test_lua_wml.cfg
@@ -1,14 +1,16 @@
+# wmllint: no translatables
+
 {GENERIC_UNIT_TEST "test_wml_actions" (
     [event]
         name = start
         [lua]
             code = <<
-				function wesnoth.wml_actions.foo(cfg)
-					if cfg.bar then
-						wml.variables["result"] = cfg.bar
-					end
-				end
-				>>
+                function wesnoth.wml_actions.foo(cfg)
+                    if cfg.bar then
+                        wml.variables["result"] = cfg.bar
+                    end
+                end
+            >>
         [/lua]
 
         {VARIABLE result 0}
@@ -39,39 +41,47 @@
         name = start
         [lua]
             code = <<
-				function wesnoth.wml_conditionals.foo(cfg)
-					return (cfg.bar == "baz")
-				end
-				>>
+                function wesnoth.wml_conditionals.foo(cfg)
+                    return (cfg.bar == "baz")
+                end
+            >>
         [/lua]
 
-        {ASSERT ([foo]
-        bar = "baz"
-    [/foo])}
-    {ASSERT ([not]
-    [foo]
-        bar = "boo"
-    [/foo]
-[/not])}
-{ASSERT ([foo]
-bar = "baz"
-[/foo]
-[or]
-    [foo]
-        bar = "boo"
-    [/foo]
-[/or])}
-{ASSERT ([not]
-[foo]
-    bar = "baz"
-[/foo]
-[and]
-    [foo]
-        bar = "boo"
-    [/foo]
-[/and]
-[/not])}
+        {ASSERT (
+            [foo]
+                bar = "baz"
+            [/foo]
+        )}
+        {ASSERT (
+            [not]
+                [foo]
+                    bar = "boo"
+                [/foo]
+            [/not]
+        )}
+        {ASSERT (
+            [foo]
+                bar = "baz"
+            [/foo]
+            [or]
+                [foo]
+                    bar = "boo"
+                [/foo]
+            [/or]
+        )}
+        {ASSERT (
+            [not]
+                [foo]
+                    bar = "baz"
+                [/foo]
+                [and]
+                    [foo]
+                        bar = "boo"
+                    [/foo]
+                [/and]
+            [/not]
+        )}
 
-{SUCCEED}
-[/event]
+        {SUCCEED}
+    [/event]
 )}


### PR DESCRIPTION
This main change here is moving tags to their own line, to avoid wmlindent
bug #1397. The lua gets a manual tabs-to-spaces conversion.