### PR TITLE
Icemonax advances to Greater Icemonax

### DIFF
--- a/data/core/units/monsters/Icemonax.cfg
+++ b/data/core/units/monsters/Icemonax.cfg
@@ -23,11 +23,10 @@
     hitpoints=35
     movement_type=largefoot
     movement=4
-    experience=25
+    experience=53
     level=0
     alignment=neutral
-    advances_to=null
-    {AMLA_DEFAULT}
+    advances_to=Great Icemonax
     undead_variation=wolf
     cost=11
     usage=fighter


### PR DESCRIPTION
I think it is perfectly reasonable to be able to have icemonax advance to greater icemonax. This makes the units feel like a proper unit line, and gives UMC authors more freedom how to use the unit. To compensate for the fact that a lvl0 unit advances to lvl2, I set the exp quite high (53) to make this not something abusable