### PR TITLE
lua/gui2: Restore layout invalidation hack when setting widget labels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
    * Add a more advanced way of manipulating version strings via `wesnoth.version` constructor function.
    * Add a `wesnoth.scenario` data module that consolidates everything there is to know about the current scenario. Much of this information was previously available through `wesnoth.game_config`, but there are some new details too.
    * Fixed a regression introduced in 1.15.5 causing GUI2 widgets set to a hidden state to remain visible but not able to be interacted with.
+   * Fixed a regression introduced in 1.15.5 causing GUI2 listboxes to break when cleared and re-filled under certain circumstances.
  ### Packaging
    * Increased minimum required version of SDL to 2.0.8 (PR #5736).
  ### Terrain

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -397,6 +397,10 @@ WIDGET_SETTER("visible", lua_index_raw, gui2::styled_widget)
 //must be last
 WIDGET_SETTER("value_compat,label", t_string, gui2::styled_widget)
 {
+	gui2::window* window = w.get_window();
+	if(window) {
+		window->invalidate_layout();
+	}
 	w.set_label(value);
 }
 


### PR DESCRIPTION
Fixes #5755.

This is one of several layout invalidation hacks used in the old Lua
GUI2 API lost in the implementation of the new API (which the old API
now wraps).

It turns out that in the previous API (see 1.14 for reference if you
need easy access to the source) there were several calls to
invalidate_layout() that weren't there just to look pretty.

For wesnoth.set_dialog_value:

 * One prior to setting the value of a text_box
 * One prior to setting the value of a unit_preview_pane
 * One prior to setting the value of a styled_widget
 * One after changing a widget's visibility to hidden

All of these were removed by the new API implementation, with the last
one ending up commented out, restored now in commit
8989eb430311092e66177bc09e1b1c344000d5aa. All the other ones are
entirely gone, however.

It turns out that the dialog layout invalidation done for the
styled_widget case was essential to get listboxes working correctly
after clearing and adding rows to them (which was automatically done
right before in the implementation of wesnoth.set_dialog_value by the
find_widget() helper function). It was done for every single listbox
item, but without it the listbox would become completely useless under
certain conditions:

  20210501 03:24:37 error gui/layout: grid [_content_grid] place: Failed to place a grid, we have 39,30 space but we need 39,93 space. This happened at a grid with the id '_content_grid' in a 'N4gui27listboxE' with the id 'list' in a 'N4gui24gridE' with the id '_window_content_grid' in a 'N4gui24gridE' with the id '_content_grid' in a 'N4gui215scrollbar_panelE' with the id '' in a 'N4gui24gridE' with the id '' in a 'N4gui26windowE' with the id ''.

Now, it seems horribly inefficient to do this for every single new row
added to the listbox, but this solution *works*. We might want to
restore the hacks for the other 2 cases as well -- or figure out a
cleaner solution for the aforementioned bug.