### PR TITLE
Ignore auto-generated Steam file in save directory

### DIFF
--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -241,9 +241,8 @@ public:
 	}
 
 private:
-	/* 'The file steam_autocloud.vdf will be created in each location specified by your Steamworks cloud paths.
-		This file is used by Steam, and can be ignored by your game.'
-		Reference: https://partner.steamgames.com/doc/features/cloud */
+	/* Steam documentation indicates games can ignore its auto-generated 'steam_autocloud.vdf'.
+	   Reference: https://partner.steamgames.com/doc/features/cloud (under Steam Auto-Cloud section as of September 2021) */
 	const std::vector<std::string> files_to_ignore_ = std::vector {std::string {"steam_autocloud.vdf"}};
 };
 

--- a/src/save_index.cpp
+++ b/src/save_index.cpp
@@ -213,6 +213,7 @@ std::shared_ptr<save_index_class> save_index_class::default_saves_dir()
 	return instance;
 }
 
+/** Filter file names based on input string. */
 class filename_filter
 {
 public:
@@ -230,6 +231,22 @@ private:
 	std::string filter_;
 };
 
+/** Ignore certain files - in particular, the auto-generated Steam cloud record. */
+class filename_ignore
+{
+public:
+	bool operator()(const std::string& filename) const
+	{
+		return std::find(files_to_ignore_.begin(), files_to_ignore_.end(), filename) != files_to_ignore_.end();
+	}
+
+private:
+	/* 'The file steam_autocloud.vdf will be created in each location specified by your Steamworks cloud paths.
+		This file is used by Steam, and can be ignored by your game.'
+		Reference: https://partner.steamgames.com/doc/features/cloud */
+	const std::vector<std::string> files_to_ignore_ = std::vector {std::string {"steam_autocloud.vdf"}};
+};
+
 /** Get a list of available saves. */
 std::vector<save_info> save_index_class::get_saves_list(const std::string* filter)
 {
@@ -238,6 +255,7 @@ std::vector<save_info> save_index_class::get_saves_list(const std::string* filte
 	std::vector<std::string> filenames;
 	filesystem::get_files_in_dir(dir(), &filenames);
 
+	filenames.erase(std::remove_if(filenames.begin(), filenames.end(), filename_ignore()), filenames.end());
 	if(filter) {
 		filenames.erase(
 			std::remove_if(filenames.begin(), filenames.end(), filename_filter(*filter)), filenames.end());


### PR DESCRIPTION
I haven't seen anyone else remark about this, which surprises me. But the `steam_autocloud.vdf` file that constantly gets updated and shown in my game load dialogue bothers me enough to make this small change.

I don't know if it's worthwhile ignoring any file that doesn't follow `*.gz` or other expected file format, but that's beyond the scope of this PR. In such a case, we may as well follow what seems to be customary in regular application load dialogues and have a filter under or next to name field, with `*.gz` as the default filter.

I also don't know if this change is small enough to be allowed into 1.16 branch, hence the back-port reminder label.

PS Any attempt to load `steam_autocloud.vdf` results in an error message 'The file you have tried to load is corrupt', so I can't imagine a normal real-world case where anyone would want to leave this file visible in the load dialogue.