### PR TITLE
add unslowable status to spectral or fire elemental units

### DIFF
--- a/data/core/macros/traits.cfg
+++ b/data/core/macros/traits.cfg
@@ -73,6 +73,36 @@ Undead units generally have undead as their only trait. Since undead units are t
     [/trait]
 #enddef
 
+#define TRAIT_ETHERAL_UNDEAD
+    # Units with trait Undead cannot be drained, poisoned, or plagued.
+    [trait]
+        id=etheral_undead
+        availability="musthave"
+        male_name= _ "undead"
+        female_name= _ "female^undead"
+        description= _ "Immune to drain, poison, slow, and plague"
+        help_text= _ "<italic>text='Undead'</italic> units are immune to poison, drain, slow, and plague." + _ "
+
+Undead units generally have undead as their only trait. Since undead units are the bodies of the dead, risen to fight again, poison has no effect upon them. This can make them invaluable in dealing with foes who use poison in conjunction with their attacks."
+        [effect]
+            apply_to=status
+            add=unpoisonable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=undrainable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=unplagueable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=unslowable
+        [/effect]
+    [/trait]
+#enddef
+
 #define TRAIT_MECHANICAL
     # Units with trait Mechanical cannot be drained, poisoned, or plagued.
     [trait]
@@ -121,6 +151,36 @@ Elemental units generally have elemental as their only trait. Since elemental un
         [effect]
             apply_to=status
             add=unplagueable
+        [/effect]
+    [/trait]
+#enddef
+
+#define TRAIT_FIRE_ELEMENTAL
+    # Units with trait Elemental cannot be drained, poisoned, or plagued.
+    [trait]
+        id=fire_elemental
+        availability="musthave"
+        male_name= _ "elemental"
+        female_name= _ "female^elemental"
+        description= _ "Immune to drain, poison, slow, and plague"
+        help_text= _ "<italic>text='Elemental'</italic> units are immune to poison, drain, slow, and plague." + _ "
+
+Elemental units generally have elemental as their only trait. Since elemental units are energy-based beings, drain, poison, slow, and plague have no effect upon them."
+        [effect]
+            apply_to=status
+            add=unpoisonable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=undrainable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=unplagueable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=unslowable
         [/effect]
     [/trait]
 #enddef

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -369,22 +369,33 @@ Trolls have inhabited the mountains of the Great Continent longer than the dwarv
         {TROLL_NAMES}
     [/race]
 
+
     # wmllint: general spellings undead undeath unlife demilich
     # wmllint: general spellings Mal fleshbag fleshbags
-    [race]
-        id=undead
-        male_name= _ "race^Undead"
-        female_name= _ "race+female^Undead"
-        plural_name= _ "race+plural^Undead"
-        description= _"Undead are not really a single race of creatures, although often treated as such. Most ordinary creatures can, by a sufficiently skilled necromancer, be reanimated into constructs of varying character — resurrection of the physical form often results in a minion that obeys its master without question, while manifestation of a soul usually produces a servant with at least a modicum of thought. A great mystery of necromancy is how these constructs are sustained and controlled without continuous effort from the necromancer. Most dark magi do not provide constant attention or maintenance to their creations, instead allowing them a small degree of independence to function autonomously in line with the provided commands. However, when left unchecked, some undead gain enough sovereignty to break free from and even turn on their masters. Accordingly, while even lesser undead require periodic maintenance, this is especially true for more powerful undead, particularly greater spirits or death knights, who possess a high degree of inherent will. In these cases, necromancy becomes a battle of resolve between mage and minion. The necromancer must maintain a delicate balance between control over their servants and allotting them free will — the source of their individual powers.
+#define GLOBAL_UNDEAD
+    male_name= _ "race^Undead"
+    female_name= _ "race+female^Undead"
+    plural_name= _ "race+plural^Undead"
+    description= _"Undead are not really a single race of creatures, although often treated as such. Most ordinary creatures can, by a sufficiently skilled necromancer, be reanimated into constructs of varying character — resurrection of the physical form often results in a minion that obeys its master without question, while manifestation of a soul usually produces a servant with at least a modicum of thought. A great mystery of necromancy is how these constructs are sustained and controlled without continuous effort from the necromancer. Most dark magi do not provide constant attention or maintenance to their creations, instead allowing them a small degree of independence to function autonomously in line with the provided commands. However, when left unchecked, some undead gain enough sovereignty to break free from and even turn on their masters. Accordingly, while even lesser undead require periodic maintenance, this is especially true for more powerful undead, particularly greater spirits or death knights, who possess a high degree of inherent will. In these cases, necromancy becomes a battle of resolve between mage and minion. The necromancer must maintain a delicate balance between control over their servants and allotting them free will — the source of their individual powers.
 
 Necromancy is almost solely limited to humans. Even the legends of magically apt races like elves and merfolk tell of very few of their kind who have ever delved in the dark arts. It is surmised that necromantic magic requires great adaptability and a flexible mind, extremes of which are most commonly found in humans. The ultimate goal of most necromancers is to turn the same art of preserving and imbuing life upon themselves, to alter themselves at whatever cost, to ultimately escape death by preserving their own mind and spirit.
 
 <header>text='Geography'</header>
 While undead lords arrived on the Great Continent in considerable numbers only in the wake of Haldric I, they were not completely unheard of by elves and dwarves before that."
-        num_traits=1
-        ignore_global_traits=yes
+    num_traits=1
+    ignore_global_traits=yes
+#enddef
+
+    [race]
+        id=undead
+        {GLOBAL_UNDEAD}
         {TRAIT_UNDEAD}
+    [/race]
+
+    [race]
+        id=spectral
+        {GLOBAL_UNDEAD}
+        {TRAIT_ETHERAL_UNDEAD}
     [/race]
 
     [race]

--- a/data/core/units/monsters/Fire_Guardian.cfg
+++ b/data/core/units/monsters/Fire_Guardian.cfg
@@ -3,7 +3,7 @@
     id=Fire Guardian
     name= _ "Fire Guardian"
     race=monster
-    {TRAIT_ELEMENTAL}
+    {TRAIT_FIRE_ELEMENTAL}
     image="units/monsters/fireghost.png"
     {DEFENSE_ANIM "units/monsters/fireghost-defend.png" "units/monsters/fireghost.png" {SOUND_LIST:DRAKE_HIT} }
     hitpoints=23

--- a/data/core/units/monsters/Jinn.cfg
+++ b/data/core/units/monsters/Jinn.cfg
@@ -3,7 +3,7 @@
     id=Jinn
     name= _ "Jinn"
     race=monster
-    {TRAIT_ELEMENTAL}
+    {TRAIT_FIRE_ELEMENTAL}
     image="units/monsters/jinn.png"
     hitpoints=58
     movement_type=spirit

--- a/data/core/units/undead/Spirit_Ghost.cfg
+++ b/data/core/units/undead/Spirit_Ghost.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Ghost
     name= _ "Ghost"
-    race=undead
+    race=spectral
     image="units/undead/ghost-s-2.png"
     profile=portraits/undead/ghost.png
     hitpoints=18

--- a/data/core/units/undead/Spirit_Nightgaunt.cfg
+++ b/data/core/units/undead/Spirit_Nightgaunt.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Nightgaunt
     name= _ "Nightgaunt"
-    race=undead
+    race=spectral
     image="units/undead/nightgaunt.png"
     profile=portraits/undead/nightgaunt.png
     hitpoints=35

--- a/data/core/units/undead/Spirit_Shadow.cfg
+++ b/data/core/units/undead/Spirit_Shadow.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Shadow
     name= _ "Shadow"
-    race=undead
+    race=spectral
     image="units/undead/shadow-s-2.png"
     profile=portraits/undead/shadow.png
     hitpoints=24

--- a/data/core/units/undead/Spirit_Spectre.cfg
+++ b/data/core/units/undead/Spirit_Spectre.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Spectre
     name= _ "Spectre"
-    race=undead
+    race=spectral
     image="units/undead/spectre.png"
     small_profile=portraits/undead/spectre.png~CROP(0,0,390,390)
     profile=portraits/undead/spectre.png

--- a/data/core/units/undead/Spirit_Wraith.cfg
+++ b/data/core/units/undead/Spirit_Wraith.cfg
@@ -2,7 +2,7 @@
 [unit_type]
     id=Wraith
     name= _ "Wraith"
-    race=undead
+    race=spectral
     image="units/undead/wraith-s.png"
     profile=portraits/undead/wraith.png
     hitpoints=25


### PR DESCRIPTION
the units make of fire, or ghost don't must be slowable by attacks like bolas or entangle, because same if these attacks damage these units,
their non-corporal nature make impossible to slow their movements.