### PR TITLE
[world conquest] add campaign icons, campaign image and credits

### DIFF
--- a/data/campaigns/World_Conquest/_main.cfg
+++ b/data/campaigns/World_Conquest/_main.cfg
@@ -1,5 +1,4 @@
 #textdomain wesnoth-wc
-## MP Campaign (Scenarios in Multiplayer >> Random Maps)
 
 [textdomain]
     name="wesnoth-wc"

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -60,7 +60,25 @@ _ "World Conquest 3p" #enddef
     [/event]
 #enddef
 
-#define WC2_CAMPAIGN_NEW PLAYERS
+# I know I can add them into the main campaign defines but it gets really messy if done that way so I prefer to keep my code clean
+
+#define ICON_ONE
+    "misc/blank-hex.png~BLIT(units/undead-necromancers/adept+female-defend-1.png~RC(magenta>brown)~CROP(10,0,72,72))~BLIT(units/dwarves/berserker/berserker-laugh-1.png~FL()~RC(magenta>white)~CROP(0,0,60,67),15,5)"
+#enddef
+
+#define ICON_TWO
+    "misc/blank-hex.png~BLIT(units/undead/spectre-se-attack-6.png~RC(magenta>darkred)~CROP(50,62,150,84),-15,-12)~BLIT(units/goblins/spearman-ne-defend.png~FL()~RC(magenta>darkblue)~CROP(0,0,60,67),20,15)"
+#enddef
+
+#define ICON_THREE
+    "misc/blank-hex.png~BLIT(units/drakes/armageddon-fire-se-4.png~RC(magenta>darkred)~CROP(10,0,72,72),-10,-10)~BLIT(units/goblins/spearman-ne-defend.png~FL()~RC(magenta>darkblue)~CROP(0,0,60,67),20,10)"
+#enddef
+
+#define IMAGE_ONE
+    "data/campaigns/The_Rise_Of_Wesnoth/images/story/trow_story_04-Fall_of_Eldaric.jpg~SCALE_INTO(800,600)"
+#enddef
+
+#define WC2_CAMPAIGN_NEW PLAYERS ICON
     [campaign]
         id = "WC_II_{PLAYERS}p"
         define = CAMPAIGN_WC_{PLAYERS}P
@@ -69,6 +87,8 @@ _ "World Conquest 3p" #enddef
         first_scenario = "WC_II_{PLAYERS}p"
         min_players={PLAYERS}
         max_players={PLAYERS}
+        icon = {ICON}
+        image = {IMAGE_ONE}
         type = mp
         abbrev = _ "WC" + {PLAYERS}\
         {WC2_CAMPAIGN_DIFFICULTY VERY_EASY {WC2_HUMAN_DIFFICULTY human-peasants/peasant purple} {STR_PEASANT} {STR_BEGINNER} 6 2 2 10 yes 0}
@@ -146,9 +166,9 @@ _ "World Conquest 3p" #enddef
     [/{TAG}]
 #enddef
 
-{WC2_CAMPAIGN_NEW 1}
-{WC2_CAMPAIGN_NEW 2}
-{WC2_CAMPAIGN_NEW 3}
+{WC2_CAMPAIGN_NEW 1 {ICON_ONE}}
+{WC2_CAMPAIGN_NEW 2 {ICON_TWO}}
+{WC2_CAMPAIGN_NEW 3 {ICON_THREE}}
 
 #ifdef EDITOR
 {WC2_SCENARIO_NEW multiplayer WC_II {WC_II_CAMPAIGN_NAME_3P} 0}

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -101,6 +101,75 @@ _ "World Conquest 3p" #enddef
         # Expert is a string that was supposed to be in wesnoth-wc but accidentally got added to wesnoth-units instead
         #textdomain wesnoth-units
         {WC2_CAMPAIGN_DIFFICULTY NIGHTMARE {WC2_NIGHTMARE_DIFFICULTY} {STR_NIGHTMARE} _"Expert" 9 7 1 0 no 20}
+
+        [about]
+            title = _ "Campaign Design"
+            [entry]
+                name = "tekelili"
+            [/entry]
+        [/about]
+
+        [about]
+            title = _ "Prose, Grammatical and Text Assistance"
+            [entry]
+                name = "TL"
+            [/entry]
+            [entry]
+                name = "Natasiel"
+            [/entry]
+            [entry]
+                name = "Rigor"
+            [/entry]
+            [entry]
+                name = "tekelili"
+            [/entry]
+        [/about]
+
+        [about]
+            title = _ "Minor Code Contributors"
+            [entry]
+                name =  "ezysquire"
+            [/entry]
+            [entry]
+                name =  "tsr"
+            [/entry]
+        [/about]
+
+        [about]
+            title = _ "Playtesting"
+            [entry]
+                name =  "Bear"
+            [/entry]
+            [entry]
+                name =  "Honor"
+            [/entry]
+            [entry]
+                name =  "jb"
+            [/entry]
+            [entry]
+                name =  "paso"
+            [/entry]
+            [entry]
+                name =  "tekelili"
+            [/entry]
+        [/about]
+
+        [about]
+            title = _ "Campaign Maintenance"
+            [entry]
+                name = "gfgtdf"
+                comment= "former maintainer"
+            [/entry]
+            [entry]
+                name =  "Celtic_Minstrel"
+                comment= "intermittent maintainer"
+            [/entry]
+            [entry]
+                name =  "Lord-Knightmare"
+                comment= "intermittent maintainer"
+            [/entry]
+        [/about]
+        
     [/campaign]
 #enddef
 

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -161,7 +161,7 @@ _ "World Conquest 3p" #enddef
                 comment= "former maintainer"
             [/entry]
             [entry]
-                name =  "Celtic_Minstrel"
+                name =  "Celtic Minstrel"
                 comment= "intermittent maintainer"
             [/entry]
             [entry]

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -169,7 +169,6 @@ _ "World Conquest 3p" #enddef
                 comment= "intermittent maintainer"
             [/entry]
         [/about]
-        
     [/campaign]
 #enddef
 


### PR DESCRIPTION
This PR addresses #5113 and #5112 for the 1.16 branch. I shall make a master branch PR of this later on. 

The credits can be left untranslated as of right now, since the priority is returning world conquest to be playable from start to finish.

![Screenshot 2021-07-12 033809](https://user-images.githubusercontent.com/5283677/125629999-72960761-1d5c-4d99-b5c8-108d0fb612ee.png)


