### PR TITLE
run_wml_tests: Print the correct test name when a test fails

### DIFF
--- a/run_wml_tests
+++ b/run_wml_tests
@@ -6,6 +6,13 @@ This script runs a sequence of wml unit test scenarios.
 
 import argparse, enum, os, re, subprocess, sys
 
+class Verbosity(enum.IntEnum):
+    """What to display depending on how many -v arguments were given on the command line."""
+    # This doesn't use enum.unique, more than one of these could have the same int level
+    NAMES_OF_TESTS_RUN = 1 # Show progress when running interactively, with a new line each time a new batch starts
+    SCRIPT_DEBUGGING = 2 # The command lines needed to run Wesnoth directly for a given test is printed
+    OUTPUT_OF_PASSING_TESTS = 3 # Print the output even when tests give the expected result
+
 class UnexpectedTestStatusException(Exception):
     """Exception raised when a unit test doesn't return the expected result."""
     pass
@@ -35,28 +42,48 @@ class TestCase:
         return "TestCase<{status}, {name}>".format(status=self.status, name=self.name)
 
 class TestResultAccumulator:
-    passed = 0
-    skipped = 0
-    failed = 0
-    crashed = 0
+    passed = []
+    skipped = []
+    failed = []
+    crashed = []
     
     def __init__(self, total):
         self.total = total
     
-    def pass_test(self, n = 1):
-        self.passed = self.passed + n
+    def pass_test(self, batch):
+        """These tests had the expected result - passed if UnitTestResult.PASS was expected, etc."""
+        self.passed += batch
     
-    def skip_test(self, n = 1):
-        self.skipped = self.skipped + n
+    def skip_test(self, batch):
+        """These tests were not run at all. For example, if they expect UnitTestResult.TIMEOUT but the run requested no timeouts."""
+        self.skipped += batch
     
-    def fail_test(self, n = 1):
-        self.failed = self.failed + n
+    def fail_test(self, batch):
+        """These tests did not crash, but did not have the expected result - they passed if UnitTestResult.FAIL was expected, etc."""
+        self.failed += batch
     
-    def crash_test(self, n = 1):
-        self.crashed = self.failed + n
+    def crash_test(self, batch):
+        """Segfaults and similar unusual exits from the program under test."""
+        self.crashed += batch
     
     def __bool__(self):
-        return self.passed + self.skipped == self.total
+        """Returns true if everything that was expected to run (based on the command line options) ran and passed."""
+        # The logic here is redundant, from the length of passed and skipped we should know that failed and crashed are both empty;
+        # however a false everything-passed result is much worse than a couple of extra checks here.
+        return len(self.passed) + len(self.skipped) == self.total and len(self.failed) == 0 and len(self.crashed) == 0
+
+    def __str__(self):
+        result = "Passed {count} of {total} tests\n".format(count=len(self.passed), total=self.total)
+        if self.skipped:
+            result += "Skipped batches containing {count} tests: ({names})\n".format(count=len(self.skipped),
+                    names=", ".join([test.name for test in self.skipped]))
+        if self.failed:
+            result += "Failed batches containing {count} tests: ({names})\n".format(count=len(self.failed),
+                    names=", ".join([test.name for test in self.failed]))
+        if self.crashed:
+            result += "Crashed during batches containing {count} tests: ({names})".format(count=len(self.crashed),
+                    names=", ".join([test.name for test in self.crashed]))
+        return result;
 
 class TestListParser:
     """Each line in the list of tests should be formatted:
@@ -84,7 +111,7 @@ class TestListParser:
                 print("Could not parse test list file: ", line)
 
             t = TestCase(UnitTestResult(int(x.groups()[0])), x.groups()[1])
-            if self.verbose > 1:
+            if self.verbose >= Verbosity.SCRIPT_DEBUGGING:
                 print(t)
             test_list.append(t)
         return batcher(test_list), TestResultAccumulator(len(test_list))
@@ -102,7 +129,7 @@ def run_with_rerun_for_sdl_video(args, timeout):
         if b"Could not initialize SDL_video" in res.stdout:
             retry = True
         if not retry:
-        	  return res
+            return res
         sdl_retries += 1
         print("Could not initialise SDL_video error, attempt", sdl_retries)
 
@@ -143,7 +170,7 @@ class WesnothRunner:
             self.common_args.extend(options.additional_arg)
         self.timeout = options.timeout
         self.batch_timeout = options.batch_timeout
-        if self.verbose > 1:
+        if self.verbose >= Verbosity.SCRIPT_DEBUGGING:
             print("Options that will be used for all Wesnoth instances:", repr(self.common_args))
 
     def run_tests(self, test_list, test_summary):
@@ -155,47 +182,49 @@ class WesnothRunner:
                 if test.status != UnitTestResult.PASS:
                     raise NotImplementedError("run_tests doesn't yet support batching tests with non-zero statuses")
         expected_result = test_list[0].status
+
+        if expected_result == UnitTestResult.TIMEOUT and self.timeout == 0:
+            test_summary.skip_test(test_list)
+            if self.verbose >= Verbosity.NAMES_OF_TESTS_RUN:
+                print('Skipping test', test_list[0].name, 'because timeout is disabled')
+            return
+        if expected_result == UnitTestResult.FAIL_BROKE_STRICT and not options.strict_mode:
+            test_summary.skip_test(test_list)
+            if self.verbose >= Verbosity.NAMES_OF_TESTS_RUN:
+                print('Skipping test', test_list[0].name, 'because strict mode is disabled')
+            return
+
         args = self.common_args.copy()
         for test in test_list:
             args.append("-u")
             args.append(test.name)
+
         if self.timeout == 0:
-            if test.status == UnitTestResult.TIMEOUT:
-                test_summary.skip_test()
-                print('Skipping test', test_list[0].name, 'because timeout is disabled')
-                return
             timeout = None
+        elif len(test_list) == 1:
+            timeout = self.timeout
         else:
-            if test.status == UnitTestResult.FAIL_BROKE_STRICT and not options.strict_mode:
-                test_summary.skip_test()
-                print('Skipping test', test_list[0].name, 'because strict mode is disabled')
-                return
-            if len(test_list) == 1:
-                timeout = self.timeout
-            else:
-                timeout = self.batch_timeout
-        if self.verbose > 0:
+            timeout = self.batch_timeout
+
+        if self.verbose >= Verbosity.NAMES_OF_TESTS_RUN:
             if len(test_list) == 1:
                 print("Running test", test_list[0].name)
             else:
                 print("Running {count} tests ({names})".format(count=len(test_list),
                     names=", ".join([test.name for test in test_list])))
-            if self.verbose > 1:
-                print(repr(args))
+        if self.verbose >= Verbosity.SCRIPT_DEBUGGING:
+            print(repr(args))
+
         try:
             res = run_with_rerun_for_sdl_video(args, timeout)
         except subprocess.TimeoutExpired as t:
-            if self.verbose > 0:
-                print("Timed out (killed by Python timeout implementation)")
+            if expected_result != UnitTestResult.TIMEOUT:
+                print("Timed out (killed by Python timeout implementation), while running batch ({names})".format(
+                    names=", ".join([test.name for test in test_list])))
             res = subprocess.CompletedProcess(args, UnitTestResult.TIMEOUT.value, t.output or b'')
-        if self.verbose > 0:
+        if self.verbose >= Verbosity.OUTPUT_OF_PASSING_TESTS:
             print(res.stdout.decode('utf-8'))
-            if self.verbose > 1:
-                print("Result:", res.returncode)
-        num_passed = 1
-        if test_list[0].status == UnitTestResult.PASS:
-            num_passed = res.stdout.count(b"PASS TEST")
-            test_summary.pass_test(num_passed)
+            print("Result:", res.returncode)
         if res.returncode < 0:
             print("Wesnoth exited because of signal", -res.returncode)
             if options.backtrace:
@@ -203,22 +232,21 @@ class WesnothRunner:
                 gdb_args = ["gdb", "-q", "-batch", "-ex", "start", "-ex", "continue", "-ex", "bt", "-ex", "quit", "--args"]
                 gdb_args.extend(args)
                 subprocess.run(gdb_args, timeout=240)
-            test_summary.crash_test()
-            test_summary.skip_test(len(test_list) - num_passed - 1)
+            test_summary.crash_test(test_list)
             raise UnexpectedTestStatusException()
         returned_result = UnitTestResult(res.returncode)
-        if returned_result != expected_result:
-            if self.verbose == 0:
-                for line in res.stdout.decode('utf-8').splitlines():
-                    if expected_result == UnitTestResult.PASS and line.startswith("PASS TEST"):
-                        continue
-                    print(line)
-            print("Failure, Wesnoth returned", returned_result, "for", test_list[num_passed].name, "but we expected", expected_result)
-            test_summary.fail_test()
-            test_summary.skip_test(len(test_list) - num_passed - 1)
+        if returned_result == expected_result:
+            test_summary.pass_test(test_list)
+        else:
+            if self.verbose < Verbosity.OUTPUT_OF_PASSING_TESTS:
+                # Batch mode only supports tests that should UnitTestResult.PASS, so the output
+                # here is likely to have many 'PASS TEST' lines with the failing test last.
+                # If support for batching other UnitTestResults is added then this needs to filter
+                # the output from the other tests.
+                print(res.stdout.decode('utf-8'))
+            print("Failure, Wesnoth returned", returned_result, "but we expected", expected_result)
+            test_summary.fail_test(test_list)
             raise UnexpectedTestStatusException()
-        elif test_list[0].status != UnitTestResult.PASS:
-            test_summary.pass_test()
 
 def test_batcher(test_list):
     """A generator function that collects tests into batches which a single
@@ -250,7 +278,7 @@ if __name__ == '__main__':
     # The options that are mandatory to support (because they're used in the Travis script)
     # are the one-letter forms of verbose, clean, timeout and backtrace.
     ap.add_argument("-v", "--verbose", action="count", default=0,
-        help="Verbose mode. Use -v twice for very verbose mode.")
+        help="Verbose mode. Additional -v arguments increase the verbosity.")
     ap.add_argument("-c", "--clean", action="store_true",
         help="Clean mode. (Don't load any add-ons. Used for mainline tests.)")
     ap.add_argument("-a", "--additional_arg", action="append",
@@ -299,27 +327,16 @@ if __name__ == '__main__':
     runner = WesnothRunner(options)
 
     for batch in test_list:
-        while len(batch) > 0:
-            last_passed_count = test_summary.passed
-            try:
-                runner.run_tests(batch, test_summary)
-                batch = []
-            except UnexpectedTestStatusException as e:
-                just_passed = test_summary.passed - last_passed_count
-                batch = batch[just_passed + 1 :]
-                test_summary.skip_test(-len(batch))
+        try:
+            runner.run_tests(batch, test_summary)
+        except UnexpectedTestStatusException as e:
+            if test_summary:
+                raise RuntimeError("Logic error in run_wml_tests - a test has failed, but test_summary says everything passed")
 
-    print("Result:" if options.verbose > 0 else "WML Unit Tests Result:", test_summary.passed, "of", test_summary.total, "tests passed")
-
-    if test_summary.passed != test_summary.total:
-        breakdown = ["{0} passed".format(test_summary.passed)]
-        if test_summary.failed != 0:
-            breakdown.append("{0} failed".format(test_summary.failed))
-        if test_summary.crashed != 0:
-            breakdown.append("{0} crashed".format(test_summary.crashed))
-        if test_summary.skipped != 0:
-            breakdown.append("{0} skipped".format(test_summary.skipped))
-        print("    ({0})".format(', '.join(breakdown)))
+    if options.verbose > 0 or not test_summary:
+        print(test_summary)
+    else:
+        print("WML Unit Tests Result:", len(test_summary.passed), "of", test_summary.total, "tests passed")
 
     if not test_summary:
         sys.exit(1)


### PR DESCRIPTION
The fix in 9535ed9 didn't work, the script still crashed on that line, the
logic for working out how many tests in the batch had passed wasn't correct.
This commit drops that logic, and drops the dependent feature of trying to
retry the next test in the batch, and simply says the entire batch failed.

The new logic for filtering the output of a failed batch is much simpler - the
script doesn't filter it and we assume the developer is just going to ignore
any line that starts "PASS TEST". Only tests that are expected to pass get
batched, so the output is going to look something like the following:

	PASS TEST: test_return
	PASS TEST: test_assert
	PASS TEST: test_return_2
	PASS TEST: test_assert_2
	Assertion failed: assert false
	FAIL TEST: test_assert_fail

	Failure, Wesnoth returned 1 FAIL but we expected 0 PASS

A set of constants is added defining how many -v arguments are needed to
enable a given set of debugging output. Expectation is that level 0 is normal,
and level 1 is for developers who like long-running build processes to print
something to show that they're not stuck.

Complete output when all tests pass, without `-v`:
```
WML Unit Tests Result: 246 of 246 tests passed
```

Output when a test times out during the main batch. This doesn't get the name directly, but searching through the list of what was in the batch shows that `recruit_facing_center` should be followed by `check_victory_basic_timeout`. That's a bit more work for the developer, but it's much better than printing the wrong name.
```
Timed out (killed by Python timeout implementation), while running batch (test_return, test_assert, fixed_lua_random_replay_with_sync_choice, test_end_turn, cve_2018_1999023, two_plus_two, order_of_nested_events, test_clear_one, test_clear_two, test_unit_map, unit_spawns_at_nearest_vacant_hex, units_offmap_goto_recall, recall_by_unit_tag, test_move, test_move_unit, test_move_unit_in_circle, sighted_events, sighted_on_opponents_turn, move_skip_no_sighted_no_share_view, move_skip_ally_sighted_no_share_view, move_skip_all_sighted_no_share_view, move_skip_no_sighted_yes_share_view, move_skip_ally_sighted_yes_share_view, move_skip_all_sighted_yes_share_view, set_gold_in_prestart_one, set_gold_in_prestart_two, modify_turns_one, modify_turns_two, modify_turns_three, modify_turns_four, replace_schedule_prestart, modify_unit_facing, event_handlers_in_events_1, event_handlers_in_events_3, event_handlers_in_events_2, event_handlers_in_events_4, event_handlers_in_events_5, event_handlers_in_events_6, event_handlers_in_events_7, event_handlers_in_events_8, event_handers_in_events__delayed, event_handlers_in_events__dynamic_filter, event_remove_test, event_repeat_test, event_test_auto_variables_side_turn, event_test_auto_variables_xy, event_test_auto_variables_units, event_test_auto_variables_weapons, event_test_auto_variables_damage, event_test_auto_variables_owner, event_test_filter_condition, event_test_filter_side, event_test_filter_unit, event_test_filter_attack, filter_vision, scatter_units, has_ally, xp_mod_1, xp_mod_2, xp_mod_3, test_role_1, test_role_2, test_role_3, test_role_lua, events-test_nonfilterable, events-test_filterable1, events-test_filterable2, events-test_filterable3, events-test_victory, events-test_defeat, events-test_die, test_store_unit_defense_on, test_terrain_mask_simple_nop, test_terrain_mask_simple_set, test_terrain_mask_simple_underlay, test_terrain_mask_simple_overlay, test_terrain_mask_simple_name, test_terrain_mask_simple_name_fail, test_terrain_mask_align_odd_on_odd, test_terrain_mask_align_odd_on_even, test_terrain_mask_align_even_on_odd, test_terrain_mask_align_even_on_even, test_terrain_mask_align_raw_on_odd, test_terrain_mask_align_raw_on_even, test_terrain_mask_deprecated_border_no, test_terrain_mask_deprecated_border_yes, test_terrain_mask_rule_basic, lua_dofile, lua_require, lua_get_sides, test_wml_actions, test_wml_conditionals, lua_wml_tagnames, test_scoped_vars, as_text, store_locations_one, store_locations_range, simple_find_path, characterize_pathfinding_reach_1, characterize_pathfinding_reach_2, characterize_pathfinding_reach_3, characterize_pathfinding_reach_4, characterize_pathfinding_reach_5, characterize_pathfinding_reach_6, characterize_pathfinding_reach_7, test_elf_movement, test_orc_movement, test_elf_fast_cave_movement, test_elf_fast_hills_movement, test_elf_fast_cave_and_hills_movement, test_orc_fast_cave_movement, test_orc_fast_forest_movement, test_elf_slow_cave_movement, test_elf_longsighted_movement, test_orc_longsighted_movement, test_elf_longsighted_fast_cave_movement, test_elf_fast_cave_longsighted_movement, test_elf_vision, test_elf_fast_cave_vision, test_elf_fast_hills_vision, test_elf_longsighted_cave_vision, test_elf_longsighted_cave_and_hills_vision, test_elf_longsighted_cave_slow_cave_vision, test_resistances, effect_move_affects_vision, effect_move_ignores_vision, effect_vision, store_reachable_locations_vision, test_grunt_tod_damage, test_time_area_damage, test_time_area_prestart, test_berzerk_firststrike, feeding, swarm_disables_upgrades, swarm_disables_upgrades_with_abilities, swarm_disables_upgrades_with_abilities_fail, swarm_disables_upgrades_with_abilities_adjacent, swarm_disables_upgrades_with_abilities_adjacent_fail, swarm_disables_upgrades_with_abilities_adjacent_leadership, swarm_disables_upgrades_with_abilities_adjacent_leadership_fail, test_force_chance_to_hit_macro, recruit_facing_enemy_one, recruit_facing_enemy_two, recruit_facing_leader, recruit_facing_center, check_victory_basic_timeout, test_wml_menu_items_1, test_wml_menu_items_3, check_conditionals_1, check_conditionals_2, filter_this_unit_wml, filter_this_unit_tl, filter_this_unit_formula, filter_formula_unit, check_interrupts_break, check_interrupts_return, check_interrupts_continue, check_interrupts_break_global, check_interrupts_return_nested, check_interrupts_continue_global, check_interrupts_elseif, check_interrupts_case, forloop_all_zero, forloop_step_zero, forloop_once_positive, forloop_once_negative, forloop_twice_matched, forloop_twice_unmatched, forloop_empty_array, forloop_array, forloop_array_reverse, forloop_step_large_positive, forloop_step_large_negative, for_defaults, for_start2, for_end2, for_end2_step2, for_end-2, for_end-2_step-2, test_basic_simplified_aspect, test_basic_abbreviated_aspect, test_basic_standard_aspect, test_basic_composite_aspect, test_basic_lua_aspect, test_basic_composite_facet, test_basic_lua_facet, test_basic_composite_default_facet, test_basic_lua_default_facet, test_modify_ai_delete_facet, test_modify_ai_change_facet, test_modify_ai_replace_facet, test_modify_ai_add_facet, test_modify_ai_change_default_facet, test_modify_ai_nested_facets, test_modify_ai_composite_default_facets, test_modify_ai_change_aspect, test_create_side, order_of_variable_events1, order_of_variable_events2, event_name_variable_substitution, heal)
PASS TEST: test_return
PASS TEST: test_assert
PASS TEST: fixed_lua_random_replay_with_sync_choice
... about 200 more PASS TEST lines ...
PASS TEST: test_force_chance_to_hit_macro
PASS TEST: recruit_facing_enemy_one
PASS TEST: recruit_facing_enemy_two
PASS TEST: recruit_facing_leader
PASS TEST: recruit_facing_center

Failure, Wesnoth returned 2 TIMEOUT but we expected 0 PASS
Passed 46 of 247 tests
Failed batches containing 201 tests: (test_return, test_assert, fixed_lua_random_replay_with_sync_choice, test_end_turn, cve_2018_1999023, two_plus_two, order_of_nested_events, test_clear_one, test_clear_two, test_unit_map, unit_spawns_at_nearest_vacant_hex, units_offmap_goto_recall, recall_by_unit_tag, test_move, test_move_unit, test_move_unit_in_circle, sighted_events, sighted_on_opponents_turn, move_skip_no_sighted_no_share_view, move_skip_ally_sighted_no_share_view, move_skip_all_sighted_no_share_view, move_skip_no_sighted_yes_share_view, move_skip_ally_sighted_yes_share_view, move_skip_all_sighted_yes_share_view, set_gold_in_prestart_one, set_gold_in_prestart_two, modify_turns_one, modify_turns_two, modify_turns_three, modify_turns_four, replace_schedule_prestart, modify_unit_facing, event_handlers_in_events_1, event_handlers_in_events_3, event_handlers_in_events_2, event_handlers_in_events_4, event_handlers_in_events_5, event_handlers_in_events_6, event_handlers_in_events_7, event_handlers_in_events_8, event_handers_in_events__delayed, event_handlers_in_events__dynamic_filter, event_remove_test, event_repeat_test, event_test_auto_variables_side_turn, event_test_auto_variables_xy, event_test_auto_variables_units, event_test_auto_variables_weapons, event_test_auto_variables_damage, event_test_auto_variables_owner, event_test_filter_condition, event_test_filter_side, event_test_filter_unit, event_test_filter_attack, filter_vision, scatter_units, has_ally, xp_mod_1, xp_mod_2, xp_mod_3, test_role_1, test_role_2, test_role_3, test_role_lua, events-test_nonfilterable, events-test_filterable1, events-test_filterable2, events-test_filterable3, events-test_victory, events-test_defeat, events-test_die, test_store_unit_defense_on, test_terrain_mask_simple_nop, test_terrain_mask_simple_set, test_terrain_mask_simple_underlay, test_terrain_mask_simple_overlay, test_terrain_mask_simple_name, test_terrain_mask_simple_name_fail, test_terrain_mask_align_odd_on_odd, test_terrain_mask_align_odd_on_even, test_terrain_mask_align_even_on_odd, test_terrain_mask_align_even_on_even, test_terrain_mask_align_raw_on_odd, test_terrain_mask_align_raw_on_even, test_terrain_mask_deprecated_border_no, test_terrain_mask_deprecated_border_yes, test_terrain_mask_rule_basic, lua_dofile, lua_require, lua_get_sides, test_wml_actions, test_wml_conditionals, lua_wml_tagnames, test_scoped_vars, as_text, store_locations_one, store_locations_range, simple_find_path, characterize_pathfinding_reach_1, characterize_pathfinding_reach_2, characterize_pathfinding_reach_3, characterize_pathfinding_reach_4, characterize_pathfinding_reach_5, characterize_pathfinding_reach_6, characterize_pathfinding_reach_7, test_elf_movement, test_orc_movement, test_elf_fast_cave_movement, test_elf_fast_hills_movement, test_elf_fast_cave_and_hills_movement, test_orc_fast_cave_movement, test_orc_fast_forest_movement, test_elf_slow_cave_movement, test_elf_longsighted_movement, test_orc_longsighted_movement, test_elf_longsighted_fast_cave_movement, test_elf_fast_cave_longsighted_movement, test_elf_vision, test_elf_fast_cave_vision, test_elf_fast_hills_vision, test_elf_longsighted_cave_vision, test_elf_longsighted_cave_and_hills_vision, test_elf_longsighted_cave_slow_cave_vision, test_resistances, effect_move_affects_vision, effect_move_ignores_vision, effect_vision, store_reachable_locations_vision, test_grunt_tod_damage, test_time_area_damage, test_time_area_prestart, test_berzerk_firststrike, feeding, swarm_disables_upgrades, swarm_disables_upgrades_with_abilities, swarm_disables_upgrades_with_abilities_fail, swarm_disables_upgrades_with_abilities_adjacent, swarm_disables_upgrades_with_abilities_adjacent_fail, swarm_disables_upgrades_with_abilities_adjacent_leadership, swarm_disables_upgrades_with_abilities_adjacent_leadership_fail, test_force_chance_to_hit_macro, recruit_facing_enemy_one, recruit_facing_enemy_two, recruit_facing_leader, recruit_facing_center, check_victory_basic_timeout, test_wml_menu_items_1, test_wml_menu_items_3, check_conditionals_1, check_conditionals_2, filter_this_unit_wml, filter_this_unit_tl, filter_this_unit_formula, filter_formula_unit, check_interrupts_break, check_interrupts_return, check_interrupts_continue, check_interrupts_break_global, check_interrupts_return_nested, check_interrupts_continue_global, check_interrupts_elseif, check_interrupts_case, forloop_all_zero, forloop_step_zero, forloop_once_positive, forloop_once_negative, forloop_twice_matched, forloop_twice_unmatched, forloop_empty_array, forloop_array, forloop_array_reverse, forloop_step_large_positive, forloop_step_large_negative, for_defaults, for_start2, for_end2, for_end2_step2, for_end-2, for_end-2_step-2, test_basic_simplified_aspect, test_basic_abbreviated_aspect, test_basic_standard_aspect, test_basic_composite_aspect, test_basic_lua_aspect, test_basic_composite_facet, test_basic_lua_facet, test_basic_composite_default_facet, test_basic_lua_default_facet, test_modify_ai_delete_facet, test_modify_ai_change_facet, test_modify_ai_replace_facet, test_modify_ai_add_facet, test_modify_ai_change_default_facet, test_modify_ai_nested_facets, test_modify_ai_composite_default_facets, test_modify_ai_change_aspect, test_create_side, order_of_variable_events1, order_of_variable_events2, event_name_variable_substitution, heal)
```

Output when a test fails during the main batch, without `-v`:
```
PASS TEST: test_return
PASS TEST: test_assert
PASS TEST: fixed_lua_random_replay_with_sync_choice
PASS TEST: test_end_turn
PASS TEST: cve_2018_1999023
... about 200 more PASS TEST lines ...
PASS TEST: test_force_chance_to_hit_macro
PASS TEST: recruit_facing_enemy_one
PASS TEST: recruit_facing_enemy_two
PASS TEST: recruit_facing_leader
PASS TEST: recruit_facing_center
FAIL TEST: check_victory_basic_fail

Failure, Wesnoth returned 1 FAIL but we expected 0 PASS
Passed 46 of 247 tests
Failed batches containing 201 tests: (test_return, test_assert, fixed_lua_random_replay_with_sync_choice, test_end_turn, cve_2018_1999023, two_plus_two, order_of_nested_events, test_clear_one, test_clear_two, test_unit_map, unit_spawns_at_nearest_vacant_hex, units_offmap_goto_recall, recall_by_unit_tag, test_move, test_move_unit, test_move_unit_in_circle, sighted_events, sighted_on_opponents_turn, move_skip_no_sighted_no_share_view, move_skip_ally_sighted_no_share_view, move_skip_all_sighted_no_share_view, move_skip_no_sighted_yes_share_view, move_skip_ally_sighted_yes_share_view, move_skip_all_sighted_yes_share_view, set_gold_in_prestart_one, set_gold_in_prestart_two, modify_turns_one, modify_turns_two, modify_turns_three, modify_turns_four, replace_schedule_prestart, modify_unit_facing, event_handlers_in_events_1, event_handlers_in_events_3, event_handlers_in_events_2, event_handlers_in_events_4, event_handlers_in_events_5, event_handlers_in_events_6, event_handlers_in_events_7, event_handlers_in_events_8, event_handers_in_events__delayed, event_handlers_in_events__dynamic_filter, event_remove_test, event_repeat_test, event_test_auto_variables_side_turn, event_test_auto_variables_xy, event_test_auto_variables_units, event_test_auto_variables_weapons, event_test_auto_variables_damage, event_test_auto_variables_owner, event_test_filter_condition, event_test_filter_side, event_test_filter_unit, event_test_filter_attack, filter_vision, scatter_units, has_ally, xp_mod_1, xp_mod_2, xp_mod_3, test_role_1, test_role_2, test_role_3, test_role_lua, events-test_nonfilterable, events-test_filterable1, events-test_filterable2, events-test_filterable3, events-test_victory, events-test_defeat, events-test_die, test_store_unit_defense_on, test_terrain_mask_simple_nop, test_terrain_mask_simple_set, test_terrain_mask_simple_underlay, test_terrain_mask_simple_overlay, test_terrain_mask_simple_name, test_terrain_mask_simple_name_fail, test_terrain_mask_align_odd_on_odd, test_terrain_mask_align_odd_on_even, test_terrain_mask_align_even_on_odd, test_terrain_mask_align_even_on_even, test_terrain_mask_align_raw_on_odd, test_terrain_mask_align_raw_on_even, test_terrain_mask_deprecated_border_no, test_terrain_mask_deprecated_border_yes, test_terrain_mask_rule_basic, lua_dofile, lua_require, lua_get_sides, test_wml_actions, test_wml_conditionals, lua_wml_tagnames, test_scoped_vars, as_text, store_locations_one, store_locations_range, simple_find_path, characterize_pathfinding_reach_1, characterize_pathfinding_reach_2, characterize_pathfinding_reach_3, characterize_pathfinding_reach_4, characterize_pathfinding_reach_5, characterize_pathfinding_reach_6, characterize_pathfinding_reach_7, test_elf_movement, test_orc_movement, test_elf_fast_cave_movement, test_elf_fast_hills_movement, test_elf_fast_cave_and_hills_movement, test_orc_fast_cave_movement, test_orc_fast_forest_movement, test_elf_slow_cave_movement, test_elf_longsighted_movement, test_orc_longsighted_movement, test_elf_longsighted_fast_cave_movement, test_elf_fast_cave_longsighted_movement, test_elf_vision, test_elf_fast_cave_vision, test_elf_fast_hills_vision, test_elf_longsighted_cave_vision, test_elf_longsighted_cave_and_hills_vision, test_elf_longsighted_cave_slow_cave_vision, test_resistances, effect_move_affects_vision, effect_move_ignores_vision, effect_vision, store_reachable_locations_vision, test_grunt_tod_damage, test_time_area_damage, test_time_area_prestart, test_berzerk_firststrike, feeding, swarm_disables_upgrades, swarm_disables_upgrades_with_abilities, swarm_disables_upgrades_with_abilities_fail, swarm_disables_upgrades_with_abilities_adjacent, swarm_disables_upgrades_with_abilities_adjacent_fail, swarm_disables_upgrades_with_abilities_adjacent_leadership, swarm_disables_upgrades_with_abilities_adjacent_leadership_fail, test_force_chance_to_hit_macro, recruit_facing_enemy_one, recruit_facing_enemy_two, recruit_facing_leader, recruit_facing_center, check_victory_basic_fail, test_wml_menu_items_1, test_wml_menu_items_3, check_conditionals_1, check_conditionals_2, filter_this_unit_wml, filter_this_unit_tl, filter_this_unit_formula, filter_formula_unit, check_interrupts_break, check_interrupts_return, check_interrupts_continue, check_interrupts_break_global, check_interrupts_return_nested, check_interrupts_continue_global, check_interrupts_elseif, check_interrupts_case, forloop_all_zero, forloop_step_zero, forloop_once_positive, forloop_once_negative, forloop_twice_matched, forloop_twice_unmatched, forloop_empty_array, forloop_array, forloop_array_reverse, forloop_step_large_positive, forloop_step_large_negative, for_defaults, for_start2, for_end2, for_end2_step2, for_end-2, for_end-2_step-2, test_basic_simplified_aspect, test_basic_abbreviated_aspect, test_basic_standard_aspect, test_basic_composite_aspect, test_basic_lua_aspect, test_basic_composite_facet, test_basic_lua_facet, test_basic_composite_default_facet, test_basic_lua_default_facet, test_modify_ai_delete_facet, test_modify_ai_change_facet, test_modify_ai_replace_facet, test_modify_ai_add_facet, test_modify_ai_change_default_facet, test_modify_ai_nested_facets, test_modify_ai_composite_default_facets, test_modify_ai_change_aspect, test_create_side, order_of_variable_events1, order_of_variable_events2, event_name_variable_substitution, heal)
```

With `-v` and all tests passing, it looks like this:
```
Running test test_return_fail
Running test test_assert_fail
Running test test_assert_fail_two
Running test empty_test
Running test break_replay_with_lua_random
Running test cve_2018_1999023_2
Running test check_victory_basic_timeout
Running test check_victory_basic_macro_check
Running test check_victory_basic
Running test check_victory_basic_fail
Running test check_victory_basic_two
Running test check_victory_basic_ai
Running test check_victory_basic_ai_fail
Running test check_victory_basic_ai_two
Running test check_victory_one_no_units_fail_one
Running test check_victory_one_no_units_fail_two
Running test check_victory_one_no_units
Running test check_victory_two_no_units_fail_one
Running test check_victory_two_no_units_fail_two
Running test check_victory_two_no_units
Running test check_victory_always_one
Running test check_victory_always_two
Running test check_victory_always_no_units_fail
Running test check_victory_always_no_units
Running test check_victory_always_fail
Running test check_victory_never_fail_one
Running test check_victory_never_fail_two
Running test check_victory_never_fail_three
Running test check_victory_never_pass
Running test check_victory_never_ai_fail
Running test two_plus_two_fail
Running test test_move_fail_1
Running test test_move_fail_2
Running test test_move_fail_3
Running test test_move_fail_4
Running test test_move_fail_5
Running test test_move_fail_6
Running test test_store_unit_defense_deprecated
Running test alice_kills_bob
Running test bob_kills_alice_on_retal
Running test alice_kills_bob_levelup
Running test bob_kills_alice
Running test alice_kills_bob_on_retal
Running test alice_kills_bob_on_retal_levelup
Running test test_wml_menu_items_2
Running test filter_formula_unit_error
Running 200 tests (test_return, test_assert, fixed_lua_random_replay_with_sync_choice, test_end_turn, cve_2018_1999023, two_plus_two, order_of_nested_events, test_clear_one, test_clear_two, test_unit_map, unit_spawns_at_nearest_vacant_hex, units_offmap_goto_recall, recall_by_unit_tag, test_move, test_move_unit, test_move_unit_in_circle, sighted_events, sighted_on_opponents_turn, move_skip_no_sighted_no_share_view, move_skip_ally_sighted_no_share_view, move_skip_all_sighted_no_share_view, move_skip_no_sighted_yes_share_view, move_skip_ally_sighted_yes_share_view, move_skip_all_sighted_yes_share_view, set_gold_in_prestart_one, set_gold_in_prestart_two, modify_turns_one, modify_turns_two, modify_turns_three, modify_turns_four, replace_schedule_prestart, modify_unit_facing, event_handlers_in_events_1, event_handlers_in_events_3, event_handlers_in_events_2, event_handlers_in_events_4, event_handlers_in_events_5, event_handlers_in_events_6, event_handlers_in_events_7, event_handlers_in_events_8, event_handers_in_events__delayed, event_handlers_in_events__dynamic_filter, event_remove_test, event_repeat_test, event_test_auto_variables_side_turn, event_test_auto_variables_xy, event_test_auto_variables_units, event_test_auto_variables_weapons, event_test_auto_variables_damage, event_test_auto_variables_owner, event_test_filter_condition, event_test_filter_side, event_test_filter_unit, event_test_filter_attack, filter_vision, scatter_units, has_ally, xp_mod_1, xp_mod_2, xp_mod_3, test_role_1, test_role_2, test_role_3, test_role_lua, events-test_nonfilterable, events-test_filterable1, events-test_filterable2, events-test_filterable3, events-test_victory, events-test_defeat, events-test_die, test_store_unit_defense_on, test_terrain_mask_simple_nop, test_terrain_mask_simple_set, test_terrain_mask_simple_underlay, test_terrain_mask_simple_overlay, test_terrain_mask_simple_name, test_terrain_mask_simple_name_fail, test_terrain_mask_align_odd_on_odd, test_terrain_mask_align_odd_on_even, test_terrain_mask_align_even_on_odd, test_terrain_mask_align_even_on_even, test_terrain_mask_align_raw_on_odd, test_terrain_mask_align_raw_on_even, test_terrain_mask_deprecated_border_no, test_terrain_mask_deprecated_border_yes, test_terrain_mask_rule_basic, lua_dofile, lua_require, lua_get_sides, test_wml_actions, test_wml_conditionals, lua_wml_tagnames, test_scoped_vars, as_text, store_locations_one, store_locations_range, simple_find_path, characterize_pathfinding_reach_1, characterize_pathfinding_reach_2, characterize_pathfinding_reach_3, characterize_pathfinding_reach_4, characterize_pathfinding_reach_5, characterize_pathfinding_reach_6, characterize_pathfinding_reach_7, test_elf_movement, test_orc_movement, test_elf_fast_cave_movement, test_elf_fast_hills_movement, test_elf_fast_cave_and_hills_movement, test_orc_fast_cave_movement, test_orc_fast_forest_movement, test_elf_slow_cave_movement, test_elf_longsighted_movement, test_orc_longsighted_movement, test_elf_longsighted_fast_cave_movement, test_elf_fast_cave_longsighted_movement, test_elf_vision, test_elf_fast_cave_vision, test_elf_fast_hills_vision, test_elf_longsighted_cave_vision, test_elf_longsighted_cave_and_hills_vision, test_elf_longsighted_cave_slow_cave_vision, test_resistances, effect_move_affects_vision, effect_move_ignores_vision, effect_vision, store_reachable_locations_vision, test_grunt_tod_damage, test_time_area_damage, test_time_area_prestart, test_berzerk_firststrike, feeding, swarm_disables_upgrades, swarm_disables_upgrades_with_abilities, swarm_disables_upgrades_with_abilities_fail, swarm_disables_upgrades_with_abilities_adjacent, swarm_disables_upgrades_with_abilities_adjacent_fail, swarm_disables_upgrades_with_abilities_adjacent_leadership, swarm_disables_upgrades_with_abilities_adjacent_leadership_fail, test_force_chance_to_hit_macro, recruit_facing_enemy_one, recruit_facing_enemy_two, recruit_facing_leader, recruit_facing_center, test_wml_menu_items_1, test_wml_menu_items_3, check_conditionals_1, check_conditionals_2, filter_this_unit_wml, filter_this_unit_tl, filter_this_unit_formula, filter_formula_unit, check_interrupts_break, check_interrupts_return, check_interrupts_continue, check_interrupts_break_global, check_interrupts_return_nested, check_interrupts_continue_global, check_interrupts_elseif, check_interrupts_case, forloop_all_zero, forloop_step_zero, forloop_once_positive, forloop_once_negative, forloop_twice_matched, forloop_twice_unmatched, forloop_empty_array, forloop_array, forloop_array_reverse, forloop_step_large_positive, forloop_step_large_negative, for_defaults, for_start2, for_end2, for_end2_step2, for_end-2, for_end-2_step-2, test_basic_simplified_aspect, test_basic_abbreviated_aspect, test_basic_standard_aspect, test_basic_composite_aspect, test_basic_lua_aspect, test_basic_composite_facet, test_basic_lua_facet, test_basic_composite_default_facet, test_basic_lua_default_facet, test_modify_ai_delete_facet, test_modify_ai_change_facet, test_modify_ai_replace_facet, test_modify_ai_add_facet, test_modify_ai_change_default_facet, test_modify_ai_nested_facets, test_modify_ai_composite_default_facets, test_modify_ai_change_aspect, test_create_side, order_of_variable_events1, order_of_variable_events2, event_name_variable_substitution, heal)
Passed 246 of 246 tests
```