### PR TITLE
Include the new-style special notes in the sidebar's unit description

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
  ### User interface
  ### WML Engine
  ### Miscellaneous and Bug Fixes
+   * The unit description tooltip in the sidebar now includes the text from `[special_note]`s.
 
 ## Version 1.15.13
  ### Add-ons client

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -192,6 +192,12 @@ static config unit_type(const unit* u)
 	str << u->type_name();
 	tooltip << _("Type: ") << "<b>" << u->type_name() << "</b>\n"
 		<< u->unit_description();
+	if(const auto& notes = u->unit_special_notes(); !notes.empty()) {
+		tooltip << "\n\n" << _("Special Notes:") << '\n';
+		for(const auto& note : notes) {
+			tooltip << "• " << note << '\n';
+		}
+	}
 	return text_report(str.str(), tooltip.str(), has_variations_prefix + "unit_" + u->type_id());
 }
 REPORT_GENERATOR(unit_type, rc)


### PR DESCRIPTION
_@irydacea asked in https://github.com/wesnoth/wesnoth/pull/5798#discussion_r639428602_:
> Which function is used for the sidebar description tooltips? Considering that singular units having different attributes than their unit types is actually an extremely common thing.

There seems to be some bug about triggering this tooltip - for me hovering the mouse over the sidebar reliably shows other tooltips, but is very intermittent with this one. However, the subject of this PR is the content of the tooltip when it does show.