### PR TITLE
Add wesnoth.interface.add_floating_label as a replacement for wesnoth.print

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -1276,6 +1276,7 @@
             text= _ "$(16 - $turn_number) turns remain to free $number_merfolk_caged| merfolk"
             size=24
             duration=5000
+            fade_time=300
             color=200,200,255
         [/print]
     [/event]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -1272,12 +1272,12 @@
         [/filter_condition]
 
         # Print a reminder of the time limit
-        [floating_label]
+        [print]
             text= _ "$(16 - $turn_number) turns remain to free $number_merfolk_caged| merfolk"
             size=24
             duration=5000
             color=200,200,255
-        [/floating_label]
+        [/print]
     [/event]
 
     # Introduce new necromancer triad member, standing on the mountains of the north-west area. He

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -1272,12 +1272,12 @@
         [/filter_condition]
 
         # Print a reminder of the time limit
-        [print]
+        [floating_label]
             text= _ "$(16 - $turn_number) turns remain to free $number_merfolk_caged| merfolk"
             size=24
             duration=5000
             color=200,200,255
-        [/print]
+        [/floating_label]
     [/event]
 
     # Introduce new necromancer triad member, standing on the mountains of the north-west area. He

--- a/data/campaigns/tutorial/utils/utils.cfg
+++ b/data/campaigns/tutorial/utils/utils.cfg
@@ -5,7 +5,7 @@
         text={STRING}
         size=18
         duration=unlimited
-        red,green,blue=255,255,255
+        color=255,255,255
     [/print]
 #enddef
 

--- a/data/campaigns/tutorial/utils/utils.cfg
+++ b/data/campaigns/tutorial/utils/utils.cfg
@@ -1,18 +1,18 @@
 #textdomain wesnoth-tutorial
 
 #define PRINT STRING
-    [print]
+    [floating_label]
         text={STRING}
         size=18
         duration=unlimited
         red,green,blue=255,255,255
-    [/print]
+    [/floating_label]
 #enddef
 
 #define CLEAR_PRINT
-    [print]
+    [floating_label]
         text=""	# wmllint: ignore
-    [/print]
+    [/floating_label]
 #enddef
 
 #define GENDER MALE_WML FEMALE_WML

--- a/data/campaigns/tutorial/utils/utils.cfg
+++ b/data/campaigns/tutorial/utils/utils.cfg
@@ -1,18 +1,18 @@
 #textdomain wesnoth-tutorial
 
 #define PRINT STRING
-    [floating_label]
+    [print]
         text={STRING}
         size=18
         duration=unlimited
         red,green,blue=255,255,255
-    [/floating_label]
+    [/print]
 #enddef
 
 #define CLEAR_PRINT
-    [floating_label]
+    [print]
         text=""	# wmllint: ignore
-    [/floating_label]
+    [/print]
 #enddef
 
 #define GENDER MALE_WML FEMALE_WML

--- a/data/core/macros/ai_controller.cfg
+++ b/data/core/macros/ai_controller.cfg
@@ -485,11 +485,11 @@
                             {VARIABLE ai_controller_{AFFIX}.defend_location.original_controller_invokation_y $y1}
                             {VARIABLE ai_controller_finished yes}
 
-                            [print]
+                            [floating_label]
                                 text= _ "Right-click to select a location to defend"
                                 duration=100
                                 {COLOR_WHITE}
-                            [/print]
+                            [/floating_label]
 
                             [set_menu_item]
                                 id=ai_controller_defend_location_picker
@@ -523,10 +523,10 @@
                                         [/goal]
                                     )}
 
-                                    [print]
+                                    [floating_label]
                                         text=" "    # wmllint: ignore
                                         duration=1
-                                    [/print]
+                                    [/floating_label]
 
                                     [fire_event]
                                         name=menu item ai_controller
@@ -551,11 +551,11 @@
                                     [then]
                                         {VARIABLE ai_controller_{AFFIX}.defend_location.picker_active no}
 
-                                        [print]
+                                        [floating_label]
                                             text= _ "Location selection canceled"
                                             duration=100
                                             {COLOR_WHITE}
-                                        [/print]
+                                        [/floating_label]
                                     [/then]
                                 [/if]
                             [/event]

--- a/data/core/macros/ai_controller.cfg
+++ b/data/core/macros/ai_controller.cfg
@@ -485,11 +485,11 @@
                             {VARIABLE ai_controller_{AFFIX}.defend_location.original_controller_invokation_y $y1}
                             {VARIABLE ai_controller_finished yes}
 
-                            [floating_label]
+                            [print]
                                 text= _ "Right-click to select a location to defend"
                                 duration=100
                                 {COLOR_WHITE}
-                            [/floating_label]
+                            [/print]
 
                             [set_menu_item]
                                 id=ai_controller_defend_location_picker
@@ -523,10 +523,10 @@
                                         [/goal]
                                     )}
 
-                                    [floating_label]
+                                    [print]
                                         text=" "    # wmllint: ignore
                                         duration=1
-                                    [/floating_label]
+                                    [/print]
 
                                     [fire_event]
                                         name=menu item ai_controller
@@ -551,11 +551,11 @@
                                     [then]
                                         {VARIABLE ai_controller_{AFFIX}.defend_location.picker_active no}
 
-                                        [floating_label]
+                                        [print]
                                             text= _ "Location selection canceled"
                                             duration=100
                                             {COLOR_WHITE}
-                                        [/floating_label]
+                                        [/print]
                                     [/then]
                                 [/if]
                             [/event]

--- a/data/lua/core/interface.lua
+++ b/data/lua/core/interface.lua
@@ -61,7 +61,7 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	wesnoth.get_viewing_side = wesnoth.deprecate_api('wesnoth.get_viewing_side', 'wesnoth.interface.get_viewing_side', 1, nil, wesnoth.interface.get_viewing_side)
 	wesnoth.message = wesnoth.deprecate_api('wesnoth.message', 'wesnoth.interface.add_chat_message', 1, nil, wesnoth.interface.add_chat_message)
 	-- wesnoth.wml_actions.print doesn't exist yet at this point, so create a helper function instead.
-	wesnoth.print = wesnoth.deprecate_api('wesnoth.print', 'wesnoth.interface.add_floating_label', 1, nil, function(cfg)
+	wesnoth.print = wesnoth.deprecate_api('wesnoth.print', 'wesnoth.interface.add_overlay_text', 1, nil, function(cfg)
 		wesnoth.wml_actions.print(cfg)
 	end)
 	-- No deprecation for these since since they're not actually public API yet

--- a/data/lua/core/interface.lua
+++ b/data/lua/core/interface.lua
@@ -60,6 +60,10 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	wesnoth.end_turn = wesnoth.deprecate_api('wesnoth.end_turn', 'wesnoth.interface.end_turn', 1, nil, wesnoth.interface.end_turn)
 	wesnoth.get_viewing_side = wesnoth.deprecate_api('wesnoth.get_viewing_side', 'wesnoth.interface.get_viewing_side', 1, nil, wesnoth.interface.get_viewing_side)
 	wesnoth.message = wesnoth.deprecate_api('wesnoth.message', 'wesnoth.interface.add_chat_message', 1, nil, wesnoth.interface.add_chat_message)
+	-- wesnoth.wml_actions.print doesn't exist yet at this point, so create a helper function instead.
+	wesnoth.print = wesnoth.deprecate_api('wesnoth.print', 'wesnoth.interface.add_floating_label', 1, nil, function(cfg)
+		wesnoth.wml_actions.print(cfg)
+	end)
 	-- No deprecation for these since since they're not actually public API yet
 	wesnoth.set_menu_item = wesnoth.interface.set_menu_item
 	wesnoth.clear_menu_item = wesnoth.interface.clear_menu_item

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -780,10 +780,6 @@ function wml_actions.print(cfg)
 	elseif cfg.red or cfg.green or cfg.blue then
 		label_text.color = {cfg.red or 0, cfg.green or 0, cfg.blue or 0}
 	end
-	local offset = nil
-	if cfg.x_offset or cfg.y_offset then
-		offset = {cfg.x_offset or 0, cfg.y_offset or 0}
-	end
 	if cfg.duration then
 		lifetime.duration = cfg.duration
 	end
@@ -791,7 +787,7 @@ function wml_actions.print(cfg)
 		lifetime.fade_time = cfg.fade_time
 	end
 
-	wml_floating_label = wesnoth.interface.add_overlay_text(label_text, lifetime, offset)
+	wml_floating_label = wesnoth.interface.add_overlay_text(label_text, lifetime)
 end
 
 function wml_actions.unsynced(cfg)

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -773,12 +773,12 @@ function wml_actions.print(cfg)
 		wml_floating_label:remove()
 	end
 	if cfg.size then
-		table.insert(label_text, cfg.size)
+		label_text.size = cfg.size
 	end
 	if cfg.color then
-		table.insert(label_text, stringx.split(cfg.color))
+		label_text.color = stringx.split(cfg.color)
 	elseif cfg.red or cfg.green or cfg.blue then
-		table.insert(label_text, {cfg.red or 0, cfg.green or 0, cfg.blue or 0})
+		label_text.color = {cfg.red or 0, cfg.green or 0, cfg.blue or 0}
 	end
 	local offset = nil
 	if cfg.x_offset or cfg.y_offset then

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -768,24 +768,6 @@ end
 
 local wml_floating_label = {valid = false}
 function wml_actions.print(cfg)
-	wesnoth.deprecated_message('[print]', 1, nil, 'use [floating_label] instead')
-	if wml_floating_label.valid then
-		wml_floating_label:remove()
-	end
-	local label_text = {cfg.text}
-	if cfg.size then
-		table.insert(label_text, cfg.size)
-	end
-	if cfg.color then
-		table.insert(label_text, stringx.split(cfg.color))
-	elseif cfg.red or cfg.green or cfg.blue then
-		table.insert(label_text, {cfg.red or 0, cfg.green or 0, cfg.blue or 0})
-	end
-
-	wml_floating_label = wesnoth.interface.add_floating_label(label_text, cfg.duration or 50)
-end
-
-function wml_actions.floating_label(cfg)
 	local label_text, lifetime = {cfg.text}, {}
 	if wml_floating_label.valid then
 		wml_floating_label:remove()
@@ -795,6 +777,8 @@ function wml_actions.floating_label(cfg)
 	end
 	if cfg.color then
 		table.insert(label_text, stringx.split(cfg.color))
+	elseif cfg.red or cfg.green or cfg.blue then
+		table.insert(label_text, {cfg.red or 0, cfg.green or 0, cfg.blue or 0})
 	end
 	local offset = nil
 	if cfg.x_offset or cfg.y_offset then
@@ -807,7 +791,7 @@ function wml_actions.floating_label(cfg)
 		lifetime.fade_time = cfg.fade_time
 	end
 
-	wml_floating_label = wesnoth.interface.add_floating_label(label_text, lifetime, offset)
+	wml_floating_label = wesnoth.interface.add_overlay_text(label_text, lifetime, offset)
 end
 
 function wml_actions.unsynced(cfg)

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -768,26 +768,26 @@ end
 
 local wml_floating_label = {valid = false}
 function wml_actions.print(cfg)
-	local label_text, lifetime = {cfg.text}, {}
+	local options = {}
 	if wml_floating_label.valid then
 		wml_floating_label:remove()
 	end
 	if cfg.size then
-		label_text.size = cfg.size
+		options.size = cfg.size
 	end
 	if cfg.color then
-		label_text.color = stringx.split(cfg.color)
+		options.color = stringx.split(cfg.color)
 	elseif cfg.red or cfg.green or cfg.blue then
-		label_text.color = {cfg.red or 0, cfg.green or 0, cfg.blue or 0}
+		options.color = {cfg.red or 0, cfg.green or 0, cfg.blue or 0}
 	end
 	if cfg.duration then
-		lifetime.duration = cfg.duration
+		options.duration = cfg.duration
 	end
 	if cfg.fade_time then
-		lifetime.fade_time = cfg.fade_time
+		options.fade_time = cfg.fade_time
 	end
 
-	wml_floating_label = wesnoth.interface.add_overlay_text(label_text, lifetime)
+	wml_floating_label = wesnoth.interface.add_overlay_text(cfg.text, options)
 end
 
 function wml_actions.unsynced(cfg)

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -766,8 +766,48 @@ function wml_actions.redraw(cfg)
 	wesnoth.redraw(cfg, clear_shroud)
 end
 
+local wml_floating_label = {valid = false}
 function wml_actions.print(cfg)
-	wesnoth.print(cfg)
+	wesnoth.deprecated_message('[print]', 1, nil, 'use [floating_label] instead')
+	if wml_floating_label.valid then
+		wml_floating_label:remove()
+	end
+	local label_text = {cfg.text}
+	if cfg.size then
+		table.insert(label_text, cfg.size)
+	end
+	if cfg.color then
+		table.insert(label_text, stringx.split(cfg.color))
+	elseif cfg.red or cfg.green or cfg.blue then
+		table.insert(label_text, {cfg.red or 0, cfg.green or 0, cfg.blue or 0})
+	end
+
+	wml_floating_label = wesnoth.interface.add_floating_label(label_text, cfg.duration or 50)
+end
+
+function wml_actions.floating_label(cfg)
+	local label_text, lifetime = {cfg.text}, {}
+	if wml_floating_label.valid then
+		wml_floating_label:remove()
+	end
+	if cfg.size then
+		table.insert(label_text, cfg.size)
+	end
+	if cfg.color then
+		table.insert(label_text, stringx.split(cfg.color))
+	end
+	local offset = nil
+	if cfg.x_offset or cfg.y_offset then
+		offset = {cfg.x_offset or 0, cfg.y_offset or 0}
+	end
+	if cfg.duration then
+		lifetime.duration = cfg.duration
+	end
+	if cfg.fade_time then
+		lifetime.fade_time = cfg.fade_time
+	end
+
+	wml_floating_label = wesnoth.interface.add_floating_label(label_text, lifetime, offset)
 end
 
 function wml_actions.unsynced(cfg)

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -764,6 +764,9 @@
 		{SIMPLE_KEY text s_t_string}
 		{SIMPLE_KEY size s_unsigned}
 		{SIMPLE_KEY duration s_unsigned,unlimited}
+		{SIMPLE_KEY fade_time s_unsigned}
+		{SIMPLE_KEY x_offset s_int}
+		{SIMPLE_KEY y_offset s_int}
 		{COLOR_KEYS s_unsigned}
 		{SIMPLE_KEY color string}
 	[/tag]

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -765,8 +765,6 @@
 		{SIMPLE_KEY size s_unsigned}
 		{SIMPLE_KEY duration s_unsigned,unlimited}
 		{SIMPLE_KEY fade_time s_unsigned}
-		{SIMPLE_KEY x_offset s_int}
-		{SIMPLE_KEY y_offset s_int}
 		{COLOR_KEYS s_unsigned}
 		{SIMPLE_KEY color string}
 	[/tag]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -5,11 +5,11 @@
     map_file=test/maps/generic_unit_test.map
     id = overlay_text_demo
     turns = unlimited
-    suppress_end_turn_confirmation = yes
     
     [side]
         side=1
         controller = human
+        suppress_end_turn_confirmation = yes
         [leader]
             name = _ "Alice"
             type = Elvish Archer
@@ -19,6 +19,7 @@
     [side]
         side=2
         controller = human
+        suppress_end_turn_confirmation = yes
         [leader]
             name = _ "Bob"
             type = Orcish Grunt

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -88,7 +88,7 @@
             code=<<
                 left_label_id = wesnoth.interface.add_overlay_text(
                     {"Left Label", size = 42, color = "ff8000"},
-                    {"unlimited", 500},
+                    {duration = "unlimited", 500},
                     -100, -60
                 )
             >>
@@ -109,7 +109,7 @@
             code=<<
                 right_label_id = wesnoth.interface.add_overlay_text(
                     {"Right Label", size = 42, color = {0, 128, 255}},
-                    {"unlimited", 500},
+                    {duration = "unlimited", 500},
                     100, -60
                 )
             >>

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -10,7 +10,7 @@
         side=1
         controller = human
         [leader]
-            name = "Alice"
+            name = _ "Alice"
             type = Elvish Archer
             id=alice
         [/leader]
@@ -19,7 +19,7 @@
         side=2
         controller = human
         [leader]
-            name = "Bob"
+            name = _ "Bob"
             type = Orcish Grunt
             id=bob
         [/leader]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -14,6 +14,9 @@
             name = _ "Alice"
             type = Elvish Archer
             id=alice
+            [modifications]
+                {TRAIT_QUICK}
+            [/modifications]
         [/leader]
     [/side]
     [side]
@@ -24,6 +27,9 @@
             name = _ "Bob"
             type = Orcish Grunt
             id=bob
+            [modifications]
+                {TRAIT_QUICK}
+            [/modifications]
         [/leader]
     [/side]
     [event]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -38,8 +38,14 @@
             code=<<
                 left_label_id = {valid = false}
                 right_label_id = {valid = false}
-                top_label_id = left_label_id
-                bottom_label_id = left_label_id
+                top_label_id = {valid = false}
+                bottom_label_id = {valid = false}
+                wesnoth.interface.add_overlay_text("A test scenario demonstrating the add_overlay_text API. Move one of the units to the labelled hexes to add, move, or remove labels at the edge of the screen.", {
+                    size = 22, color = "ff8000",
+                    duration = "unlimited",
+                    max_width = 300,
+                    valign = "top", halign = "right"
+                })
             >>
         [/lua]
     [/event]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -88,7 +88,7 @@
             code=<<
                 left_label_id = wesnoth.interface.add_overlay_text(
                     {"Left Label", size = 42, color = "ff8000"},
-                    "unlimited",
+                    {"unlimited", 500},
                     -100, -60
                 )
             >>
@@ -109,7 +109,7 @@
             code=<<
                 right_label_id = wesnoth.interface.add_overlay_text(
                     {"Right Label", size = 42, color = {0, 128, 255}},
-                    "unlimited",
+                    {"unlimited", 500},
                     100, -60
                 )
             >>

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -5,6 +5,7 @@
     map_file=test/maps/generic_unit_test.map
     id = overlay_text_demo
     turns = unlimited
+    suppress_end_turn_confirmation = yes
     
     [side]
         side=1
@@ -86,11 +87,12 @@
         [/filter]
         [lua]
             code=<<
-                left_label_id = wesnoth.interface.add_overlay_text(
-                    {"Left Label", size = 42, color = "ff8000"},
-                    {duration = "unlimited", 500},
-                    -100, -60
-                )
+                left_label_id = wesnoth.interface.add_overlay_text("Left Label", {
+                    size = 42, color = "ff8000",
+                    duration = "unlimited", fade_time = 500,
+                    location = {100, -60},
+                    halign = "left"
+                })
             >>
         [/lua]
     [/event]
@@ -107,11 +109,12 @@
         [/filter]
         [lua]
             code=<<
-                right_label_id = wesnoth.interface.add_overlay_text(
-                    {"Right Label", size = 42, color = {0, 128, 255}},
-                    {duration = "unlimited", 500},
-                    100, -60
-                )
+                right_label_id = wesnoth.interface.add_overlay_text("Right Label", {
+                    size = 42, color = {0, 128, 255},
+                    duration = "unlimited", fade_time = 500,
+                    location = {100, -60},
+                    halign = "right"
+                })
             >>
         [/lua]
     [/event]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -87,7 +87,7 @@
         [lua]
             code=<<
                 left_label_id = wesnoth.interface.add_overlay_text(
-                    {"Left Label", 42, "ff8000"},
+                    {"Left Label", size = 42, color = "ff8000"},
                     "infinity",
                     -100, -60
                 )
@@ -108,7 +108,7 @@
         [lua]
             code=<<
                 right_label_id = wesnoth.interface.add_overlay_text(
-                    {"Right Label", 42, "0080ff"},
+                    {"Right Label", size = 42, color = {0, 128, 255}},
                     "infinity",
                     100, -60
                 )

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -88,7 +88,7 @@
             code=<<
                 left_label_id = wesnoth.interface.add_overlay_text(
                     {"Left Label", size = 42, color = "ff8000"},
-                    "infinity",
+                    "unlimited",
                     -100, -60
                 )
             >>
@@ -109,7 +109,7 @@
             code=<<
                 right_label_id = wesnoth.interface.add_overlay_text(
                     {"Right Label", size = 42, color = {0, 128, 255}},
-                    "infinity",
+                    "unlimited",
                     100, -60
                 )
             >>

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -37,7 +37,7 @@
         [lua]
             code=<<
                 left_label_id = {valid = false}
-                right_label_id = left_label_id
+                right_label_id = {valid = false}
                 top_label_id = left_label_id
                 bottom_label_id = left_label_id
             >>

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -35,8 +35,8 @@
     [/event]
     [label]
         x,y=3,8
-        text="Remove label left"
-        tooltip="Removes the text on the left side of the screen"
+        text=_"Remove label left"
+        tooltip=_"Removes the text on the left side of the screen"
     [/label]
     [event]
         name=moveto
@@ -55,8 +55,8 @@
     [/event]
     [label]
         x,y=15,8
-        text="Remove text right"
-        tooltip="Removes the text on the right side of the screen"
+        text=_"Remove text right"
+        tooltip=_"Removes the text on the right side of the screen"
     [/label]
     [event]
         name=moveto
@@ -75,8 +75,8 @@
     [/event]
     [label]
         x,y=3,6
-        text="Add text left"
-        tooltip="Adds text on the left side of the screen"
+        text=_"Add text left"
+        tooltip=_"Adds text on the left side of the screen"
     [/label]
     [event]
         name=moveto
@@ -96,8 +96,8 @@
     [/event]
     [label]
         x,y=15,6
-        text="Add text right"
-        tooltip="Adds text on the right side of the screen"
+        text=_"Add text right"
+        tooltip=_"Adds text on the right side of the screen"
     [/label]
     [event]
         name=moveto
@@ -117,8 +117,8 @@
     [/event]
     [label]
         x,y=9,6
-        text="Shift text towards centre"
-        tooltip="Shifts the text towards the centre of the screen"
+        text=_"Shift text towards centre"
+        tooltip=_"Shifts the text towards the centre of the screen"
     [/label]
     [event]
         name=moveto
@@ -139,8 +139,8 @@
     [/event]
     [label]
         x,y=9,8
-        text="Shift text away from centre"
-        tooltip="Shifts the text away from the centre of the screen"
+        text=_"Shift text away from centre"
+        tooltip=_"Shifts the text away from the centre of the screen"
     [/label]
     [event]
         name=moveto

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -1,0 +1,162 @@
+#textdomain wesnoth-test
+
+[test]
+    name = _ "Overlay Text Demo"
+    map_file=test/maps/generic_unit_test.map
+    id = overlay_text_demo
+    turns = unlimited
+    
+    [side]
+        side=1
+        controller = human
+        [leader]
+            name = "Alice"
+            type = Elvish Archer
+            id=alice
+        [/leader]
+    [/side]
+    [side]
+        side=2
+        controller = human
+        [leader]
+            name = "Bob"
+            type = Orcish Grunt
+            id=bob
+        [/leader]
+    [/side]
+    [event]
+        name=preload
+        [lua]
+            code=<<
+                left_label_id = {valid = false}
+                right_label_id = left_label_id
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=3,8
+        text="Remove label left"
+        tooltip="Removes the text on the left side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x=3,3
+            y=6,8
+        [/filter]
+        [lua]
+            code=<<
+                if left_label_id.valid then
+                    left_label_id:remove()
+                end
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=15,8
+        text="Remove text right"
+        tooltip="Removes the text on the right side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x=15,15
+            y=6,8
+        [/filter]
+        [lua]
+            code=<<
+                if right_label_id.valid then
+                    right_label_id:remove()
+                end
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=3,6
+        text="Add text left"
+        tooltip="Adds text on the left side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=3,6
+        [/filter]
+        [lua]
+            code=<<
+                left_label_id = wesnoth.interface.add_overlay_text(
+                    {"Left Label", 42, "ff8000"},
+                    "infinity",
+                    -100, -60
+                )
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=15,6
+        text="Add text right"
+        tooltip="Adds text on the right side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=15,6
+        [/filter]
+        [lua]
+            code=<<
+                right_label_id = wesnoth.interface.add_overlay_text(
+                    {"Right Label", 42, "0080ff"},
+                    "infinity",
+                    100, -60
+                )
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=9,6
+        text="Shift text towards centre"
+        tooltip="Shifts the text towards the centre of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=9,6
+        [/filter]
+        [lua]
+            code=<<
+                if left_label_id.valid then
+                    left_label_id:move(20,0)
+                end
+                if right_label_id.valid then
+                    right_label_id:move(-20,0)
+                end
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=9,8
+        text="Shift text away from centre"
+        tooltip="Shifts the text away from the centre of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=9,8
+        [/filter]
+        [lua]
+            code=<<
+                if left_label_id.valid then
+                    left_label_id:move(-20,0)
+                end
+                if right_label_id.valid then
+                    right_label_id:move(20,0)
+                end
+            >>
+        [/lua]
+    [/event]
+[/test]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -32,12 +32,14 @@
             code=<<
                 left_label_id = {valid = false}
                 right_label_id = left_label_id
+                top_label_id = left_label_id
+                bottom_label_id = left_label_id
             >>
         [/lua]
     [/event]
     [label]
         x,y=3,8
-        text=_"Remove label left"
+        text=_"Remove text left"
         tooltip=_"Removes the text on the left side of the screen"
     [/label]
     [event]
@@ -51,6 +53,46 @@
             code=<<
                 if left_label_id.valid then
                     left_label_id:remove()
+                end
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=5,8
+        text=_"Remove text top"
+        tooltip=_"Removes the text on the top side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x=5,5
+            y=6,8
+        [/filter]
+        [lua]
+            code=<<
+                if top_label_id.valid then
+                    top_label_id:remove()
+                end
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=13,8
+        text=_"Remove text bottom"
+        tooltip=_"Removes the text on the bottom side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x=13,13
+            y=6,8
+        [/filter]
+        [lua]
+            code=<<
+                if bottom_label_id.valid then
+                    bottom_label_id:remove()
                 end
             >>
         [/lua]
@@ -98,6 +140,50 @@
         [/lua]
     [/event]
     [label]
+        x,y=5,6
+        text=_"Add text top"
+        tooltip=_"Adds text on the top side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=5,6
+        [/filter]
+        [lua]
+            code=<<
+                top_label_id = wesnoth.interface.add_overlay_text("Top Label", {
+                    size = 42, color = "ff0080",
+                    duration = "unlimited", fade_time = 500,
+                    location = {-60, 100},
+                    valign = "top"
+                })
+            >>
+        [/lua]
+    [/event]
+    [label]
+        x,y=13,6
+        text=_"Add text bottom"
+        tooltip=_"Adds text on the bottom side of the screen"
+    [/label]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=13,6
+        [/filter]
+        [lua]
+            code=<<
+                bottom_label_id = wesnoth.interface.add_overlay_text("Bottom Label", {
+                    size = 42, color = {128, 0, 255},
+                    duration = "unlimited", fade_time = 500,
+                    location = {-60, 100},
+                    valign = "bottom"
+                })
+            >>
+        [/lua]
+    [/event]
+    [label]
         x,y=15,6
         text=_"Add text right"
         tooltip=_"Adds text on the right side of the screen"
@@ -135,8 +221,14 @@
                 if left_label_id.valid then
                     left_label_id:move(20,0)
                 end
+                if top_label_id.valid then
+                    top_label_id:move(0,20)
+                end
                 if right_label_id.valid then
                     right_label_id:move(-20,0)
+                end
+                if bottom_label_id.valid then
+                    bottom_label_id:move(0,-20)
                 end
             >>
         [/lua]
@@ -157,8 +249,14 @@
                 if left_label_id.valid then
                     left_label_id:move(-20,0)
                 end
+                if top_label_id.valid then
+                    top_label_id:move(0,-20)
+                end
                 if right_label_id.valid then
                     right_label_id:move(20,0)
+                end
+                if bottom_label_id.valid then
+                    bottom_label_id:move(0,20)
                 end
             >>
         [/lua]

--- a/data/test/scenarios/overlay_text_demo.cfg
+++ b/data/test/scenarios/overlay_text_demo.cfg
@@ -44,6 +44,7 @@
                     size = 22, color = "ff8000",
                     duration = "unlimited",
                     max_width = 300,
+                    bgcolor = "996633", bgalpha = 128,
                     valign = "top", halign = "right"
                 })
             >>

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -273,6 +273,9 @@ void remove_floating_label(int handle, int fadeout)
 		if(fadeout > 0) {
 			i->second.set_lifetime(0, fadeout);
 			return;
+		} else if(fadeout < 0) {
+			i->second.set_lifetime(0, i->second.get_fade_time());
+			return;
 		}
 		labels.erase(i);
 	}

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -79,7 +79,7 @@ public:
 	void show(const bool value) { visible_ = value; }
 
 	LABEL_SCROLL_MODE scroll() const { return scroll_; }
-	
+
 	// TODO: Might be good to have more getters, right?
 	int get_fade_time() const { return fadeout_; }
 

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -79,6 +79,9 @@ public:
 	void show(const bool value) { visible_ = value; }
 
 	LABEL_SCROLL_MODE scroll() const { return scroll_; }
+	
+	// TODO: Might be good to have more getters, right?
+	int get_fade_time() const { return fadeout_; }
 
 private:
 
@@ -121,6 +124,7 @@ void scroll_floating_labels(double xmove, double ymove);
 
 /** removes the floating label given by 'handle' from the screen */
 /** if fadeout is given, the label fades out over that duration */
+/** if fadeout is less than 0, it uses the fadeout setting from the label */
 void remove_floating_label(int handle, int fadeout = 0);
 
 /** hides or shows a floating label */

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2371,10 +2371,10 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 					lifetime = lua_tointegerx(L, -1, &found_number);
 					if(!found_number && !lua_isnil(L, -1)) {
 						auto value = luaW_tostring(L, -1);
-						if(value == "infinity") {
+						if(value == "unlimited") {
 							lifetime = -1;
 						} else {
-							return luaL_argerror(L, first_arg + 1, "duration should be integer or 'infinity'");
+							return luaL_argerror(L, first_arg + 1, "duration should be integer or 'unlimited'");
 						}
 					}
 				}
@@ -2384,13 +2384,13 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			lifetime = lua_tointeger(L, first_arg + 1);
 			break;
 		case LUA_TSTRING:
-			if(luaW_tostring(L, first_arg + 1) == "infinity") {
+			if(luaW_tostring(L, first_arg + 1) == "unlimited") {
 				lifetime = -1;
 				break;
 			}
 			[[fallthrough]];
 		default:
-			return luaW_type_error(L, first_arg + 1, "integer or 'infinity'");
+			return luaW_type_error(L, first_arg + 1, "integer or 'unlimited'");
 	}
 
 	if(!found_location && !lua_isnoneornil(L, first_arg + 2)) {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2375,11 +2375,11 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			loc = luaW_checklocation(L, -1);
 		}
 		if(luaW_tableget(L, 2, "halign")) {
-			const char* options[] = {"left", "center", "right"};
+			static const char* options[] = {"left", "center", "right"};
 			alignment = font::ALIGN(luaL_checkoption(L, -1, nullptr, options));
 		}
 		if(luaW_tableget(L, 2, "valign")) {
-			const char* options[] = {"top", "center", "bottom"};
+			static const char* options[] = {"top", "center", "bottom"};
 			vertical_alignment = font::ALIGN(luaL_checkoption(L, -1, nullptr, options));
 		}
 	}
@@ -2422,6 +2422,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			// The size * 1.5 adjustment avoids the text being cut off if placed at y = 0
 			// This is necessary because the text is positioned by the top edge but we want it to
 			// seem like it's positioned by the bottom edge.
+			// This wouldn't work for multiline text, but we don't expect that to be common in this API anyway.
 			y = rect.y + rect.h - loc.wml_y() - static_cast<int>(size * 1.5);
 			break;
 	}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2336,7 +2336,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 				return luaL_argerror(L, 1, "string or table with string as first element");
 			}
 		}
-		text = luaL_checkstring(L, -1);
+		text = luaW_checktstring(L, -1);
 		if(luaW_tableget(L, first_arg, "size")) {
 			size = luaL_checkinteger(L, -1);
 		}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2298,8 +2298,10 @@ static int impl_floating_label_getmethod(lua_State* L)
 int game_lua_kernel::intf_remove_floating_label(lua_State* L)
 {
 	int* handle = luaW_check_floating_label(L, 1);
+	int fade = luaL_optinteger(L, 2, -1);
 	if(*handle != 0) {
-		font::remove_floating_label(*handle);
+		// Passing -1 as the second argument means it uses the fade time that was set when the label was created
+		font::remove_floating_label(*handle, fade);
 	}
 	*handle = 0;
 	return 0;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2365,14 +2365,18 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			if(luaW_tolocation(L, first_arg + 1, loc)) {
 				found_location = true;
 			} else {
-				lifetime = luaW_table_get_def(L, first_arg + 1, "duration", 2000);
 				fadeout = luaW_table_get_def(L, first_arg + 1, "fade_time", 100);
-				// Check for lifetime = 'infinity'
-				auto actual_lifetime = luaW_table_get_def<std::string_view>(L, first_arg + 1, "duration", "");
-				if(actual_lifetime == "infinity") {
-					lifetime = -1;
-				} else if(actual_lifetime != std::to_string(lifetime)) {
-					return luaL_argerror(L, first_arg + 1, "duration should be integer or 'infinity'");
+				if(luaW_tableget(L, first_arg + 1, "duration")) {
+					int found_number;
+					lifetime = lua_tointegerx(L, -1, &found_number);
+					if(!found_number && !lua_isnil(L, -1)) {
+						auto value = luaW_tostring(L, -1);
+						if(value == "infinity") {
+							lifetime = -1;
+						} else {
+							return luaL_argerror(L, first_arg + 1, "duration should be integer or 'infinity'");
+						}
+					}
 				}
 			}
 			break;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2419,7 +2419,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			y = rect.y + rect.h / 2 + loc.wml_y();
 			break;
 		case font::ALIGN::RIGHT_ALIGN: // bottom
-			y = rect.y + rect.h - loc.wml_y() - size;
+			y = rect.y + rect.h - loc.wml_y() - static_cast<int>(size * 1.5);
 			break;
 	}
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2335,7 +2335,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 	color_t color = font::LABEL_COLOR;
 	int lifetime = 2'000, fadeout = 100;
 	font::ALIGN alignment = font::ALIGN::CENTER_ALIGN, vertical_alignment = font::ALIGN::CENTER_ALIGN;
-	// This is actually a relative screen location, but map_location already supports
+	// This is actually a relative screen location in pixels, but map_location already supports
 	// everything needed to read in a pair of coordinates.
 	// Depending on the chosen alignment, it may be relative to centre, an edge centre, or a corner.
 	map_location loc{0, 0, wml_loc()};

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2358,6 +2358,8 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 	}
 
 	int lifetime = 2'000, fadeout = 100;
+	// This is actually a centre-relative screen location, but map_location already supports
+	// everything needed to read in a pair of coordinates.
 	map_location loc{0, 0, wml_loc()};
 	bool found_location = false;
 	switch(lua_type(L, first_arg + 1)) {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2332,6 +2332,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 {
 	t_string text = luaW_checktstring(L, 1);
 	int size = font::SIZE_SMALL;
+	int width = 0;
 	color_t color = font::LABEL_COLOR;
 	int lifetime = 2'000, fadeout = 100;
 	font::ALIGN alignment = font::ALIGN::CENTER_ALIGN, vertical_alignment = font::ALIGN::CENTER_ALIGN;
@@ -2342,6 +2343,9 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 	if(lua_istable(L, 2)) {
 		if(luaW_tableget(L, 2, "size")) {
 			size = luaL_checkinteger(L, -1);
+		}
+		if(luaW_tableget(L, 2, "max_width")) {
+			width = luaL_checkinteger(L, -1);
 		}
 		if(luaW_tableget(L, 2, "color")) {
 			if(lua_isstring(L, -1)) {
@@ -2398,17 +2402,28 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 		font::remove_floating_label(*handle);
 	}
 
-	const SDL_Rect& rect = game_display_->map_outside_area();
+	SDL_Rect rect = game_display_->map_outside_area();
 	int x = 0, y = 0;
 	switch(alignment) {
 		case font::ALIGN::LEFT_ALIGN:
 			x = rect.x + loc.wml_x();
+			if(width > 0) {
+				rect.w = std::min(rect.w, width);
+			}
 			break;
 		case font::ALIGN::CENTER_ALIGN:
 			x = rect.x + rect.w / 2 + loc.wml_x();
+			if(width > 0) {
+				rect.w = std::min(rect.w, width);
+				rect.x = x - rect.w / 2;
+			}
 			break;
 		case font::ALIGN::RIGHT_ALIGN:
 			x = rect.x + rect.w - loc.wml_x();
+			if(width > 0) {
+				rect.x = (rect.x + rect.w) - std::min(rect.w, width);
+				rect.w = std::min(rect.w, width);
+			}
 			break;
 	}
 	switch(vertical_alignment) {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2419,6 +2419,9 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			y = rect.y + rect.h / 2 + loc.wml_y();
 			break;
 		case font::ALIGN::RIGHT_ALIGN: // bottom
+			// The size * 1.5 adjustment avoids the text being cut off if placed at y = 0
+			// This is necessary because the text is positioned by the top edge but we want it to
+			// seem like it's positioned by the bottom edge.
 			y = rect.y + rect.h - loc.wml_y() - static_cast<int>(size * 1.5);
 			break;
 	}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4641,7 +4641,7 @@ game_lua_kernel::game_lua_kernel(game_state & gs, play_controller & pc, reports 
 		{"end_turn", &dispatch<&game_lua_kernel::intf_end_turn>},
 		{"get_viewing_side", &intf_get_viewing_side},
 		{"add_chat_message", &dispatch<&game_lua_kernel::intf_message>},
-		{"add_floating_label", &dispatch2<&game_lua_kernel::intf_set_floating_label, true>},
+		{"add_overlay_text", &dispatch2<&game_lua_kernel::intf_set_floating_label, true>},
 		{ nullptr, nullptr }
 	};
 	lua_getglobal(L, "wesnoth");

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2333,7 +2333,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 	t_string text = luaW_checktstring(L, 1);
 	int size = font::SIZE_SMALL;
 	int width = 0;
-	color_t color = font::LABEL_COLOR;
+	color_t color = font::LABEL_COLOR, bgcolor{0, 0, 0, 0};
 	int lifetime = 2'000, fadeout = 100;
 	font::ALIGN alignment = font::ALIGN::CENTER_ALIGN, vertical_alignment = font::ALIGN::CENTER_ALIGN;
 	// This is actually a relative screen location in pixels, but map_location already supports
@@ -2358,6 +2358,23 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 				color.r = vec[0];
 				color.g = vec[1];
 				color.b = vec[2];
+			}
+		}
+		if(luaW_tableget(L, 2, "bgcolor")) {
+			if(lua_isstring(L, -1)) {
+				bgcolor = color_t::from_hex_string(lua_tostring(L, -1));
+			} else {
+				auto vec = lua_check<std::vector<int>>(L, -1);
+				if(vec.size() != 3) {
+					return luaL_error(L, "floating label background color should be a hex string or an array of 3 integers");
+				}
+				bgcolor.r = vec[0];
+				bgcolor.g = vec[1];
+				bgcolor.b = vec[2];
+				bgcolor.a = ALPHA_OPAQUE;
+			}
+			if(luaW_tableget(L, 2, "bgalpha")) {
+				bgcolor.a = luaL_checkinteger(L, -1);
 			}
 		}
 		if(luaW_tableget(L, 2, "duration")) {
@@ -2445,6 +2462,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 	font::floating_label flabel(text);
 	flabel.set_font_size(size);
 	flabel.set_color(color);
+	flabel.set_bg_color(bgcolor);
 	flabel.set_alignment(alignment);
 	flabel.set_position(x, y);
 	flabel.set_lifetime(lifetime, fadeout);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2372,7 +2372,7 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 				if(actual_lifetime == "infinity") {
 					lifetime = -1;
 				} else if(actual_lifetime != std::to_string(lifetime)) {
-					return luaW_type_error(L, first_arg + 1, "that duration should be integer or 'infinity'");
+					return luaL_argerror(L, first_arg + 1, "duration should be integer or 'infinity'");
 				}
 			}
 			break;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2320,10 +2320,13 @@ int game_lua_kernel::intf_move_floating_label(lua_State* L)
  * Arg 1: text - string
  * Arg 2: options table
  * - size: font size
+ * - max_width: max width for word wrapping
  * - color: font color
+ * - bgcolor: background color
+ * - bgalpha: background opacity
  * - duration: display duration (integer or the string "unlimited")
  * - fade_time: duration of fade-out
- * - x,y: screen offset
+ * - location: screen offset
  * - valign: vertical alignment and anchoring - "top", "center", or "bottom"
  * - halign: horizontal alignment and anchoring - "left", "center", or "right"
  * Returns: label handle

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -117,7 +117,9 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_heal_unit(lua_State *L);
 	int intf_message(lua_State *L);
 	int intf_play_sound(lua_State *L);
-	int intf_print(lua_State *L);
+	int intf_set_floating_label(lua_State* L, bool spawn);
+	int intf_remove_floating_label(lua_State* L);
+	int intf_move_floating_label(lua_State* L);
 	void put_unit_helper(const map_location& loc);
 	int intf_put_unit(lua_State *L);
 	int intf_erase_unit(lua_State *L);

--- a/utils/emmylua/wesnoth/interface.lua
+++ b/utils/emmylua/wesnoth/interface.lua
@@ -78,6 +78,22 @@ function wesnoth.interface.add_chat_message(speaker, message) end
 ---Clear all messages in the onscreen chat
 function wesnoth.interface.clear_chat_messages() end
 
+---@alias horizontal_align "'left'"|"'center'"|"'right'"
+---@alias vertical_align "'top'"|"'center'"|"'bottom'"
+---@class overlay_text_options
+---@field size integer The default font size
+---@field color string|integer[] The default text colour as either a hex string or an RGB triple
+---@field duration integer|"'unlimited'" How long the text should be displayed, in milliseconds
+---@field fade_time integer If duration is not unlimited, this is how long it takes to fade out after the duration expires
+---@field location location The screen location of the text, relative to the specified anchor (default: center of the screen)
+---@field halign horizontal_align How the text should be anchored horizontally to the screen
+---@field valign vertical_align How the text should be anchored vertically to the screen
+
+---Add overlay text on the screen
+---@param text string|tstring The text to display. Supports Pango markup.
+---@param options overlay_text_options
+function wesnoth.interface.add_overlay_text(text, options) end
+
 ---Place an overlay image on a hex
 ---@param location location
 ---@param cfg WML

--- a/utils/emmylua/wesnoth/interface.lua
+++ b/utils/emmylua/wesnoth/interface.lua
@@ -82,9 +82,10 @@ function wesnoth.interface.clear_chat_messages() end
 ---@alias vertical_align "'top'"|"'center'"|"'bottom'"
 ---@class overlay_text_options
 ---@field size integer The default font size
+---@field max_width integer The maximum width in which to display the text; if longer, it will be word-wrapped
 ---@field color string|integer[] The default text colour as either a hex string or an RGB triple
 ---@field duration integer|"'unlimited'" How long the text should be displayed, in milliseconds
----@field fade_time integer If duration is not unlimited, this is how long it takes to fade out after the duration expires
+---@field fade_time integer This is how long it takes to fade out when the label is removed, either explicitly or because the duration expired
 ---@field location location The screen location of the text, relative to the specified anchor (default: center of the screen)
 ---@field halign horizontal_align How the text should be anchored horizontally to the screen
 ---@field valign vertical_align How the text should be anchored vertically to the screen

--- a/utils/emmylua/wesnoth/interface.lua
+++ b/utils/emmylua/wesnoth/interface.lua
@@ -84,6 +84,8 @@ function wesnoth.interface.clear_chat_messages() end
 ---@field size integer The default font size
 ---@field max_width integer The maximum width in which to display the text; if longer, it will be word-wrapped
 ---@field color string|integer[] The default text colour as either a hex string or an RGB triple
+---@field bgcolor string|integer[] The default background colour as either a hex string or an RGB triple; the default is no background (fully transparent)
+---@field bgalpha integer Alpha value for the background, in the range [0,255]; defaults to 255 if a bgcolor is specified
 ---@field duration integer|"'unlimited'" How long the text should be displayed, in milliseconds
 ---@field fade_time integer This is how long it takes to fade out when the label is removed, either explicitly or because the duration expired
 ---@field location location The screen location of the text, relative to the specified anchor (default: center of the screen)

--- a/utils/emmylua/wesnoth/interface.lua
+++ b/utils/emmylua/wesnoth/interface.lua
@@ -82,7 +82,7 @@ function wesnoth.interface.clear_chat_messages() end
 ---@alias vertical_align "'top'"|"'center'"|"'bottom'"
 ---@class overlay_text_options
 ---@field size integer The default font size
----@field max_width integer The maximum width in which to display the text; if longer, it will be word-wrapped
+---@field max_width integer|string The maximum width in which to display the text, as either a pixel width or a percentage (a string ending in %); if longer, it will be word-wrapped
 ---@field color string|integer[] The default text colour as either a hex string or an RGB triple
 ---@field bgcolor string|integer[] The default background colour as either a hex string or an RGB triple; the default is no background (fully transparent)
 ---@field bgalpha integer Alpha value for the background, in the range [0,255]; defaults to 255 if a bgcolor is specified


### PR DESCRIPTION
This returns a label handle which allows you to remove, reposition, or replace the label later.

In addition to all the features of wesnoth.print, you can now specify where the label appears onscreen,
as well as a fadeout time separate from the duration.