### PR TITLE
Don't check SDL version on each surface::free_surface() call

### DIFF
--- a/src/sdl/surface.cpp
+++ b/src/sdl/surface.cpp
@@ -24,6 +24,10 @@ const SDL_PixelFormat surface::neutral_pixel_format = []() {
 #endif
 }();
 
+const bool surface::sdl_freesurface_bug_ = []() {
+	return sdl_get_version() == version_info(2, 0, 6);
+}();
+
 surface::surface(SDL_Surface* surf)
 	: surface_(surf)
 {
@@ -98,7 +102,7 @@ void surface::free_surface()
 		*
 		* - Jyrki, 2017-09-23
 		*/
-		if(surface_->refcount > 1 && sdl_get_version() == version_info(2, 0, 6)) {
+		if(surface_->refcount > 1 && sdl_freesurface_bug_) {
 			--surface_->refcount;
 		} else {
 			SDL_FreeSurface(surface_);

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -110,6 +110,12 @@ private:
 	SDL_Surface* surface_;
 
 	static const SDL_PixelFormat neutral_pixel_format;
+
+	/**
+	 * Apply a workaround for SDL2.0.6 bug. SDL_FreeSurface() frees the blit map
+	 * unconditionally without checking if the reference count has fallen to zero.
+	 */
+	static const bool sdl_freesurface_bug_;
 };
 
 bool operator<(const surface& a, const surface& b);


### PR DESCRIPTION
While running Wesnoth under profiler I've noticed that  `free_surface()` always checks and compares SDL version to decide if
a workaround for SDL2.0.6 bug should be applied. This results in dynamic memory (de)allocations.
This check can be done only once and stored in a static variable, thus removing these memory allocations from the function which is called frequently in the rendering path.

Alternatively, the minimal SDL2 version could be bumped to 2.0.7, this would also allow removing some compile-time checks from the code.
