### PR TITLE
Switch to hard-coded colours instead of relying on pango names

### DIFF
--- a/src/gui/dialogs/formula_debugger.cpp
+++ b/src/gui/dialogs/formula_debugger.cpp
@@ -46,8 +46,8 @@ void formula_debugger::pre_show(window& window)
 		for(int d = 0; d < c; ++d) {
 			stack_text << indent;
 		}
-		stack_text << "#<span color=\"green\">" << i.counter()
-				   << "</span>: \"<span color=\"green\">" << font::escape_text(i.name())
+		stack_text << "#<span color=\"#00ff00\">" << i.counter()
+				   << "</span>: \"<span color=\"#00ff00\">" << font::escape_text(i.name())
 				   << "</span>\": (" << font::escape_text(i.str()) << ") " << std::endl;
 		++c;
 	}
@@ -68,14 +68,14 @@ void formula_debugger::pre_show(window& window)
 			execution_text << indent;
 		}
 		if(!i.evaluated()) {
-			execution_text << "#<span color=\"green\">" << i.counter()
-						   << "</span>: \"<span color=\"green\">" << font::escape_text(i.name())
+			execution_text << "#<span color=\"#00ff00\">" << i.counter()
+						   << "</span>: \"<span color=\"#00ff00\">" << font::escape_text(i.name())
 						   << "</span>\": (" << font::escape_text(i.str()) << ") " << std::endl;
 		} else {
-			execution_text << "#<span color=\"yellow\">" << i.counter()
-						   << "</span>: \"<span color=\"yellow\">" << font::escape_text(i.name())
+			execution_text << "#<span color=\"#ffff00\">" << i.counter()
+						   << "</span>: \"<span color=\"#ffff00\">" << font::escape_text(i.name())
 						   << "</span>\": (" << font::escape_text(i.str()) << ") = "
-						   << "<span color=\"orange\">"
+						   << "<span color=\"#ffa500\">"
 						   << font::escape_text(i.value().to_debug_string())
 						   << "</span>" << std::endl;
 		}

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -397,7 +397,6 @@ const std::vector<std::string>& topic_text::parsed_text() const
 
 static std::string time_of_day_bonus_colored(const int time_of_day_bonus)
 {
-	// Use same red/green colouring scheme as time_of_day_at() in reports.cpp for consistency
 	return std::string("<format>color='") + (time_of_day_bonus > 0 ? "green" : (time_of_day_bonus < 0 ? "red" : "white")) + "' text='" + std::to_string(time_of_day_bonus) + "'</format>";
 }
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1269,13 +1269,12 @@ static config time_of_day_at(reports::context & rc, const map_location& mouseove
 	std::string chaotic_color("white");
 	std::string liminal_color("white");
 
-	// Use same red/green colouring scheme as time_of_day_bonus_colored() in help/help_impl.cpp for consistency
 	if (b != 0) {
-		lawful_color  = (b > 0) ? "green" : "red";
-		chaotic_color = (b < 0) ? "green" : "red";
+		lawful_color  = (b > 0) ? "#0f0" : "#f00";
+		chaotic_color = (b < 0) ? "#0f0" : "#f00";
 	}
 	if (l != 0) {
-		liminal_color = (l > 0) ? "green" : "red";
+		liminal_color = (l > 0) ? "#0f0" : "#f00";
 	}
 	tooltip << _("Time of day:") << " <b>" << tod.name << "</b>\n"
 		<< _("Lawful units: ") << "<span foreground=\"" << lawful_color  << "\">"

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -444,7 +444,7 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 				"<span color=\"$color\">$number_or_percent</span> damage",
 				"<span color=\"$color\">$number_or_percent</span> damage",
 				std::stoi(increase_damage),
-				{{"number_or_percent", utils::print_modifier(increase_damage)}, {"color", increase_damage[0] == '-' ? "red" : "green"}}));
+				{{"number_or_percent", utils::print_modifier(increase_damage)}, {"color", increase_damage[0] == '-' ? "#f00" : "#0f0"}}));
 		}
 
 		if(!set_damage.empty()) {
@@ -462,7 +462,7 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 				"<span color=\"$color\">$number_or_percent</span> strike",
 				"<span color=\"$color\">$number_or_percent</span> strikes",
 				std::stoi(increase_attacks),
-				{{"number_or_percent", utils::print_modifier(increase_attacks)}, {"color", increase_attacks[0] == '-' ? "red" : "green"}}));
+				{{"number_or_percent", utils::print_modifier(increase_attacks)}, {"color", increase_attacks[0] == '-' ? "#f00" : "#0f0"}}));
 		}
 
 		if(!set_attacks.empty()) {
@@ -485,7 +485,7 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 			desc.emplace_back(VGETTEXT(
 				// TRANSLATORS: Current value for WML code increase_accuracy, documented in https://wiki.wesnoth.org/EffectWML
 				"<span color=\"$color\">$number_or_percent|%</span> accuracy",
-				{{"number_or_percent", utils::print_modifier(increase_accuracy)}, {"color", increase_accuracy[0] == '-' ? "red" : "green"}}));
+				{{"number_or_percent", utils::print_modifier(increase_accuracy)}, {"color", increase_accuracy[0] == '-' ? "#f00" : "#0f0"}}));
 		}
 
 		if(!set_parry.empty()) {
@@ -499,7 +499,7 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 			desc.emplace_back(VGETTEXT(
 				// TRANSLATORS: Current value for WML code increase_parry, documented in https://wiki.wesnoth.org/EffectWML
 				"<span color=\"$color\">$number_or_percent</span> parry",
-				{{"number_or_percent", utils::print_modifier(increase_parry)}, {"color", increase_parry[0] == '-' ? "red" : "green"}}));
+				{{"number_or_percent", utils::print_modifier(increase_parry)}, {"color", increase_parry[0] == '-' ? "#f00" : "#0f0"}}));
 		}
 
 		if(!set_movement.empty()) {
@@ -517,7 +517,7 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 				"<span color=\"$color\">$number_or_percent</span> movement point",
 				"<span color=\"$color\">$number_or_percent</span> movement points",
 				std::stoi(increase_movement),
-				{{"number_or_percent", utils::print_modifier(increase_movement)}, {"color", increase_movement[0] == '-' ? "red" : "green"}}));
+				{{"number_or_percent", utils::print_modifier(increase_movement)}, {"color", increase_movement[0] == '-' ? "#f00" : "#0f0"}}));
 		}
 
 		*description = utils::format_conjunct_list("", desc);

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1859,7 +1859,7 @@ std::string unit::describe_builtin_effect(std::string apply_to, const config& ef
 		if(!increase_total.empty()) {
 			return VGETTEXT(
 				"<span color=\"$color\">$number_or_percent</span> HP",
-				{{"number_or_percent", utils::print_modifier(increase_total)}, {"color", increase_total[0] == '-' ? "red" : "green"}});
+				{{"number_or_percent", utils::print_modifier(increase_total)}, {"color", increase_total[0] == '-' ? "#f00" : "#0f0"}});
 		}
 	} else {
 		const std::string& increase = effect["increase"];
@@ -1871,31 +1871,31 @@ std::string unit::describe_builtin_effect(std::string apply_to, const config& ef
 				"<span color=\"$color\">$number_or_percent</span> move",
 				"<span color=\"$color\">$number_or_percent</span> moves",
 				std::stoi(increase),
-				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "red" : "green"}});
+				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "#f00" : "#0f0"}});
 		} else if(apply_to == "vision") {
 			return VGETTEXT(
 				"<span color=\"$color\">$number_or_percent</span> vision",
-				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "red" : "green"}});
+				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "#f00" : "#0f0"}});
 		} else if(apply_to == "jamming") {
 			return VGETTEXT(
 				"<span color=\"$color\">$number_or_percent</span> jamming",
-				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "red" : "green"}});
+				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "#f00" : "#0f0"}});
 		} else if(apply_to == "max_experience") {
 			// Unlike others, decreasing experience is a *GOOD* thing
 			return VGETTEXT(
 				"<span color=\"$color\">$number_or_percent</span> XP to advance",
-				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "green" : "red"}});
+				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "#0f0" : "#f00"}});
 		} else if(apply_to == "max_attacks") {
 			return VNGETTEXT(
 					"<span color=\"$color\">$number_or_percent</span> attack per turn",
 					"<span color=\"$color\">$number_or_percent</span> attacks per turn",
 					std::stoi(increase),
-					{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "red" : "green"}});
+					{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "#f00" : "#0f0"}});
 		} else if(apply_to == "recall_cost") {
 			// Unlike others, decreasing recall cost is a *GOOD* thing
 			return VGETTEXT(
 				"<span color=\"$color\">$number_or_percent</span> cost to recall",
-				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "green" : "red"}});
+				{{"number_or_percent", utils::print_modifier(increase)}, {"color", increase[0] == '-' ? "#0f0" : "#f00"}});
 		}
 	}
 	return "";


### PR DESCRIPTION
Resolves #4348

Pango changed its definition of 'green' in version 1.32.2 to align with CSS specifications (see #4348 for details). This change focuses only on instances of `<span color="green">`, leaving instances of named colours that don't use 'green'. For example:
https://github.com/wesnoth/wesnoth/blob/f8a41624e3022947b6d7d9ac6b0311c4a7d1fee4/src/gui/dialogs/gamestate_inspector.cpp#L598

**Problem**: I cannot see how to use this approach with `<format>` so it breaks time-of-day bonus colour consistency. Then again, I'm not sure if the green used in `<format>` is the same as the green used in `<span>`...
https://github.com/wesnoth/wesnoth/blob/f8a41624e3022947b6d7d9ac6b0311c4a7d1fee4/src/help/help_impl.cpp#L398-L402
![tod-schedule](https://user-images.githubusercontent.com/13679322/133606593-e0fc09b4-075e-44d5-acab-a48815539fdc.png)

Also:
https://github.com/wesnoth/wesnoth/blob/f8a41624e3022947b6d7d9ac6b0311c4a7d1fee4/src/help/help_topic_generators.cpp#L63-L68
Plus coloured text for 'vision' and 'jamming' that I can't find in the GUI.

**Questions**:
* How might `<format>` colours be updated? (Edit: Is it a case of Help being stuck on GUI1?)
* Where is the formula debugger used? I didn't change this one because I can't find where to test it: https://github.com/wesnoth/wesnoth/blob/f8a41624e3022947b6d7d9ac6b0311c4a7d1fee4/src/gui/dialogs/formula_debugger.cpp#L49-L51

**Comparisons**:
![intelligent-before](https://user-images.githubusercontent.com/13679322/133606300-aae33d66-45b0-455d-81b8-c17be947179b.png)![intelligent-after](https://user-images.githubusercontent.com/13679322/133606313-09e829e2-11de-4197-bf1d-bfcc2e4add15.png)
![quick-before](https://user-images.githubusercontent.com/13679322/133606358-3e1f4e15-4551-4138-9856-49535506c532.png)![quick-after](https://user-images.githubusercontent.com/13679322/133606366-13a66602-1a8d-4370-87ff-e01b54adcee4.png)
![resilient-before](https://user-images.githubusercontent.com/13679322/133606383-e86ff137-d342-4028-921d-0d1c113e304d.png)![resilient-after](https://user-images.githubusercontent.com/13679322/133606387-8e18cbd9-bd14-4ae5-a437-21e408de9913.png)
![strong-before](https://user-images.githubusercontent.com/13679322/133606404-e24799cd-b1de-4f33-8330-8ea9ac76d98a.png)![strong-after](https://user-images.githubusercontent.com/13679322/133606407-9f9a02bb-bc6f-4ac2-9a5a-c573e01445d7.png)
![tod-before](https://user-images.githubusercontent.com/13679322/133606461-aa5fc06a-3e01-4c82-af9c-61db1e0a2e7c.png)![tod-after](https://user-images.githubusercontent.com/13679322/133606488-f1c5fedf-f019-4ef8-8f0c-f63706eb3a89.png)
