### PR TITLE
Add support for forum_auth when uploading to campaignd.

### DIFF
--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -20,6 +20,7 @@
 #include "cursor.hpp"
 #include "font/pango/escape.hpp"
 #include "formula/string_utils.hpp"
+#include "game_config.hpp"
 #include "gettext.hpp"
 #include "gui/dialogs/addon/addon_auth.hpp"
 #include "gui/dialogs/addon/install_dependencies.hpp"
@@ -199,6 +200,11 @@ bool addons_client::upload_addon(const std::string& id, std::string& response_me
 			VGETTEXT("The add-on <i>$addon_title</i> contains files or directories with case conflicts. "
 				"File or directory names may not be differently-cased versions of the same string.", i18n_symbols);
 		last_error_data_ = font::escape_text(utils::join(badnames, "\n"));
+		return false;
+	}
+
+	if(cfg["forum_auth"].to_bool() && !conn_->using_tls() && !game_config::allow_insecure) {
+		last_error_ = VGETTEXT("The connection to the remote server is not secure. The add-on <i>$addon_title</i> cannot be uploaded.", i18n_symbols);
 		return false;
 	}
 

--- a/src/addon/validation.cpp
+++ b/src/addon/validation.cpp
@@ -391,6 +391,10 @@ std::string addon_check_status_desc(unsigned int code)
 			N_("Incorrect add-on passphrase.")
 		},
 		{
+			ADDON_CHECK_STATUS::USER_DOES_NOT_EXIST,
+			N_("Forum authentication was requested for a user that is not registered on the forums.")
+		},
+		{
 			ADDON_CHECK_STATUS::DENIED,
 			N_("Upload denied. Please contact the server administration for assistance.")
 		},
@@ -492,6 +496,10 @@ std::string addon_check_status_desc(unsigned int code)
 			ADDON_CHECK_STATUS::INVALID_UTF8_ATTRIBUTE,
 			N_("The add-on publish information contains an invalid UTF-8 sequence.")
 		},
+		{
+			ADDON_CHECK_STATUS::AUTH_TYPE_MISMATCH,
+			N_("The add-on's forum_auth attribute does not match what was previously uploaded.")
+		},
 
 		//
 		// Server errors
@@ -512,6 +520,10 @@ std::string addon_check_status_desc(unsigned int code)
 		{
 			ADDON_CHECK_STATUS::SERVER_DELTA_NO_VERSIONS,
 			N_("Empty add-on version list on the server.")
+		},
+		{
+			ADDON_CHECK_STATUS::SERVER_FORUM_AUTH_DISABLED,
+			N_("This server does not support using the forum_auth attribute in your pbl.")
 		}
 	};
 

--- a/src/addon/validation.hpp
+++ b/src/addon/validation.hpp
@@ -36,6 +36,7 @@ enum class ADDON_CHECK_STATUS : unsigned int
 	SUCCESS						= 0x0,			/**< No error */
 	UNAUTHORIZED				= 0x1,			/**< Authentication failed */
 	DENIED						= 0x2,			/**< Upload denied */
+	USER_DOES_NOT_EXIST			= 0x3,			/**< Requested forum authentication for a user that doesn't exist on the forums */
 	UNEXPECTED_DELTA			= 0xD,			/**< Delta for a non-existent add-on */
 	//
 	// Structure errors
@@ -62,6 +63,7 @@ enum class ADDON_CHECK_STATUS : unsigned int
 	INVALID_UTF8_ATTRIBUTE		= 0x2FF,		/**< Invalid UTF-8 sequence in add-on metadata */
 	BAD_FEEDBACK_TOPIC_ID       = 0x209,        /**< The provided topic ID for the addon's feedback forum thread is invalid */
 	FEEDBACK_TOPIC_ID_NOT_FOUND = 0x2A0,        /**< The provided topic ID for the addon's feedback forum thread wasn't found in the forum database */
+	AUTH_TYPE_MISMATCH			= 0x2B0,		/**< The addon's forum_auth value does not match its previously set value */
 	//
 	// Server errors
 	//
@@ -69,6 +71,7 @@ enum class ADDON_CHECK_STATUS : unsigned int
 	SERVER_READ_ONLY			= 0xF001,		/**< Server read-only mode on */
 	SERVER_ADDONS_LIST			= 0xF002,		/**< Corrupted server add-ons list */
 	SERVER_DELTA_NO_VERSIONS	= 0xF003,		/**< No versions to deltify against */
+	SERVER_FORUM_AUTH_DISABLED	= 0xF004,		/**< No versions to deltify against */
 };
 
 std::string addon_check_status_desc(unsigned int code);

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -142,24 +142,33 @@ inline util::ms_optimer service_timer(const campaignd::server::request& req, con
 
 /**
  * WML version of campaignd::auth::verify_passphrase().
+ * The salt and hash are retrieved from the @a passsalt and @a passhash attributes, respectively, if not using forum_auth.
  *
- * The salt and hash are retrieved from the @a passsalt and @a passhash
- * attributes, respectively.
+ * @param addon The config of the addon being authenticated for upload.
+ * @param passphrase The password being validated.
+ * @return Whether the password is correct for the addon.
  */
 inline bool authenticate(config& addon, const config::attribute_value& passphrase)
 {
-	return auth::verify_passphrase(passphrase, addon["passsalt"], addon["passhash"]);
+	if(!addon["forum_auth"].to_bool()) {
+		return auth::verify_passphrase(passphrase, addon["passsalt"], addon["passhash"]);
+	}
+	return false;
 }
 
 /**
  * WML version of campaignd::auth::generate_hash().
+ * The salt and hash are written into the @a passsalt and @a passhash attributes, respectively, if not using forum_auth.
  *
- * The salt and hash are written into the @a passsalt and @a passhash
- * attributes, respectively.
+ * @param addon The addon whose password is being set.
+ * @param passphrase The password being hashed.
  */
 inline void set_passphrase(config& addon, const std::string& passphrase)
 {
-	std::tie(addon["passsalt"], addon["passhash"]) = auth::generate_hash(passphrase);
+	// don't do anything if using forum authorization
+	if(!addon["forum_auth"].to_bool()) {
+		std::tie(addon["passsalt"], addon["passhash"]) = auth::generate_hash(passphrase);
+	}
 }
 
 /**
@@ -464,6 +473,7 @@ void server::load_config()
 			exit(1);
 		}
 		user_handler_.reset(new fuh(user_handler));
+		LOG_CS << "User handler initialized.\n";
 	}
 #endif
 
@@ -603,6 +613,8 @@ void server::handle_read_from_fifo(const boost::system::error_code& error, std::
 			} else if(newpass.empty()) {
 				// Shouldn't happen!
 				ERR_CS << "Add-on passphrases may not be empty!\n";
+			} else if(addon["forum_auth"].to_bool()) {
+				ERR_CS << "Can't set passphrase for add-on using forum_auth.\n";
 			} else {
 				set_passphrase(addon, newpass);
 				mark_dirty(addon_id);
@@ -1291,8 +1303,26 @@ ADDON_CHECK_STATUS server::validate_addon(const server::request& req, config*& e
 		return ADDON_CHECK_STATUS::NO_PASSPHRASE;
 	}
 
-	if(existing_addon && !authenticate(*existing_addon, upload["passphrase"])) {
-		LOG_CS << "Validation error: passphrase does not match\n";
+	if(existing_addon && upload["forum_auth"].to_bool() != (*existing_addon)["forum_auth"].to_bool()) {
+		LOG_CS << "Validation error: forum_auth is " << upload["forum_auth"].to_bool() << " but was previously uploaded set to " << (*existing_addon)["forum_auth"].to_bool() << "\n";
+		return ADDON_CHECK_STATUS::AUTH_TYPE_MISMATCH;
+	} else if(upload["forum_auth"].to_bool()) {
+		if(!user_handler_) {
+			LOG_CS << "Validation error: client requested forum authentication but server does not support it\n";
+			return ADDON_CHECK_STATUS::SERVER_FORUM_AUTH_DISABLED;
+		} else {
+			if(!user_handler_->user_exists(upload["author"].str())) {
+				LOG_CS << "Validation error: forum auth requested for an author who doesn't exist\n";
+				return ADDON_CHECK_STATUS::USER_DOES_NOT_EXIST;
+			}
+
+			if(!authenticate_forum(upload, upload["passphrase"].str())) {
+				LOG_CS << "Validation error: forum passphrase does not match\n";
+				return ADDON_CHECK_STATUS::UNAUTHORIZED;
+			}
+		}
+	} else if(existing_addon && !authenticate(*existing_addon, upload["passphrase"])) {
+		LOG_CS << "Validation error: campaignd passphrase does not match\n";
 		return ADDON_CHECK_STATUS::UNAUTHORIZED;
 	}
 
@@ -1379,7 +1409,8 @@ ADDON_CHECK_STATUS server::validate_addon(const server::request& req, config*& e
 		return ADDON_CHECK_STATUS::NO_DESCRIPTION;
 	}
 
-	if(upload["email"].empty()) {
+	// if using forum_auth, email will be pulled from the forum database later
+	if(upload["email"].empty() && !upload["forum_auth"].to_bool()) {
 		LOG_CS << "Validation error: no add-on email specified\n";
 		return ADDON_CHECK_STATUS::NO_EMAIL;
 	}
@@ -1463,13 +1494,13 @@ void server::handle_upload(const server::request& req)
 
 	addon.copy_attributes(upload,
 		"title", "name", "author", "description", "version", "icon",
-		"translate", "dependencies", "type", "tags", "email");
+		"translate", "dependencies", "type", "tags", "email", "forum_auth");
 
 	const std::string& pathstem = "data/" + name;
 	addon["filename"] = pathstem;
 	addon["upload_ip"] = req.addr;
 
-	if(!is_existing_upload) {
+	if(!is_existing_upload && !addon["forum_auth"].to_bool()) {
 		set_passphrase(addon, upload["passphrase"]);
 	}
 
@@ -1489,7 +1520,10 @@ void server::handle_upload(const server::request& req)
 	}
 
 	if(user_handler_) {
-		user_handler_->db_insert_addon_info(server_id_, name, addon["title"].str(), addon["type"].str(), addon["version"].str(), false, topic_id);
+		if(addon["forum_auth"].to_bool()) {
+			addon["email"] = user_handler_->get_user_email(upload["author"].str());
+		}
+		user_handler_->db_insert_addon_info(server_id_, name, addon["title"].str(), addon["type"].str(), addon["version"].str(), addon["forum_auth"].to_bool(), topic_id);
 	}
 
 	// Copy in any metadata translations provided directly in the .pbl.
@@ -1796,9 +1830,16 @@ void server::handle_delete(const server::request& req)
 		return;
 	}
 
-	if(!authenticate(addon, pass)) {
-		send_error("The passphrase is incorrect.", req.sock);
-		return;
+	if(!addon["forum_auth"].to_bool()) {
+		if(!authenticate(addon, pass)) {
+			send_error("The passphrase is incorrect.", req.sock);
+			return;
+		}
+	} else {
+		if(!authenticate_forum(addon, pass)) {
+			send_error("The passphrase is incorrect.", req.sock);
+			return;
+		}
 	}
 
 	if(addon["hidden"].to_bool()) {
@@ -1826,6 +1867,8 @@ void server::handle_change_passphrase(const server::request& req)
 
 	if(!addon) {
 		send_error("No add-on with that name exists.", req.sock);
+	} else if(addon["forum_auth"].to_bool()) {
+		send_error("Changing the password for add-ons using forum_auth is not supported.", req.sock);
 	} else if(!authenticate(addon, cpass["passphrase"])) {
 		send_error("Your old passphrase was incorrect.", req.sock);
 	} else if(addon["hidden"].to_bool()) {
@@ -1839,6 +1882,17 @@ void server::handle_change_passphrase(const server::request& req)
 		write_config();
 		send_message("Passphrase changed.", req.sock);
 	}
+}
+
+bool server::authenticate_forum(const config& addon, const std::string& passphrase) {
+	if(!user_handler_) {
+		return false;
+	}
+
+	std::string author = addon["author"].str();
+	std::string salt = user_handler_->extract_salt(author);
+	std::string hashed_password = hash_password(passphrase, salt, author);
+	return user_handler_->login(author, hashed_password);
 }
 
 } // end namespace campaignd

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -268,6 +268,8 @@ private:
 	 * and message is recorded to the server log.
 	 */
 	void send_error(const std::string& msg, const std::string& extra_data, unsigned int status_code, const any_socket_ptr& sock);
+
+	bool authenticate_forum(const config& addon, const std::string& passphrase);
 };
 
 } // end namespace campaignd

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -182,6 +182,10 @@ std::string fuh::get_hashed_password_from_db(const std::string& user) {
 	return conn_.get_user_string(db_users_table_, "user_password", user);
 }
 
+std::string fuh::get_user_email(const std::string& user) {
+	return conn_.get_user_string(db_users_table_, "user_email", user);
+}
+
 std::time_t fuh::get_lastlogin(const std::string& user) {
 	return std::time_t(conn_.get_user_int(db_extra_table_, "user_lastvisit", user));
 }

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -255,6 +255,12 @@ public:
 	 */
 	void get_ips_for_user(const std::string& username, std::ostringstream* out);
 
+	/**
+	 * @param user The player's username.
+	 * @return The player's email address from the phpbb forum database.
+	 */
+	std::string get_user_email(const std::string& user);
+
 private:
 	/** An instance of the class responsible for executing the queries and handling the database connection. */
 	dbconn conn_;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -78,6 +78,9 @@ public:
 	/** Returns the forum user id for the given username */
 	virtual long get_forum_id(const std::string& name) = 0;
 
+	/** Returns the user's email from the forum database */
+	virtual std::string get_user_email(const std::string& user) = 0;
+
 	/** Returns true if the specified user account is usable for logins. */
 	virtual bool user_is_active(const std::string& name) = 0;
 


### PR DESCRIPTION
---

Note that the `db_users_table` attribute now needs to be set in the campaignd server config file.