### PR TITLE
Remove the 10ms delay before closing a window

### DIFF
--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -559,7 +559,9 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 			}
 
 			// Add a delay so we don't keep spinning if there's no event.
-			SDL_Delay(10);
+			if(status_ != status::CLOSED) {
+				SDL_Delay(10);
+			}
 		}
 	}
 	catch(...)


### PR DESCRIPTION
This delay is to stop the loop running continously, it isn't necessary to do
that when we're about to exit the loop anyway. I'm unsure whether this makes
any noticeable difference, but it seems reasonable to remove delays when
possible.

I'm tempted to change the enclosing loop to a `do ... while` instead of a `for`
that has an empty clause.