### PR TITLE
replace deprecated special= by special_id/type in Utbs and scenario-test

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -276,7 +276,7 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
         first_time_only=no
 
         [filter_attack]
-            special=daze
+            special_id=daze
         [/filter_attack]
 
         [filter_second]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -653,7 +653,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         first_time_only=yes
 
         [filter_attack]
-            special=chance_to_hit
+            special_type=chance_to_hit
         [/filter_attack]
 
         [message]
@@ -666,7 +666,7 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         first_time_only=yes
 
         [filter_attack]
-            special=magical
+            special_id=magical
         [/filter_attack]
 
         [message]


### PR DESCRIPTION
special attribute is deprecated and must be replaced by special_id or special_type before 1.17