### PR TITLE
Say what the error is when a broken .po file stops Wesnoth starting

### DIFF
--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -146,7 +146,7 @@ namespace
 			std::ostringstream err;
 			err << "Error opening language file for " << lang << ", textdomain " << dom
 				<< ":\n  " << detail << '\n';
-			ERR_G << err.rdbuf() << std::flush;
+			ERR_G << err.str() << std::flush;
 			throw game::error(err.str());
 		}
 


### PR DESCRIPTION
Bug #5923 is that a broken .po file can make Wesnoth fail to start, not
even reaching the title screen. Additionally, the error message printed
to the console just said "*timestamp* error general:", and then missed
the details of what had broken.

This commit fixes the error message to show which add-on and which line
are causing the problem.