### PR TITLE
Fix custom synced commands not changing the AI game state

### DIFF
--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -338,6 +338,7 @@ WML_HANDLER_FUNCTION(do_command,, cfg)
 			/*show*/ true,
 			/*error_handler*/ &on_replay_error
 		);
+		ai::manager::get_singleton().raise_gamestate_changed();
 	}
 }
 


### PR DESCRIPTION
The old `ai.synced_command` function always set the AI-context game state to changed when executing such a command. This was inadvertently omitted when the implementation was changed to `invoke_synced_command` in fef953a4. While custom synced commands may or may not change the game state and the engine has no means of determining this correctly in all cases (meaning that neither behavior is technically wrong), the fact that the behavior was changed should be considered a bug. This commit changes it back to how it was before fef953a4.

There are a variety of places where setting the game state to changed could be added in the code. I chose this one, as it is analogous to what is done for the `replace_map` function [later in the same file](https://github.com/wesnoth/wesnoth/blob/master/src/game_events/action_wml.cpp#L646).

As I consider this a bug fix, I believe this should be backported to both 1.16 and 1.14.