### PR TITLE
[1.16] Title screen: move "change language" back to the text-button area

### DIFF
--- a/data/gui/window/title_screen.cfg
+++ b/data/gui/window/title_screen.cfg
@@ -254,6 +254,7 @@ where
 			{_GUI_BUTTON "addons" _"Add-ons" _"Download usermade campaigns, eras, or map packs"}
 			{_GUI_BUTTON "editor" _"Map Editor" _"Start the map editor"}
 			{_GUI_BUTTON "preferences" _"Preferences" _"Configure the game’s settings"}
+			{_GUI_BUTTON "language" _"Language" _"Change the language"}
 			{_GUI_BUTTON "credits" _"Credits" _"View the credits"}
 			{_GUI_BUTTON "quit" _"Quit" _"Quit the game"}
 			# This debug feature doesn't need to be translated, so put it in the test textdomain.
@@ -473,17 +474,6 @@ where
 									id = "revision_number"
 									definition = "default_small"
 								[/label]
-							[/column]
-
-							[column]
-								grow_factor = 0
-								horizontal_alignment = "right"
-								[button]
-									id = "language"
-									definition = "action_language"
-									label = _ "Language"
-									tooltip = _ "Change the language"
-								[/button]
 							[/column]
 
 						[/row]


### PR DESCRIPTION
Okay for the string-freeze - the necessary string was re-added in fc50458b.

No forward-port required, as master will have a full title screen redesign in
issue #4531. This commit is reverting acc96b16, which is a part of #4531,
because the redesign has paused at a place that causes problems with large
screens - the button added in acc96b16 moves further from the center of the
screen as the screen size increases, and it doesn't scale with screen size. On
an 800x600 window it's easily noticeable, but on 2560x1440 it's less obvious
than either Dan Tonk or Weldyn.