### PR TITLE
Remove scaling by zoom_factor in unit height adjustment calculation

### DIFF
--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -348,9 +348,10 @@ void unit_drawer::redraw_unit (const unit & u) const
 	const t_translation::terrain_code terrain_dst = map.get_terrain(dst);
 	const terrain_type& terrain_dst_info = map.get_terrain_info(terrain_dst);
 
-	int height_adjust_unit = static_cast<int>((terrain_info.unit_height_adjust() * (1.0 - adjusted_params.offset) +
-											  terrain_dst_info.unit_height_adjust() * adjusted_params.offset) *
-											  zoom_factor);
+	// height_adjust_unit is not scaled by zoom_factor here otherwise it results in a squared offset that results in #5974
+	// It appears the tiles and units are scaled together somewhere else
+	int height_adjust_unit = static_cast<int>(terrain_info.unit_height_adjust() * (1.0 - adjusted_params.offset) +
+											  terrain_dst_info.unit_height_adjust() * adjusted_params.offset);
 	if (is_flying && height_adjust_unit < 0) {
 		height_adjust_unit = 0;
 	}


### PR DESCRIPTION
Resolves #5974... I think.

It appears double `zoom_factor` scaling results in units being drawn way off their actual hex at high zoom, for tiles with a large (~20 pixels) unit height offset parameter, for example on certain keeps and bridges.

I'm not super-confident this is the 'right' way to resolve the issue, but empirical testing does suggest removing at least one of the `zoom_factor` scalings produces the desired result.