### PR TITLE
Fix an intermittent crash with keyboard input during the load screen

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
  ### User interface
  ### WML Engine
  ### Miscellaneous and Bug Fixes
+   * Fixed: keyboard input during the loading screen intermittently caused a crash (issue #4447)
 
 ## Version 1.15.14
  ### Add-ons client

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -111,12 +111,16 @@ bool game_config_manager::init_game_config(FORCE_RELOAD_CONFIG force_reload)
 
 	game_config::load_config(game_config().child("game_config"));
 
-	hotkey::deactivate_all_scopes();
-	hotkey::set_scope_active(hotkey::SCOPE_MAIN_MENU);
+	// It's necessary to block the event thread while load_hotkeys() runs, otherwise keyboard input
+	// can cause a crash by accessing the list of hotkeys while it's being modified.
+	events::call_in_main_thread([this]() {
+		hotkey::deactivate_all_scopes();
+		hotkey::set_scope_active(hotkey::SCOPE_MAIN_MENU);
 
-	// Load the standard hotkeys, then apply any player customizations.
-	hotkey::load_hotkeys(game_config(), true);
-	preferences::load_hotkeys();
+		// Load the standard hotkeys, then apply any player customizations.
+		hotkey::load_hotkeys(game_config(), true);
+		preferences::load_hotkeys();
+	});
 
 	// TODO: consider making this part of preferences::manager in some fashion
 	preferences::init_advanced_manager(game_config());


### PR DESCRIPTION
Fixes #4447, and will be cherry-picked to the 1.16 branch too.