### PR TITLE
Remove a leading space from the Silver Mage's [special_note]

### DIFF
--- a/data/core/units/humans/Mage_Silver.cfg
+++ b/data/core/units/humans/Mage_Silver.cfg
@@ -22,7 +22,7 @@ They have, in fact, their own order amongst the ranks of magi, an order which wi
 
 Silver magi are often more physically adept than other magi, and their skills are of undeniable use on the battlefield, if one can manage to induce the mage to apply them."
     [special_note]
-        note= _"SPECIAL_NOTE^ Silver Magi are well-attuned to their magical natures and are highly resistant to non-physical damage."
+        note= _"SPECIAL_NOTE^Silver Magi are well-attuned to their magical natures and are highly resistant to non-physical damage."
     [/special_note]
     die_sound={SOUND_LIST:HUMAN_DIE}
     [resistance]


### PR DESCRIPTION
The strings in special-notes.cfg don't have a leading space,
and this one causes a warning in poedit.