### PR TITLE
add the names of the abilities used as weapons in the attack prediction window

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
    * Updated translations: Bulgarian, Chinese (Traditional), Czech, Italian, Portuguese (Brazil), Russian, Spanish, Turkish
  ### Units
  ### User interface
+   * The names of the abilities used as specials appear in the attack prediction window with specials weapons
    * Added a prompt to allow migrating settings and redownloading add-ons used in a previous version of Wesnoth when starting a new versions for the first time.
  ### WML Engine
  ### Miscellaneous and Bug Fixes

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -858,7 +858,7 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 	const unit_map& units = display::get_singleton()->get_units();
 	if(self_){
 		std::set<std::string> checking_name;
-		for (const config::any_child &sp : (*self_).abilities().all_children_range()){
+		for (const config::any_child sp : (*self_).abilities().all_children_range()){
 			const bool active = check_self_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, self_loc_, AFFECT_EITHER, sp.key);
 
 			const std::string& name = active ? sp.cfg["name"].str() : "";
@@ -876,7 +876,7 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 				continue;
 			if(&*it == self_.get())
 				continue;
-			for (const config::any_child &sp : (*it).abilities().all_children_range()){
+			for (const config::any_child sp : (*it).abilities().all_children_range()){
 				const bool active = check_adj_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, *it, i, self_loc_, AFFECT_EITHER, sp.key);
 
 				const std::string& name = active ? sp.cfg["name"].str() : "";

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -872,7 +872,7 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 				const std::string& name = active ? sp.cfg["name"].str() : "";
 
 				if (!name.empty() && checking_name.count(name) == 0) {
-					checking_name.insert(std::move(name));
+					checking_name.insert(name);
 					if (!res.empty()) res += ", ";
 					res += name;
 				}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -865,7 +865,9 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 
 			if (!name.empty() && checking_name.count(name) == 0) {
 				checking_name.insert(name);
-				if (!res.empty()) res += ", ";
+				if (!res.empty()){
+					res += ", ";
+				}
 				res += name;
 			}
 		}
@@ -883,7 +885,9 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 
 				if (!name.empty() && checking_name.count(name) == 0) {
 					checking_name.insert(name);
-					if (!res.empty()) res += ", ";
+					if (!res.empty()){
+						res += ", ";
+					}
 					res += name;
 				}
 			}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -858,16 +858,26 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 	const unit_map& units = display::get_singleton()->get_units();
 	if(self_){
 		std::set<std::string> checking_name;
+		for (const config::any_child &sp : (*self_).abilities().all_children_range()){
+			const bool active = check_self_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, self_loc_, AFFECT_EITHER, sp.key);
+
+			const std::string& name = active ? sp.cfg["name"].str() : "";
+
+			if (!name.empty() && checking_name.count(name) == 0) {
+				checking_name.insert(name);
+				if (!res.empty()) res += ", ";
+				res += name;
+			}
+		}
 		const auto adjacent = get_adjacent_tiles(self_loc_);
 		for(unsigned i = 0; i < adjacent.size(); ++i) {
 			const unit_map::const_iterator it = units.find(adjacent[i]);
 			if (it == units.end() || it->incapacitated())
 				continue;
+			if(&*it == self_.get())
+				continue;
 			for (const config::any_child &sp : (*it).abilities().all_children_range()){
-				const bool active =
-					(&*it == self_.get())
-					? check_self_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, self_loc_, AFFECT_EITHER, sp.key)
-					: check_adj_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, *it, i, self_loc_, AFFECT_EITHER, sp.key);
+				const bool active = check_adj_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, *it, i, self_loc_, AFFECT_EITHER, sp.key);
 
 				const std::string& name = active ? sp.cfg["name"].str() : "";
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -864,13 +864,10 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 			if (it == units.end() || it->incapacitated())
 				continue;
 			for (const config::any_child &sp : (*it).abilities().all_children_range()){
-				bool affect_adj_or_self;
-				if ( &*it == self_.get() ){
-					affect_adj_or_self = check_self_abilities(sp.cfg, sp.key);
-				} else {
-					affect_adj_or_self = check_adj_abilities(sp.cfg, sp.key, i , *it);
-				}
-				const bool active = (*it).checking_tags().count(sp.key) != 0 && affect_adj_or_self && special_active(sp.cfg, AFFECT_EITHER, sp.key, is_backstab, "filter_student");
+				const bool active =
+					(&*it == self_.get())
+					? check_self_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, self_loc_, AFFECT_EITHER, sp.key)
+					: check_adj_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, *it, i, self_loc_, AFFECT_EITHER, sp.key);
 
 				const std::string& name = active ? sp.cfg["name"].str() : "";
 


### PR DESCRIPTION

Now, if a weapon is affected by an ability used as a weapon, the name will appear as if it was a classic special.