### PR TITLE
Rewrite the WML unit test for sighted events

### DIFF
--- a/data/test/scenarios/sighted_events.cfg
+++ b/data/test/scenarios/sighted_events.cfg
@@ -1,133 +1,176 @@
+# wmllint: no translatables
+
 # This test checks that sighted events are being triggered
-# at the appropriate time. An elvish archer moves towards
-# and discovers an orcish grunt.
-# We pass if the elvish archer is the discoverer, and the
-# variable "sighted_should_trigger" is set.
-# The second test checks what happens if the orc is discovered
-# on the elf's turn.
+# correctly due to units moving - whether that's the viewer
+# moving and revealing hexes in the fog, or whether that's
+# the enemy units moving into the already-revealed hexes.
+[test]
+    name = "Unit Test sighted_on_move"
+    map_file=test/maps/sighted_events.map
+    turns = 4
+    id = sighted_on_move
+    random_start_time = no
+    is_unit_test = yes
 
-#define TEST_SIGHTED_EVENTS_SCEN ID BOB_CONDITION
-    [test]
-        name = "Unit Test {ID}"
-        map_file=test/maps/sighted_events.map
-        turns = 4
-        id = {ID}
-        random_start_time = no
-        is_unit_test = yes
+    {DAWN}
 
-        {DAWN}
+    [side]
+        side=1
+        controller=human
+        name = "Alice"
+        type = Elvish Archer
+        id=alice
+        fog=yes
+    [/side]
+    [side]
+        side=2
+        controller=human
+        name = "Bob"
+        type = Orcish Grunt
+        id=bob
+        # For simplicity of counting the triggered events, disable fog so that
+        # there are no sighted-by-side-2 events.
+        fog=no
+    [/side]
 
-        [side]
-            side=1
-            controller=human
-            name = "Alice"
-            type = Elvish Archer
-            id=alice
-            fog=yes
-        [/side]
-        [side]
-            side=2
-            controller=human
-            name = "Bob"
-            type = Orcish Grunt
-            id=bob
-            fog=yes
-        [/side]
+    #This makes the sides pass their turns, when the other events have taken place.
+    [event]
+        name = side turn
+        first_time_only = no
+        [end_turn]
+        [/end_turn]
+    [/event]
 
-        [event]
-            name = prestart
-            {VARIABLE sighted_should_trigger no}
-        [/event]
+    [event]
+        name = prestart
+        {VARIABLE sighted_count 0}
+    [/event]
 
-        [event]
-            name = sighted
-            {ASSERT ({VARIABLE_CONDITIONAL unit.id equals bob})}
-            {ASSERT ({VARIABLE_CONDITIONAL second_unit.id equals alice})}
-            {RETURN ({VARIABLE_CONDITIONAL sighted_should_trigger boolean_equals yes})}
-        [/event]
+    [event]
+        name = sighted
+        first_time_only = no
+        [set_variable]
+            name=sighted_count
+            add=1
+        [/set_variable]
+        {ASSERT ({VARIABLE_CONDITIONAL unit.id equals bob})}
+        {ASSERT ({VARIABLE_CONDITIONAL second_unit.id equals alice})}
+    [/event]
 
-        #Alice moves towards Bob.
-        [event]
-            name = side 1 turn 1 refresh
-            [do_command]
-                [move]
-                    x=1,2,3,4,5,6,7
-                    y=3,3,3,3,3,3,3
-                [/move]
-            [/do_command]
-        [/event]
+    # Alice moves towards Bob, but stays far away enough that he is still hidden by the fog.
+    [event]
+        name = side 1 turn 1 refresh
+        [do_command]
+            [move]
+                x=1,2,3,4,5,6,7
+                y=3,3,3,3,3,3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 0})}
+    [/event]
 
-        #Bob moves either down, then up (unseen), or left, then right (seen)
-        [event]
-            name = side 2 turn 1 refresh
-            [if]
-                {BOB_CONDITION}
-                [then]
-                    [do_command]
-                        [move]
-                            x=16,16,16
-                            y=3,4,5
-                        [/move]
-                    [/do_command]
-                    [do_command]
-                        [move]
-                            x=16,16,16
-                            y=5,4,3
-                        [/move]
-                    [/do_command]
-                [/then]
-                [else]
-                    {VARIABLE sighted_should_trigger yes}
-                    [do_command]
-                        [move]
-                            x=16,15,14
-                            y=3,3,3
-                        [/move]
-                    [/do_command]
-                    [do_command]
-                        [move]
-                            x=14,15,16
-                            y=3,3,3
-                        [/move]
-                    [/do_command]
-                [/else]
-            [/if]
-        [/event]
+    # Bob moves around near the edge of Alice's vision
+    [event]
+        name = side 2 turn 1 refresh
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 0})}
 
-        #Alice discovers Bob.
-        [event]
-            name = side 1 turn 2 refresh
-            [do_command]
-                [move]
-                    x=7,8
-                    y=3,3
-                [/move]
-            [/do_command]
-            #With the next stop Bob should be visible.
-            {VARIABLE sighted_should_trigger yes}
-            [do_command]
-                [move]
-                    x=8,9
-                    y=3,3
-                [/move]
-            [/do_command]
-        [/event]
+        # Give the unit enough MP, so that he doesn't run out of moves while
+        # moving around. The error without this is "found corrupt movement in
+        # replay", which isn't obvious about what caused the problem.
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            moves="$({UNREACHABLE} - 1)"
+        [/modify_unit]
 
-        #If we got this far without triggering sighted, we fail the test.
-        [event]
-            name = side 2 turn 2
-            {FAIL}
-        [/event]
+        # Bob moves down, then up. This doesn't move closer to Alice, so he should remain unseen.
+        [do_command]
+            [move]
+                x=16,16,16
+                y=3,4,5
+            [/move]
+        [/do_command]
+        [do_command]
+            [move]
+                x=16,16,16
+                y=5,4,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 0})}
 
-        #This makes the sides pass their turns, when the other events have taken place.
-        [event]
-            name = side turn
-            first_time_only = no
-            [end_turn]
-            [/end_turn]
-        [/event]
-    [/test]
-#enddef
+        # Bob moves left twice, then back to the right. He should be seen on the second step left.
+        [do_command]
+            [move]
+                x=16,15
+                y=3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 0})}
+        [do_command]
+            [move]
+                x=15,14
+                y=3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 1})}
+        [do_command]
+            [move]
+                x=14,15,16
+                y=3,3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 1})}
 
-{TEST_SIGHTED_EVENTS_SCEN sighted_events ([true][/true])}
-{TEST_SIGHTED_EVENTS_SCEN sighted_on_opponents_turn ([false][/false])}
+        # Bob moves left twice within a single [move]. He should be seen on 14,3.
+        [do_command]
+            [move]
+                x=16,15,14
+                y=3,3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 2})}
+
+        # Alice can already see Bob, so this shouldn't trigger more sighted events
+        [do_command]
+            [move]
+                x=14,13,12
+                y=3,3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 2})}
+
+        # Return to the starting spot
+        [do_command]
+            [move]
+                x=12,13,14,15,16
+                y=3,3,3,3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 2})}
+    [/event]
+
+    # Alice moves further toward Bob
+    [event]
+        name = side 1 turn 2 refresh
+        {VARIABLE sighted_count 0}
+        [do_command]
+            [move]
+                x=7,8
+                y=3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 0})}
+
+        # With the next stop Bob should be visible.
+        [do_command]
+            [move]
+                x=8,9
+                y=3,3
+            [/move]
+        [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL sighted_count equals 1})}
+
+        {SUCCEED}
+    [/event]
+[/test]

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -89,8 +89,7 @@
 5 test_move_fail_6
 0 test_move_unit
 0 test_move_unit_in_circle
-0 sighted_events
-0 sighted_on_opponents_turn
+0 sighted_on_move
 0 move_skip_no_sighted_no_share_view
 0 move_skip_ally_sighted_no_share_view
 0 move_skip_all_sighted_no_share_view


### PR DESCRIPTION
The old version's [event]name=sighted had a {RETURN} statement in it,
which meant the test stopped on the first sighting. Most of the test
wasn't testing anything.