### PR TITLE
Add option to pre-populate wesnothd's user list with dummy users.

### DIFF
--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -257,6 +257,11 @@ private:
 	void start_lan_server_timer();
 	void abort_lan_server_timer();
 	void handle_lan_server_shutdown(const boost::system::error_code& error);
+
+	boost::asio::steady_timer dummy_player_timer_;
+	int dummy_player_timer_interval_;
+	void start_dummy_player_updates();
+	void dummy_player_updates(const boost::system::error_code& ec);
 };
 
 }


### PR DESCRIPTION
None of the dummy players have an actual connection or client, so any attempt to interact with them will fail. The main usecase for this right now is testing the performance of the MP lobby UI updates when there are many players online.