### PR TITLE
Add a unit test for wesnoth.current.synced_state

### DIFF
--- a/data/test/scenarios/test_synced_state.cfg
+++ b/data/test/scenarios/test_synced_state.cfg
@@ -1,0 +1,90 @@
+# wmllint: no translatables
+
+# Check that wesnoth.current.synced_state works as documented, and that a subset of the standard events match the docs
+# in https://wiki.wesnoth.org/EventWML#Multiplayer_safety
+{GENERIC_UNIT_TEST "test_synced_state" (
+    [event]
+        name = preload
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'preload', 'preload should have its own state')
+                >>
+        [/lua]
+    [/event]
+
+    [event]
+        name = start
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'start should be synchronised')
+                    local result = wesnoth.sync.evaluate_single(
+                        function()
+                            unit_test.assert_equal(wesnoth.current.synced_state, 'local_choice', 'expected value to be local_choice, within synced event')
+                            return { value = wesnoth.current.synced_state }
+                        end)
+                    unit_test.assert_equal(result.value, 'local_choice', 'wrong value returned, within synced event')
+                >>
+        [/lua]
+    [/event]
+
+    [event]
+        name=turn 1
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'synced', '“turn X” should be synced')
+                >>
+        [/lua]
+
+        # Trigger the events below. The order that they're triggered in is checked in events-test_victory.cfg.
+        [kill]
+            side=2
+        [/kill]
+    [/event]
+
+    [event]
+        name=enemies defeated
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'enemies_defeated should be synced')
+                >>
+        [/lua]
+    [/event]
+
+    [event]
+        name=local_victory
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'unsynced', 'local_victory should be unsynced')
+                    -- evaluate_single a.k.a. synchronize_choice (for a single side) doesn't sync when called in an unsynced state.
+                    -- In 1.13.0 (commit 3b86c955616c), that changed from generating an error to a comment in the C++ that it "doesn't cause problems".
+                    -- In the same commit, the multiple-side version was left generating an error.
+                    -- This doesn't give me confidence that the behavior is replay-safe, but let's at least check that the behavior is consistent.
+                    local result = wesnoth.sync.evaluate_single(
+                        function()
+                            unit_test.assert_equal(wesnoth.current.synced_state, 'unsynced', 'within unsynced event')
+                            return { value = wesnoth.current.synced_state }
+                        end)
+                    unit_test.assert_equal(result.value, 'unsynced', 'wrong value returned, within unsynced event')
+                >>
+        [/lua]
+    [/event]
+
+    [event]
+        name=victory
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'victory should be synced')
+                >>
+        [/lua]
+    [/event]
+
+    [event]
+        name=scenario_end
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'scenario_end should be synced')
+                >>
+        [/lua]
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -33,9 +33,13 @@
 0 test_lua_assert_errors8
 1 test_lua_assert_errors9
 2 empty_test
+0 test_end_turn
+#
+# The synchronisation mechanism
+#
 4 break_replay_with_lua_random
 0 fixed_lua_random_replay_with_sync_choice
-0 test_end_turn
+0 test_synced_state
 #
 # Security test
 #


### PR DESCRIPTION
Note that this file gets formattedly badly by wmlindent, however it seems that wmlindent already skips the `data/test/scenarios` directory, the same issue affects `data/test/scenarios/recruit_facing.cfg`. Still working out if that is #1397 or if it should be a separate bug; I think it's a bug that needs fixing in wmlindent for 1.16, as it seems to break on any use of wesnoth.sync.evaluate_single in a `.cfg` file.