### PR TITLE
Tutorial S01: Don't let the first Quintain attack on turn 2

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -621,6 +621,19 @@
         {PRINT (_"End your turn")}
     [/event]
 
+    # On the Quintain's first turn, it's always next to the player, but
+    # sometimes the AI chooses to move before attacking. If it moves onto
+    # 12,4 and then the player chooses to heal in the 10,3 village, the
+    # Quintain can move to 11,4 and kill a player who's following the
+    # instructions to the letter.
+    [event]
+        name=side 2 turn 1 refresh
+
+        {CLEAR_PRINT}
+
+        {MODIFY_UNIT (id=Quintain) moves 0}
+    [/event]
+
     # TURN 2: lesson in healing
     # There is a 1 in 170,000 chance that the quintain will miss on all
     # 10 attacks. Ignoring that.


### PR DESCRIPTION
(cherry picked from commit b02b1ad2ff31d2e56828729cc9d2a952453b8761, so I'm just going to do a CI run and merge)

A player can follow Dacyn's instructions to the letter, yet get
killed if they choose a village 2 hexes away from the Quintain on
turn 2.

There are better suggestions about handling this in
https://r.wesnoth.org/t54644 , however during the string-freeze
let's simply make the Quintain stay on its starting spot on turn 1.

Add a CLEAR_PRINT because the player has just completed the
"End your turn" instruction.