### PR TITLE
UtBS S02: Don't move Nym if she's already adjacent to the bottle

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -722,7 +722,25 @@
             message=_"Hey! Look there, they dropped something... A stone bottle, sealed. I wonder what’s inside..."
         [/message]
 
-        {MOVE_UNIT id=Nym $x1 $y1}
+        # Move Nym adjacent to the bottle. During a die event, $unit is still blocking the hex, so
+        # Nym probably ends up running to the hex north-west of $x1,$y1.
+        #
+        # Don't move her if she's already adjacent to it - if she landed the killing blow, moving
+        # her now means that she doesn't get the XP. Also, the unit still has ZoC, and she'll take a
+        # longer route to avoid it, which looks particularly obvious if Nym was adjacent the ogre.
+        [if]
+            [not]
+                [have_unit]
+                    id=Nym
+                    [filter_adjacent]
+                        id=$unit.id
+                    [/filter_adjacent]
+                [/have_unit]
+            [/not]
+            [then]
+                {MOVE_UNIT id=Nym $x1 $y1}
+            [/then]
+        [/if]
 
         [message]
             speaker=Zhul


### PR DESCRIPTION
Forward-port of #6048, just doing a CI check before merging. Fixes #6044.

(cherry picked from commit 8919c2e9482b6068db3f16b708628d7c5ba89ecd)