### PR TITLE
[MP] Isle of Mists - a new 1p/2p Survival Scenario. 

### DIFF
--- a/data/multiplayer/maps/2p_Isle_of_Mists_basic.map
+++ b/data/multiplayer/maps/2p_Isle_of_Mists_basic.map
@@ -1,0 +1,19 @@
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Wwr, Uh, Uu^Vu, Qlf, Qlf, Xu, Xu, Ai, Ms, Ms, Ms, Aa^Fpa, Aa, Aa, Ss, Ss, Ss, Wo, Aa, Aa^Fpa, Aa^Vea, Ha, Ms, Ms, Ms, Aa^Fpa, Wo, Wo, Wo
+Wo, Wo, Wo, Wwt, Ds, Uu^Tf, Uu^Tf, Ur, Uu, Uu, Xu, Ai, Aa^Vha, Ms, Ha, Ha, Rb^Tf, Rb^Fms, Rb^Fms, Ss^Vhs, Hh, Wwf, Wwf, Aa^Fpa, Aa, Wwf, Ha, Ms, Aa^Fpa, Ai, Wwt, Wo, Wo
+Wo, Wo, Wo, Ds, Dd^Do, Sm, Sm, Ur, Ur, Uh, Ai, Aa, Aa, Aa, Aa^Fpa, Rb, Rb, Rb^Tf, Rb, Hh, Rb, Wwr, Wwt, Re, Re, Re, Re, Aa^Fpa, Wwt, Wwt, Mm, Wo, Wo
+Wo, Wo, Ww, Dd, Dd, Dd, Mdd, Sm, Ds, Ds, Wo, Ai, Wwf, Aa^Fpa, Ha, Re, Re, Rb, Mm, Re, Re, Rb, Ww^Bw/, Re, Gs^Fms, Gg, Gg, Wwt, Re, Gs^Fms, Hh, Wo, Wo
+Wo, Wo, Ww, Gs^Fms, Dd, Mdd, Mdd, Hd, Re, Wwt, Mm, Wwf, Re^Tf, Re, Rb, Rb, Ias, Re, Hh, Re^Fet, Rb, Re, Ww, Wwt, Wwf, Hh, Wwt, Wwt, Gg, Re, Gs^Vht, Wo, Wo
+Wo, Wo, Mm, Gs^Fms, Hh, Dd, Gg, Hd, Re, Re^Fms, Hh, Re^Vct, Rb, Re, Ias, Ch, Ch, Ias, Ias, Rb, Re, Re, Mm, Wo, Ds, Wwf, Ss, Gs^Ft, Gg, Re, Gg, Wo, Wo
+Wo, Wo, Gs^Fms, Hh, Re^Tf, Gg, Gs^Fms, Re, Wwt, Wwt, Re, Rb, Re, Ias, 3 Kh, Ch, Irs, Rrc^Vd, Ch, Ias, Rb, Hh, Re^Fms, Re, Ds, Ss^Vhs, Hh, Gs^Ft, Re, Re, Xu, Wo, Wo
+Wo, Wo, Hh, Re^Vc, Re^Tf, Gg, Re, Re, Re, Ww^Bw/, Wwf, Re, Rb, Ias, Ch, Irs, Kh, Irs, Ch, Ch, Rb, Re, Re, Re, Ww, Re, Re, Re, Uu, Uh, Xu, Wo, Wo
+Wo, Wo, Gg, Re, Re, Re, Gs^Fms, Hhd, Wwf, Wo, Wwt, Re^Fms, Rb, Ch, Ch, Irs, Irs, Irs, 4 Kh, Ias, Mm, Gs^Fms, Re, Wwf, Wwf, Re, Re^Fetd, Ur, Ur, Qxu, Qxu, Wo, Wo
+Wo, Wo, Gg^Fet, Gg, Gg, Gg, Wwt, Wwf, Rd^Ft, Mm, Rd, Wwt, Re, Ias, Ias, Rrc^Vd, Ch, Ch, Ias, Ias, Hh, Gs^Fms, Ww^Bw|, Wwt, Mm, Ww, Wwf, Uu^Tf, Ur, Uu^Vud, Uh, Wo, Wo
+Wo, Wo, Gll^Fp, Gll^Fp, Ds, Ds, Wwt, Rd, Rd, Hhd, Rd, Re, Mm, Rb, Rb, Ias, Ias, Ch, Rd^Tf, Rd, Wwt, Wwf, Rr, Hh, Gs^Fms, Wo, Wwt, Uu^Tf, Ur, Uu, Wo, Wo, Wo
+Wo, Wo, Hh, Hh, Wwt, Wwt, Qlf, Rd, Hd, Qlf, Dd, Rd, Wwf, Hhd, Rd^Ft, Rb, Re, Re^Fms, Mm, Wwt, Rr, Rr, Gg, Rr, Rr, Gg, Gg, Wwf, Ds, Ds, Wo, Wo, Wo
+Wo, Wo, Mm, Mm, Wwt, Qlf, Ds, Rd, Hd, Qlf, Dd^Vda, Dd, Ww, Wwf, Rd^Ft, Uu, Ur, Re, Ss^Bw\r, Ss, Rr, Gg, Gs^Ft, Gs^Ft, Dd, Rr, Rr, Wwt, Wwr, Wwr, Wo, Wo, Wo
+Wo, Wo, Gs^Fms, Mm, Wwt, Wwr, Wwr, Ds, Rd^Ft, Rd^Ft, Mv, Hd, Hd, Ww, Uu^Tf, Uu^Tf, Uu, Ss, Gs^Ft, Rr, Dd, Hd, Md, Md, Dd^Do, Dd, Rr, Wwt, Wwt, Ww, Wo, Wo, Wo
+Wo, Wo, Wo, Wwt, Ww^Vm, Wwt, Wo, Wo, Wo, Md, Md, Md, Rd^Ft, Qxu, Qxu, Uh, Wo, Ss, Hh, Dd, Dd^Vda, Dd, Dd^Dc, Md, Md, Dd, Rr, Ias^Vhc, Wwt, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo

--- a/data/multiplayer/maps/2p_Isle_of_Mists_drought.map
+++ b/data/multiplayer/maps/2p_Isle_of_Mists_drought.map
@@ -1,0 +1,19 @@
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wo
+Wo, Ww, Ww, Wwr, Wwr, Uh, Uu^Vu, Qlf, Qlf, Xu, Xu, Wwf, Ms, Ms, Ms, Gg^Tf, Gg, Gg, Ss, Ss, Ss, Ww, Gg, Gg^Tf, Aa^Vea, Hh, Ms, Ms, Ms, Gg^Tf, Ww, Ww, Wo
+Wo, Ww, Ww, Wwf, Ds, Uu^Tf, Uu^Tf, Ur, Uu, Uu, Xu, Wwf, Aa^Vha, Ms, Hh, Hh, Rb^Tf, Rb^Tf, Rb^Tf, Ss^Vhs, Hh, Wwf, Wwf, Gg^Tf, Gg, Wwf, Hh, Ms, Gg^Tf, Wwf, Wwf, Ww, Wo
+Wo, Ww, Ww, Ds, Dd^Do, Sm, Sm, Ur, Ur, Uh, Wwf, Gg, Gg, Gg, Gg^Tf, Dd, Dd, Rb^Tf, Dd, Hh, Dd, Wwr, Wwf, Re, Re, Re, Re, Gg^Tf, Wwf, Wwf, Mm, Ww, Wo
+Wo, Ww, Wwf, Dd, Dd, Dd, Mdd, Sm, Ds, Ds, Ww, Wwf, Wwf, Gg^Tf, Hh, Re, Re, Dd, Mm, Re, Re, Dd, Ww^Bw/, Re, Gs^Tf, Dd, Dd, Wwf, Re, Gs^Tf, Hh, Ww, Wo
+Wo, Ww, Wwf, Dd^Tf, Dd, Mdd, Mdd, Hd, Re, Wwf, Mm, Wwf, Re^Tf, Re, Dd, Dd, Ias, Re, Hh, Re^Fet, Dd, Re, Wwf, Wwf, Wwf, Hh, Wwf, Wwf, Dd, Re, Gs^Vht, Ww, Wo
+Wo, Ww, Mm, Dd^Tf, Hh, Dd, Dd, Hd, Re, Re^Tf, Hh, Re^Vct, Dd, Re, Ias, Ch, Ch, Ias, Ias, Dd, Re, Re, Mm, Ww, Ds, Wwf, Ss, Gs^Tf, Dd, Re, Dd, Ww, Wo
+Wo, Ww, Gs^Tf, Hh, Re^Tf, Dd, Gs^Tf, Re, Wwf, Wwf, Re, Dd, Re, Ias, 3 Kh, Ch, Irs, Rrc^Vd, Ch, Ias, Dd, Hh, Re^Tf, Re, Ds, Ss^Vhs, Hh, Gs^Tf, Re, Re, Xu, Ww, Wo
+Wo, Ww, Hh, Re^Vc, Re^Tf, Dd, Re, Re, Re, Ww^Bw/, Wwf, Re, Dd, Ias, Ch, Irs, Kh, Irs, Ch, Ch, Dd, Re, Re, Re, Wwf, Re, Re, Re, Uu, Uh, Xu, Ww, Wo
+Wo, Ww, Dd, Re, Re, Re, Gs^Tf, Hhd, Wwf, Wo, Wwf, Re^Tf, Dd, Ch, Ch, Irs, Irs, Irs, 4 Kh, Ias, Mm, Gs^Tf, Re, Wwf, Wwf, Re, Re^Fetd, Ur, Ur, Qxu, Qxu, Ww, Wo
+Wo, Ww, Gg^Fet, Dd, Dd, Dd, Wwf, Wwf, Rd^Tf, Mm, Dd, Wwf, Re, Ias, Ias, Rrc^Vd, Ch, Ch, Ias, Ias, Hh, Gs^Tf, Ww^Bw|, Wwf, Mm, Wwf, Wwf, Uu^Tf, Ur, Uu^Vud, Uh, Ww, Wo
+Wo, Ww, Gll^Tf, Gll^Tf, Ds, Ds, Wwf, Dd, Dd, Hhd, Dd, Re, Mm, Dd, Dd, Ias, Ias, Ch, Rd^Tf, Rd, Wwf, Wwf, Rr, Hh, Gs^Tf, Ww, Wwf, Uu^Tf, Ur, Uu, Ww, Ww, Wo
+Wo, Ww, Hh, Hh, Wwf, Wwf, Qlf, Dd, Hd, Qlf, Dd, Dd, Wwf, Hhd, Rd^Tf, Dd, Re, Re^Tf, Mm, Wwf, Rr, Rr, Dd, Rr, Rr, Dd, Dd, Wwf, Ds, Ds, Ww, Ww, Wo
+Wo, Ww, Mm, Mm, Wwf, Qlf, Ds, Dd, Hd, Qlf, Dd^Vda, Dd, Wwf, Wwf, Rd^Tf, Uu, Ur, Re, Ss^Bw\r, Ss, Rr, Dd, Gs^Tf, Gs^Tf, Dd, Rr, Rr, Wwf, Wwr, Wwr, Ww, Ww, Wo
+Wo, Ww, Gs^Tf, Mm, Wwf, Wwr, Wwr, Ds, Rd^Tf, Rd^Tf, Mv, Hd, Hd, Wwf, Uu^Tf, Uu^Tf, Uu, Ss, Gs^Tf, Rr, Dd, Hd, Md, Md, Dd^Do, Dd, Rr, Wwf, Wwf, Wwf, Ww, Ww, Wo
+Wo, Ww, Ww, Wwf, Ww^Vm, Wwf, Ww, Ww, Ww, Md, Md, Md, Rd^Tf, Qxu, Qxu, Uh, Ww, Ss, Hh, Dd, Dd^Vda, Dd, Dd^Dc, Md, Md, Dd, Rr, Ias^Vhc, Wwf, Ww, Ww, Ww, Wo
+Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo

--- a/data/multiplayer/maps/2p_Isle_of_Mists_rain.map
+++ b/data/multiplayer/maps/2p_Isle_of_Mists_rain.map
@@ -1,0 +1,19 @@
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Wwr, Uh, Uu^Vu, Qlf, Qlf, Xu, Xu, Ai, Ms, Ms, Ms, Aa^Fpa, Aa, Aa, Ss, Ss, Ss, Wo, Aa, Aa^Fpa, Aa^Vea, Ha, Ms, Ms, Ms, Aa^Fpa, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wwr, Uu^Tf, Uu^Tf, Wwf, Uu, Uu, Xu, Ai, Aa^Vha, Ms, Ha, Ha, Rb^Tf, Rb^Fms, Rb^Fms, Ss^Vhs, Hh, Ww, Ww, Aa^Fpa, Aa, Ww, Ha, Ms, Aa^Fpa, Ai, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Dd^Do, Sm, Sm, Wwf, Wwf, Uh, Ai, Aa, Aa, Aa, Aa^Fpa, Wwf, Wwf, Rb^Tf, Wwf, Hh, Wwf, Wwr, Wo, Wwf, Wwf, Wwf, Wwf, Aa^Fpa, Wo, Wo, Mm, Wo, Wo
+Wo, Wo, Wo, Dd, Dd, Dd, Mdd, Sm, Wwr, Wwr, Wo, Ai, Ww, Aa^Fpa, Ha, Wwf, Wwf, Wwf, Mm, Wwf, Wwf, Wwf, Ww, Wwf, Gs^Fms, Wwf, Wwf, Wo, Wwf, Gs^Fms, Hh, Wo, Wo
+Wo, Wo, Wo, Gs^Fms, Dd, Mdd, Mdd, Hd, Wwf, Wo, Mm, Ww, Re^Tf, Wwf, Wwf, Wwf, Ias, Wwf, Hh, Re^Fet, Wwf, Wwf, Wo, Wo, Ww, Hh, Wo, Wo, Wwf, Wwf, Gs^Vht, Wo, Wo
+Wo, Wo, Mm, Gs^Fms, Hh, Dd, Wwf, Hd, Wwf, Re^Fms, Hh, Re^Vct, Wwf, Wwf, Ias, Ch, Ch, Ias, Ias, Wwf, Wwf, Wwf, Mm, Wo, Wwr, Ww, Ss, Gs^Ft, Wwf, Wwf, Wwf, Wo, Wo
+Wo, Wo, Gs^Fms, Hh, Re^Tf, Wwf, Gs^Fms, Wwf, Wo, Wo, Wwf, Wwf, Wwf, Ias, 3 Kh, Ch, Irs, Rrc^Vd, Ch, Ias, Wwf, Hh, Re^Fms, Wwf, Wwr, Ss^Vhs, Hh, Gs^Ft, Wwf, Wwf, Xu, Wo, Wo
+Wo, Wo, Hh, Re^Vc, Re^Tf, Wwf, Wwf, Wwf, Wwf, Ww, Ww, Wwf, Wwf, Ias, Ch, Irs, Kh, Irs, Ch, Ch, Wwf, Wwf, Wwf, Wwf, Wo, Wwf, Wwf, Wwf, Uu, Uh, Xu, Wo, Wo
+Wo, Wo, Wwf, Wwf, Wwf, Wwf, Gs^Fms, Hhd, Ww, Wo, Wo, Re^Fms, Wwf, Ch, Ch, Irs, Irs, Irs, 4 Kh, Ias, Mm, Gs^Fms, Wwf, Ww, Ww, Wwf, Re^Fetd, Wwf, Wwf, Qxu, Qxu, Wo, Wo
+Wo, Wo, Gg^Fet, Wwf, Wwf, Wwf, Wo, Ww, Rd^Ft, Mm, Wwr, Wo, Wwf, Ias, Ias, Rrc^Vd, Ch, Ch, Ias, Ias, Hh, Gs^Fms, Ww, Wo, Mm, Ww, Ww, Uu^Tf, Wwf, Uu^Vud, Uh, Wo, Wo
+Wo, Wo, Gll^Fp, Gll^Fp, Wwr, Wwr, Wo, Wwr, Wwr, Hhd, Wwr, Wwf, Mm, Wwf, Wwf, Ias, Ias, Ch, Rd^Tf, Wwf, Wo, Ww, Wwf, Hh, Gs^Fms, Wo, Wo, Uu^Tf, Wwf, Uu, Wo, Wo, Wo
+Wo, Wo, Hh, Hh, Wo, Wo, Qlf, Wwr, Hd, Qlf, Dd, Wwr, Wo, Hhd, Rd^Ft, Wwf, Wwf, Re^Fms, Mm, Wo, Wwf, Wwf, Wwf, Wwf, Wwf, Wwf, Wwf, Ww, Wwr, Wwr, Wo, Wo, Wo
+Wo, Wo, Mm, Mm, Wo, Qlf, Ds, Wwr, Hd, Qlf, Dd^Vda, Dd, Wo, Wo, Rd^Ft, Uu, Ur, Wwf, Ss^Bw\r, Ss, Wwf, Wwf, Gs^Ft, Gs^Ft, Wwr, Wwf, Wwf, Wo, Ww, Ww, Wo, Wo, Wo
+Wo, Wo, Gs^Fms, Mm, Wo, Wwr, Wwr, Ds, Rd^Ft, Rd^Ft, Mv, Hd, Hd, Wo, Uu^Tf, Uu^Tf, Uu, Ss, Gs^Ft, Wwf, Wwr, Hd, Md, Md, Dd^Do, Wwr, Wwf, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Ww^Vm, Wo, Wo, Wo, Wo, Md, Md, Md, Rd^Ft, Qxu, Qxu, Uh, Wo, Ss, Hh, Wwr, Dd^Vda, Dd, Wwr, Md, Md, Dd, Wwf, Ias^Vhc, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo

--- a/data/multiplayer/maps/2p_Isle_of_Mists_secondrain.map
+++ b/data/multiplayer/maps/2p_Isle_of_Mists_secondrain.map
@@ -1,0 +1,19 @@
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Wwr, Uh, Uu^Vu, Qlf, Qlf, Xu, Xu, Ai, Ms, Ms, Ms, Aa^Fpa, Aa, Aa, Ss, Ss, Ss, Wo, Aa, Aa^Fpa, Aa^Vea, Ha, Ms, Ms, Ms, Aa^Fpa, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wwr, Uu^Tf, Uu^Tf, Ww, Uu, Uu, Xu, Ai, Aa^Vha, Ms, Ha, Ha, Rb^Tf, Rb^Fms, Rb^Fms, Ss^Vhs, Hh, Ww, Ww, Aa^Fpa, Aa, Ww, Ha, Ms, Aa^Fpa, Ai, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Dd^Do, Sm, Sm, Ww, Ww, Uh, Ai, Aa, Aa, Aa, Aa^Fpa, Ww, Ww, Rb^Tf, Ww, Hh, Ww, Wwr, Wo, Ww, Ww, Ww, Ww, Aa^Fpa, Wo, Wo, Mm, Wo, Wo
+Wo, Wo, Wo, Ww, Ww, Ww, Mdd, Sm, Wwr, Wwr, Wo, Ai, Ww, Aa^Fpa, Ha, Ww, Ww, Ww, Mm, Ww, Ww, Ww, Ww, Ww, Gs^Fms, Ww, Ww, Wo, Ww, Gs^Fms, Hh, Wo, Wo
+Wo, Wo, Wo, Gs^Fms, Ww, Mdd, Mdd, Hd, Ww, Wo, Mm, Ww, Re^Tf, Ww, Ww, Ww, Wwf, Ww, Hh, Re^Fet, Ww, Ww, Wo, Wo, Ww, Hh, Wo, Wo, Ww, Ww, Gs^Vht, Wo, Wo
+Wo, Wo, Mm, Gs^Fms, Hh, Ww, Ww, Hd, Ww, Re^Fms, Hh, Re^Vct, Ww, Ww, Wwf, Ch, Ch, Wwf, Wwf, Ww, Ww, Ww, Mm, Wo, Wwr, Ww, Ss, Gs^Ft, Ww, Ww, Ww, Wo, Wo
+Wo, Wo, Gs^Fms, Hh, Re^Tf, Ww, Gs^Fms, Ww, Wo, Wo, Ww, Ww, Ww, Wwf, 3 Kh, Ch, Irs, Rrc^Vd, Ch, Wwf, Ww, Hh, Re^Fms, Ww, Wwr, Ss^Vhs, Hh, Gs^Ft, Ww, Ww, Xu, Wo, Wo
+Wo, Wo, Hh, Re^Vc, Re^Tf, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wwf, Ch, Irs, Kh, Irs, Ch, Ch, Ww, Ww, Ww, Ww, Wo, Ww, Ww, Ww, Uu, Uh, Xu, Wo, Wo
+Wo, Wo, Ww, Ww, Ww, Ww, Gs^Fms, Hhd, Ww, Wo, Wo, Re^Fms, Ww, Ch, Ch, Irs, Irs, Irs, 4 Kh, Wwf, Mm, Gs^Fms, Ww, Ww, Ww, Ww, Re^Fetd, Ww, Ww, Qxu, Qxu, Wo, Wo
+Wo, Wo, Gg^Fet, Ww, Ww, Ww, Wo, Ww, Rd^Ft, Mm, Wwr, Wo, Ww, Wwf, Wwf, Rrc^Vd, Ch, Ch, Wwf, Wwf, Hh, Gs^Fms, Ww, Wo, Mm, Ww, Ww, Uu^Tf, Ww, Uu^Vud, Uh, Wo, Wo
+Wo, Wo, Gll^Fp, Gll^Fp, Wwr, Wwr, Wo, Wwr, Wwr, Hhd, Wwr, Ww, Mm, Ww, Ww, Wwf, Wwf, Ch, Rd^Tf, Ww, Wo, Ww, Ww, Hh, Gs^Fms, Wo, Wo, Uu^Tf, Ww, Uu, Wo, Wo, Wo
+Wo, Wo, Hh, Hh, Wo, Wo, Qlf, Wwr, Hd, Qlf, Ww, Wwr, Wo, Hhd, Rd^Ft, Ww, Ww, Re^Fms, Mm, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wwr, Wwr, Wo, Wo, Wo
+Wo, Wo, Mm, Mm, Wo, Qlf, Ww, Wwr, Hd, Qlf, Dd^Vda, Ww, Wo, Wo, Rd^Ft, Uu, Ur, Ww, Ss^Bw\r, Ss, Ww, Ww, Gs^Ft, Gs^Ft, Wwr, Ww, Ww, Wo, Ww, Ww, Wo, Wo, Wo
+Wo, Wo, Gs^Fms, Mm, Wo, Wwr, Wwr, Ww, Rd^Ft, Rd^Ft, Mv, Hd, Hd, Wo, Uu^Tf, Uu^Tf, Uu, Ss, Gs^Ft, Ww, Wwr, Hd, Md, Md, Dd^Do, Wwr, Ww, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Ww^Vm, Wo, Wo, Wo, Wo, Md, Md, Md, Rd^Ft, Qxu, Qxu, Uh, Wo, Ss, Hh, Wwr, Dd^Vda, Ww, Wwr, Md, Md, Ww, Ww, Ias^Vhc, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo

--- a/data/multiplayer/maps/2p_Isle_of_Mists_secondsnow.map
+++ b/data/multiplayer/maps/2p_Isle_of_Mists_secondsnow.map
@@ -1,0 +1,19 @@
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Wwr, Uh, Uu^Vu, Qlf, Qlf, Xu, Xu, Ai, Ms, Ms, Ms, Aa^Fpa, Aa, Aa, Ss, Ss, Ss, Wo, Aa, Aa^Fpa, Aa^Vea, Ha, Ms, Ms, Ms, Aa^Fpa, Wo, Wo, Wo
+Wo, Wo, Wo, Ai, Ds, Uu^Tf, Uu^Tf, Ur, Uu, Uu, Xu, Ai, Aa^Vha, Ms, Ha, Ha, Rb^Tf, Aa^Fpa, Aa^Fpa, Ss^Vhs, Ha, Wwf, Wwf, Aa^Fpa, Aa, Wwf, Ha, Ms, Aa^Fpa, Ai, Ai, Wo, Wo
+Wo, Wo, Wo, Ds, Dd^Do, Sm, Sm, Ur, Ur, Uh, Ai, Aa, Aa, Aa, Aa^Fpa, Aa, Aa, Rb^Tf, Aa, Ha, Aa, Wwr, Ai, Re, Re, Re, Re, Aa^Fpa, Ai, Ai, Ms, Wo, Wo
+Wo, Wo, Ai, Dd, Dd, Dd, Mdd, Sm, Ds, Ds, Ai, Ai, Wwf, Aa^Fpa, Ha, Re, Re, Aa, Ms, Re, Re, Aa, Ww^Bw/, Re, Aa^Fpa, Aa, Aa, Ai, Re, Aa^Fpa, Ha, Wo, Wo
+Wo, Wo, Ai, Aa^Fpa, Dd, Mdd, Mdd, Hd, Re, Ai, Ms, Wwf, Re^Tf, Re, Aa, Aa, Ias, Re, Ha, Aa^Fet, Aa, Re, Ai, Ai, Wwf, Ha, Ai, Ai, Aa, Re, Aa^Vht, Wo, Wo
+Wo, Wo, Ms, Aa^Fpa, Ha, Dd, Aa, Hd, Re, Aa^Fpa, Ha, Re^Vct, Aa, Re, Ias, Ch, Ch, Ias, Ias, Aa, Re, Re, Ms, Wo, Ds, Wwf, Ss, Aa^Fpa, Aa, Re, Aa, Wo, Wo
+Wo, Wo, Aa^Fpa, Ha, Re^Tf, Aa, Aa^Fpa, Re, Ai, Ai, Re, Aa, Re, Ias, 3 Kh, Ch, Irs, Rrc^Vd, Ch, Ias, Aa, Ha, Aa^Fpa, Re, Ds, Ss^Vhs, Ha, Aa^Fpa, Re, Re, Xu, Wo, Wo
+Wo, Wo, Ha, Aa^Vc, Re^Tf, Aa, Re, Re, Re, Ww^Bw/, Wwf, Re, Aa, Ias, Ch, Irs, Kh, Irs, Ch, Ch, Aa, Re, Re, Re, Ai, Re, Aa, Aa, Uu, Uh, Xu, Wo, Wo
+Wo, Wo, Aa, Re, Re, Re, Aa^Fpa, Ha, Wwf, Ai, Ai, Aa^Fpa, Aa, Ch, Ch, Irs, Irs, Irs, 4 Kh, Ias, Ms, Aa^Fpa, Re, Wwf, Wwf, Re, Aa^Fetd, Ur, Ur, Qxu, Qxu, Wo, Wo
+Wo, Wo, Aa^Fet, Aa, Aa, Aa, Ai, Wwf, Aa^Fpa, Ms, Rd, Ai, Re, Ias, Ias, Rrc^Vd, Ch, Ch, Ias, Ias, Ha, Aa^Fpa, Ww^Bw|, Ai, Ms, Ai, Wwf, Uu^Tf, Ur, Uu^Vud, Uh, Wo, Wo
+Wo, Wo, Aa^Fpa, Aa^Fpa, Ds, Ds, Ai, Rd, Rd, Ha, Rd, Re, Ms, Aa, Aa, Ias, Ias, Ch, Rd^Tf, Rd, Ai, Wwf, Rr, Ha, Aa^Fpa, Wo, Ai, Uu^Tf, Ur, Uu, Wo, Wo, Wo
+Wo, Wo, Ha, Ha, Ai, Ai, Qlf, Rd, Hd, Qlf, Dd, Rd, Wwf, Ha, Aa^Fpa, Aa, Re, Aa^Fpa, Ms, Ai, Rr, Rr, Aa, Rr, Rr, Aa, Aa, Wwf, Ds, Ds, Wo, Wo, Wo
+Wo, Wo, Ms, Ms, Ai, Qlf, Ds, Rd, Hd, Qlf, Dd^Vda, Dd, Ai, Wwf, Aa^Fpa, Uu, Ur, Re, Ss^Bw\r, Ss, Rr, Aa, Aa^Fpa, Aa^Fpa, Dd, Rr, Rr, Ai, Wwr, Wwr, Wo, Wo, Wo
+Wo, Wo, Aa^Fpa, Ms, Ai, Wwr, Wwr, Ds, Rd^Ft, Rd^Ft, Mv, Hd, Hd, Ai, Uu^Tf, Uu^Tf, Uu, Ss, Aa^Fpa, Rr, Dd, Hd, Md, Md, Dd^Do, Dd, Rr, Ai, Ai, Ai, Wo, Wo, Wo
+Wo, Wo, Wo, Ai, Ww^Vm, Ai, Wo, Wo, Wo, Md, Md, Md, Rd^Ft, Qxu, Qxu, Uh, Ai, Ss, Ha, Dd, Dd^Vda, Dd, Dd^Dc, Md, Md, Dd, Rr, Ias^Vhc, Ai, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo

--- a/data/multiplayer/maps/2p_Isle_of_Mists_snow.map
+++ b/data/multiplayer/maps/2p_Isle_of_Mists_snow.map
@@ -1,0 +1,19 @@
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wwr, Wwr, Uh, Uu^Vu, Qlf, Qlf, Xu, Xu, Ai, Ms, Ms, Ms, Aa^Fpa, Aa, Aa, Ss, Ss, Ss, Wo, Aa, Aa^Fpa, Aa^Vea, Ha, Ms, Ms, Ms, Aa^Fpa, Wo, Wo, Wo
+Wo, Wo, Wo, Ai, Ds, Uu^Tf, Uu^Tf, Ur, Uu, Uu, Xu, Ai, Aa^Vha, Ms, Ha, Ha, Rb^Tf, Aa^Fpa, Aa^Fpa, Ss^Vhs, Hh, Wwf, Wwf, Aa^Fpa, Aa, Wwf, Ha, Ms, Aa^Fpa, Ai, Ai, Wo, Wo
+Wo, Wo, Wo, Ds, Dd^Do, Sm, Sm, Ur, Ur, Uh, Ai, Aa, Aa, Aa, Aa^Fpa, Rb, Rb, Rb^Tf, Aa, Hh, Rb, Wwr, Ai, Re, Re, Re, Re, Aa^Fpa, Ai, Ai, Ms, Wo, Wo
+Wo, Wo, Ai, Dd, Dd, Dd, Mdd, Sm, Ds, Ds, Ai, Ai, Wwf, Aa^Fpa, Ha, Re, Re, Aa, Ms, Re, Re, Aa, Ww^Bw/, Re, Gs^Fms, Aa, Gg, Ai, Re, Aa^Fpa, Hh, Wo, Wo
+Wo, Wo, Ai, Gs^Fms, Dd, Mdd, Mdd, Hd, Re, Ai, Ms, Wwf, Re^Tf, Re, Rb, Rb, Ias, Re, Hh, Re^Fet, Aa, Re, Ww, Ai, Wwf, Hh, Ai, Ai, Gg, Re, Gs^Vht, Wo, Wo
+Wo, Wo, Ms, Aa^Fpa, Hh, Dd, Gg, Hd, Re, Aa^Fpa, Hh, Re^Vct, Aa, Re, Ias, Ch, Ch, Ias, Ias, Rb, Re, Re, Ms, Wo, Ds, Wwf, Ss, Aa^Fpa, Aa, Re, Aa, Wo, Wo
+Wo, Wo, Aa^Fpa, Ha, Re^Tf, Aa, Gs^Fpa, Re, Ai, Ai, Re, Rb, Re, Ias, 3 Kh, Ch, Irs, Rrc^Vd, Ch, Ias, Aa, Hh, Aa^Fpa, Re, Ds, Ss^Vhs, Hh, Aa^Fpa, Re, Re, Xu, Wo, Wo
+Wo, Wo, Hh, Re^Vc, Re^Tf, Gg, Re, Re, Re, Ww^Bw/, Wwf, Re, Aa, Ias, Ch, Irs, Kh, Irs, Ch, Ch, Rb, Re, Re, Re, Ai, Re, Re, Re, Uu, Uh, Xu, Wo, Wo
+Wo, Wo, Aa, Re, Re, Re, Aa^Fpa, Hhd, Wwf, Ai, Ai, Re^Fms, Rb, Ch, Ch, Irs, Irs, Irs, 4 Kh, Ias, Ms, Gs^Fms, Re, Wwf, Wwf, Re, Re^Fetd, Ur, Ur, Qxu, Qxu, Wo, Wo
+Wo, Wo, Gg^Fet, Gg, Gg, Aa, Ai, Wwf, Aa^Fpa, Ms, Rd, Ai, Re, Ias, Ias, Rrc^Vd, Ch, Ch, Ias, Ias, Hh, Aa^Fpa, Ww^Bw|, Ai, Ms, Ai, Wwf, Uu^Tf, Ur, Uu^Vud, Uh, Wo, Wo
+Wo, Wo, Gll^Fp, Aa^Fpa, Ds, Ds, Ai, Rd, Rd, Hhd, Rd, Re, Ms, Rb, Rb, Ias, Ias, Ch, Rd^Tf, Rd, Ai, Wwf, Rr, Hh, Aa^Fpa, Wo, Ai, Uu^Tf, Ur, Uu, Wo, Wo, Wo
+Wo, Wo, Hh, Ha, Ai, Ai, Qlf, Rd, Hd, Qlf, Dd, Rd, Wwf, Hhd, Rd^Ft, Aa, Re, Re^Fms, Ms, Ai, Rr, Rr, Aa, Rr, Rr, Aa, Gg, Wwf, Ds, Ds, Wo, Wo, Wo
+Wo, Wo, Mm, Mm, Ai, Qlf, Ds, Rd, Hd, Qlf, Dd^Vda, Dd, Ai, Wwf, Aa^Fpa, Uu, Ur, Re, Ss^Bw\r, Ss, Rr, Gg, Gs^Ft, Gs^Ft, Dd, Rr, Rr, Ai, Wwr, Wwr, Wo, Wo, Wo
+Wo, Wo, Aa^Fpa, Mm, Ai, Wwr, Wwr, Ds, Rd^Ft, Rd^Ft, Mv, Hd, Hd, Ai, Uu^Tf, Uu^Tf, Uu, Ss, Aa^Fpa, Rr, Dd, Hd, Md, Md, Dd^Do, Dd, Rr, Ai, Ai, Ai, Wo, Wo, Wo
+Wo, Wo, Wo, Ai, Ww^Vm, Ai, Wo, Wo, Wo, Md, Md, Md, Rd^Ft, Qxu, Qxu, Uh, Ai, Ss, Hh, Dd, Dd^Vda, Dd, Dd^Dc, Md, Md, Dd, Rr, Ias^Vhc, Ai, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -217,7 +217,7 @@
         [/message]
         [message]
             side=4
-            message= _"The invaders are rumored to be a strange alliance of races, and our control over this isle might be threatened. We must be prepared for the surprises thrown at us."
+            message= _"Phantom armies approach on the horizon. If we defeat them all, they may be released from this timeless prison."
         [/message]
         [message]
             side=3

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -8,7 +8,7 @@
     id=multiplayer_2p_Isle_of_Mists
     name= _ "2p — Isle of Mists (Survival)"
     description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units, catered for experienced players. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. Default map settings are required for the scenario to work properly. By Lord-Knightmare."
-    experience_modifier=100
+    experience_modifier=90
     map_file=multiplayer/maps/2p_Isle_of_Mists_basic.map
     victory_when_enemies_defeated=no
     force_lock_settings=yes

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-IoM
 
 #define ISLE_OF_MISTS_MSG_STR
- _ "Your aim is to survive the spawning waves of units and defeat the final archenemies. The spawning waves are randomly generated and will be different each time Isle of Mists is played. They appear along the north, south, and west map edges — though they are most likely to spawn on the west edge. The waves appear at somewhat regular intervals. The weather will also change randomly, affecting the layout of the map."
+    _ "Your aim is to survive the spawning waves of units and defeat the final archenemies. The spawning waves are randomly generated and will be different each time Isle of Mists is played. They appear along the north, south, and west map edges — though they are most likely to spawn on the west edge. The waves appear at somewhat regular intervals. The weather will also change randomly, affecting the layout of the map."
 #enddef
 
 [multiplayer]

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -1,0 +1,299 @@
+#textdomain wesnoth-IoM
+
+#define ISLE_OF_MISTS_MSG_STR
+ _ "Your aim is to survive the spawning waves of units and defeat the final archenemies. The spawning waves are randomly generated and will be different each time Isle of Mists is played. They appear along the north, south, and west map edges — though they are most likely to spawn on the west edge. The waves appear at somewhat regular intervals. The weather will also change randomly, affecting the layout of the map."
+#enddef
+
+[multiplayer]
+    id=multiplayer_2p_Isle_of_Mists
+    name= _ "2p — Isle of Mists (Survival) (Default)"
+    description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. You need to use the default map settings for the scenario to work right. By Lord-Knightmare."
+    experience_modifier=100
+    map_file=2p_Isle_of_Mists_basic.map
+    victory_when_enemies_defeated=no
+    force_lock_settings=yes
+
+    {DEFAULT_SCHEDULE}
+    random_start_time=yes
+
+    mp_village_gold=1
+
+    [side]
+        side=1
+        team_name="invaders"
+        color=darkred
+        user_team_name= _ "teamname^Invaders"
+        allow_player=no
+        disallow_observers=yes
+        {FLAG_VARIANT6 ragged}
+        no_leader=yes
+        controller="ai"
+        defeat_condition=never
+    [/side]
+
+    [side]
+        side=2
+        color=darkred
+        team_name="invaders"
+        user_team_name= _ "teamname^Invaders"
+        allow_player=no
+        disallow_observers=yes
+        {FLAG_VARIANT6 ragged}
+        no_leader=yes
+        controller="ai"
+        [ai]
+            aggression=-4.0
+            caution=0.99
+            grouping=defensive
+            village_value=12
+        [/ai]
+    [/side]
+
+    [side]
+        side=3
+        canrecruit=yes
+        team_name="human"
+        user_team_name= _ "teamname^Defenders"
+        controller="human"
+        save_id="Player1"
+        gold=100
+        income=0
+        gold_lock=yes
+        income_lock=yes
+        {FLAG_VARIANT long}
+        controller_lock=no
+        team_lock=yes
+        faction_lock=no
+        leader_lock=no
+        color_lock=no
+        fog=yes
+        share_vision=all
+        # Otherwise the era may add the quick trait.
+        # This is not a PvP game, for which this bonus is designed.
+        # If the player chooses a slow unit, he should also take the disadvantages.
+        [variables]
+            dont_make_me_quick=yes
+        [/variables]
+    [/side]
+
+    [side]
+        side=4
+        canrecruit=yes
+        team_name="human"
+        user_team_name= _ "teamname^Defenders"
+        controller="human"
+        save_id="Player2"
+        gold=100
+        income=0
+        gold_lock=yes
+        {FLAG_VARIANT long}
+        income_lock=yes
+        controller_lock=no
+        team_lock=yes
+        faction_lock=no
+        leader_lock=no
+        color_lock=no
+        fog=yes
+        share_vision=all
+        [variables]
+            dont_make_me_quick=yes
+        [/variables]
+    [/side]
+
+    [side]
+        side=5
+        color=black
+        team_name="human"
+        user_team_name= _ "teamname^Defenders"
+        allow_player=no
+        hidden=yes
+        disallow_observers=yes
+        {FLAG_VARIANT long}
+        no_leader=yes
+        controller="ai"
+    [/side]
+
+    [lua]
+        code = << wesnoth.dofile( "multiplayer/scenarios/2p_Isle_of_Mists.lua" ) >>
+    [/lua]
+
+    [event]
+        name=prestart
+        [store_unit]
+            variable=leader
+            [filter]
+                side=3,4
+            [/filter]
+            kill=no
+        [/store_unit]
+        [if]
+            [variable]
+                name=leader.length
+                less_than=2
+            [/variable]
+            [then]
+                {VARIABLE lose_condition_string ( _ "Death of your leader")}
+                {VARIABLE notes ( _ "Since your team has only one leader, the enemy waves will not be at full strength.")}
+            [/then]
+            [else]
+                {VARIABLE lose_condition_string ( _ "Death of both of your team’s leaders")}
+                {VARIABLE notes ( _ "Since your team has two leaders, the enemy waves will be at full strength.")}
+                # each village will now support an upkeep of 2 instead of 1
+                # this makes the scenario somewhat passable now.
+                [modify_side]
+                    side=3,4
+                    village_support=2
+                [/modify_side]
+            [/else]
+        [/if]
+        {CLEAR_VARIABLE leader}
+        [music]
+            name=wanderer.ogg
+            ms_before=2000
+        [/music]
+        [music]
+            name=battle.ogg
+            ms_before=2000
+            append=yes
+        [/music]
+        [music]
+            name=breaking_the_chains.ogg
+            play_once=yes
+            immediate=yes
+        [/music]
+
+        [objectives]
+            [objective]
+                description= _ "Survive and defeat all enemy waves"
+                condition=win
+            [/objective]
+            [objective]
+                description=$lose_condition_string
+                condition=lose
+            [/objective]
+
+            [note]
+                description=$notes
+            [/note]
+        [/objectives]
+
+        {CLEAR_VARIABLE lose_condition_string}
+        {CLEAR_VARIABLE notes}
+
+        [label]
+            x,y = 16,9
+            text = _"Healing Keep"
+        [/label]
+
+        [unit]
+            side=5
+            type="Elvish Lady"
+            id="healer_elf"
+            x,y=16,9
+            canrecruit=no
+            moves=0
+            max_moves=0
+            hitpoints=28
+            max_hitpoints=28
+            generate_name=yes
+            [modifications]
+                {TRAIT_INTELLIGENT}
+                {TRAIT_DEXTROUS}
+            [/modifications]
+        [/unit]
+    [/event]
+
+    [event]
+        name=start
+        [message]
+            caption= _"Isle of Mists — a random survival scenario"
+            speaker=narrator
+            image="portraits/monsters/fire-dragon.png"
+            #wmllint: local spellings jb Rhuvaen
+            message={ISLE_OF_MISTS_MSG_STR}
+        [/message]
+        [message]
+            side=3
+            message= _"Invaders approach on the horizon! Let us prepare defences!"
+        [/message]
+        [message]
+            side=4
+            message= _"The invaders are rumored to be a strange alliance of races, and our control over this isle might be threatened. We must be prepared for the surprises thrown at us."
+        [/message]
+        [message]
+            side=3
+            message= _"Then let us make them regret their incursion."
+        [/message]
+    [/event]
+
+    [event]
+        name=last breath
+        first_time_only=no
+        [filter]
+            side=3,4
+            canrecruit=yes
+        [/filter]
+        [if]
+            [have_unit]
+                side=3,4
+                canrecruit=yes
+            [/have_unit]
+            [then]
+                [message]
+                    speaker=unit
+                    message= _"Ugh! How can this be? Defeated by mere barbarians! My gods have forsaken me..."
+                [/message]
+            [/then]
+            [else]
+                [music]
+                    name=defeat.ogg
+                    play_once=yes
+                    immediate=yes
+                [/music]
+                [sound]
+                    name=dwarf-laugh.wav
+                [/sound]
+                [message]
+                    speaker=second_unit
+                    message= _"Cheers of your enemy are the last thing you hear as you slip into death...their joy fills your last moments with pure hate."
+                [/message]
+                [endlevel]
+                    result=defeat
+                [/endlevel]
+            [/else]
+        [/if]
+    [/event]
+
+    [event]
+        name=time over
+        [music]
+            name=defeat.ogg
+            play_once=yes
+            immediate=yes
+        [/music]
+        [sound]
+            name=dwarf-laugh.wav
+        [/sound]
+        [message]
+            side=1,2
+            canrecruit=yes
+            message= _ "The enemy cheers as a dark mist rises from the land, engulfing you. As ghostly wisps drain away your will, you realize that your time in this land is over."
+        [/message]
+    [/event]
+
+    [options]
+        [slider]
+            id = "enemy_gold_factor"
+            default = 0
+            min = -30
+            max = 60
+            step = 10
+            #textdomain wesnoth-lib
+            name = _ "Difficulty"
+            #textdomain wesnoth-multiplayer
+            description =_  "Changes the gold worth of the enemy spawns by a certain percentage"
+        [/slider]
+    [/options]
+[/multiplayer]
+
+#undef ISLE_OF_MISTS_MSG_STR

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -209,7 +209,6 @@
             caption= _"Isle of Mists — a random survival scenario"
             speaker=narrator
             image="portraits/monsters/fire-dragon.png"
-            #wmllint: local spellings jb Rhuvaen
             message={ISLE_OF_MISTS_MSG_STR}
         [/message]
         [message]

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -6,10 +6,10 @@
 
 [multiplayer]
     id=multiplayer_2p_Isle_of_Mists
-    name= _ "2p — Isle of Mists (Survival) (Default)"
+    name= _ "2p — Isle of Mists (Survival)"
     description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. You need to use the default map settings for the scenario to work right. By Lord-Knightmare."
     experience_modifier=100
-    map_file=2p_Isle_of_Mists_basic.map
+    map_file=multiplayer/maps/2p_Isle_of_Mists_basic.map
     victory_when_enemies_defeated=no
     force_lock_settings=yes
 

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -213,7 +213,7 @@
         [/message]
         [message]
             side=3
-            message= _"Invaders approach on the horizon! Let us prepare defences!"
+            message= _"You arrive near a mystic shrine, where the apparitions of ancient armies are forever trapped and doomed to eternally cleanse the isle of all interlopers."
         [/message]
         [message]
             side=4

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -7,7 +7,7 @@
 [multiplayer]
     id=multiplayer_2p_Isle_of_Mists
     name= _ "2p — Isle of Mists (Survival)"
-    description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units, catered for experienced players. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. You need to use the default map settings for the scenario to work right. By Lord-Knightmare."
+    description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units, catered for experienced players. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. Default map settings are required for the scenario to work properly. By Lord-Knightmare."
     experience_modifier=100
     map_file=multiplayer/maps/2p_Isle_of_Mists_basic.map
     victory_when_enemies_defeated=no

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -221,7 +221,7 @@
         [/message]
         [message]
             side=3
-            message= _"Then let us make them regret their incursion."
+            message= _"Let us prepare ourselves for the coming battle."
         [/message]
     [/event]
 

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -134,6 +134,10 @@
             [then]
                 {VARIABLE lose_condition_string ( _ "Death of your leader")}
                 {VARIABLE notes ( _ "Since your team has only one leader, the enemy waves will not be at full strength.")}
+                [gold]
+                    side=3,4
+                    amount=25
+                [/gold]
             [/then]
             [else]
                 {VARIABLE lose_condition_string ( _ "Death of both of your team’s leaders")}
@@ -278,6 +282,20 @@
             canrecruit=yes
             message= _ "A dark mist rises from the land, draining your senses and your will away. You dimly realize that you will soon join the other ghosts as another faceless guardian of the ancient shrine."
         [/message]
+    [/event]
+
+    [event]
+        name="die"
+        first_time_only=yes
+        [filter]
+            id="healer_elf"
+        [/filter]
+
+        # clear the label
+        [label]
+            x,y=16,9
+            text=""
+        [/label]
     [/event]
 
     [options]

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -7,7 +7,7 @@
 [multiplayer]
     id=multiplayer_2p_Isle_of_Mists
     name= _ "2p — Isle of Mists (Survival)"
-    description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units, catered for experienced players. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. Default map settings are required for the scenario to work properly. By Lord-Knightmare."
+    description= _ "Isle of Mists is a survival scenario which can be played alone or with another player against randomly spawned AI units, catered for experienced players. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. Default map settings are required for the scenario to work properly. By Lord-Knightmare."
     experience_modifier=90
     map_file=multiplayer/maps/2p_Isle_of_Mists_basic.map
     victory_when_enemies_defeated=no

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -276,7 +276,7 @@
         [message]
             side=1,2
             canrecruit=yes
-            message= _ "The enemy cheers as a dark mist rises from the land, engulfing you. As ghostly wisps drain away your will, you realize that your time in this land is over."
+            message= _ "A dark mist rises from the land, draining your senses and your will away. You dimly realize that you will soon join the other ghosts as another faceless guardian of the ancient shrine."
         [/message]
     [/event]
 

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -240,7 +240,7 @@
             [then]
                 [message]
                     speaker=unit
-                    message= _"Ugh! How can this be? Defeated by mere barbarians! My gods have forsaken me..."
+                    message= _"How can this be? My gods have forsaken me..."
                 [/message]
             [/then]
             [else]

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -7,7 +7,7 @@
 [multiplayer]
     id=multiplayer_2p_Isle_of_Mists
     name= _ "2p — Isle of Mists (Survival)"
-    description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. You need to use the default map settings for the scenario to work right. By Lord-Knightmare."
+    description= _ "Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units, catered for experienced players. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. You need to use the default map settings for the scenario to work right. By Lord-Knightmare."
     experience_modifier=100
     map_file=multiplayer/maps/2p_Isle_of_Mists_basic.map
     victory_when_enemies_defeated=no

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -1,7 +1,7 @@
 #textdomain wesnoth-IoM
 
 #define ISLE_OF_MISTS_MSG_STR
-    _ "Your aim is to survive the spawning waves of units and defeat the final archenemies. The spawning waves are randomly generated and will be different each time Isle of Mists is played. They appear along the north, south, and west map edges — though they are most likely to spawn on the west edge. The waves appear at somewhat regular intervals. The weather will also change randomly, affecting the layout of the map."
+    _ "Your aim is to survive spawning waves of units and defeat the final archenemies. Spawns are randomly generated and will be different each time Isle of Mists is played. The waves appear at somewhat regular intervals. The weather will also change randomly, affecting the layout of the map."
 #enddef
 
 [multiplayer]

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -254,7 +254,7 @@
                 [/sound]
                 [message]
                     speaker=second_unit
-                    message= _"Cheers of your enemy are the last thing you hear as you slip into death...their joy fills your last moments with pure hate."
+                    message= _"As the cold grasp of death draws nearer, you feel your spirit being separated from your body. You realize that you will soon be doomed to the same fate as the phantom guardians of the shrine."
                 [/message]
                 [endlevel]
                     result=defeat

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -319,7 +319,7 @@ on_event("new turn", function()
 	wesnoth.wml_actions.message {
 		side="3,4",
 		canrecruit=true,
-		message= _ "The last and most powerful of these creatures are almost upon us. I feel that if we can finish them off in time, we shall be victorious.",
+		message= _ "The last and most powerful of our enemies are upon us. If we can finish them off in time, we shall be victorious.",
 	}
 
 	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(2,3)

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -370,7 +370,7 @@ end)
 -------------------------------------------------------------------------------
 -------------------------- Weather events -------------------------------------
 -------------------------------------------------------------------------------
--- The weather evens are complateleey unrelated to the spawn events.
+-- The weather events are completely unrelated to the spawn events.
 
 local function get_weather_duration(max_duration)
 	local res = wesnoth.random(2)

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -315,14 +315,14 @@ on_event("new turn", function()
 		append = true,
 	}
 	final_spawn()
-	wesnoth.scenario.turns = wesnoth.current.turn + 12
+	wesnoth.scenario.turns = wesnoth.current.turn + 16
 	wesnoth.wml_actions.message {
 		side="3,4",
 		canrecruit=true,
 		message= _ "The last and most powerful of these creatures are almost upon us. I feel that if we can finish them off in time, we shall be victorious.",
 	}
 
-	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(1,2)
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(2,3)
 end)
 
 -- after the first final spawn, spawn a new final spawn every 1 or 2 turns.

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -80,7 +80,7 @@ local random_spawns = {
 	{
 		{"Dwarvish Fighter", "Dwarvish Steelclad", "more", "Dwarvish Lord"},
 		{"Poacher", "Trapper", "more", "none"},
-		{"Jinn", "more", "more", "none"},
+		{"Fire Wraith", "more", "more", "none"},
 	},
 	{
 		{"Horned Scarab", "more", "more", "more"},
@@ -169,12 +169,12 @@ local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_
 	local end_spawns = 0
 	for spawn_number = 1, num_spawns do
 		local turn = 3 + (spawn_number - 1) * interval
-		local gold = base_gold_amount + (turn - 3) * gold_increment
+		local gold = (base_gold_amount * 0.60) + (turn - 3) * gold_increment
 		if spawn_number > 1 then
 			-- formula taken from original Dark forecast, TODO: find easier formula.
 			local unit_gold = (turn - 3) * gold_increment + math.min(mathx.random(base_gold_amount), mathx.random(base_gold_amount))
 			local gold_per_unit = gold_per_unit_amount + turn / 1.5
-			local units = unit_gold / gold_per_unit + units_amount + mathx.random(-1, 1)
+			local units = (unit_gold * 0.60) / gold_per_unit + units_amount + mathx.random(-1, 1)
 			if mathx.random(5) == 5 then
 				units = units - 1
 			end
@@ -213,18 +213,7 @@ end
 local function place_units(unittypes, x, y)
 	for i,v in ipairs(unittypes) do
 		local u = wesnoth.units.create { type = v, passable = true, placement = "map", generate_name = true, side = 2 }
-		u:add_modification("object", {
-			T.effect {
-				apply_to = "movement_costs",
-				replace = true,
-				T.movement_costs {
-					flat = 1,
-					sand = 2,
-					forest = 2,
-					deep_water = 3,
-				}
-			}
-		})
+
 		-- give the unit less moves on its first turn.
 		u.status.slowed = true
 		u:add_modification("object", {
@@ -267,9 +256,9 @@ end)
 on_event("prestart", function()
 	local leaders = wesnoth.units.find_on_map { side = "3,4", canrecruit= true}
 	if #leaders < 2 then
-		create_timed_spawns(5, 6, 45, 5, 3, 21)
+		create_timed_spawns(6, 11, 25, 5, 3, 21)
 	else
-		create_timed_spawns(4, 6, 90, 4, 4, 23)
+		create_timed_spawns(5, 11, 55, 4, 4, 23)
 	end
 end)
 
@@ -322,7 +311,7 @@ on_event("new turn", function()
 		message= _ "The last and most powerful of our enemies are upon us. If we can finish them off in time, we shall be victorious.",
 	}
 
-	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(2,3)
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(1,2)
 end)
 
 -- after the first final spawn, spawn a new final spawn every 1 or 2 turns.
@@ -369,7 +358,7 @@ on_event("prestart", function()
 	wml.array_access.set("fixed_spawn", {
 		fixed_spawn(27, 3, "Armageddon Drake", "Wild Wyvern", "Grand Knight"),
 		fixed_spawn(8, 14, "Dune Paragon", "Dune Luminary", "Fire Drake"),
-		fixed_spawn(4, 9, "Necromancer", "Necrophage", "Dune Explorer", "Dune Rover", "Dune Falconer", "Dune Captain", "Dune Soldier", "Dune Rover", "Dune Soldier"),
+		fixed_spawn(4, 9, "Necromancer", "Dune Soldier", "Dune Rover", "Dune Rover", "Dune Falconer", "Dune Captain", "Dune Rover", "Dune Soldier"),
 		fixed_spawn(28,11, "Elvish Champion", "Dune Spearguard", "Dwarvish Stalwart", "Necrophage"),
 		fixed_spawn(5, 3, "Dwarvish Arcanister", "Mage of Light", "Drake Warrior", "Arch Mage"),
 	})

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -174,7 +174,7 @@ local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_
 			-- formula taken from original Dark forecast, TODO: find easier formula.
 			local unit_gold = (turn - 3) * gold_increment + math.min(mathx.random(base_gold_amount), mathx.random(base_gold_amount))
 			local gold_per_unit = gold_per_unit_amount + turn / 1.5
-			local units = unit_gold / gold_per_unit + units_amount + mathx.random(-1, 2)
+			local units = unit_gold / gold_per_unit + units_amount + mathx.random(-1, 1)
 			if mathx.random(5) == 5 then
 				units = units - 1
 			end
@@ -267,9 +267,9 @@ end)
 on_event("prestart", function()
 	local leaders = wesnoth.units.find_on_map { side = "3,4", canrecruit= true}
 	if #leaders < 2 then
-		create_timed_spawns(5, 11, 30, 5, 4, 21)
+		create_timed_spawns(5, 6, 45, 5, 3, 21)
 	else
-		create_timed_spawns(4, 11, 60, 4, 5, 23)
+		create_timed_spawns(4, 6, 90, 4, 4, 23)
 	end
 end)
 

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -1,0 +1,534 @@
+local helper = wesnoth.require("helper")
+local _ = wesnoth.textdomain 'wesnoth-multiplayer'
+local T = wml.tag
+local on_event = wesnoth.require("on_event")
+
+local random_spawns = {
+	{
+		{"Heavy Infantryman", "Shock Trooper", "Iron Mauler", "none"},
+		{"Elvish Fighter", "Elvish Hero", "more", "Elvish Champion"},
+		{"Goblin Spearman", "more", "more", "more"},
+		{"Goblin Spearman", "Goblin Rouser", "none", "none"},
+		{"Dune Soldier", "Dune Swordsman", "Dune Blademaster", "Dune Paragon"},
+	},
+	{
+		{"Mage", "Red Mage", "Silver Mage", "none"},
+		{"Footpad", "Outlaw", "more", "none"},
+		{"Drake Fighter", "Drake Warrior", "Drake Blademaster", "none"},
+		{"Walking Corpse", "more", "more", "more"},
+	},
+	{
+		{"Merman Hunter", "Merman Spearman", "Merman Entangler", "none"},
+		{"Naga Dirkfang", "Naga Ophidian", "Naga Sicarius", "none"},
+		{"Spearman", "Pikeman", "none", "Halberdier"},
+	},
+	{
+		{"Elvish Shaman", "Elvish Druid", "Elvish Shyde", "Elvish Sylph"},
+		{"Drake Burner", "Fire Drake", "Inferno Drake", "Armageddon Drake"},
+		{"Skeleton", "Revenant", "more", "Draug"},
+	},
+	{
+		{"Rock Scorpion", "Wild Wyvern", "none", "none"},
+		{"Fire Ant", "more", "Cave Bear", "more"},
+	},
+	{
+		{"Ghoul", "Necrophage", "more", "none"},
+		{"Elvish Archer", "Elvish Marksman", "none", "Elvish Sharpshooter"},
+		{"Dune Burner", "Dune Scorcher", "Dune Firetrooper", "none"},
+		{"Drake Clasher", "Drake Thrasher", "more", "Drake Enforcer"},
+	},
+	{
+		{"Skeleton Archer", "Bone Shooter", "more", "Banebow"},
+		{"Dune Skirmisher", "Dune Strider", "none", "Dune Harrier"},
+		{"Drake Glider", "Sky Drake", "Hurricane Drake", "none"},
+	},
+	{
+		{"Merman Fighter", "Merman Warrior", "more", "Merman Triton"},
+		{"Dark Adept", "Dark Sorcerer", "Necromancer", "none"},
+		{"Elvish Scout", "Elvish Rider", "more", "none"},
+	},
+	{
+		{"Wose", "Elder Wose", "Ancient Wose", "none"},
+		{"Orcish Archer", "Orcish Crossbowman", "Orcish Slurbow", "none"},
+		{"Saurian Skirmisher", "more", "Saurian Ambusher", "more"},
+	},
+	{
+		{"Dune Soldier", "Dune Swordsman", "more", "none"},
+		{"Vampire Bat", "Blood Bat", "more", "none"},
+		{"Dwarvish Thunderer", "Dwarvish Thunderguard", "none", "none"},
+		{"Giant Ant", "more", "more", "more"},
+		{"Giant Scorpling", "more", "Sergeant", "Orcish Ruler"},
+	},
+	{
+		{"Dwarvish Guardsman", "Dwarvish Stalwart", "none", "none"},
+		{"Bowman", "Longbowman", "more", "Master Bowman"},
+		{"Troll Whelp", "Troll", "Troll Warrior", "none"},
+	},
+	{
+		{"Orcish Assassin", "Orcish Slayer", "more", "none"},
+		{"Dune Rider", "Dune Sunderer", "more", "Dune Cataphract"},
+		{"Saurian Augur", "Saurian Soothsayer", "none", "none"},
+	},
+	{
+		{"Wolf Rider", "Goblin Pillager", "more", "none"},
+		{"Ghost", "Shadow", "more", "more"},
+		{"Sergeant", "Lieutenant", "General", "Grand Marshal"},
+	},
+	{
+		{"Gryphon Rider", "none", "more", "none"},
+		{"Dune Rover", "Dune Explorer", "more", "Dune Wayfarer"},
+	},
+	{
+		{"Dwarvish Fighter", "Dwarvish Steelclad", "more", "Dwarvish Lord"},
+		{"Poacher", "Trapper", "more", "none"},
+		{"Jinn", "more", "more", "none"},
+	},
+	{
+		{"Horned Scarab", "more", "more", "more"},
+		{"Dwarvish Ulfserker", "Dwarvish Berserker", "more", "none"},
+		{"Mage", "White Mage", "Mage of Light", "none"},
+		{"Orcish Grunt", "Orcish Warrior", "more", "none"},
+	},
+}
+
+local function get_spawn_types(num_units, max_gold, unit_pool)
+	local gold_left = max_gold
+	local units_left = num_units
+	local current_types = {}
+	while gold_left > 0 and units_left > 0 do
+		local unit_group = wesnoth.random(#unit_pool)
+		local unit_rank = 1
+		local unit_type = wesnoth.unit_types[unit_pool[unit_group][unit_rank]]
+		table.insert(current_types, { group = unit_group, type =  unit_type})
+		gold_left = gold_left - unit_type.cost
+		units_left = units_left - 1
+	end
+	-- Upgrade units, eigher by replacing them with better units or by duplicating them.
+	for next_rank = 2,4 do
+		local next_types = {}
+		for i,v in ipairs(current_types) do
+			local advanceto = unit_pool[v.group][next_rank] or ""
+			local unit_type = wesnoth.unit_types[advanceto]
+			if unit_type then
+				local upgrade_cost = math.ceil((unit_type.cost - v.type.cost) * 1.25)
+				if gold_left >= upgrade_cost then
+					gold_left = gold_left - upgrade_cost
+					table.insert(next_types, { group = v.group, type = unit_type})
+				else
+					table.insert(next_types, { group = v.group, type = v.type})
+				end
+			elseif advanceto == "more" then
+				local upgrade_cost = v.type.cost + 2
+				if gold_left >= upgrade_cost then
+					gold_left = gold_left - upgrade_cost
+					table.insert(next_types, { group = v.group, type = v.type})
+				end
+				table.insert(next_types, { group = v.group, type = v.type})
+			else
+				table.insert(next_types, { group = v.group, type = v.type})
+			end
+		end
+		current_types = next_types
+	end
+	--spend remaining gold
+	local min_cost = 100
+	for i,v in ipairs(unit_pool) do
+		min_cost = math.min(min_cost, wesnoth.unit_types[v[1]].cost)
+	end
+	while gold_left >= min_cost do
+		local possible_groups = {}
+		for i,v in ipairs(unit_pool) do
+			local unit_type = wesnoth.unit_types[v[1]]
+			if unit_type.cost <= gold_left then
+				table.insert(possible_groups, { group = i, type = unit_type})
+			end
+		end
+		local index = wesnoth.random(#possible_groups)
+		table.insert(current_types, possible_groups[index])
+		gold_left = gold_left - possible_groups[index].type.cost
+	end
+	local res = {}
+	for i,v in ipairs(current_types) do
+		table.insert(res, v.type.id)
+	end
+	return res
+end
+
+-- creates the 'timed_spawn' wml array.
+-- @a num_spawns: the total number of times units get spawned
+-- @a interval: the number of turns between 2 spawns
+-- @a base_gold_amount, gold_increment: used to calculate the amount of gold available for each timed spawn
+-- @a units_amount, gold_per_unit_amount: used to calculate the number of units spawned in each timed spawn
+local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_increment, units_amount, gold_per_unit_amount)
+	local configure_gold_factor = ((wml.variables["enemy_gold_factor"] or 0) + 100)/100
+	local random_spawn_numbers = {}
+	for i = 1, #random_spawns do
+		table.insert(random_spawn_numbers, i)
+	end
+	helper.shuffle(random_spawn_numbers)
+	local final_turn = math.ceil(((num_spawns - 1) * interval + 40 + wesnoth.random(2,4))/2)
+	local end_spawns = 0
+	for spawn_number = 1, num_spawns do
+		local turn = 3 + (spawn_number - 1) * interval
+		local gold = base_gold_amount + (turn - 3) * gold_increment
+		if spawn_number > 1 then
+			-- formula taken from original Dark forecast, TODO: find easier formula.
+			local unit_gold = (turn - 3) * gold_increment + math.min(wesnoth.random(base_gold_amount), wesnoth.random(base_gold_amount))
+			local gold_per_unit = gold_per_unit_amount + turn / 1.5
+			local units = unit_gold / gold_per_unit + units_amount + wesnoth.random(-1, 2)
+			if wesnoth.random(5) == 5 then
+				units = units - 1
+			end
+			-- end complicated formula
+			turn = turn + wesnoth.random(-1, 1)
+			-- reduce gold and units for spawns after the final spawn
+			if turn >= final_turn then
+				units = units / (end_spawns + 3)
+				gold = gold / (end_spawns + 4)
+				end_spawns = end_spawns + 1
+				-- we only want two spawns after the final turn.
+				if end_spawns > 2 then
+					break
+				end
+			end
+			wml.variables[string.format("timed_spawn[%d]", spawn_number - 1)] = {
+				units = math.ceil(units),
+				turn = turn,
+				gold = helper.round(gold * configure_gold_factor),
+				pool_num = random_spawn_numbers[spawn_number],
+			}
+		else
+			wml.variables[string.format("timed_spawn[%d]", spawn_number - 1)] = {
+				units = units_amount + 1,
+				turn = turn,
+				gold = gold,
+				pool_num = random_spawn_numbers[spawn_number],
+			}
+		end
+	end
+	wml.variables["final_turn"] = final_turn
+end
+
+-- @a unittypes: a array of strings
+-- @a x,y: the location where to spawn the units on the map.
+local function place_units(unittypes, x, y)
+	for i,v in ipairs(unittypes) do
+		local u = wesnoth.units.create { type = v, passable = true, placement = "map", generate_name = true, side = 2 }
+		u:add_modification("object", {
+			T.effect {
+				apply_to = "movement_costs",
+				replace = true,
+				T.movement_costs {
+					flat = 1,
+					sand = 2,
+					forest = 2,
+					deep_water = 3,
+				}
+			}
+		})
+		-- give the unit less moves on its first turn.
+		u.status.slowed = true
+		u:add_modification("object", {
+			duration = "turn end",
+			T.effect {
+				apply_to = "movement",
+				increase = "-50%",
+			}
+		})
+		local dst_x, dst_y = wesnoth.find_vacant_tile(x, y, u)
+		u:to_map(dst_x, dst_y)
+		wesnoth.add_known_unit(v)
+		wesnoth.map.set_owner(dst_x, dst_y, 1)
+	end
+end
+
+local function final_spawn()
+	local spawns_left = wml.variables["fixed_spawn.length"]
+	if spawns_left == 0 then
+		return
+	end
+	local spawn_index = wesnoth.random(spawns_left) - 1
+	local spawn = wml.variables[string.format("fixed_spawn[%d]", spawn_index)]
+	wml.variables[string.format("fixed_spawn[%d]", spawn_index)] = nil
+	local types = {}
+	for tag in wml.child_range(spawn, "type") do
+		table.insert(types, tag.type)
+	end
+	place_units(types, spawn.x, spawn.y)
+end
+
+-- convert all 'veteran' units from side 2 to the more aggressive side 1
+-- this must happen before the new units are created from spawns.
+on_event("new turn", function()
+	for i, unit in ipairs(wesnoth.units.find_on_map { side = 2 }) do
+		unit.side = 1
+	end
+end)
+
+on_event("prestart", function()
+	local leaders = wesnoth.units.find_on_map { side = "3,4", canrecruit= true}
+	if #leaders < 2 then
+		create_timed_spawns(5, 11, 50, 5, 4, 21)
+	else
+		create_timed_spawns(4, 11, 90, 4, 5, 23)
+	end
+end)
+
+-- the regular spawns:
+--   when they appear is defined in the 'timed_spawn' wml array. which is created at prestart
+--   which unit types get spawned is defined in the 'main_spawn' wml array which is also spawned at prestart
+on_event("new turn", function()
+	local next_spawn = wml.variables["timed_spawn[0]"]
+	if next_spawn == nil then
+		return
+	end
+	if wesnoth.current.turn ~= next_spawn.turn then
+		return
+	end
+	wml.variables["timed_spawn[0]"] = nil
+	local unit_types = get_spawn_types(next_spawn.units, next_spawn.gold, random_spawns[next_spawn.pool_num])
+	local spawn_areas = {{"6", "3"}, {"4", "6"}, {"3", "9"}, {"3", "13"}, {"7", "14"}, {"10", "14"}, {"14", "14"}, {"20", "15"}, {"26", "15"}, {"28", "11"}, {"29", "7"}, {"25", "3"}, {"29", "3"}, {"19", "3"}, {"15", "3"}, {"12", "3"}, {"8", "4"},}
+	local spawn_area = spawn_areas[wesnoth.random(#spawn_areas)]
+	local locations_in_area = wesnoth.map.find { x = spawn_area[1], y = spawn_area[2], radius=1, include_borders=false }
+	local chosen_location = locations_in_area[wesnoth.random(#locations_in_area)]
+	place_units(unit_types, chosen_location[1], chosen_location[2])
+end)
+
+-- on turn 'final_turn' the first 'final spawn' appears
+on_event("new turn", function()
+	if wesnoth.current.turn ~= wml.variables["final_turn"] then
+		return
+	end
+	wesnoth.wml_actions.music {
+		name = "battle.ogg",
+		ms_before = 200,
+		immediate = true,
+		append = true,
+	}
+	final_spawn()
+	wesnoth.game_config.last_turn = wesnoth.current.turn + 12
+	wesnoth.wml_actions.message {
+		side="3,4",
+		canrecruit=true,
+		message= _ "The last and most powerful of these creatures are almost upon us. I feel that if we can finish them off in time, we shall be victorious.",
+	}
+
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + wesnoth.random(1,2)
+end)
+
+-- after the first final spawn, spawn a new final spawn every 1 or 2 turns.
+on_event("new turn", function()
+	if wesnoth.current.turn ~= wml.variables["next_final_spawn"] then
+		return
+	end
+	final_spawn()
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + wesnoth.random(1,2)
+end)
+
+-- The victory condition: win when there are no enemy unit after the first final spawn appeared.
+on_event("die", function()
+	if wesnoth.current.turn < wml.variables["final_turn"] then
+		return
+	end
+	if wesnoth.wml_conditionals.have_unit { side = "1,2"} then
+		return
+	end
+	wesnoth.wml_actions.music {
+		name = "victory.ogg",
+		play_once = true,
+		immediate = true,
+	}
+	wesnoth.wml_actions.message {
+		speaker = "narrator",
+		message = _"The screams and pleas for mercy are finally silenced, as you remove your blood soaked blade from the last of the invaders. There will be no more assailants coming to your shores. Your reign has finally earned stability.",
+		image ="wesnoth-icon.png",
+	}
+	wesnoth.wml_actions.endlevel {
+		result = "victory",
+	}
+end)
+
+-- initilize the 'fixed_spawn' and 'main_spawn'
+on_event("prestart", function()
+	local fixed_spawn = function(x, y, ...)
+		local res = { x = x, y = y }
+		for i,v in ipairs {...} do
+			table.insert(res, T.type { type = v })
+		end
+		return res
+	end
+	wml.array_access.set("fixed_spawn", {
+		fixed_spawn(27, 3, "Armageddon Drake", "Wild Wyvern", "Grand Knight"),
+		fixed_spawn(8, 14, "Dune Paragon", "Dune Luminary", "Fire Drake"),
+		fixed_spawn(4, 9, "Necromancer", "Necrophage", "Dune Explorer", "Dune Rover", "Dune Falconer", "Dune Captain", "Dune Soldier", "Dune Rover", "Dune Soldier"),
+		fixed_spawn(28,11, "Elvish Champion", "Dune Spearguard", "Dwarvish Stalwart", "Necrophage"),
+		fixed_spawn(5, 3, "Dwarvish Arcanister", "Mage of Light", "Drake Warrior", "Arch Mage"),
+	})
+end)
+
+
+-------------------------------------------------------------------------------
+-------------------------- Weather events -------------------------------------
+-------------------------------------------------------------------------------
+-- The weather evens are complateleey unrelated to the spawn events.
+
+local function get_weather_duration(max_duration)
+	local res = wesnoth.random(2)
+	while res < max_duration and wesnoth.random(2) == 2 do
+		res = res + 1
+	end
+	return res
+end
+-- initilize the weather_event wml array which defines at which turns the weather changes.
+on_event("prestart", function()
+	local turn = wesnoth.random(4,6)
+	local event_num = 0
+	local weather_to_dispense = {
+		{ turns_left = 10, id = "drought"},
+		{ turns_left = 12, id = "heavy rain"},
+		{ turns_left = 9, id = "snowfall"},
+	}
+	local clear_turns_left = 22
+	local heavy_snowfall_turns_left = 6
+	local second_rain_turns_left = 12
+	while turn < 55 and #weather_to_dispense > 0 do
+		-- pick a random weather except 'clear' and 'heavy snow'
+		local index = wesnoth.random(#weather_to_dispense)
+		local num_turns = get_weather_duration(weather_to_dispense[index].turns_left)
+		local weather_id = weather_to_dispense[index].id
+		weather_to_dispense[index].turns_left = weather_to_dispense[index].turns_left - num_turns
+		if weather_to_dispense[index].turns_left <= 0 then
+			table.remove(weather_to_dispense, index)
+		end
+		wml.variables[string.format("weather_event[%d]", event_num)] = {
+			turn = turn,
+			weather_id = weather_id,
+		}
+		event_num = event_num + 1
+		turn = turn + num_turns
+		-- Second snow happens half the time.
+		if weather_id == "snowfall" and heavy_snowfall_turns_left >= 0 and wesnoth.random(2) == 2 then
+			num_turns = get_weather_duration(heavy_snowfall_turns_left)
+			wml.variables[string.format("weather_event[%d]", event_num)] = {
+				turn = turn,
+				weather_id = "heavy snowfall",
+			}
+			event_num = event_num + 1
+			turn = turn + num_turns
+			heavy_snowfall_turns_left = heavy_snowfall_turns_left - num_turns
+		end
+
+		-- second heavy rain/inundation happens one-thirds the time
+		if weather_id == "heavy rain" and second_rain_turns_left >= 0 and wesnoth.random(3) == 3 then
+			num_turns = get_weather_duration(second_rain_turns_left)
+			wml.variables[string.format("weather_event[%d]", event_num)] = {
+				turn = turn,
+				weather_id = "second rain",
+			}
+			event_num = event_num + 1
+			turn = turn + num_turns
+			second_rain_turns_left = second_rain_turns_left - num_turns
+		end
+
+		-- Go back to clear weather.
+		num_turns = get_weather_duration(clear_turns_left)
+		wml.variables[string.format("weather_event[%d]", event_num)] = {
+			turn = turn,
+			weather_id = "clear",
+		}
+		event_num = event_num + 1
+		turn = turn + num_turns
+		clear_turns_left = clear_turns_left - num_turns
+	end
+end)
+
+local function weather_alert(text, red, green, blue)
+	wesnoth.wml_actions.print {
+		text = text,
+		duration = 120,
+		size = 26,
+		red = red,
+		green = green,
+		blue = blue,
+	}
+end
+
+local function weather_map(name)
+	wesnoth.wml_actions.terrain_mask {
+		mask = wesnoth.read_file(name),
+		x = 1,
+		y = 1,
+		border = true,
+	}
+	wesnoth.redraw {}
+end
+
+-- change weather at side 1 turns
+-- initially this was set for every side 3 turns which allowed a cheat to be used by players.
+-- the cheat was activated by setting side 3 as Empty and picking a faction optimised for the default/basic map for side 4.
+-- the result was that the weather change feature never triggered.
+on_event("side 1 turn", function()
+	-- get next weather event
+	local weather_event = wml.variables["weather_event[0]"]
+	if weather_event == nil then
+		return
+	end
+	if wesnoth.current.turn ~= weather_event.turn then
+		return
+	end
+	-- remove the to-be-consumed weather event from the todo list.
+	wml.variables["weather_event[0]"] = nil
+	if weather_event.weather_id == "clear" then
+		weather_map("multiplayer/maps/2p_Isle_of_Mists_basic.map")
+		wesnoth.wml_actions.sound {
+			name = "magic-holy-miss-2.ogg",
+		}
+		weather_alert(_"Clear Weather", 221, 253, 171)
+	elseif weather_event.weather_id == "drought" then
+		weather_map ("multiplayer/maps/2p_Isle_of_Mists_drought.map")
+		wesnoth.wml_actions.sound {
+			name = "gryphon-shriek-1.ogg",
+		}
+		weather_alert(_"Drought", 251, 231, 171)
+	elseif weather_event.weather_id == "heavy rain" then
+		weather_map("multiplayer/maps/2p_Isle_of_Mists_rain.map")
+		wesnoth.wml_actions.sound {
+			name = "magic-faeriefire-miss.ogg",
+		}
+		wesnoth.wml_actions.delay {
+			time = 250,
+		}
+		wesnoth.wml_actions.sound {
+			name = "ambient/ship.ogg",
+		}
+		weather_alert(_"Heavy Rains", 174, 220, 255)
+
+	elseif weather_event.weather_id == "second rain" then
+		weather_map("multiplayer/maps/2p_Isle_of_Mists_secondrain.map")
+		wesnoth.wml_actions.sound {
+			name = "magic-faeriefire-miss.ogg",
+		}
+		wesnoth.wml_actions.delay {
+			time = 250,
+		}
+		wesnoth.wml_actions.sound {
+			name = "ambient/ship.ogg",
+		}
+		weather_alert(_"Inundation", 174, 220, 255)
+
+	elseif weather_event.weather_id == "snowfall" then
+		weather_map("multiplayer/maps/2p_Isle_of_Mists_snow.map")
+		wesnoth.wml_actions.sound {
+			name = "wail.wav",
+		}
+		weather_alert(_"Snowfall", 229, 243, 241)
+	elseif weather_event.weather_id == "heavy snowfall" then
+		weather_map("multiplayer/maps/2p_Isle_of_Mists_secondsnow.map")
+		wesnoth.wml_actions.sound {
+			name = "bat-flapping.wav",
+		}
+		weather_alert(_"Heavy Snowfall", 224, 255, 251)
+	else
+		error("unknown weather '" .. tostring(weather_event.weather_id) .. "'")
+	end
+end)

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -267,9 +267,9 @@ end)
 on_event("prestart", function()
 	local leaders = wesnoth.units.find_on_map { side = "3,4", canrecruit= true}
 	if #leaders < 2 then
-		create_timed_spawns(5, 11, 50, 5, 4, 21)
+		create_timed_spawns(5, 11, 30, 5, 4, 21)
 	else
-		create_timed_spawns(4, 11, 90, 4, 5, 23)
+		create_timed_spawns(4, 11, 60, 4, 5, 23)
 	end
 end)
 
@@ -285,12 +285,22 @@ on_event("new turn", function()
 		return
 	end
 	wml.variables["timed_spawn[0]"] = nil
+
+	-- first spawn wave
 	local unit_types = get_spawn_types(next_spawn.units, next_spawn.gold, random_spawns[next_spawn.pool_num])
 	local spawn_areas = {{"6", "3"}, {"4", "6"}, {"3", "9"}, {"3", "13"}, {"7", "14"}, {"10", "14"}, {"14", "14"}, {"20", "15"}, {"26", "15"}, {"28", "11"}, {"29", "7"}, {"25", "3"}, {"29", "3"}, {"19", "3"}, {"15", "3"}, {"12", "3"}, {"8", "4"},}
 	local spawn_area = spawn_areas[mathx.random(#spawn_areas)]
 	local locations_in_area = wesnoth.map.find { x = spawn_area[1], y = spawn_area[2], radius=1, include_borders=false }
 	local chosen_location = locations_in_area[mathx.random(#locations_in_area)]
 	place_units(unit_types, chosen_location[1], chosen_location[2])
+
+	-- second follow up spawn wave
+	local unit_types_second = get_spawn_types(next_spawn.units, next_spawn.gold, random_spawns[next_spawn.pool_num])
+	local spawn_areas_second = {{"6", "3"}, {"4", "6"}, {"3", "9"}, {"3", "13"}, {"7", "14"}, {"10", "14"}, {"14", "14"}, {"20", "15"}, {"26", "15"}, {"28", "11"}, {"29", "7"}, {"25", "3"}, {"29", "3"}, {"19", "3"}, {"15", "3"}, {"12", "3"}, {"8", "4"},}
+	local spawn_area_second = spawn_areas_second[mathx.random(#spawn_areas)]
+	local locations_in_area_second = wesnoth.map.find { x = spawn_area_second[1], y = spawn_area_second[2], radius=1, include_borders=false }
+	local chosen_location_second = locations_in_area_second[mathx.random(#locations_in_area_second)]
+	place_units(unit_types_second, chosen_location_second[1], chosen_location_second[2])
 end)
 
 -- on turn 'final_turn' the first 'final spawn' appears

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -1,4 +1,3 @@
-local helper = wesnoth.require("helper")
 local _ = wesnoth.textdomain 'wesnoth-multiplayer'
 local T = wml.tag
 local on_event = wesnoth.require("on_event")
@@ -96,7 +95,7 @@ local function get_spawn_types(num_units, max_gold, unit_pool)
 	local units_left = num_units
 	local current_types = {}
 	while gold_left > 0 and units_left > 0 do
-		local unit_group = wesnoth.random(#unit_pool)
+		local unit_group = mathx.random(#unit_pool)
 		local unit_rank = 1
 		local unit_type = wesnoth.unit_types[unit_pool[unit_group][unit_rank]]
 		table.insert(current_types, { group = unit_group, type =  unit_type})
@@ -143,7 +142,7 @@ local function get_spawn_types(num_units, max_gold, unit_pool)
 				table.insert(possible_groups, { group = i, type = unit_type})
 			end
 		end
-		local index = wesnoth.random(#possible_groups)
+		local index = mathx.random(#possible_groups)
 		table.insert(current_types, possible_groups[index])
 		gold_left = gold_left - possible_groups[index].type.cost
 	end
@@ -165,22 +164,22 @@ local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_
 	for i = 1, #random_spawns do
 		table.insert(random_spawn_numbers, i)
 	end
-	helper.shuffle(random_spawn_numbers)
-	local final_turn = math.ceil(((num_spawns - 1) * interval + 40 + wesnoth.random(2,4))/2)
+	mathx.shuffle(random_spawn_numbers)
+	local final_turn = math.ceil(((num_spawns - 1) * interval + 40 + mathx.random(2,4))/2)
 	local end_spawns = 0
 	for spawn_number = 1, num_spawns do
 		local turn = 3 + (spawn_number - 1) * interval
 		local gold = base_gold_amount + (turn - 3) * gold_increment
 		if spawn_number > 1 then
 			-- formula taken from original Dark forecast, TODO: find easier formula.
-			local unit_gold = (turn - 3) * gold_increment + math.min(wesnoth.random(base_gold_amount), wesnoth.random(base_gold_amount))
+			local unit_gold = (turn - 3) * gold_increment + math.min(mathx.random(base_gold_amount), mathx.random(base_gold_amount))
 			local gold_per_unit = gold_per_unit_amount + turn / 1.5
-			local units = unit_gold / gold_per_unit + units_amount + wesnoth.random(-1, 2)
-			if wesnoth.random(5) == 5 then
+			local units = unit_gold / gold_per_unit + units_amount + mathx.random(-1, 2)
+			if mathx.random(5) == 5 then
 				units = units - 1
 			end
 			-- end complicated formula
-			turn = turn + wesnoth.random(-1, 1)
+			turn = turn + mathx.random(-1, 1)
 			-- reduce gold and units for spawns after the final spawn
 			if turn >= final_turn then
 				units = units / (end_spawns + 3)
@@ -194,7 +193,7 @@ local function create_timed_spawns(interval, num_spawns, base_gold_amount, gold_
 			wml.variables[string.format("timed_spawn[%d]", spawn_number - 1)] = {
 				units = math.ceil(units),
 				turn = turn,
-				gold = helper.round(gold * configure_gold_factor),
+				gold = mathx.round(gold * configure_gold_factor),
 				pool_num = random_spawn_numbers[spawn_number],
 			}
 		else
@@ -247,7 +246,7 @@ local function final_spawn()
 	if spawns_left == 0 then
 		return
 	end
-	local spawn_index = wesnoth.random(spawns_left) - 1
+	local spawn_index = mathx.random(spawns_left) - 1
 	local spawn = wml.variables[string.format("fixed_spawn[%d]", spawn_index)]
 	wml.variables[string.format("fixed_spawn[%d]", spawn_index)] = nil
 	local types = {}
@@ -288,9 +287,9 @@ on_event("new turn", function()
 	wml.variables["timed_spawn[0]"] = nil
 	local unit_types = get_spawn_types(next_spawn.units, next_spawn.gold, random_spawns[next_spawn.pool_num])
 	local spawn_areas = {{"6", "3"}, {"4", "6"}, {"3", "9"}, {"3", "13"}, {"7", "14"}, {"10", "14"}, {"14", "14"}, {"20", "15"}, {"26", "15"}, {"28", "11"}, {"29", "7"}, {"25", "3"}, {"29", "3"}, {"19", "3"}, {"15", "3"}, {"12", "3"}, {"8", "4"},}
-	local spawn_area = spawn_areas[wesnoth.random(#spawn_areas)]
+	local spawn_area = spawn_areas[mathx.random(#spawn_areas)]
 	local locations_in_area = wesnoth.map.find { x = spawn_area[1], y = spawn_area[2], radius=1, include_borders=false }
-	local chosen_location = locations_in_area[wesnoth.random(#locations_in_area)]
+	local chosen_location = locations_in_area[mathx.random(#locations_in_area)]
 	place_units(unit_types, chosen_location[1], chosen_location[2])
 end)
 
@@ -306,14 +305,14 @@ on_event("new turn", function()
 		append = true,
 	}
 	final_spawn()
-	wesnoth.game_config.last_turn = wesnoth.current.turn + 12
+	wesnoth.scenario.turns = wesnoth.current.turn + 12
 	wesnoth.wml_actions.message {
 		side="3,4",
 		canrecruit=true,
 		message= _ "The last and most powerful of these creatures are almost upon us. I feel that if we can finish them off in time, we shall be victorious.",
 	}
 
-	wml.variables["next_final_spawn"] = wesnoth.current.turn + wesnoth.random(1,2)
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(1,2)
 end)
 
 -- after the first final spawn, spawn a new final spawn every 1 or 2 turns.
@@ -322,7 +321,7 @@ on_event("new turn", function()
 		return
 	end
 	final_spawn()
-	wml.variables["next_final_spawn"] = wesnoth.current.turn + wesnoth.random(1,2)
+	wml.variables["next_final_spawn"] = wesnoth.current.turn + mathx.random(1,2)
 end)
 
 -- The victory condition: win when there are no enemy unit after the first final spawn appeared.
@@ -373,15 +372,15 @@ end)
 -- The weather events are completely unrelated to the spawn events.
 
 local function get_weather_duration(max_duration)
-	local res = wesnoth.random(2)
-	while res < max_duration and wesnoth.random(2) == 2 do
+	local res = mathx.random(2)
+	while res < max_duration and mathx.random(2) == 2 do
 		res = res + 1
 	end
 	return res
 end
 -- initilize the weather_event wml array which defines at which turns the weather changes.
 on_event("prestart", function()
-	local turn = wesnoth.random(4,6)
+	local turn = mathx.random(4,6)
 	local event_num = 0
 	local weather_to_dispense = {
 		{ turns_left = 10, id = "drought"},
@@ -393,7 +392,7 @@ on_event("prestart", function()
 	local second_rain_turns_left = 12
 	while turn < 55 and #weather_to_dispense > 0 do
 		-- pick a random weather except 'clear' and 'heavy snow'
-		local index = wesnoth.random(#weather_to_dispense)
+		local index = mathx.random(#weather_to_dispense)
 		local num_turns = get_weather_duration(weather_to_dispense[index].turns_left)
 		local weather_id = weather_to_dispense[index].id
 		weather_to_dispense[index].turns_left = weather_to_dispense[index].turns_left - num_turns
@@ -407,7 +406,7 @@ on_event("prestart", function()
 		event_num = event_num + 1
 		turn = turn + num_turns
 		-- Second snow happens half the time.
-		if weather_id == "snowfall" and heavy_snowfall_turns_left >= 0 and wesnoth.random(2) == 2 then
+		if weather_id == "snowfall" and heavy_snowfall_turns_left >= 0 and mathx.random(2) == 2 then
 			num_turns = get_weather_duration(heavy_snowfall_turns_left)
 			wml.variables[string.format("weather_event[%d]", event_num)] = {
 				turn = turn,
@@ -419,7 +418,7 @@ on_event("prestart", function()
 		end
 
 		-- second heavy rain/inundation happens one-thirds the time
-		if weather_id == "heavy rain" and second_rain_turns_left >= 0 and wesnoth.random(3) == 3 then
+		if weather_id == "heavy rain" and second_rain_turns_left >= 0 and mathx.random(3) == 3 then
 			num_turns = get_weather_duration(second_rain_turns_left)
 			wml.variables[string.format("weather_event[%d]", event_num)] = {
 				turn = turn,
@@ -455,7 +454,7 @@ end
 
 local function weather_map(name)
 	wesnoth.wml_actions.terrain_mask {
-		mask = wesnoth.read_file(name),
+		mask = filesystem.read_file(name),
 		x = 1,
 		y = 1,
 		border = true,

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -256,9 +256,11 @@ end)
 on_event("prestart", function()
 	local leaders = wesnoth.units.find_on_map { side = "3,4", canrecruit= true}
 	if #leaders < 2 then
-		create_timed_spawns(6, 11, 25, 5, 3, 21)
+		--create_timed_spawns(5, 11, 50, 5, 4, 21)
+		create_timed_spawns(5, 11, 50, 5, 4, 18)
 	else
-		create_timed_spawns(5, 11, 55, 4, 4, 23)
+		--create_timed_spawns(4, 11, 90, 4, 5, 23)
+		create_timed_spawns(5, 11, 90, 4, 5, 20)
 	end
 end)
 

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -349,7 +349,7 @@ on_event("die", function()
 	}
 	wesnoth.wml_actions.message {
 		speaker = "narrator",
-		message = _"The screams and pleas for mercy are finally silenced, as you remove your blood soaked blade from the last of the invaders. There will be no more assailants coming to your shores. Your reign has finally earned stability.",
+		message = _"As you finally defeat your last remaining foes, the dreary mists around the island seem to lift. The phantoms fade away, at last released from their eternal guardianship. You have finally cleansed the ancient shrine... for now.",
 		image ="wesnoth-icon.png",
 	}
 	wesnoth.wml_actions.endlevel {

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -27,7 +27,7 @@ local random_spawns = {
 		{"Skeleton", "Revenant", "more", "Draug"},
 	},
 	{
-		{"Rock Scorpion", "Wild Wyvern", "none", "none"},
+		{"Rock Scorpion", "Fire Wraith", "none", "none"},
 		{"Fire Ant", "more", "Cave Bear", "more"},
 	},
 	{


### PR DESCRIPTION
Description:
_Isle of Mists is a survival scenario for solitaire or two-player team-based play against randomly-spawned AI units. Victory is achieved by surviving and defeating all enemy waves. During the course of play, the terrain will change based on random weather effects. You need to use the default map settings for the scenario to work right._

This PR contains:
1. Adds a new multiplayer survival scenario.
2. Lua (similar to Dark Forecast one) code file used for the enemy waves and weather change events
3. Comes with 6 weather conditions (6 maps)

Features:
1. Default difficulty is set at `0`.
2. Has 1p/2p modes
3. 5 final waves
4. 8 difficulty levels, ranging from `-30` to `+60`, with `+60` being catered especially for veteran/skilled players.

Replays: 
Default difficulty | 2player mode | Drakes + Rebels
[2p — Isle of Mists (Survival) replay 20210429-050016.gz](https://github.com/wesnoth/wesnoth/files/6395359/2p.Isle.of.Mists.Survival.replay.20210429-050016.gz)


Reviewers:
I would like to request reviews from nemaara, Pentarctagon and whoever is involved in MP scenario content development.