### PR TITLE
UtBS: Silence the Dust Devil

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
@@ -1458,10 +1458,12 @@
             message= _ "Argh! Curse you! May you never live to see daylight again!"
         [/message]
 
+        {CHECK_SPEAKER}
         [message]
-            speaker=second_unit
+            speaker=$speaking_unit.id
             message= _ "And so, at last, it ends."
         [/message]
+        {CLEAR_VARIABLE speaking_unit}
 
         [message]
             side=4

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -759,10 +759,12 @@
             message= _ "Ha, you’re trapped. I’ve got you right where I want you, and this time no one is gonna save you."
         [/message]
 
+        {CHECK_SPEAKER}
         [message]
-            speaker=second_unit
+            speaker=$speaking_unit.id
             message= _ "How did a troll get stuck all the way back here?"
         [/message]
+        {CLEAR_VARIABLE speaking_unit}
     [/event]
 
     # When Vengeful Dwarf dies
@@ -1170,10 +1172,12 @@
             side=1
         [/filter_second]
 
+        {CHECK_SPEAKER}
         [message]
-            speaker=second_unit
+            speaker=$speaking_unit.id
             message= _ "Incoming! Ugh, it’s big, hairy, and nasty. I hate bats, I really hate bats."
         [/message]
+        {CLEAR_VARIABLE speaking_unit}
     [/event]
 
     [event]
@@ -1413,10 +1417,12 @@
             message= _ "Faugh! Even in death I curse you! You will never escape these tunnels alive!"
         [/message]
 
+        {CHECK_SPEAKER}
         [message]
-            speaker=second_unit
+            speaker=$speaking_unit.id
             message= _ "And so, at last, it ends."
         [/message]
+        {CLEAR_VARIABLE speaking_unit}
 
         [message]
             side=6

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
@@ -626,11 +626,13 @@
             fire_event=no
         [/kill]
 
+        {CHECK_SPEAKER}
         [message]
-            speaker=second_unit
+            speaker=$speaking_unit.id
             # wmllint: local spelling creeped
             message= _ "I say good riddance. He creeped me out."
         [/message]
+        {CLEAR_VARIABLE speaking_unit}
     [/event]
 
     # Event 4.5 Naga leaders appear, activate sides 7 + 8
@@ -978,6 +980,7 @@
             fire_event=no
         [/kill]
 
+        {CHECK_SPEAKER}
         [if]
             [variable]
                 name=found_door
@@ -986,18 +989,19 @@
 
             [then]
                 [message]
-                    speaker=second_unit
+                    speaker=$speaking_unit.id
                     message= _ "Look, I found a gold key on a chain around his neck. This must be one of the keys needed to enter the black citadel."
                 [/message]
             [/then]
 
             [else]
                 [message]
-                    speaker=second_unit
+                    speaker=$speaking_unit.id
                     message= _ "Look, I found a gold key on a chain around his neck. I wonder what this key is for? I bet it will become useful eventually. I’ll keep it just in case."
                 [/message]
             [/else]
         [/if]
+        {CLEAR_VARIABLE speaking_unit}
 
         [fire_event]
             name=found_both_keys_and_door
@@ -1024,6 +1028,7 @@
             fire_event=no
         [/kill]
 
+        {CHECK_SPEAKER}
         [if]
             [variable]
                 name=found_door
@@ -1032,18 +1037,19 @@
 
             [then]
                 [message]
-                    speaker=second_unit
+                    speaker=$speaking_unit.id
                     message= _ "Look, I found an iron key on a chain around his neck. This must be one of the keys needed to enter the black citadel."
                 [/message]
             [/then]
 
             [else]
                 [message]
-                    speaker=second_unit
+                    speaker=$speaking_unit.id
                     message= _ "Look, I found an iron key on a chain around his neck. I wonder what this key is for? I bet it will become useful eventually. I’ll keep it just in case."
                 [/message]
             [/else]
         [/if]
+        {CLEAR_VARIABLE speaking_unit}
 
         [fire_event]
             name=found_both_keys_and_door


### PR DESCRIPTION
Use existing macro to avoid situations where Nym's otherwise-mute Dust Devil pet might speak.

Resolves #4892.

Note: I'm not familiar with WML so I'm not sure if I've done this 'right'. But for a quick test, focusing on the Draug mentioned in the aforementioned issue, I did the following (GUI Debug Tools wasn't working for me - maybe not yet working for 1.17.0+dev):
* Start UtBS campaign and debug-skip to Battle for Zocthanol Isle.
* Debug-remove fog and shroud.
* Debug-create Mage of Light adjacent to Kelur and attack to bring its HP down (high probability of all three attacks hitting).
* Debug-create Dust Devil and use it to finish off Kelur.

Before: Dust Devil remarks about the key left behind.
After: Nym speaks on the Dust Devil's behalf.