### PR TITLE
Tutorial S01: HDPI support

### DIFF
--- a/data/campaigns/tutorial/gui/character_selection.cfg
+++ b/data/campaigns/tutorial/gui/character_selection.cfg
@@ -1,8 +1,6 @@
 #textdomain wesnoth-tutorial
 
 [resolution]
-    maximum_height = 250
-    maximum_width = 400
     [helptip]
         id="tooltip_large"
     [/helptip]

--- a/data/campaigns/tutorial/maps/01_Tutorial_part_1.map
+++ b/data/campaigns/tutorial/maps/01_Tutorial_part_1.map
@@ -10,4 +10,5 @@ Gs^Fds, Gll^Fds, Gg, Gg, Gg, Gg, Gs, Gg, Gg, Gg, Re, Re, Ww, Gg, Gg^Efm, Gs, Gg,
 Gs^Fds, Gll^Fds, Gll^Fds, Gg, Gs, Gg, Gs, Gg, Re, Re, Gg, Gg, Gg, Ww, Ww, Gg, Gg, Gg, Gg, Gg, Gll^Fds, Gll^Fds
 Gs^Fds, Gs^Fms, Gll^Fms, Gs^Fms, Gs^Fds, Gs, Gs, Gs, Re, Gs, Gs, Gg, Gg, Gg, Ww, Gg, Gs, Gs, Gs, Gll^Fds, Gs^Fds, Gs^Fms
 Gs^Fms, Gll^Fds, Gll^Fms, Gs^Fms, Gs^Fds, Gg, Gs, Gg, Re, Gs, Gs, Gg, Gg, Gg, Ww, Gs, Gg, Gg, Gs^Fds, Gs^Fms, Gs^Fms, Gs^Fms
-Gs^Fds, Gs^Fms, Gs^Fds, Gs^Fds, Gs^Fds, Gg, Gg, Re, Gg, Gs, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gg, Gs^Fds, Gs^Fds, Gs^Fds, Gs^Fms
+Gs^Fds, Gs^Fms, Gs^Fds, Gs^Fds, Gs^Fds, Gg, Re, Re, Gg, Gs, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gg, Gs^Fds, Gs^Fds, Gs^Fds, Gs^Fms
+Gs^Fds, Gs^Fms, Gs^Fds, Gs^Fds, Gs^Fds, Gg, Re, Gg^Fet, Gg, Gs, Gg, Gg, Gg^Efm, Gg, Ww, Gg, Gg, Gg, Gs^Fds, Gs^Fds, Gs^Fds, Gs^Fms

--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -1201,7 +1201,7 @@
             blue=0
         [/color_adjust]
 
-        {MOVE_UNIT (id=Delfador) (12,8,8,8) (7,9,10,11)}
+        {MOVE_UNIT (id=Delfador) (12,8,8,8,6) (7,9,10,11,12)}
 
         [scroll_to_unit]
             type=Quintain


### PR DESCRIPTION
Remove the maximum size for the character-select dialog, the window will
automatically choose the minimum size that fits the text.

Extend the map 1 hex south. This means that, if the full map fits on screen,
the horizontal center of the map (where the print statements appear) is between
the keep and the south village, thus their labels don't overlap the print
statements.

This backports cleanly (and has been tested on 1.16), it fixes 2 of the points in #5544.

Placement of `[print]` on HDPI:
![image](https://user-images.githubusercontent.com/101462/127685100-9a250999-cc45-47be-82ab-a7bafc8fa30f.png)

The character selection still looks good in a minimum-sized window:
![image](https://user-images.githubusercontent.com/101462/127684999-26ced045-836a-4830-ab21-d46c949e5318.png)