### PR TITLE
Rename kick attack for horses and wyverns

### DIFF
--- a/data/core/units/monsters/Horse.cfg
+++ b/data/core/units/monsters/Horse.cfg
@@ -28,8 +28,8 @@
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png" "units/monsters/horse/horse-defend-1.png" {SOUND_LIST:HORSE_HIT} }
     [attack]
-        name=kick
-        description=_"kick"
+        name=hooves
+        description=_"hooves"
         icon=attacks/hoof.png
         type=impact
         range=melee
@@ -38,7 +38,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=hooves
         [/filter_attack]
         start_time=-550
         offset=0.0~-0.05:350,-0.05~0.7:200,0.7~0.0:320
@@ -94,8 +94,8 @@
         arcane=100
     [/resistance]
     [attack]
-        name=kick
-        description=_"kick"
+        name=hooves
+        description=_"hooves"
         icon=attacks/hoof.png
         type=impact
         range=melee
@@ -104,7 +104,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=hooves
         [/filter_attack]
         start_time=-550
         offset=0.0~-0.05:350,-0.05~0.7:200,0.7~0.0:320
@@ -166,8 +166,8 @@
     description=_ "Dark Horses are wild animals, but they seem to take an odd interest in the civilized races. They leave no signs of their passage, but they have been noticed scouting camps and outposts during the night."
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]
-        name=kick
-        description=_"kick"
+        name=hooves
+        description=_"hooves"
         icon=attacks/hoof-nightmare.png
         type=impact
         range=melee
@@ -185,7 +185,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=hooves
         [/filter_attack]
         start_time=-550
         offset=0.0~-0.05:350,-0.05~0.7:200,0.7~0.0:320

--- a/data/core/units/monsters/Horse_Black.cfg
+++ b/data/core/units/monsters/Horse_Black.cfg
@@ -37,8 +37,8 @@
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-larger-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-larger-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]
-        name=kick
-        description=_"kick"
+        name=hooves
+        description=_"hooves"
         icon=attacks/hoof-nightmare.png
         type=impact
         range=melee
@@ -56,7 +56,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=hooves
         [/filter_attack]
         start_time=-550
         offset=0.0~-0.05:350,-0.05~0.7:200,0.7~0.0:320

--- a/data/core/units/monsters/Horse_Great.cfg
+++ b/data/core/units/monsters/Horse_Great.cfg
@@ -29,8 +29,8 @@
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-larger-defend-2.png" "units/monsters/horse/horse-larger-defend-1.png" {SOUND_LIST:HORSE_HIT} }
     [attack]
-        name=kick
-        description=_"kick"
+        name=hooves
+        description=_"hooves"
         icon=attacks/hoof.png
         type=impact
         range=melee
@@ -39,7 +39,7 @@
     [/attack]
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=hooves
         [/filter_attack]
         start_time=-550
         offset=0.0~-0.05:350,-0.05~0.7:200,0.7~0.0:320

--- a/data/core/units/monsters/Wild_Wyvern.cfg
+++ b/data/core/units/monsters/Wild_Wyvern.cfg
@@ -82,8 +82,8 @@ Wyverns are social creatures, usually traveling in pairs or small groups. Their 
         [/frame]
     [/post_movement_anim]
     [attack]
-        name=kick
-        description= _ "kick"
+        name=slam
+        description= _ "slam"
         icon=attacks/slam-drake.png
         type=impact
         range=melee
@@ -102,7 +102,7 @@ Wyverns are social creatures, usually traveling in pairs or small groups. Their 
 
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=slam
         [/filter_attack]
         terrain_type={UNWALKABLE_TERRAINS_TEMP}
 
@@ -130,7 +130,7 @@ Wyverns are social creatures, usually traveling in pairs or small groups. Their 
     [/attack_anim]
     [attack_anim]
         [filter_attack]
-            name=kick
+            name=slam
         [/filter_attack]
 
         start_time=-200


### PR DESCRIPTION
Makes attack name consistent with other weapon attacks and also avoids translation issues (resolves #6071).