### PR TITLE
Credits: remove the i18n entries for languages that had no strings committed

### DIFF
--- a/data/core/about_i18n.cfg
+++ b/data/core/about_i18n.cfg
@@ -37,12 +37,7 @@ sort=yes
     [/entry]
 [/about]
 
-# no strings committed so far
-[about]
-    title = _"Asturian Translation" # wmllint: no spellcheck
-    #    [entry]
-    #    [/entry]
-[/about]
+# No [about] for the Asturian translation, that translation was removed because no strings were committed
 
 [about]
     title = _"Basque Translation" # wmllint: no spellcheck
@@ -703,13 +698,7 @@ sort=yes
     [/entry]
 [/about]
 
-# no strings committed so far
-[about]
-    title = _"Friulian Translation" # wmllint: no spellcheck
-    [entry]
-        name = ""
-    [/entry]
-[/about]
+# No [about] for the Friulian translation, that translation was removed because no strings were committed
 
 [about]
     title = _"Galician Translation" # wmllint: no spellcheck


### PR DESCRIPTION
These were removed in ad7699bffc16f7c982c95f1989ad6f932a1580b4, but were reintroduced when the credits were synced with 1.14. Adding comments so that they don't get re-merged.

@ivanovic, I think these should be removed, but this PR is a question to you about whether you want to keep them. These strings themselves have already been translated into almost all languages, so it's not going to save effort for the other languages' translation teams.

Looking at the credits screen itself (you'll need a recent build with #3265 fixed), the heading for Asturian doesn't show up, but the one for Friulian does. Probably because Asturian has no `[entry]` tags, while Friulian has a blank one.