### PR TITLE
Revert "Updated a few places that didn't handle locations in the unified way"

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -275,7 +275,10 @@ static int ai_recruit(lua_State *L, bool exec)
 	const char *unit_name = luaL_checkstring(L, 1);
 	int side = get_readonly_context(L).get_side();
 	map_location where;
-	luaW_tolocation(L, 2, where);
+	if (!lua_isnoneornil(L, 2)) {
+		where.set_wml_x(lua_tonumber(L, 2));
+		where.set_wml_y(lua_tonumber(L, 3));
+	}
 	map_location from = map_location::null_location();
 	ai::recruit_result_ptr recruit_result = ai::actions::execute_recruit_action(side,exec,std::string(unit_name),where,from);
 	return transform_ai_action(L,recruit_result);
@@ -296,7 +299,10 @@ static int ai_recall(lua_State *L, bool exec)
 	const char *unit_id = luaL_checkstring(L, 1);
 	int side = get_readonly_context(L).get_side();
 	map_location where;
-	luaW_tolocation(L, 2, where);
+	if (!lua_isnoneornil(L, 2)) {
+		where.set_wml_x(lua_tonumber(L, 2));
+		where.set_wml_y(lua_tonumber(L, 3));
+	}
 	map_location from = map_location::null_location();
 	ai::recall_result_ptr recall_result = ai::actions::execute_recall_action(side,exec,std::string(unit_id),where,from);
 	return transform_ai_action(L,recall_result);
@@ -390,7 +396,7 @@ static int cfun_ai_get_avoid(lua_State *L)
 	std::set<map_location> locs;
 	terrain_filter avoid = get_readonly_context(L).get_avoid();
 	avoid.get_locations(locs);
-	luaW_push_locationset(L, locs);
+	lua_push(L, locs);
 
 	return 1;
 }

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -160,7 +160,7 @@ void statistics_dialog::add_damage_row(
 
 	const int shift = statistics::stats::decimal_shift;
 
-	const auto damage_str = [](long long damage, long long expected) {
+	const auto damage_str = [shift](long long damage, long long expected) {
 		const long long shifted = ((expected * 20) + shift) / (2 * shift);
 		std::ostringstream str;
 		write_actual_and_expected(str, damage, static_cast<double>(shifted) * 0.1);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1931,7 +1931,18 @@ int game_lua_kernel::intf_find_vision_range(lua_State *L)
 		vision_set.insert(d.curr);
 	}
 
-	luaW_push_locationset(L, vision_set);
+	lua_createtable(L, vision_set.size(), 0);
+	int i = 1;
+	for (const map_location& loc : vision_set)
+	{
+		lua_createtable(L, 2, 0);
+		lua_pushinteger(L, loc.wml_x());
+		lua_rawseti(L, -2, 1);
+		lua_pushinteger(L, loc.wml_y());
+		lua_rawseti(L, -2, 2);
+		lua_rawseti(L, -2, i);
+		++i;
+	}
 	return 1;
 }
 
@@ -2147,18 +2158,6 @@ int game_lua_kernel::intf_find_cost_map(lua_State *L)
 
 		lua_pushinteger(L, cost_map.get_pair_at(loc).second);
 		lua_rawseti(L, -2, 4);
-		
-		lua_pushinteger(L, loc.wml_x());
-		lua_setfield(L, -2, "x");
-
-		lua_pushinteger(L, loc.wml_y());
-		lua_setfield(L, -2, "y");
-
-		lua_pushinteger(L, cost_map.get_pair_at(loc).first);
-		lua_setfield(L, -2, "cost");
-
-		lua_pushinteger(L, cost_map.get_pair_at(loc).second);
-		lua_setfield(L, -2, "reach");
 
 		lua_rawseti(L, -2, counter);
 		++counter;
@@ -3007,7 +3006,18 @@ int game_lua_kernel::intf_get_locations(lua_State *L)
 		t_filter.get_locations(res, true);
 	}
 
-	luaW_push_locationset(L, res);
+	lua_createtable(L, res.size(), 0);
+	int i = 1;
+	for (const map_location& loc : res)
+	{
+		lua_createtable(L, 2, 0);
+		lua_pushinteger(L, loc.wml_x());
+		lua_rawseti(L, -2, 1);
+		lua_pushinteger(L, loc.wml_y());
+		lua_rawseti(L, -2, 2);
+		lua_rawseti(L, -2, i);
+		++i;
+	}
 	return 1;
 }
 
@@ -4056,7 +4066,8 @@ int game_lua_kernel::intf_toggle_fog(lua_State *L, const bool clear)
 			sides.insert(t.side()+1);
 		}
 	}
-	const auto& locs = luaW_check_locationset(L, lua_istable(L, 2) ? 2 : 1);
+	const auto& v_locs = lua_check<std::vector<map_location>>(L, lua_istable(L, 2) ? 2 : 1);
+	std::set<map_location> locs(v_locs.begin(), v_locs.end());
 
 	for(const int &side_num : sides) {
 		if(side_num < 1 || static_cast<std::size_t>(side_num) > teams().size()) {

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -671,12 +671,6 @@ void luaW_pushlocation(lua_State *L, const map_location& ml)
 
 	lua_pushinteger(L, ml.wml_y());
 	lua_rawseti(L, -2, 2);
-	
-	lua_pushinteger(L, ml.wml_x());
-	lua_setfield(L, -2, "x");
-
-	lua_pushinteger(L, ml.wml_y());
-	lua_setfield(L, -2, "y");
 }
 
 bool luaW_tolocation(lua_State *L, int index, map_location& loc) {
@@ -692,7 +686,7 @@ bool luaW_tolocation(lua_State *L, int index, map_location& loc) {
 
 	index = lua_absindex(L, index);
 
-	if (lua_istable(L, index) || lua_isuserdata(L, index)) {
+	if (lua_istable(L, index) || luaW_tounit(L, index) || luaW_tovconfig(L, index, dummy_vcfg)) {
 		map_location result;
 		int x_was_num = 0, y_was_num = 0;
 		lua_getfield(L, index, "x");
@@ -702,7 +696,7 @@ bool luaW_tolocation(lua_State *L, int index, map_location& loc) {
 		lua_pop(L, 2);
 		if (!x_was_num || !y_was_num) {
 			// If we get here and it was userdata, checking numeric indices won't help
-			// (It won't help if it was a WML table either, but there's no easy way to check that.)
+			// (It won't help if it was a config either, but there's no easy way to check that.)
 			if (lua_isuserdata(L, index)) {
 				return false;
 			}
@@ -741,7 +735,11 @@ int luaW_push_locationset(lua_State* L, const std::set<map_location>& locs)
 	lua_createtable(L, locs.size(), 0);
 	int i = 1;
 	for(const map_location& loc : locs) {
-		luaW_pushlocation(L, loc);
+		lua_createtable(L, 2, 0);
+		lua_pushinteger(L, loc.wml_x());
+		lua_rawseti(L, -2, 1);
+		lua_pushinteger(L, loc.wml_y());
+		lua_rawseti(L, -2, 2);
 		lua_rawseti(L, -2, i);
 		++i;
 	}


### PR DESCRIPTION
While it might be a good idea, the code as committed fails the unit tests.
Reverting these changes also fixes the whitespace errors.

This reverts commit 5a9c24c4e79d624e34aa475949a4aa49b1984322.