### PR TITLE
font: Remove dead code and WML previously associated to SDL_ttf

### DIFF
--- a/data/hardwired/fonts.cfg
+++ b/data/hardwired/fonts.cfg
@@ -11,7 +11,7 @@
     # All respective font files are automatically loaded.
     #
     # NOTE: these are technically supposed to be lists to provide fallbacks
-    # like the SDL_TTF code does. However, there's a weird bug in Pango itself
+    # like the SDL_TTF code did. However, there's a weird bug in Pango itself
     # where a comma seperated list of fonts will result in newlines not being
     # rendered and font space metrics being off on Windows.
     #
@@ -29,34 +29,4 @@
     family_order_monospace= _ "DejaVu Sans Mono"
     family_order_light= _ "Lato Light"
     family_order_script = _ "Oldania ADF Std"
-
-    #
-    # Legagy SDL_TTF stuff.
-    #
-    order= _ "Lato-Regular.ttf,DejaVuSans.ttf,Andagii.ttf,DroidSansJapanese.ttf,DroidSansFallbackFull.ttf,Junicode-Regular.ttf"
-
-    [font]
-        name="Lato-Regular.ttf"
-        bold_name="Lato-Bold.ttf"
-        italic_name="Lato-Italic.ttf"
-    [/font]
-
-    [font]
-        name="DejaVuSans.ttf"
-        bold_name="DejaVuSans-Bold.ttf"
-        italic_name="DejaVuSans-Oblique.ttf"
-    [/font]
-    [font]
-        name="Andagii.ttf"
-    [/font]
-    [font]
-        name="DroidSansJapanese.ttf"
-    [/font]
-    [font]
-        name="DroidSansFallbackFull.ttf"
-    [/font]
-    #[font]
-    #    name="Junicode-Regular.ttf"
-    #    codepoints="5792-5872"
-    #[/font]
 [/fonts]

--- a/src/font/font_config.cpp
+++ b/src/font/font_config.cpp
@@ -82,19 +82,6 @@ bool check_font_file(std::string name) {
 
 namespace
 {
-bool add_font_to_fontlist(const config &fonts_config,
-	std::vector<font::subset_descriptor>& fontlist, const std::string& name)
-{
-	const config &font = fonts_config.find_child("font", "name", name);
-	if (!font) {
-		return false;
-	}
-	//DBG_FT << "Adding a font record: " << font.debug() << std::endl;
-
-	fontlist.push_back(font::subset_descriptor(font));
-
-	return true;
-}
 
 #ifdef CAIRO_HAS_WIN32_FONT
 bool is_valid_font_file(const std::string& file)
@@ -146,17 +133,6 @@ bool load_font_config()
 	if (!fonts_config)
 		return false;
 
-	std::set<std::string> known_fonts;
-	for (const config &font : fonts_config.child_range("font")) {
-		known_fonts.insert(font["name"]);
-		if (font.has_attribute("bold_name")) {
-			known_fonts.insert(font["bold_name"]);
-		}
-		if (font.has_attribute("italic_name")) {
-			known_fonts.insert(font["italic_name"]);
-		}
-	}
-
 	family_order_sans = fonts_config["family_order"];
 	family_order_mono = fonts_config["family_order_monospace"];
 	family_order_light = fonts_config["family_order_light"];
@@ -176,20 +152,6 @@ bool load_font_config()
 		ERR_FT << "No script font family order defined, falling back to sans serif order\n";
 		family_order_script = family_order_sans;
 	}
-
-	std::vector<font::subset_descriptor> fontlist;
-
-	for(auto font : utils::split(fonts_config["order"])) {
-		add_font_to_fontlist(fonts_config, fontlist, font);
-		known_fonts.erase(font);
-	}
-
-	for(auto kfont : known_fonts) {
-		add_font_to_fontlist(fonts_config, fontlist, kfont);
-	}
-
-	if(fontlist.empty())
-		return false;
 
 	return true;
 }


### PR DESCRIPTION
The [fonts] [font] WML was only used to set up SDL_ttf fonts. The engine
code to read it was left in after
2dfdc0061d400ffad39f974d7fe9348204af0d08 in a dead state (some
structures are filled with data that never gets used).