### PR TITLE
Make command-line option --language never require --all-translations

### DIFF
--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -292,7 +292,7 @@ bool game_launcher::init_language()
 
 	language_def locale;
 	if(cmdline_opts_.language) {
-		std::vector<language_def> langs = get_languages();
+		std::vector<language_def> langs = get_languages(true);
 		for(const language_def& def : langs) {
 			if(def.localename == *cmdline_opts_.language) {
 				locale = def;

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -113,13 +113,13 @@ bool load_language_list()
 	return true;
 }
 
-language_list get_languages()
+language_list get_languages(bool all)
 {
 	// We sort every time, the local might have changed which can modify the
 	// sort order.
 	std::sort(known_languages.begin(), known_languages.end());
 
-	if(min_translation_percent == 0) {
+	if(all || min_translation_percent == 0) {
 		return known_languages;
 	}
 

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -78,9 +78,16 @@ extern symbol_table string_table;
 
 bool& time_locale_correct();
 
-//function which, given the main configuration object, will return
-//a list of the translations of the game available.
-std::vector<language_def> get_languages();
+/**
+ * Return a list of available translations.
+ *
+ * The list will normally be filtered with incomplete (according to
+ * min_translation_percent) translations removed.
+ *
+ *@param all if true, include incomplete translations
+ *@pre load_language_list() has already been called
+ */
+std::vector<language_def> get_languages(bool all=false);
 
 //function which, given the main configuration object, and a locale,
 //will set string_table to be populated with data from that locale.


### PR DESCRIPTION
When the user supplies an exact locale identifier on the command line,
it doesn't make sense to check whether it's an incomplete translation.