### PR TITLE
Add-ons manager: show tags in the details panel

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## Version 1.15.12+dev
  ### Add-ons client
+   * The details panel now shows the list of tags in each add-on.
  ### Add-ons server
  ### Campaigns
  ### Editor

--- a/data/gui/window/addon_manager.cfg
+++ b/data/gui/window/addon_manager.cfg
@@ -503,6 +503,36 @@
 
 										[label]
 											definition = "default_small"
+											label = _ "Website:"
+										[/label]
+
+									[/column]
+
+									[column]
+										grow_factor = 1
+										border = "all"
+										border_size = 5
+										horizontal_grow = true
+
+										[label]
+											id = "url"
+											definition = "default_small"
+										[/label]
+
+									[/column]
+
+								[/row]
+
+								[row]
+
+									[column]
+										grow_factor = 0
+										border = "all"
+										border_size = 5
+										horizontal_alignment = "left"
+
+										[label]
+											definition = "default_small"
 											label = _ "Dependencies:"
 										[/label]
 
@@ -553,36 +583,6 @@
 											definition = "default_small"
 											label = _ "translations^None"
 											can_shrink = true
-										[/label]
-
-									[/column]
-
-								[/row]
-
-								[row]
-
-									[column]
-										grow_factor = 0
-										border = "all"
-										border_size = 5
-										horizontal_alignment = "left"
-
-										[label]
-											definition = "default_small"
-											label = _ "Website:"
-										[/label]
-
-									[/column]
-
-									[column]
-										grow_factor = 1
-										border = "all"
-										border_size = 5
-										horizontal_grow = true
-
-										[label]
-											id = "url"
-											definition = "default_small"
 										[/label]
 
 									[/column]

--- a/data/gui/window/addon_manager.cfg
+++ b/data/gui/window/addon_manager.cfg
@@ -589,6 +589,38 @@
 
 								[/row]
 
+								[row]
+
+									[column]
+										grow_factor = 0
+										border = "all"
+										border_size = 5
+										horizontal_grow = true
+
+										[label]
+											definition = "default_small"
+											label = _ "Tags:"
+										[/label]
+
+									[/column]
+
+									[column]
+										grow_factor = 1
+										border = "all"
+										border_size = 5
+										horizontal_grow = true
+
+										# Using a scroll_label prevents the dialog expanding horizontally when there are many tags.
+										[scroll_label]
+											id = "tags"
+											definition = "default_small"
+											horizontal_scrollbar_mode = "never"
+										[/scroll_label]
+
+									[/column]
+
+								[/row]
+
 							[/grid]
 
 						[/column]

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -883,6 +883,10 @@ void addon_manager::on_addon_select()
 	find_widget<styled_widget>(parent, "created", false).set_label(format_addon_time(info->created));
 	find_widget<styled_widget>(parent, "updated", false).set_label(format_addon_time(info->updated));
 
+	// Although this is a user-visible string, use utils::join instead of format_conjunct_list
+	// because "x, y, z" is clearer than "x, y and z" in this context.
+	find_widget<styled_widget>(parent, "tags", false).set_label(utils::join(info->tags, ", "));
+
 	find_widget<styled_widget>(parent, "dependencies", false).set_label(!info->depends.empty()
 		? make_display_dependencies(info->id, addons_, tracking_info_)
 		: _("addon_dependencies^None"));

--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -39,15 +39,16 @@ namespace dialogs
  * @ingroup GUIWindowDefinitionWML
  *
  * Shows the list of addons on the server available for installation.
- * This dialog is under construction and only used with --new-widgets.
+ *
  * Key               |Type          |Mandatory|Description
  * ------------------|--------------|---------|-----------
  * addons            | @ref listbox |yes      |A listbox that will contain the info about all addons on the server.
- * name              | control      |no       |The name of the addon.
- * version           | control      |no       |The version number of the addon.
- * author            | control      |no       |The author of the addon.
- * downloads         | control      |no       |The number of times the addon has been downloaded.
- * size              | control      |no       |The size of the addon.
+ * name              | label        |yes      |The name of the addon.
+ * version_filter    | menu_button  |yes      |List allowing current or older versions to be selected.
+ * author            | label        |yes      |The author of the addon.
+ * downloads         | label        |yes      |The number of times the addon has been downloaded.
+ * size              | label        |yes      |The size of the addon.
+ * tags              | label        |yes      |Contents of the PblWML "tags" attribute.
  */
 class addon_manager : public modal_dialog
 {


### PR DESCRIPTION
Show the contents of PblWML's "tags" attribute in the add-ons dialog. They're
shown at the bottom of the right-hand panel (only if the window size is large
enough to trigger that dialog's two-panel layout).

This started as part of #5765, I've split it because I think this part is ready to
merge, but the filtering-by-tags part needs an inspiration about the descriptive
strings.