### PR TITLE
A few WFL updates

### DIFF
--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -26,7 +26,9 @@
 #include "log.hpp"
 #include "recall_list_manager.hpp"
 #include "deprecation.hpp"
-#include "version.hpp"
+#include "game_board.hpp"
+#include "game_version.hpp"
+#include "resources.hpp"
 
 static lg::log_domain log_scripting_formula("scripting/formula");
 #define LOG_SF LOG_STREAM(info, log_scripting_formula)
@@ -187,6 +189,11 @@ variant unit_callable::get_value(const std::string& key) const
 		}
 
 		return variant(std::make_shared<location_callable>(loc_));
+	} else if(key == "terrain") {
+		if(loc_ == map_location::null_location()) {
+			return variant();
+		}
+		return variant(std::make_shared<terrain_callable>(*resources::gameboard, loc_));
 	} else if(key == "id") {
 		return variant(u_.id());
 	} else if(key == "type") {
@@ -319,6 +326,7 @@ void unit_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "x");
 	add_input(inputs, "y");
 	add_input(inputs, "loc");
+	add_input(inputs, "terrain");
 	add_input(inputs, "id");
 	add_input(inputs, "type");
 	add_input(inputs, "name");

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -25,6 +25,8 @@
 #include "units/types.hpp"
 #include "log.hpp"
 #include "recall_list_manager.hpp"
+#include "deprecation.hpp"
+#include "version.hpp"
 
 static lg::log_domain log_scripting_formula("scripting/formula");
 #define LOG_SF LOG_STREAM(info, log_scripting_formula)
@@ -234,7 +236,10 @@ variant unit_callable::get_value(const std::string& key) const
 	} else if(key == "states" || key == "status") {
 		return formula_callable::convert_set(u_.get_states());
 	} else if(key == "side") {
+		deprecated_message("unit.side", DEP_LEVEL::FOR_REMOVAL, version_info("1.17"), "This returns 0 for side 1 etc and should not be used. Use side_number instead.");
 		return variant(u_.side()-1);
+	} else if(key == "side_number") {
+		return variant(u_.side());
 	} else if(key == "cost") {
 		return variant(u_.cost());
 	} else if(key == "upkeep") {
@@ -331,7 +336,7 @@ void unit_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "max_moves");
 	add_input(inputs, "attacks_left");
 	add_input(inputs, "max_attacks");
-	add_input(inputs, "side");
+	add_input(inputs, "side_number");
 	add_input(inputs, "extra_recruit");
 	add_input(inputs, "advances_to");
 	add_input(inputs, "status");
@@ -537,7 +542,7 @@ int config_callable::do_compare(const formula_callable* callable) const
 	return cfg_.hash().compare(cfg_callable->get_config().hash());
 }
 
-terrain_callable::terrain_callable(const display_context& dc, const map_location& loc) : loc_(loc), t_(dc.map().get_terrain_info(loc)), owner_(dc.village_owner(loc) - 1)
+terrain_callable::terrain_callable(const display_context& dc, const map_location& loc) : loc_(loc), t_(dc.map().get_terrain_info(loc)), owner_(dc.village_owner(loc))
 {
 	type_ = TERRAIN_C;
 }
@@ -571,6 +576,9 @@ variant terrain_callable::get_value(const std::string& key) const
 	} else if(key == "healing") {
 		return variant(t_.gives_healing());
 	} else if(key == "owner") {
+		deprecated_message("terrain.owner", DEP_LEVEL::FOR_REMOVAL, version_info("1.17"), "This returns 0 for side 1 etc and should not be used. Use owner_side instead.");
+		return variant(owner_ - 1);
+	} else if(key == "owner_side") {
 		return variant(owner_);
 	}
 
@@ -592,7 +600,7 @@ void terrain_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "castle");
 	add_input(inputs, "keep");
 	add_input(inputs, "healing");
-	add_input(inputs, "owner");
+	add_input(inputs, "owner_side");
 }
 
 int terrain_callable::do_compare(const formula_callable* callable) const
@@ -655,7 +663,7 @@ variant gamemap_callable::get_value(const std::string& key) const
 
 void team_callable::get_inputs(formula_input_vector& inputs) const
 {
-	add_input(inputs, "side");
+	add_input(inputs, "side_number");
 	add_input(inputs, "id");
 	add_input(inputs, "gold");
 	add_input(inputs, "start_gold");
@@ -688,6 +696,9 @@ void team_callable::get_inputs(formula_input_vector& inputs) const
 variant team_callable::get_value(const std::string& key) const
 {
 	if(key == "side") {
+		deprecated_message("team.side", DEP_LEVEL::INDEFINITE, version_info("1.17"), "Use side_number instead.");
+		return variant(team_.side());
+	} else if(key == "side_number") {
 		return variant(team_.side());
 	} else if(key == "id") {
 		return variant(team_.save_id());

--- a/src/formula/function_gamestate.cpp
+++ b/src/formula/function_gamestate.cpp
@@ -21,6 +21,9 @@
 #include "pathutils.hpp"
 #include "units/types.hpp"
 #include "units/unit.hpp"
+#include "play_controller.hpp"
+#include "tod_manager.hpp"
+#include "resources.hpp"
 
 namespace wfl {
 
@@ -394,6 +397,52 @@ DEFINE_WFL_FUNCTION(resistance_on, 3, 4)
 	return variant();
 }
 
+DEFINE_WFL_FUNCTION(tod_bonus, 0, 2)
+{
+	map_location loc;
+	int turn = resources::controller->turn();
+	if(args().size() > 0) {
+		variant loc_arg = args()[0]->evaluate(variables, add_debug_info(fdb, 0, "tod_bonus:loc"));
+		if(auto p = loc_arg.try_convert<location_callable>()) {
+			loc = p->loc();
+		} else return variant();
+
+		if(args().size() > 1) {
+			variant turn_arg = args()[1]->evaluate(variables, add_debug_info(fdb, 0, "tod_bonus:turn"));
+			if(turn_arg.is_int()) {
+				turn = turn_arg.as_int();
+			} else if(!turn_arg.is_null()) {
+				return variant();
+			}
+		}
+	}
+	int bonus = resources::tod_manager->get_illuminated_time_of_day(resources::gameboard->units(), resources::gameboard->map(), loc, turn).lawful_bonus;
+	return variant(bonus);
+}
+
+DEFINE_WFL_FUNCTION(base_tod_bonus, 0, 2)
+{
+	map_location loc;
+	int turn = resources::controller->turn();
+	if(args().size() > 0) {
+		variant loc_arg = args()[0]->evaluate(variables, add_debug_info(fdb, 0, "tod_bonus:loc"));
+		if(auto p = loc_arg.try_convert<location_callable>()) {
+			loc = p->loc();
+		} else return variant();
+
+		if(args().size() > 1) {
+			variant turn_arg = args()[1]->evaluate(variables, add_debug_info(fdb, 0, "tod_bonus:turn"));
+			if(turn_arg.is_int()) {
+				turn = turn_arg.as_int();
+			} else if(!turn_arg.is_null()) {
+				return variant();
+			}
+		}
+	}
+	int bonus = resources::tod_manager->get_time_of_day(loc, turn).lawful_bonus;
+	return variant(bonus);
+}
+
 } // namespace gamestate
 
 gamestate_function_symbol_table::gamestate_function_symbol_table(std::shared_ptr<function_symbol_table> parent) : function_symbol_table(parent) {
@@ -410,6 +459,8 @@ gamestate_function_symbol_table::gamestate_function_symbol_table(std::shared_ptr
 	DECLARE_WFL_FUNCTION(adjacent_locs); // This is deliberately duplicated here; this form excludes off-map locations, while the core form does not
 	DECLARE_WFL_FUNCTION(locations_in_radius);
 	DECLARE_WFL_FUNCTION(enemy_of);
+	DECLARE_WFL_FUNCTION(tod_bonus);
+	DECLARE_WFL_FUNCTION(base_tod_bonus);
 }
 
 }


### PR DESCRIPTION
Opening a PR to ensure CI passes; assuming it does, I'll merge tomorrow.

I don't expect much controversy in this PR, but it:

* Deprecates "side" in WFL formulas in favour of "side_number", which is consistently 1-based
* Adds tod_bonus and base_tod_bonus gamestate functions
* Adds "terrain" to unit objects, which looks up the terrain info for the unit's current location