### PR TITLE
TRoW S04a: Typographic style is not to have a hyphen in "un-life"

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
@@ -491,8 +491,8 @@ Enter at Your Own Risk!"
         [/filter]
         [message]
             speaker=Lollyra
-            # wmllint: local spelling Un-death
-            message= _ "May I live forever in Un-death!"
+            # wmllint: local spelling Undeath
+            message= _ "May I live forever in Undeath!"
         [/message]
     [/event]
 


### PR DESCRIPTION
For consistency, there should also be no hyphen in "un-death".
The style was decided in PR #5525.