### PR TITLE
Add wesnoth.colors[name].pango_color and use it in the multiplayer turns-over dialog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
  ### Campaigns
  ### Editor
  ### Multiplayer
+ ### Lua API
+   * Added `pango_color` to the `wesnoth.colors` table, for easy use in formatted text.
  ### Packaging
    * Increased minimum required version of SDL to 2.0.8 (PR #5736).
  ### Terrain
@@ -12,6 +14,7 @@
  ### Units
    * Update piglet/boar graphics
  ### User interface
+   * The multiplayer "turns over" dialog now uses each team's colors when showing teams' names.
  ### WML Engine
    * Modify implementation of overwrite_specials attribute for replace yes/no parameter by none/one_side/both_sides and select abilities used like weapons and specials who must be overwrited(owned by fighter where special applied or both)
  ### Miscellaneous and Bug Fixes

--- a/data/multiplayer/eras.lua
+++ b/data/multiplayer/eras.lua
@@ -47,10 +47,7 @@ res.turns_over_advantage = function()
 	local winners_color = "#000000"
 	for side, team in all_sides() do
 		if not team.__cfg.hidden then
-			-- The translatable strings include support for coloring the side names, but here we just use white. The team colors accessible to Lua
-			-- could be "red", "blue", etc (which are also supported by Pango's markup), but could also be user-defined names from a color changer mod.
-			-- Logged as bug #5722.
-			local side_color = "#ffffff"
+			local side_color = wesnoth.colors[team.color].pango_color
 			if # wesnoth.units.find_on_map( { side = side } ) == 0 then
 				-- po: In the end-of-match summary, a side which has no units left and therefore lost. In English the loss is shown by displaying it with the text struck through.
 				local side_text = _ "<span strikethrough='true' foreground='$side_color'>Side $side_number</span>:  Has lost all units"

--- a/data/test/scenarios/test_lua_color.cfg
+++ b/data/test/scenarios/test_lua_color.cfg
@@ -1,0 +1,71 @@
+# Check that team colors are accessible via wesnoth.colors, and that the Lua
+# layer is putting the correct channel's value into each of r, g, b and a.
+#
+# This test is lax about the exact values, it's meant to test the API layer
+# rather than detect someone altering the exact hue in team-colors.cfg.
+{GENERIC_UNIT_TEST "test_lua_colors" (
+    [event]
+        name = prestart
+        [lua]
+            code = <<
+                local red = wesnoth.colors["red"]
+                unit_test.assert(red, "no definition for color 'red'")
+                unit_test.assert_greater(red.mid.r, 10 + red.mid.g + red.mid.b, "color red's mid isn't red")
+                unit_test.assert_equal(red.mid.a, 0xff, "color red's mid isn't opaque")
+                unit_test.assert_greater(red.minimap.r, 10 + red.minimap.g + red.minimap.b, "color red's minimap isn't red")
+                unit_test.assert_equal(red.minimap.a, 0xff, "color red's minimap isn't opaque")
+
+                -- The min and max can be black and white, a min of (0,0,0) is likely.
+                -- These asserts are just for checking that 'min' and 'max' supported.
+                unit_test.assert_less(red.min.r, 10, "color red's min is brighter than expected")
+                unit_test.assert_greater_equal(red.min.r, red.min.g, "color red's min is more green")
+                unit_test.assert_greater_equal(red.min.r, red.min.b, "color red's min is more blue")
+                unit_test.assert_greater_equal(red.max.r, red.max.g, "color red's max is more green")
+                unit_test.assert_greater_equal(red.max.r, red.max.b, "color red's max is more blue")
+                unit_test.assert_greater(red.max.r, 0xf0, "color red's max is darker than expected")
+
+                -- Green's midpoint has a lot of white in it, for green.mid g < r + b
+                local green = wesnoth.colors["green"]
+                unit_test.assert(green, "no definition for color 'green'")
+                unit_test.assert_greater(green.mid.g, 10 + green.mid.r, "color green's mid is too red")
+                unit_test.assert_greater(green.mid.g, 10 + green.mid.b, "color green's mid is too blue")
+                unit_test.assert_greater(green.minimap.g, 10 + green.minimap.r + green.minimap.b, "color green's minimap isn't green")
+
+                local blue = wesnoth.colors["blue"]
+                unit_test.assert(blue, "no definition for color 'blue'")
+                unit_test.assert_greater(blue.mid.b, 10 + blue.mid.r + blue.mid.g, "color blue's mid isn't blue")
+                unit_test.assert_greater(blue.minimap.b, 10 + blue.minimap.r + blue.minimap.g, "color blue's minimap isn't blue")
+
+                local gold = wesnoth.colors["gold"]
+                unit_test.assert(gold, "no definition for color 'gold'")
+                unit_test.assert_greater(gold.mid.r, 0xf0, "expected more red in 'gold'")
+                unit_test.assert_greater(gold.mid.g, 0xf0, "expected more green in 'gold'")
+                unit_test.assert_greater(gold.mid.b, 0x50, "expected more blue in 'gold'")
+                unit_test.assert_less(gold.mid.b, 0x80, "expected less blue in 'gold'")
+
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}
+
+# Test that the pango_color data works.
+#
+# For simplicity, these string comparisons use the exact values.
+{GENERIC_UNIT_TEST "test_lua_colors_hexadecimal" (
+    [event]
+        name = prestart
+        [lua]
+            code = <<
+                local red = wesnoth.colors["red"]
+                unit_test.assert_equal(red.pango_color, "#ff0000", "Not the expected hex string for red")
+                local blue = wesnoth.colors["blue"]
+                unit_test.assert_equal(blue.pango_color, "#2e419b", "Not the expected hex string for blue")
+                local gold = wesnoth.colors["gold"]
+                unit_test.assert_equal(gold.pango_color, "#fff35a", "Not the expected hex string for gold")
+
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/src/scripting/lua_color.cpp
+++ b/src/scripting/lua_color.cpp
@@ -118,11 +118,11 @@ static int impl_color_get(lua_State *L)
 	if(strcmp(m, "minimap") == 0) {
 		return luaW_pushsinglecolor(L, c.rep());
 	}
-	// TODO: i think this shortcut would be useful, but im not sure yet on the best attribute name.
-	//if(strcmp(m, "pango_hex") == 0) {
-	//	lua_push(L, c.mid().to_hex_string());
-	//	return 1;
-	//}
+	// returns a string which can be used in Pango's foreground= attribute
+	if(strcmp(m, "pango_color") == 0) {
+		lua_push(L, c.mid().to_hex_string());
+		return 1;
+	}
 	return 0;
 }
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -216,6 +216,11 @@
 # [store_locations]
 0 store_reachable_locations_vision
 #
+# General information queries
+#
+0 test_lua_colors
+0 test_lua_colors_hexadecimal
+#
 # Attack calculations & codepath tests
 #
 8 alice_kills_bob


### PR DESCRIPTION
The first of the two commits already has PR #5723, this PR will be for the second one once that merges. It's mainly about the unit test and whether `pango_color` is the right name.

Fixes #5722.

With Ravana's color changer mod:
![wesnoth_turns_over_with_popup_color](https://user-images.githubusercontent.com/101462/116296451-8b5f1a80-a79a-11eb-9a68-676147a48cb5.png)