### PR TITLE
Tutorial S02 and tips: Mention holding shift for accelerated speed

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -405,7 +405,7 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
         [/message]
     [/event]
 
-    # Mention upkeep and income
+    # Easter egg if you recruit all Shamans
     [event]
         name=recruit,recall
         [filter]
@@ -425,7 +425,6 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
 
         {CLEAR_PRINT}
 
-        # Easter egg if you recruit all Shamans
         [message]
             speaker=Galdrad
             message= _ "You certainly have a fondness for shamans, I see. They will provide a lot of healing, but not much offensive potential."
@@ -449,6 +448,7 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
         [/disallow_end_turn]
     [/event]
 
+    # Mention upkeep and income; or remind about undo if capturing a village without recruiting
     [event]
         name=capture
         first_time_only=no
@@ -1010,6 +1010,17 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
             caption= _ "Victory Conditions"
             image=wesnoth-icon.png
             message= _ "In this scenario, you only need to defeat the orc leader to win. Victory conditions for a scenario are given under <b>Scenario Objectives</b> in the <b>Menu</b> menu."
+        [/message]
+    [/event]
+
+    [event]
+        name=turn 12
+
+        [message]
+            speaker=narrator
+            caption= _ "Speeding Up Animations"
+            image=wesnoth-icon.png
+            message= _ "Holding down <b>shift</b> will make the animations for moving and fighting quicker. The <b>acceleration factor</b> can be set, and turned on by default, in the <b>Preferences</b> menu’s <b>General</b> tab."
         [/message]
     [/event]
 

--- a/data/tips.cfg
+++ b/data/tips.cfg
@@ -272,6 +272,10 @@
     source= _ "<i>― Lord Tallin of Knalga, 538 YW</i>"
 [/tip]
 [tip]
+    text= _ "Holding down <b>shift</b> will make the animations for moving and fighting quicker. The <i>acceleration factor</i> can be set, and turned on by default, in the <i>Preferences</i> menu’s <i>General</i> tab."
+    source= _ "<i>― The Wesnoth Tactical Guide</i>"
+[/tip]
+[tip]
     # po: Translate "Change difficulty" and "Load Game" as in wesnoth-lib textdomain
     text= _ "Did you know that you can change the difficulty level during a campaign? Select the <i>Change difficulty</i> option at the bottom of the <i>Load Game</i> screen when loading start-of-scenario save files."
     source= _ "<i>― The Wesnoth Tactical Guide</i>"


### PR DESCRIPTION
One of these uses bold for the menu's name, the other uses italic, because that
seems more consistent with the other hints in the same context.

Re-attach the comment about upkeep to the correct [event], and move the comment
about the easter-egg event to the start of its [event].