### PR TITLE
WC: Add a WC_ prefix to defines with generic names

### DIFF
--- a/data/campaigns/World_Conquest/era/campaign/heroes.cfg
+++ b/data/campaigns/World_Conquest/era/campaign/heroes.cfg
@@ -54,8 +54,8 @@
 #define WORLD_CONQUEST_II_TRAIT_HEROIC
     [trait]
         id=heroic
-        male_name= {STR_HEROIC}
-        female_name= {STR_HEROIC_FEMALE}
+        male_name= {WC_STR_HEROIC}
+        female_name= {WC_STR_HEROIC_FEMALE}
         [effect]
             apply_to=loyal
         [/effect]
@@ -92,8 +92,8 @@
 #define WORLD_CONQUEST_II_TRAIT_EXPERT
     [trait]
         id=expert
-        male_name= {STR_EXPERT}
-        female_name= {STR_EXPERT_FEMALE}
+        male_name= {WC_STR_EXPERT}
+        female_name= {WC_STR_EXPERT_FEMALE}
         [effect]
             apply_to=attack
             range=melee
@@ -109,9 +109,9 @@
 #define WORLD_CONQUEST_II_TRAIT_EPIC
     [trait]
         id=epic
-        male_name= {STR_EPIC}
-        female_name= {STR_EPIC_FEMALE}
-        description= {STR_EPIC_DESCRIPTION}
+        male_name= {WC_STR_EPIC}
+        female_name= {WC_STR_EPIC_FEMALE}
+        description= {WC_STR_EPIC_DESCRIPTION}
         [effect]
             apply_to=hitpoints
             increase_total=6
@@ -162,9 +162,9 @@
 #define WORLD_CONQUEST_II_TRAIT_LEGENDARY_ZOMBIE
     [trait]
         id=legendary_zombie
-        male_name= {STR_LEGENDARY}
-        female_name= {STR_LEGENDARY_FEMALE}
-        description= {STR_LEGENDARY_ZOMBIE_DESCRIPTION}
+        male_name= {WC_STR_LEGENDARY}
+        female_name= {WC_STR_LEGENDARY_FEMALE}
+        description= {WC_STR_LEGENDARY_ZOMBIE_DESCRIPTION}
         [effect]
             apply_to=hitpoints
             increase_total=5
@@ -206,9 +206,9 @@
 #define WORLD_CONQUEST_II_TRAIT_LEGENDARY_GOBLIN
     [trait]
         id=legendary_goblin
-        male_name= {STR_LEGENDARY}
-        female_name= {STR_LEGENDARY_FEMALE}
-        description= {STR_LEGENDARY_GOBLIN_DESCRIPTION}
+        male_name= {WC_STR_LEGENDARY}
+        female_name= {WC_STR_LEGENDARY_FEMALE}
+        description= {WC_STR_LEGENDARY_GOBLIN_DESCRIPTION}
         [effect]
             apply_to=hitpoints
             increase_total=5

--- a/data/campaigns/World_Conquest/era/campaign/strings.cfg
+++ b/data/campaigns/World_Conquest/era/campaign/strings.cfg
@@ -1,34 +1,34 @@
 #textdomain wesnoth-wc
 
-#define STR_HEROIC
+#define WC_STR_HEROIC
 _ "heroic" #enddef
 
-#define STR_HEROIC_FEMALE
+#define WC_STR_HEROIC_FEMALE
 _ "female^heroic" #enddef
 
-#define STR_EXPERT
+#define WC_STR_EXPERT
 _ "expert" #enddef
 
-#define STR_EXPERT_FEMALE
+#define WC_STR_EXPERT_FEMALE
 _ "female^expert" #enddef
 
-#define STR_EPIC
+#define WC_STR_EPIC
 _ "epic" #enddef
 
-#define STR_EPIC_FEMALE
+#define WC_STR_EPIC_FEMALE
 _ "female^epic" #enddef
 
-#define STR_EPIC_DESCRIPTION
+#define WC_STR_EPIC_DESCRIPTION
 _ "Always AMLA with 60 XP and raises maximum health by 6 HP." #enddef
 
-#define STR_LEGENDARY
+#define WC_STR_LEGENDARY
 _ "legendary" #enddef
 
-#define STR_LEGENDARY_FEMALE
+#define WC_STR_LEGENDARY_FEMALE
 _ "female^legendary" #enddef
 
-#define STR_LEGENDARY_ZOMBIE_DESCRIPTION
+#define WC_STR_LEGENDARY_ZOMBIE_DESCRIPTION
 _ "Special advancement to Chocobone enabled." #enddef
 
-#define STR_LEGENDARY_GOBLIN_DESCRIPTION
+#define WC_STR_LEGENDARY_GOBLIN_DESCRIPTION
 _ "Special advancement to Goblin Pillager enabled." #enddef

--- a/data/campaigns/World_Conquest/era/era.cfg
+++ b/data/campaigns/World_Conquest/era/era.cfg
@@ -5,9 +5,9 @@
 
 #define WORLD_CONQUEST_II_ERA
     [era]
-        id= "{STR_ERA_ID_WC_II}"
-        name= {STR_ERA_NAME_WC_II}
-        description= {STR_ERA_DESCRIPTION_WC_II}
+        id= "{WC_STR_ERA_ID_WC_II}"
+        name= {WC_STR_ERA_NAME_WC_II}
+        description= {WC_STR_ERA_DESCRIPTION_WC_II}
 
         allow_scenario=WC_II_1p,WC_II_2p,WC_II_3p
         hide_help=yes

--- a/data/campaigns/World_Conquest/era/factions/The_Alliance.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Alliance.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_ALLIANCE
     [multiplayer_side]
         id=The Alliance
-        name={STR_ALLIANCE}
+        name={WC_STR_ALLIANCE}
         recruit=Spearman, Dwarvish Fighter,Bowman,Poacher,Horseman, Dwarvish Thunderer,Fencer,Thief,Mage,Dwarvish Ulfserker,Heavy Infantryman,Dwarvish Guardsman,Cavalryman,Footpad,Merman Fighter,Gryphon Rider
         image={IMG_ALLIANCE}
         type=random
@@ -13,7 +13,7 @@
             commanders=Loyalists,Knalgans
             heroes=Rebels_All,Drakes
             deserters=Undead,Northerners,Young Ogre
-            deserters_names={STR_YOUNG_OGRE}+", "+{STR_THE_UNDEAD}+{STR_AND}+{STR_NORTHERENS}
+            deserters_names={WC_STR_YOUNG_OGRE}+", "+{WC_STR_THE_UNDEAD}+{WC_STR_AND}+{WC_STR_NORTHERENS}
             {WC_II_PAIR "Spearman" "Dwarvish Fighter"}
             {WC_II_PAIR "Bowman" "Poacher"}
             {WC_II_PAIR "Horseman" "Dwarvish Thunderer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Cult.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Cult.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_CULT
     [multiplayer_side]
         id=The Cult
-        name={STR_CULT}
+        name={WC_STR_CULT}
         recruit=Spearman,Spearman,Skeleton,Skeleton,Bowman,Bowman,Skeleton Archer,Skeleton Archer,Mage,Mage,Dark Adept,Dark Adept,Horseman,Horseman,Ghoul,Ghoul,Fencer,Fencer,Dune Herbalist,Walking Corpse,Heavy Infantryman,Ghost,Cavalryman,Cavalryman,Vampire Bat,Vampire Bat,Merman Fighter,Merman Fighter
         image={IMG_CULT}
         type=random
@@ -13,7 +13,7 @@
             commanders=Loyalists,Undead,Dune Herbalist
             heroes=Rebels_All,Knalgans_All
             deserters=Drakes,Northerners,Young Ogre
-            deserters_names={STR_YOUNG_OGRE}+", "+{STR_DRAKES}+{STR_AND}+{STR_NORTHERENS}
+            deserters_names={WC_STR_YOUNG_OGRE}+", "+{WC_STR_DRAKES}+{WC_STR_AND}+{WC_STR_NORTHERENS}
             {WC_II_PAIR "Spearman" "Spearman"}
             {WC_II_PAIR "Skeleton" "Skeleton"}
             {WC_II_PAIR "Bowman" "Bowman"}

--- a/data/campaigns/World_Conquest/era/factions/The_Empire.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Empire.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_EMPIRE
     [multiplayer_side]
         id=The Empire
-        name={STR_EMPIRE}
+        name={WC_STR_EMPIRE}
         recruit=Dune Rover,Elvish Fighter,Dune Burner,Drake Burner,Dune Soldier,Spearman,Dune Skirmisher,Dwarvish Fighter,Dune Herbalist,Dune Herbalist,Dune Rider,Orcish Archer,Falcon,Vampire Bat
         image={IMG_EMPIRE}
         type=random

--- a/data/campaigns/World_Conquest/era/factions/The_Gang.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Gang.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_GANG
     [multiplayer_side]
         id=The Gang
-        name={STR_GANG}
+        name={WC_STR_GANG}
         recruit=Troll Whelp,Elvish Fighter,Orcish Grunt,Orcish Grunt,Elvish Archer,Elvish Archer,Orcish Archer,Orcish Archer,Elvish Shaman,Elvish Shaman,Orcish Assassin,Orcish Assassin,Wose,Wose,Goblin Spearman,Mage,Wolf Rider,Elvish Scout,Naga Fighter,Merman Hunter
         image={IMG_GANG}
         type=random
@@ -13,7 +13,7 @@
             commanders=Rebels,Northerners
             heroes=Drakes,Undead_All
             deserters=Loyalists,Knalgans,Dune Herbalist
-            deserters_names={STR_DUNE_HERBALIST}+", "+{STR_LOYALISTS}+{STR_AND}+{STR_KNALGAN}
+            deserters_names={WC_STR_DUNE_HERBALIST}+", "+{WC_STR_LOYALISTS}+{WC_STR_AND}+{WC_STR_KNALGAN}
             {WC_II_PAIR "Troll Whelp" "Elvish Fighter"}
             {WC_II_PAIR "Orcish Grunt" "Orcish Grunt"}
             {WC_II_PAIR "Elvish Archer" "Elvish Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Guild.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Guild.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_GUILD
     [multiplayer_side]
         id=The Guild
-        name={STR_GUILD}
+        name={WC_STR_GUILD}
         recruit=Elvish Fighter,Elvish Fighter,Dark Adept,Dark Adept,Elvish Archer,Skeleton Archer,Mage,Walking Corpse,Elvish Shaman,Ghoul,Wose,Skeleton,Elvish Scout,Vampire Bat,Ghost,Ghost,Merman Hunter,Merman Hunter,Mermaid Initiate,Mermaid Initiate
         image={IMG_GUILD}
         type=random
@@ -13,7 +13,7 @@
             commanders=Rebels,Undead
             heroes=Knalgans_All,Northerners_All,Young Ogre
             deserters=Loyalists,Drakes,Dune Soldier
-            deserters_names={STR_DUNE_SOLDIER}+", "+{STR_LOYALISTS}+{STR_AND}+{STR_DRAKES}
+            deserters_names={WC_STR_DUNE_SOLDIER}+", "+{WC_STR_LOYALISTS}+{WC_STR_AND}+{WC_STR_DRAKES}
             {WC_II_PAIR "Elvish Fighter" "Elvish Fighter"}
             {WC_II_PAIR "Dark Adept" "Dark Adept"}
             {WC_II_PAIR "Elvish Archer" "Skeleton Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Hand.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Hand.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_HAND
     [multiplayer_side]
         id=The Hand
-        name={STR_HAND}
+        name={WC_STR_HAND}
         recruit=Spearman,Orcish Grunt,Bowman,Orcish Assassin,Mage,Orcish Archer,Troll Whelp,Troll Whelp,Heavy Infantryman,Heavy Infantryman,Young Ogre,Young Ogre,Cavalryman,Wolf Rider,Horseman,Orcish Leader,Fencer,Goblin Spearman,Merman Fighter,Naga Fighter
         image={IMG_HAND}
         type=random
@@ -14,7 +14,7 @@
             heroes=Undead_All,Rebels_All
             # TODO: this contained 'Dune Piercer' in 1.14
             deserters=Knalgans,Drakes
-            deserters_names={STR_DUNE_RIDER}+", "+{STR_KNALGAN}+{STR_AND}+{STR_DRAKES}
+            deserters_names={WC_STR_DUNE_RIDER}+", "+{WC_STR_KNALGAN}+{WC_STR_AND}+{WC_STR_DRAKES}
             {WC_II_PAIR "Spearman" "Orcish Grunt"}
             {WC_II_PAIR "Bowman" "Orcish Assassin"}
             {WC_II_PAIR "Mage" "Orcish Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Horde.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Horde.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_HORDE
     [multiplayer_side]
         id=The Horde
-        name={STR_HORDE}
+        name={WC_STR_HORDE}
         recruit=Orcish Grunt,Drake Fighter,Orcish Archer,Drake Burner,Orcish Assassin,Saurian Augur,Troll Whelp,Drake Clasher,Wolf Rider,Drake Glider,Goblin Spearman,Goblin Spearman,Saurian Skirmisher,Saurian Skirmisher,Naga Fighter,Naga Fighter
         image={IMG_HORDE}
         type=random
@@ -13,7 +13,7 @@
             commanders=Drakes,Northerners
             heroes=Undead_All,Loyalists_All
             deserters=Knalgans,Rebels,Dune Rider
-            deserters_names={STR_DUNE_RIDER}+", "+{STR_KNALGAN}+{STR_AND}+{STR_REBELS}
+            deserters_names={WC_STR_DUNE_RIDER}+", "+{WC_STR_KNALGAN}+{WC_STR_AND}+{WC_STR_REBELS}
             {WC_II_PAIR "Orcish Grunt" "Drake Fighter"}
             {WC_II_PAIR "Orcish Archer" "Drake Burner"}
             {WC_II_PAIR "Orcish Assassin" "Saurian Augur"}

--- a/data/campaigns/World_Conquest/era/factions/The_Militia.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Militia.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_MILITIA
     [multiplayer_side]
         id=The Militia
-        name={STR_MILITIA}
+        name={WC_STR_MILITIA}
         recruit=Dwarvish Fighter,Elvish Scout,Thug,Elvish Fighter,Dwarvish Thunderer,Elvish Archer,Poacher,Elvish Shaman,Dwarvish Guardsman,Wose,Footpad,Mage,Dwarvish Ulfserker,Thief,Gryphon Rider,Merman Hunter
         image={IMG_MILITIA}
         type=random
@@ -13,7 +13,7 @@
             commanders=Rebels,Knalgans,Thug
             heroes=Northerners_All,Young Ogre,Drakes
             deserters=Undead,Loyalists,Dune Rover
-            deserters_names={STR_DUNE_ROVER}+", "+{STR_THE_UNDEAD}+{STR_AND}+{STR_LOYALISTS}
+            deserters_names={WC_STR_DUNE_ROVER}+", "+{WC_STR_THE_UNDEAD}+{WC_STR_AND}+{WC_STR_LOYALISTS}
             {WC_II_PAIR "Dwarvish Fighter" "Elvish Scout"}
             {WC_II_PAIR "Thug" "Elvish Fighter"}
             {WC_II_PAIR "Dwarvish Thunderer" "Elvish Archer"}

--- a/data/campaigns/World_Conquest/era/factions/The_Scourge.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Scourge.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_SCOURGE
     [multiplayer_side]
         id=The Scourge
-        name={STR_SCOURGE}
+        name={WC_STR_SCOURGE}
         recruit=Skeleton,Drake Fighter,Skeleton Archer,Drake Burner,Dark Adept,Saurian Augur,Ghoul,Drake Clasher,Ghost,Saurian Skirmisher,Vampire Bat,Drake Glider,Walking Corpse,Walking Corpse
         image={IMG_SCOURGE}
         type=random
@@ -13,7 +13,7 @@
             commanders=Drakes,Undead
             heroes=Loyalists_All,Knalgans_All
             deserters=Rebels,Northerners,Young Ogre
-            deserters_names={STR_YOUNG_OGRE}+", "+{STR_REBELS}+{STR_AND}+{STR_NORTHERENS}
+            deserters_names={WC_STR_YOUNG_OGRE}+", "+{WC_STR_REBELS}+{WC_STR_AND}+{WC_STR_NORTHERENS}
             {WC_II_PAIR "Skeleton" "Drake Fighter"}
             {WC_II_PAIR "Skeleton Archer" "Drake Burner"}
             {WC_II_PAIR "Dark Adept" "Saurian Augur"}

--- a/data/campaigns/World_Conquest/era/factions/The_Trust.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Trust.cfg
@@ -3,7 +3,7 @@
 #define MULTIPLAYER_SIDE_THE_TRUST
     [multiplayer_side]
         id=The Trust
-        name={STR_TRUST}
+        name={WC_STR_TRUST}
         recruit=Drake Fighter,Dwarvish Fighter,Drake Burner,Dwarvish Thunderer,Saurian Augur,Dwarvish Ulfserker,Drake Clasher,Dwarvish Guardsman,Saurian Skirmisher,Poacher,Drake Glider,Footpad,Thief,Thief
         image={IMG_TRUST}
         type=random
@@ -13,7 +13,7 @@
             commanders=Drakes,Knalgans
             heroes=Loyalists_All,Northerners_All,Young Ogre
             deserters=Rebels,Undead,Dune Burner
-            deserters_names={STR_DUNE_BURNER}+", "+{STR_REBELS}+{STR_AND}+{STR_THE_UNDEAD}
+            deserters_names={WC_STR_DUNE_BURNER}+", "+{WC_STR_REBELS}+{WC_STR_AND}+{WC_STR_THE_UNDEAD}
             {WC_II_PAIR "Drake Fighter" "Dwarvish Fighter"}
             {WC_II_PAIR "Drake Burner" "Dwarvish Thunderer"}
             {WC_II_PAIR "Saurian Augur" "Dwarvish Ulfserker"}

--- a/data/campaigns/World_Conquest/era/factions/strings.cfg
+++ b/data/campaigns/World_Conquest/era/factions/strings.cfg
@@ -1,43 +1,43 @@
 #textdomain wesnoth-wc
 
-#define STR_ERA_ID_WC_II
+#define WC_STR_ERA_ID_WC_II
 world_conquest_era#enddef
 
-#define STR_ERA_NAME_WC_II
+#define WC_STR_ERA_NAME_WC_II
 _"World Conquest" #enddef
 
-#define STR_ERA_DESCRIPTION_WC_II
+#define WC_STR_ERA_DESCRIPTION_WC_II
     _"Units are defined as pairs in recruit list: Every time a unit is recruited, it is replaced by its pair. This era is designed to be balanced playing World Conquest II.
 Includes an in-game help to know pairs status, with a right-click on an empty hex." #enddef
 
-#define STR_HORDE
+#define WC_STR_HORDE
 _"The Horde" #enddef
 
-#define STR_ALLIANCE
+#define WC_STR_ALLIANCE
 _"The Alliance" #enddef
 
-#define STR_GUILD
+#define WC_STR_GUILD
 _"The Guild" #enddef
 
-#define STR_TRUST
+#define WC_STR_TRUST
 _"The Trust" #enddef
 
-#define STR_GANG
+#define WC_STR_GANG
 _"The Gang" #enddef
 
-#define STR_CULT
+#define WC_STR_CULT
 _"The Cult" #enddef
 
-#define STR_MILITIA
+#define WC_STR_MILITIA
 _"The Militia" #enddef
 
-#define STR_SCOURGE
+#define WC_STR_SCOURGE
 _"The Scourge" #enddef
 
-#define STR_HAND
+#define WC_STR_HAND
 _"The Hand" #enddef
 
-#define STR_EMPIRE
+#define WC_STR_EMPIRE
 _"The Empire" #enddef
 
 ######################################
@@ -45,42 +45,42 @@ _"The Empire" #enddef
 #textdomain wesnoth-units
 #################################
 
-#define STR_DUNE_SOLDIER
+#define WC_STR_DUNE_SOLDIER
 _ "Dune Soldier" #enddef
 
-#define STR_DUNE_HERBALIST
+#define WC_STR_DUNE_HERBALIST
 _ "Dune Herbalist" #enddef
 
-#define STR_DUNE_ROVER
+#define WC_STR_DUNE_ROVER
 _ "Dune Rover" #enddef
 
-#define STR_DUNE_BURNER
+#define WC_STR_DUNE_BURNER
 _ "Dune Burner" #enddef
 
-#define STR_DUNE_RIDER
+#define WC_STR_DUNE_RIDER
 _ "Dune Rider" #enddef
 
-#define STR_YOUNG_OGRE
+#define WC_STR_YOUNG_OGRE
 _ "Young Ogre" #enddef
 
 #################################
 #textdomain wesnoth-multiplayer
 #################################
 
-#define STR_DRAKES
+#define WC_STR_DRAKES
 _ "Drakes" #enddef
 
-#define STR_KNALGAN
+#define WC_STR_KNALGAN
 _ "Knalgan Alliance" #enddef
 
-#define STR_LOYALISTS
+#define WC_STR_LOYALISTS
 _ "Loyalists" #enddef
 
-#define STR_NORTHERENS
+#define WC_STR_NORTHERENS
 _ "Northerners" #enddef
 
-#define STR_REBELS
+#define WC_STR_REBELS
 _ "Rebels" #enddef
 
-#define STR_THE_UNDEAD
+#define WC_STR_THE_UNDEAD
 _ "Undead" #enddef

--- a/data/campaigns/World_Conquest/resources/data/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/data/artifacts.cfg
@@ -2,32 +2,32 @@
 
 # FIXME: Need to stop building complex strings from translatable fragments with the WML preprocessor
 
-#define STR_AND
+#define WC_STR_AND
 _ " and " #enddef
 
-#define STR_DAMAGE
+#define WC_STR_DAMAGE
 _ "damage" #enddef
 
-#define STR_RESISTANCE
+#define WC_STR_RESISTANCE
 _ " resistance vs " #enddef
 
-#define STR_MOVES
+#define WC_STR_MOVES
 _ "moves" #enddef
 
-#define STR_STRIKE
+#define WC_STR_STRIKE
 _ "strike" #enddef
 
-#define STR_EXPERIENCE
+#define WC_STR_EXPERIENCE
 _ "XP to advance" #enddef
 
 #define WORLD_CONQUEST_TEK_ARTIFACT_DEFINITIONS
     ## in alphabetic order by name
     ## uses some macros from training
     [artifact]
-        name= {STR_ITEM_STEADFAST_NAME}
+        name= {WC_STR_ITEM_STEADFAST_NAME}
         icon=items/armor.png
-        description={STR_BLADE}+"/"+{STR_IMPACT}+"/"+{STR_PIERCE}+": "+{STR_UP_TO 10}+{STR_RESISTANCES}+", "+{STR_STEADFAST}
-        info= {STR_ITEM_STEADFAST_INFO}
+        description={WC_STR_BLADE}+"/"+{WC_STR_IMPACT}+"/"+{WC_STR_PIERCE}+": "+{WC_STR_UP_TO 10}+{WC_STR_RESISTANCES}+", "+{WC_STR_STEADFAST}
+        info= {WC_STR_ITEM_STEADFAST_INFO}
         sound=dagger-swish.wav
         [effect]
             apply_to=new_ability
@@ -45,10 +45,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_BACKSTAB_NAME}
+        name= {WC_STR_ITEM_BACKSTAB_NAME}
         icon=items/ring-brown.png
-        description={STR_MELEE}+": "+{STR_BACKSTAB}
-        info= {STR_ITEM_BACKSTAB_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_BACKSTAB}
+        info= {WC_STR_ITEM_BACKSTAB_INFO}
         {WCT_ANIMATION_RING assassin "60,55,60"}
         [filter]
             formula = "size(filter(attacks, range = 'melee')) > 0"
@@ -64,10 +64,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_SUBMERGE_NAME}
+        name= {WC_STR_ITEM_SUBMERGE_NAME}
         icon=items/ball-blue.png
-        description={STR_SWIM}+", "+{STR_SUBMERGE}
-        info= {STR_ITEM_SUBMERGE_INFO}
+        description={WC_STR_SWIM}+", "+{WC_STR_SUBMERGE}
+        info= {WC_STR_ITEM_SUBMERGE_INFO}
         sound=dagger-swish.wav
         [effect]
             apply_to=new_ability
@@ -97,10 +97,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_TENACITY_NAME}
+        name= {WC_STR_ITEM_TENACITY_NAME}
         icon=items/ball-green.png
-        description={STR_FEARLESS}+", "+{STR_UNDEAD}+", "+{STR_HEALTHY}+", "+{STR_TENACITY}
-        info= {STR_ITEM_TENACITY_INFO}
+        description={WC_STR_FEARLESS}+", "+{WC_STR_UNDEAD}+", "+{WC_STR_HEALTHY}+", "+{WC_STR_TENACITY}
+        info= {WC_STR_ITEM_TENACITY_INFO}
         sound=heal.wav
         {TRAIT_UNDEAD}
         {TRAIT_FEARLESS}
@@ -113,10 +113,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_DRAIN_M_NAME}
+        name= {WC_STR_ITEM_DRAIN_M_NAME}
         icon=items/ring-red.png
-        description={STR_MELEE}+": "+{STR_DRAIN}
-        info= {STR_ITEM_DRAIN_M_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_DRAIN}
+        info= {WC_STR_ITEM_DRAIN_M_INFO}
         {WCT_ANIMATION_RING blood "255,60,60"}
         [filter]
             formula = "size(filter(attacks, range = 'melee')) > 0"
@@ -132,10 +132,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_CHARGE_NAME}
+        name= {WC_STR_ITEM_CHARGE_NAME}
         icon=items/spear-fancy.png
-        description={STR_MELEE}+": "+{STR_CHARGE}
-        info= {STR_ITEM_CHARGE_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_CHARGE}
+        info= {WC_STR_ITEM_CHARGE_INFO}
         sound=dagger-swish.wav
         [filter]
             formula = "size(filter(attacks, range = 'melee')) > 0"
@@ -151,10 +151,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_DRAIN_R_NAME}
+        name= {WC_STR_ITEM_DRAIN_R_NAME}
         icon=items/ankh-necklace.png
-        description={STR_RANGED}+": "+{STR_DRAIN}
-        info= {STR_ITEM_DRAIN_R_INFO}
+        description={WC_STR_RANGED}+": "+{WC_STR_DRAIN}
+        info= {WC_STR_ITEM_DRAIN_R_INFO}
         {WCT_ANIMATION_RING blood "255,60,60"}
         [filter]
             formula = "size(filter(attacks, range = 'ranged')) > 0"
@@ -170,10 +170,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_MARKSMAN_R_NAME}
+        name= {WC_STR_ITEM_MARKSMAN_R_NAME}
         icon=items/bow.png
-        description={STR_RANGED}+": "+{STR_MARKSMAN}+{STR_AND}+"+25% "+{STR_DAMAGE}
-        info= {STR_ITEM_MARKSMAN_R_INFO}
+        description={WC_STR_RANGED}+": "+{WC_STR_MARKSMAN}+{WC_STR_AND}+"+25% "+{WC_STR_DAMAGE}
+        info= {WC_STR_ITEM_MARKSMAN_R_INFO}
         sound=dagger-swish.wav
         [filter]
             formula = "size(filter(attacks, range = 'ranged')) > 0"
@@ -194,10 +194,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_PLAGUE_NAME}
+        name= {WC_STR_ITEM_PLAGUE_NAME}
         icon=items/book5.png
-        description={STR_MELEE}+": "{STR_PLAGUE}
-        info= {STR_ITEM_PLAGUE_INFO}
+        description={WC_STR_MELEE}+": "{WC_STR_PLAGUE}
+        info= {WC_STR_ITEM_PLAGUE_INFO}
         {WCT_ANIMATION idling}
         [filter]
             formula = "size(filter(attacks, range = 'melee')) > 0"
@@ -214,10 +214,10 @@ _ "XP to advance" #enddef
     [/artifact]
     [artifact]
         ## credit to ezysquire for this item idea
-        name= {STR_ITEM_FORCEFIELD_NAME}
+        name= {WC_STR_ITEM_FORCEFIELD_NAME}
         icon=items/buckler.png
-        description= {STR_ITEM_FORCEFIELD_DESC}
-        info= {STR_ITEM_FORCEFIELD_INFO}
+        description= {WC_STR_ITEM_FORCEFIELD_DESC}
+        info= {WC_STR_ITEM_FORCEFIELD_INFO}
         sound=magic-missile-3.ogg
         [effect]
             apply_to=new_ability
@@ -226,9 +226,9 @@ _ "XP to advance" #enddef
                     id=forcefield
                     value=-13
                     cumulative=no
-                    name= {STR_FORCEFIELD}
-                    female_name= {STR_FORCEFIELD}
-                    description= {STR_FORCEFIELD_DESCRIPTION}
+                    name= {WC_STR_FORCEFIELD}
+                    female_name= {WC_STR_FORCEFIELD}
+                    description= {WC_STR_FORCEFIELD_DESCRIPTION}
                     affect_self=no
                     affect_allies=no
                     affect_enemies=yes
@@ -243,10 +243,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_FEEDING_NAME}
+        name= {WC_STR_ITEM_FEEDING_NAME}
         icon=items/potion-red.png
-        description={STR_FEEDING}+", +3 "+{STR_HITPOINTS}
-        info= {STR_ITEM_FEEDING_INFO}
+        description={WC_STR_FEEDING}+", +3 "+{WC_STR_HITPOINTS}
+        info= {WC_STR_ITEM_FEEDING_INFO}
         sound=potion.ogg
         {WCT_FEEDING}
         [effect]
@@ -267,10 +267,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_FIRE_NAME}
+        name= {WC_STR_ITEM_FIRE_NAME}
         icon=items/ball-magenta.png
-        description={STR_MELEE}+": "+{STR_FIRE}+{STR_AND}+"+25% "+{STR_DAMAGE}+", +30 "+{STR_RESISTANCE}+{STR_FIRE}
-        info= {STR_ITEM_FIRE_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_FIRE}+{WC_STR_AND}+"+25% "+{WC_STR_DAMAGE}+", +30 "+{WC_STR_RESISTANCE}+{WC_STR_FIRE}
+        info= {WC_STR_ITEM_FIRE_INFO}
         sound=torch.ogg
         [effect]
             apply_to=attack
@@ -287,10 +287,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_ILLUMINATES_NAME}
+        name= {WC_STR_ITEM_ILLUMINATES_NAME}
         icon=items/armor-golden.png
-        description={STR_ILLUMINATES}+", "+{STR_LAWFUL}+", "+{STR_HEALS}+", "+{STR_FIRSTSTRIKE}
-        info= {STR_ITEM_ILLUMINATES_INFO}
+        description={WC_STR_ILLUMINATES}+", "+{WC_STR_LAWFUL}+", "+{WC_STR_HEALS}+", "+{WC_STR_FIRSTSTRIKE}
+        info= {WC_STR_ITEM_ILLUMINATES_INFO}
         sound_male=horn-signals/horn-1.ogg
         sound_female=horn-signals/horn-2.ogg
         [effect]
@@ -325,10 +325,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_ARCANE_NAME}
+        name= {WC_STR_ITEM_ARCANE_NAME}
         icon=items/holy-water.png
-        description={STR_MELEE}+": "+{STR_ARCANE}+{STR_AND}+"+25% "+{STR_DAMAGE}+", +30 "+{STR_RESISTANCE}+{STR_ARCANE}
-        info= {STR_ITEM_ARCANE_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_ARCANE}+{WC_STR_AND}+"+25% "+{WC_STR_DAMAGE}+", +30 "+{WC_STR_RESISTANCE}+{WC_STR_ARCANE}
+        info= {WC_STR_ITEM_ARCANE_INFO}
         sound_male=magic-holy-1.ogg
         sound_female=magic-holy-miss-4.ogg
         [effect]
@@ -346,15 +346,15 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_SLOW_R_NAME}
+        name= {WC_STR_ITEM_SLOW_R_NAME}
         icon=items/bow-crystal.png
-        description="19-1 "+{STR_RANGED}+"-"+{STR_COLD}+" "+{STR_SLOW}
-        info= {STR_ITEM_SLOW_R_INFO}
+        description="19-1 "+{WC_STR_RANGED}+"-"+{WC_STR_COLD}+" "+{WC_STR_SLOW}
+        info= {WC_STR_ITEM_SLOW_R_INFO}
         sound=dagger-swish.wav
         [effect]
             apply_to=new_attack
             name="ice bow"
-            description= {STR_ART_SLOW_R}
+            description= {WC_STR_ART_SLOW_R}
             icon=attacks/lightning.png
             type=cold
             range=ranged
@@ -392,10 +392,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_CURES_NAME}
+        name= {WC_STR_ITEM_CURES_NAME}
         icon=items/flower1.png
-        description={STR_CURES}
-        info= {STR_ITEM_CURES_INFO}
+        description={WC_STR_CURES}
+        info= {WC_STR_ITEM_CURES_INFO}
         sound=heal.wav
         [effect]
             apply_to=remove_ability
@@ -413,10 +413,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_DRUG_NAME}
+        name= {WC_STR_ITEM_DRUG_NAME}
         icon=items/potion-yellow.png
-        description={STR_LIVING}+" +1 "+{STR_DAMAGE}+{STR_AND}+"+1 "+{STR_MOVES}+{STR_AND}+"-20% "+{STR_EXPERIENCE}
-        info= {STR_ITEM_DRUG_INFO}
+        description={WC_STR_LIVING}+" +1 "+{WC_STR_DAMAGE}+{WC_STR_AND}+"+1 "+{WC_STR_MOVES}+{WC_STR_AND}+"-20% "+{WC_STR_EXPERIENCE}
+        info= {WC_STR_ITEM_DRUG_INFO}
         sound=potion.ogg
         [filter]
             [not]
@@ -443,10 +443,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_POISON_NAME}
+        name= {WC_STR_ITEM_POISON_NAME}
         icon=items/potion-poison.png
-        description={STR_BLADE}+"/"+{STR_PIERCE}+": "+{STR_POISON}+{STR_AND}+"+20% "+{STR_DAMAGE}
-        info= {STR_ITEM_POISON_INFO}
+        description={WC_STR_BLADE}+"/"+{WC_STR_PIERCE}+": "+{WC_STR_POISON}+{WC_STR_AND}+"+20% "+{WC_STR_DAMAGE}
+        info= {WC_STR_ITEM_POISON_INFO}
         sound=poison.ogg
         [filter]
             formula = "size(filter(attacks, type = 'blade' or type = 'pierce')) > 0"
@@ -463,10 +463,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_SLOW_M_NAME}
+        name= {WC_STR_ITEM_SLOW_M_NAME}
         icon=items/ring-white.png
-        description={STR_MELEE}+": "+{STR_COLD}+{STR_AND}+{STR_SLOW}
-        info= {STR_ITEM_SLOW_M_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_COLD}+{WC_STR_AND}+{WC_STR_SLOW}
+        info= {WC_STR_ITEM_SLOW_M_INFO}
         {WCT_ANIMATION_RING cold "180,180,255"}
         [filter]
             formula = "size(filter(attacks, range = 'melee')) > 0"
@@ -483,10 +483,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_ELEMENTALS_NAME}
+        name= {WC_STR_ITEM_ELEMENTALS_NAME}
         icon=items/ring-gold.png
-        description={STR_ARCANE}+"/"+{STR_COLD}+"/"+{STR_FIRE}+": "+{STR_DISENGAGE}+{STR_AND}+"+20% "+{STR_DAMAGE}
-        info= {STR_ITEM_ELEMENTALS_INFO}
+        description={WC_STR_ARCANE}+"/"+{WC_STR_COLD}+"/"+{WC_STR_FIRE}+": "+{WC_STR_DISENGAGE}+{WC_STR_AND}+"+20% "+{WC_STR_DAMAGE}
+        info= {WC_STR_ITEM_ELEMENTALS_INFO}
         {WCT_ANIMATION_RING power "210,210,57"}
         not_available=enemy
         [filter]
@@ -500,10 +500,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_IMPACT_NAME}
+        name= {WC_STR_ITEM_IMPACT_NAME}
         icon=items/hammer-runic.png
-        description={STR_IMPACT}+": +1 "+{STR_STRIKE}+{STR_AND}+"+2 "+{STR_DAMAGE}
-        info= {STR_ITEM_IMPACT_INFO}
+        description={WC_STR_IMPACT}+": +1 "+{WC_STR_STRIKE}+{WC_STR_AND}+"+2 "+{WC_STR_DAMAGE}
+        info= {WC_STR_ITEM_IMPACT_INFO}
         sound=dagger-swish.wav
         not_available=enemy,player
         [filter]
@@ -517,10 +517,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_MAGICAL_NAME}
+        name= {WC_STR_ITEM_MAGICAL_NAME}
         icon=items/sword.png
-        description={STR_MELEE}+": "+{STR_MAGICAL}
-        info= {STR_ITEM_MAGICAL_INFO}
+        description={WC_STR_MELEE}+": "+{WC_STR_MAGICAL}
+        info= {WC_STR_ITEM_MAGICAL_INFO}
         sound=dagger-swish.wav
         [filter]
             formula = "size(filter(attacks, range = 'melee')) > 0"
@@ -536,15 +536,15 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_ATTACK_ARCANE_NAME}
+        name= {WC_STR_ITEM_ATTACK_ARCANE_NAME}
         icon=items/staff-magic.png
-        description="11-3 "+{STR_RANGED}+"-"+{STR_ARCANE}+" "+{STR_MAGICAL}
-        info= {STR_ITEM_ATTACK_ARCANE_INFO}
+        description="11-3 "+{WC_STR_RANGED}+"-"+{WC_STR_ARCANE}+" "+{WC_STR_MAGICAL}
+        info= {WC_STR_ITEM_ATTACK_ARCANE_INFO}
         sound=dagger-swish.wav
         [effect]
             apply_to=new_attack
             name=staff of radiance
-            description= {STR_ART_ARCANE}
+            description= {WC_STR_ART_ARCANE}
             icon=attacks/lightbeam.png
             type=arcane
             range=ranged
@@ -582,10 +582,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_BERSEK_NAME}
+        name= {WC_STR_ITEM_BERSEK_NAME}
         icon=items/flame-sword.png
-        description={STR_MELEE}+": "+ {STR_FURY}
-        info= {STR_ITEM_BERSEK_INFO}
+        description={WC_STR_MELEE}+": "+ {WC_STR_FURY}
+        info= {WC_STR_ITEM_BERSEK_INFO}
         sound=dagger-swish.wav
         not_available=player
         [filter]
@@ -598,19 +598,19 @@ _ "XP to advance" #enddef
                 mode=append
                 [berserk]
                     id=wct_fury
-                    name= {STR_FURY}
-                    female_name= {STR_FURY}
-                    description= {STR_FURY_DESCRIPTION}
+                    name= {WC_STR_FURY}
+                    female_name= {WC_STR_FURY}
+                    description= {WC_STR_FURY_DESCRIPTION}
                     value=3
                 [/berserk]
             [/set_specials]
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_STRIKES_R_NAME}
+        name= {WC_STR_ITEM_STRIKES_R_NAME}
         icon=items/bow-elven.png
-        description={STR_RANGED}+"-"+{STR_BLADE}+"/"+{STR_IMPACT}+"/"+{STR_PIERCE}+": +60% "+{STR_STRIKES}+{STR_AND}+"+1 "+{STR_DAMAGE}
-        info= {STR_ITEM_STRIKES_R_INFO}
+        description={WC_STR_RANGED}+"-"+{WC_STR_BLADE}+"/"+{WC_STR_IMPACT}+"/"+{WC_STR_PIERCE}+": +60% "+{WC_STR_STRIKES}+{WC_STR_AND}+"+1 "+{WC_STR_DAMAGE}
+        info= {WC_STR_ITEM_STRIKES_R_INFO}
         sound=dagger-swish.wav
         not_available=enemy,player
         [filter]
@@ -625,10 +625,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_DARKNESS_NAME}
+        name= {WC_STR_ITEM_DARKNESS_NAME}
         icon=items/scarecrow.png
-        description= {STR_DARKNESS}+", "+{STR_CHAOTIC}+", "+{STR_CORRUPTION}+", "+{STR_DISTRACT}
-        info= {STR_ITEM_DARKNESS_INFO}
+        description= {WC_STR_DARKNESS}+", "+{WC_STR_CHAOTIC}+", "+{WC_STR_CORRUPTION}+", "+{WC_STR_DISTRACT}
+        info= {WC_STR_ITEM_DARKNESS_INFO}
         sound_male=dwarf-laugh.wav
         sound_female=witches-laugh.wav
         [effect]
@@ -648,16 +648,16 @@ _ "XP to advance" #enddef
                     value=-25
                     min_value=-25
                     cumulative=no
-                    name= {STR_DARKNESS}
-                    female_name= {STR_DARKNESS}
-                    description= {STR_DARKNESS_DESCRIPTION}
+                    name= {WC_STR_DARKNESS}
+                    female_name= {WC_STR_DARKNESS}
+                    description= {WC_STR_DARKNESS_DESCRIPTION}
                     affect_self=yes
                 [/illuminates]
                 [dummy]
                     id=wc2_corruption
-                    name= {STR_CORRUPTION}
-                    female_name= {STR_CORRUPTION}
-                    description= {STR_CORRUPTION_DESCRIPTION}
+                    name= {WC_STR_CORRUPTION}
+                    female_name= {WC_STR_CORRUPTION}
+                    description= {WC_STR_CORRUPTION_DESCRIPTION}
                 [/dummy]
             [/abilities]
         [/effect]
@@ -670,10 +670,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_TELEPORT_NAME}
+        name= {WC_STR_ITEM_TELEPORT_NAME}
         icon=items/key.png
-        description={STR_TELEPORT}
-        info= {STR_ITEM_TELEPORT_INFO}
+        description={WC_STR_TELEPORT}
+        info= {WC_STR_ITEM_TELEPORT_INFO}
         sound=dagger-swish.wav
         not_available=enemy
         [effect]
@@ -695,10 +695,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_XP_NAME}
+        name= {WC_STR_ITEM_XP_NAME}
         icon=items/book1.png
-        description="-50% "+{STR_EXPERIENCE}
-        info= {STR_ITEM_XP_INFO}
+        description="-50% "+{WC_STR_EXPERIENCE}
+        info= {WC_STR_ITEM_XP_INFO}
         {WCT_ANIMATION idling}
         [effect]
             apply_to=max_experience
@@ -706,15 +706,15 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_ATTACK_FIRE_NAME}
+        name= {WC_STR_ITEM_ATTACK_FIRE_NAME}
         icon=items/storm-trident.png
-        description="17-2 "+{STR_RANGED}+"-"+{STR_FIRE}+" "+{STR_MAGICAL}
-        info= {STR_ITEM_ATTACK_FIRE_INFO}
+        description="17-2 "+{WC_STR_RANGED}+"-"+{WC_STR_FIRE}+" "+{WC_STR_MAGICAL}
+        info= {WC_STR_ITEM_ATTACK_FIRE_INFO}
         sound=dagger-swish.wav
         [effect]
             apply_to=new_attack
             name=storm trident
-            description= {STR_ART_FIRE}
+            description= {WC_STR_ART_FIRE}
             icon=attacks/lightning.png
             type=fire
             range=ranged
@@ -729,10 +729,10 @@ _ "XP to advance" #enddef
         {LIGHTNING_ANIMATION "storm trident" 3}
     [/artifact]
     [artifact]
-        name= {STR_ITEM_REGENERATES_NAME}
+        name= {WC_STR_ITEM_REGENERATES_NAME}
         icon=items/potion-grey.png
-        description={STR_REGENERATES}
-        info= {STR_ITEM_REGENERATES_INFO}
+        description={WC_STR_REGENERATES}
+        info= {WC_STR_ITEM_REGENERATES_INFO}
         sound=potion.ogg
         [effect]
             apply_to=new_ability
@@ -742,10 +742,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_LEADERSHIP_NAME}
+        name= {WC_STR_ITEM_LEADERSHIP_NAME}
         icon=items/orcish-flag.png
-        description= {STR_ITEM_LEADERSHIP_DESC}
-        info= {STR_ITEM_LEADERSHIP_INFO}
+        description= {WC_STR_ITEM_LEADERSHIP_DESC}
+        info= {WC_STR_ITEM_LEADERSHIP_INFO}
         {WCT_ANIMATION leading}
         {WCT_ANIMATION leading}
         [effect]
@@ -755,9 +755,9 @@ _ "XP to advance" #enddef
                     id=banner
                     value=20
                     cumulative=yes
-                    name= {STR_BANNER}
-                    female_name= {STR_BANNER}
-                    description= {STR_BANNER_DESCRIPTION}
+                    name= {WC_STR_BANNER}
+                    female_name= {WC_STR_BANNER}
+                    description= {WC_STR_BANNER_DESCRIPTION}
                     affect_self=no
                     affect_allies=yes
                     [affect_adjacent]
@@ -768,10 +768,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_FLYING_NAME}
+        name= {WC_STR_ITEM_FLYING_NAME}
         icon=items/staff.png
-        description= {STR_FLIGHT}
-        info= {STR_ITEM_FLYING_INFO}
+        description= {WC_STR_FLIGHT}
+        info= {WC_STR_ITEM_FLYING_INFO}
         sound=dagger-swish.wav
         [effect]
             apply_to=movement_costs
@@ -811,10 +811,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_SNOW_NAME}
+        name= {WC_STR_ITEM_SNOW_NAME}
         icon=items/flower3.png
-        description="+15 "+{STR_HITPOINTS}+", "+{STR_UP_TO 20}+{STR_RESISTANCE}+{STR_COLD}
-        info= {STR_ITEM_SNOW_INFO}
+        description="+15 "+{WC_STR_HITPOINTS}+", "+{WC_STR_UP_TO 20}+{WC_STR_RESISTANCE}+{WC_STR_COLD}
+        info= {WC_STR_ITEM_SNOW_INFO}
         sound=heal.wav
         [effect]
             apply_to=hitpoints
@@ -829,10 +829,10 @@ _ "XP to advance" #enddef
         [/effect]
     [/artifact]
     [artifact]
-        name= {STR_ITEM_SKIRMISHER_NAME}
+        name= {WC_STR_ITEM_SKIRMISHER_NAME}
         icon=items/cloak-green.png
-        description={STR_SKIRMISHER}+", "+{STR_AMBUSH}+", "+{STR_NIGHTSTALK}+", +2 "+{STR_MOVES}
-        info= {STR_ITEM_SKIRMISHER_INFO}
+        description={WC_STR_SKIRMISHER}+", "+{WC_STR_AMBUSH}+", "+{WC_STR_NIGHTSTALK}+", +2 "+{WC_STR_MOVES}
+        info= {WC_STR_ITEM_SKIRMISHER_INFO}
         sound=bat-flapping.wav
         [effect]
             apply_to=new_ability

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -7,8 +7,8 @@
         type=Lich
         advanced_type=Ancient Lich
         image=attacks/curse.png
-        name= {STR_DARK_NAME}
-        dialogue= {STR_DARK_FOUND}
+        name= {WC_STR_DARK_NAME}
+        dialogue= {WC_STR_DARK_FOUND}
         [grade]
         [/grade]
         [grade]
@@ -56,8 +56,8 @@
         type=Duelist
         advanced_type=Master at Arms
         image=icons/boots_elven.png
-        name= {STR_MOVEMENT_NAME}
-        dialogue= {STR_MOVEMENT_FOUND}
+        name= {WC_STR_MOVEMENT_NAME}
+        dialogue= {WC_STR_MOVEMENT_FOUND}
         [grade]
         [/grade]
         [grade]
@@ -74,8 +74,8 @@
         type=Orcish Warrior
         advanced_type=Orcish Warlord
         image=attacks/halberd.png
-        name= {STR_MELEE_NAME}
-        dialogue= {STR_MELEE_FOUND}
+        name= {WC_STR_MELEE_NAME}
+        dialogue= {WC_STR_MELEE_FOUND}
         [grade]
         [/grade]
         [grade]
@@ -99,7 +99,7 @@
             {WCT_CHANCE_SP 5 MELEE MARKSMAN}
             [chance]
                 value=2
-                info={STR_MELEE}+": +1 "+{STR_STRIKES}
+                info={WC_STR_MELEE}+": +1 "+{WC_STR_STRIKES}
                 [effect]
                     apply_to=attack
                     range=melee
@@ -117,8 +117,8 @@
         type=Elvish Ranger
         advanced_type=Elvish Avenger
         image=attacks/bow-elven.png
-        name= {STR_RANGER_NAME}
-        dialogue= {STR_RANGER_FOUND}
+        name= {WC_STR_RANGER_NAME}
+        dialogue= {WC_STR_RANGER_FOUND}
         [grade]
         [/grade]
         [grade]
@@ -156,8 +156,8 @@
         type=Drake Flare
         advanced_type=Drake Flameheart
         image=icons/letter_and_ale.png
-        name= {STR_EXPERIENCE_NAME}
-        dialogue= {STR_EXPERIENCE_FOUND}
+        name= {WC_STR_EXPERIENCE_NAME}
+        dialogue= {WC_STR_EXPERIENCE_FOUND}
         [grade]
         [/grade]
         [grade]
@@ -183,8 +183,8 @@
         type=Dwarvish Runesmith
         advanced_type=Dwarvish Runemaster
         image=icons/cuirass_muscled.png
-        name= {STR_HEALTH_NAME}
-        dialogue= {STR_HEALTH_FOUND}
+        name= {WC_STR_HEALTH_NAME}
+        dialogue= {WC_STR_HEALTH_FOUND}
         [grade]
         [/grade]
         [grade]
@@ -217,7 +217,7 @@
 #define WCT_CHANCE_RANGED_DISENGAGE CHANCE
     [chance]
         value={CHANCE}
-        info={STR_RANGED}+": "+{STR_DISENGAGE}
+        info={WC_STR_RANGED}+": "+{WC_STR_DISENGAGE}
         [effect]
             apply_to=attack
             range=ranged
@@ -231,8 +231,8 @@
         mode=append
         [dummy]
             id=wc2_disengage
-            name= {STR_DISENGAGE}
-            description= {STR_DISENGAGE_DESCRIPTION}
+            name= {WC_STR_DISENGAGE}
+            description= {WC_STR_DISENGAGE_DESCRIPTION}
             [filter_self]
                 ## works around a bug with special_actve filter.
             [/filter_self]
@@ -243,7 +243,7 @@
 #define WCT_CHANCE_MOVE_ON_RECRUIT CHANCE
     [chance]
         value={CHANCE}
-        info={STR_MOVE_ON_RECRUIT}
+        info={WC_STR_MOVE_ON_RECRUIT}
         [effect]
             apply_to="wc2_move_on_recruit"
         [/effect]
@@ -253,7 +253,7 @@
 #define WCT_CHANCE_ALWAYS_REST CHANCE
     [chance]
         value={CHANCE}
-        info={STR_ALWAYS_REST}
+        info={WC_STR_ALWAYS_REST}
         [effect]
             [filter]
                 [filter_wml]
@@ -279,7 +279,7 @@
     ## (but couldnt find a better way using modify_unit)
     [chance]
         value={CHANCE}
-        info={STR_FEARLESS}
+        info={WC_STR_FEARLESS}
         [filter]
             [not]
                 [filter_wml]
@@ -307,14 +307,14 @@
         value={CHANCE}
         info=_"$range|: $special|"
         [info_data]
-            range={STR_{RANGE}}
-            special={STR_{SPECIAL}}
+            range={WC_STR_{RANGE}}
+            special={WC_STR_{SPECIAL}}
         [/info_data]
         [effect]
             [filter]
                 [filter_wml]
                     [attack]
-                        range={STR_ID_{RANGE}}
+                        range={WC_STR_ID_{RANGE}}
                         [specials]
                             {WEAPON_SPECIAL_{SPECIAL}}
                         [/specials]
@@ -327,8 +327,8 @@
         [/effect]
         [effect]
             apply_to=attack
-            range={STR_ID_{RANGE}}
-            remove_specials={STR_ID_{SPECIAL}}
+            range={WC_STR_ID_{RANGE}}
+            remove_specials={WC_STR_ID_{SPECIAL}}
             [set_specials]
                 mode=append
                 {WEAPON_SPECIAL_{SPECIAL}}
@@ -340,10 +340,10 @@
 #define WCT_CHANCE_ABILITY CHANCE ABILITY
     [chance]
         value={CHANCE}
-        info={STR_{ABILITY}}
+        info={WC_STR_{ABILITY}}
         [effect]
             [filter]
-                ability={STR_ID_{ABILITY}}
+                ability={WC_STR_ID_{ABILITY}}
             [/filter]
             apply_to=hitpoints
             increase_total=1
@@ -353,9 +353,9 @@
         [effect]
             apply_to=remove_ability
             [abilities]
-                [{STR_TAG_{ABILITY}}]
-                    id={STR_ID_{ABILITY}}
-                [/{STR_TAG_{ABILITY}}]
+                [{WC_STR_TAG_{ABILITY}}]
+                    id={WC_STR_ID_{ABILITY}}
+                [/{WC_STR_TAG_{ABILITY}}]
             [/abilities]
         [/effect]
         [effect]
@@ -370,7 +370,7 @@
 #define CHANCE_WCT_ABILITY CHANCE ABILITY
     [chance]
         value={CHANCE}
-        info={STR_{ABILITY}}
+        info={WC_STR_{ABILITY}}
         [effect]
             apply_to=new_ability
             [abilities]
@@ -383,9 +383,9 @@
 #define WCT_ABILITY_DISTRACT
     [skirmisher]
         id=distract
-        name= {STR_DISTRACT}
-        female_name= {STR_DISTRACT}
-        description= {STR_DISTRACT_DESCRIPTION}
+        name= {WC_STR_DISTRACT}
+        female_name= {WC_STR_DISTRACT}
+        description= {WC_STR_DISTRACT_DESCRIPTION}
         affect_self=no
         affect_allies=yes
         [affect_adjacent]
@@ -407,9 +407,9 @@
         [filter_base_value]
             less_than=0
         [/filter_base_value]
-        name= {STR_TENACITY}
-        female_name= {STR_TENACITY}
-        description= {STR_TENACITY_DESCRIPTION}
+        name= {WC_STR_TENACITY}
+        female_name= {WC_STR_TENACITY}
+        description= {WC_STR_TENACITY_DESCRIPTION}
         affect_self=yes
         active_on=defense
     [/resistance]
@@ -418,7 +418,7 @@
 #define WCT_CHANCE_BACKSTAB CHANCE
     [chance]
         value={CHANCE}
-        info={STR_BACKSTAB}
+        info={WC_STR_BACKSTAB}
         [effect]
             [filter]
                 [filter_wml]
@@ -447,7 +447,7 @@
 #define WCT_CHANCE_HEALS_UNPOISON CHANCE
     [chance]
         value={CHANCE}
-        info={STR_HEALS_UNPOISON}
+        info={WC_STR_HEALS_UNPOISON}
         [effect]
             [filter]
                 ability=healing
@@ -478,7 +478,7 @@
 #define WCT_CHANCE_FEEDING CHANCE
     [chance]
         value={CHANCE}
-        info={STR_FEEDING}
+        info={WC_STR_FEEDING}
         [effect]
             [filter]
                 ability=feeding
@@ -503,7 +503,7 @@
 #define WCT_CHANCE_LEADERSHIP CHANCE
     [chance]
         value={CHANCE}
-        info={STR_LEADERSHIP}
+        info={WC_STR_LEADERSHIP}
         [effect]
             [filter]
                 ability=leadership
@@ -535,12 +535,12 @@
         value={CHANCE}
         info= _"$range|: +$boost| damage"
         [info_data]
-            range={STR_{RANGE}}
+            range={WC_STR_{RANGE}}
             boost={BOOST}
         [/info_data]
         [effect]
             apply_to=attack
-            range={STR_ID_{RANGE}}
+            range={WC_STR_ID_{RANGE}}
             increase_damage={BOOST}
         [/effect]
     [/chance]
@@ -551,11 +551,11 @@
         value={CHANCE}
         info= _"$range|: +1 damage per level"
         [info_data]
-            range={STR_{RANGE}}
+            range={WC_STR_{RANGE}}
         [/info_data]
         [effect]
             apply_to=attack
-            range={STR_ID_{RANGE}}
+            range={WC_STR_ID_{RANGE}}
             increase_damage=1
             times=per level
         [/effect]
@@ -610,7 +610,7 @@
 #define WCT_CHANCE_LOYAL CHANCE
     [chance]
         value={CHANCE}
-        info={STR_FREE_UPKEEP}
+        info={WC_STR_FREE_UPKEEP}
         [effect]
             apply_to=loyal
         [/effect]
@@ -637,14 +637,14 @@
         apply_to=defense
         replace=false
         [defense]
-            {STR_ID_{TERRAIN}}=-{DEF}
+            {WC_STR_ID_{TERRAIN}}=-{DEF}
         [/defense]
     [/effect]
     [effect]
         apply_to=movement_costs
         replace=true
         [movement_costs]
-            {STR_ID_{TERRAIN}}=1
+            {WC_STR_ID_{TERRAIN}}=1
         [/movement_costs]
     [/effect]
 #enddef
@@ -654,17 +654,17 @@
         value={CHANCE}
         info= _"$terrain|: +$def| defense and full movement, +$res| resistance vs $dmg_type|"
         [info_data]
-            terrain={STR_{TERRAIN}}
+            terrain={WC_STR_{TERRAIN}}
             def = {DEF}
             res = {RES}
-            dmg_type= {STR_{DMG_TYPE}}
+            dmg_type= {WC_STR_{DMG_TYPE}}
         [/info_data]
         {WCT_WILD_DEFENSE {TERRAIN} {DEF}}
         [effect]
             apply_to=resistance
             replace=false
             [resistance]
-                {STR_ID_{DMG_TYPE}}=-{RES}
+                {WC_STR_ID_{DMG_TYPE}}=-{RES}
             [/resistance]
         [/effect]
     [/chance]
@@ -683,7 +683,7 @@
         value={CHANCE}
         info= _"$terrain|: +10 defense and full movement"
         [info_data]
-            terrain={STR_{TERRAIN}}
+            terrain={WC_STR_{TERRAIN}}
         [/info_data]
         {WCT_WILD_DEFENSE {TERRAIN} 10}
     [/chance]
@@ -729,13 +729,13 @@
         value={CHANCE}
         info= _"$range|: arcane and +25% damage"
         [info_data]
-            range={STR_{RANGE}}
+            range={WC_STR_{RANGE}}
         [/info_data]
         [effect]
             [filter]
                 [filter_wml]
                     [attack]
-                        range={STR_ID_{RANGE}}
+                        range={WC_STR_ID_{RANGE}}
                         type=arcane
                     [/attack]
                 [/filter_wml]
@@ -746,7 +746,7 @@
         [/effect]
         [effect]
             apply_to=attack
-            range={STR_ID_{RANGE}}
+            range={WC_STR_ID_{RANGE}}
             set_type=arcane
             increase_damage=25%
         [/effect]
@@ -756,7 +756,7 @@
 #define WCT_CHANCE_TELEPORT CHANCE
     [chance]
         value={CHANCE}
-        info={STR_TELEPORT}
+        info={WC_STR_TELEPORT}
         [effect]
             [filter]
                 ability=teleport

--- a/data/campaigns/World_Conquest/resources/strings/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/artifacts.cfg
@@ -1,211 +1,211 @@
 #textdomain wesnoth-wc
 
-#define STR_ITEM_STEADFAST_NAME
+#define WC_STR_ITEM_STEADFAST_NAME
 _ "Adamant armor" #enddef
 
-#define STR_ITEM_STEADFAST_INFO
+#define WC_STR_ITEM_STEADFAST_INFO
 _ "The sturdy plates of this lightweight armor increase the user’s physical resistances (to a maximum of 10%) and grants the steadfast ability." #enddef
 
-#define STR_ITEM_BACKSTAB_NAME
+#define WC_STR_ITEM_BACKSTAB_NAME
 _ "Assassin’s ring" #enddef
 
-#define STR_ITEM_BACKSTAB_INFO
+#define WC_STR_ITEM_BACKSTAB_INFO
 _ "This plain ring with a pleasantly smooth and slippery surface gives its owner unmatched sneak attacking skills." #enddef
 
-#define STR_ITEM_SUBMERGE_NAME
+#define WC_STR_ITEM_SUBMERGE_NAME
 _ "Azure pearl" #enddef
 
-#define STR_ITEM_SUBMERGE_INFO
+#define WC_STR_ITEM_SUBMERGE_INFO
 _ "This wondrous gem lets the bearer breathe and move through water as if it was air, strongly improving their mobility in water and granting the submerge ability." #enddef
 
-#define STR_ITEM_TENACITY_NAME
+#define WC_STR_ITEM_TENACITY_NAME
 _ "Bezoar" #enddef
 
-#define STR_ITEM_TENACITY_INFO
+#define WC_STR_ITEM_TENACITY_INFO
 _ "This shamanic totem protects from poison, drain, and plague. Bearers of the totem are immune to fear and their vulnerabilities are reduced." #enddef
 
-#define STR_ITEM_DRAIN_M_NAME
+#define WC_STR_ITEM_DRAIN_M_NAME
 _ "Blood ring" #enddef
 
-#define STR_ITEM_DRAIN_M_INFO
+#define WC_STR_ITEM_DRAIN_M_INFO
 _ "This pulsing ring empowers the bearer’s melee attacks with the ability to drain lifeforce from their victim." #enddef
 
-#define STR_ITEM_DRAIN_R_NAME
+#define WC_STR_ITEM_DRAIN_R_NAME
 _ "Cursed symbol of life" #enddef
 
-#define STR_ITEM_DRAIN_R_INFO
+#define WC_STR_ITEM_DRAIN_R_INFO
 _ "This vampiric amulet allows a unit to drain enemy life from a safe distance." #enddef
 
-#define STR_ITEM_MARKSMAN_R_NAME
+#define WC_STR_ITEM_MARKSMAN_R_NAME
 _ "Eagle eye longbow" #enddef
 
-#define STR_ITEM_MARKSMAN_R_INFO
+#define WC_STR_ITEM_MARKSMAN_R_INFO
 _ "This enchanted longbow enhances the wielder’s ranged attacks with uncanny precision and increased damage." #enddef
 
-#define STR_ITEM_PLAGUE_NAME
+#define WC_STR_ITEM_PLAGUE_NAME
 _ "Forbidden grimoire" #enddef
 
-#define STR_ITEM_PLAGUE_INFO
+#define WC_STR_ITEM_PLAGUE_INFO
 _ "This unholy manual gives the user the arcane knowledge to resurrect enemies slain in melee combat as the walking dead." #enddef
 
-#define STR_ITEM_FORCEFIELD_NAME
+#define WC_STR_ITEM_FORCEFIELD_NAME
 _ "Forcefield" #enddef
 
-#define STR_ITEM_FORCEFIELD_DESC
+#define WC_STR_ITEM_FORCEFIELD_DESC
 _ "adjacent enemies do 13% less damage" #enddef
 
-#define STR_ITEM_FORCEFIELD_INFO
+#define WC_STR_ITEM_FORCEFIELD_INFO
 _ "Charged with intense magic, this shield generates a forcefield causing adjacent enemies to inflict less damage around the wielder." #enddef
 
-#define STR_ITEM_FEEDING_NAME
+#define WC_STR_ITEM_FEEDING_NAME
 _ "Ghast’s marrow" #enddef
 
-#define STR_ITEM_FEEDING_INFO
+#define WC_STR_ITEM_FEEDING_INFO
 _ "This grisly concoction instills the drinker with an insatiable unholy hunger for more blood. Every time a foe is slain, a part of his lifeforce is eternally claimed through arcane ghoulish powers." #enddef
 
-#define STR_ITEM_IMPACT_NAME
+#define WC_STR_ITEM_IMPACT_NAME
 _ "Root of the Elder Wose" #enddef
 
-#define STR_ITEM_IMPACT_INFO
+#define WC_STR_ITEM_IMPACT_INFO
 _ " Dwarven forged, this blunt weapon mimics the crushing power of the Wose." #enddef
 
-#define STR_ITEM_CHARGE_NAME
+#define WC_STR_ITEM_CHARGE_NAME
 _ "Cruel spike" #enddef
 
-#define STR_ITEM_CHARGE_INFO
+#define WC_STR_ITEM_CHARGE_INFO
 _ "This enchanted spear drives the owner to commit himself to his rage. A unit’s melee strikes are doubled in power when attacking, but the same is true for the retaliation strike of the defender." #enddef
 
-#define STR_ITEM_FIRE_NAME
+#define WC_STR_ITEM_FIRE_NAME
 _ "Heart of fire" #enddef
 
-#define STR_ITEM_FIRE_INFO
+#define WC_STR_ITEM_FIRE_INFO
 _ "This magic orb infuses the wielder’s melee attacks with fiery power, changing their damage type. It also improves fire resistance." #enddef
 
-#define STR_ITEM_ILLUMINATES_NAME
+#define WC_STR_ITEM_ILLUMINATES_NAME
 _ "Herald armor" #enddef
 
-#define STR_ITEM_ILLUMINATES_INFO
+#define WC_STR_ITEM_ILLUMINATES_INFO
 _ "This holy armor of thin gold radiates pure light, illuminating the bearer’s body and soul. This effect will heal allies, blind evil, and preemptively smite those who seek to do harm." #enddef
 
-#define STR_ITEM_ARCANE_NAME
+#define WC_STR_ITEM_ARCANE_NAME
 _ "Holy water" #enddef
 
-#define STR_ITEM_ARCANE_INFO
+#define WC_STR_ITEM_ARCANE_INFO
 _ "This sacred vial anoints melee attacks with arcane power, increasing their damage and changing their damage type. It also increases arcane resistance." #enddef
 
-#define STR_ITEM_SLOW_R_NAME
+#define WC_STR_ITEM_SLOW_R_NAME
 _ "Ice bow" #enddef
 
-#define STR_ITEM_SLOW_R_INFO
+#define WC_STR_ITEM_SLOW_R_INFO
 _ "Draw this magical bow summon an ice arrow that will freeze and slow its target upon hit." #enddef
 
-#define STR_ITEM_CURES_NAME
+#define WC_STR_ITEM_CURES_NAME
 _ "Medicinal herbs" #enddef
 
-#define STR_ITEM_CURES_INFO
+#define WC_STR_ITEM_CURES_INFO
 _ "These potent herbs give the bearer the ability to heal adjacent units and cure their poison." #enddef
 
-#define STR_ITEM_DRUG_NAME
+#define WC_STR_ITEM_DRUG_NAME
 _ "Melange" #enddef
 
-#define STR_ITEM_DRUG_INFO
+#define WC_STR_ITEM_DRUG_INFO
 _ "This exotic drug of organic origin enhances user’s vitality and awareness. It has no effect when consumed by undead." #enddef
 
-#define STR_ITEM_SLOW_M_NAME
+#define WC_STR_ITEM_SLOW_M_NAME
 _ "Ring of frostbite" #enddef
 
-#define STR_ITEM_SLOW_M_INFO
+#define WC_STR_ITEM_SLOW_M_INFO
 _ "This frigid ring envelops the user’s melee attacks with icy cold, changing their damage to cold and allowing them to inflict deathly chills that slow the enemy." #enddef
 
-#define STR_ITEM_ELEMENTALS_NAME
+#define WC_STR_ITEM_ELEMENTALS_NAME
 _ "Ring of power" #enddef
 
-#define STR_ITEM_ELEMENTALS_INFO
+#define WC_STR_ITEM_ELEMENTALS_INFO
 _ "Wearing this ring enhances damage with arcane and elemental attacks, allowing using them with supernatural skill and presence." #enddef
 
-#define STR_ITEM_MAGICAL_NAME
+#define WC_STR_ITEM_MAGICAL_NAME
 _ "Runic sword" #enddef
 
-#define STR_ITEM_MAGICAL_INFO
+#define WC_STR_ITEM_MAGICAL_INFO
 _ "This magic sword empowers the wielder’s melee attacks with the magical property." #enddef
 
-#define STR_ITEM_ATTACK_ARCANE_NAME
+#define WC_STR_ITEM_ATTACK_ARCANE_NAME
 _ "Staff of radiance" #enddef
 
-#define STR_ITEM_ATTACK_ARCANE_INFO
+#define WC_STR_ITEM_ATTACK_ARCANE_INFO
 _ "This sacred rod can unleash brilliant bursts of luminous energy." #enddef
 
-#define STR_ITEM_BERSEK_NAME
+#define WC_STR_ITEM_BERSEK_NAME
 _ "Stormbringer" #enddef
 
-#define STR_ITEM_BERSEK_INFO
+#define WC_STR_ITEM_BERSEK_INFO
 _ "This tormented sword causes rage in any who wield it. Melee attacks will gain the fury ability pressing engagement for 3 rounds." #enddef
 
-#define STR_ITEM_STRIKES_R_NAME
+#define WC_STR_ITEM_STRIKES_R_NAME
 _ "Sylph bow" #enddef
 
-#define STR_ITEM_STRIKES_R_INFO
+#define WC_STR_ITEM_STRIKES_R_INFO
 _ "A runic bow. This elvish heirloom, passed from Queen to Princess, gathers power with each generation and speeds up the wielders movements so that more strikes can be landed before the engagement is over." #enddef
 
-#define STR_ITEM_DARKNESS_NAME
+#define WC_STR_ITEM_DARKNESS_NAME
 _ "Terror disguise" #enddef
 
-#define STR_ITEM_DARKNESS_INFO
+#define WC_STR_ITEM_DARKNESS_INFO
 _ "This cursed outfit spreads a trail of darkness, harming those who get too close." #enddef
 
-#define STR_ITEM_TELEPORT_NAME
+#define WC_STR_ITEM_TELEPORT_NAME
 _ "The Key" #enddef
 
-#define STR_ITEM_TELEPORT_INFO
+#define WC_STR_ITEM_TELEPORT_INFO
 _ "This magical object opens the gateway between dimensions." #enddef
 
-#define STR_ITEM_XP_NAME
+#define WC_STR_ITEM_XP_NAME
 _ "Tome of secrets" #enddef
 
-#define STR_ITEM_XP_INFO
+#define WC_STR_ITEM_XP_INFO
 _ "This forgotten book imparts ancient knowledge to the reader." #enddef
 
-#define STR_ITEM_ATTACK_FIRE_NAME
+#define WC_STR_ITEM_ATTACK_FIRE_NAME
 _ "Trident of storms" #enddef
 
-#define STR_ITEM_ATTACK_FIRE_INFO
+#define WC_STR_ITEM_ATTACK_FIRE_INFO
 _ "This legendary trident can summon lightning from the heavens, granting its wielder magical ranged fire attack." #enddef
 
-#define STR_ITEM_REGENERATES_NAME
+#define WC_STR_ITEM_REGENERATES_NAME
 _ "Trolls blood potion" #enddef
 
-#define STR_ITEM_REGENERATES_INFO
+#define WC_STR_ITEM_REGENERATES_INFO
 _ "This foul-smelling potion allows the imbiber to regenerate health." #enddef
 
-#define STR_ITEM_POISON_NAME
+#define WC_STR_ITEM_POISON_NAME
 _ "Ointment of venom" #enddef
 
-#define STR_ITEM_POISON_INFO
+#define WC_STR_ITEM_POISON_INFO
 _ "This deadly poison envenoms the user’s blade and pierce attacks, increasing damage and allowing them to inflict poison." #enddef
 
-#define STR_ITEM_LEADERSHIP_NAME
+#define WC_STR_ITEM_LEADERSHIP_NAME
 _ "War banner" #enddef
 
-#define STR_ITEM_LEADERSHIP_DESC
+#define WC_STR_ITEM_LEADERSHIP_DESC
 _ "adjacent allies do 20% more damage" #enddef
 
-#define STR_ITEM_LEADERSHIP_INFO
+#define WC_STR_ITEM_LEADERSHIP_INFO
 _ "This inspiring banner rallies the bearer’s allies to war, imparting a damage bonus to the allied units around it." #enddef
 
-#define STR_ITEM_FLYING_NAME
+#define WC_STR_ITEM_FLYING_NAME
 _ "Winged scepter" #enddef
 
-#define STR_ITEM_FLYING_INFO
+#define WC_STR_ITEM_FLYING_INFO
 _ "This wondrous rod imparts the user the ability to soar through the skies, making it a breeze to move through most terrain. Units that can already fly get improved defenses." #enddef
 
-#define STR_ITEM_SNOW_NAME
+#define WC_STR_ITEM_SNOW_NAME
 _ "Winter’s bloom" #enddef
 
-#define STR_ITEM_SNOW_INFO
+#define WC_STR_ITEM_SNOW_INFO
 _ "This delicate blossom rarely found in snowy peaks, is strongly appreciated for its beneficial effects on health." #enddef
 
-#define STR_ITEM_SKIRMISHER_NAME
+#define WC_STR_ITEM_SKIRMISHER_NAME
 _ "Zephyr cloak" #enddef
 
-#define STR_ITEM_SKIRMISHER_INFO
+#define WC_STR_ITEM_SKIRMISHER_INFO
 _ "This lightweight cloak renders its wearer almost invisible in the darkness and lets them move with fluid grace past enemies with ease." #enddef

--- a/data/campaigns/World_Conquest/resources/strings/effects.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/effects.cfg
@@ -1,94 +1,94 @@
 #textdomain wesnoth-wc
 
-#define STR_ART_ARCANE
+#define WC_STR_ART_ARCANE
 _ "staff of radiance" #enddef
 
-#define STR_ART_FIRE
+#define WC_STR_ART_FIRE
 _ "storm trident" #enddef
 
-#define STR_ART_SLOW_R
+#define WC_STR_ART_SLOW_R
 _ "ice bow" #enddef
 
-#define STR_BANNER
+#define WC_STR_BANNER
 _ "banner" #enddef
 
-#define STR_BANNER_DESCRIPTION
+#define WC_STR_BANNER_DESCRIPTION
 _ "This unit can lead ~allied~ units that are next to it, making them fight better. Adjacent allied units will do 20% more damage. This is cumulative with leadership." #enddef
 
-#define STR_CORRUPTION
+#define WC_STR_CORRUPTION
 _ "corruption" #enddef
 
-#define STR_CORRUPTION_DESCRIPTION
+#define WC_STR_CORRUPTION_DESCRIPTION
 _ "This unit corrupts adjacent enemies at the beginning of our turn. Corrupted units lose 6 HP or are reduced to 1 HP. Corruption cannot, of itself, kill a unit." #enddef
 
-#define STR_DARKNESS
+#define WC_STR_DARKNESS
 _ "darkness" #enddef
 
-#define STR_DARKNESS_DESCRIPTION
+#define WC_STR_DARKNESS_DESCRIPTION
 _ "This unit darkens the surrounding area, making chaotic units fight better, and lawful units fight worse. Any units adjacent to this unit will fight as if it were dusk when it is day, and as if it were night when it is dusk." #enddef
 
-#define STR_DISTRACT
+#define WC_STR_DISTRACT
 _ "distract" #enddef
 
-#define STR_DISTRACT_DESCRIPTION
+#define WC_STR_DISTRACT_DESCRIPTION
 _ "Allied units ignore enemy zones of control adjacent to this unit." #enddef
 
-#define STR_FLIGHT
+#define WC_STR_FLIGHT
 _ "flight" #enddef
 
-#define STR_FLIGHT_DESCRIPTION
+#define WC_STR_FLIGHT_DESCRIPTION
 _ "Full movement and up to 50% defense in all terrains but cave or mushroom grove." #enddef
 
-#define STR_SWIM
+#define WC_STR_SWIM
 _ "swim" #enddef
 
-#define STR_SWIM_DESCRIPTION
+#define WC_STR_SWIM_DESCRIPTION
 _ "Full movement and up to 60% defense in water or swamp and up to 70% defense in reef." #enddef
 
-#define STR_FORCEFIELD
+#define WC_STR_FORCEFIELD
 _ "forcefield" #enddef
 
-#define STR_FORCEFIELD_DESCRIPTION
+#define WC_STR_FORCEFIELD_DESCRIPTION
 _ "Adjacent enemies do 13% less damage." #enddef
 
-#define STR_FURY
+#define WC_STR_FURY
 _ "fury" #enddef
 
-#define STR_FURY_DESCRIPTION
+#define WC_STR_FURY_DESCRIPTION
 _ "Whether used offensively or defensively, this attack presses the engagement until one of the combatants is slain, or 3 rounds of attacks have occurred." #enddef
 
-#define STR_MOVE_ON_RECRUIT
+#define WC_STR_MOVE_ON_RECRUIT
 _ "Full movement on turn recruited or recalled" #enddef
 
-#define STR_OPTIONAL_CHARGE
+#define WC_STR_OPTIONAL_CHARGE
 _ "optional charge" #enddef
 
-#define STR_TENACITY
+#define WC_STR_TENACITY
 _ "tenacity" #enddef
 
-#define STR_TENACITY_DESCRIPTION
+#define WC_STR_TENACITY_DESCRIPTION
 _ "This unit’s vulnerabilities are halved when defending." #enddef
 
-#define STR_FREE_UPKEEP
+#define WC_STR_FREE_UPKEEP
 _ "free upkeep" #enddef
 
-#define STR_FULL_MOVEMENT
+#define WC_STR_FULL_MOVEMENT
 _ "full movement" #enddef
 
-#define STR_WATER
+#define WC_STR_WATER
 _ "terrain^water" #enddef
 
-#define STR_DEFENSES_IMP
+#define WC_STR_DEFENSES_IMP
 _ "improved defenses" #enddef
 
-#define STR_LIVING
+#define WC_STR_LIVING
 _ "no undead^consumed by a living being:" #enddef
 
-#define STR_UP_TO VALUE
+#define WC_STR_UP_TO VALUE
 _ "up to"+" {VALUE}% " #enddef
 
-#define STR_DISENGAGE
+#define WC_STR_DISENGAGE
 _ "disengage" #enddef
 
-#define STR_DISENGAGE_DESCRIPTION
+#define WC_STR_DISENGAGE_DESCRIPTION
 _ "Attack with this weapon gives unit 1 moves at end of combat (unit doesn’t gain a new attack)." #enddef

--- a/data/campaigns/World_Conquest/resources/strings/mainline.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/mainline.cfg
@@ -1,222 +1,222 @@
 #textdomain wesnoth-wc
 
-#define STR_PER_LEVEL
+#define WC_STR_PER_LEVEL
 _ "per level" #enddef
 
 #################################
 #textdomain wesnoth-help
 #################################
 
-#define STR_ALWAYS_REST
+#define WC_STR_ALWAYS_REST
 _ "Always rest heals" #enddef
 
-#define STR_AMBUSH
+#define WC_STR_AMBUSH
 _ "ambush" #enddef
 
-#define STR_BACKSTAB
+#define WC_STR_BACKSTAB
 _ "backstab" #enddef
 
-#define STR_CASTLE
+#define WC_STR_CASTLE
 _ "Castle" #enddef
 
-#define STR_CAVE
+#define WC_STR_CAVE
 _ "Cave" #enddef
 
-#define STR_CHARGE
+#define WC_STR_CHARGE
 _ "charge" #enddef
 
-#define STR_CONCEALMENT
+#define WC_STR_CONCEALMENT
 _ "concealment" #enddef
 
-#define STR_CURES
+#define WC_STR_CURES
 _ "heals +8"+", "+_ "cures" #enddef
 
-#define STR_DEFENSE
+#define WC_STR_DEFENSE
 _ "Defense" #enddef
 
-#define STR_DRAIN
+#define WC_STR_DRAIN
 _ "drains" #enddef
 
-#define STR_FEARLESS
+#define WC_STR_FEARLESS
 _ "fearless" #enddef
 
-#define STR_FEEDING
+#define WC_STR_FEEDING
 _ "feeding" #enddef
 
-#define STR_FEEDING_DESCRIPTION
+#define WC_STR_FEEDING_DESCRIPTION
 _ "This unit gains 1 hitpoint added to its maximum whenever it kills a unit, except units that are immune to plague." #enddef
 
-#define STR_FEEDING_EFFECT
+#define WC_STR_FEEDING_EFFECT
 _ "+1 max HP" #enddef
 
-#define STR_FIRSTSTRIKE
+#define WC_STR_FIRSTSTRIKE
 _ "firststrike" #enddef
 
-#define STR_FLAT
+#define WC_STR_FLAT
 _ "Flat" #enddef
 
-#define STR_FOREST
+#define WC_STR_FOREST
 _ "Forest" #enddef
 
-#define STR_FROZEN
+#define WC_STR_FROZEN
 _ "Frozen" #enddef
 
-#define STR_HEALS
+#define WC_STR_HEALS
 _ "heals +4" #enddef
 
-#define STR_HEALS_UNPOISON
+#define WC_STR_HEALS_UNPOISON
 _ "heals +4"+", "+_ "cures" #enddef
 
-#define STR_EXTRA_HEAL
+#define WC_STR_EXTRA_HEAL
 _ "heals +8" #enddef
 
-#define STR_HEALTHY
+#define WC_STR_HEALTHY
 _ "healthy" #enddef
 
-#define STR_HILLS
+#define WC_STR_HILLS
 _ "Hills" #enddef
 
-#define STR_ILLUMINATES
+#define WC_STR_ILLUMINATES
 _ "illuminates" #enddef
 
-#define STR_LEADERSHIP
+#define WC_STR_LEADERSHIP
 _ "leadership" #enddef
 
-#define STR_MAGICAL
+#define WC_STR_MAGICAL
 _ "magical" #enddef
 
-#define STR_MARKSMAN
+#define WC_STR_MARKSMAN
 _ "marksman" #enddef
 
-#define STR_MUSHROOM
+#define WC_STR_MUSHROOM
 _ "Mushroom Grove" #enddef
 
-#define STR_NIGHTSTALK
+#define WC_STR_NIGHTSTALK
 _ "nightstalk" #enddef
 
-#define STR_PLAGUE
+#define WC_STR_PLAGUE
 _ "plague" #enddef
 
-#define STR_POISON
+#define WC_STR_POISON
 _ "poison" #enddef
 
-#define STR_REGENERATES
+#define WC_STR_REGENERATES
 _ "regenerates" #enddef
 
-#define STR_RESISTANCES
+#define WC_STR_RESISTANCES
 _ "Resistances" #enddef
 
-#define STR_SAND
+#define WC_STR_SAND
 _ "Sand" #enddef
 
-#define STR_SKIRMISHER
+#define WC_STR_SKIRMISHER
 _ "skirmisher" #enddef
 
-#define STR_SLOW
+#define WC_STR_SLOW
 _ "slows" #enddef
 
-#define STR_STEADFAST
+#define WC_STR_STEADFAST
 _ "steadfast" #enddef
 
-#define STR_STRIKES
+#define WC_STR_STRIKES
 _ "Strikes" #enddef
 
-#define STR_SUBMERGE
+#define WC_STR_SUBMERGE
 _ "submerge" #enddef
 
-#define STR_SWAMP
+#define WC_STR_SWAMP
 _ "Swamp" #enddef
 
-#define STR_TELEPORT
+#define WC_STR_TELEPORT
 _ "teleport" #enddef
 
-#define STR_UNDEAD
+#define WC_STR_UNDEAD
 _ "undead" #enddef
 
-#define STR_UNPOISON
+#define WC_STR_UNPOISON
 _ "cures" #enddef
 
-#define STR_VILLAGE
+#define WC_STR_VILLAGE
 _ "Village" #enddef
 
 #################################
 #textdomain wesnoth
 #################################
 
-#define STR_ARCANE
+#define WC_STR_ARCANE
 _ "arcane" #enddef
 
-#define STR_BLADE
+#define WC_STR_BLADE
 _ "blade" #enddef
 
-#define STR_CHAOTIC
+#define WC_STR_CHAOTIC
 _ "chaotic" #enddef
 
-#define STR_COLD
+#define WC_STR_COLD
 _ "cold" #enddef
 
-#define STR_EASY
+#define WC_STR_EASY
 _ "Easy" #enddef
 
-#define STR_FIRE
+#define WC_STR_FIRE
 _ "fire" #enddef
 
-#define STR_HARD
+#define WC_STR_HARD
 _ "Hard" #enddef
 
-#define STR_HITPOINTS
+#define WC_STR_HITPOINTS
 _ "HP" #enddef
 
-#define STR_IMPACT
+#define WC_STR_IMPACT
 _ "impact" #enddef
 
-#define STR_LAWFUL
+#define WC_STR_LAWFUL
 _ "lawful" #enddef
 
-#define STR_MELEE
+#define WC_STR_MELEE
 _ "melee" #enddef
 
-#define STR_NIGHTMARE
+#define WC_STR_NIGHTMARE
 _ "Nightmare" #enddef
 
-#define STR_MEDIUM
+#define WC_STR_MEDIUM
 _ "Medium" #enddef
 
-#define STR_PIERCE
+#define WC_STR_PIERCE
 _ "pierce" #enddef
 
-#define STR_RANGED
+#define WC_STR_RANGED
 _ "ranged" #enddef
 
 #################################
 #textdomain wesnoth-lib
 #################################
 
-#define STR_RANDOM
+#define WC_STR_RANDOM
 _ "gender^Random" #enddef
 
 #################################
 #textdomain wesnoth-units
 #################################
 
-#define STR_PEASANT
+#define WC_STR_PEASANT
 _ "Peasant" #enddef
 
-#define STR_SERGEANT
+#define WC_STR_SERGEANT
 _ "Sergeant" #enddef
 
-#define STR_LIEUTENANT
+#define WC_STR_LIEUTENANT
 _ "Lieutenant" #enddef
 
-#define STR_GENERAL
+#define WC_STR_GENERAL
 _ "General" #enddef
 
-#define STR_GRAND_MARSHAL
+#define WC_STR_GRAND_MARSHAL
 _ "Grand Marshal" #enddef
 
 #################################
 #textdomain wesnoth-tutorial
 #################################
 
-#define STR_BEGINNER
+#define WC_STR_BEGINNER
 _ "Beginner" #enddef

--- a/data/campaigns/World_Conquest/resources/strings/training.cfg
+++ b/data/campaigns/World_Conquest/resources/strings/training.cfg
@@ -1,139 +1,139 @@
 #textdomain wesnoth-wc
 
-#define STR_MELEE_NAME
+#define WC_STR_MELEE_NAME
 _ "Melee Combat" #enddef
 
-#define STR_MELEE_FOUND
+#define WC_STR_MELEE_FOUND
 _ "Looks like you could use some help. A grizzled old veteran like me won’t be much use on the field, but I bet I can teach your men a thing or two about swordplay." #enddef
 
-#define STR_RANGER_NAME
+#define WC_STR_RANGER_NAME
 _ "Ranger Tactics" #enddef
 
-#define STR_RANGER_FOUND
+#define WC_STR_RANGER_FOUND
 _ "I sympathize with your cause, but this is not my battle. I will not fight for you, but I will gladly instruct your recruits in the art of the ranger, that they may better fight on their own." #enddef
 
-#define STR_HEALTH_NAME
+#define WC_STR_HEALTH_NAME
 _ "Health" #enddef
 
-#define STR_HEALTH_FOUND
+#define WC_STR_HEALTH_FOUND
 _ "Looks like a pretty grim fight you’ve got up ahead. I’ve got too many troubles of my own to join in, but stick about a while and I’ll put some steel in your backbone. When I’m through with you you’ll be able to keep on going no matter the odds!" #enddef
 
-#define STR_MOVEMENT_NAME
+#define WC_STR_MOVEMENT_NAME
 _ "Movement" #enddef
 
-#define STR_MOVEMENT_FOUND
+#define WC_STR_MOVEMENT_FOUND
 _ "What, you want me to join the fight? Quite out of the question, old boy! I’m afraid battlefields just aren’t my scene - no drama, no style, no romance! No finesse at all! You probably wouldn’t understand, so let me show you. I’ll teach you how to break out of those dreary marching formations and step light as a feather!" #enddef
 
-#define STR_EXPERIENCE_NAME
+#define WC_STR_EXPERIENCE_NAME
 _ "Combat Experience" #enddef
 
-#define STR_EXPERIENCE_FOUND
+#define WC_STR_EXPERIENCE_FOUND
 _ " Join the battle? Nay, lads, my talents would be wasted on the frontlines. Give me some raw recruits to work with, though, and I’ll whip ’em into shape for you. I know what real battle is like; by the time I’m through with ’em, your newbies might have some idea of it too." #enddef
 
-#define STR_DARK_NAME
+#define WC_STR_DARK_NAME
 _ "Dark" #enddef
 
-#define STR_DARK_FOUND
+#define WC_STR_DARK_FOUND
 _ "I haven’t lived centuries fighting others’ battles, but I could combat boredom teaching your men a couple of things about dark techniques." #enddef
 
-#define STR_ID_AMBUSH
+#define WC_STR_ID_AMBUSH
 ambush #enddef
 
-#define STR_TAG_AMBUSH
+#define WC_STR_TAG_AMBUSH
 hides #enddef
 
-#define STR_ID_BLADE
+#define WC_STR_ID_BLADE
 blade #enddef
 
-#define STR_ID_CAVE
+#define WC_STR_ID_CAVE
 cave #enddef
 
-#define STR_ID_COLD
+#define WC_STR_ID_COLD
 cold #enddef
 
-#define STR_ID_CONCEALMENT
+#define WC_STR_ID_CONCEALMENT
 concealment #enddef
 
-#define STR_TAG_CONCEALMENT
+#define WC_STR_TAG_CONCEALMENT
 hides #enddef
 
-#define STR_ID_CURES
+#define WC_STR_ID_CURES
 healing #enddef
 
-#define STR_TAG_CURES
+#define WC_STR_TAG_CURES
 heals #enddef
 
-#define STR_ID_DRAIN
+#define WC_STR_ID_DRAIN
 drains #enddef
 
-#define STR_ID_FIRE
+#define WC_STR_ID_FIRE
 fire #enddef
 
-#define STR_ID_FIRSTSTRIKE
+#define WC_STR_ID_FIRSTSTRIKE
 firststrike #enddef
 
-#define STR_ID_FOREST
+#define WC_STR_ID_FOREST
 forest #enddef
 
-#define STR_ID_FROZEN
+#define WC_STR_ID_FROZEN
 frozen #enddef
 
-#define STR_ID_HILLS
+#define WC_STR_ID_HILLS
 hills #enddef
 
-#define STR_ID_IMPACT
+#define WC_STR_ID_IMPACT
 impact #enddef
 
-#define STR_ID_MARKSMAN
+#define WC_STR_ID_MARKSMAN
 marksman #enddef
 
-#define STR_ID_MELEE
+#define WC_STR_ID_MELEE
 melee #enddef
 
-#define STR_ID_MUSHROOM
+#define WC_STR_ID_MUSHROOM
 fungus #enddef
 
-#define STR_ID_NIGHTSTALK
+#define WC_STR_ID_NIGHTSTALK
 nightstalk #enddef
 
-#define STR_TAG_NIGHTSTALK
+#define WC_STR_TAG_NIGHTSTALK
 hides #enddef
 
-#define STR_ID_PIERCE
+#define WC_STR_ID_PIERCE
 pierce #enddef
 
-#define STR_ID_PLAGUE
+#define WC_STR_ID_PLAGUE
 plague #enddef
 
-#define STR_ID_POISON
+#define WC_STR_ID_POISON
 poison #enddef
 
-#define STR_ID_RANGED
+#define WC_STR_ID_RANGED
 ranged #enddef
 
-#define STR_ID_REGENERATES
+#define WC_STR_ID_REGENERATES
 regenerates #enddef
 
-#define STR_TAG_REGENERATES
+#define WC_STR_TAG_REGENERATES
 regenerate #enddef
 
-#define STR_ID_SAND
+#define WC_STR_ID_SAND
 sand #enddef
 
-#define STR_ID_SKIRMISHER
+#define WC_STR_ID_SKIRMISHER
 skirmisher #enddef
 
-#define STR_TAG_SKIRMISHER
+#define WC_STR_TAG_SKIRMISHER
 skirmisher #enddef
 
-#define STR_ID_SLOW
+#define WC_STR_ID_SLOW
 slow #enddef
 
-#define STR_ID_SWAMP
+#define WC_STR_ID_SWAMP
 swamp_water #enddef
 
-#define STR_ID_UNPOISON
+#define WC_STR_ID_UNPOISON
 curing #enddef
 
-#define STR_TAG_UNPOISON
+#define WC_STR_TAG_UNPOISON
 heals #enddef

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -91,16 +91,16 @@ _ "World Conquest 3p" #enddef
         image = {IMAGE_ONE}
         type = mp
         abbrev = _ "WC" + {PLAYERS}\
-        {WC2_CAMPAIGN_DIFFICULTY VERY_EASY {WC2_HUMAN_DIFFICULTY human-peasants/peasant purple} {STR_PEASANT} {STR_BEGINNER} 6 2 2 10 yes 0}
-        {WC2_CAMPAIGN_DIFFICULTY EASY {WC2_HUMAN_DIFFICULTY human-loyalists/sergeant black} {STR_SERGEANT} {STR_EASY} 7 3 2 7 yes 5}
-        {WC2_CAMPAIGN_DIFFICULTY NORMAL {WC2_HUMAN_DIFFICULTY human-loyalists/lieutenant brown} {STR_LIEUTENANT} {STR_MEDIUM} 8 4 2 5 yes 10} {DEFAULT_DIFFICULTY}
-        {WC2_CAMPAIGN_DIFFICULTY HARD {WC2_HUMAN_DIFFICULTY human-loyalists/general orange} {STR_GENERAL} {STR_HARD} 8 5 2 2 no 13}
+        {WC2_CAMPAIGN_DIFFICULTY VERY_EASY {WC2_HUMAN_DIFFICULTY human-peasants/peasant purple} {WC_STR_PEASANT} {WC_STR_BEGINNER} 6 2 2 10 yes 0}
+        {WC2_CAMPAIGN_DIFFICULTY EASY {WC2_HUMAN_DIFFICULTY human-loyalists/sergeant black} {WC_STR_SERGEANT} {WC_STR_EASY} 7 3 2 7 yes 5}
+        {WC2_CAMPAIGN_DIFFICULTY NORMAL {WC2_HUMAN_DIFFICULTY human-loyalists/lieutenant brown} {WC_STR_LIEUTENANT} {WC_STR_MEDIUM} 8 4 2 5 yes 10} {DEFAULT_DIFFICULTY}
+        {WC2_CAMPAIGN_DIFFICULTY HARD {WC2_HUMAN_DIFFICULTY human-loyalists/general orange} {WC_STR_GENERAL} {WC_STR_HARD} 8 5 2 2 no 13}
         # Challenging is a string that exists in mainline but only in campaigns so it probably counts as adding a string?
         #textdomain wesnoth-httt
-        {WC2_CAMPAIGN_DIFFICULTY VERY_HARD {WC2_HUMAN_DIFFICULTY human-loyalists/marshal white} {STR_GRAND_MARSHAL} _"Challenging" 9 6 2 1 no 17}
+        {WC2_CAMPAIGN_DIFFICULTY VERY_HARD {WC2_HUMAN_DIFFICULTY human-loyalists/marshal white} {WC_STR_GRAND_MARSHAL} _"Challenging" 9 6 2 1 no 17}
         # Expert is a string that was supposed to be in wesnoth-wc but accidentally got added to wesnoth-units instead
         #textdomain wesnoth-units
-        {WC2_CAMPAIGN_DIFFICULTY NIGHTMARE {WC2_NIGHTMARE_DIFFICULTY} {STR_NIGHTMARE} _"Expert" 9 7 1 0 no 20}
+        {WC2_CAMPAIGN_DIFFICULTY NIGHTMARE {WC2_NIGHTMARE_DIFFICULTY} {WC_STR_NIGHTMARE} _"Expert" 9 7 1 0 no 20}
 
         [about]
             title = _ "Campaign Design"


### PR DESCRIPTION
Forward-port of #6063, will merge after CI passes.

Macros with very generic names such as "STR_CASTLE" were defined and not
undefined. This prefixes all of them to be WC_STR_CASTLE, etc.

Either fixes or reduces the severity of #6062.

(cherry picked from commit d3d21e59ee797cfe9eecd50aabae10a353547328)