### PR TITLE
Default [print]duration= to 5 seconds, tutorial uses "unlimited"

### DIFF
--- a/data/campaigns/tutorial/utils/utils.cfg
+++ b/data/campaigns/tutorial/utils/utils.cfg
@@ -4,7 +4,7 @@
     [print]
         text={STRING}
         size=18
-        duration=10000
+        duration=unlimited
         red,green,blue=255,255,255
     [/print]
 #enddef

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -763,7 +763,7 @@
 		max=infinite
 		{SIMPLE_KEY text s_t_string}
 		{SIMPLE_KEY size s_unsigned}
-		{SIMPLE_KEY duration s_unsigned}
+		{SIMPLE_KEY duration s_unsigned,unlimited}
 		{COLOR_KEYS s_unsigned}
 		{SIMPLE_KEY color string}
 	[/tag]

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1998,7 +1998,12 @@ int game_lua_kernel::intf_print(lua_State *L) {
 		return 0;
 
 	int size = cfg["size"].to_int(font::SIZE_SMALL);
-	int lifetime = cfg["duration"].to_int(50);
+	int lifetime;
+	if(cfg["duration"] == "unlimited") {
+		lifetime = -1;
+	} else {
+		lifetime = cfg["duration"].to_int(5000);
+	}
 
 	color_t color = font::LABEL_COLOR;
 


### PR DESCRIPTION
In 1.14, the default was 50 frames, or around 1.7 seconds. In 1.15.4, commit
a9d9e48c72e70fd41ae9759e3894752eb9708596 changed the interpretation of that
number to milliseconds, but missed that this affected the [print] tag; this
left the default time that the text is shown as an unreadable 50ms.

All places in mainline that use [print] specify a duration, so the default
isn't used. Here I've plucked the new value from UtBS S09, where it was chosen
in f405b916a1141c2a4bc3bda3f88bbe0a8b8fe91b.

The tutorial is a special case - it originally displayed the text until the
player did the requested move (or almost, it used a duration of 10000 frames,
or around 40 minutes). That makes more sense to me than displaying it for 10
seconds, and as documented in floating_label.hpp the value -1 is already
supported to mean "display until the label is removed".

Relax the schema to accept the supported value of -1.