### PR TITLE
[1.16] Tutorial S01 and SotA: Synchronise calls to gui.show_dialog

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie_recruit_dialog.lua
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie_recruit_dialog.lua
@@ -88,12 +88,17 @@ wml.variables["recruitedZombieType"] = "cancel" -- default value
 if zExists==false then
     gui.show_prompt("", _ "There are no corpses available.", "")
 else
-    --TODO: this seems not to be synced.
-    local returned = gui.show_dialog(wml.get_child(zombie_recruit_dialog, 'resolution'), preshow, postshow)
-    if  returned ~= -2 and sides[1].gold  < recruitCost then
-        gui.show_prompt("", _ "You do not have enough gold to recruit that unit", "")
-    elseif returned ~= -2 and (sides[1].gold ) >= recruitCost then
-        wml.variables["recruitedZombieType"] = recruitedType
-        wml.variables["recruitedZombieCost"] = recruitCost
-    end
+    local result = wesnoth.sync.evaluate_single(function()
+        local res = gui.show_dialog(wml.get_child(zombie_recruit_dialog, 'resolution'), preshow, postshow)
+        if res == -2 then
+            return {recruitCost = 0, recruitedType = "cancel"}
+        end
+        if sides[1].gold  < recruitCost then
+            gui.show_prompt("", _ "You do not have enough gold to recruit that unit", "")
+            return {recruitCost = 0, recruitedType = "cancel"}
+        end
+        return {recruitCost = recruitCost, recruitedType = recruitedType}
+    end)
+    wml.variables["recruitedZombieType"] = result.recruitedType
+    wml.variables["recruitedZombieCost"] = result.recruitCost
 end

--- a/data/campaigns/tutorial/lua/character_selection.lua
+++ b/data/campaigns/tutorial/lua/character_selection.lua
@@ -11,7 +11,10 @@ function wml_actions.select_character()
 	local character_selection_dialog = wml.load "campaigns/tutorial/gui/character_selection.cfg"
 	local dialog_wml = wml.get_child(character_selection_dialog, 'resolution')
 
-	local character = gui.show_dialog(dialog_wml)
+	local result = wesnoth.sync.evaluate_single(function()
+		return { value = gui.show_dialog(dialog_wml) }
+	end)
+	local character = result.value
 	local unit = wml.variables.student_store
 
 	if character == 2 then


### PR DESCRIPTION
Backport of #5994. Fixes #5334, fixes #5926.

Cherry-picked cleanly, and (aside from whitespace differences) already tested on 1.16 before opening the PR for master.