### PR TITLE
[world conquest] [1.16] [lua] Check for wc2_scenario value before executing wc2_start_units function 

### DIFF
--- a/data/campaigns/World_Conquest/lua/campaign/scenario.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/scenario.lua
@@ -66,9 +66,11 @@ end)
 -- NOTE: this is a bit fragile, in particualr it breaks if difficulty_selection happens before the prestart event above.
 on_event("wc2_start", function(cx)
 	for side_num = 1, wml.variables.wc2_player_count do
-		wesnoth.wml_actions.wc2_start_units {
-			side = side_num
-		}
+		if wml.variables.wc2_scenario == 1 then
+			wesnoth.wml_actions.wc2_start_units {
+				side = side_num
+			}
+		end
 	end
 
 	if wml.variables.wc2_difficulty.extra_training then

--- a/data/campaigns/World_Conquest/lua/campaign/scenario.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/scenario.lua
@@ -65,8 +65,8 @@ end)
 -- we need to do this also after difficulty selection.
 -- NOTE: this is a bit fragile, in particualr it breaks if difficulty_selection happens before the prestart event above.
 on_event("wc2_start", function(cx)
-	for side_num = 1, wml.variables.wc2_player_count do
-		if wml.variables.wc2_scenario == 1 then
+	if wml.variables.wc2_scenario == 1 then
+		for side_num = 1, wml.variables.wc2_player_count do
 			wesnoth.wml_actions.wc2_start_units {
 				side = side_num
 			}


### PR DESCRIPTION
What this does is just checks the value of wc2_scenario before executing the function, and executes it for the first scenario only as intended.
Same as #6052, Fixes #5900 for 1.16