### PR TITLE
Separate `import yaml` from other import statements in wmlunits

### DIFF
--- a/data/tools/wmlunits
+++ b/data/tools/wmlunits
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import traceback
 
-# PyYAML needs to be downloaded and installed from PyPI using `pip install pyyaml`.
+# PyYAML needs to be downloaded and installed using a package manager, e.g. from PyPI  using `pip install pyyaml`.
 import yaml
 
 import unit_tree.animations as animations

--- a/data/tools/wmlunits
+++ b/data/tools/wmlunits
@@ -14,6 +14,7 @@ import traceback
 import subprocess
 import multiprocessing
 import queue
+
 import yaml
 
 import wesnoth.wmlparser3 as wmlparser3

--- a/data/tools/wmlunits
+++ b/data/tools/wmlunits
@@ -7,22 +7,23 @@ Run without arguments to see usage.
 """
 
 import argparse
+import multiprocessing
 import os
+import queue
 import shutil
+import subprocess
 import sys
 import traceback
-import subprocess
-import multiprocessing
-import queue
 
+# PyYAML needs to be downloaded and installed from PyPI using `pip install pyyaml`.
 import yaml
 
-import wesnoth.wmlparser3 as wmlparser3
-import unit_tree.helpers as helpers
 import unit_tree.animations as animations
+import unit_tree.helpers as helpers
 import unit_tree.html_output as html_output
 import unit_tree.overview
 import unit_tree.wiki_output as wiki_output
+import wesnoth.wmlparser3 as wmlparser3
 
 TIMEOUT = 20
 

--- a/data/tools/wmlunits
+++ b/data/tools/wmlunits
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import traceback
 
-# PyYAML needs to be downloaded and installed using a package manager, e.g. from PyPI  using `pip install pyyaml`.
+# PyYAML needs to be downloaded and installed using a package manager, e.g. from PyPI using `pip install pyyaml`.
 import yaml
 
 import unit_tree.animations as animations


### PR DESCRIPTION
Make it clear that the `yaml` package is not part of Python's Standard Library and should be installed with a package manager as outlined in [this](https://pep8.org/#imports) section of PEP8.