### PR TITLE
fix text don't readable because duration not specified

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -29,7 +29,7 @@
 					wesnoth.wml_actions.print{
 						text = splash:vformat{units_to_slay = n},
 						size = 18,
-						duration = 1000,
+						duration = 2000,
 						red = 255, green = 255, blue = 255
 					}
 				end

--- a/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/23_Test_of_the_Clans.cfg
@@ -29,6 +29,7 @@
 					wesnoth.wml_actions.print{
 						text = splash:vformat{units_to_slay = n},
 						size = 18,
+						duration = 1000,
 						red = 255, green = 255, blue = 255
 					}
 				end


### PR DESCRIPTION
When a enemy is killed in 23_Test_of_the_Clans.cfg of Httt, the show of number to enmy to vanquish is too breve for be read.