### PR TITLE
TEST FAILS: Add a unit test that [select_unit]fire_event=yes works

### DIFF
--- a/data/test/scenarios/fire_select_event.cfg
+++ b/data/test/scenarios/fire_select_event.cfg
@@ -1,0 +1,25 @@
+# wmllint: no translatables
+
+# Check that [select_unit]fire_event=yes or Lua's unit:select(true, true) triggers
+# an [event]name=select. Using the WML tag here, so that the test can easily be run
+# on 1.14 as well as 1.16.
+{GENERIC_UNIT_TEST "fire_select_event" (
+    [event]
+        name=select
+
+        {VARIABLE select_event_happened yes}
+    [/event]
+
+    [event]
+        name=turn 1
+
+        {VARIABLE select_event_happened no}
+        [select_unit]
+            id=alice
+            fire_event=yes
+        [/select_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL select_event_happened boolean_equals yes})}
+        {CLEAR_VARIABLE select_event_happened}
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -108,6 +108,7 @@
 0 modify_turns_four
 0 replace_schedule_prestart
 0 modify_unit_facing
+0 fire_select_event
 0 event_handlers_in_events_1
 0 event_handlers_in_events_3
 0 event_handlers_in_events_2


### PR DESCRIPTION
@CelticMinstrel following on from #5927, I looked at testing `[select_unit]fire_event` or `unit:select(true, true)`. This version of the test is written in WML so that it can be run on 1.14 too.

It doesn't appear to work, nor did it work on 1.14.

Running the test interactively doesn't make it work either.

Running the test interactively and manually clicking on Alice with the mouse
does fire the event.