### PR TITLE
Slight optimisation of canvas::set_variables using std::move

### DIFF
--- a/src/formula/callable.hpp
+++ b/src/formula/callable.hpp
@@ -255,6 +255,12 @@ public:
 		return *this;
 	}
 
+	map_formula_callable& add(const std::string& key, variant&& value)
+	{
+		values_[key] = std::move(value);
+		return *this;
+	}
+
 	void set_fallback(const_formula_callable_ptr fallback)
 	{
 		fallback_ = fallback;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -946,11 +946,6 @@ void canvas::clear_shapes(const bool force)
 	}
 }
 
-void canvas::invalidate_cache()
-{
-	viewport_ = nullptr;
-}
-
 /***** ***** ***** ***** ***** SHAPE ***** ***** ***** ***** *****/
 
 } // namespace gui2

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -164,9 +164,9 @@ public:
 		return h_;
 	}
 
-	void set_variable(const std::string& key, const wfl::variant& value)
+	void set_variable(const std::string& key, wfl::variant&& value)
 	{
-		variables_.add(key, value);
+		variables_.add(key, std::move(value));
 		set_is_dirty(true);
 		invalidate_cache();
 	}
@@ -227,7 +227,11 @@ private:
 	void parse_cfg(const config& cfg);
 
 	void clear_shapes(const bool force);
-	void invalidate_cache();
+
+	void invalidate_cache()
+	{
+		viewport_ = nullptr;
+	}
 };
 
 } // namespace gui2


### PR DESCRIPTION
Doesn't make much difference for release builds built with GCC,
it takes between 1% and 7% off the cost of std::update_canvas().
Calculated using the time taken by gui2::widget::get_best_size()
as a reference.

It's a tiny improvement, but it's also a tiny change, and the
improvement is in the loop that's MP lobby's performance problem,
as described in issue #5578.