### PR TITLE
Fix save_index issues

### DIFF
--- a/src/save_index.hpp
+++ b/src/save_index.hpp
@@ -124,6 +124,8 @@ private:
 	config& data();
 
 	static void fix_leader_image_path(config& data);
+	/** Deletes non-existent save files from the index. */
+	void clean_up_index();
 
 	bool loaded_;
 	config data_;
@@ -134,5 +136,7 @@ private:
 	 * write_save_index() and delete() are no-ops.
 	 */
 	bool read_only_;
+	/** Flag to only run the clean_up_index method once. */
+	bool clean_up_index_;
 };
 } // end of namespace savegame

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -541,8 +541,6 @@ void savegame::finish_save_game(const config_writer& out)
 		if(!out.good()) {
 			throw game::save_game_failed(_("Could not write to file"));
 		}
-
-		save_index_manager_->remove(gamestate_.classification().label);
 	} catch(const filesystem::io_exception& e) {
 		throw game::save_game_failed(e.what());
 	}


### PR DESCRIPTION
This pull request fixes some issues related to save_index:
* fixes a bug in save_index_class::remove() method.
  The method incorrectly tries to remove an attribute from root config instead of removing 'save' children.
  In effect, save files were not being removed from the save_index file.
* removes call to save_index_manager_->remove() in savegame::finish_save_game
  This call to remove() is incorrect and has no effect except causing unneeded call to write_save_index().
* introduces a new clean_up_index() method in save_index_class.
  The method removes non-existing save files from the index. Clean up is triggered only during the first
  synchronisation of the index to disc and only if the index has more save files than found on disk.

Fixes  #5702.