### PR TITLE
Keep the Windows CIs on a version of vcpkg that builds Wesnoth

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -317,7 +317,8 @@ jobs:
       - name: DOS1
         shell: cmd
         run: |
-          git clone --depth=1 https://github.com/microsoft/vcpkg.git ../vcpkg
+          git clone --shallow-since=2021-04-25 https://github.com/microsoft/vcpkg.git ../vcpkg
+          git -C ../vcpkg checkout a9b27ed5dffbf70b135eddb0c4729f3ca87f106c
           %~dp0../wesnoth/vcpkg/bootstrap-vcpkg.bat
       - name: DOS2
         shell: cmd
@@ -350,7 +351,8 @@ jobs:
       - name: DOS1
         shell: cmd
         run: |
-          git clone --depth=1 https://github.com/microsoft/vcpkg.git ../vcpkg
+          git clone --shallow-since=2021-04-25 https://github.com/microsoft/vcpkg.git ../vcpkg
+          git -C ../vcpkg checkout a9b27ed5dffbf70b135eddb0c4729f3ca87f106c
           %~dp0../wesnoth/vcpkg/bootstrap-vcpkg.bat
       - name: DOS2
         shell: cmd


### PR DESCRIPTION
Quick workaround for #5741, the Windows builds weren't finding Pango's header
files when used with vcpkg version 546813ae7b9e2873dd3d38e78b27ac5582feae10
([glib up to gtk] update and make it work with meson).

Hopefully we can revert this workaround soon.

(Note: don't merge until the CI build has passed)