### PR TITLE
[1.16] Allow the campaign selection to be bigger on HDPI screens

### DIFF
--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -380,8 +380,8 @@
 		automatic_placement = true
 		vertical_placement = "center"
 		horizontal_placement = "center"
-		maximum_height = 750
-		maximum_width = 1050
+		maximum_height = "(max(750, min({GUI_SCALE_RESOLUTION 750}, screen_height * 4/5)))"
+		maximum_width = "(max(1050, min({GUI_SCALE_RESOLUTION 1050}, screen_width * 4/5)))"
 
 		[linked_group]
 			id = "icon_area"


### PR DESCRIPTION
This doesn't scale the campaign image (and the campaign images are generally
350x350 images anyway), so it looks a bit wrong, but it's a lot more useable
on HDPI than putting a 1050x750 limit on a treeview with a text panel.

(cherry picked from commit 62a8bad97c89c08f0b96d5f1728e60b3bee7ec34)