### PR TITLE
Remove nonce and double hashing as it's no longer needed.

### DIFF
--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -444,8 +444,6 @@ std::unique_ptr<wesnothd_connection> mp_manager::open_connection(std::string hos
 					error_message = VGETTEXT("The nickname ‘$nick’ is registered on this server.", i18n_symbols)
 							+ "\n\n" + _("WARNING: There is already a client using this nickname, "
 							"logging in will cause that client to be kicked!");
-				} else if(ec == MP_NO_SEED_ERROR) {
-					error_message = _("Error in the login procedure (the server had no seed for your connection).");
 				} else if(ec == MP_INCORRECT_PASSWORD_ERROR) {
 					error_message = _("The password you provided was incorrect.");
 				} else if(ec == MP_TOO_MANY_ATTEMPTS_ERROR) {

--- a/src/multiplayer_error_codes.hpp
+++ b/src/multiplayer_error_codes.hpp
@@ -32,7 +32,6 @@
 
 #define MP_PASSWORD_REQUEST                     "200"
 #define MP_PASSWORD_REQUEST_FOR_LOGGED_IN_NAME  "201"
-#define MP_NO_SEED_ERROR                        "202"
 #define MP_INCORRECT_PASSWORD_ERROR             "203"
 #define MP_TOO_MANY_ATTEMPTS_ERROR              "204"
 #define MP_HASHING_PASSWORD_FAILED              "205"

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -37,11 +37,10 @@ public:
 	 *
 	 * @param name The username used to login.
 	 * @param password The hashed password sent by the client.
-	 * @param nonce The nonce created for this login attempt.
 	 *             @see server::send_password_request().
 	 * @return Whether the hashed password sent by the client matches the hash retrieved from the phpbb database.
 	 */
-	bool login(const std::string& name, const std::string& password, const std::string& nonce);
+	bool login(const std::string& name, const std::string& password);
 
 	/**
 	 * Needed because the hashing algorithm used by phpbb requires some info

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -136,11 +136,11 @@ public:
 	 * Handles hashing the password provided by the player before comparing it to the hashed password in the forum database.
 	 *
 	 * @param pw The plaintext password.
-	 * @param plain_salt The salt as retrieved from the forum database.
+	 * @param salt The salt as retrieved from the forum database.
 	 * @param username The player attempting to log in.
 	 * @return The hashed password, or empty if the password couldn't be hashed.
 	 */
-	std::pair<std::string, std::string> hash_password(const std::string& pw, const std::string& plain_salt, const std::string& username);
+	std::string hash_password(const std::string& pw, const std::string& salt, const std::string& username);
 
 protected:
 	unsigned short port_;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -60,7 +60,7 @@ public:
 	 * Currently the login procedure in the server and client code is hardcoded
 	 * for the forum_user_handler implementation
 	 */
-	virtual bool login(const std::string& name, const std::string& password, const std::string& seed) = 0;
+	virtual bool login(const std::string& name, const std::string& password) = 0;
 
 	/** Executed when the user with the given name logged in. */
 	virtual void user_logged_in(const std::string& name) = 0;

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -905,7 +905,7 @@ template<class SocketPtr> bool server::authenticate(
 					"may fix this problem.");
 				return false;
 			}
-			const auto [hashed_password, nonce] = hash_password(password, salt, username);
+			const std::string hashed_password = hash_password(password, salt, username);
 
 			// This name is registered and no password provided
 			if(password.empty()) {
@@ -923,19 +923,14 @@ template<class SocketPtr> bool server::authenticate(
 				return false;
 			}
 
-			// A password was provided, however the generated nonce is empty for some reason
-			if(nonce.empty()) {
-				send_password_request(socket, "Please try again.", MP_NO_SEED_ERROR);
-				return false;
-			}
 			// hashing the password failed
 			// note: this could be due to other related problems other than *just* the hashing step failing
-			else if(hashed_password.empty()) {
+			if(hashed_password.empty()) {
 				async_send_error(socket, "Password hashing failed.", MP_HASHING_PASSWORD_FAILED);
 				return false;
 			}
 			// This name is registered and an incorrect password provided
-			else if(!(user_handler_->login(username, hashed_password, nonce))) {
+			else if(!(user_handler_->login(username, hashed_password))) {
 				const std::time_t now = std::time(nullptr);
 
 				login_log login_ip { client_address(socket), 0, now };


### PR DESCRIPTION
---

Tested as working locally with the password `password` when hashed as md5 (`$H$9ZDzPE45CDau6Dx3EgubHP5V77/Q3P/`) and bcrypt (`$2y$10$0xhi24E6CXeoICokaHKsA.qWrUDtzzCJGQD9W4Bhxyxv9rOD7pLfG`).