### PR TITLE
Add a method to clear and then add multiple items to a tree view.

### DIFF
--- a/data/advanced_preferences.cfg
+++ b/data/advanced_preferences.cfg
@@ -64,13 +64,6 @@
 [/advanced_preference]
 
 [advanced_preference]
-    field=lobby_playerlist_group_players
-    name= _ "Group players in lobby"
-    type=boolean
-    default=yes
-[/advanced_preference]
-
-[advanced_preference]
     field=scroll_to_action
     name= _ "Follow unit actions"
     description= _ "Choose whether the map view should scroll to a unit when an action or move is animated"

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -120,8 +120,7 @@ user_info::user_info(const config& c)
 	update_relation();
 }
 
-void user_info::update_state(int selected_game_id,
-							 const room_info* current_room /*= nullptr*/)
+void user_info::update_state(int selected_game_id)
 {
 	if(game_id != 0) {
 		if(game_id == selected_game_id) {
@@ -130,11 +129,7 @@ void user_info::update_state(int selected_game_id,
 			state = user_state::GAME;
 		}
 	} else {
-		if(current_room != nullptr && current_room->is_member(name)) {
-			state = user_state::SEL_ROOM;
-		} else {
-			state = user_state::LOBBY;
-		}
+		state = user_state::LOBBY;
 	}
 	update_relation();
 }

--- a/src/game_initialization/lobby_data.hpp
+++ b/src/game_initialization/lobby_data.hpp
@@ -105,7 +105,7 @@ struct user_info
 {
 	explicit user_info(const config& c);
 
-	void update_state(int selected_game_id, const room_info* current_room = nullptr);
+	void update_state(int selected_game_id);
 
 	void update_relation();
 
@@ -118,7 +118,6 @@ struct user_info
 
 	enum class user_state {
 		LOBBY,
-		SEL_ROOM,
 		GAME,
 		SEL_GAME
 	};

--- a/src/game_initialization/lobby_info.cpp
+++ b/src/game_initialization/lobby_info.cpp
@@ -372,10 +372,10 @@ void lobby_info::apply_game_filter()
 	}
 }
 
-void lobby_info::update_user_statuses(int game_id, const room_info* room)
+void lobby_info::update_user_statuses(int game_id)
 {
 	for(auto& user : users_) {
-		user.update_state(game_id, room);
+		user.update_state(game_id);
 	}
 }
 

--- a/src/game_initialization/lobby_info.hpp
+++ b/src/game_initialization/lobby_info.hpp
@@ -98,7 +98,7 @@ public:
 	/** Returns info on the user with the given name, or nullptr if they don't eixst. */
 	user_info* get_user(const std::string& name);
 
-	void update_user_statuses(int game_id, const room_info* room);
+	void update_user_statuses(int game_id);
 
 	const std::vector<game_info*>& games() const
 	{

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -637,16 +637,6 @@ void mp_lobby::update_playerlist()
 				ERR_LB << "Bad user relation in lobby: " << static_cast<int>(user.relation) << "\n";
 		}
 
-		// TODO: on the official server this results in every name being bold since we
-		// require a registered account. Leaving this commented out in case we ever
-		// walk that back and want to have such an indication again (it's useless for
-		// custom servers since registered logins aren't supported there).
-#if 0
-		if(user.registered) {
-			name = "<b>" + name + "</b>";
-		}
-#endif
-
 		icon_ss << ".png";
 
 		if(!preferences::playerlist_group_players()) {

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -105,9 +105,6 @@ void player_list::init(window& w)
 {
 	active_game.init(w, _("Selected Game"), true);
 	other_rooms.init(w, _("Lobby"), true);
-#ifdef ENABLE_ROOM_MEMBER_TREE
-	active_room.init(w, _("Current Room"));
-#endif
 	other_games.init(w, _("Other Games"));
 
 	tree = find_widget<tree_view>(&w, "player_tree", false, true);
@@ -584,30 +581,15 @@ void mp_lobby::update_playerlist()
 {
 	SCOPE_LB;
 	DBG_LB << "Playerlist update: " << lobby_info_.users().size() << "\n";
-	lobby_info_.update_user_statuses(selected_game_id_, chatbox_->active_window_room());
-
-#ifdef ENABLE_ROOM_MEMBER_TREE
-	bool lobby = false;
-	if(mp::room_info* ri = chatbox_->active_window_room()) {
-		if(ri->name() == "lobby") {
-			lobby = true;
-		}
-	}
-#endif
+	lobby_info_.update_user_statuses(selected_game_id_);
 
 	assert(player_list_.active_game.tree);
-#ifdef ENABLE_ROOM_MEMBER_TREE
-	assert(player_list_.active_room.tree);
-#endif
 	assert(player_list_.other_games.tree);
 	assert(player_list_.other_rooms.tree);
 
 	unsigned scrollbar_position = player_list_.tree->get_vertical_scrollbar_item_position();
 
 	player_list_.active_game.tree->clear();
-#ifdef ENABLE_ROOM_MEMBER_TREE
-	player_list_.active_room.tree->clear();
-#endif
 	player_list_.other_games.tree->clear();
 	player_list_.other_rooms.tree->clear();
 
@@ -619,15 +601,6 @@ void mp_lobby::update_playerlist()
 		std::stringstream icon_ss;
 		icon_ss << "lobby/status";
 		switch(user.state) {
-#ifdef ENABLE_ROOM_MEMBER_TREE
-			case mp::user_info::user_state::SEL_ROOM:
-				icon_ss << "-lobby";
-				target_list = &player_list_.active_room;
-				if(lobby) {
-					target_list = &player_list_.other_rooms;
-				}
-				break;
-#endif
 			case mp::user_info::user_state::LOBBY:
 				icon_ss << "-lobby";
 				target_list = &player_list_.other_rooms;
@@ -700,9 +673,6 @@ void mp_lobby::update_playerlist()
 	}
 
 	player_list_.active_game.update_player_count_label();
-#ifdef ENABLE_ROOM_MEMBER_TREE
-	player_list_.active_room.update_player_count_label();
-#endif
 	player_list_.other_rooms.update_player_count_label();
 	player_list_.other_games.update_player_count_label();
 

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -639,10 +639,6 @@ void mp_lobby::update_playerlist()
 
 		icon_ss << ".png";
 
-		if(!preferences::playerlist_group_players()) {
-			target_list = &player_list_.other_rooms;
-		}
-
 		assert(target_list->tree);
 
 		string_map tree_group_field;

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -54,7 +54,6 @@ struct player_list
 	void init(window& w);
 
 	sub_player_list active_game;
-	sub_player_list active_room;
 	sub_player_list other_rooms;
 	sub_player_list other_games;
 

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -54,7 +54,7 @@ struct player_list
 	void init(window& w);
 
 	sub_player_list active_game;
-	sub_player_list other_rooms;
+	sub_player_list lobby_players;
 	sub_player_list other_games;
 
 	tree_view* tree;

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -59,7 +59,7 @@ tree_view_node& tree_view::add_node(
 	return get_root_node().add_child(id, data, index);
 }
 
-std::pair<tree_view_node::ptr_t, int> tree_view::remove_node(tree_view_node* node)
+std::pair<std::shared_ptr<tree_view_node>, int> tree_view::remove_node(tree_view_node* node)
 {
 	assert(node && node != root_node_ && node->parent_node_);
 	const point node_size = node->get_size();

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -88,7 +88,7 @@ public:
 	 * @returns         A pair consisting of a smart pointer managing the removed
 	 *                  node, and its position before removal.
 	 */
-	std::pair<tree_view_node::ptr_t, int> remove_node(tree_view_node* node);
+	std::pair<std::shared_ptr<tree_view_node>, int> remove_node(tree_view_node* node);
 
 	void clear();
 

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -35,8 +35,7 @@ class tree_view_node : public widget
 	friend class tree_view;
 
 public:
-	using ptr_t = std::shared_ptr<tree_view_node>;
-	using node_children_vector = std::vector<ptr_t>;
+	using node_children_vector = std::vector<std::shared_ptr<tree_view_node>>;
 
 	bool operator==(const tree_view_node& node)
 	{
@@ -74,13 +73,26 @@ public:
 	}
 
 	/**
+	 * Replaces all children of this tree with new children.
+	 * The motivation here is to provide a way to add multiple children without calculating the trees size for each child added.
+	 * This is a waste of time since the results of that resizing will be immediately thrown out except for the final child added.
+	 *
+	 * @param id The id of the node definition to use for the new nodes.
+	 * @param data data.first is a unique identifying value to be associated to the respective tree_view_node that's returned.
+	 * 			   data.second is the data to provide to the tree_node_view's constructor.
+	 * @return return_value.first is data.first
+	 * 		   return_value.second is the tree_view_node created from data.second
+	 */
+	std::map<std::string, std::shared_ptr<gui2::tree_view_node>> replace_children(const std::string& id, const std::map<std::string, std::map<std::string /* widget id */, string_map>>& data);
+
+	/**
 	 * Adds a previously-constructed node as a child of this node at the given position.
 	 *
 	 * @param new_node            A smart pointer to the node object to insert.
 	 * @param index               The item before which to add the new item,
 	 *                            0 == begin, -1 == end.
 	 */
-	tree_view_node& add_child(ptr_t new_node, const int index = -1)
+	tree_view_node& add_child(std::shared_ptr<tree_view_node> new_node, const int index = -1)
 	{
 		new_node->parent_node_ = this;
 		return add_child_impl(std::move(new_node), index);
@@ -109,7 +121,7 @@ public:
 
 private:
 	/** Implementation detail for @ref add_child. */
-	tree_view_node& add_child_impl(ptr_t&& new_node, const int index);
+	tree_view_node& add_child_impl(std::shared_ptr<tree_view_node>&& new_node, const int index);
 
 public:
 	/**

--- a/src/preferences/lobby.cpp
+++ b/src/preferences/lobby.cpp
@@ -32,11 +32,6 @@ bool auto_open_whisper_windows()
 	return preferences::get("lobby_auto_open_whisper_windows", true);
 }
 
-bool playerlist_group_players()
-{
-	return preferences::get("lobby_playerlist_group_players", true);
-}
-
 bool fi_invert()
 {
 	return preferences::get("fi_invert", false);

--- a/src/preferences/lobby.hpp
+++ b/src/preferences/lobby.hpp
@@ -24,8 +24,6 @@ void set_whisper_friends_only(bool v);
 bool auto_open_whisper_windows();
 void set_auto_open_whisper_windows(bool v);
 
-bool playerlist_group_players();
-
 bool fi_invert();
 void set_fi_invert(bool value);
 


### PR DESCRIPTION
This addresses the lobby performance issue as far as the playerlist updating. Previously for every player an item was added and the size of the tree view recalculated, which led to an increasingly unresponsive UI when the number of players in the lobby got to around 150+. With this change, the replace_children() method adds all the players and then after that recalculates the tree view's size once.

---

With a -O0 build, it now takes a fraction of a second to update the playerlist, down from over 30 seconds previously, when adding/removing a player from a playerlist with 500 entries.

For reference with #5578, the profile with this change applied:
![prof](https://user-images.githubusercontent.com/3030250/121796289-72d98100-cbdd-11eb-85bf-1a5ec3ceccbc.gif)
