### PR TITLE
Credits: hide the blank section for Friulian

### DIFF
--- a/data/core/about_i18n.cfg
+++ b/data/core/about_i18n.cfg
@@ -706,9 +706,6 @@ sort=yes
 # no strings committed so far
 [about]
     title = _"Friulian Translation" # wmllint: no spellcheck
-    [entry]
-        name = ""
-    [/entry]
 [/about]
 
 [about]


### PR DESCRIPTION
When an [about] section has a title but no [entry] tags, it's automatically
hidden in the credits. The entry with name="" was causing the title to show
up with a blank section under it.

Asturian and Friulian were removed in ad7699bffc16f7c982c95f1989ad6f932a1580b4
because they'd been added to the translation framework but hadn't received any
translated strings.

The reason that I'm leaving these in rather than completely removing them is
that the string "Friulian Translation" has already been translated into almost
all of the languages that Wesnoth supports. "Asturian Translation" has been
translated into around half of them, although the fuzzy-string support has put
the translation of "Estonian Translation" into the other half.