### PR TITLE
Tutorial S01 and SotA: Synchronise calls to gui.show_dialog

### DIFF
--- a/data/campaigns/tutorial/lua/character_selection.lua
+++ b/data/campaigns/tutorial/lua/character_selection.lua
@@ -11,7 +11,10 @@ function wml_actions.select_character()
 	local character_selection_dialog = wml.load "campaigns/tutorial/gui/character_selection.cfg"
 	local dialog_wml = wml.get_child(character_selection_dialog, 'resolution')
 
-	local character = gui.show_dialog(dialog_wml)
+	local result = wesnoth.sync.evaluate_single(function()
+		return { value = gui.show_dialog(dialog_wml) }
+	end)
+	local character = result.value
 	local unit = wml.variables.student_store
 
 	if character == 2 then


### PR DESCRIPTION
Two related bugfixes, put into one PR because, if we find things to change on one, there may be things to change on the other one too. Both will backport cleanly and are already tested on the 1.16 branch.

Tutorial S01: Synchronise the choice of character
---

This avoids showing the dialog during replays, and thus avoids an
OOS if the person watching the replay chooses the other character.

Fixes (on master) #5926.

SotA: Synchronise the zombie recruitment dialog
---
    
This dialog works by setting variables in the postshow function,
so the code had to be moved around to ensure that those variables
were synchronised, not just the return value of the dialog.
    
The message about not having enough gold isn't necessary for the
replay, so that gets moved into the synchronised code too.

Fixes (on master) #5334.