### PR TITLE
Specify a non-zero value for nplayers.

### DIFF
--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -240,7 +240,7 @@ _ "World Conquest 3p" #enddef
 
 #ifdef EDITOR
 #ifndef SCHEMA_VALIDATION
-{WC2_SCENARIO_NEW multiplayer WC_II {WC_II_CAMPAIGN_NAME_3P} 0}
+{WC2_SCENARIO_NEW multiplayer WC_II {WC_II_CAMPAIGN_NAME_3P} 1}
 #endif
 #else
 


### PR DESCRIPTION
Fixes #6077

---

While no errors/warnings are present anymore, changing the number of players does print to the terminal for some reason.  For example, changing from 1 player to 3 players printed:
```
1	1
2	1
3	1
```