### PR TITLE
Fix an off-by-one in mapgen's x and y filters, and add unit tests

### DIFF
--- a/data/test/scenarios/lua_map_find.cfg
+++ b/data/test/scenarios/lua_map_find.cfg
@@ -1,0 +1,35 @@
+#textdomain wesnoth-test
+
+# Tests for the game kernel's version of w.map.find.
+{GENERIC_UNIT_TEST "lua_map_find" (
+    [event]
+        name = start
+        [lua]
+            code = <<
+                local gg_locs = wesnoth.map.find({terrain = "Gg"})
+                unit_test.assert_equal(#gg_locs, 13, "unexpected number of 'Gg' terrains found")
+
+                local gg_kov_locs = wesnoth.map.find({terrain = "Gg^Kov"})
+                unit_test.assert_equal(#gg_kov_locs, 149, "unexpected number of 'Gg^Kov' terrains found")
+
+                -- "keep_locs" and "castle_locs", ignoring that the whole map has the keep overlay
+                local castle_locs = wesnoth.map.find({terrain = "C*^*"})
+                unit_test.assert_equal(#castle_locs, 16, "unexpected number of castle terrains found")
+
+                local keep_locs = wesnoth.map.find({terrain = "K*^*"})
+                unit_test.assert_equal(#keep_locs, 2, "unexpected number of keep terrains found")
+
+                local column_one = wesnoth.map.find({x = 1})
+                unit_test.assert_equal(#column_one, 10, "unexpected map height on odd columns")
+
+                local column_two = wesnoth.map.find({x = 2})
+                unit_test.assert_equal(#column_two, 10, "unexpected map height on even columns")
+
+                local row_one = wesnoth.map.find({y = 1})
+                unit_test.assert_equal(#row_one, 18, "unexpected map width")
+
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/data/test/scenarios/mapgen_filter.cfg
+++ b/data/test/scenarios/mapgen_filter.cfg
@@ -1,0 +1,103 @@
+#textdomain wesnoth-test
+
+# Check that the mapgen kernel's wesnoth.map.filter correctly handles "terrain" values.
+# This will load the generic_unit_test map, change all of the hexes that are between Alice's and
+# Bob's castles to void, and then check that the map looks as expected.
+{GENERIC_UNIT_TEST "mapgen_filter_terrain" (
+    map_generation=lua
+    map_data=""
+    map_file=""
+    [generator]
+        id = "string only shown in error messages (id)"
+        config_name = _ "string only shown in error messages (config_name)"
+        create_map = <<
+            local template_map_data = filesystem.read_file("test/maps/generic_unit_test.map")
+            local map = wesnoth.map.create(template_map_data)
+
+            local filter_hexes_to_change = wesnoth.map.filter(
+                {"any",
+                    {"terrain", "C*^*"},
+                    {"terrain", "K*^*"}
+                }
+            )
+            for i,loc in ipairs(map:find(filter_hexes_to_change)) do
+                map[loc] = "Xv"
+            end
+
+            return map.data
+        >>
+    [/generator]
+
+    # The mechanism used to test the results of the generator is itself tested in lua_map_find.
+    [event]
+        name = start
+        [lua]
+            code = <<
+                local gg_locs = wesnoth.map.find({terrain = "Gg"})
+                unit_test.assert_equal(#gg_locs, 13, "unexpected number of 'Gg' terrains found")
+
+                local gg_kov_locs = wesnoth.map.find({terrain = "Gg^Kov"})
+                unit_test.assert_equal(#gg_kov_locs, 149, "unexpected number of 'Gg^Kov' terrains found")
+
+                local changed_locs = wesnoth.map.find({terrain = "Xv"})
+                unit_test.assert_equal(#changed_locs, 18, "unexpected number of changes found")
+
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}
+
+# Check that the mapgen kernel's wesnoth.map.filter correctly handles "x" and "y" ranges.
+# This will load the generic_unit_test map, change all of the hexes that are between Alice's and
+# Bob's castles to void, and then check that the map looks as expected.
+{GENERIC_UNIT_TEST "mapgen_filter_range" (
+    map_generation=lua
+    map_data=""
+    map_file=""
+    [generator]
+        id = "string only shown in error messages (id)"
+        config_name = _ "string only shown in error messages (config_name)"
+        create_map = <<
+            local template_map_data = filesystem.read_file("test/maps/generic_unit_test.map")
+            local map = wesnoth.map.create(template_map_data)
+
+            local filter_hexes_to_change = wesnoth.map.filter(
+                {"all",
+                    {"x", "8-12"},
+                    {"y", "2-4"}
+                }
+            )
+            for i,loc in ipairs(map:find(filter_hexes_to_change)) do
+                map[loc] = "Xv"
+            end
+
+            return map.data
+        >>
+    [/generator]
+
+    # The mechanism used to test the results of the generator is itself tested in lua_map_find.
+    [event]
+        name = start
+        [lua]
+            code = <<
+                local changed_locs = wesnoth.map.find({terrain = "Xv"})
+                unit_test.assert_equal(#changed_locs, 15, "unexpected number of changes found")
+
+                -- "keep_locs" and "castle_locs", ignoring that the whole map has the keep overlay
+                -- failing on these would suggest the x filter failed
+                local castle_locs = wesnoth.map.find({terrain = "C*^*"})
+                unit_test.assert_equal(#castle_locs, 16, "castles should not have changed")
+
+                local keep_locs = wesnoth.map.find({terrain = "K*^*"})
+                unit_test.assert_equal(#keep_locs, 2, "keeps should not have changed")
+
+                -- failing on these would suggest the y filter failed
+                unit_test.assert_equal(wesnoth.current.map[{10, 1}], "Gg^Kov", "row 1 should not have changed")
+                unit_test.assert_equal(wesnoth.current.map[{10, 5}], "Gg^Kov", "row 5 should not have changed")
+
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/src/scripting/lua_terrainfilter.cpp
+++ b/src/scripting/lua_terrainfilter.cpp
@@ -347,7 +347,8 @@ public:
 	bool matches(const gamemap_base&, map_location l) override
 	{
 		LOG_MATCHES(x);
-		return l.x >= 0 && l.x < int(filter_.size()) && filter_[l.x];
+		const auto value = l.wml_x();
+		return value >= 0 && value < int(filter_.size()) && filter_[value];
 	}
 	dynamic_bitset filter_;
 };
@@ -367,7 +368,8 @@ public:
 	bool matches(const gamemap_base&, map_location l) override
 	{
 		LOG_MATCHES(y);
-		return l.y >= 0 && l.y < int(filter_.size()) && filter_[l.y];
+		const auto value = l.wml_y();
+		return value >= 0 && value < int(filter_.size()) && filter_[value];
 	}
 
 	dynamic_bitset filter_;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -348,3 +348,8 @@
 0 unknown_scenario_false_positives
 0 unknown_scenario_interpolated
 9 unknown_scenario_1_0
+
+# Lua API tests
+0 lua_map_find
+0 mapgen_filter_range
+0 mapgen_filter_terrain


### PR DESCRIPTION
Forward-port of 6055, fixes #5108 and closes #6501 (the question of how to test the mapgen filter).

(cherry picked from commit 30f50bac681fda1566f5cee5aad7be6b65cb0fdb)