### PR TITLE
Balance changes for 1.15.14

### DIFF
--- a/data/core/units/dunefolk/Apothecary.cfg
+++ b/data/core/units/dunefolk/Apothecary.cfg
@@ -16,7 +16,7 @@ units/dunefolk/herbalist/#enddef
         {ABILITY_SELF_HEAL}
     [/abilities]
     movement=5
-    experience=100
+    experience=65
     level=2
     alignment=liminal
     advances_to=Dune Luminary

--- a/data/core/units/dunefolk/Captain.cfg
+++ b/data/core/units/dunefolk/Captain.cfg
@@ -11,7 +11,7 @@ units/dunefolk/soldier/#enddef
     hitpoints=48
     movement_type=dunearmoredfoot
     movement=5
-    experience=86
+    experience=75
     level=2
     alignment=lawful
     advances_to=Dune Warmaster

--- a/data/core/units/dunefolk/Herbalist.cfg
+++ b/data/core/units/dunefolk/Herbalist.cfg
@@ -20,7 +20,7 @@ units/dunefolk/herbalist/#enddef
     level=1
     alignment=liminal
     advances_to=Dune Apothecary,Dune Alchemist
-    cost=15
+    cost=14
     usage=healer
     description= _ "As those responsible for caring for the ill and wounded among the Dunefolk, herbalists possess both the medicinal skills to heal a variety of afflictions and the skill to seek and gather restorative herbs. Their motivations are many; some look to it as an adventure or as a steady source of pay while others feel it to be a duty to their society. No matter the reason, these healers are an invaluable part of Dunefolk society and are especially useful for their ability to administer quick treatments in the midst of battle or while traveling in the desert.
 

--- a/data/core/units/dunefolk/Horse_Archer.cfg
+++ b/data/core/units/dunefolk/Horse_Archer.cfg
@@ -11,7 +11,7 @@ units/dunefolk/rider/#enddef
     hitpoints=44
     movement_type=dunehorse
     movement=8
-    experience=90
+    experience=65
     level=2
     alignment=liminal
     advances_to=Dune Windbolt

--- a/data/core/units/monsters/Fire_Guardian.cfg
+++ b/data/core/units/monsters/Fire_Guardian.cfg
@@ -14,11 +14,10 @@
         impact=100
     [/resistance]
     movement=6
-    experience=50
+    experience=29
     level=1
     alignment=neutral
-    advances_to=null
-    {AMLA_DEFAULT}
+    advances_to=Fire Wraith
     cost=11
     usage=mixed fighter
     die_sound=drake-die.ogg

--- a/data/core/units/monsters/Fire_Wraith.cfg
+++ b/data/core/units/monsters/Fire_Wraith.cfg
@@ -30,7 +30,7 @@ units/monsters/firewraith#enddef
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=25
+    cost=22
     usage=mixed fighter
     die_sound=drake-die.ogg
     description= _ "Fire Wraiths are spirits of smoke and flame. No one is exactly sure where they come from, but they are occasionally summoned by powerful mages to do their bidding. The odd armor they wear hints at a former life or creator, but whatever ancient civilization was involved has been lost to history."

--- a/data/core/units/monsters/Horse.cfg
+++ b/data/core/units/monsters/Horse.cfg
@@ -10,23 +10,21 @@
     hitpoints=30
     movement_type=mounted
     movement=8
-    experience=50
-    {AMLA_DEFAULT}
+    experience=44
     level=1
     alignment=neutral
-    advances_to=null
-    cost=15
+    advances_to=Great Horse
+    cost=16
     usage=scout
     description=_ "Horses need a better description."
     die_sound=horse-die.ogg
     [defense]
-        village=60
-        forest=40
+        hills=50
     [/defense]
     [resistance]
-        blade=90
-        pierce=110
-        impact=100
+        blade=100
+        pierce=120
+        impact=90
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png" "units/monsters/horse/horse-defend-1.png" {SOUND_LIST:HORSE_HIT} }
     [attack]
@@ -35,7 +33,7 @@
         icon=attacks/hoof.png
         type=impact
         range=melee
-        damage=9
+        damage=10
         number=2
     [/attack]
     [attack_anim]
@@ -79,27 +77,31 @@
     [/base_unit]
     image="units/monsters/horse/horse.png{HORSE_WHITE_IPF}"
     profile="portraits/monsters/horse.png{HORSE_WHITE_IPF_2}"
-    [movement_costs]
-        forest=1
-        shallow_water=2
-        reef=2
-        swamp_water=2
-        cave=2
-    [/movement_costs]
-    [resistance]
-        arcane=100
-        blade=100
-        pierce=100
-        impact=100
-    [/resistance]
-    [defense]
-        village=60
-        forest=40
-    [/defense]
+    hitpoints=31
+    advances_to=null
+    {AMLA_DEFAULT}
+    movement_type=woodland
     movement=9
-    cost=18
     description=_ "Some horses have a white color, and they are merely white horses.  But there exist a special breed, found only in the wild woods, that are White Horses.  As if blessed by the faerie world, they have a grace and agility not found in their more common relatives."
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_WHITE_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_WHITE_IPF}" {SOUND_LIST:HORSE_HIT} }
+    [defense]
+        forest=40
+        village=60
+    [/defense]
+    [resistance]
+        pierce=120
+        impact=100
+        arcane=100
+    [/resistance]
+    [attack]
+        name=kick
+        description=_"kick"
+        icon=attacks/hoof.png
+        type=impact
+        range=melee
+        damage=8
+        number=2
+    [/attack]
     [attack_anim]
         [filter_attack]
             name=kick
@@ -147,32 +149,20 @@
     {TRAIT_INTELLIGENT}
     {TRAIT_RESILIENT}
     {TRAIT_QUICK}
-    [movement_costs]
-        frozen=1
-        shallow_water=2
-        reef=2
-        sand=2
-        swamp_water=2
-        cave=2
-    [/movement_costs]
     [resistance]
-        arcane=120
-        fire=120
-        cold=90
-        blade=90
-        pierce=100
+        blade=100
+        pierce=120
         impact=90
+        cold=90
+        arcane=100
     [/resistance]
     [defense]
-        village=60
         forest=50
-        frozen=60
-        sand=60
+        hills=50
     [/defense]
     advances_to=Black Horse
     alignment=chaotic
     movement=8
-    cost=18
     description=_ "Dark Horses are wild animals, but they seem to take an odd interest in the civilized races.  They leave no signs of their passage, but they have been noticed scouting camps and outposts during the night."
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]
@@ -183,6 +173,15 @@
         range=melee
         damage=9
         number=2
+    [/attack]
+    [attack]
+        name=whinny
+        description=_"whinny"
+        icon=attacks/fangs-horse.png~GS()~CS(-30,-5,35)
+        type=cold
+        range=ranged
+        damage=3
+        number=1
     [/attack]
     [attack_anim]
         [filter_attack]
@@ -198,6 +197,18 @@
             image="units/monsters/horse/horse.png{HORSE_BLACK_IPF}:60"
         [/frame]
         {SOUND:HIT club.ogg -100}
+    [/attack_anim]
+    # we can work on a better animation later
+    [attack_anim]
+        [filter_attack]
+            name=whinny
+        [/filter_attack]
+        start_time=-550
+        {MISSILE_FRAME_WAIL}
+        [frame]
+            image="units/monsters/horse/horse.png{HORSE_BLACK_IPF}:60"
+        [/frame]
+        {SOUND:HIT wail-sml.wav -100}
     [/attack_anim]
     [male]
         name= _ "female^Dark Horse"

--- a/data/core/units/monsters/Horse_Black.cfg
+++ b/data/core/units/monsters/Horse_Black.cfg
@@ -25,13 +25,15 @@
     description=_ "The true nature of Black Horses is impossible to discern, but the fire in their eyes and the unnerving, unnatural sound of their calls suggest they are malevolent spirits."
     die_sound=horse-die.ogg
     [defense]
-        village=60
-        forest=40
+        forest=50
+        hills=50
     [/defense]
     [resistance]
-        blade=90
-        pierce=110
-        impact=100
+        blade=100
+        pierce=120
+        impact=90
+        cold=90
+        arcane=100
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-larger-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-larger-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]

--- a/data/core/units/monsters/Horse_Great.cfg
+++ b/data/core/units/monsters/Horse_Great.cfg
@@ -20,13 +20,12 @@
     description=_ "Great Horses need a better description."
     die_sound=horse-die.ogg
     [defense]
-        village=60
-        forest=40
+        hills=50
     [/defense]
     [resistance]
-        blade=90
-        pierce=110
-        impact=100
+        blade=100
+        pierce=120
+        impact=110
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-larger-defend-2.png" "units/monsters/horse/horse-larger-defend-1.png" {SOUND_LIST:HORSE_HIT} }
     [attack]

--- a/data/core/units/monsters/Jinn.cfg
+++ b/data/core/units/monsters/Jinn.cfg
@@ -11,17 +11,24 @@ units/monsters/jinn#enddef
     image="{IMG_PATH_TEMP}/jinn.png"
     hitpoints=58
     movement_type=spirit
-    movement=8
+    movement=6
     experience=100
     level=2
     alignment=liminal
     advances_to=null
     {AMLA_DEFAULT}
-    cost=56
+    cost=53
     usage=archer
     description=""
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
     undead_variation=null
+    [resistance]
+        blade=80
+        pierce=70
+        impact=100
+        fire=80
+        cold=120
+    [/resistance]
     [defend]
         start_time=-126
         [frame]
@@ -101,7 +108,7 @@ units/monsters/jinn#enddef
         icon=attacks/lightning.png
         type=fire
         range=ranged
-        damage=18
+        damage=20
         number=1
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/core/units/nagas/Sicarius.cfg
+++ b/data/core/units/nagas/Sicarius.cfg
@@ -6,7 +6,7 @@
     gender=male,female
     image="units/nagas/sicarius.png"
     # profile="portraits/nagas/naga-hunter.png"
-    hitpoints=55
+    hitpoints=53
     movement_type=naga
     movement=7
     experience=150
@@ -28,7 +28,7 @@
         description=_"curved blade"
         type=blade
         range=melee
-        damage=9
+        damage=6
         number=3
         icon=attacks/blade-curved.png
         [specials]


### PR DESCRIPTION
For changelog:
Dune Apothecary experience changed from 100 to 65.
Dune Captain experience changed from 86 to 75.
Dune Herbalist cost changed form 15 to 14.
Dune Horse Archer experience cost changed form 70 to 65.
Naga Sicarius hp changed form 55 to 53 and melee damage changed form 9 to 6, new special "deflect" added to melee attack.
Fire Guardian can now level into Fire Wraith.
Revised statistics of all animal horses in order for them to fit better within lore and not violate PIPLB. Bay Horse can now level into Great Horse.

Jinn - a lot changed within JInn, but the most impactful one is resistance change, it should allow for more wide use of this unit.
Fire Wraith cost changed from 25 ot 22.

Horses were changed a lot here are the most important changes:
Bay Horse can now level into Great Horse.
White Horse now has resistances and movement type very similar to elvish horses, it works well with its description.
Dark Horse now has "whinny" attack (in my opinion animation of this attack looks better on Dark Horse than it does on Black Horse), Dark Horse no longer violates RIPLB while leveling up.

I tried to make animal horses as distinct as possible while still staying horses in core. Bay and Great Horses are just plain old horses, Dark and Black are a bit nightmareish but still horses, White one is closest to elvish ones.