### PR TITLE
config: Don't create differently-typed copies of input in loops

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -489,7 +489,7 @@ public:
 	void merge_attributes(const config &);
 	template<typename... T>
 	void remove_attributes(T... keys) {
-		for(const std::string key : {keys...}) {
+		for(const auto& key : {keys...}) {
 			remove_attribute(key);
 		}
 	}
@@ -497,7 +497,7 @@ public:
 	template<typename... T>
 	void copy_attributes(const config& from, T... keys)
 	{
-		for(const std::string key : {keys...}) {
+		for(const auto& key : {keys...}) {
 			auto* attr = from.get(key);
 			if(attr) {
 				(*this)[key] = *attr;


### PR DESCRIPTION
This is prompted by 1f8101ef22bb23699421505235f4962802773c77. This
approach should still be correct while hopefully not bothering any
compilers *and* avoiding unnecessary copies or conversions until the
input actually needs to be converted to a different type (in this case
std::string_view, which is cheaper than std::string).