### PR TITLE
UtBS: Remove leading whitespace from Ethereal Shadow's special note

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/undead/Ethereal_Shadow.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/undead/Ethereal_Shadow.cfg
@@ -23,6 +23,6 @@
 That is a question which is easily answered by a necromancer."
     {NOTE_ETHEREAL}
     [special_note]
-        note=_"SPECIAL_NOTE^ Unlike normal Shadows, Ethereal Shadows cannot hide at night."
+        note=_"SPECIAL_NOTE^Unlike normal Shadows, Ethereal Shadows cannot hide at night."
     [/special_note]
 [/unit_type]


### PR DESCRIPTION
The Ethereal Nightgaunt's equivalent note was already fixed in f94d0bb80a425b02873f13e67ea856151a05ae6f.

Fixes #4480.