### PR TITLE
[World Conquest] multiple deprecated code fixes

### DIFF
--- a/data/campaigns/World_Conquest/changelog.txt
+++ b/data/campaigns/World_Conquest/changelog.txt
@@ -30,6 +30,13 @@ email=#####
 
 # Changelog:
 
+0.8.3:
+- fixed some instances of deprecated Lua
+- re-added Dunefolk in selection
+- re-enabled "The Empire" faction in World Conquest MP Era
+- slightly reduced the overall difficulty (100% --> 75%)
+- update changelog
+
 0.8.2:
 - misc bugfixes, mostly related to the new lua map generator
 - Disable dune piercer and The empire faction, since units were 

--- a/data/campaigns/World_Conquest/era/campaign/heroes.cfg
+++ b/data/campaigns/World_Conquest/era/campaign/heroes.cfg
@@ -297,10 +297,9 @@
     [Bonus]
         types="Goblin Spearman,Walking Corpse,Ruffian,Peasant,Woodsman"
     [/Bonus]
-    [Khalifate]
-        #TODO: this contained 'Dune Piercer' in 1.14
-        types="Dune Rover,Dune Rider,Dune Burner,Dune Herbalist,Dune Soldier"
-    [/Khalifate]
+    [Dunefolk]
+        types="Dune Rover,Dune Rider,Dune Skirmisher,Dune Burner,Dune Herbalist,Dune Soldier"
+    [/Dunefolk]
     [Empire_commanders]
         types="Elvish Fighter,Dwarvish Fighter,Orcish Archer,Spearman,Drake Burner"
     [/Empire_commanders]
@@ -311,6 +310,6 @@
         types="Heavy Infantryman,Sergeant,Drake Glider,Saurian Augur,Elvish Shaman,Elvish Scout,Thug,Dwarvish Scout,Troll Whelp,Orcish Assassin,Ghoul,Skeleton Archer"
     [/Empire_deserters]
     [Bonus_All]
-        types="Northerners_All,Rebels_All,Loyalists_All,Knalgans_All,Drakes,Undead_All,Young Ogre,Thug,Bonus,Khalifate"
+        types="Northerners_All,Rebels_All,Loyalists_All,Knalgans_All,Drakes,Undead_All,Young Ogre,Thug,Bonus,Dunefolk"
     [/Bonus_All]
 #enddef

--- a/data/campaigns/World_Conquest/era/era.cfg
+++ b/data/campaigns/World_Conquest/era/era.cfg
@@ -22,7 +22,7 @@
         {MULTIPLAYER_SIDE_THE_SCOURGE}
         {MULTIPLAYER_SIDE_THE_ALLIANCE}
         #TODO: disabled since it contains 'Dune Piercer'
-        # {MULTIPLAYER_SIDE_THE_EMPIRE}
+        {MULTIPLAYER_SIDE_THE_EMPIRE}
         [load_resource]
             id = "wc2_era_res{ID_SUFFIX}"
         [/load_resource]

--- a/data/campaigns/World_Conquest/era/era.cfg
+++ b/data/campaigns/World_Conquest/era/era.cfg
@@ -21,7 +21,6 @@
         {MULTIPLAYER_SIDE_THE_GANG}
         {MULTIPLAYER_SIDE_THE_SCOURGE}
         {MULTIPLAYER_SIDE_THE_ALLIANCE}
-        #TODO: disabled since it contains 'Dune Piercer'
         {MULTIPLAYER_SIDE_THE_EMPIRE}
         [load_resource]
             id = "wc2_era_res{ID_SUFFIX}"

--- a/data/campaigns/World_Conquest/era/factions/Random.cfg
+++ b/data/campaigns/World_Conquest/era/factions/Random.cfg
@@ -6,7 +6,5 @@
         name= _ "Random"
         image= units/random-dice.png
         random_faction=yes
-        ## The empire is not complteley blaanced to exclude it for now from random.
-        # except=The Empire
     [/multiplayer_side]
 #enddef

--- a/data/campaigns/World_Conquest/era/factions/Random.cfg
+++ b/data/campaigns/World_Conquest/era/factions/Random.cfg
@@ -7,6 +7,6 @@
         image= units/random-dice.png
         random_faction=yes
         ## The empire is not complteley blaanced to exclude it for now from random.
-        except=The Empire
+        # except=The Empire
     [/multiplayer_side]
 #enddef

--- a/data/campaigns/World_Conquest/era/factions/The_Empire.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Empire.cfg
@@ -4,28 +4,27 @@
     [multiplayer_side]
         id=The Empire
         name={STR_EMPIRE}
-        recruit=Dune Rover,Elvish Fighter,Dune Burner,Drake Burner,Dune Soldier,Spearman,Dune Piercer,Dwarvish Fighter,Dune Herbalist,Dune Herbalist,Dune Rider,Orcish Archer,Falcon,Vampire Bat
+        recruit=Dune Rover,Elvish Fighter,Dune Burner,Drake Burner,Dune Soldier,Spearman,Dune Skirmisher,Dwarvish Fighter,Dune Herbalist,Dune Herbalist,Dune Rider,Orcish Archer,Falcon,Vampire Bat
         image={IMG_EMPIRE}
         type=random
         leader= Dune Explorer,Dune Swordsman,Dune Spearguard,Dune Skirmisher,Dune Apothecary,Dune Scorcher
         random_leader= {RANDOM_LEADERS_EMPIRE}
         [world_conquest_data]
-            commanders=Khalifate,Empire_commanders
+            commanders=Dunefolk,Empire_commanders
             heroes=Empire_heroes
             deserters=Empire_deserters,Young Ogre
             {WC_II_PAIR "Dune Rover" "Elvish Fighter"}
             {WC_II_PAIR "Dune Burner" "Drake Burner"}
             {WC_II_PAIR "Dune Soldier" "Spearman"}
-            {WC_II_PAIR "Dune Piercer" "Dwarvish Fighter"}
+            {WC_II_PAIR "Dune Skirmisher" "Dwarvish Fighter"}
             {WC_II_PAIR "Dune Herbalist" "Dune Herbalist"}
             {WC_II_PAIR "Dune Rider" "Orcish Archer"}
-            {WC_II_PAIR "Falcon" "Vampire Bat"}
         [/world_conquest_data]
     [/multiplayer_side]
 #enddef
 
 #define RANDOM_LEADERS_EMPIRE
-Dune Explorer,Dune Swordsman,Dune Spearguard,Dune Skirmisher,Dune Scorcher #enddef
+Dune Explorer,Dune Swordsman,Dune Spearguard,Dune Strider,Dune Scorcher #enddef
 
 #define IMG_EMPIRE
-"misc/blank-hex.png~BLIT(units/dunefolk/scorcher.png~RC(magenta>teal)~CROP(0,13,57,59),15,0)~BLIT(units/dunefolk/explorer.png~RC(magenta>teal)~FL()~CROP(11,0,61,67),0,5)" #enddef
+"misc/blank-hex.png~BLIT(units/dunefolk/burner/scorcher.png~RC(magenta>teal)~CROP(0,13,57,59),15,0)~BLIT(units/dunefolk/rover/explorer.png~RC(magenta>teal)~FL()~CROP(11,0,61,67),0,5)" #enddef

--- a/data/campaigns/World_Conquest/lua/campaign/enemy.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/enemy.lua
@@ -209,7 +209,7 @@ function enemy.do_gold(cfg, side)
 	--difficulty_enemy_power is in [6,9]
 	local enemy_power = (wml.variables["wc2_difficulty.enemy_power"] or 6)
 	local factor = (cfg.nplayers + 1 ) * enemy_power/6 - 2
-	side.gold = side.gold + cfg.bonus_gold * factor * 0.75
+	side.gold = side.gold + cfg.bonus_gold * factor
 end
 
 function enemy.init_data()

--- a/data/campaigns/World_Conquest/lua/campaign/enemy.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/enemy.lua
@@ -209,7 +209,7 @@ function enemy.do_gold(cfg, side)
 	--difficulty_enemy_power is in [6,9]
 	local enemy_power = (wml.variables["wc2_difficulty.enemy_power"] or 6)
 	local factor = (cfg.nplayers + 1 ) * enemy_power/6 - 2
-	side.gold = side.gold + cfg.bonus_gold * factor
+	side.gold = side.gold + cfg.bonus_gold * factor * 0.75
 end
 
 function enemy.init_data()

--- a/data/campaigns/World_Conquest/lua/campaign/enemy_data.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/enemy_data.lua
@@ -300,6 +300,56 @@ enemy_army.group = {
 			},
 		}
 	},
+	{
+		id = "dunefolk",
+		recruit = {"Dune Soldier","Dune Burner","Dune Rider","Dune Skirmisher","Dune Rover","Naga Dirkfang"},
+		recall = {
+			level2 = {"Dune Captain","Dune Strider","Dune Scorcher","Dune Alchemist","Dune Falconer","Dune Swordsman","Dune Horse Archer","Dune Sunderer","Dune Scorcher","Dune Apothecary","Dune Swordsman","Dune Spearguard"},
+			level3 = {"Dune Blademaster","Dune Sky Hunter","Dune Firetrooper","Dune Warmaster","Dune Cataphract","Dune Blademaster","Dune Luminary","Dune Firetrooper","Dune Spearmaster","Dune Cataphract"},
+		},
+		commander = {
+			level1 = {"Dune Soldier","Dune Soldier","Dune Burner","Dune Skirmisher"},
+			level2 = {"Dune Captain","Dune Spearguard","Dune Strider","Dune Scorcher","Dune Alchemist","Dune Apothecary","Dune Swordsman"},
+			level3 = {"Dune Blademaster","Dune Luminary","Dune Firetrooper","Dune Warmaster","Dune Spearmaster"},
+		},
+		leader = {
+			{
+				level2 = "Dune Swordsman",
+				level3 = "Dune Blademaster",
+				recruit = {"Dune Soldier","Dune Burner","Dune Rider","Dune Skirmisher"},
+			},
+			{
+				level2 = "Dune Apothecary",
+				level3 = "Dune Luminary",
+				recruit = {"Dune Soldier","Dune Burner","Dune Skirmisher","Dune Herbalist"},
+			},
+			{
+				level2 = "Dune Alchemist",
+				level3 = "Dune Spearmaster",
+				recruit = {"Dune Soldier","Dune Skirmisher","Dune Rider","Dune Herbalist"},
+			},
+			{
+				level2 = "Dune Scorcher",
+				level3 = "Dune Firetrooper",
+				recruit = {"Dune Soldier","Dune Burner","Dune Rider","Dune Skirmisher"},
+			},
+			{
+				level2 = "Dune Strider",
+				level3 = "Dune Harrier",
+				recruit = {"Dune Soldier","Dune Burner","Dune Rider","Dune Skirmisher","Naga Dirkfang"},
+			},
+			{
+				level2 = "Dune Raider",
+				level3 = "Dune Marauder",
+				recruit = {"Dune Skirmisher","Dune Soldier","Dune Rider","Dune Burner","Dune Herbalist"},
+			},
+			{
+				level2 = "Dune Captain",
+				level3 = "Dune Warmaster",
+				recruit = {"Dune Soldier","Dune Rover","Dune Rider","Dune Burner"},
+			},
+		}
+	},
 }
 enemy_army.factions_available = {}
 -- each faction can be picked up to 4 times along campaign

--- a/data/campaigns/World_Conquest/lua/game_mechanics/artifacts.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/artifacts.lua
@@ -182,7 +182,7 @@ on_event("die", function(event_context)
 	if not wml.variables["wc2_config_experimental_pickup"] and wc2_scenario.is_human_side(unit.side) then
 		return
 	end
-	for object in helper.child_range(wml.get_child(unit.__cfg, "modifications") or {}, "object") do
+	for object in wml.child_range(wml.get_child(unit.__cfg, "modifications") or {}, "object") do
 		if object.wc2_atrifact_id then
 			artifacts.place_item(unit.x, unit.y, object.wc2_atrifact_id)
 			artifacts.drop_message(object.wc2_atrifact_id)

--- a/data/campaigns/World_Conquest/lua/game_mechanics/effects.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/effects.lua
@@ -26,7 +26,7 @@ function wesnoth.effects.wc2_optional_attack(u, cfg)
 		end
 	end
 	for k,v in ipairs(attacks_to_add) do
-		wesnoth.add_modification(u, "object", { T.effect ( v)}, false)
+		wesnoth.units.add_modification(u, "object", { T.effect ( v)}, false)
 	end
 
 	if #names > 0 then
@@ -34,13 +34,13 @@ function wesnoth.effects.wc2_optional_attack(u, cfg)
 		attack_mod.apply_to = "attack"
 		attack_mod.name = table.concat(names, ",")
 
-		wesnoth.add_modification(u, "object", { T.effect (attack_mod) }, false)
+		wesnoth.units.add_modification(u, "object", { T.effect (attack_mod) }, false)
 	end
 end
 
 -- The implementation of the moves defense bonus in movement training.
 function wesnoth.effects.wc2_moves_defense(u, cfg)
-	wesnoth.add_modification(u, "object", { T.effect {
+	wesnoth.units.add_modification(u, "object", { T.effect {
 		apply_to = "defense",
 		replace = false,
 		T.defense {
@@ -78,7 +78,7 @@ function wesnoth.effects.wc2_min_resistance(u, cfg)
 			end
 		end
 	end
-	wesnoth.add_modification(u, "object", {
+	wesnoth.units.add_modification(u, "object", {
 		T.effect {
 			apply_to = "resistance",
 			replace = true,
@@ -97,7 +97,7 @@ function wesnoth.effects.wc2_min_defense(u, cfg)
 			defense_new[k] = v
 		end
 	end
-	wesnoth.add_modification(u, "object", {
+	wesnoth.units.add_modification(u, "object", {
 		T.effect {
 			apply_to = "defense",
 			replace = true,
@@ -127,7 +127,7 @@ function wesnoth.effects.wc2_update_aura(u, cfg)
 		halo = "halo/illuminates-aura.png"
 	end
 	
-	wesnoth.add_modification(u, "object", {
+	wesnoth.units.add_modification(u, "object", {
 		T.effect {
 			apply_to = "halo",
 			halo = halo,
@@ -156,7 +156,7 @@ function wesnoth.effects.wc2_overlay(u, cfg)
 		cfg.add = table.concat(to_add_new,",")
 	end
 	cfg.apply_to = "overlay"
-	wesnoth.add_modification(u, "object", { T.effect(cfg)} , false)
+	wesnoth.units.add_modification(u, "object", { T.effect(cfg)} , false)
 end
 
 -- Can move in same turn as when recruited/recalled

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -173,7 +173,7 @@ function training.give_bonus(side_num, cx, amount, traintype_index)
 		speaker = teacher.id,
 		message = traintype.dialogue,
 	}
-	wesnoth.extract_unit(teacher)
+	wesnoth.units.extract(teacher)
 	local message = training.generate_message(traintype_index, new_level)
 	wesnoth.wml_actions.message(message)
 

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/1A_Start.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/1A_Start.lua
@@ -133,7 +133,7 @@ function wct_map_1_post_castle_expansion_fix()
 end
 
 function wct_store_possible_encampment_ford()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Ww"),
 		f.adjacent(f.terrain("Ce,Chw,Chs*^V*")),
 		f.adjacent(f.terrain("W*^B*,Wo"), nil, 0)

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/2A_Springs.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/2A_Springs.lua
@@ -20,7 +20,7 @@ function world_conquest_tek_map_decoration_2a()
 
 	-- chances of tropical palm forest near caves
 	if wesnoth.random(2) == 1 then
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Hh*^F*"),
 			f.adjacent(f.terrain("Xu,U*^*,Mv,Ql,Qxu"))
 		))
@@ -33,7 +33,7 @@ function world_conquest_tek_map_decoration_2a()
 		end
 	end
 	if wesnoth.random(2) == 1 then
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("G*^F*"),
 			f.adjacent(f.terrain("Xu,U*^*,Mv,Ql,Qxu"))
 		))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/2B_Lakes.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/2B_Lakes.lua
@@ -2,7 +2,7 @@
 local function world_conquest_tek_map_repaint_2b()
 	-- Add snow and ice
 	if wesnoth.random(2) == 1 then
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("!,Ss,D*^*,Hd,W*^*,Mm^Xm,Xu,Mv,Q*^*,U*^*"),
 			f.radius(2, f.terrain("M*^*"))
 		))
@@ -141,7 +141,7 @@ local function world_conquest_tek_map_repaint_2b()
 
 	end
 	-- chance of diferent forest based in map temperature
-	local terrain_to_change = map:get_locations(f.terrain("A*^*,Ha*^*,Ms^*"))
+	local terrain_to_change = map:find(f.terrain("A*^*,Ha*^*,Ms^*"))
 
 	local chance = 2000 * #terrain_to_change // total_tiles
 	if wesnoth.random(0, 99 ) > chance then

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/2C_Glaciers.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/2C_Glaciers.lua
@@ -137,7 +137,7 @@ function world_conquest_tek_map_decoration_2c()
 		fraction = 15,
 	}
 
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("Wo"),
 		f.adjacent(f.terrain("!,Wo"), nil, 0)
 	))
@@ -148,7 +148,7 @@ function world_conquest_tek_map_decoration_2c()
 		map[terrain_to_change[i]] = "Ai"
 	end
 
-	local icepack_candiates = map:get_locations(f.all(
+	local icepack_candiates = map:find(f.all(
 		f.terrain("Wo"),
 		f.adjacent(f.terrain("!,Wo,Ai"), nil, 0)
 	))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/2D_Provinces.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/2D_Provinces.lua
@@ -26,27 +26,27 @@ end
 
 function world_conquest_tek_map_decoration_2d()
 	for i = 1, 2 do
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Hh,Mm,Mm^Xm,Xu,*^F*"),
 			f.adjacent(f.terrain("D*^*,Hd*^*")),
 			wct_provinces_castle_separation()
 		))
 		wct_provinces_castle(terrain_to_change, "Cd")
 
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Hh^F*"),
 			wct_provinces_castle_separation()
 		))
 		wct_provinces_castle(terrain_to_change,  "Cv^Fds")
 
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Hh"),
 			f.none(f.radius(2, f.terrain("D*^*,Hd*^*"))),
 			wct_provinces_castle_separation()
 		))
 		wct_provinces_castle(terrain_to_change,  "Ce")
 
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Mm"),
 			wct_provinces_castle_separation()
 		))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/2E_Paradise.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/2E_Paradise.lua
@@ -123,7 +123,7 @@ end
 function wct_map_yard(directions, counter_directions)
 	-- todo: is this code 'symmetric' andin the sense that switching
 	--       directions and counter_directions  doesn't change anythign at all?
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("Gg"),
 		f.adjacent(f.terrain("Gg"), directions, 3),
 		f.any(
@@ -145,7 +145,7 @@ function wct_map_yard(directions, counter_directions)
 end
 
 function wct_conect_isolated_citadel()
-	local isolated = map:get_locations(f.all(
+	local isolated = map:find(f.all(
 		f.terrain("Rr*^*,Ch,Kh,W*^Bsb*"),
 		f.adjacent(f.terrain("R*^*,Ch,Kh,W*^Bsb*"), nil, 0)
 	))
@@ -165,7 +165,7 @@ function wct_conect_isolated_citadel()
 end
 
 function wct_store_empty_citadel()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Rr"),
 		f.none(
 			f.radius(4, f.terrain("Rr^Vhc"), f.terrain("Rr*^*,Ch*,Kh*,W*^Bsb*"))
@@ -186,7 +186,7 @@ function wct_map_decoration_3e_keeps()
 end
 
 function wct_map_decoration_3e_leantos()
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("Rr"),
 		f.none(
 			f.find_in("bonus_point")

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/3C_Delta.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/3C_Delta.lua
@@ -51,7 +51,7 @@ function world_conquest_tek_map_constructor_delta()
 		end
 	end
 
-	local water_tiles = map:get_locations(f.terrain("W*"))
+	local water_tiles = map:find(f.terrain("W*"))
 	for i, loc in ipairs(water_tiles) do
 		-- todo: it mighjt be nice to add suppot for a lua function filter, so that we
 		--      can pass is_in_octaegon to get_location, and use set_terrain directly.

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/3F_Wetland.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/3F_Wetland.lua
@@ -238,7 +238,7 @@ function wct_map_3f_post_bunus_decoration(bonus_points)
 end
 
 function wct_store_cave_passages_candidates()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Mm^Xm"),
 		f.adjacent(f.terrain("Mm^Xm,Xu"), nil, "2-6"),
 		f.adjacent(f.terrain("U*^*"))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/4B_Volcanic.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/4B_Volcanic.lua
@@ -187,7 +187,7 @@ function world_conquest_tek_map_repaint_4b()
 	}
 
 	-- create volcanos where possible and force one
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("Ql"),
 		f.adjacent(f.terrain("M*,M*^Xm"), "se,s,sw", 2),
 		f.adjacent(f.terrain("K*^*,C*^*,*^V"), "se,s,sw", 0)
@@ -207,7 +207,7 @@ function world_conquest_tek_map_repaint_4b()
 			f.adjacent(f.terrain("Md^Xm,Md"), "se,s,sw", 3)
 		),
 	}
-	local terrain_to_change = map:get_locations(f.terrain("Mv"))
+	local terrain_to_change = map:find(f.terrain("Mv"))
 
 	for i, v in ipairs(terrain_to_change) do
 		local loc = terrain_to_change[i]
@@ -276,7 +276,7 @@ function world_conquest_tek_map_repaint_4b()
 	}
 
 	-- mushrooms, base amount in map surface
-	local terrain_to_change = map:get_locations(f.terrain("Hhd,Hhd^F^*"))
+	local terrain_to_change = map:find(f.terrain("Hhd,Hhd^F^*"))
 	helper.shuffle(terrain_to_change)
 	local r = helper.rand(tostring(total_tiles // 600) .. ".." .. tostring(total_tiles // 300))
 
@@ -315,7 +315,7 @@ function world_conquest_tek_map_repaint_4b()
 	}
 
 	-- whirpools
-	local whirlpool_candidats  = map:get_locations(f.all(
+	local whirlpool_candidats  = map:find(f.all(
 		f.terrain("Ww"),
 		f.adjacent(f.terrain("Wo")),
 		f.adjacent(f.terrain("Uue"))
@@ -352,7 +352,7 @@ function world_conquest_tek_map_repaint_4b()
 	}
 
 	-- very dirt coast
-	local terrain_to_change = map:get_locations(f.terrain("Ds"))
+	local terrain_to_change = map:find(f.terrain("Ds"))
 
 	helper.shuffle(terrain_to_change)
 	for i = 1, #terrain_to_change // wesnoth.random(3, 4) do

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/4C_Mines.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/4C_Mines.lua
@@ -5,7 +5,7 @@ local images = {
 
 function wct_map_4c_conect_rails()
 	-- conect rails where possible
-	local terrain_to_change = map:get_locations(f.any(
+	local terrain_to_change = map:find(f.any(
 		f.all(
 			f.terrain("*^Br|"),
 			f.adjacent(f.terrain("*^Br*"), "n,s", 0)
@@ -256,7 +256,7 @@ function world_conquest_tek_map_repaint_4c()
 end
 function wct_map_4c_post_bunus_decoration()
 	-- dwarvish forges and keeps
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("*^Uf"),
 		f.adjacent(f.terrain("*^Vud"))
 	))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/4F_Wild.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/4F_Wild.lua
@@ -50,7 +50,7 @@ function repaint(map_data)
 	local heights = wesnoth.dofile("./../postgeneration_utils/wild_zones.lua")
 
 	-- store and remove villages
-	local villages = map:get_locations(f.terrain("*^Vh"))
+	local villages = map:find(f.terrain("*^Vh"))
 	set_terrain { "*",
 		f.terrain("*^Vh"),
 		layer = "overlay",
@@ -213,7 +213,7 @@ function wild_zones_store(heights)
 	for i_height, height in ipairs(heights) do
 		for i_temp, temp in ipairs(height) do
 			-- oldname: 'regions'
-			temp.all_locs = map:get_locations(f.terrain(temp.terrain))
+			temp.all_locs = map:find(f.terrain(temp.terrain))
 			-- oldname: 'zone[$zone_i].loc'
 			temp.zones = connected_components(temp.all_locs)
 		end
@@ -255,11 +255,11 @@ end
 
 -- to place right image in bonus points
 function wild_store_cave_zone(map_data)
-	map_data.road_in_cave = map:get_locations(f.terrain("X*^*"))
+	map_data.road_in_cave = map:find(f.terrain("X*^*"))
 end
 
 function wild_store_roads_in_cave_zone(map_data)
-	map_data.road_in_cave = map:get_locations(f.terrain("R*,Ur"), map_data.road_in_cave)
+	map_data.road_in_cave = map:find(f.terrain("R*,Ur"), map_data.road_in_cave)
 end
 
 local _ = wesnoth.textdomain 'wesnoth-wc'

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/6A_Rural.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/6A_Rural.lua
@@ -167,7 +167,7 @@ local function world_conquest_tek_map_decoration_6a()
 	}
 
 	-- add snow, base amount in map surface
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("!,Ss,D*^*,Hd,W*^*,Mm^Xm,Xu,Mv,Q*^*,U*^*"),
 		f.radius(3, f.all(
 			f.terrain("Gd^Fdf,Hh,Hh^Fdf"),
@@ -275,7 +275,7 @@ local function world_conquest_tek_map_decoration_6a()
 		terrain_to_change = wct_store_possible_dwarven_castle()
 	end
 	-- decorative farmlands in base to log villages
-	local terrain_to_change = map:get_locations(f.terrain("Gs^Vl"))
+	local terrain_to_change = map:find(f.terrain("Gs^Vl"))
 	for i = 1, wesnoth.random(0, 2 * #terrain_to_change) do
 		set_terrain { "Gg^Gvs",
 			f.all(
@@ -320,7 +320,7 @@ local function world_conquest_tek_map_decoration_6a()
 
 	-- chance of fences near farmlands
 	if wesnoth.random(2) == 1 then
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Gs,Gg,Gll,Aa,Ai"),
 			f.adjacent(f.terrain("Gg^Gvs")),
 			f.adjacent(f.all(

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/6B_Maritime.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/6B_Maritime.lua
@@ -8,7 +8,7 @@ function get_possible_maritime_bridge()
 	return {
 		{
 			type = "Bsb|",
-			locs = map:get_locations(f.all(
+			locs = map:find(f.all(
 				f.terrain("Ww"),
 				f.adjacent(f.terrain("Chw"), "s,n", nil),
 				f.adjacent(f.terrain("Ch,Kh"), "s,n", nil),
@@ -17,7 +17,7 @@ function get_possible_maritime_bridge()
 		},
 		{
 			type = "Bsb\\",
-			locs = map:get_locations(f.all(
+			locs = map:find(f.all(
 				f.terrain("Ww"),
 				f.adjacent(f.terrain("Chw"), "se,nw", nil),
 				f.adjacent(f.terrain("Ch,Kh"), "se,nw", nil),
@@ -26,7 +26,7 @@ function get_possible_maritime_bridge()
 		},
 		{
 			type = "Bsb/",
-			locs = map:get_locations(f.all(
+			locs = map:find(f.all(
 				f.terrain("Ww"),
 				f.adjacent(f.terrain("Chw"), "sw,ne", nil),
 				f.adjacent(f.terrain("Ch,Kh"), "sw,ne", nil),
@@ -61,7 +61,7 @@ function roads_to_dock(radius)
 end
 
 function wct_roads_to_dock(radius)
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("!,W*^*"),
 		f.adjacent(f.all(
 			f.terrain("Iwr^Vl,Rp"),
@@ -103,7 +103,7 @@ function wct_roads_to_river(radius)
 	local f_src = f.terrain("*^Vhc")
 	local f_path_taken = f.terrain("Rp")
 
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f_valid_path_tiles,
 		-- adjacent to open ends or startign points.
 		f.adjacent(f.all(
@@ -184,8 +184,8 @@ function world_conquest_tek_map_decoration_6b()
 	roads_to_dock(4)
 	roads_to_river(4)
 
-	if #map:get_locations(f.terrain("Iwr^Vl")) == 0 then
-		local locs = map:get_locations(f.all(
+	if #map:find(f.terrain("Iwr^Vl")) == 0 then
+		local locs = map:find(f.all(
 			f.terrain("*^V*"),
 			f.adjacent(f.terrain("W*^*"), nil, "2-5"),
 			f.adjacent(f.terrain("Wog,Wwg"))
@@ -236,7 +236,7 @@ function world_conquest_tek_map_decoration_6b()
 			f.adjacent(f.terrain("Iwr"), "s,n", nil)
 		),
 	}
-	local locs = map:get_locations(f.terrain("Iwr"))
+	local locs = map:find(f.terrain("Iwr"))
 	for ship_i, ship_loc in ipairs(locs) do
 		if wesnoth.random(2) == 1 then
 			table.insert(prestart_event, wml.tag.item {
@@ -370,7 +370,7 @@ function world_conquest_tek_map_decoration_6b()
 	-- chance of expand rivers into sea
 	local r = tonumber(helper.rand("0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,2,2,3"))
 	for i = 1 , r do
-		local terrain_to_change = map:get_locations(f.all(
+		local terrain_to_change = map:find(f.all(
 			f.terrain("Wog,Wwg,Wwrg"),
 			f.adjacent(f.terrain("Ww,Wwf,Wo"))
 		))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/6C_Industrial.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/6C_Industrial.lua
@@ -1,11 +1,11 @@
 -- Industrial
 -- TODO: this is somwwhta slow, maybe it because it used wct_iterate_road_to ?
 local function wct_conect_factory_rails()
-	local rails_conected = map:get_locations(f.all(
+	local rails_conected = map:find(f.all(
 		f.terrain("*^Br*"),
 		f.adjacent(f.terrain("*^Vhh"))
 	))
-	while #map:get_locations(wesnoth.map.filter(
+	while #map:find(wesnoth.map.filter(
 		f.all(
 			f.terrain("*^Br*"),
 			f.adjacent(f.find_in("rails_conected")),
@@ -55,7 +55,7 @@ local function wct_conect_factory_rails()
 			filter_extra = { rails_conected = rails_conected },
 			layer = "overlay",
 		}
-		rails_conected = map:get_locations(wesnoth.map.filter(
+		rails_conected = map:find(wesnoth.map.filter(
 			f.all(
 				f.terrain("*^Br*"),
 				f.radius(1, f.find_in("rails_conected"))
@@ -93,7 +93,7 @@ local function wct_conect_factory_rails()
 end
 
 local function wct_store_possible_dirty_delta()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Wwg,Sm"),
 		f.adjacent(f.terrain("Wwg^*,Sm^*"), nil, "5-6")
 	))
@@ -111,7 +111,7 @@ local function wct_dirty_deltas()
 end
 
 local function wct_store_possible_ford_delta()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Wwf"),
 		f.adjacent(f.terrain("W*^*"), nil, "5-6")
 	))
@@ -132,7 +132,7 @@ end
 
 local function wct_rails_to_industrial_keep(radius)
 	-- "Cud^Br|"
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("C*"),
 		f.adjacent(f.all(
 			f.terrain("*^Br*,*^Vhh"),
@@ -150,7 +150,7 @@ end
 
 local function wct_roads_to_industrial_village(radius)
 	-- "Rb"
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("!,W*^*,*^V*,*^Bcx*,Urb,C*,K*^*,R*"),
 		f.adjacent(f.all(
 			f.terrain("*^Ve,*^Vl,Rb"),
@@ -168,7 +168,7 @@ end
 
 local function wct_roads_to_industrial_city(radius)
 	-- "Rrc"
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("!,W*^*,*^V*,*^Bcx*,Urb,C*,K*^*,R*"),
 		f.adjacent(f.all(
 			f.terrain("*^Vhc,Rrc"),
@@ -186,7 +186,7 @@ end
 
 local function wct_roads_to_factory(radius)
 	--"Rr"
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("!,W*^*,*^V*,*^Bcx*,Urb,C*,K*^*,R*"),
 		f.adjacent(f.all(
 			f.terrain("*^Vhh,Rr"),
@@ -204,7 +204,7 @@ end
 
 local function wct_roads_to_river_industry(radius)
 	-- "Re"
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("!,W*^*,*^V*,*^Bcx*,Urb,C*,K*^*,R*"),
 		f.adjacent(f.all(
 			f.terrain("*^Vud,Re,Rr"),
@@ -379,7 +379,7 @@ local function world_conquest_tek_map_decoration_6c()
 		),
 		layer = "base",
 	}
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("Sm^*"),
 		f.adjacent(f.terrain("Ww^*"))
 	))
@@ -396,7 +396,7 @@ local function world_conquest_tek_map_decoration_6c()
 		}
 	end
 	-- dirty rivers
-	local terrain_to_change = map:get_locations(f.all(
+	local terrain_to_change = map:find(f.all(
 		f.terrain("Sm^*"),
 		f.adjacent(f.terrain("Ww^*"))
 	))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration/6D_Feudal.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration/6D_Feudal.lua
@@ -5,7 +5,7 @@
 -- `wct_iterate_roads_to(wct_roads_to_feudal_castle, 3, "Rr")`
 -- instead of `roads_to_feudal_castle(3)`
 local function wct_roads_to_feudal_castle(radius)
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("!,W*,*^V*,Ds,C*,K*,R*"),
 		f.adjacent(f.all(
 			f.terrain("Chs,Rr"),
@@ -134,12 +134,12 @@ local function world_conquest_tek_map_repaint_6d()
 	else
 		-- this is faster.
 		local r8_Re = map:get_tiles_radius(
-			map:get_locations(f.terrain("Re")),
+			map:find(f.terrain("Re")),
 			wesnoth.map.filter(f.all()),
 			8
 		)
 		local r6_Khs = map:get_tiles_radius(
-			map:get_locations(f.terrain("Khs")),
+			map:find(f.terrain("Khs")),
 			wesnoth.map.filter(f.all()),
 			6
 		)

--- a/data/campaigns/World_Conquest/lua/map/postgeneration_utils/engine.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration_utils/engine.lua
@@ -38,7 +38,7 @@ f = {
 
 function get_locations(t)
 	local filter = wesnoth.map.filter(t.filter, t.filter_extra or {})
-	return map:get_locations(filter, t.locs)
+	return map:find(filter, t.locs)
 end
 
 function set_terrain_impl(data)
@@ -47,7 +47,7 @@ function set_terrain_impl(data)
 	for i = 1, #data do
 		if data[i].filter then
 			local f = wesnoth.map.filter(data[i].filter, data[i].known or {})
-			locs[i] = map:get_locations(f, data[i].locs)
+			locs[i] = map:find(f, data[i].locs)
 		else
 			locs[i] = data[i].locs
 		end

--- a/data/campaigns/World_Conquest/lua/map/postgeneration_utils/events.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration_utils/events.lua
@@ -58,7 +58,7 @@ function wct_volcanos()
 			f.adjacent(f.terrain("Mv"), "n,ne,nw", nil)
 		),
 	}
-	local terrain_to_change = map:get_locations(f.terrain("Mv"))
+	local terrain_to_change = map:find(f.terrain("Mv"))
 	--todo figure out whether there is a differnce between many sound_source and on with a hige x,y list.
 	for volcano_i, volcano_loc in ipairs(terrain_to_change) do
 		table.insert(prestart_event, wml.tag.sound_source {
@@ -165,7 +165,7 @@ function get_oceanic()
 		f.x("1," .. tostring(map.width - 1)),
 		f.y("1," .. tostring(map.height - 1))
 	)
-	local water_border_tiles = map:get_locations(f.all(f_is_border, f.terrain("Wo*")))
+	local water_border_tiles = map:find(f.all(f_is_border, f.terrain("Wo*")))
 	local filter_radius = wesnoth.map.filter(f.all(
 		f.terrain("W*^V*,Wwr*,Ww,Wwg,Wwt,Wo*"),
 		--ignore rivers

--- a/data/campaigns/World_Conquest/lua/map/postgeneration_utils/noise.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration_utils/noise.lua
@@ -1,12 +1,12 @@
 function world_conquest_tek_map_noise_proxy(radius, fraction, terrain)
-	local terrain_to_change = map:get_locations(f.terrain(terrain))
+	local terrain_to_change = map:find(f.terrain(terrain))
 	local nop_filter = wesnoth.map.filter(f.all())
 	helper.shuffle(terrain_to_change)
 	for terrain_i = 1, math.ceil(#terrain_to_change / fraction) do
 		local loc_a = terrain_to_change[terrain_i]
 		local terrain_to_swap_b = map:get_tiles_radius({loc_a}, nop_filter, radius)
 		
-		terrain_to_swap_b  = map:get_locations(f.all(
+		terrain_to_swap_b  = map:find(f.all(
 			f.none(f.is_loc(loc_a)),
 			f.terrain(terrain)
 		), terrain_to_swap_b)

--- a/data/campaigns/World_Conquest/lua/map/postgeneration_utils/utilities.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration_utils/utilities.lua
@@ -172,7 +172,7 @@ function wct_map_decorative_docks()
 end
 
 function wct_store_possible_flowers(terrain)
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Gs,Gg"),
 		f.adjacent(f.terrain(terrain)),
 		f.adjacent(f.terrain("D*^*,S*^*,Hd"), nil, 0)
@@ -182,7 +182,7 @@ function wct_store_possible_flowers(terrain)
 end
 
 function wct_store_possible_map4_castle(value)
-	return  map:get_locations(f.all(
+	return  map:find(f.all(
 		f.terrain("H*^F*"),
 		f.adjacent(f.terrain("H*^F*"), nil, 6)
 	))
@@ -198,14 +198,14 @@ function wct_possible_map4_castle(terrain, value)
 end
 
 function wct_store_possible_dwarven_castle()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Uh"),
 		f.adjacent(f.terrain("Uh"), nil, "5-6")
 	))
 end
 
 function wct_store_possible_roads(village)
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Gg,Gs"),
 		f.adjacent(f.all(
 			f.terrain(village),
@@ -247,14 +247,14 @@ end
 -- roads have a maximum length of @a radius and can only be
 -- placed on tiles that match @a f_dest
 function wct_iterate_roads_to_2(f_validpath, f_src, f_dest, terrain_road, radius)
-	local src_tiles = map:get_locations(f_src)
-	local dest_tiles = map:get_locations(f_dest)
+	local src_tiles = map:find(f_src)
+	local dest_tiles = map:find(f_dest)
 	local filter_path = wesnoth.map.filter(f_validpath)
 	local map = _G.map
 
 	local function filter_path_function(x, y)
 		local xy_list = { {x,y} }
-		local res = #map:get_locations(filter_path, xy_list) > 0
+		local res = #map:find(filter_path, xy_list) > 0
 		return res
 	end
 	-- calculate for each tile its distance to any of the tiles in dest_tiles.
@@ -316,7 +316,7 @@ function wct_break_walls(wall, terrain)
 end
 
 function wct_store_broken_wall_candidates(wall)
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain(wall),
 		f.adjacent(f.terrain("M*^Xm,X*"), nil, "2-6"),
 		f.adjacent(f.terrain("Mv"), nil, 0)
@@ -325,7 +325,7 @@ function wct_store_broken_wall_candidates(wall)
 end
 
 function wct_store_possible_muddy_swamps()
-	return map:get_locations(f.all(
+	return map:find(f.all(
 		f.terrain("Ss"),
 		f.adjacent(f.terrain("D*^*,Hd,Sm,Rd"), nil, "5-6")
 	))

--- a/data/campaigns/World_Conquest/lua/map/postgeneration_utils/wild_zones.lua
+++ b/data/campaigns/World_Conquest/lua/map/postgeneration_utils/wild_zones.lua
@@ -4,7 +4,7 @@ local function wct_terrain_replace(t)
 end
 
 local function wild_volcano_for_lava_zone(terrain_to_change)
-	local possible_volcano = map:get_locations(f.all(
+	local possible_volcano = map:find(f.all(
 		f.find_in("terrain_to_change"),
 		f.adjacent(f.find_in("terrain_to_change"), "se,s,sw", 3)
 	), { terrain_to_change = terrain_to_change })
@@ -681,7 +681,7 @@ local function river_to_lava_postfix(terrain_to_change)
 		f.adjacent(f.find_in("terrain_to_change"))
 	), { terrain_to_change = terrain_to_change })
 	
-	adjacent_grssland = map:get_locations(filter_adjacent_grassland)
+	adjacent_grssland = map:find(filter_adjacent_grassland)
 	
 	set_terrain {
 		terrain = "Ur,Re,Re,Gd,Gd,Gd",

--- a/data/campaigns/World_Conquest/lua/map/scenario_utils/bonus_points.lua
+++ b/data/campaigns/World_Conquest/lua/map/scenario_utils/bonus_points.lua
@@ -163,7 +163,7 @@ function wct_bonus_chose_scenery(loc, theme, filter_extra)
 
 	local function matches_location(f)
 		local filter_object = wesnoth.map.filter(f, filter_extra)
-		return #map:get_locations(filter_object, {loc}) > 0
+		return #map:find(filter_object, {loc}) > 0
 	end
 
 	-- chance of rock cairn on isolated hills
@@ -402,7 +402,7 @@ function world_conquest_tek_bonus_points(theme)
 	local scenario_num = wesnoth.get_variable("wc2_scenario") or 1
 	oceanic = get_oceanic()
 	f_wct_bonus_location_filter = wesnoth.map.filter(get_f_wct_bonus_location_filter(map), { oceanic = oceanic })
-	local possible_locs = map:get_locations(f_wct_bonus_location_filter)
+	local possible_locs = map:find(f_wct_bonus_location_filter)
 	function place_item(loc)
 		scenery = wct_bonus_chose_scenery(loc, theme, { oceanic = oceanic })
 		table.insert(prestart_event, wml.tag.wc2_place_bonus {

--- a/data/campaigns/World_Conquest/lua/map/tools/filter_converter.lua
+++ b/data/campaigns/World_Conquest/lua/map/tools/filter_converter.lua
@@ -3,7 +3,7 @@
 ---- A helper tool, that works (mostly) indpendently  ----
 ---- of the rest to convert location filter wml to    ----
 ---- the filter syntax used in this addon             ----
----- (map:get_locations)                              ----
+---- (map:find)                              ----
 ----------------------------------------------------------
 
 
@@ -208,7 +208,7 @@ function convert_filter()
 			local variable = content.variable
 			local f = parse_wml_filter(content)
 
-			std_print("local " .. variable .. " = map:get_locations(" .. print_filter(f, 1) .. ")")
+			std_print("local " .. variable .. " = map:find(" .. print_filter(f, 1) .. ")")
 		end
 	end
 	--local filter = parse_wml_filter(cfg)

--- a/data/campaigns/World_Conquest/lua/map/tools/filter_converter.lua
+++ b/data/campaigns/World_Conquest/lua/map/tools/filter_converter.lua
@@ -3,7 +3,7 @@
 ---- A helper tool, that works (mostly) indpendently  ----
 ---- of the rest to convert location filter wml to    ----
 ---- the filter syntax used in this addon             ----
----- (map:find)                              ----
+---- (map:find)                                       ----
 ----------------------------------------------------------
 
 


### PR DESCRIPTION
**Summary of this PR:**

1. Fixed most of the deprecated lua functions
2. Added new 1.15 Dunefolk enemy data Nested Array.
3. Re-added "The Empire" faction of World Conquest Era with ID fixes of 1.15 Dunefolk
4. Added Dunefolk units to the Heroes list
5. Replaced all Khalifate instances with Dunefolk
6. Reduced enemy strength by 25% (since I don't think it's winnable on the higher difficulty)
7. updated changelog

**Important Note on the deprecation code left:**
<https://forums.wesnoth.org/viewtopic.php?f=58&t=54219>

**Still existing bugs/crashes:**
1. It is possible to "exploit" the open gold, income, team, and controller settings in Side/Faction selection GUI menu and make Nightmare difficulty a joke.
2. After the completion of "Final Battle" scenario, there is an error message and it crashes to Main Menu. However, the campaign is completed and the replay is available.
[WC II 1 Final Battle -  replay 20210415-060343.gz](https://github.com/wesnoth/wesnoth/files/6352170/WC.II.1.Final.Battle.-.replay.20210415-060343.gz)


**Note:**
How do I add particular users to ask for a review? Possibly CelticMinstrel and/or gfgtdf (if he is still active).