### PR TITLE
IoM: Add translation hint about the "Healing Keep"

### DIFF
--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -186,6 +186,8 @@
 
         [label]
             x,y = 16,9
+            # po: In the scenario Isle of Mists, there's an allied AI unit with heals+8.
+            # po: This label is added to the hex that she starts on, and she doesn't move.
             text = _"Healing Keep"
         [/label]
 


### PR DESCRIPTION
@knyghtmare I think this is needed because we're translating the role of that hex, rather than a terrain that acts like both a keep and an oasis.