### PR TITLE
Make callers of help::show_help not need a help_manager

### DIFF
--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -193,7 +193,6 @@ void faction_select::profile_button_callback()
 	const unit_type* ut = unit_types.find(leader_type);
 	if(ut != nullptr) {
 		preferences::encountered_units().insert(ut->id());
-		help::help_manager help_manager(&game_config_manager::get()->game_config());
 		help::show_unit_description(*ut);
 	}
 }

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -1070,7 +1070,6 @@ void mp_lobby::refresh_lobby()
 
 void mp_lobby::show_help_callback()
 {
-	help::help_manager help_manager(&game_config_);
 	help::show_help();
 }
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -241,7 +241,6 @@ void title_screen::pre_show(window& win)
 			gui2::dialogs::help_browser::display();
 		}
 
-		help::help_manager help_manager(&game_config_manager::get()->game_config());
 		help::show_help();
 	});
 
@@ -282,9 +281,6 @@ void title_screen::pre_show(window& win)
 	// Addons
 	//
 	register_button(win, "addons", hotkey::TITLE_SCREEN__ADDONS, [&win]() {
-		// NOTE: we need the help_manager to get access to the Add-ons section in the game help!
-		help::help_manager help_manager(&game_config_manager::get()->game_config());
-
 		if(manage_addons()) {
 			win.set_retval(RELOAD_GAME_DATA);
 		}

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -25,6 +25,7 @@
 #include "events.hpp"                   // for raise_draw_event, pump, etc
 #include "font/constants.hpp"           // for relative_size
 #include "preferences/game.hpp"
+#include "game_config_manager.hpp"
 #include "gettext.hpp"                  // for _
 #include "gui/dialogs/transient_message.hpp"
 #include "help/help_browser.hpp"             // for help_browser
@@ -53,19 +54,38 @@ static lg::log_domain log_help("help");
 #define ERR_HELP LOG_STREAM(err, log_help)
 
 namespace help {
+/**
+ * Open a help dialog using a specified toplevel.
+ *
+ * This would allow for complete customization of the contents, although not in a
+ * very easy way. It's used as the internal implementation of the other help*
+ * functions.
+ *
+ *@pre The help_manager must already exist; this is different to the functions
+ * declared in help.hpp, which is why this one's declaration is in the .cpp
+ * file. Because this takes a section as an argument, it wouldn't make sense
+ * for it to call ensure_cache_lifecycle() internally - if the help_manager
+ * doesn't already exist, that would likely destroy the referenced object at
+ * the point that this function exited.
+ */
+void show_with_toplevel(const section &toplevel, const std::string& show_topic="", int xloc=-1, int yloc=-1);
+
 
 void show_unit_description(const unit &u)
 {
+	auto cache_lifecycle = ensure_cache_lifecycle();
 	help::show_unit_description(u.type());
 }
 
 void show_terrain_description(const terrain_type &t)
 {
+	auto cache_lifecycle = ensure_cache_lifecycle();
 	help::show_terrain_help(t.id(), t.hide_help());
 }
 
 void show_unit_description(const unit_type &t)
 {
+	auto cache_lifecycle = ensure_cache_lifecycle();
 	std::string var_id = t.get_cfg()["variation_id"].str();
 	if (var_id.empty())
 		var_id = t.get_cfg()["variation_name"].str();
@@ -87,15 +107,26 @@ void show_unit_description(const unit_type &t)
 		help::show_unit_help(t.id(), t.show_variations_in_help(), hide_help);
 }
 
-static game_config_view dummy_view;
 help_manager::help_manager(const game_config_view *cfg)
-	: guard(game_cfg, cfg == nullptr ? &dummy_view : cfg)
 {
+	assert(!game_cfg);
+	assert(cfg);
+	// This is a global rawpointer in the help:: namespace.
+	game_cfg = cfg;
+}
+
+std::unique_ptr<help_manager> ensure_cache_lifecycle()
+{
+	// The internals of help_manager are that this global raw pointer is
+	// non-null if and only if an instance of help_manager already exists.
+	if(game_cfg)
+		return nullptr;
+	return std::make_unique<help_manager>(&game_config_manager::get()->game_config());
 }
 
 help_manager::~help_manager()
 {
-//	map = nullptr;
+	game_cfg = nullptr;
 	default_toplevel.clear();
 	hidden_sections.clear();
     // These last numbers must be reset so that the content is regenerated.
@@ -111,7 +142,8 @@ help_manager::~help_manager()
  */
 void show_help(const std::string& show_topic, int xloc, int yloc)
 {
-	show_help(default_toplevel, show_topic, xloc, yloc);
+	auto cache_lifecycle = ensure_cache_lifecycle();
+	show_with_toplevel(default_toplevel, show_topic, xloc, yloc);
 }
 
 /**
@@ -121,7 +153,8 @@ void show_help(const std::string& show_topic, int xloc, int yloc)
  */
 void show_unit_help(const std::string& show_topic, bool has_variations, bool hidden, int xloc, int yloc)
 {
-	show_help(default_toplevel,
+	auto cache_lifecycle = ensure_cache_lifecycle();
+	show_with_toplevel(default_toplevel,
 			  hidden_symbol(hidden) + (has_variations ? ".." : "") + unit_prefix + show_topic, xloc, yloc);
 }
 
@@ -132,7 +165,8 @@ void show_unit_help(const std::string& show_topic, bool has_variations, bool hid
  */
 void show_terrain_help(const std::string& show_topic, bool hidden, int xloc, int yloc)
 {
-	show_help(default_toplevel, hidden_symbol(hidden) + terrain_prefix + show_topic, xloc, yloc);
+	auto cache_lifecycle = ensure_cache_lifecycle();
+	show_with_toplevel(default_toplevel, hidden_symbol(hidden) + terrain_prefix + show_topic, xloc, yloc);
 }
 
 /**
@@ -140,7 +174,8 @@ void show_terrain_help(const std::string& show_topic, bool hidden, int xloc, int
  */
 void show_variation_help(const std::string& unit, const std::string &variation, bool hidden, int xloc, int yloc)
 {
-	show_help(default_toplevel, hidden_symbol(hidden) + variation_prefix + unit + "_" + variation, xloc, yloc);
+	auto cache_lifecycle = ensure_cache_lifecycle();
+	show_with_toplevel(default_toplevel, hidden_symbol(hidden) + variation_prefix + unit + "_" + variation, xloc, yloc);
 }
 
 /**
@@ -149,7 +184,7 @@ void show_variation_help(const std::string& unit, const std::string &variation, 
  * This allows for complete customization of the contents, although not in a
  * very easy way.
  */
-void show_help(const section &toplevel_sec,
+void show_with_toplevel(const section &toplevel_sec,
 			   const std::string& show_topic,
 			   int xloc, int yloc)
 {

--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -21,31 +21,49 @@ class unit_type;
 class CVideo;
 class game_config_view;
 
+#include <memory>
 #include <string>
-#include "utils/guard_value.hpp"
 
 namespace help {
 
+/**
+ * The help implementation caches data parsed from the game_config. This class
+ * is used to control the lifecycle of that cache, so that the cache will be
+ * cleared before the game_config itself changes.
+ *
+ * Note: it's okay to call any of the help::show_* functions without creating
+ * an instance of help_manager - that will simply mean that the cache is
+ * cleared before the show function returns.
+ *
+ * Creating two instances of this will cause an assert.
+ */
 struct help_manager {
 	help_manager(const game_config_view *game_config);
+	help_manager(const help_manager&) = delete;
+	help_manager& operator=(const help_manager&) = delete;
 	~help_manager();
-private:
-	utils::guard_value<const game_config_view*> guard;
 };
 
-struct section;
 /**
- * Open a help dialog using a toplevel other than the default. This
- * allows for complete customization of the contents, although not in a
- * very easy way.
+ * Helper function for any of the show_help functions to control the cache's
+ * lifecycle; can also be used by any other caller that wants to ensure the
+ * cache is reused over multiple show_help calls.
+ *
+ * Treat the return type as opaque, it can return nullptr on success. Also
+ * don't extend the cache lifecycle beyond the lifecycle of the
+ * game_config_manager or over a reload of the game config.
+ *
+ *@pre game_config_manager has been initialised
  */
-void show_help(const section &toplevel, const std::string& show_topic="",
-			   int xloc=-1, int yloc=-1);
+std::unique_ptr<help_manager> ensure_cache_lifecycle();
 
 /**
  * Open the help browser. The help browser will have the topic with id
  * show_topic open if it is not the empty string. The default topic
  * will be shown if show_topic is the empty string.
+ *
+ *@pre game_config_manager has been initialised, or the instance of help_manager
+ * has been created with an alternative config.
  */
 void show_help(const std::string& show_topic="", int xloc=-1, int yloc=-1);
 

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -253,11 +253,9 @@ int show_gamestate_inspector(const vconfig& cfg, const game_data& data, const ga
 
 int show_help(lua_State *L)
 {
-	help::help_manager help_manager(&game_config_manager::get()->game_config());
 	help::show_help(luaL_checkstring(L, 1));
 	return 0;
 }
-
 
 /**
  * - Arg 1: string, widget type


### PR DESCRIPTION
Most of the places that created a help_manager did so just to call show_help on
the next line. Move knowledge of the internals out of those callers and into
help.cpp.

This leaves editor_controller and play_controller with knowledge of help_manager,
however both of those classes handle ownership of the game_config too.

@CelticMinstrel, I still have some `\todo` comments to check, but I think this is a better way to handle help_manager.