### PR TITLE
Allow the campaign selection to be bigger on HDPI screens

### DIFF
--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -380,8 +380,8 @@
 		automatic_placement = true
 		vertical_placement = "center"
 		horizontal_placement = "center"
-		maximum_height = 750
-		maximum_width = 1050
+		maximum_height = "(max(750, min({GUI_SCALE_RESOLUTION 750}, screen_height * 4/5)))"
+		maximum_width = "(max(1050, min({GUI_SCALE_RESOLUTION 1050}, screen_width * 4/5)))"
 
 		[linked_group]
 			id = "icon_area"


### PR DESCRIPTION
This doesn't scale the campaign image (and the campaign images are generally
350x350 images anyway), so it looks a bit wrong, but it's a lot more useable
on HDPI than putting a 1050x750 limit on a treeview with a text panel.

Without this change:
![hdpi_old_campaign_selection](https://user-images.githubusercontent.com/101462/127694966-e4dc0aac-6d86-43a8-9c36-12df5451ba4f.jpg)

With this change:
![hdpi_new_campaign_selection_thot](https://user-images.githubusercontent.com/101462/127694962-2e1e4150-d89f-4809-820c-b67a11dc4ff0.jpg)
![hdpi_new_campaign_selection_tutorial](https://user-images.githubusercontent.com/101462/127694965-caf4ebec-78f1-40f7-aafb-7e5573441e36.jpg)
