### PR TITLE
Update Dirkfang.cfg

### DIFF
--- a/data/core/units/nagas/Dirkfang.cfg
+++ b/data/core/units/nagas/Dirkfang.cfg
@@ -63,6 +63,7 @@
         [/filter_attack]
         start_time=-800
         missile_start_time=-150
+        sound_start_time=-150
         [if]
             hits=yes
             [missile_frame]
@@ -72,8 +73,10 @@
             [/missile_frame]
             [frame]
                 image="units/nagas/dirkfang-throw[1~10].png:[90,100,120,150,150,100,100,130,130,120]"
-                sound=throwing-knife.ogg
             [/frame]
+            [sound_frame]
+                sound=throwing-knife.ogg
+            [/sound_frame]
         [/if]
         [else]
             hits=no
@@ -86,8 +89,10 @@
             [/missile_frame]
             [frame]
                 image="units/nagas/dirkfang-throw[1~10].png:[90,100,120,150,150,100,100,130,130,120]"
-                sound=throwing-knife-miss.ogg
             [/frame]
+            [sound_frame]
+                sound=throwing-knife-miss.ogg
+            [/sound_frame]
         [/else]
     [/attack_anim]
     [female]


### PR DESCRIPTION
Sound plays at -800 long before the missile anim begins and ends. I believe this should fix it to play at the correct time.