### PR TITLE
[world conquest] [master/1.17] Replacement of khalifate unit types with dunefolk unit types

### DIFF
--- a/data/campaigns/World_Conquest/era/factions/The_Gang.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Gang.cfg
@@ -13,7 +13,7 @@
             commanders=Rebels,Northerners
             heroes=Drakes,Undead_All
             deserters=Loyalists,Knalgans,Dune Herbalist
-            deserters_names={STR_HAKIM}+", "+{STR_LOYALISTS}+{STR_AND}+{STR_KNALGAN}
+            deserters_names={STR_DUNE_HERBALIST}+", "+{STR_LOYALISTS}+{STR_AND}+{STR_KNALGAN}
             {WC_II_PAIR "Troll Whelp" "Elvish Fighter"}
             {WC_II_PAIR "Orcish Grunt" "Orcish Grunt"}
             {WC_II_PAIR "Elvish Archer" "Elvish Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Guild.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Guild.cfg
@@ -13,7 +13,7 @@
             commanders=Rebels,Undead
             heroes=Knalgans_All,Northerners_All,Young Ogre
             deserters=Loyalists,Drakes,Dune Soldier
-            deserters_names={STR_ARIF}+", "+{STR_LOYALISTS}+{STR_AND}+{STR_DRAKES}
+            deserters_names={STR_DUNE_SOLDIER}+", "+{STR_LOYALISTS}+{STR_AND}+{STR_DRAKES}
             {WC_II_PAIR "Elvish Fighter" "Elvish Fighter"}
             {WC_II_PAIR "Dark Adept" "Dark Adept"}
             {WC_II_PAIR "Elvish Archer" "Skeleton Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Hand.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Hand.cfg
@@ -14,7 +14,7 @@
             heroes=Undead_All,Rebels_All
             # TODO: this contained 'Dune Piercer' in 1.14
             deserters=Knalgans,Drakes
-            deserters_names={STR_KHAIYAL}+", "+{STR_KNALGAN}+{STR_AND}+{STR_DRAKES}
+            deserters_names={STR_DUNE_RIDER}+", "+{STR_KNALGAN}+{STR_AND}+{STR_DRAKES}
             {WC_II_PAIR "Spearman" "Orcish Grunt"}
             {WC_II_PAIR "Bowman" "Orcish Assassin"}
             {WC_II_PAIR "Mage" "Orcish Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Horde.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Horde.cfg
@@ -13,7 +13,7 @@
             commanders=Drakes,Northerners
             heroes=Undead_All,Loyalists_All
             deserters=Knalgans,Rebels,Dune Rider
-            deserters_names={STR_RAMI}+", "+{STR_KNALGAN}+{STR_AND}+{STR_REBELS}
+            deserters_names={STR_DUNE_RIDER}+", "+{STR_KNALGAN}+{STR_AND}+{STR_REBELS}
             {WC_II_PAIR "Orcish Grunt" "Drake Fighter"}
             {WC_II_PAIR "Orcish Archer" "Drake Burner"}
             {WC_II_PAIR "Orcish Assassin" "Saurian Augur"}

--- a/data/campaigns/World_Conquest/era/factions/The_Militia.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Militia.cfg
@@ -13,7 +13,7 @@
             commanders=Rebels,Knalgans,Thug
             heroes=Northerners_All,Young Ogre,Drakes
             deserters=Undead,Loyalists,Dune Rover
-            deserters_names={STR_JUNDI}+", "+{STR_THE_UNDEAD}+{STR_AND}+{STR_LOYALISTS}
+            deserters_names={STR_DUNE_ROVER}+", "+{STR_THE_UNDEAD}+{STR_AND}+{STR_LOYALISTS}
             {WC_II_PAIR "Dwarvish Fighter" "Elvish Scout"}
             {WC_II_PAIR "Thug" "Elvish Fighter"}
             {WC_II_PAIR "Dwarvish Thunderer" "Elvish Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Trust.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Trust.cfg
@@ -13,7 +13,7 @@
             commanders=Drakes,Knalgans
             heroes=Loyalists_All,Northerners_All,Young Ogre
             deserters=Rebels,Undead,Dune Burner
-            deserters_names={STR_NAFFAT}+", "+{STR_REBELS}+{STR_AND}+{STR_THE_UNDEAD}
+            deserters_names={STR_DUNE_BURNER}+", "+{STR_REBELS}+{STR_AND}+{STR_THE_UNDEAD}
             {WC_II_PAIR "Drake Fighter" "Dwarvish Fighter"}
             {WC_II_PAIR "Drake Burner" "Dwarvish Thunderer"}
             {WC_II_PAIR "Saurian Augur" "Dwarvish Ulfserker"}

--- a/data/campaigns/World_Conquest/era/factions/strings.cfg
+++ b/data/campaigns/World_Conquest/era/factions/strings.cfg
@@ -45,22 +45,19 @@ _"The Empire" #enddef
 #textdomain wesnoth-units
 #################################
 
-#define STR_ARIF
+#define STR_DUNE_SOLDIER
 _ "Dune Soldier" #enddef
 
-#define STR_HAKIM
+#define STR_DUNE_HERBALIST
 _ "Dune Herbalist" #enddef
 
-#define STR_JUNDI
+#define STR_DUNE_ROVER
 _ "Dune Rover" #enddef
 
-#define STR_KHAIYAL
-_ "Dune Piercer" #enddef
-
-#define STR_NAFFAT
+#define STR_DUNE_BURNER
 _ "Dune Burner" #enddef
 
-#define STR_RAMI
+#define STR_DUNE_RIDER
 _ "Dune Rider" #enddef
 
 #define STR_YOUNG_OGRE


### PR DESCRIPTION
```
Arif -> Dune Soldier

Hakim -> Dune Herbalist
Jundi -> Dune Rover

Khaiyal -> Dune Piercer

Naffat -> Dune Burner

Rami -> Dune Rider
```

I have also substituted the "Dune Piercer" with "Dune Rider", since it's a non-existent unit in 1.16 and master.