### PR TITLE
Re-add attribution to copyright notices.

### DIFF
--- a/src/about.cpp
+++ b/src/about.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/about.hpp
+++ b/src/about.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/create.hpp
+++ b/src/actions/create.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/heal.hpp
+++ b/src/actions/heal.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/move.hpp
+++ b/src/actions/move.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/undo.hpp
+++ b/src/actions/undo.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/undo_action.cpp
+++ b/src/actions/undo_action.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/undo_action.hpp
+++ b/src/actions/undo_action.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/unit_creator.hpp
+++ b/src/actions/unit_creator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/vision.cpp
+++ b/src/actions/vision.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/actions/vision.hpp
+++ b/src/actions/vision.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/manager.cpp
+++ b/src/addon/manager.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/manager_ui.hpp
+++ b/src/addon/manager_ui.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/state.cpp
+++ b/src/addon/state.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/state.hpp
+++ b/src/addon/state.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/validation.cpp
+++ b/src/addon/validation.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/addon/validation.hpp
+++ b/src/addon/validation.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2008 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/actions.cpp
+++ b/src/ai/actions.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/actions.hpp
+++ b/src/ai/actions.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/ai.cpp
+++ b/src/ai/composite/ai.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/ai.hpp
+++ b/src/ai/composite/ai.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/aspect.cpp
+++ b/src/ai/composite/aspect.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/aspect.hpp
+++ b/src/ai/composite/aspect.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/component.cpp
+++ b/src/ai/composite/component.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/component.hpp
+++ b/src/ai/composite/component.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/contexts.cpp
+++ b/src/ai/composite/contexts.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/contexts.hpp
+++ b/src/ai/composite/contexts.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/engine.cpp
+++ b/src/ai/composite/engine.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/engine.hpp
+++ b/src/ai/composite/engine.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/goal.cpp
+++ b/src/ai/composite/goal.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/goal.hpp
+++ b/src/ai/composite/goal.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/property_handler.hpp
+++ b/src/ai/composite/property_handler.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/rca.cpp
+++ b/src/ai/composite/rca.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/rca.hpp
+++ b/src/ai/composite/rca.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/stage.cpp
+++ b/src/ai/composite/stage.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/stage.hpp
+++ b/src/ai/composite/stage.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/composite/value_translator.hpp
+++ b/src/ai/composite/value_translator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/configuration.cpp
+++ b/src/ai/configuration.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/configuration.hpp
+++ b/src/ai/configuration.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/contexts.cpp
+++ b/src/ai/contexts.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/contexts.hpp
+++ b/src/ai/contexts.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/aspect_attacks.hpp
+++ b/src/ai/default/aspect_attacks.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/attack.cpp
+++ b/src/ai/default/attack.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/ca.cpp
+++ b/src/ai/default/ca.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/ca.hpp
+++ b/src/ai/default/ca.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/ca_move_to_targets.cpp
+++ b/src/ai/default/ca_move_to_targets.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/ca_move_to_targets.hpp
+++ b/src/ai/default/ca_move_to_targets.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/contexts.cpp
+++ b/src/ai/default/contexts.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/contexts.hpp
+++ b/src/ai/default/contexts.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/engine_cpp.cpp
+++ b/src/ai/default/engine_cpp.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/engine_cpp.hpp
+++ b/src/ai/default/engine_cpp.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Felix Bauer
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/recruitment.hpp
+++ b/src/ai/default/recruitment.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Felix Bauer
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/stage_rca.cpp
+++ b/src/ai/default/stage_rca.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/default/stage_rca.hpp
+++ b/src/ai/default/stage_rca.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/ai.cpp
+++ b/src/ai/formula/ai.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/ai.hpp
+++ b/src/ai/formula/ai.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/callable_objects.cpp
+++ b/src/ai/formula/callable_objects.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Bartosz Waresiak <dragonking@o2.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/callable_objects.hpp
+++ b/src/ai/formula/callable_objects.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Bartosz Waresiak <dragonking@o2.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/candidates.cpp
+++ b/src/ai/formula/candidates.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Bartosz Waresiak <dragonking@o2.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/candidates.hpp
+++ b/src/ai/formula/candidates.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Bartosz Waresiak <dragonking@o2.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/engine_fai.cpp
+++ b/src/ai/formula/engine_fai.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/engine_fai.hpp
+++ b/src/ai/formula/engine_fai.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/function_table.cpp
+++ b/src/ai/formula/function_table.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Bartosz Waresiak <dragonking@o2.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/function_table.hpp
+++ b/src/ai/formula/function_table.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Bartosz Waresiak <dragonking@o2.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/stage_side_formulas.cpp
+++ b/src/ai/formula/stage_side_formulas.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/stage_side_formulas.hpp
+++ b/src/ai/formula/stage_side_formulas.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/stage_unit_formulas.cpp
+++ b/src/ai/formula/stage_unit_formulas.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/formula/stage_unit_formulas.hpp
+++ b/src/ai/formula/stage_unit_formulas.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/game_info.cpp
+++ b/src/ai/game_info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/game_info.hpp
+++ b/src/ai/game_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/gamestate_observer.cpp
+++ b/src/ai/gamestate_observer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/gamestate_observer.hpp
+++ b/src/ai/gamestate_observer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/aspect_advancements.cpp
+++ b/src/ai/lua/aspect_advancements.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Felix Bauer <fehlxb+wesnoth@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/aspect_advancements.hpp
+++ b/src/ai/lua/aspect_advancements.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Felix Bauer <fehlxb+wesnoth@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/core.hpp
+++ b/src/ai/lua/core.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/engine_lua.cpp
+++ b/src/ai/lua/engine_lua.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/engine_lua.hpp
+++ b/src/ai/lua/engine_lua.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/lua_object.cpp
+++ b/src/ai/lua/lua_object.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Dmitry Kovalenko <nephro.wes@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/lua/lua_object.hpp
+++ b/src/ai/lua/lua_object.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Dmitry Kovalenko <nephro.wes@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/manager.cpp
+++ b/src/ai/manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/manager.hpp
+++ b/src/ai/manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/registry.cpp
+++ b/src/ai/registry.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/registry.hpp
+++ b/src/ai/registry.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/simulated_actions.cpp
+++ b/src/ai/simulated_actions.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Guorui Xi <kevin.xgr@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/simulated_actions.hpp
+++ b/src/ai/simulated_actions.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Guorui Xi <kevin.xgr@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/testing.cpp
+++ b/src/ai/testing.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/ai/testing.hpp
+++ b/src/ai/testing.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/animated.cpp
+++ b/src/animated.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Jeremy Rosen <jeremy.rosen@enst-bretagne.fr>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/animated.hpp
+++ b/src/animated.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/animated.tpp
+++ b/src/animated.tpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2004 by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/arrow.cpp
+++ b/src/arrow.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/arrow.hpp
+++ b/src/arrow.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Rusty Russell <rusty@rustcorp.com.au>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/attack_prediction.hpp
+++ b/src/attack_prediction.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/boilerplate-header.cpp
+++ b/src/boilerplate-header.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/buffered_istream.hpp
+++ b/src/buffered_istream.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/build_info.hpp
+++ b/src/build_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/carryover.cpp
+++ b/src/carryover.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/chat_events.hpp
+++ b/src/chat_events.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/chat_log.cpp
+++ b/src/chat_log.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/chat_log.hpp
+++ b/src/chat_log.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/color_range.cpp
+++ b/src/color_range.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/color_range.hpp
+++ b/src/color_range.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Lukasz Dobrogowski <lukasz.dobrogowski@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Lukasz Dobrogowski <lukasz.dobrogowski@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/config_attribute_value.cpp
+++ b/src/config_attribute_value.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/config_cache.hpp
+++ b/src/config_cache.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/configr_assign.hpp
+++ b/src/configr_assign.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/cursor.hpp
+++ b/src/cursor.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_battery_info.hpp
+++ b/src/desktop/apple_battery_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_battery_info.mm
+++ b/src/desktop/apple_battery_info.mm
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+    by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_notification.hpp
+++ b/src/desktop/apple_notification.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_notification.mm
+++ b/src/desktop/apple_notification.mm
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Google Inc.
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_version.hpp
+++ b/src/desktop/apple_version.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_version.mm
+++ b/src/desktop/apple_version.mm
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_video.hpp
+++ b/src/desktop/apple_video.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/apple_video.mm
+++ b/src/desktop/apple_video.mm
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/battery_info.cpp
+++ b/src/desktop/battery_info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/battery_info.hpp
+++ b/src/desktop/battery_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Martin Hrubý <hrubymar10@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/clipboard.cpp
+++ b/src/desktop/clipboard.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/clipboard.hpp
+++ b/src/desktop/clipboard.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/dbus_features.cpp
+++ b/src/desktop/dbus_features.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/dbus_features.hpp
+++ b/src/desktop/dbus_features.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/notifications.cpp
+++ b/src/desktop/notifications.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/notifications.hpp
+++ b/src/desktop/notifications.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/open.cpp
+++ b/src/desktop/open.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/open.hpp
+++ b/src/desktop/open.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/paths.cpp
+++ b/src/desktop/paths.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/paths.hpp
+++ b/src/desktop/paths.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/version.hpp
+++ b/src/desktop/version.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/windows_battery_info.cpp
+++ b/src/desktop/windows_battery_info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/windows_battery_info.hpp
+++ b/src/desktop/windows_battery_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Maxim Biro <nurupo.contributions@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/desktop/windows_tray_notification.hpp
+++ b/src/desktop/windows_tray_notification.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Maxim Biro <nurupo.contributions@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/display_chat_manager.hpp
+++ b/src/display_chat_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/display_context.hpp
+++ b/src/display_context.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action.cpp
+++ b/src/editor/action/action.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action.hpp
+++ b/src/editor/action/action.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_base.hpp
+++ b/src/editor/action/action_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_item.cpp
+++ b/src/editor/action/action_item.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_item.hpp
+++ b/src/editor/action/action_item.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_label.cpp
+++ b/src/editor/action/action_label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_label.hpp
+++ b/src/editor/action/action_label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_select.cpp
+++ b/src/editor/action/action_select.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_select.hpp
+++ b/src/editor/action/action_select.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_unit.cpp
+++ b/src/editor/action/action_unit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_unit.hpp
+++ b/src/editor/action/action_unit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_village.cpp
+++ b/src/editor/action/action_village.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/action_village.hpp
+++ b/src/editor/action/action_village.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action.cpp
+++ b/src/editor/action/mouse/mouse_action.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action.hpp
+++ b/src/editor/action/mouse/mouse_action.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_item.hpp
+++ b/src/editor/action/mouse/mouse_action_item.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_map_label.cpp
+++ b/src/editor/action/mouse/mouse_action_map_label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_map_label.hpp
+++ b/src/editor/action/mouse/mouse_action_map_label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_select.cpp
+++ b/src/editor/action/mouse/mouse_action_select.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_select.hpp
+++ b/src/editor/action/mouse/mouse_action_select.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_unit.cpp
+++ b/src/editor/action/mouse/mouse_action_unit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_unit.hpp
+++ b/src/editor/action/mouse/mouse_action_unit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_village.cpp
+++ b/src/editor/action/mouse/mouse_action_village.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/action/mouse/mouse_action_village.hpp
+++ b/src/editor/action/mouse/mouse_action_village.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/editor_common.hpp
+++ b/src/editor/editor_common.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/editor_main.cpp
+++ b/src/editor/editor_main.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/editor_main.hpp
+++ b/src/editor/editor_main.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/context_manager.hpp
+++ b/src/editor/map/context_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/editor_map.cpp
+++ b/src/editor/map/editor_map.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/editor_map.hpp
+++ b/src/editor/map/editor_map.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/map_fragment.cpp
+++ b/src/editor/map/map_fragment.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/map/map_fragment.hpp
+++ b/src/editor/map/map_fragment.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/common_palette.hpp
+++ b/src/editor/palette/common_palette.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/empty_palette.hpp
+++ b/src/editor/palette/empty_palette.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/item_palette.cpp
+++ b/src/editor/palette/item_palette.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/item_palette.hpp
+++ b/src/editor/palette/item_palette.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/palette_manager.cpp
+++ b/src/editor/palette/palette_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/palette_manager.hpp
+++ b/src/editor/palette/palette_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/terrain_palettes.cpp
+++ b/src/editor/palette/terrain_palettes.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/terrain_palettes.hpp
+++ b/src/editor/palette/terrain_palettes.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/tristate_button.hpp
+++ b/src/editor/palette/tristate_button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/unit_palette.cpp
+++ b/src/editor/palette/unit_palette.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/palette/unit_palette.hpp
+++ b/src/editor/palette/unit_palette.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/toolkit/brush.cpp
+++ b/src/editor/toolkit/brush.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/toolkit/brush.hpp
+++ b/src/editor/toolkit/brush.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/toolkit/editor_toolkit.cpp
+++ b/src/editor/toolkit/editor_toolkit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/editor/toolkit/editor_toolkit.hpp
+++ b/src/editor/toolkit/editor_toolkit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/exceptions.hpp
+++ b/src/exceptions.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/fake_unit_manager.cpp
+++ b/src/fake_unit_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/fake_unit_manager.hpp
+++ b/src/fake_unit_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/fake_unit_ptr.cpp
+++ b/src/fake_unit_ptr.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/fake_unit_ptr.hpp
+++ b/src/fake_unit_ptr.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/filter_context.hpp
+++ b/src/filter_context.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/floating_textbox.cpp
+++ b/src/floating_textbox.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/floating_textbox.hpp
+++ b/src/floating_textbox.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/constants.cpp
+++ b/src/font/constants.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/constants.hpp
+++ b/src/font/constants.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/error.hpp
+++ b/src/font/error.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Chris Beck<render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/font_config.cpp
+++ b/src/font/font_config.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Chris Beck<render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/font_config.hpp
+++ b/src/font/font_config.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Chris Beck<render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/font_description.hpp
+++ b/src/font/font_description.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Chris Beck<render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/font_options.hpp
+++ b/src/font/font_options.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/pango/escape.hpp
+++ b/src/font/pango/escape.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/pango/font.hpp
+++ b/src/font/pango/font.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/pango/hyperlink.hpp
+++ b/src/font/pango/hyperlink.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Chris Beck<render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/pango/stream_ops.hpp
+++ b/src/font/pango/stream_ops.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/sdl_ttf_compat.cpp
+++ b/src/font/sdl_ttf_compat.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2021 - 2021
+	by Iris Morelle <shadowm@wesnoth.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/sdl_ttf_compat.hpp
+++ b/src/font/sdl_ttf_compat.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2021 - 2021
+	by Iris Morelle <shadowm@wesnoth.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/standard_colors.cpp
+++ b/src/font/standard_colors.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/standard_colors.hpp
+++ b/src/font/standard_colors.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/format_time_summary.cpp
+++ b/src/format_time_summary.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/format_time_summary.hpp
+++ b/src/format_time_summary.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formatter.hpp
+++ b/src/formatter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/callable.hpp
+++ b/src/formula/callable.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/callable_fwd.hpp
+++ b/src/formula/callable_fwd.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/callable_objects.hpp
+++ b/src/formula/callable_objects.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/debugger.cpp
+++ b/src/formula/debugger.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/debugger.hpp
+++ b/src/formula/debugger.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/debugger_fwd.cpp
+++ b/src/formula/debugger_fwd.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/debugger_fwd.hpp
+++ b/src/formula/debugger_fwd.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/formula.hpp
+++ b/src/formula/formula.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/formula_fwd.hpp
+++ b/src/formula/formula_fwd.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/function.hpp
+++ b/src/formula/function.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/function_gamestate.cpp
+++ b/src/formula/function_gamestate.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/function_gamestate.hpp
+++ b/src/formula/function_gamestate.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/tokenizer.cpp
+++ b/src/formula/tokenizer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/tokenizer.hpp
+++ b/src/formula/tokenizer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/variant.cpp
+++ b/src/formula/variant.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/formula/variant.hpp
+++ b/src/formula/variant.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_classification.hpp
+++ b/src/game_classification.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_config_view.cpp
+++ b/src/game_config_view.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_config_view.hpp
+++ b/src/game_config_view.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_data.cpp
+++ b/src/game_data.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_data.hpp
+++ b/src/game_data.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_end_exceptions.cpp
+++ b/src/game_end_exceptions.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_end_exceptions.hpp
+++ b/src/game_end_exceptions.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_errors.hpp
+++ b/src/game_errors.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2005 - 2021
+	by Yann Dirson <ydirson@altern.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/action_wml.hpp
+++ b/src/game_events/action_wml.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/conditional_wml.cpp
+++ b/src/game_events/conditional_wml.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/conditional_wml.hpp
+++ b/src/game_events/conditional_wml.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/entity_location.cpp
+++ b/src/game_events/entity_location.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/entity_location.hpp
+++ b/src/game_events/entity_location.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/handlers.hpp
+++ b/src/game_events/handlers.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/manager_impl.cpp
+++ b/src/game_events/manager_impl.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/manager_impl.hpp
+++ b/src/game_events/manager_impl.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/menu_item.cpp
+++ b/src/game_events/menu_item.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/menu_item.hpp
+++ b/src/game_events/menu_item.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/pump.hpp
+++ b/src/game_events/pump.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/wmi_manager.cpp
+++ b/src/game_events/wmi_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_events/wmi_manager.hpp
+++ b/src/game_events/wmi_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/configure_engine.hpp
+++ b/src/game_initialization/configure_engine.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Nathan Walker <nathan.b.walker@vanderbilt.edu>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/create_engine.hpp
+++ b/src/game_initialization/create_engine.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/depcheck.cpp
+++ b/src/game_initialization/depcheck.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Boldizsár Lipka <lipkab@zoho.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/depcheck.hpp
+++ b/src/game_initialization/depcheck.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Boldizsár Lipka <lipkab@zoho.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/lobby_data.hpp
+++ b/src/game_initialization/lobby_data.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/lobby_info.cpp
+++ b/src/game_initialization/lobby_info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/lobby_info.hpp
+++ b/src/game_initialization/lobby_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/mp_game_utils.cpp
+++ b/src/game_initialization/mp_game_utils.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/mp_game_utils.hpp
+++ b/src/game_initialization/mp_game_utils.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/multiplayer.hpp
+++ b/src/game_initialization/multiplayer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 - 2005 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/playcampaign.hpp
+++ b/src/game_initialization/playcampaign.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 - 2005 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_initialization/singleplayer.hpp
+++ b/src/game_initialization/singleplayer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Nathan Walker <nathan.b.walker@vanderbilt.edu>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_state.hpp
+++ b/src/game_state.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_version.cpp
+++ b/src/game_version.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/game_version.hpp
+++ b/src/game_version.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/cave_map_generator.cpp
+++ b/src/generators/cave_map_generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/cave_map_generator.hpp
+++ b/src/generators/cave_map_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/default_map_generator.cpp
+++ b/src/generators/default_map_generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/default_map_generator.hpp
+++ b/src/generators/default_map_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/default_map_generator_job.cpp
+++ b/src/generators/default_map_generator_job.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/default_map_generator_job.hpp
+++ b/src/generators/default_map_generator_job.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/lua_map_generator.cpp
+++ b/src/generators/lua_map_generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/lua_map_generator.hpp
+++ b/src/generators/lua_map_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/map_create.cpp
+++ b/src/generators/map_create.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/map_create.hpp
+++ b/src/generators/map_create.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/map_generator.cpp
+++ b/src/generators/map_generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generators/map_generator.hpp
+++ b/src/generators/map_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generic_event.cpp
+++ b/src/generic_event.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/generic_event.hpp
+++ b/src/generic_event.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/field-fwd.hpp
+++ b/src/gui/auxiliary/field-fwd.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/field.hpp
+++ b/src/gui/auxiliary/field.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/filter.hpp
+++ b/src/gui/auxiliary/filter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/find_widget.hpp
+++ b/src/gui/auxiliary/find_widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/exception.hpp
+++ b/src/gui/auxiliary/iterator/exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/iterator.cpp
+++ b/src/gui/auxiliary/iterator/iterator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/iterator.hpp
+++ b/src/gui/auxiliary/iterator/iterator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/policy_order.hpp
+++ b/src/gui/auxiliary/iterator/policy_order.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/policy_visit.hpp
+++ b/src/gui/auxiliary/iterator/policy_visit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker.hpp
+++ b/src/gui/auxiliary/iterator/walker.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker_grid.cpp
+++ b/src/gui/auxiliary/iterator/walker_grid.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker_grid.hpp
+++ b/src/gui/auxiliary/iterator/walker_grid.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker_tree_node.cpp
+++ b/src/gui/auxiliary/iterator/walker_tree_node.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker_tree_node.hpp
+++ b/src/gui/auxiliary/iterator/walker_tree_node.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker_widget.cpp
+++ b/src/gui/auxiliary/iterator/walker_widget.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/iterator/walker_widget.hpp
+++ b/src/gui/auxiliary/iterator/walker_widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/tips.cpp
+++ b/src/gui/auxiliary/tips.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/tips.hpp
+++ b/src/gui/auxiliary/tips.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/auxiliary/typed_formula.hpp
+++ b/src/gui/auxiliary/typed_formula.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/dispatcher.cpp
+++ b/src/gui/core/event/dispatcher.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/dispatcher.hpp
+++ b/src/gui/core/event/dispatcher.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/dispatcher_private.hpp
+++ b/src/gui/core/event/dispatcher_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/distributor.hpp
+++ b/src/gui/core/event/distributor.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/handler.hpp
+++ b/src/gui/core/event/handler.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/event/message.hpp
+++ b/src/gui/core/event/message.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/gui_definition.cpp
+++ b/src/gui/core/gui_definition.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/gui_definition.hpp
+++ b/src/gui/core/gui_definition.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/layout_exception.hpp
+++ b/src/gui/core/layout_exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/linked_group_definition.cpp
+++ b/src/gui/core/linked_group_definition.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/linked_group_definition.hpp
+++ b/src/gui/core/linked_group_definition.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/log.cpp
+++ b/src/gui/core/log.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/log.hpp
+++ b/src/gui/core/log.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/notifiee.hpp
+++ b/src/gui/core/notifiee.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/notifier.hpp
+++ b/src/gui/core/notifier.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/placer.cpp
+++ b/src/gui/core/placer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/placer.hpp
+++ b/src/gui/core/placer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/placer/horizontal_list.cpp
+++ b/src/gui/core/placer/horizontal_list.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/placer/horizontal_list.hpp
+++ b/src/gui/core/placer/horizontal_list.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/placer/vertical_list.cpp
+++ b/src/gui/core/placer/vertical_list.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/placer/vertical_list.hpp
+++ b/src/gui/core/placer/vertical_list.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/register_widget.hpp
+++ b/src/gui/core/register_widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/static_registry.cpp
+++ b/src/gui/core/static_registry.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/static_registry.hpp
+++ b/src/gui/core/static_registry.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/timer.cpp
+++ b/src/gui/core/timer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/timer.hpp
+++ b/src/gui/core/timer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/widget_definition.cpp
+++ b/src/gui/core/widget_definition.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/widget_definition.hpp
+++ b/src/gui/core/widget_definition.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/window_builder.hpp
+++ b/src/gui/core/window_builder.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/window_builder/helper.cpp
+++ b/src/gui/core/window_builder/helper.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/window_builder/helper.hpp
+++ b/src/gui/core/window_builder/helper.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/window_builder/instance.cpp
+++ b/src/gui/core/window_builder/instance.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/core/window_builder/instance.hpp
+++ b/src/gui/core/window_builder/instance.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/connect.cpp
+++ b/src/gui/dialogs/addon/connect.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/connect.hpp
+++ b/src/gui/dialogs/addon/connect.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/install_dependencies.cpp
+++ b/src/gui/dialogs/addon/install_dependencies.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/install_dependencies.hpp
+++ b/src/gui/dialogs/addon/install_dependencies.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/license_prompt.cpp
+++ b/src/gui/dialogs/addon/license_prompt.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Iris Morelle <shadowm@wesnoth.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/license_prompt.hpp
+++ b/src/gui/dialogs/addon/license_prompt.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Iris Morelle <shadowm@wesnoth.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/uninstall_list.cpp
+++ b/src/gui/dialogs/addon/uninstall_list.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/addon/uninstall_list.hpp
+++ b/src/gui/dialogs/addon/uninstall_list.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/attack_predictions.hpp
+++ b/src/gui/dialogs/attack_predictions.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/campaign_difficulty.hpp
+++ b/src/gui/dialogs/campaign_difficulty.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/chat_log.cpp
+++ b/src/gui/dialogs/chat_log.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/chat_log.hpp
+++ b/src/gui/dialogs/chat_log.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/core_selection.cpp
+++ b/src/gui/dialogs/core_selection.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/core_selection.hpp
+++ b/src/gui/dialogs/core_selection.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/debug_clock.cpp
+++ b/src/gui/dialogs/debug_clock.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/debug_clock.hpp
+++ b/src/gui/dialogs/debug_clock.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/depcheck_confirm_change.cpp
+++ b/src/gui/dialogs/depcheck_confirm_change.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Boldizsár Lipka <lipkab@zoho.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/depcheck_confirm_change.hpp
+++ b/src/gui/dialogs/depcheck_confirm_change.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Boldizsár Lipka <lipkab@zoho.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/depcheck_select_new.cpp
+++ b/src/gui/dialogs/depcheck_select_new.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Boldizsár Lipka <lipkab@zoho.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/depcheck_select_new.hpp
+++ b/src/gui/dialogs/depcheck_select_new.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Boldizsár Lipka <lipkab@zoho.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/drop_down_menu.hpp
+++ b/src/gui/dialogs/drop_down_menu.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/edit_label.cpp
+++ b/src/gui/dialogs/edit_label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/edit_label.hpp
+++ b/src/gui/dialogs/edit_label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/edit_text.cpp
+++ b/src/gui/dialogs/edit_text.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/edit_text.hpp
+++ b/src/gui/dialogs/edit_text.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/custom_tod.hpp
+++ b/src/gui/dialogs/editor/custom_tod.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/edit_label.cpp
+++ b/src/gui/dialogs/editor/edit_label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Müller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/edit_label.hpp
+++ b/src/gui/dialogs/editor/edit_label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/edit_scenario.cpp
+++ b/src/gui/dialogs/editor/edit_scenario.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Müller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/edit_scenario.hpp
+++ b/src/gui/dialogs/editor/edit_scenario.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Müller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/edit_side.cpp
+++ b/src/gui/dialogs/editor/edit_side.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Müller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/edit_side.hpp
+++ b/src/gui/dialogs/editor/edit_side.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Müller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/generate_map.cpp
+++ b/src/gui/dialogs/editor/generate_map.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/generate_map.hpp
+++ b/src/gui/dialogs/editor/generate_map.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/new_map.cpp
+++ b/src/gui/dialogs/editor/new_map.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/new_map.hpp
+++ b/src/gui/dialogs/editor/new_map.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/resize_map.cpp
+++ b/src/gui/dialogs/editor/resize_map.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/editor/resize_map.hpp
+++ b/src/gui/dialogs/editor/resize_map.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/file_dialog.cpp
+++ b/src/gui/dialogs/file_dialog.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/file_dialog.hpp
+++ b/src/gui/dialogs/file_dialog.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/folder_create.cpp
+++ b/src/gui/dialogs/folder_create.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/folder_create.hpp
+++ b/src/gui/dialogs/folder_create.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/formula_debugger.cpp
+++ b/src/gui/dialogs/formula_debugger.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/formula_debugger.hpp
+++ b/src/gui/dialogs/formula_debugger.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_cache_options.cpp
+++ b/src/gui/dialogs/game_cache_options.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_cache_options.hpp
+++ b/src/gui/dialogs/game_cache_options.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_delete.cpp
+++ b/src/gui/dialogs/game_delete.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_delete.hpp
+++ b/src/gui/dialogs/game_delete.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_save.cpp
+++ b/src/gui/dialogs/game_save.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_save.hpp
+++ b/src/gui/dialogs/game_save.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_version_dialog.cpp
+++ b/src/gui/dialogs/game_version_dialog.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/game_version_dialog.hpp
+++ b/src/gui/dialogs/game_version_dialog.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/gamestate_inspector.hpp
+++ b/src/gui/dialogs/gamestate_inspector.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/help_browser.cpp
+++ b/src/gui/dialogs/help_browser.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Charles Dang <exodia339@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/help_browser.hpp
+++ b/src/gui/dialogs/help_browser.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Charles Dang <exodia339@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/language_selection.hpp
+++ b/src/gui/dialogs/language_selection.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/lua_interpreter.hpp
+++ b/src/gui/dialogs/lua_interpreter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/message.cpp
+++ b/src/gui/dialogs/message.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/message.hpp
+++ b/src/gui/dialogs/message.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/modal_dialog.hpp
+++ b/src/gui/dialogs/modal_dialog.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/modeless_dialog.cpp
+++ b/src/gui/dialogs/modeless_dialog.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/modeless_dialog.hpp
+++ b/src/gui/dialogs/modeless_dialog.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_alerts_options.cpp
+++ b/src/gui/dialogs/multiplayer/mp_alerts_options.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_alerts_options.hpp
+++ b/src/gui/dialogs/multiplayer/mp_alerts_options.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_change_control.cpp
+++ b/src/gui/dialogs/multiplayer/mp_change_control.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Lukasz Dobrogowski <lukasz.dobrogowski@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_change_control.hpp
+++ b/src/gui/dialogs/multiplayer/mp_change_control.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Lukasz Dobrogowski <lukasz.dobrogowski@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_connect.cpp
+++ b/src/gui/dialogs/multiplayer/mp_connect.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_connect.hpp
+++ b/src/gui/dialogs/multiplayer/mp_connect.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_host_game_prompt.cpp
+++ b/src/gui/dialogs/multiplayer/mp_host_game_prompt.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2008 - 2021
+	Copyright (C) 2012 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2008 - 2018 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_host_game_prompt.hpp
+++ b/src/gui/dialogs/multiplayer/mp_host_game_prompt.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2008 - 2021
+	Copyright (C) 2012 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2008 - 2018 by Jörg Hinrichs <joerg.hinrichs@alice-dsl.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_join_game_password_prompt.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game_password_prompt.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_join_game_password_prompt.hpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game_password_prompt.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_login.cpp
+++ b/src/gui/dialogs/multiplayer/mp_login.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_login.hpp
+++ b/src/gui/dialogs/multiplayer/mp_login.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_method_selection.cpp
+++ b/src/gui/dialogs/multiplayer/mp_method_selection.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/mp_method_selection.hpp
+++ b/src/gui/dialogs/multiplayer/mp_method_selection.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/player_info.cpp
+++ b/src/gui/dialogs/multiplayer/player_info.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/player_info.hpp
+++ b/src/gui/dialogs/multiplayer/player_info.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/synced_choice_wait.cpp
+++ b/src/gui/dialogs/multiplayer/synced_choice_wait.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/multiplayer/synced_choice_wait.hpp
+++ b/src/gui/dialogs/multiplayer/synced_choice_wait.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/outro.cpp
+++ b/src/gui/dialogs/outro.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Charles Dang <exodia339@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/outro.hpp
+++ b/src/gui/dialogs/outro.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Charles Dang <exodia339@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Charles Dang <exodia339gmail.com>
+	Copyright (C) 2011, 2015 by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Charles Dang <exodia339gmail.com>
+	Copyright (C) 2011, 2015 by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/screenshot_notification.cpp
+++ b/src/gui/dialogs/screenshot_notification.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/screenshot_notification.hpp
+++ b/src/gui/dialogs/screenshot_notification.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/simple_item_selector.cpp
+++ b/src/gui/dialogs/simple_item_selector.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/simple_item_selector.hpp
+++ b/src/gui/dialogs/simple_item_selector.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/story_viewer.cpp
+++ b/src/gui/dialogs/story_viewer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Charles Dang <exodia339@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/story_viewer.hpp
+++ b/src/gui/dialogs/story_viewer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Charles Dang <exodia339@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/surrender_quit.cpp
+++ b/src/gui/dialogs/surrender_quit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Amir Hassan <amir@viel-zu.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/surrender_quit.hpp
+++ b/src/gui/dialogs/surrender_quit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by Amir Hassan <amir@viel-zu.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/theme_list.cpp
+++ b/src/gui/dialogs/theme_list.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/theme_list.hpp
+++ b/src/gui/dialogs/theme_list.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/tooltip.cpp
+++ b/src/gui/dialogs/tooltip.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/tooltip.hpp
+++ b/src/gui/dialogs/tooltip.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/transient_message.cpp
+++ b/src/gui/dialogs/transient_message.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/transient_message.hpp
+++ b/src/gui/dialogs/transient_message.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/unit_attack.cpp
+++ b/src/gui/dialogs/unit_attack.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/unit_attack.hpp
+++ b/src/gui/dialogs/unit_attack.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/unit_create.hpp
+++ b/src/gui/dialogs/unit_create.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/wml_error.cpp
+++ b/src/gui/dialogs/wml_error.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/wml_error.hpp
+++ b/src/gui/dialogs/wml_error.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/wml_message.cpp
+++ b/src/gui/dialogs/wml_message.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/dialogs/wml_message.hpp
+++ b/src/gui/dialogs/wml_message.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/button.cpp
+++ b/src/gui/widgets/button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/button.hpp
+++ b/src/gui/widgets/button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/clickable_item.hpp
+++ b/src/gui/widgets/clickable_item.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/container_base.cpp
+++ b/src/gui/widgets/container_base.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/container_base.hpp
+++ b/src/gui/widgets/container_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/debug.cpp
+++ b/src/gui/widgets/debug.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/debug.hpp
+++ b/src/gui/widgets/debug.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/drawing.cpp
+++ b/src/gui/widgets/drawing.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/drawing.hpp
+++ b/src/gui/widgets/drawing.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/event_executor.hpp
+++ b/src/gui/widgets/event_executor.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/generator.cpp
+++ b/src/gui/widgets/generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/generator.hpp
+++ b/src/gui/widgets/generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/generator_private.hpp
+++ b/src/gui/widgets/generator_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/grid_private.hpp
+++ b/src/gui/widgets/grid_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/helper.cpp
+++ b/src/gui/widgets/helper.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/helper.hpp
+++ b/src/gui/widgets/helper.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/horizontal_scrollbar.cpp
+++ b/src/gui/widgets/horizontal_scrollbar.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/horizontal_scrollbar.hpp
+++ b/src/gui/widgets/horizontal_scrollbar.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/image.cpp
+++ b/src/gui/widgets/image.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/image.hpp
+++ b/src/gui/widgets/image.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/integer_selector.hpp
+++ b/src/gui/widgets/integer_selector.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/label.hpp
+++ b/src/gui/widgets/label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/matrix.cpp
+++ b/src/gui/widgets/matrix.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/matrix.hpp
+++ b/src/gui/widgets/matrix.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/menu_button.hpp
+++ b/src/gui/widgets/menu_button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/multi_page.cpp
+++ b/src/gui/widgets/multi_page.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/multimenu_button.cpp
+++ b/src/gui/widgets/multimenu_button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/multimenu_button.hpp
+++ b/src/gui/widgets/multimenu_button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/pane.cpp
+++ b/src/gui/widgets/pane.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/pane.hpp
+++ b/src/gui/widgets/pane.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/password_box.cpp
+++ b/src/gui/widgets/password_box.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>, Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/password_box.hpp
+++ b/src/gui/widgets/password_box.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>, Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/progress_bar.cpp
+++ b/src/gui/widgets/progress_bar.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/progress_bar.hpp
+++ b/src/gui/widgets/progress_bar.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/repeating_button.cpp
+++ b/src/gui/widgets/repeating_button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/repeating_button.hpp
+++ b/src/gui/widgets/repeating_button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/retval.hpp
+++ b/src/gui/widgets/retval.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scroll_label.cpp
+++ b/src/gui/widgets/scroll_label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scroll_label.hpp
+++ b/src/gui/widgets/scroll_label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar.cpp
+++ b/src/gui/widgets/scrollbar.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar.hpp
+++ b/src/gui/widgets/scrollbar.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar_container_private.hpp
+++ b/src/gui/widgets/scrollbar_container_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar_panel.cpp
+++ b/src/gui/widgets/scrollbar_panel.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/scrollbar_panel.hpp
+++ b/src/gui/widgets/scrollbar_panel.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/selectable_item.hpp
+++ b/src/gui/widgets/selectable_item.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/settings.hpp
+++ b/src/gui/widgets/settings.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/size_lock.cpp
+++ b/src/gui/widgets/size_lock.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/size_lock.hpp
+++ b/src/gui/widgets/size_lock.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/slider.hpp
+++ b/src/gui/widgets/slider.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/slider_base.cpp
+++ b/src/gui/widgets/slider_base.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/slider_base.hpp
+++ b/src/gui/widgets/slider_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/stacked_widget.cpp
+++ b/src/gui/widgets/stacked_widget.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/stacked_widget.hpp
+++ b/src/gui/widgets/stacked_widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/toggle_button.hpp
+++ b/src/gui/widgets/toggle_button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/vertical_scrollbar.cpp
+++ b/src/gui/widgets/vertical_scrollbar.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/vertical_scrollbar.hpp
+++ b/src/gui/widgets/vertical_scrollbar.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/viewport.cpp
+++ b/src/gui/widgets/viewport.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/viewport.hpp
+++ b/src/gui/widgets/viewport.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/widget_helpers.cpp
+++ b/src/gui/widgets/widget_helpers.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/widget_helpers.hpp
+++ b/src/gui/widgets/widget_helpers.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/gui/widgets/window_private.hpp
+++ b/src/gui/widgets/window_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hash.hpp
+++ b/src/hash.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_browser.cpp
+++ b/src/help/help_browser.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_browser.hpp
+++ b/src/help/help_browser.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_impl.hpp
+++ b/src/help/help_impl.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_menu.cpp
+++ b/src/help/help_menu.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_menu.hpp
+++ b/src/help/help_menu.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_text_area.hpp
+++ b/src/help/help_text_area.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/help/help_topic_generators.hpp
+++ b/src/help/help_topic_generators.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/command_executor.hpp
+++ b/src/hotkey/command_executor.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_command.hpp
+++ b/src/hotkey/hotkey_command.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_handler.hpp
+++ b/src/hotkey/hotkey_handler.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_handler_mp.cpp
+++ b/src/hotkey/hotkey_handler_mp.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_handler_mp.hpp
+++ b/src/hotkey/hotkey_handler_mp.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_handler_sp.cpp
+++ b/src/hotkey/hotkey_handler_sp.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_handler_sp.hpp
+++ b/src/hotkey/hotkey_handler_sp.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_manager.cpp
+++ b/src/hotkey/hotkey_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/hotkey/hotkey_manager.hpp
+++ b/src/hotkey/hotkey_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/key.hpp
+++ b/src/key.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/libc_error.hpp
+++ b/src/libc_error.hpp
@@ -1,15 +1,9 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
-	This program is free software; you can redistribute it and/or modify
-	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; either version 2 of the License, or
-	(at your option) any later version.
-	This program is distributed in the hope that it will be useful,
-	but WITHOUT ANY WARRANTY.
-
-	See the COPYING file for more details.
+	The contents of this file are placed in the public domain.
 */
 
 #pragma once

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/log_windows.cpp
+++ b/src/log_windows.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/log_windows.hpp
+++ b/src/log_windows.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/lua_jailbreak_exception.cpp
+++ b/src/lua_jailbreak_exception.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/lua_jailbreak_exception.hpp
+++ b/src/lua_jailbreak_exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/exception.hpp
+++ b/src/map/exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/label.cpp
+++ b/src/map/label.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/label.hpp
+++ b/src/map/label.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/location.cpp
+++ b/src/map/location.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/location.hpp
+++ b/src/map/location.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map_settings.cpp
+++ b/src/map_settings.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/map_settings.hpp
+++ b/src/map_settings.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/minimap.hpp
+++ b/src/minimap.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mouse_handler_base.hpp
+++ b/src/mouse_handler_base.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/movetype.hpp
+++ b/src/movetype.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mp_game_settings.cpp
+++ b/src/mp_game_settings.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mp_ui_alerts.cpp
+++ b/src/mp_ui_alerts.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mp_ui_alerts.hpp
+++ b/src/mp_ui_alerts.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mt_rng.cpp
+++ b/src/mt_rng.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/mt_rng.hpp
+++ b/src/mt_rng.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/multiplayer_error_codes.hpp
+++ b/src/multiplayer_error_codes.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/network_asio.cpp
+++ b/src/network_asio.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/network_asio.hpp
+++ b/src/network_asio.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathfind/astarsearch.cpp
+++ b/src/pathfind/astarsearch.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathfind/pathfind.cpp
+++ b/src/pathfind/pathfind.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathfind/pathfind.hpp
+++ b/src/pathfind/pathfind.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathfind/teleport.hpp
+++ b/src/pathfind/teleport.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Fabian Mueller <fabianmueller5@gmx.de>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathutils.cpp
+++ b/src/pathutils.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/pathutils.hpp
+++ b/src/pathutils.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/persist_context.cpp
+++ b/src/persist_context.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Jody Northup
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/persist_context.hpp
+++ b/src/persist_context.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Jody Northup
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/persist_manager.cpp
+++ b/src/persist_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Jody Northup
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/persist_manager.hpp
+++ b/src/persist_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Jody Northup
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/persist_var.cpp
+++ b/src/persist_var.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Jody Northup
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/persist_var.hpp
+++ b/src/persist_var.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Jody Northup
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/playmp_controller.hpp
+++ b/src/playmp_controller.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2006 - 2021
+	by Joerg Hinrichs <joerg.hinrichs@alice-dsl.de>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/playturn.hpp
+++ b/src/playturn.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/display.cpp
+++ b/src/preferences/display.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/display.hpp
+++ b/src/preferences/display.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/editor.cpp
+++ b/src/preferences/editor.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/editor.hpp
+++ b/src/preferences/editor.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/game.hpp
+++ b/src/preferences/game.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/lobby.cpp
+++ b/src/preferences/lobby.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/preferences/lobby.hpp
+++ b/src/preferences/lobby.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/random_deterministic.cpp
+++ b/src/random_deterministic.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/random_deterministic.hpp
+++ b/src/random_deterministic.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/random_synced.cpp
+++ b/src/random_synced.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/random_synced.hpp
+++ b/src/random_synced.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/recall_list_manager.cpp
+++ b/src/recall_list_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/recall_list_manager.hpp
+++ b/src/recall_list_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/replay.hpp
+++ b/src/replay.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/replay_helper.cpp
+++ b/src/replay_helper.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/replay_helper.hpp
+++ b/src/replay_helper.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/reports.hpp
+++ b/src/reports.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/resources.hpp
+++ b/src/resources.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/save_blocker.cpp
+++ b/src/save_blocker.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Daniel Franke
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/save_blocker.hpp
+++ b/src/save_blocker.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Daniel Franke
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Jörg Hinrichs, David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/save_index.hpp
+++ b/src/save_index.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Jörg Hinrichs, David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Jörg Hinrichs, David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Jörg Hinrichs, David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/application_lua_kernel.hpp
+++ b/src/scripting/application_lua_kernel.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/debug_lua.cpp
+++ b/src/scripting/debug_lua.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/debug_lua.hpp
+++ b/src/scripting/debug_lua.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_common.cpp
+++ b/src/scripting/lua_common.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_common.hpp
+++ b/src/scripting/lua_common.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_cpp_function.cpp
+++ b/src/scripting/lua_cpp_function.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_cpp_function.hpp
+++ b/src/scripting/lua_cpp_function.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_fileops.cpp
+++ b/src/scripting/lua_fileops.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_fileops.hpp
+++ b/src/scripting/lua_fileops.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_gui2.hpp
+++ b/src/scripting/lua_gui2.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_kernel_base.hpp
+++ b/src/scripting/lua_kernel_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_map_location_ops.cpp
+++ b/src/scripting/lua_map_location_ops.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_map_location_ops.hpp
+++ b/src/scripting/lua_map_location_ops.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_preferences.cpp
+++ b/src/scripting/lua_preferences.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_preferences.hpp
+++ b/src/scripting/lua_preferences.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_race.cpp
+++ b/src/scripting/lua_race.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_race.hpp
+++ b/src/scripting/lua_race.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_rng.cpp
+++ b/src/scripting/lua_rng.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_rng.hpp
+++ b/src/scripting/lua_rng.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_stringx.cpp
+++ b/src/scripting/lua_stringx.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_stringx.hpp
+++ b/src/scripting/lua_stringx.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_team.cpp
+++ b/src/scripting/lua_team.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_team.hpp
+++ b/src/scripting/lua_team.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_unit.hpp
+++ b/src/scripting/lua_unit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_unit_attacks.hpp
+++ b/src/scripting/lua_unit_attacks.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_unit_type.hpp
+++ b/src/scripting/lua_unit_type.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_widget.cpp
+++ b/src/scripting/lua_widget.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_widget.hpp
+++ b/src/scripting/lua_widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_widget_attributes.hpp
+++ b/src/scripting/lua_widget_attributes.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_wml.cpp
+++ b/src/scripting/lua_wml.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/lua_wml.hpp
+++ b/src/scripting/lua_wml.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/mapgen_lua_kernel.cpp
+++ b/src/scripting/mapgen_lua_kernel.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/mapgen_lua_kernel.hpp
+++ b/src/scripting/mapgen_lua_kernel.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/plugins/context.cpp
+++ b/src/scripting/plugins/context.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/plugins/context.hpp
+++ b/src/scripting/plugins/context.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/plugins/manager.cpp
+++ b/src/scripting/plugins/manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/scripting/plugins/manager.hpp
+++ b/src/scripting/plugins/manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/exception.cpp
+++ b/src/sdl/exception.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/exception.hpp
+++ b/src/sdl/exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/point.cpp
+++ b/src/sdl/point.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/point.hpp
+++ b/src/sdl/point.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sdl/window.hpp
+++ b/src/sdl/window.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/seed_rng.cpp
+++ b/src/seed_rng.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/seed_rng.hpp
+++ b/src/seed_rng.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/base64.cpp
+++ b/src/serialization/base64.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/base64.hpp
+++ b/src/serialization/base64.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/binary_or_text.cpp
+++ b/src/serialization/binary_or_text.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/binary_or_text.hpp
+++ b/src/serialization/binary_or_text.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/compression.hpp
+++ b/src/serialization/compression.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/parser.cpp
+++ b/src/serialization/parser.cpp
@@ -1,5 +1,8 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2005 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/parser.hpp
+++ b/src/serialization/parser.hpp
@@ -1,5 +1,8 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2005 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema/key.cpp
+++ b/src/serialization/schema/key.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema/key.hpp
+++ b/src/serialization/schema/key.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema/tag.cpp
+++ b/src/serialization/schema/tag.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema/tag.hpp
+++ b/src/serialization/schema/tag.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema/type.cpp
+++ b/src/serialization/schema/type.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema/type.hpp
+++ b/src/serialization/schema/type.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema_validator.cpp
+++ b/src/serialization/schema_validator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/schema_validator.hpp
+++ b/src/serialization/schema_validator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -1,5 +1,8 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2005 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/string_utils.hpp
+++ b/src/serialization/string_utils.hpp
@@ -1,5 +1,8 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2005 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/tokenizer.cpp
+++ b/src/serialization/tokenizer.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2004 - 2021
+	Copyright (C) 2010 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2004 - 2009 by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/tokenizer.hpp
+++ b/src/serialization/tokenizer.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2004 - 2021
+	Copyright (C) 2010 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2004 - 2009 by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/ucs4_convert_impl.hpp
+++ b/src/serialization/ucs4_convert_impl.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/ucs4_iterator_base.hpp
+++ b/src/serialization/ucs4_iterator_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2017 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/unicode.cpp
+++ b/src/serialization/unicode.cpp
@@ -1,5 +1,8 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2005 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/unicode.hpp
+++ b/src/serialization/unicode.hpp
@@ -1,5 +1,8 @@
 /*
 	Copyright (C) 2003 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2005 by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/unicode_cast.hpp
+++ b/src/serialization/unicode_cast.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/utf8_exception.hpp
+++ b/src/serialization/utf8_exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/validator.cpp
+++ b/src/serialization/validator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/serialization/validator.hpp
+++ b/src/serialization/validator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sytyi Nick <nsytyi@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/addon_utils.cpp
+++ b/src/server/campaignd/addon_utils.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
+	Copyright (C) 2013 - 2015 by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/addon_utils.hpp
+++ b/src/server/campaignd/addon_utils.hpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
+	Copyright (C) 2013 - 2015 by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/auth.cpp
+++ b/src/server/campaignd/auth.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/auth.hpp
+++ b/src/server/campaignd/auth.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/blacklist.cpp
+++ b/src/server/campaignd/blacklist.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/blacklist.hpp
+++ b/src/server/campaignd/blacklist.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/control.hpp
+++ b/src/server/campaignd/control.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/fs_commit.cpp
+++ b/src/server/campaignd/fs_commit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/fs_commit.hpp
+++ b/src/server/campaignd/fs_commit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/options.cpp
+++ b/src/server/campaignd/options.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/options.hpp
+++ b/src/server/campaignd/options.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2018 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
+	Copyright (C) 2003 - 2018 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Sergey Popov <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Sergey Popov <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/simple_wml.cpp
+++ b/src/server/common/simple_wml.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/simple_wml.hpp
+++ b/src/server/common/simple_wml.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Thomas Baumhauer <thomas.baumhauer@NOSPAMgmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/ban.cpp
+++ b/src/server/wesnothd/ban.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/ban.hpp
+++ b/src/server/wesnothd/ban.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/metrics.cpp
+++ b/src/server/wesnothd/metrics.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/metrics.hpp
+++ b/src/server/wesnothd/metrics.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/player.cpp
+++ b/src/server/wesnothd/player.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/player.hpp
+++ b/src/server/wesnothd/player.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/player_connection.cpp
+++ b/src/server/wesnothd/player_connection.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/player_connection.hpp
+++ b/src/server/wesnothd/player_connection.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/player_network.cpp
+++ b/src/server/wesnothd/player_network.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>, Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/player_network.hpp
+++ b/src/server/wesnothd/player_network.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>, Tomasz Sniatowski <kailoran@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/show_dialog.hpp
+++ b/src/show_dialog.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/side_filter.hpp
+++ b/src/side_filter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Yurii Chernyi <terraninfo@terraninfo.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sound_music_track.cpp
+++ b/src/sound_music_track.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>, Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/sound_music_track.hpp
+++ b/src/sound_music_track.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>, Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Karol Nowak <grzywacz@sul.uni.lodz.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/soundsource.hpp
+++ b/src/soundsource.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Karol Nowak <grzywacz@sul.uni.lodz.pl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/statistics.cpp
+++ b/src/statistics.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/storyscreen/controller.cpp
+++ b/src/storyscreen/controller.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>, Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/storyscreen/controller.hpp
+++ b/src/storyscreen/controller.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/storyscreen/parser.cpp
+++ b/src/storyscreen/parser.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/storyscreen/parser.hpp
+++ b/src/storyscreen/parser.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/storyscreen/part.cpp
+++ b/src/storyscreen/part.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/storyscreen/part.hpp
+++ b/src/storyscreen/part.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/synced_checkup.cpp
+++ b/src/synced_checkup.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/synced_checkup.hpp
+++ b/src/synced_checkup.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/synced_commands.hpp
+++ b/src/synced_commands.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/synced_context.cpp
+++ b/src/synced_context.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/synced_context.hpp
+++ b/src/synced_context.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/syncmp_handler.cpp
+++ b/src/syncmp_handler.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/syncmp_handler.hpp
+++ b/src/syncmp_handler.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/teambuilder.cpp
+++ b/src/teambuilder.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/teambuilder.hpp
+++ b/src/teambuilder.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/builder.cpp
+++ b/src/terrain/builder.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/builder.hpp
+++ b/src/terrain/builder.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/filter.hpp
+++ b/src/terrain/filter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/movement.hpp
+++ b/src/terrain/movement.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2018 - 2021
+	by Jyrki Vesterinen <sandgtx@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/terrain.cpp
+++ b/src/terrain/terrain.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/translation.cpp
+++ b/src/terrain/translation.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/translation.hpp
+++ b/src/terrain/translation.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/type_data.cpp
+++ b/src/terrain/type_data.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/terrain/type_data.hpp
+++ b/src/terrain/type_data.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/gui/fire_event.cpp
+++ b/src/tests/gui/fire_event.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/gui/iterator.cpp
+++ b/src/tests/gui/iterator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/gui/visitor.cpp
+++ b/src/tests/gui/visitor.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Karol Nowak <grywacz@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_addons.cpp
+++ b/src/tests/test_addons.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_commandline_options.cpp
+++ b/src/tests/test_commandline_options.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Lukasz Dobrogowski <lukasz.dobrogowski@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_config_cache.cpp
+++ b/src/tests/test_config_cache.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2015 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_formula_ai.cpp
+++ b/src/tests/test_formula_ai.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_formula_function.cpp
+++ b/src/tests/test_formula_function.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_formula_timespan.cpp
+++ b/src/tests/test_formula_timespan.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2019 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Karol Kozub <karol.alt@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_lexical_cast.cpp
+++ b/src/tests/test_lexical_cast.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_make_enum.cpp
+++ b/src/tests/test_make_enum.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_map_location.cpp
+++ b/src/tests/test_map_location.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_mp_connect.cpp
+++ b/src/tests/test_mp_connect.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2013 - 2021
+	by Andrius Silinskas <silinskas.andrius@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_recall_list.cpp
+++ b/src/tests/test_recall_list.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_serialization.cpp
+++ b/src/tests/test_serialization.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Karol Nowak <grywacz@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_team.cpp
+++ b/src/tests/test_team.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Karol Nowak <grywacz@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_unit_map.cpp
+++ b/src/tests/test_unit_map.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_util.cpp
+++ b/src/tests/test_util.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Karol Nowak <grywacz@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_version.cpp
+++ b/src/tests/test_version.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/test_whiteboard_side_actions.cpp
+++ b/src/tests/test_whiteboard_side_actions.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Étienne Simon <etienne.jl.simon@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/auto_parameterized.hpp
+++ b/src/tests/utils/auto_parameterized.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/fake_display.cpp
+++ b/src/tests/utils/fake_display.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/fake_display.hpp
+++ b/src/tests/utils/fake_display.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/game_config_manager_tests.cpp
+++ b/src/tests/utils/game_config_manager_tests.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/game_config_manager_tests.hpp
+++ b/src/tests/utils/game_config_manager_tests.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by Pauli Nieminen <paniemin@cc.hut.fi>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/wml_equivalence.cpp
+++ b/src/tests/utils/wml_equivalence.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by CrawlCycle <73139676+CrawlCycle@users.noreply.github.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/utils/wml_equivalence.hpp
+++ b/src/tests/utils/wml_equivalence.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by CrawlCycle <73139676+CrawlCycle@users.noreply.github.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tests/wml/test_macro_define.cpp
+++ b/src/tests/wml/test_macro_define.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by CrawlCycle <73139676+CrawlCycle@users.noreply.github.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/time_of_day.cpp
+++ b/src/time_of_day.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/time_of_day.hpp
+++ b/src/time_of_day.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tod_manager.cpp
+++ b/src/tod_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Eugen Jiresch
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tod_manager.hpp
+++ b/src/tod_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2009 - 2021
+	by Eugen Jiresch
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tooltips.hpp
+++ b/src/tooltips.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tracer.hpp
+++ b/src/tracer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tstring.cpp
+++ b/src/tstring.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2004 by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/tstring.hpp
+++ b/src/tstring.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Dominic Bolin <dominic.bolin@exong.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Dominic Bolin <dominic.bolin@exong.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Jeremy Rosen <jeremy.rosen@enst-bretagne.fr>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/animation.hpp
+++ b/src/units/animation.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Jeremy Rosen <jeremy.rosen@enst-bretagne.fr>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/drawer.hpp
+++ b/src/units/drawer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/formula_manager.cpp
+++ b/src/units/formula_manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/formula_manager.hpp
+++ b/src/units/formula_manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Jeremy Rosen <jeremy.rosen@enst-bretagne.fr>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/frame.hpp
+++ b/src/units/frame.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Jeremy Rosen <jeremy.rosen@enst-bretagne.fr>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/frame_private.hpp
+++ b/src/units/frame_private.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Jeremy Rosen <jeremy.rosen@enst-bretagne.fr>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/helper.cpp
+++ b/src/units/helper.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/helper.hpp
+++ b/src/units/helper.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/id.cpp
+++ b/src/units/id.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/id.hpp
+++ b/src/units/id.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2008 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/make.cpp
+++ b/src/units/make.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/make.hpp
+++ b/src/units/make.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/map.cpp
+++ b/src/units/map.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2006 - 2021
+	Copyright (C) 2010 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2006 - 2009 by Rusty Russell <rusty@rustcorp.com.au>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/map.hpp
+++ b/src/units/map.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2006 - 2021
+	Copyright (C) 2010 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2006 - 2009 by Rusty Russell <rusty@rustcorp.com.au>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/orb_status.cpp
+++ b/src/units/orb_status.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Steve Cotton <steve@octalot.co.uk>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/orb_status.hpp
+++ b/src/units/orb_status.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Steve Cotton <steve@octalot.co.uk>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/ptr.hpp
+++ b/src/units/ptr.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/race.cpp
+++ b/src/units/race.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/race.hpp
+++ b/src/units/race.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/udisplay.hpp
+++ b/src/units/udisplay.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/const_clone.hpp
+++ b/src/utils/const_clone.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2012 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/context_free_grammar_generator.cpp
+++ b/src/utils/context_free_grammar_generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Ján Dugáček
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/context_free_grammar_generator.hpp
+++ b/src/utils/context_free_grammar_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Ján Dugáček
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/iterable_pair.hpp
+++ b/src/utils/iterable_pair.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/make_enum.cpp
+++ b/src/utils/make_enum.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/make_enum.hpp
+++ b/src/utils/make_enum.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2014 - 2021
+	by Chris Beck <render787@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/markov_generator.cpp
+++ b/src/utils/markov_generator.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/markov_generator.hpp
+++ b/src/utils/markov_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/math.hpp
+++ b/src/utils/math.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/name_generator.hpp
+++ b/src/utils/name_generator.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/name_generator_factory.hpp
+++ b/src/utils/name_generator_factory.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	by Marius Spix
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/optimer.hpp
+++ b/src/utils/optimer.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2020 - 2021
+	by Iris Morelle <shadowm2006@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/parse_network_address.cpp
+++ b/src/utils/parse_network_address.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2019 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/parse_network_address.hpp
+++ b/src/utils/parse_network_address.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2019 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/utils/reference_counter.hpp
+++ b/src/utils/reference_counter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Philippe Plantier <ayin@anathas.org>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/variable.hpp
+++ b/src/variable.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/variable_info.cpp
+++ b/src/variable_info.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/variable_info.hpp
+++ b/src/variable_info.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/variable_info_detail.hpp
+++ b/src/variable_info_detail.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/variable_info_private.hpp
+++ b/src/variable_info_private.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2005 - 2021
+	by Philippe Plantier <ayin@anathas.org>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wesnoth_lua_config.h
+++ b/src/wesnoth_lua_config.h
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2016 - 2021
+	Gregory A Lundberg
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wesnothd_connection.cpp
+++ b/src/wesnothd_connection.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wesnothd_connection_error.hpp
+++ b/src/wesnothd_connection_error.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Sergey Popov <loonycyborg@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/action.cpp
+++ b/src/whiteboard/action.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/action.hpp
+++ b/src/whiteboard/action.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/attack.cpp
+++ b/src/whiteboard/attack.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/attack.hpp
+++ b/src/whiteboard/attack.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/highlighter.cpp
+++ b/src/whiteboard/highlighter.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/highlighter.hpp
+++ b/src/whiteboard/highlighter.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/manager.hpp
+++ b/src/whiteboard/manager.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/mapbuilder.cpp
+++ b/src/whiteboard/mapbuilder.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/mapbuilder.hpp
+++ b/src/whiteboard/mapbuilder.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/move.cpp
+++ b/src/whiteboard/move.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/move.hpp
+++ b/src/whiteboard/move.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/recall.cpp
+++ b/src/whiteboard/recall.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/recall.hpp
+++ b/src/whiteboard/recall.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/recruit.cpp
+++ b/src/whiteboard/recruit.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/recruit.hpp
+++ b/src/whiteboard/recruit.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/side_actions.cpp
+++ b/src/whiteboard/side_actions.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/side_actions.hpp
+++ b/src/whiteboard/side_actions.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/suppose_dead.cpp
+++ b/src/whiteboard/suppose_dead.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Tommy Schmitz
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/suppose_dead.hpp
+++ b/src/whiteboard/suppose_dead.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2011 - 2021
+	by Tommy Schmitz
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/typedefs.hpp
+++ b/src/whiteboard/typedefs.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/utility.cpp
+++ b/src/whiteboard/utility.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/utility.hpp
+++ b/src/whiteboard/utility.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/whiteboard/visitor.hpp
+++ b/src/whiteboard/visitor.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2010 - 2021
+	by Gabriel Morin <gabrielmorin (at) gmail (dot) com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/button.hpp
+++ b/src/widgets/button.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/menu_style.cpp
+++ b/src/widgets/menu_style.cpp
@@ -1,5 +1,7 @@
 /*
 	Copyright (C) 2006 - 2021
+	by Patrick Parker <patrick_x99@hotmail.com>
+	Copyright (C) 2003 - 2005 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/scrollarea.hpp
+++ b/src/widgets/scrollarea.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/scrollbar.hpp
+++ b/src/widgets/scrollbar.hpp
@@ -1,5 +1,7 @@
 /*
-	Copyright (C) 2003 - 2021
+	Copyright (C) 2004 - 2021
+	by Guillaume Melquiond <guillaume.melquiond@gmail.com>
+	Copyright (C) 2003 by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/textbox.hpp
+++ b/src/widgets/textbox.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wml_exception.cpp
+++ b/src/wml_exception.cpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wml_exception.hpp
+++ b/src/wml_exception.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2007 - 2021
+	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify

--- a/src/wml_separators.hpp
+++ b/src/wml_separators.hpp
@@ -1,5 +1,6 @@
 /*
 	Copyright (C) 2003 - 2021
+	by David White <dave@whitevine.net>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
These are mostly useless and outdated/wrong, but apparently it's probably illegal to remove them.