### PR TITLE
Add a new months tip to the main menu

### DIFF
--- a/data/tips.cfg
+++ b/data/tips.cfg
@@ -272,6 +272,24 @@
     text= _ "Did you know that you can change the difficulty level during a campaign? Select the <i>Change difficulty</i> option at the bottom of the <i>Load Game</i> screen when loading start-of-scenario save files."
     source= _ "<i>― The Wesnoth Tactical Guide</i>"
 [/tip]
+[tip]
+    # po: Each year in the Wesnoth calendar is composed of 12 months. These are, in order:
+    # po: January - Whitefire
+    # po: February - Bleeding Moon
+    # po: March - Scatterseed
+    # po: April - Deeproot
+    # po: May - Scryer's Bloom
+    # po: June - Thorntress
+    # po: July - Summit Star
+    # po: August - Kindlefire
+    # po: September - Stillseed
+    # po: October - Reaper's Moon
+    # po: November - Verglas Bloom
+    # po: December - Blackfire
+    # po: See also Wesnoth's in-game encyclopedia and Liberty for reference
+    text= _ "It starts with shiny Whitefire then darkens into Bleeding Moon. Scatterseed and Deeproot is when we care of our future food. The weeded growth in Scryer’s Bloom and Thorntress will thrive in Summit Star. In Kindlefire chills come amid the warmth. We harvest what the land gave us when leaves go red in Stillseed, under Reaper’s Moon and hope we'd have enough to hold the cold of Verglas Bloom and lift the darkness of Blackfire. And then, my son, the year starts all over."
+    source= _ "<i>― Baldras, the magistrate of Dallben, 490 YW</i>"
+[/tip]
 #ifdef __UNUSED__
 [tip]
     text= _ "<i>Feral</i> units, such as Bats and wild animals, will avoid villages. Even if they occupy a village hex, they do not gain any defensive benefits from the village, although they will still be healed."


### PR DESCRIPTION
As quite a few players complained, the new months system in Liberty is pretty confusing. To lessen it a tiny bit I'm proposing to add a some sort of prose explanation to the list of random main menu tips. Both the months naming and the Liberty rework is @nemaara 's territory, so i'd be glad to hear any changes or a rewrite of this note.

Currently, it is a small teaching by Baldras to younger Harper:


_It starts with shiny Whitefire then darkens into Bleeding Moon. Scatterseed and Deeproot is when we care of our future food. The weeded growth in Scryer’s Bloom and Thorntress will thrive in Summit Star. In Kindlefire chills come amid the warmth. We harvest what the land gave us when leaves go red in Stillseed, under Reaper’s Moon and hope we'd have enough to hold the cold of Verglas Bloom and lift the darkness of Blackfire. And then, my son, the year starts all over._

_― Baldras, the magistrate of Dallben, 490 YW_

As for the length, it's few words longer than the longest tip, and shouldn't be a big problem.

If it passes, we can backport it to 1.16.1 when the string freeze ends.