### PR TITLE
Resolve #6019 - allied side not triggering failure condition when sighted

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
  ### Add-ons client
  ### Add-ons server
  ### Campaigns
+   * Liberty
+     * S06: Enforce failure condition for allied team (issue #6019)
  ### Editor
  ### Multiplayer
  ### Lua API

--- a/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
@@ -1204,7 +1204,7 @@ The sun don’t really shine at all in these Grey Woods, but truth be told, I ha
     [event]
         name=sighted
         [filter]
-            side=1
+            side=1,2
         [/filter]
         [filter_second]
             side=4


### PR DESCRIPTION
Issue #6019

Can be back-ported to 1.16 assuming corrections are still allowed at this time.