### PR TITLE
Format times in the add-on manager using utils::format_time_summary

### DIFF
--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -956,8 +956,8 @@ static std::string format_addon_time(std::time_t time)
 		std::ostringstream ss;
 
 		const char* format = preferences::use_twelve_hour_clock_format()
-			? "%B %d %Y, %I:%M %p"
-			: "%B %d %Y, %H:%M";
+			? "%Y-%m-%d %I:%M %p"
+			: "%Y-%m-%d %H:%M";
 
 		ss << std::put_time(std::localtime(&time), format);
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -46,6 +46,7 @@
 #include "gui/widgets/text_box.hpp"
 #include "gui/widgets/window.hpp"
 #include "serialization/string_utils.hpp"
+#include "format_time_summary.hpp"
 #include "formula/string_utils.hpp"
 #include "picture.hpp"
 #include "language.hpp"
@@ -952,19 +953,10 @@ void addon_manager::show_help()
 
 static std::string format_addon_time(std::time_t time)
 {
-	if(time) {
-		std::ostringstream ss;
-
-		const char* format = preferences::use_twelve_hour_clock_format()
-			? "%Y-%m-%d %I:%M %p"
-			: "%Y-%m-%d %H:%M";
-
-		ss << std::put_time(std::localtime(&time), format);
-
-		return ss.str();
+	if(!time) {
+		return font::unicode_em_dash;
 	}
-
-	return font::unicode_em_dash;
+	return utils::format_time_summary(time);
 }
 
 void addon_manager::on_addon_select()


### PR DESCRIPTION
As it's a date, this needs to be a translatable string, and one that can be backported to 1.16 (so using a string that's already in 1.16). Possible choices for doing that are:
* using the utils::format_time_summary() function
* using one of the strings already used by the utils::format_time_summary() function
* using the strings from src/save_index.cpp's save_info::format_time_local()

DRAFT: The layout is broken in a way that causes these dates to often get ellipsed. That isn't a new issue introduced by the main (second) commit here, it's already an issue in 873946142fe73f4bf01d758e5cc4ad54182503a1 which will be addressed by @Vultraz's layout changes.