### PR TITLE
When starting or loading a game, warn if the next scenario is unknown

### DIFF
--- a/data/test/scenarios/unknown_scenario_warning.cfg
+++ b/data/test/scenarios/unknown_scenario_warning.cfg
@@ -1,0 +1,106 @@
+# wmllint: no translatables
+
+# Check that the "this will lead to an unknown scenario" warning doesn't get triggered.
+{GENERIC_UNIT_TEST "unknown_scenario_false_positives" (
+    # Note: the C++ code under test runs after all name=start events have run,
+    # so putting the {SUCCEED} in a start event will skip the test.
+    [event]
+        name = side 1 turn 1
+        {SUCCEED}
+    [/event]
+
+    # This event doesn't get triggered, but its contents will be checked.
+    [event]
+        name = turn 2
+
+        # A scenario that exists (has to be a [test], as the current scenario's tagname is used).
+        [endlevel]
+            next_scenario = "empty_test"
+        [/endlevel]
+
+        # Variable interpolation (false negatives are acceptable, but not false positives).
+        {VARIABLE chosen_branch empty_test}
+        [endlevel]
+            next_scenario = "$chosen_branch"
+        [/endlevel]
+
+        # Using the scenario's next_scenario instead of overriding it
+        [endlevel]
+            result=victory
+        [/endlevel]
+
+#ifndef SCHEMA_SHOULD_SKIP_THIS
+        # Should only check [endlevel] tags, not similarly named attributes in other tags
+        [dummy]
+            next_scenario = "non_existent_scenario"
+        [/dummy]
+#endif
+    [/event]
+)}
+
+# Not a branching scenario, but the only route uses a variable
+{GENERIC_UNIT_TEST "unknown_scenario_interpolated" (
+    # Note: the C++ code under test runs after all name=start events have run,
+    # so putting the {SUCCEED} in a start event will skip the test.
+    [event]
+        name = side 1 turn 1
+        {SUCCEED}
+    [/event]
+
+    next_scenario = "$chosen_branch"
+)}
+
+# The tests below should all trigger the dialog, thus returning result BROKE_STRICT.
+#
+# There are variants to trigger all the alternative wordings of the dialog for interactive testing.
+#
+# For the automated testing, there's value in running exactly one of these, because any of them will
+# check that triggering the dialog results in BROKE_STRICT, making the tests above fail.
+#
+# This is effectively a varargs macro. There's always a branch to "non_existent_scenario", and since
+# the code under test combines non-unique ids then any next_scenario that points at the same id
+# won't change the warning message.
+#define TEST_UNKNOWN_SCENARIO NAME
+#arg SCEN2
+    "non_existent_scenario"
+#endarg
+#arg SCEN3
+    "non_existent_scenario"
+#endarg
+#arg SCEN4
+    "non_existent_scenario"
+#endarg
+{GENERIC_UNIT_TEST {NAME} (
+    [event]
+        name = side 1 turn 1
+        {SUCCEED}
+    [/event]
+
+    next_scenario = "non_existent_scenario"
+
+    [event]
+        name = turn 2
+
+        [endlevel]
+            next_scenario = {SCEN2}
+        [/endlevel]
+        [endlevel]
+            next_scenario = {SCEN3}
+        [/endlevel]
+        [endlevel]
+            next_scenario = {SCEN4}
+        [/endlevel]
+    [/event]
+)}
+#enddef
+
+# The numbers in the names are (number of broken branches) (number of ok branches) (last scenario)
+{TEST_UNKNOWN_SCENARIO "unknown_scenario_1_0"}
+{TEST_UNKNOWN_SCENARIO "unknown_scenario_1_0_last" SCEN2=""}
+{TEST_UNKNOWN_SCENARIO "unknown_scenario_1_1" SCEN2="test_return"}
+{TEST_UNKNOWN_SCENARIO "unknown_scenario_2_0" SCEN2="non_existent_scenario_2"}
+
+# This should give the same message as unknown_scenario_1_1_last, because "" and "null" are equivalent
+{TEST_UNKNOWN_SCENARIO "unknown_scenario_1_1_last_null" SCEN2="test_return" SCEN3="" SCEN4="null"}
+
+#undef TEST_UNKNOWN_SCENARIO

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -406,6 +406,11 @@ private:
 
 	void init(const config& level);
 
+	/**
+	 * This shows a warning dialog if either [scenario]next_scenario or any [endlevel]next_scenario would lead to an "Unknown Scenario" dialog.
+	 */
+	void check_next_scenario_is_known();
+
 	bool victory_when_enemies_defeated_;
 	bool remove_from_carryover_on_defeat_;
 	std::vector<std::string> victory_music_;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -329,3 +329,7 @@
 0 event_name_variable_substitution
 # Game mechanics
 0 heal
+# Warnings about WML
+0 unknown_scenario_false_positives
+0 unknown_scenario_interpolated
+5 unknown_scenario_1_0


### PR DESCRIPTION
Check that the scenario's next_scenario= exists, and display a warning
if it would lead to an "Unknown Scenario" error. This also checks any
[endlevel] tags in events.

The error message includes the id of the missing scenario. If there
are multiple branches and some should be okay then a slightly
different message is shown saying which ones should work, hopefully
the ids will be something that hints to the player how to reach the
working branches.

The warnings' translatable strings could have plural and singular
forms, but these errors should be rare enough that it seems excessive
to have those separate plural and singular forms.

Fixes #5530.

![wesnoth_unknown_next_scenario](https://user-images.githubusercontent.com/101462/120997964-ec114800-c787-11eb-90f6-5d342ee0040b.png)
![wesnoth_unknown_and_known_next_scenarios_800x600](https://user-images.githubusercontent.com/101462/120997971-eca9de80-c787-11eb-8ac1-385b3a75a5a3.png)