### PR TITLE
Add a prompt to migrate data from previous versions of wesnoth.

### DIFF
--- a/data/gui/window/migrate_version_selection.cfg
+++ b/data/gui/window/migrate_version_selection.cfg
@@ -1,0 +1,111 @@
+#textdomain wesnoth-lib
+###
+### Definition of the window to ask which Wesnoth version to migrate data from
+###
+
+[window]
+	id = "migrate_version_selection"
+	description = "Dialog to select a previous version of Wesnoth to migrate data from."
+
+	[resolution]
+		definition = "default"
+
+		[linked_group]
+			id = "version_group"
+			fixed_width = true
+		[/linked_group]
+
+		[linked_group]
+			id = "radio_options"
+			fixed_width = true
+		[/linked_group]
+
+		[tooltip]
+			id = "tooltip"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip"
+		[/helptip]
+
+		[grid]
+			[row]
+				[column]
+
+					[label]
+						definition = "default"
+						label = _ "Choose which version of Wesnoth to import your data from:"
+					[/label]
+
+				[/column]
+			[/row]
+			[row]
+				[column]
+					[listbox]
+						id = "versions_listbox"
+						definition = "default"
+						horizontal_scrollbar_mode = "never"
+
+						[list_definition]
+							[row]
+								[column]
+									vertical_grow = true
+									horizontal_grow = true
+									[toggle_panel]
+										definition = "default"
+										[grid]
+											[row]
+												[column]
+													grow_factor = 1
+													horizontal_alignment = "left"
+
+													[label]
+														id = "version_label"
+														definition = "default"
+													[/label]
+
+												[/column]
+											[/row]
+										[/grid]
+									[/toggle_panel]
+								[/column]
+							[/row]
+						[/list_definition]
+					[/listbox]
+				[/column]
+			[/row]
+			[row]
+				[column]
+					[grid]
+						[row]
+							[column]
+								grow_factor = 1
+								border = "all"
+
+								[button]
+									id = "ok"
+									definition = "default"
+
+									label = _ "OK"
+								[/button]
+
+							[/column]
+							[column]
+								grow_factor = 1
+								border = "all"
+
+								[button]
+									id = "cancel"
+									definition = "default"
+
+									label = _ "Skip"
+								[/button]
+
+							[/column]
+						[/row]
+					[/grid]
+				[/column]
+			[/row]
+        [/grid]
+    [/resolution]
+[/window]

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -206,6 +206,7 @@ gui/dialogs/loading_screen.cpp
 gui/dialogs/log_settings.cpp
 gui/dialogs/lua_interpreter.cpp
 gui/dialogs/message.cpp
+gui/dialogs/migrate_version_selection.cpp
 gui/dialogs/modal_dialog.cpp
 gui/dialogs/modeless_dialog.cpp
 gui/dialogs/multiplayer/faction_select.cpp

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -568,6 +568,9 @@ static void setup_user_data_dir()
 #if defined(__APPLE__) && !defined(__IPHONEOS__)
 	migrate_apple_config_directory_for_unsandboxed_builds();
 #endif
+	if(!file_exists(user_data_dir)) {
+		game_config::did_userdata_setup = true;
+	}
 
 	if(!create_directory_if_missing_recursive(user_data_dir)) {
 		ERR_FS << "could not open or create user data directory at " << user_data_dir.string() << '\n';
@@ -1078,6 +1081,11 @@ void write_file(const std::string& fname, const std::string& data)
 			throw io_exception("Error writing to file: '" + fname + "'");
 		}
 	}
+}
+
+void copy_file(const std::string& src, const std::string& dest)
+{
+	write_file(dest, read_file(src));
 }
 
 bool create_directory_if_missing(const std::string& dirname)

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -121,14 +121,13 @@ static const blacklist_pattern_list default_blacklist{
 };
 
 /**
- * Populates 'files' with all the files and
- * 'dirs' with all the directories in dir.
- * If files or dirs are nullptr they will not be used.
- *
- * mode: determines whether the entire path or just the filename is retrieved.
- * filter: determines if we skip images and sounds directories
- * reorder: triggers the special handling of _main.cfg and _final.cfg
- * checksum: can be used to store checksum info
+ * @param dir The directory to examine.
+ * @param[out] files The files in @a dir. Won't be used if nullptr.
+ * @param[out] dirs The directories in @a dir. Won't be used if nullptr.
+ * @param mode Determines whether the entire path or just the filename is retrieved.
+ * @param filter Determines if we skip images and sounds directories.
+ * @param reorder Triggers the special handling of _main.cfg and _final.cfg.
+ * @param[out] checksum Can be used to store checksum info.
  */
 void get_files_in_dir(const std::string &dir,
                       std::vector<std::string>* files,
@@ -208,6 +207,13 @@ filesystem::scoped_istream istream_file(const std::string& fname, bool treat_fai
 filesystem::scoped_ostream ostream_file(const std::string& fname, std::ios_base::openmode mode = std::ios_base::binary, bool create_directory = true);
 /** Throws io_exception if an error occurs. */
 void write_file(const std::string& fname, const std::string& data);
+/**
+ * Read a file and then writes it back out.
+ * 
+ * @param src The source file.
+ * @param dest The destination of the copied file.
+ */
+void copy_file(const std::string& src, const std::string& dest);
 
 std::string read_map(const std::string& name);
 

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -43,6 +43,7 @@ std::string default_preferences_path = DEFAULT_PREFS_PATH;
 #else
 std::string default_preferences_path = "";
 #endif
+bool did_userdata_setup = false;
 
 std::string wesnoth_program_dir;
 

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -71,6 +71,7 @@ namespace game_config
 
 	extern std::string path;
 	extern std::string default_preferences_path;
+	extern bool did_userdata_setup;
 
 	struct server_info
 	{

--- a/src/gui/dialogs/migrate_version_selection.cpp
+++ b/src/gui/dialogs/migrate_version_selection.cpp
@@ -1,0 +1,123 @@
+/*
+   Copyright (C) 2008 - 2018 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "gui/dialogs/migrate_version_selection.hpp"
+
+#include "addon/manager_ui.hpp"
+#include "filesystem.hpp"
+#include "game_version.hpp"
+#include "gui/auxiliary/find_widget.hpp"
+#include "gui/dialogs/migrate_version_selection.hpp"
+#include "gui/widgets/listbox.hpp"
+#include "gui/widgets/window.hpp"
+
+#include <boost/algorithm/string.hpp>
+
+static lg::log_domain log_version_migration{"gui/dialogs/migrate_version_selection"};
+#define ERR_LOG_VERSION_MIGRATION   LOG_STREAM(err,   log_version_migration)
+#define WRN_LOG_VERSION_MIGRATION   LOG_STREAM(warn,  log_version_migration)
+#define LOG_LOG_VERSION_MIGRATION   LOG_STREAM(info,  log_version_migration)
+#define DBG_LOG_VERSION_MIGRATION   LOG_STREAM(debug, log_version_migration)
+
+namespace gui2::dialogs
+{
+REGISTER_DIALOG(migrate_version_selection)
+
+void migrate_version_selection::execute()
+{
+    migrate_version_selection mig = migrate_version_selection();
+    if(mig.versions_.size() > 0)
+    {
+        mig.show();
+    }
+}
+
+migrate_version_selection::migrate_version_selection()
+{
+    version_info current_version = game_config::wesnoth_version;
+    std::string current_version_str = std::to_string(current_version.major_version())+"."+std::to_string(current_version.minor_version());
+
+    for(unsigned int i = 1; i < current_version.minor_version(); i++)
+    {
+        std::string previous_version_str = std::to_string(current_version.major_version())+"."+std::to_string(current_version.minor_version()-i);
+        std::string previous_addons_dir = boost::replace_all_copy(filesystem::get_addons_dir(), current_version_str, previous_version_str);
+
+        if(filesystem::file_exists(previous_addons_dir))
+        {
+            versions_.push_back(previous_version_str);
+        }
+    }
+}
+
+void migrate_version_selection::pre_show(window& window)
+{
+    listbox& version_list = find_widget<listbox>(&window, "versions_listbox", false);
+
+    for(unsigned int i = 0; i < versions_.size(); i++)
+    {
+        std::map<std::string, string_map> data;
+        string_map item_label;
+        std::string version = versions_.at(i);
+
+        item_label["label"] = version;
+        data["version_label"] = item_label;
+
+        version_list.add_row(data);
+    }
+}
+
+void migrate_version_selection::post_show(window& window)
+{
+    version_info current_version = game_config::wesnoth_version;
+    std::string current_version_str = std::to_string(current_version.major_version())+"."+std::to_string(current_version.minor_version());
+    listbox& version_list = find_widget<listbox>(&window, "versions_listbox", false);
+    int selected_row = version_list.get_selected_row();
+    std::string selected = versions_.at(selected_row);
+
+    if(this->get_retval() == gui2::OK)
+    {
+        std::string migrate_addons_dir = boost::replace_all_copy(filesystem::get_addons_dir(), current_version_str, selected);
+        std::string migrate_prefs_file = boost::replace_all_copy(filesystem::get_prefs_file(), current_version_str, selected);
+        std::string migrate_credentials_file = boost::replace_all_copy(filesystem::get_credentials_file(), current_version_str, selected);
+
+        // given self-compilation and linux distros being able to do whatever they want plus command line options to alter locations
+        // make sure the directories/files are actually different before doing anything with them
+        // TODO: test what happens when add-on isn't found
+        if(migrate_addons_dir != filesystem::get_addons_dir())
+        {
+            std::vector<std::string> migrate_addons;
+            filesystem::get_files_in_dir(migrate_addons_dir, nullptr, &migrate_addons);
+            if(migrate_addons.size() > 0)
+            {
+                ad_hoc_addon_fetch_session(migrate_addons);
+            }
+        }
+
+        // TODO: test
+        if(migrate_prefs_file != filesystem::get_prefs_file() && filesystem::file_exists(migrate_prefs_file))
+        {
+            filesystem::copy_file(migrate_prefs_file, filesystem::get_prefs_file());
+        }
+
+        // TODO: test
+        // TODO: see about fixing the credentials file not handling multiple login IDs
+        if(migrate_credentials_file != filesystem::get_credentials_file() && filesystem::file_exists(migrate_credentials_file))
+        {
+            filesystem::copy_file(migrate_credentials_file, filesystem::get_credentials_file());
+        }
+    }
+}
+}

--- a/src/gui/dialogs/migrate_version_selection.hpp
+++ b/src/gui/dialogs/migrate_version_selection.hpp
@@ -1,0 +1,43 @@
+/*
+   Copyright (C) 2008 - 2018
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "gui/dialogs/modal_dialog.hpp"
+
+namespace gui2
+{
+
+namespace dialogs
+{
+/**
+ * @ingroup GUIWindowDefinitionWML
+ *
+ * This shows the dialog to select a previous version of Wesnoth to migrate preferences from and redownload add-ons.
+ */
+class migrate_version_selection : public modal_dialog
+{
+public:
+    migrate_version_selection();
+    static void execute();
+
+private:
+	virtual void pre_show(window& window) override;
+	virtual void post_show(window& window) override;
+	virtual const std::string& window_id() const override;
+
+    std::vector<std::string> versions_;
+};
+}
+}

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -32,6 +32,7 @@
 #include "gui/dialogs/language_selection.hpp"
 #include "gui/dialogs/lua_interpreter.hpp"
 #include "gui/dialogs/message.hpp"
+#include "gui/dialogs/migrate_version_selection.hpp"
 #include "gui/dialogs/multiplayer/mp_host_game_prompt.hpp"
 #include "gui/dialogs/multiplayer/mp_method_selection.hpp"
 #include "gui/dialogs/preferences_dialog.hpp"
@@ -338,6 +339,12 @@ void title_screen::pre_show(window& win)
 	auto clock = find_widget<button>(&win, "clock", false, false);
 	if(clock) {
 		clock->set_visible(show_debug_clock_button ? widget::visibility::visible : widget::visibility::invisible);
+	}
+
+	// if the userdata directories were created fresh when wesnoth started this time
+	// then check for any migration from a previous version
+	if(game_config::did_userdata_setup) {
+		gui2::dialogs::migrate_version_selection::execute();
 	}
 }
 

--- a/src/wesconfig.h
+++ b/src/wesconfig.h
@@ -40,11 +40,12 @@
   #undef VERSION
 #endif
 
-#define VERSION "1.15.14+dev"
+// TODO: undo changes to this file before merge
+#define VERSION "1.16.0"
 
 // Used for the Windows executables' version info resource.
 #define RC_VERSION_MAJOR        1
-#define RC_VERSION_MINOR        15
-#define RC_VERSION_REVISION     15
+#define RC_VERSION_MINOR        16
+#define RC_VERSION_REVISION     0
 
 #endif


### PR DESCRIPTION
Currently migrated, if existing:
* Add-ons (redownloaded if present on new add-ons server)
* Preferences file
* Credentials file

---

Currently incompletely tested, but mostly seems to be working.  The current (I assume pretty terrible) prompt UI:
![Screenshot from 2021-07-03 13-42-52](https://user-images.githubusercontent.com/3030250/124364045-9d2ec500-dc04-11eb-8995-f3512c4ef816.png)

One thing I'm also unsure about is whether/how to have the prompt show up *after* the titlescreen is displayed rather than immediately before.