### PR TITLE
[world conquest] World Conquest Era is only available for the campaign

### DIFF
--- a/data/campaigns/World_Conquest/era/era.cfg
+++ b/data/campaigns/World_Conquest/era/era.cfg
@@ -8,6 +8,10 @@
         id= "{STR_ERA_ID_WC_II}"
         name= {STR_ERA_NAME_WC_II}
         description= {STR_ERA_DESCRIPTION_WC_II}
+
+        allow_scenario=WC_II_1p,WC_II_2p,WC_II_3p
+        hide_help=yes
+
         require_era=no
         # addon_min_version="8.2"
 


### PR DESCRIPTION
Until a proper solution is found for #5228 , this will have to do. It suppresses the appearance of the era in the era selection list for other scenarios, preventing the bug from happening.
Hmm, I guess the [campaign] tag should support the `allow_era=` key in future but for the moment, this will do.

Players can play WC with Default, Default+Dunefolk, Age of Heroes, AOH+Dunefolk and UMC eras for the time being. 