### PR TITLE
Apostrophe review

### DIFF
--- a/data/campaigns/Delfadors_Memoirs/_main.cfg
+++ b/data/campaigns/Delfadors_Memoirs/_main.cfg
@@ -47,7 +47,7 @@
     [about]
         title= _ "Co-Authors"
         [entry]
-            name="Oto 'tapik' Buchta"
+            name="Oto ‘tapik’ Buchta"
             comment="First scenario, various improvements"
         [/entry]
         [entry]
@@ -62,7 +62,7 @@
     [about]
         title = _ "Campaign Maintenance"
         [entry]
-            name = "Jeffrey 'Sigurd' Westcoat (SigurdFireDragon)"
+            name = "Jeffrey ‘Sigurd’ Westcoat (SigurdFireDragon)"
             comment= "former maintainer"
         [/entry]
     [/about]
@@ -91,7 +91,7 @@
         title= _ "Additional thanks to"
         [entry]
             name="Arkadiusz D. Danilecki"
-            comment="Inspiration and borrowings from his 'A New Order'"
+            comment="Inspiration and borrowings from his ‘A New Order’"
         [/entry]
     [/about]
 [/campaign]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/06_Swamps_of_Illuven.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/06_Swamps_of_Illuven.cfg
@@ -155,11 +155,11 @@
 #ifdef EASY
                     [message]
                         speaker=Garrath
-                        message=_"You know, you really ought to be more careful before handing over money to suspicious strangers like me. But, since I'm feeling nice at the moment, I think I will actually keep my word and offer you some protection."
+                        message=_"You know, you really ought to be more careful before handing over money to suspicious strangers like me. But, since I’m feeling nice at the moment, I think I will actually keep my word and offer you some protection."
                     [/message]
                     [message]
                         speaker=Harold
-                        message=_"Hey, what's your problem, Garrath? I thought we had a deal!"
+                        message=_"Hey, what’s your problem, Garrath? I thought we had a deal!"
                     [/message]
                     [message]
                         speaker=Garrath
@@ -181,7 +181,7 @@
                     [/redraw]
                     [message]
                         speaker=Delfador
-                        message=_"...I'm not entirely sure what just happened here, but I guess I should be grateful?"
+                        message=_"...I’m not entirely sure what just happened here, but I guess I should be grateful?"
                     [/message]
                     [message]
                         speaker=Lionel
@@ -251,7 +251,7 @@
                                             [then]
                                                 [message]
                                                     speaker=Garrath
-                                                    message=_"Hey, that was one of OUR villages! Deal's off; we're no longer protecting you!"
+                                                    message=_"Hey, that was one of OUR villages! Deal’s off; we’re no longer protecting you!"
                                                 [/message]
                                                 # Need to conditionalize here to ensure Garrath's reply makes sense:
                                                 [if]
@@ -271,7 +271,7 @@
                                                 [/if]
                                                 [message]
                                                     speaker=Delfador
-                                                    message=_"Wait, I'm sorry! I didn't realize you were so attached to that village! Please give me a chance to make it up to you!"
+                                                    message=_"Wait, I’m sorry! I didn’t realize you were so attached to that village! Please give me a chance to make it up to you!"
                                                 [/message]
                                                 [message]
                                                     speaker=Garrath
@@ -290,7 +290,7 @@
                                                         [message]
                                                             speaker=Delfador
                                                             # If debugging, feel free to edit the variable $gold into this message to see how much you have left:
-                                                            message=_"I'm afraid I don't have much gold left..."
+                                                            message=_"I’m afraid I don’t have much gold left..."
                                                         [/message]
                                                         [message]
                                                             speaker=Garrath
@@ -307,7 +307,7 @@
                                                             speaker=Delfador
                                                             message=_"Well..."
                                                             [option]
-                                                                label=_"Here's 20 more gold."
+                                                                label=_"Here’s 20 more gold."
                                                                 [command]
                                                                     [gold]
                                                                         side=1
@@ -320,18 +320,18 @@
                                                                     {VARIABLE_OP times_garrath_paid add 1}
                                                                     [message]
                                                                         speaker=Garrath
-                                                                        message=_"Pleasure doing business with you! Just don't let it happen again!"
+                                                                        message=_"Pleasure doing business with you! Just don’t let it happen again!"
                                                                     [/message]
                                                                     # If Harold is dead, dialogue will still make sense with this omitted:
                                                                     [message]
                                                                         speaker=Harold
-                                                                        message=_"Sheesh, Garrath, won't you make up your mind already?!"
+                                                                        message=_"Sheesh, Garrath, won’t you make up your mind already?!"
                                                                     [/message]
                                                                     # (nothing else to do; Garrath stays an ally)
                                                                 [/command]
                                                             [/option]
                                                             [option]
-                                                                label=_"Nope, I'm not giving you any more gold."
+                                                                label=_"Nope, I’m not giving you any more gold."
                                                                 [command]
                                                                     [message]
                                                                         speaker=Garrath
@@ -364,12 +364,12 @@
                                                     [/message]
                                                     [message]
                                                         speaker=Delfador
-                                                        message=_"Sorry! It's a hard habit to break! Perhaps I can pay you again to make up for it?"
+                                                        message=_"Sorry! It’s a hard habit to break! Perhaps I can pay you again to make up for it?"
                                                         # (possible future direction: actually let him do so, but at a higher price than before. For now, though, we won't.)
                                                     [/message]
                                                     [message]
                                                         speaker=Garrath
-                                                        message=_"Nope, I'm through with your games! Men, attack!"
+                                                        message=_"Nope, I’m through with your games! Men, attack!"
                                                     [/message]
                                                     [modify_side]
                                                         side=2
@@ -411,7 +411,7 @@
                             [then]
                                 [message]
                                     speaker=Garrath
-                                    message=_"Hm, it looks like you don't have any gold left. We're not interested in you anymore; bye!"
+                                    message=_"Hm, it looks like you don’t have any gold left. We’re not interested in you anymore; bye!"
                                 [/message]
                                 [kill]
                                     side=2
@@ -436,7 +436,7 @@
                         [/filter_second]
                         [message]
                             speaker=Harold
-                            message=_"I'll be taking back that money that your men “borrowed” from me now, Garrath!"
+                            message=_"I’ll be taking back that money that your men “borrowed” from me now, Garrath!"
                         [/message]
                     [/event]
 

--- a/data/campaigns/Delfadors_Memoirs/scenarios/12_Terror_at_the_Ford_of_Parthyn.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/12_Terror_at_the_Ford_of_Parthyn.cfg
@@ -296,7 +296,7 @@
             [then]
                 [message]
                     speaker=unit
-                    message= _ "There's something there in the mist!"
+                    message= _ "There’s something there in the mist!"
                 [/message]
             [/then]
         [/if]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/15_Save_the_King.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/15_Save_the_King.cfg
@@ -316,7 +316,7 @@
         [/filter]
         [message]
             speaker=Zorlan
-            message=_ "Argh! It can't be, beaten by these swine!"
+            message=_ "Argh! It can’t be, beaten by these swine!"
         [/message]
     [/event]
 

--- a/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
@@ -393,7 +393,7 @@
         [/message]
         [message]
             speaker=Delfador
-            message=_"(<i>To the dwarves</i>). Now that the portal is closed, his power will start to weaken, but that doesn't help us now. Quickly, back in the tunnel! I will stay last to seal the entrance."
+            message=_"(<i>To the dwarves</i>). Now that the portal is closed, his power will start to weaken, but that doesn’t help us now. Quickly, back in the tunnel! I will stay last to seal the entrance."
         [/message]
         #Delf collapses the cave entrance
 

--- a/data/campaigns/Descent_Into_Darkness/utils/amlas.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/amlas.cfg
@@ -602,7 +602,7 @@
 #define AMLA_OPTION_SORROW1
     [advancement]
         max_times=1
-        description=_"Reduces nearby enemy units' damage"
+        description=_"Reduces nearby enemy units’ damage"
         image="attacks/curse.png"
         id=eidolon_sorrow1
         strict_amla=yes

--- a/data/campaigns/Eastern_Invasion/scenarios/07a_The_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07a_The_Crossing.cfg
@@ -150,7 +150,7 @@
         [/message]
         [message]
             speaker=Dacyn
-            message= _ "We must cross here. The undead are chasing us, and their hordes are much too great for us to defeat. We've haven't faced even a small part of their force yet. We need to cross the river before the bulk of their army arrives!"
+            message= _ "We must cross here. The undead are chasing us, and their hordes are much too great for us to defeat. We’ve haven’t faced even a small part of their force yet. We need to cross the river before the bulk of their army arrives!"
         [/message]
         [message]
             speaker=Owaec
@@ -211,7 +211,7 @@
         [/message]
         [message]
             speaker=Dacyn
-            message= _ "They're closing in on us! We must get moving quickly."
+            message= _ "They’re closing in on us! We must get moving quickly."
         [/message]
     [/event]
 
@@ -244,7 +244,7 @@
 
         [message]
             speaker=Mal-Hakralan
-            message= _ "I see, this is where the scared dogs ran to. Don't think you can get away <b>this</b> easily."
+            message= _ "I see, this is where the scared dogs ran to. Don’t think you can get away <b>this</b> easily."
         [/message]
         [message]
             speaker=Dacyn

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Training_the_Ogres.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Training_the_Ogres.cfg
@@ -254,7 +254,7 @@
                     [/value]
 
                     [value]
-                        message= _ "Don't hurt $ogre_name|!"
+                        message= _ "Don’t hurt $ogre_name|!"
                     [/value]
 
                     [value]

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -411,35 +411,35 @@
 
         [message]
             speaker=narrator
-            message= _ "Several of Gweddry's men find themselves locked away in a crude orcish cell."
+            message= _ "Several of Gweddry’s men find themselves locked away in a crude orcish cell."
             image=wesnoth-icon.png
         [/message]
 
         [message]
             role=escapee sidekick 1
-            message= _ "We've got to get out of here!"
+            message= _ "We’ve got to get out of here!"
         [/message]
 
         [message]
             role=escapee sidekick 2
-            message= _ "I'm sure the commander will come and save us!"
+            message= _ "I’m sure the commander will come and save us!"
         [/message]
 
         [message]
             role=escapee sidekick 1
-            message= _ "What? Didn't you see those huge trolls drag them away? It's hopeless!"
+            message= _ "What? Didn’t you see those huge trolls drag them away? It’s hopeless!"
         [/message]
 
         [message]
             role=escapee leader
-            message= _ "Be quiet, you two! There's something back here..."
+            message= _ "Be quiet, you two! There’s something back here..."
         [/message]
 
         {MOVE_UNIT role="escapee leader" 22 2}
 
         [message]
             role=escapee leader
-            message= _ "Look! There's a gap in the wall over here. I think I can slip through if I clear away some of these rocks..."
+            message= _ "Look! There’s a gap in the wall over here. I think I can slip through if I clear away some of these rocks..."
         [/message]
 
         [animate_unit]
@@ -508,7 +508,7 @@
 
         [message]
             speaker=unit
-            message= _ "The door won't open from this side."
+            message= _ "The door won’t open from this side."
         [/message]
     [/event]
 
@@ -526,7 +526,7 @@
 
         [message]
             speaker=unit
-            message= _ "There's strange noises coming from those pits. I don't like this."
+            message= _ "There’s strange noises coming from those pits. I don’t like this."
         [/message]
 
         [event]
@@ -583,7 +583,7 @@
 
         [message]
             speaker=unit
-            message= _ "This tunnel seems to go deeper into the caves. We can't go that way."
+            message= _ "This tunnel seems to go deeper into the caves. We can’t go that way."
         [/message]
     [/event]
 
@@ -598,7 +598,7 @@
 
         [message]
             speaker=unit
-            message= _ "There's a pile of orcish gear and trash here. The stench is wretched."
+            message= _ "There’s a pile of orcish gear and trash here. The stench is wretched."
         [/message]
     [/event]
 
@@ -632,7 +632,7 @@
             [not]
                 x,y=$x1,$y1
             [/not]
-            message= _ "But there's too many of them!"
+            message= _ "But there’s too many of them!"
         [/message]
 
         [message]
@@ -688,7 +688,7 @@
 
                 [message]
                     id=$unit.id
-                    message= _ "I'll try to slip past the trolls. You wait here."
+                    message= _ "I’ll try to slip past the trolls. You wait here."
                 [/message]
             [/then]
         [/if]
@@ -881,7 +881,7 @@
 
         [message]
             speaker=unit
-            message= _ "Here's one of the prison cells! Let me open it..."
+            message= _ "Here’s one of the prison cells! Let me open it..."
         [/message]
 
         [sound]
@@ -951,7 +951,7 @@
         [message]
             x=13-16
             y=8-10
-            message= _ "Finally, we're rescued!"
+            message= _ "Finally, we’re rescued!"
         [/message]
 
         [fire_event]
@@ -1017,7 +1017,7 @@
         [message]
             x=29-32
             y=7-9
-            message= _ "Now let's get out of here!"
+            message= _ "Now let’s get out of here!"
         [/message]
 
         [fire_event]
@@ -1041,7 +1041,7 @@
 
         [message]
             speaker=King Dra-Nak
-            message= _ "What? Who's there? Get them!"
+            message= _ "What? Who’s there? Get them!"
         [/message]
 
         [fire_event]
@@ -1282,7 +1282,7 @@
 
         [message]
             speaker=narrator
-            message= _ "You've regained $stored_player_gold gold!"
+            message= _ "You’ve regained $stored_player_gold gold!"
             image=wesnoth-icon.png
             sound=gold.ogg
         [/message]

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_Weldyn_Besieged.cfg
@@ -266,7 +266,7 @@
 
         [message]
             speaker=Gweddry
-            message= _ "But how? We don't know which one of them he is."
+            message= _ "But how? We don’t know which one of them he is."
         [/message]
 
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -446,7 +446,7 @@
 
         [message]
             speaker=Relgorn
-            message= _ "You are right, friend. I will put my best men at your disposal, though we know naught of the Sceptre's location. Legend says it is hidden in the eastern tunnels."
+            message= _ "You are right, friend. I will put my best men at your disposal, though we know naught of the Sceptre’s location. Legend says it is hidden in the eastern tunnels."
         [/message]
 
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -626,12 +626,12 @@
         [message]
             race=merman
             # po: Comic relief
-            message=_ "I wouldn't know, milord. Without a river running though it, such hot, dry places are anathema to my kind. Whatever monsters may abide in these depths, are known not to my kin."
+            message=_ "I wouldn’t know, milord. Without a river running though it, such hot, dry places are anathema to my kind. Whatever monsters may abide in these depths, are known not to my kin."
         [/message]
         [message]
             race=merman
             # po: Comic relief
-            message=_ "Nor do I know, my most eccentric lord, what I am doing in a cave. No Mer has yet entered the caves under the mountain and lived to tell the tale. I would gladly die for you, milord, but I would that you didn't spend my life for nothing, looking for another dwarf to rescue when there is none."
+            message=_ "Nor do I know, my most eccentric lord, what I am doing in a cave. No Mer has yet entered the caves under the mountain and lived to tell the tale. I would gladly die for you, milord, but I would that you didn’t spend my life for nothing, looking for another dwarf to rescue when there is none."
         [/message]
         [if]
             [have_unit]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/20b_Underground_Channels.cfg
@@ -510,7 +510,7 @@
 
             [message]
                 speaker=Konrad
-                message= _ "Yes, Delfador. I'm afraid we must be going, Sir Wose."
+                message= _ "Yes, Delfador. I’m afraid we must be going, Sir Wose."
             [/message]
 
             [message]
@@ -536,7 +536,7 @@
 
                 # po: Over 50 years ago, probably 52, to be more precise.
 
-                message= _ "That was many years ago, I'm afraid. Now, we really must be moving along ..."
+                message= _ "That was many years ago, I’m afraid. Now, we really must be moving along ..."
             [/message]
 
             [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -232,12 +232,12 @@
 
         [message]
             speaker=Tallin
-            message= _ "This challenger has made the orcs careless — I managed to sneak in and filch the key to the storerooms. Come with me lads, and grab some weapons! Let them hack at each other, we can use this as our chance to get rid of this scum once and for all. Who's with me?"
+            message= _ "This challenger has made the orcs careless — I managed to sneak in and filch the key to the storerooms. Come with me lads, and grab some weapons! Let them hack at each other, we can use this as our chance to get rid of this scum once and for all. Who’s with me?"
         [/message]
 
         [message]
             speaker=Zlex
-            message= _ "Brave words, Tallin, but if I didn't know you better I'd say you were moon-touched. These are not weapons, just pitchforks and hunting bows. We have no armor, no training. Are we supposed to beat them with bad breath and colorful language?"
+            message= _ "Brave words, Tallin, but if I didn’t know you better I’d say you were moon-touched. These are not weapons, just pitchforks and hunting bows. We have no armor, no training. Are we supposed to beat them with bad breath and colorful language?"
         [/message]
 
         [message]
@@ -492,7 +492,7 @@
 
         [message]
             speaker=Tallin
-            message= _ "If only we were faster escaping into the mines this wouldn't have happened. At least we will die free..."
+            message= _ "If only we were faster escaping into the mines this wouldn’t have happened. At least we will die free..."
         [/message]
     [/event]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
@@ -1141,12 +1141,12 @@
         name=time over
         [message]
             speaker= narrator
-            message= _ "Without eating or sleeping for days, Tallin's men begin to fall one by one."
+            message= _ "Without eating or sleeping for days, Tallin’s men begin to fall one by one."
         [/message]
 
         [message]
             speaker=Tallin
-            message= _ "We were too slow in finding the dwarves. I don't think we can fight for much longer!"
+            message= _ "We were too slow in finding the dwarves. I don’t think we can fight for much longer!"
         [/message]
     [/event]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_02_Meeting_With_Dwarves.cfg
@@ -88,7 +88,7 @@
 
         [message]
             speaker=Camerin
-            message= _ "And I, don't forget me!"
+            message= _ "And I, don’t forget me!"
         [/message]
 
         [message]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -831,7 +831,7 @@
         [/message]
         [message]
             speaker=Haldric II
-            message= _ "That's a bluff, what sort of reinforcements can this little band of thieves possibly count on?"
+            message= _ "That’s a bluff, what sort of reinforcements can this little band of thieves possibly count on?"
         [/message]
     [/event]
     [event]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
@@ -138,19 +138,19 @@
         # need to check if this makes sense, has Rugnur seen an orc before?
         [message]
             speaker=Rugnur
-            message= _ "Those are orcs, aren't they?"
+            message= _ "Those are orcs, aren’t they?"
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Aye, in all their destructive glory. Looks like they're trying to strip the metal from the rails."
+            message= _ "Aye, in all their destructive glory. Looks like they’re trying to strip the metal from the rails."
         [/message]
         [message]
             speaker=Alanin
-            message= _ "That's terrible, someone should stop them!"
+            message= _ "That’s terrible, someone should stop them!"
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Do orcs always stink so bad? I've heard that they are stupid and messy, but this is almost unbearable!"
+            message= _ "Do orcs always stink so bad? I’ve heard that they are stupid and messy, but this is almost unbearable!"
         [/message]
         [message]
             speaker=Bragdash
@@ -158,20 +158,20 @@
         [/message]
         [message]
             speaker=Pidmer
-            message= _ "Um... Aren't we needed for the salvage?"
+            message= _ "Um... Aren’t we needed for the salvage?"
         [/message]
         [message]
             speaker=Bragdash
-            message= _ "No! You've been straining and struggling, but those metal tracks defeat you! It takes a strong orc to break that steel, you go deal with those little cave rats. You can keep their shiny helmets, they might fit you!"
+            message= _ "No! You’ve been straining and struggling, but those metal tracks defeat you! It takes a strong orc to break that steel, you go deal with those little cave rats. You can keep their shiny helmets, they might fit you!"
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Uh, well, we're not getting through without a fight..."
+            message= _ "Uh, well, we’re not getting through without a fight..."
         [/message]
         {MOVE_UNIT id=Rugnur 13 27}
         [message]
             speaker=Rugnur
-            message= _ "... Let's set up a base here."
+            message= _ "... Let’s set up a base here."
         [/message]
         [terrain]
             terrain=Ce
@@ -203,7 +203,7 @@
         [/filter]
         [message]
             speaker=unit
-            message= _ "This old cart still rolls smoothly on the track... It's forged by us dwarves, I shouldn't be surprised!"
+            message= _ "This old cart still rolls smoothly on the track... It’s forged by us dwarves, I shouldn’t be surprised!"
         [/message]
         [message]
             speaker=narrator
@@ -220,15 +220,15 @@
         [/filter]
         [message]
             speaker=unit
-            message= _ "(*gasp*) I think I've found the source of the terrible smell, it wasn't the orcs..."
+            message= _ "(*gasp*) I think I’ve found the source of the terrible smell, it wasn’t the orcs..."
         [/message]
         [message]
             speaker=Bragdash
-            message= _ "Of course it wasn't us, you worm!"
+            message= _ "Of course it wasn’t us, you worm!"
         [/message]
         [message]
             speaker=unit
-            message= _ "This underground river is choked off with a rotting mess, it's overgrown with fungus. I can try to see what's underneath... Whoops!"
+            message= _ "This underground river is choked off with a rotting mess, it’s overgrown with fungus. I can try to see what’s underneath... Whoops!"
         [/message]
         {QUAKE "rumble.ogg"}
         [terrain]
@@ -261,7 +261,7 @@
         [/redraw]
         [message]
             speaker=Pidmer
-            message= _ "Help! We can't swim!"
+            message= _ "Help! We can’t swim!"
         [/message]
         [kill]
             [and]
@@ -274,11 +274,11 @@
         [/kill]
         [message]
             speaker=Bragdash
-            message= _ "You've flooded your own tunnel, you stupid little gophers!"
+            message= _ "You’ve flooded your own tunnel, you stupid little gophers!"
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Och, we 'ave... But our rails are as strong and stout as we are!"
+            message= _ "Och, we ’ave... But our rails are as strong and stout as we are!"
         [/message]
         [message]
             speaker=Rugnur
@@ -286,7 +286,7 @@
         [/message]
         [message]
             speaker=Alanin
-            message= _ "That's good, because that water looks so cold!"
+            message= _ "That’s good, because that water looks so cold!"
         [/message]
         [kill]
             [and]
@@ -317,7 +317,7 @@
         [/filter]
         [message]
             speaker=Bragdash
-            message= _ "Arg, I never should'a come to this stinkin' cathole!"
+            message= _ "Arg, I never should’a come to this stinkin’ cathole!"
         [/message]
     [/event]
 
@@ -347,11 +347,11 @@
         [/filter]
         [message]
             speaker=Rugnur
-            message= _ "The air smells much better up ahead, let's leave this place behind us. Too bad the rails are damaged here, the carts could have been handy."
+            message= _ "The air smells much better up ahead, let’s leave this place behind us. Too bad the rails are damaged here, the carts could have been handy."
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Aye, but the carts are common enough, the real beauty is the rail track! Let's follow the straight steel path as far north as it will take us."
+            message= _ "Aye, but the carts are common enough, the real beauty is the rail track! Let’s follow the straight steel path as far north as it will take us."
         [/message]
         [endlevel]
             result=victory

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2t_In_the_Dwarven_City.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2t_In_the_Dwarven_City.cfg
@@ -112,7 +112,7 @@
         [/scroll_to]
         [message]
             speaker=Durstorn
-            message= _ "Another day older, another foot stuck in the sludge! Let's start with some soft clay... Rugnur, how goes it at the western gate?"
+            message= _ "Another day older, another foot stuck in the sludge! Let’s start with some soft clay... Rugnur, how goes it at the western gate?"
         [/message]
         {MODIFY_UNIT (id=Durstorn) facing se}
         [delay]
@@ -137,7 +137,7 @@
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "Where's that fool Rugnur? He should be here to report on events in the surface world. He’s late!"
+            message= _ "Where’s that fool Rugnur? He should be here to report on events in the surface world. He’s late!"
         [/message]
         [message]
             speaker=Noiraran
@@ -162,7 +162,7 @@
         [/recall]
         [message]
             speaker=Rugnur
-            message= _ "(whew!) Sorry I'm late, but King Haldric came by just now, wanted to talk to you..."
+            message= _ "(whew!) Sorry I’m late, but King Haldric came by just now, wanted to talk to you..."
         [/message]
         [message]
             speaker=Durstorn
@@ -195,7 +195,7 @@
         [/message]
         [message]
             speaker=Noiraran
-            message= _ "More important than that, what'd the king offer for this sceptre, eh?"
+            message= _ "More important than that, what’d the king offer for this sceptre, eh?"
         [/message]
         [message]
             speaker=Rugnur
@@ -239,11 +239,11 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Thank you, Lord. I'll find him and do us proud!"
+            message= _ "Thank you, Lord. I’ll find him and do us proud!"
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "Too late for that, young fool. But go on, I can see there's hope for you yet."
+            message= _ "Too late for that, young fool. But go on, I can see there’s hope for you yet."
         [/message]
         {VARIABLE changealanin.x 2}
         {VARIABLE changealanin.y 5}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -38,7 +38,7 @@
 
     [story]
         [part]
-            story= _ "It was a couple more weeks of marching along the tracks before a chill breeze touched Rugnur's group, washing over them from a side tunnel leading up to the surface. Had they reached the Northlands?"
+            story= _ "It was a couple more weeks of marching along the tracks before a chill breeze touched Rugnur’s group, washing over them from a side tunnel leading up to the surface. Had they reached the Northlands?"
         [/part]
         [part]
             story= _ "Much to his chagrin, Alanin was dispatched to scout further up the rails, but he soon came back and claimed the rails ended, the main tunnel was unfinished to the north. For this reason, Rugnur lead the dwarves up the cold passage, and began to search for the runesmith named Thursagan. Thursagan, the Sage of Fire."
@@ -216,7 +216,7 @@
 
         [message]
             speaker=Alanin
-            message= _ "Now where are we going, anyway? I've had to ride down cold, dark, unknown caves... It's been quite harrowing, this trip had better be worth all that!"
+            message= _ "Now where are we going, anyway? I’ve had to ride down cold, dark, unknown caves... It’s been quite harrowing, this trip had better be worth all that!"
         [/message]
         [message]
             speaker=Baglur
@@ -232,7 +232,7 @@
         [/message]
         [message]
             speaker=Alanin
-            message= _ "Except for trolls and ogres, right? I've heard they live in the far Northlands. They’re probably lurking around here somewhere."
+            message= _ "Except for trolls and ogres, right? I’ve heard they live in the far Northlands. They’re probably lurking around here somewhere."
         [/message]
         [message]
             speaker=Baglur
@@ -542,7 +542,7 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "You don’t want to make a sceptre to contain the power of the Ruby of Fire? It would be quite a challenge, I could see why you wouldn't want to touch it!"
+            message= _ "You don’t want to make a sceptre to contain the power of the Ruby of Fire? It would be quite a challenge, I could see why you wouldn’t want to touch it!"
         [/message]
         [message]
             speaker=Thursagan
@@ -566,15 +566,15 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "No wait, I wasn't clear! We need to contain this power, build some sort of magical cage!"
+            message= _ "No wait, I wasn’t clear! We need to contain this power, build some sort of magical cage!"
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Aye, a cage, and we can't do it on our own, Thursagan. We need your skill and expertise!"
+            message= _ "Aye, a cage, and we can’t do it on our own, Thursagan. We need your skill and expertise!"
         [/message]
         [message]
             speaker=Thursagan
-            message= _ "Hrmph, so you need to deliver this power to the king, but also seek to contain that foolish man... I see your dilemma, and I do love a challenge, so let's build this powerful artifact. I expect it will take years."
+            message= _ "Hrmph, so you need to deliver this power to the king, but also seek to contain that foolish man... I see your dilemma, and I do love a challenge, so let’s build this powerful artifact. I expect it will take years."
         [/message]
         [message]
             speaker=Baglur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3t_The_Council_Regathers.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3t_The_Council_Regathers.cfg
@@ -42,7 +42,7 @@
 
     [story]
         [part]
-            story= _ "The path back to the dwarven city was well known to the travelers this time, so the journey south was relatively quick and uneventful. A week's march brought the expedition to the familiar plaza, with two new members of their party — one expected, and one not."
+            story= _ "The path back to the dwarven city was well known to the travelers this time, so the journey south was relatively quick and uneventful. A week’s march brought the expedition to the familiar plaza, with two new members of their party — one expected, and one not."
         [/part]
     [/story]
 
@@ -182,7 +182,7 @@
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "Fine, so be it! Do what you have to, Thursagan, but don't try anything sneaky..."
+            message= _ "Fine, so be it! Do what you have to, Thursagan, but don’t try anything sneaky..."
         [/message]
         {MOVE_UNIT id=Thursagan 11 4}
         [remove_item]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
@@ -145,7 +145,7 @@
         [/message]
         [message]
             speaker=Thursagan
-            message= _ "We don’t need you, we need the ruby. I'll take it to Theganli and we'll review the cuts we plan to make."
+            message= _ "We don’t need you, we need the ruby. I’ll take it to Theganli and we’ll review the cuts we plan to make."
         [/message]
         {MODIFY_UNIT (id=Durstorn) facing se}
         [message]
@@ -300,7 +300,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Well... Maybe you can ask the Shorbear clan? They have good tools... Chisels and grit of some rare mineral, I don't know what it is or how they got it, but their work is well known among us gem crafters."
+            message= _ "Well... Maybe you can ask the Shorbear clan? They have good tools... Chisels and grit of some rare mineral, I don’t know what it is or how they got it, but their work is well known among us gem crafters."
         [/message]
         [message]
             speaker=Rugnur
@@ -308,7 +308,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Another group of dwarves that live south of here... Above ground, if you can believe it! Yes, they're the best jewelers..."
+            message= _ "Another group of dwarves that live south of here... Above ground, if you can believe it! Yes, they’re the best jewelers..."
         [/message]
         [message]
             speaker=Durstorn

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -441,7 +441,7 @@
         [/unit]
         [message]
             speaker=narrator
-            message= _ "A brave dwarf ran out, grabbed a friendly gryphon by the sturdy neck-feathers, and hauled himself up over its back. The big animal took it all in stride, and seemed to understand what the pats and strokes of the dwarf's hands meant."
+            message= _ "A brave dwarf ran out, grabbed a friendly gryphon by the sturdy neck-feathers, and hauled himself up over its back. The big animal took it all in stride, and seemed to understand what the pats and strokes of the dwarf’s hands meant."
             image=wesnoth-icon.png
         [/message]
         [message]
@@ -479,7 +479,7 @@
         [/terrain]
         [message]
             speaker=Glildur
-            message= _ "Aha! I've been looking all over for you dwarves, but now I’ve found you! Prepare to die!"
+            message= _ "Aha! I’ve been looking all over for you dwarves, but now I’ve found you! Prepare to die!"
         [/message]
         [message]
             speaker=Glonoin
@@ -507,7 +507,7 @@
         [/message]
         [message]
             speaker=Glonoin
-            message= _ "Deal! Not like this is the first time we've faced this sort of insanity. We have no idea what this ruby is, and don't care!"
+            message= _ "Deal! Not like this is the first time we’ve faced this sort of insanity. We have no idea what this ruby is, and don’t care!"
         [/message]
         [message]
             speaker=Durstorn
@@ -861,7 +861,7 @@
         [/filter]
         [message]
             speaker=Glildur
-            message= _ "Well played, little dwarves, but this isn't over..."
+            message= _ "Well played, little dwarves, but this isn’t over..."
         [/message]
         {MOVE_UNIT (id=Glildur) 1 38}
         [heal_unit]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -318,7 +318,7 @@
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "You little fool, honor is less important than life! Open the gates, I'm going out to negotiate our safe passage out of here!"
+            message= _ "You little fool, honor is less important than life! Open the gates, I’m going out to negotiate our safe passage out of here!"
         [/message]
         [terrain]
             [and]
@@ -342,7 +342,7 @@
         [/message]
         [message]
             speaker=Durstorn
-            message= _ "I can't believe what I'm hearing, do all of you want to die? Enough talk!"
+            message= _ "I can’t believe what I’m hearing, do all of you want to die? Enough talk!"
         [/message]
         {MOVE_UNIT (id=Durstorn) 15 22}
         [message]
@@ -356,7 +356,7 @@
         [/message]
         [message]
             speaker=Glildur
-            message= _ "My, you're a bold little dwarf! You've brought me the Ruby?"
+            message= _ "My, you’re a bold little dwarf! You’ve brought me the Ruby?"
         [/message]
         [message]
             speaker=Durstorn
@@ -536,7 +536,7 @@
         {MODIFY_UNIT (id=Glildur) facing ne}
         [message]
             speaker=Glildur
-            message= _ "Come out, dwarves, let's get this over with!"
+            message= _ "Come out, dwarves, let’s get this over with!"
         [/message]
     [/event]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
@@ -443,19 +443,19 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "That's great, we could really use some resources about now."
+            message= _ "That’s great, we could really use some resources about now."
         [/message]
         [message]
             speaker=Khrakrahs
-            message= _ "Thieves!  I won't forget this..."
+            message= _ "Thieves!  I won’t forget this..."
         [/message]
         [message]
             side=2
-            message= _ "Haha, you're making friends all over, you cowards!"
+            message= _ "Haha, you’re making friends all over, you cowards!"
         [/message]
         [message]
             speaker=Khrakrahs
-            message= _ "I don't care about your petty squabbles, I curse all of you!  I curse all who invade my lair!"
+            message= _ "I don’t care about your petty squabbles, I curse all of you!  I curse all who invade my lair!"
         [/message]
         {CLEAR_VARIABLE dragon_sighted}
     [/event]
@@ -523,7 +523,7 @@
         [/if]
         [message]
             speaker=Khrakrahs
-            message= _ "That's my rock slab, leave it be!"
+            message= _ "That’s my rock slab, leave it be!"
         [/message]
 
         {VARIABLE found_forge yes}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -453,7 +453,7 @@
             name=gathor_fit
             [message]
                 speaker=Gathor
-                message= _ "Argh, this is not good! But I've still got a trick up my sleeve..."
+                message= _ "Argh, this is not good! But I’ve still got a trick up my sleeve..."
             [/message]
             [message]
                 speaker=narrator
@@ -674,11 +674,11 @@
             [/filter_condition]
             [message]
                 speaker=Krawg
-                message= _ "Wha'?"
+                message= _ "Wha’?"
             [/message]
             [message]
                 speaker=narrator
-                message= _ "Krawg puzzled over a stone tile sitting loose on the small mesa. Beneath a spattering of bat guano, there was a glowing rune. Krawg didn't know what to make of it, so the gryphon left it for now."
+                message= _ "Krawg puzzled over a stone tile sitting loose on the small mesa. Beneath a spattering of bat guano, there was a glowing rune. Krawg didn’t know what to make of it, so the gryphon left it for now."
                 image=wesnoth-icon.png
             [/message]
         [/event]
@@ -724,11 +724,11 @@
             [/message]
             [message]
                 speaker=Rugnur
-                message= _ "Wait! If Krawg can escape, shouldn't we give him the Sceptre?"
+                message= _ "Wait! If Krawg can escape, shouldn’t we give him the Sceptre?"
             [/message]
             [message]
                 speaker=Thursagan
-                message= _ "No, too risky, even if Krawg drops it in King Haldric's hand. You've seen how the elves have behaved, you've seen how your lord behaved. The corrupting emissions from the ruby are nothing compared to the greed already out there, and my crafted gold cage does nothing to contain that."
+                message= _ "No, too risky, even if Krawg drops it in King Haldric’s hand. You’ve seen how the elves have behaved, you’ve seen how your lord behaved. The corrupting emissions from the ruby are nothing compared to the greed already out there, and my crafted gold cage does nothing to contain that."
             [/message]
             [message]
                 speaker=Thursagan
@@ -970,7 +970,7 @@
             [/filter]
             [message]
                 speaker=unit
-                message= _ "Ah! We aren't wandering the bowels o' the earth, this is crafted stone! It's very old though..."
+                message= _ "Ah! We aren’t wandering the bowels o’ the earth, this is crafted stone! It’s very old though..."
             [/message]
         [/event]
         [event]
@@ -982,7 +982,7 @@
             [/filter]
             [message]
                 speaker=unit
-                message= _ "This is some sort of notebook... I can't read the text, but there are drawings showing three arcs spanning what must be the volcano. There are three symbols for these arcs... Well, it must describe the volcano somehow, but I can't puzzle it out now."
+                message= _ "This is some sort of notebook... I can’t read the text, but there are drawings showing three arcs spanning what must be the volcano. There are three symbols for these arcs... Well, it must describe the volcano somehow, but I can’t puzzle it out now."
             [/message]
         [/event]
         [item]
@@ -1050,12 +1050,12 @@
         #messages
         [message]
             speaker=Rugnur
-            message= _ "Well, we've put some distance between us and the elves, so we have a little time to think. What is this place?"
+            message= _ "Well, we’ve put some distance between us and the elves, so we have a little time to think. What is this place?"
         [/message]
         [message]
             speaker=Thursagan
             # wmllint: local spelling Khrakrahs
-            message= _ "Remember what Khrakrahs said, about this being a volcano? Well, it seems we're under the crater, sitting on the magma chamber... I think we should try to cause it to erupt."
+            message= _ "Remember what Khrakrahs said, about this being a volcano? Well, it seems we’re under the crater, sitting on the magma chamber... I think we should try to cause it to erupt."
         [/message]
         [message]
             speaker=Rugnur
@@ -1067,7 +1067,7 @@
         [/message]
         [message]
             speaker=Thursagan
-            message= _ "Look up, if this were a normal volcano, you'd see stars and sky. Instead, there's a high ceiling, shaped like a cone. At the center of this chamber, we'll find what is holding back the lava flow, and there lies our chance."
+            message= _ "Look up, if this were a normal volcano, you’d see stars and sky. Instead, there’s a high ceiling, shaped like a cone. At the center of this chamber, we’ll find what is holding back the lava flow, and there lies our chance."
         [/message]
         [message]
             speaker=Rugnur
@@ -1097,7 +1097,7 @@
         [/filter]
         [message]
             speaker=Rugnur
-            message= _ "Friends, brothers, this is a desperate situation, I need your help. Can we negotiate pay after we're back to safety?"
+            message= _ "Friends, brothers, this is a desperate situation, I need your help. Can we negotiate pay after we’re back to safety?"
         [/message]
         [message]
             speaker=narrator
@@ -1217,7 +1217,7 @@
         [/filter]
         [message]
             speaker=unit
-            message= _ "This must be the center of the volcano! It's plugged up with this enchanted courtyard?"
+            message= _ "This must be the center of the volcano! It’s plugged up with this enchanted courtyard?"
         [/message]
         [message]
             speaker=Thursagan
@@ -1235,7 +1235,7 @@
         [/filter]
         [message]
             speaker=unit
-            message= _ "It's very hot here, above the lava. This bridge also seems rather delicate, I'd better not loiter here."
+            message= _ "It’s very hot here, above the lava. This bridge also seems rather delicate, I’d better not loiter here."
         [/message]
     [/event]
 
@@ -1255,7 +1255,7 @@
         [/filter_second]
         [message]
             speaker=Rugnur
-            message= _ "These trolls are not like others I've seen, and they seem to be guarding this chamber."
+            message= _ "These trolls are not like others I’ve seen, and they seem to be guarding this chamber."
         [/message]
         [message]
             [and]
@@ -1271,11 +1271,11 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Us?  We're nice, not like the elves chasing us."
+            message= _ "Us?  We’re nice, not like the elves chasing us."
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Aye, but it's no use, Rugnur. There's no peace between dwarves and trolls, never has been."
+            message= _ "Aye, but it’s no use, Rugnur. There’s no peace between dwarves and trolls, never has been."
         [/message]
     [/event]
 
@@ -1319,15 +1319,15 @@
         [/redraw]
         [message]
             speaker=Gathor
-            message= _ "Ah ha! I knew it, there are intruders! And yet our damned bridge is broken, it was built by idiots. Come, come, bring planks, we've got to get across!"
+            message= _ "Ah ha! I knew it, there are intruders! And yet our damned bridge is broken, it was built by idiots. Come, come, bring planks, we’ve got to get across!"
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "Huh. Well, let's not stay here too long."
+            message= _ "Huh. Well, let’s not stay here too long."
         [/message]
         [message]
             speaker=Thursagan
-            message= _ "Right, if we can get both the orcs and the elves behind us, maybe they'll fight each other."
+            message= _ "Right, if we can get both the orcs and the elves behind us, maybe they’ll fight each other."
         [/message]
     [/event]
 [/scenario]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -135,7 +135,7 @@
         [/message]
         [message]
             speaker=Alanin
-            message= _ "I believe it was completed, my lord, but I do not have it. I'm afraid it is buried deep in the mountains of the Northlands."
+            message= _ "I believe it was completed, my lord, but I do not have it. I’m afraid it is buried deep in the mountains of the Northlands."
         [/message]
         [message]
             speaker=Haldric II
@@ -199,11 +199,11 @@
         [/message]
         [message]
             speaker=Haldric II
-            message= _ "What the devil! I'm supposed to believe this?"
+            message= _ "What the devil! I’m supposed to believe this?"
         [/message]
         [message]
             speaker=Alanin
-            message= _ "It's difficult to accept, you are right, my liege. However, I have fought side-by-side with the dwarves and this gryphon, and I stake my honor on the story. What's more, the gryphon has some evidence. Show him, Krawg."
+            message= _ "It’s difficult to accept, you are right, my liege. However, I have fought side-by-side with the dwarves and this gryphon, and I stake my honor on the story. What’s more, the gryphon has some evidence. Show him, Krawg."
         [/message]
         [message]
             speaker=Krawg

--- a/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
@@ -30,7 +30,7 @@
                     [then]
                         [message]
                             speaker=unit
-                            message=_"We don't have the funds..."
+                            message=_"We don’t have the funds..."
                         [/message]
                         [set_variable]
                             name=no_funds
@@ -283,7 +283,7 @@
             [/filter]
             [rune_choice]
                 speaker=Thursagan
-                message= _ "I can hammer out a quick little runic charm, it should help you somewhat. This isn't the place to do really good work though, so the effects will vanish in the future. What do you say, is it worth a bit of gold and crystal?"
+                message= _ "I can hammer out a quick little runic charm, it should help you somewhat. This isn’t the place to do really good work though, so the effects will vanish in the future. What do you say, is it worth a bit of gold and crystal?"
                 [option]
                     default=yes
                     image=attacks/blank-attack.png~BLIT(icons/unit-groups/cross_30.png~SCALE(60,60),0,0)
@@ -296,7 +296,7 @@
                     default=yes
                     image=attacks/blank-attack.png~BLIT(icons/unit-groups/cross_30.png~BLEND(200,0,0,1.0)~SCALE(60,60),0,0)
                     label= _ "Reject"
-                    description = _ "No thanks, don't ask again."
+                    description = _ "No thanks, don’t ask again."
                     [command]
                         [set_variable]
                             name=unit.variables.no_rune
@@ -376,7 +376,7 @@
         {CLEAR_VARIABLE chest_{X}_{Y}}
         [rune_choice]
             speaker=unit
-            message= _ "This is part of our stash of field runes, we can use them to get a small temporary boost. We don't have very many though, and need to contribute funds for replacements. Should I take this one?"
+            message= _ "This is part of our stash of field runes, we can use them to get a small temporary boost. We don’t have very many though, and need to contribute funds for replacements. Should I take this one?"
             [option]
                 default=yes
                 image=attacks/blank-attack.png~BLIT(icons/unit-groups/cross_30.png~SCALE(60,60),0,0)

--- a/data/campaigns/Secrets_of_the_Ancients/_main.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/_main.cfg
@@ -19,7 +19,7 @@
     {CAMPAIGN_DIFFICULTY NORMAL "units/undead-skeletal/revenant/revenant-defend-2.png~RC(magenta>red)" ( _ "Corrupt") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD "units/undead-skeletal/deathknight.png~RC(magenta>red)" ( _ "Diabolic") ( _ "Difficult")}
     define=CAMPAIGN_SECRETS_OF_THE_ANCIENTS
-    description= _ "Rediscover the secrets known by the lich lords of the Green Isle. They knew how to live forever, so why can't you?
+    description= _ "Rediscover the secrets known by the lich lords of the Green Isle. They knew how to live forever, so why can’t you?
 
 (Hard level, 18 scenarios.)
 "
@@ -34,7 +34,7 @@
     [about]
         title = _ "Campaign Maintenance"
         [entry]
-            name = "Jeffrey 'Sigurd' Westcoat (SigurdFireDragon)"
+            name = "Jeffrey ‘Sigurd’ Westcoat (SigurdFireDragon)"
             comment= "former maintainer"
         [/entry]
     [/about]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/01_Slipping_Away.cfg
@@ -340,7 +340,7 @@ With further observation, I have determined that this is probably not the way to
         [/filter]
         [message]
             speaker=Ardonna
-            message= _ "A wolf! This journey may be more dangerous than I thought. If we need to, I suppose we could rest inside a farmer's or woodcutter's fence."
+            message= _ "A wolf! This journey may be more dangerous than I thought. If we need to, I suppose we could rest inside a farmer’s or woodcutter’s fence."
         [/message]
     [/event]
 

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -156,7 +156,7 @@ I decided to hide in the cemetery. That way I could try my experiment to animate
                     [message]
                         speaker=narrator
                         image=items/gold-coins-message.png
-                        message=_ "You don't have enough gold to raise that unit."
+                        message=_ "You don’t have enough gold to raise that unit."
                     [/message]
                 [/then]
                 [else]
@@ -393,13 +393,13 @@ of Healing"
             [then]
                 [message]
                     speaker=Ardonna
-                    message= _ "Oh, hello friend! I didn't know you were hiding in there."
+                    message= _ "Oh, hello friend! I didn’t know you were hiding in there."
                 [/message]
             [/then]
             [else]
                 [message]
                     speaker=Ardonna
-                    message= _ "Oh, hello! You're a handsome one."
+                    message= _ "Oh, hello! You’re a handsome one."
                 [/message]
             [/else]
         [/if]
@@ -416,7 +416,7 @@ of Healing"
         [/move_unit_fake]
         [message]
             speaker=Ardonna
-            message= _ "Hey, come back! I didn't mean to frighten you."
+            message= _ "Hey, come back! I didn’t mean to frighten you."
         [/message]
         [message]
             speaker=Ardonna
@@ -491,7 +491,7 @@ of Healing"
                         [message]
                             speaker=narrator
                             image=items/gold-coins-message.png
-                            message=_ "You don't have enough gold to summon the bat."
+                            message=_ "You don’t have enough gold to summon the bat."
                         [/message]
                     [/then]
                     [else]
@@ -905,15 +905,15 @@ Well, I might as well do my experiment and worry about leaving later."
         [/message]
         [message]
             speaker=Ardonna
-            message= _ "Oh, him. See here, I don't want any trouble, but he is a little... ah..."
+            message= _ "Oh, him. See here, I don’t want any trouble, but he is a little... ah..."
         [/message]
         [message]
             speaker=Caradoc
-            message= _ "He's <i>dead</i>! This is dark sorcery like in my granddad’s time in the old country! The penalty is death. Attack and destroy them both!"
+            message= _ "He’s <i>dead</i>! This is dark sorcery like in my granddad’s time in the old country! The penalty is death. Attack and destroy them both!"
         [/message]
         [message]
             speaker=Ardonna
-            message= _ "Hey! Don't do that, or I will need more of them."
+            message= _ "Hey! Don’t do that, or I will need more of them."
         [/message]
         [message]
             speaker=Ardonna

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/04_Becalmed.cfg
@@ -57,9 +57,9 @@ Research sometimes requires experiments, so I began.  I knew the bandit had inte
             [/image]
             story= _ "I passed him a wineskin, to put him at ease. He eyed me suspiciously, then took a sip, calculating my intentions. I then placed a portion of my gold resources on the table, and his eyes locked upon it.
 
-I then placed upon the table a ring stripped off the bandit named 'Mossa', his beloved partner in crime.  His gaze shifted from the gold to the ring, and then quickly to my eyes.  Had he not been tied to the chair, he would have attacked me.
+I then placed upon the table a ring stripped off the bandit named ‘Mossa’, his beloved partner in crime.  His gaze shifted from the gold to the ring, and then quickly to my eyes.  Had he not been tied to the chair, he would have attacked me.
 
-I added more gold to the pile, but he didn't notice, he only glared at me with such hatred.  The hunger for vengeance radiated off of him like heat from a thousand suns - I could feel it more strongly than the fear or hunger from any of my pets..."
+I added more gold to the pile, but he didn’t notice, he only glared at me with such hatred.  The hunger for vengeance radiated off of him like heat from a thousand suns - I could feel it more strongly than the fear or hunger from any of my pets..."
         [/part]
         [part]
             [background_layer] # this needs to be replaced at some point

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/07_Meeting_of_the_Minds.cfg
@@ -218,7 +218,7 @@ The tunnel at the back of the cave narrowed and ran on for quite some time. Patc
         [/message]
         [message]
             speaker=Ras-Tabahn
-            message= _ "Splendid. Here is what I propose. First, we part ways for a time, and you raise a force of ghosts following my instructions. Meanwhile, I am going to try to train some local peasants in the magical arts. I don't expect much from that uneducated rabble, but hopefully some will be intelligent enough to add to our firepower. When we reunite, you will show me how to make one of those shambling ghouls. I am actually in no hurry, as they have a terrible odor."
+            message= _ "Splendid. Here is what I propose. First, we part ways for a time, and you raise a force of ghosts following my instructions. Meanwhile, I am going to try to train some local peasants in the magical arts. I don’t expect much from that uneducated rabble, but hopefully some will be intelligent enough to add to our firepower. When we reunite, you will show me how to make one of those shambling ghouls. I am actually in no hurry, as they have a terrible odor."
         [/message]
         [message]
             speaker=Ardonna

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/11_Battleground.cfg
@@ -24,7 +24,7 @@ Ras-Tabahn seems like an acceptable ally. He is quite different from the stodgy 
                 image=story/book.png
                 scale=no
             [/background_layer]
-            story= _ "The question remains whether or not it is wise to trust him. As he said, I don't need to at this time, but if we are to travel together it will become necessary. He has shown me something marvelous in the ghosts, so that is a large mark in his favor. On consideration, I have decided to trust him, but only provisionally. For now, we are both vulnerable, and he must know that attacking me would be unwise. However, if he were to become indestructible first, I would do well to stay alert."
+            story= _ "The question remains whether or not it is wise to trust him. As he said, I don’t need to at this time, but if we are to travel together it will become necessary. He has shown me something marvelous in the ghosts, so that is a large mark in his favor. On consideration, I have decided to trust him, but only provisionally. For now, we are both vulnerable, and he must know that attacking me would be unwise. However, if he were to become indestructible first, I would do well to stay alert."
         [/part]
         [part]
             [background_layer]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/14_Entering_the_Northlands.cfg
@@ -170,7 +170,7 @@ We reached the Ford of Abez as the dawn light spread behind the mountain peaks t
             [then]
                 [message]
                     speaker=Vendraxis
-                    message= _ "I have a sssense of dark foreboding regarding the sssnowy peaksss ahead. We may meet our doom if we don't have enough coinsss." # no spellcheck
+                    message= _ "I have a sssense of dark foreboding regarding the sssnowy peaksss ahead. We may meet our doom if we don’t have enough coinsss." # no spellcheck
                 [/message]
             [/then]
             [else]

--- a/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
@@ -160,7 +160,7 @@
         [/filter]
         [message]
             speaker=Ardonna
-            message= _ "But I don't know how to bring you back yet!"
+            message= _ "But I don’t know how to bring you back yet!"
         [/message]
         [endlevel]
             result=defeat
@@ -199,7 +199,7 @@
                 [/message]
                 [message]
                     speaker=Ardonna
-                    message= _ "I'm not sure that's such a good..."
+                    message= _ "I’m not sure that’s such a good..."
                 [/message]
                 [message]
                     speaker=Ras-Tabahn
@@ -256,7 +256,7 @@
                 [/message]
                 [message]
                     speaker=Ras-Tabahn
-                    message= _ "It's not possible. She was already back from the dead. She has been utterly destroyed this time."
+                    message= _ "It’s not possible. She was already back from the dead. She has been utterly destroyed this time."
                 [/message]
             [/then]
         [/if]
@@ -320,7 +320,7 @@
             [then]
                 [message]
                     speaker=Carcyn
-                    message= _ "I'm going to miss him."
+                    message= _ "I’m going to miss him."
                 [/message]
             [/then]
             [else]
@@ -365,7 +365,7 @@
         [/filter_condition]
         [message]
             speaker=Ardonna
-            message= _ "Don't worry, my pet. I can save you."
+            message= _ "Don’t worry, my pet. I can save you."
         [/message]
     [/event]
 #enddef

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/09_Shan_Taum_the_Smug.cfg
@@ -200,7 +200,7 @@
         [/message]
         [message]
             speaker="Pirk"
-            message= _ "Go defend Prestim, Kapou'e. In the meantime, now that the council is complete again, we will decide. We may have to form the Great Horde again, and give you the leadership of it."
+            message= _ "Go defend Prestim, Kapou’e. In the meantime, now that the council is complete again, we will decide. We may have to form the Great Horde again, and give you the leadership of it."
         [/message]
         [kill]
             id="Pirk"

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/11_Clash_of_Armies.cfg
@@ -22,7 +22,7 @@
                 show_turn_counter=yes
             [/objective]
             [objective]
-                description= _ "You don't control all villages on the north side of the river when turns run out"
+                description= _ "You don’t control all villages on the north side of the river when turns run out"
                 condition=lose
             [/objective]
             [objective]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg
@@ -279,13 +279,13 @@
 
         [message]
             speaker=Dulcatulos
-            message= _ "It has been... so many years since I’ve been down here. Only Karrag and his personal followers used this level. I can't believe I never wondered about that before."
+            message= _ "It has been... so many years since I’ve been down here. Only Karrag and his personal followers used this level. I can’t believe I never wondered about that before."
         [/message]
 
         [message]
             speaker=Angarthing
             # wmllint: local spelling glamours
-            message= _ "It is Karrag's doing—his will, and his dark magic. I think he has been casting glamours on all of you ever since he passed over."
+            message= _ "It is Karrag’s doing—his will, and his dark magic. I think he has been casting glamours on all of you ever since he passed over."
         [/message]
 
         [message]
@@ -361,7 +361,7 @@
 
         [message]
             speaker=unit
-            message= _ "Poor guy didn't make it."
+            message= _ "Poor guy didn’t make it."
         [/message]
 
         # Secret easter egg bonus
@@ -392,7 +392,7 @@
 
         [message]
             speaker=unit
-            message= _ "There's some gold in here!"
+            message= _ "There’s some gold in here!"
         [/message]
 
         [gold]
@@ -521,13 +521,13 @@
             [then]
                 [message]
                     speaker=unit
-                    message= _ "There's something behind this door. I shall break it down!"
+                    message= _ "There’s something behind this door. I shall break it down!"
                 [/message]
             [/then]
             [else]
                 [message]
                     speaker=unit
-                    message= _ "There's something behind this door."
+                    message= _ "There’s something behind this door."
                 [/message]
 
                 [message]
@@ -612,7 +612,7 @@
 
         [message]
             speaker=second_unit
-            message= _ "You could not stop us before and you won't be stopping us now!"
+            message= _ "You could not stop us before and you won’t be stopping us now!"
         [/message]
 
         # Activate side 3
@@ -638,12 +638,12 @@
 
         [message]
             speaker=second_unit
-            message= _ "You won't stop us!"
+            message= _ "You won’t stop us!"
         [/message]
 
         [message]
             speaker=Dufon
-            message= _ "Fools! Even should you defeat me, the master's ritual will soon be complete and you shall all become his slaves!"
+            message= _ "Fools! Even should you defeat me, the master’s ritual will soon be complete and you shall all become his slaves!"
         [/message]
 
         [gold]
@@ -663,7 +663,7 @@
 
         [message]
             speaker=Aragoth
-            message= _ "Your path forward ends here! Once the lord's spell is complete, your souls will soon be chained to his will!"
+            message= _ "Your path forward ends here! Once the lord’s spell is complete, your souls will soon be chained to his will!"
         [/message]
 
         # Give side 4 some gold
@@ -877,7 +877,7 @@
 
         [message]
             speaker=unit
-            message= _ "We've found a runic key!"
+            message= _ "We’ve found a runic key!"
         [/message]
 
         [delay]
@@ -1307,7 +1307,7 @@
 
         [message]
             speaker=Dufon
-            message= _ "The master's ritual... must not be... interrupted..."
+            message= _ "The master’s ritual... must not be... interrupted..."
         [/message]
     [/event]
 
@@ -1319,7 +1319,7 @@
 
         [message]
             speaker=Dranath
-            message= _ "Imbeciles! Once the master's dark rite is complete, I will return to slay you myself!"
+            message= _ "Imbeciles! Once the master’s dark rite is complete, I will return to slay you myself!"
         [/message]
     [/event]
 
@@ -1371,7 +1371,7 @@
 
         [message]
             speaker=Angarthing
-            message= _ "Karrag's spell grows more powerful with every passing moment. If we do not defeat him now, we will all turn into his thralls!"
+            message= _ "Karrag’s spell grows more powerful with every passing moment. If we do not defeat him now, we will all turn into his thralls!"
         [/message]
     [/event]
 

--- a/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/05_Choice_In_The_Fog.cfg
@@ -708,7 +708,7 @@
 
         [message]
             speaker=Sir Gerrick
-            message= _ "<i>Indeed, these elves are not as incorruptible and pure as they like to believe they are. I suspect that this sage's pride led him to believe that he could master a power that is uncontrollable.</i>"
+            message= _ "<i>Indeed, these elves are not as incorruptible and pure as they like to believe they are. I suspect that this sage’s pride led him to believe that he could master a power that is uncontrollable.</i>"
         [/message]
 
         # In the unlikely case that the player did defeat Mal M'Brin, but not sight Urza Afalas

--- a/data/campaigns/The_South_Guard/scenarios/07a_Return_to_Kerlath.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/07a_Return_to_Kerlath.cfg
@@ -371,7 +371,7 @@
         [message]
             speaker=Deoran
             # po: Defeat message after time-over
-            message= _ "The elves are attacking Westin! They'll surely destroy the city without us there to defend it..."
+            message= _ "The elves are attacking Westin! They’ll surely destroy the city without us there to defend it..."
         [/message]
     [/event]
 

--- a/data/campaigns/The_South_Guard/units/Junior_Commander.cfg
+++ b/data/campaigns/The_South_Guard/units/Junior_Commander.cfg
@@ -22,7 +22,7 @@
     [abilities]
         {ABILITY_LEADERSHIP}
     [/abilities]
-    description= _ "At scarcely 17 or 18 years of age, squires are not yet full knights, but still have the knowledge and skill to master their mounts whilst in full panoply. Talented squires are sometimes given command of small units in Wesnoth' s army, where they gain experience leading fellow troops and honing their prowess in battle."
+    description= _ "At scarcely 17 or 18 years of age, squires are not yet full knights, but still have the knowledge and skill to master their mounts whilst in full panoply. Talented squires are sometimes given command of small units in Wesnoth’s army, where they gain experience leading fellow troops and honing their prowess in battle."
     die_sound=horse-die.ogg
     [attack]
         name=spear

--- a/data/campaigns/The_South_Guard/utils/sg_story.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_story.cfg
@@ -79,7 +79,7 @@
         [part]
             background=story/fall.jpg
             # po: Intro to scenario 6a
-            {STORY: _"He wondered briefly why she had stopped mentioning Mebrin and his whereabouts, but something told him that now was not the time to mention the sage’s name. Perhaps, he thought, she suspected that the bandits’ story was indeed true and that Mebrin had been corrupted by his dabbling in undead magic. Perhaps she simply hadn't come to terms with it."}
+            {STORY: _"He wondered briefly why she had stopped mentioning Mebrin and his whereabouts, but something told him that now was not the time to mention the sage’s name. Perhaps, he thought, she suspected that the bandits’ story was indeed true and that Mebrin had been corrupted by his dabbling in undead magic. Perhaps she simply hadn’t come to terms with it."}
         [/part]
 
         [part]
@@ -166,7 +166,7 @@
         [part]
             background=story/winter.jpg
             # po: Epilogue B
-            {STORY: _"As the lich’s final death scream echoed across the battlefield, his skeletal form began to crumble. Decayed bones disintegrated into ash, borne away on the frigid wind, another immortal soul cast back into the endless flow of time. With their master's power gone, the undead warriors fell back to lifelessness, crumbling into inanimate heaps of bones. The rustling wind floated across the battlefield in gentle streams, carrying with it the souls of the fallen and ascending toward the sky where the sun began to break through the ashen clouds. As the sunlight broke through, the wind passed, and all was still."}
+            {STORY: _"As the lich’s final death scream echoed across the battlefield, his skeletal form began to crumble. Decayed bones disintegrated into ash, borne away on the frigid wind, another immortal soul cast back into the endless flow of time. With their master’s power gone, the undead warriors fell back to lifelessness, crumbling into inanimate heaps of bones. The rustling wind floated across the battlefield in gentle streams, carrying with it the souls of the fallen and ascending toward the sky where the sun began to break through the ashen clouds. As the sunlight broke through, the wind passed, and all was still."}
             music=revelation.ogg
         [/part]
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -4427,7 +4427,7 @@
         {MOVE_UNIT (id=Dummy Unit7) 66 2}
         [message]
             speaker=Dummy Unit7
-            message= _ "Eastern scouts, reporting back! If you like sand and hot dust, there's plenty more out there! No water, or signs of others, we had to turn back."
+            message= _ "Eastern scouts, reporting back! If you like sand and hot dust, there’s plenty more out there! No water, or signs of others, we had to turn back."
         [/message]
 
         [message]
@@ -4604,7 +4604,7 @@
 
         [message]
             speaker=Kaleh
-            message= _ "With you back, Nym, the only scouts yet to return are Tanstafaal's group."
+            message= _ "With you back, Nym, the only scouts yet to return are Tanstafaal’s group."
         [/message]
 
         [message]

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -373,7 +373,7 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
                     image=$unit.profile
                     caption= _ "Multiple Healers"
                     # po: one healer is a level one shaman, but the other healer is a druid or (very unlikely) a shyde
-                    message= _ "You now have two healers. Your Druid can heal adjacent units by 8 hitpoints per turn compared to your Shaman's 4. However, each unit can only receive healing from one healer — a unit next to multiple healers is healed by the most advanced one."
+                    message= _ "You now have two healers. Your Druid can heal adjacent units by 8 hitpoints per turn compared to your Shaman’s 4. However, each unit can only receive healing from one healer — a unit next to multiple healers is healed by the most advanced one."
                 [/message]
             [/else]
         [/if]


### PR DESCRIPTION
Replace 'straight' apostrophes with 'curly' or 'typesetter' apostrophes or quotes as per https://wiki.wesnoth.org/Typography_Style_Guide

Prompted by the first point in #4145, but I reviewed all campaigns not just Eastern Invasion. This is something that's easy to miss so it makes sense that it needs to be reviewed periodically. Unfortunately there will be the same impact to translation work as #6067.

I believe I was pretty thorough so unless there were omissions or other mistakes, I don't anticipate needing to make any further commits to this in the short-term.