### PR TITLE
Filtering by tags in the add-on manager

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## Version 1.15.12+dev
  ### Add-ons client
    * The details panel now shows the list of tags in each add-on.
+   * Added a filter based on tags.
  ### Add-ons server
  ### Campaigns
  ### Editor

--- a/data/gui/window/addon_manager.cfg
+++ b/data/gui/window/addon_manager.cfg
@@ -718,6 +718,32 @@
 
 				[label]
 					definition = "default"
+					label = _ "Tags:"
+				[/label]
+
+			[/column]
+
+			[column]
+				grow_factor = 0
+				border = "all"
+				border_size = 5
+
+				horizontal_alignment = "left"
+
+				[multimenu_button]
+					id = "tag_filter"
+					definition = "default"
+				[/multimenu_button]
+			[/column]
+
+			[column]
+				grow_factor = 0
+				border = "all"
+				border_size = 5
+				horizontal_alignment = "left"
+
+				[label]
+					definition = "default"
 					label = _ "Order:"
 				[/label]
 			[/column]

--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -156,6 +156,7 @@ private:
 
 	boost::dynamic_bitset<> get_name_filter_visibility() const;
 	boost::dynamic_bitset<> get_status_filter_visibility() const;
+	boost::dynamic_bitset<> get_tag_filter_visibility() const;
 	boost::dynamic_bitset<> get_type_filter_visibility() const;
 
 	void on_selected_version_change();


### PR DESCRIPTION
Add a new drop-down filter to the add-ons manager, based on PblWML's
`tags` attribute.

The existing PblWML specification includes a comma-separated list of tags.
Until now there are no official tag names, but some of the 1.14 add-ons already
have some unofficial ones. If this feature is included in 1.16 then I assume
many UMC authors will use the newly-official tags.

For a larger add-on list than the dev server has, use port 15014 which will
connect to the 1.14 server instead (in the connect dialog change the address to
addons.wesnoth.org:15014).