### PR TITLE
UtBS S09: Reveal the boss of the scenario at the end of part 1

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -1,5 +1,10 @@
 #textdomain wesnoth-utbs
 
+# This scenario happens in three parts:
+# * rescuing the merfolk,
+# * fighting the elvish rebels in the north-east,
+# * fighting the Iron Council in the north-west
+
 [scenario]
     id=09_Blood_is_Thicker_Than_Water
     name= _ "Blood is Thicker than Water"
@@ -659,8 +664,8 @@
             [/have_unit]
             [then]
                 [remove_shroud]
-                    x=20-24
-                    y=21-25
+                    x,y=22,23
+                    radius=2
                     side=1
                 [/remove_shroud]
                 [message]
@@ -1278,6 +1283,29 @@
         [/print]
     [/event]
 
+    # Introduce new necromancer triad member, standing on the mountains of the north-west area. He
+    # appears as part of the events when all cages have either opened or are about to catch fire; in
+    # addition to providing flavor this is a hint about where the final part of this scenario will
+    # be.
+    #
+    # Note: this event expects to be first_time_only=yes (the default). If the player reaches turn
+    # 16 with some merfolk still caged but enough freed to continue then the `turn 16` event fires
+    # the `human_retreat` event, and both of those will `[fire_event]name=enter_hekuba`.
+    [event]
+        name=enter_hekuba
+
+        [remove_shroud]
+            x,y=16,17
+            radius=1
+            side=1
+        [/remove_shroud]
+
+        {NAMED_NOTRAIT_UNIT 4 (Necromancer) 16 17 (Hekuba) ( _ "Hekuba")}
+        [+unit]
+            random_gender=no
+        [/unit]
+    [/event]
+
     [event]
         name=turn 16
 
@@ -1305,50 +1333,17 @@
             id=rescue_wejial
         [/remove_event]
 
-        # To do: add dialogue when merfolk die
+        # Member of the Iron Council watching from the north-west mountains. Assuming that the
+        # player has rescued enough merfolk to avoid immediate defeat, this event will trigger
+        # human_retreat, which will remove the Hekuba spawned here.
+        [fire_event]
+            name=enter_hekuba
+        [/fire_event]
 
-        # remove shroud around human leader
-
-        [if]
-            [have_unit]
-                id=Darius
-            [/have_unit]
-            [then]
-                [remove_shroud]
-                    x=20-24
-                    y=21-25
-                    side=1
-                [/remove_shroud]
-                [message]
-                    speaker=Darius
-                    message= _ "The time has come. On this most holy day, let us sacrifice these infidels unto the Dark Lady. Their suffering shall be a testament to her power and glory!"
-                [/message]
-            [/then]
-            [else]
-                # introduce new necromancer triad member
-
-                [remove_shroud]
-                    x=13-17
-                    y=26-30
-                    side=1
-                [/remove_shroud]
-                {NAMED_NOTRAIT_UNIT 4 (Necromancer) 15 28 (Hekuba) ( _ "Hekuba")}
-                [+unit]
-                    random_gender=no
-                [/unit]
-                [message]
-                    speaker=Hekuba
-                    message= _ "The time has come, my brethren. On this most holy day, let us sacrifice these infidels unto The Dark Lady. Their suffering shall be a testament to her power and glory!"
-                [/message]
-
-                # Hekuba disappears again
-                [kill]
-                    id=Hekuba
-                    animate=no
-                    fire_event=no
-                [/kill]
-            [/else]
-        [/if]
+        [message]
+            speaker=Hekuba
+            message= _ "The time has come, my brethren. On this most holy day, let us sacrifice these infidels unto The Dark Lady. Their suffering shall be a testament to her power and glory!"
+        [/message]
 
         #have screen flash red
 
@@ -1494,8 +1489,8 @@
                     [/have_unit]
                     [then]
                         [remove_shroud]
-                            x=20-24
-                            y=21-25
+                            x,y=22,23
+                            radius=2
                             side=1
                         [/remove_shroud]
                         [message]
@@ -1519,6 +1514,10 @@
     [event]
         name=human_retreat
 
+        [fire_event]
+            name=enter_hekuba
+        [/fire_event]
+
         [if]
             [have_unit]
                 id=Darius
@@ -1537,39 +1536,8 @@
                     variable=stored_Darius
                 [/store_unit]
             [/then]
-            [else]
-                # introduce new necromancer triad member
-
-                [remove_shroud]
-                    x=13-17
-                    y=26-30
-                    side=1
-                [/remove_shroud]
-
-                {NAMED_NOTRAIT_UNIT 4 (Necromancer) 15 28 (Hekuba) ( _ "Hekuba")}
-                [+unit]
-                    random_gender=no
-                [/unit]
-
-                [message]
-                    speaker=Hekuba
-                    message= _ "Curse them! The elves have stolen our offering to the Lady. We will have our vengeance. Keep fighting and execute plan C!"
-                [/message]
-                [kill]
-                    id=Hekuba
-                    animate=no
-                    fire_event=no
-                [/kill]
-                [message]
-                    speaker=Nym
-                    message= _ "Who was that?"
-                [/message]
-                [message]
-                    race=merman
-                    message= _ "That was one of the Iron Triad. Rarely do they leave their sanctuary. They prefer to let their minions do the dirty work."
-                [/message]
-            [/else]
         [/if]
+
         [if]
             [have_unit]
                 id=Zelgant
@@ -1624,6 +1592,49 @@
                 [/store_unit]
             [/then]
         [/if]
+
+        # If Darius is still alive then he'll have said something about plan B or plan C in the
+        # event that fired this one. If not, have Hekuba respond as his generals come in to report.
+        # There's no significance to whether the new plan is "B" or "C".
+        [message]
+            speaker=Hekuba
+            message= _ "Curse them! The elves have stolen our offering to the Lady. We will have our vengeance. Keep fighting and execute plan C!"
+            [show_if]
+                [variable]
+                    name=stored_Darius.length
+                    equals=0
+                [/variable]
+            [/show_if]
+        [/message]
+
+        # Hekuba disappears again
+        [scroll_to_unit]
+            id=Hekuba
+        [/scroll_to_unit]
+        [delay]
+            time=500
+        [/delay]
+        {MOVE_UNIT (id=Hekuba) (17) (15)}
+        [kill]
+            id=Hekuba
+            animate=no
+            fire_event=no
+        [/kill]
+        [message]
+            speaker=Nym
+            # po: Nym is talking about Hekuba, the male necromancer who is the final enemy leader in
+            # the last part of this scenario. This line is at the end of the rescuing-merfolk part,
+            # so far Hekuba has either watched silently (if Darius is still alive), or has said
+            # versions of Darius' lines about the sacrifice.
+            #
+            # Either way, he just walked into the shrouded area in the north-west.
+            message= _ "Who was that?"
+        [/message]
+        [message]
+            race=merman
+            # po: subject is a male necromancer
+            message= _ "That was one of the Iron Triad. Rarely do they leave their sanctuary. They prefer to let their minions do the dirty work."
+        [/message]
     [/event]
 
     # Event 4.5:


### PR DESCRIPTION
Forward-port of #6024, fixes #5540. As it's a forward-port I'm just running the CI.

This foreshadows that the player will need to attack the north-west after
defeating the north-east enemy, which is a bit fairer to anyone playing this
scenario for the first time.

Removes a now-unused string (Darius' pre-sacrifice speech). There are no new
strings here, the others are just being moved around.

For clearing shroud, change to using radius= because clearing a circle looks
better than clearing a square.

There's no significance to whether the new plan is "Plan B" or "Plan C" - back
in Wesnoth 1.10 it seems to have been dependent on whether all the merfolk had
been rescued.

Fixes issue #5540 about Hekuba spawning on a water hex.

(cherry picked from commit 25163c06a258b2a9f4627a1345a83f52447165dd)