### PR TITLE
WC: End the campaign at the end of the final scenario

### DIFF
--- a/data/campaigns/World_Conquest/lua/map/scenario_utils/plot.lua
+++ b/data/campaigns/World_Conquest/lua/map/scenario_utils/plot.lua
@@ -83,6 +83,7 @@ function add_plot(scenario, scenario_num, nplayers)
 			result = "victory",
 			music = "sad.ogg",
 			end_text = _"The End",
+			next_scenario = "",
 		})
 	end
 end


### PR DESCRIPTION
Fixes the campaign part of #5891 (which is the main part of that bug).