### PR TITLE
Scenario editor help: remove the warning about 1.14 bugs

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -231,9 +231,7 @@ The editor features two modes of operation: terrain mode and scenario mode.
 
 The <ref>dst='..editor_mode_terrain' text='Terrain Mode'</ref> is similar to a simple paint application, with tools to <ref>dst='editor_tool_paint' text='paint'</ref>, <ref>dst='editor_tool_fill' text='fill'</ref>, <ref>dst='editor_tool_select' text='select (and copy)'</ref>, and <ref>dst='editor_tool_paste' text='paste'</ref>. It also has the tool for setting the leaders’ <ref>dst='editor_tool_starting' text='starting locations'</ref>.
 
-The <ref>dst='..editor_mode_scenario' text='Scenario Mode'</ref>, in addition to the tools available in terrain mode, adds support for adding <ref>dst='editor_tool_label' text='labels'</ref>, <ref>dst='editor_tool_scenery' text='scenery items'</ref>, <ref>dst='editor_tool_unit' text='units'</ref> in addition to the leader, and assigning <ref>dst='editor_tool_village' text='village ownership'</ref> at the start of the scenario. There’s also a <ref>dst='editor_playlist' text='playlist manager'</ref> for the music.
-
-<bold>text='Warning: the Scenario Mode is buggy in 1.14.'</bold> Improving it is one of the main blockers for the 1.16 release, however in 1.14 its quality is far below that of the game and the terrain mode." + "
+The <ref>dst='..editor_mode_scenario' text='Scenario Mode'</ref>, in addition to the tools available in terrain mode, adds support for adding <ref>dst='editor_tool_label' text='labels'</ref>, <ref>dst='editor_tool_scenery' text='scenery items'</ref>, <ref>dst='editor_tool_unit' text='units'</ref> in addition to the leader, and assigning <ref>dst='editor_tool_village' text='village ownership'</ref> at the start of the scenario. There’s also a <ref>dst='editor_playlist' text='playlist manager'</ref> for the music." + "
 
 " + _ "<header>text='What you do *not* get'</header>
 


### PR DESCRIPTION
The editor/help.cfg file was kept in sync between 1.14 and 1.16, it's now time
for 1.16-specific changes, starting with dropping this warning.