### PR TITLE
Split styled_widget::update_canvas into ..._size

### DIFF
--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -59,6 +59,10 @@ label::label(const implementation::builder_label& builder)
 		std::bind(&label::signal_handler_mouse_motion, this, std::placeholders::_3, std::placeholders::_5));
 	connect_signal<event::MOUSE_LEAVE>(
 		std::bind(&label::signal_handler_mouse_leave, this, std::placeholders::_3));
+
+	for(auto& tmp : get_canvases()) {
+		tmp.set_variable("text_alpha", wfl::variant(text_alpha_));
+	}
 }
 
 void label::update_canvas()

--- a/src/gui/widgets/scrollbar.cpp
+++ b/src/gui/widgets/scrollbar.cpp
@@ -175,7 +175,7 @@ void scrollbar_base::set_item_position(const unsigned item_position)
 #endif
 }
 
-void scrollbar_base::update_canvas()
+void scrollbar_base::update_canvas_size()
 {
 	for(auto & tmp : get_canvases())
 	{

--- a/src/gui/widgets/scrollbar.hpp
+++ b/src/gui/widgets/scrollbar.hpp
@@ -197,11 +197,12 @@ protected:
 	}
 
 	/**
-	 * See @ref styled_widget::update_canvas.
+	 * See @ref styled_widget::update_canvas_size.
 	 *
-	 * After a recalculation the canvasses also need to be updated.
+	 * A scrollbar has to adjust the size of its positioner whenever either the
+	 * contained items or the container itself change size.
 	 */
-	virtual void update_canvas() override;
+	virtual void update_canvas_size() override;
 
 	/**
 	 * Callback for subclasses to get notified about positioner movement.

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -56,6 +56,10 @@ slider::slider(const implementation::builder_slider& builder)
 	//		std::bind(&slider::signal_handler_left_button_down, this, std::placeholders::_2, std::placeholders::_3));
 
 	connect_signal<event::LEFT_BUTTON_UP>(std::bind(&slider::signal_handler_left_button_up, this, std::placeholders::_2, std::placeholders::_3));
+
+	for(auto& tmp : get_canvases()) {
+		tmp.set_variable("text", wfl::variant(get_value_label()));
+	}
 }
 
 point slider::calculate_best_size() const

--- a/src/gui/widgets/slider_base.cpp
+++ b/src/gui/widgets/slider_base.cpp
@@ -140,7 +140,7 @@ void slider_base::set_slider_position(int item_position)
 	update_canvas();
 }
 
-void slider_base::update_canvas()
+void slider_base::update_canvas_size()
 {
 	for(auto& tmp : get_canvases()) {
 		tmp.set_variable("positioner_offset", wfl::variant(positioner_offset_));

--- a/src/gui/widgets/slider_base.hpp
+++ b/src/gui/widgets/slider_base.hpp
@@ -159,12 +159,7 @@ protected:
 		return positioner_length_;
 	}
 
-	/**
-	 * See @ref styled_widget::update_canvas.
-	 *
-	 * After a recalculation the canvasses also need to be updated.
-	 */
-	virtual void update_canvas() override;
+	virtual void update_canvas_size() override;
 
 	/**
 	 * Callback for subclasses to get notified about positioner movement.

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -333,12 +333,36 @@ protected:
 	/***** ***** ***** ***** miscellaneous ***** ***** ***** *****/
 
 	/**
-	 * Updates the canvas(ses).
+	 * This function is called when the properties other than the size and
+	 * placement change, for example when the text or color change.
 	 *
-	 * This function should be called if either the size of the widget changes
-	 * or the text on the widget changes.
+	 * Updates (currently creates fresh instances of) WFL objects that are used
+	 * for calculations within the canvas.
+	 *
+	 * \todo The following paragraphs come from different designs, this is in the
+	 * middle of trying to fix performance issues.
+	 *
+	 * The canvas itself will run the calculations, with inputs available in
+	 * the canvas. It shouldn't be necessary to create new instances of all the
+	 * WFL objects just because the size changed.
+	 *
+	 * The original design of this function was that it should be called if
+	 * either the size of the widget changes, or the text on the widget changes.
+	 * The GUI2 layout code repeatedly changes the size of widgets, so this ended
+	 * up being a performance bottleneck (see bug #5578); for that reason changes
+	 * in size only call update_canvas_size and not this function.
+	 *
+	 * This function will internally call update_canvas_size, which is itself more
+	 * expensive than a function that gets called in the layout loop should be.
 	 */
 	virtual void update_canvas();
+
+	/**
+	 * This gets called when the size or placement changes.
+	 *
+	 * It will be called by update_canvas(), and directly by calls to place().
+	 */
+	virtual void update_canvas_size();
 
 	/**
 	 * Resolves and returns the text_font_size

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -128,6 +128,7 @@ void text_box::place(const point& origin, const point& size)
 	// Inherited.
 	styled_widget::place(origin, size);
 
+	// \todo why does it do this *after* the (via inheritance) call to update_canvas_size()?
 	set_maximum_width(get_text_maximum_width());
 	set_maximum_height(get_text_maximum_height(), false);
 
@@ -136,7 +137,7 @@ void text_box::place(const point& origin, const point& size)
 	update_offsets();
 }
 
-void text_box::update_canvas()
+void text_box::update_canvas_size()
 {
 	/***** Gather the info *****/
 
@@ -289,8 +290,7 @@ void text_box::update_offsets()
 
 	// Since this variable doesn't change set it here instead of in
 	// update_canvas().
-	for(auto & tmp : get_canvases())
-	{
+	for(auto & tmp : get_canvases()) {
 		tmp.set_variable("text_font_height", wfl::variant(text_height_));
 	}
 

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -183,8 +183,12 @@ protected:
 
 	/***** ***** ***** ***** Inherited ***** ***** ***** *****/
 
-	/** See @ref styled_widget::update_canvas. */
-	virtual void update_canvas() override;
+	/*
+	 * \todo: this should probably only override update_canvas, but as there
+	 * are unlikely to be many instances of this class in the same window it
+	 * doesn't seem necessary to look at optimising it.
+	 */
+	virtual void update_canvas_size() override;
 
 	/** Inherited from text_box_base. */
 	void goto_end_of_line(const bool select = false) override

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -54,6 +54,10 @@ toggle_button::toggle_button(const implementation::builder_toggle_button& builde
 			this,
 			std::placeholders::_2,
 			std::placeholders::_3));
+
+	for(auto & canvas : get_canvases()) {
+		canvas.set_variable("icon", wfl::variant(icon_name_));
+	}
 }
 
 unsigned toggle_button::num_states() const
@@ -99,10 +103,7 @@ void toggle_button::update_canvas()
 	// Inherit.
 	styled_widget::update_canvas();
 
-	// set icon in canvases
-	std::vector<canvas>& canvases = styled_widget::get_canvases();
-	for(auto & canvas : canvases)
-	{
+	for(auto & canvas : get_canvases()) {
 		canvas.set_variable("icon", wfl::variant(icon_name_));
 	}
 


### PR DESCRIPTION
Try and reduce GUI2's overhead of creating wfl::variants, by making a smaller function that only updates the size. Removes about three-quarters of the biggest box on those profile graphs in issue #5578, but avoids calling a virtual function that several subclasses have overridden.

WIP: Needs a careful check of the subclasses that haven't been changed in this commit, to see if any others should be changed. Going to open a draft PR as-is, to save anyone else looking at the same optimisation.

This is not the fix for #5578, the real issue there is how often this function gets called. But this will still be a general GUI2 optimisation, so worthwhile even without that issue.
