### PR TITLE
Add-ons manager: Fix bugs that return to the title screen with an "Invalid WML" message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## Version 1.15.13+dev
  ### Add-ons client
+   * Fixed: using the versions drop-down in small-screen mode returned to the title screen (issue #5810)
+   * Fixed: keyboard input in small-screen mode returned to the title screen (part of issue #3059)
  ### Add-ons server
  ### Campaigns
  ### Editor

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -666,12 +666,23 @@ boost::dynamic_bitset<> addon_manager::get_type_filter_visibility() const
 
 void addon_manager::apply_filters()
 {
+	// In the small-screen layout, the text_box for the filter keeps keyboard focus even when the
+	// details panel is visible, which means this can be called when the list isn't visible. That
+	// causes problems both because find_widget can throw exceptions, but also because changing the
+	// filters can trigger on_addon_select and thus affect which add-on's details are shown.
+	//
+	// Quick workaround is to not process the new filter if the list isn't visible.
+	auto list = find_widget<addon_list>(get_window(), "addons", false, false);
+	if(!list) {
+		return;
+	}
+
 	boost::dynamic_bitset<> res =
 		get_status_filter_visibility()
 		& get_tag_filter_visibility()
 		& get_type_filter_visibility()
 		& get_name_filter_visibility();
-	find_widget<addon_list>(get_window(), "addons", false).set_addon_shown(res);
+	list->set_addon_shown(res);
 }
 
 void addon_manager::order_addons()
@@ -1034,11 +1045,13 @@ void addon_manager::on_addon_select()
 void addon_manager::on_selected_version_change()
 {
 	widget* parent = get_window();
+	widget* parent_of_addons_list = parent;
 	if(stacked_widget* stk = find_widget<stacked_widget>(get_window(), "main_stack", false, false)) {
 		parent = stk->get_layer_grid(1);
+		parent_of_addons_list = stk->get_layer_grid(0);
 	}
 
-	const addon_info* info = find_widget<addon_list>(get_window(), "addons", false).get_selected_addon();
+	const addon_info* info = find_widget<addon_list>(parent_of_addons_list, "addons", false).get_selected_addon();
 
 	if(info == nullptr) {
 		return;


### PR DESCRIPTION
This fixes two specific causes of #3059, where code assumes that all parts of
the add-ons manager's UI are accessible, an assumption that fails when the
dialog uses a stacked widget to handle small window sizes.

It would be better to redesign the C++ for this dialog, but a quick workaround
for the observed issues is much easier.

* Fixes #5810, triggered by using the version drop-down in small-screen mode.
* Adds a workaround for keyboard input changing the selected add-on on small screens.