### PR TITLE
Tips: remove hints about tooltips and the hotkey preferences

### DIFF
--- a/data/tips.cfg
+++ b/data/tips.cfg
@@ -157,10 +157,6 @@
     source= _ "<i>― Princess Li’sar, 515YW</i>"
 [/tip]
 [tip]
-    text= _ "Read the <b>Hotkeys</b> list in the <b>Preferences</b> menu."
-    source= _ "<i>― The Wesnoth Tactical Guide</i>"
-[/tip]
-[tip]
     text= _ "If you move a unit, but don’t attack or discover any additional information, you can undo your move by pressing <b>u</b>."
     source= _ "<i>― The Wesnoth Tactical Guide</i>"
 [/tip]
@@ -190,10 +186,6 @@
 [/tip]
 [tip]
     text= _ "Instead of leveling up, high-level units gain an <i>After Maximum Level Advancement</i> (AMLA) bonus, which usually increases the unit’s maximum hitpoints by three and fully heals it. This is much less than the normal benefits of advancing a level, so it is generally wiser to advance your lower-level units instead."
-    source= _ "<i>― The Wesnoth Tactical Guide</i>"
-[/tip]
-[tip]
-    text= _ "Nearly every button and icon in the Wesnoth game has a tooltip. Hover the mouse pointer over any button or icon to get a description or explanation of what it does."
     source= _ "<i>― The Wesnoth Tactical Guide</i>"
 [/tip]
 [tip]


### PR DESCRIPTION
Tooltips are such a common GUI feature that having a tip of the day about them
seems unnecessary. I'd expect a player to find out that we have them the first
time that the player wonders "what does that button do?".

While having hints about specific hotkeys seems logical, a general hint to
read the list of keybinds doesn't seem helpful.