### PR TITLE
DM S7: Clarify objectives (resolves #5608)

### DIFF
--- a/data/campaigns/Delfadors_Memoirs/scenarios/07_Night_in_the_Swamp.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/07_Night_in_the_Swamp.cfg
@@ -86,7 +86,7 @@
             [/objective]
             [objective]
                 {ALTERNATIVE_OBJECTIVE_CAPTION}
-                description=_ "Destroy the stones"
+                description=_ "Destroy the stones and defeat all enemies"
                 condition=win
             [/objective]
             [objective]


### PR DESCRIPTION
According to the bonus objective as it stands, it should be possible to end the scenario early by simply destroying the 'generator' stones even if leaving a few skeletons around. However, the way victory condition is established simply by counting the number of enemy units at the start of a turn - if there are no units left, then the stones are assumed to be destroyed. (No generator stones active -> no enemy units)

As a work-around, simply update the objectives to make it clear that all enemies need to be eliminated for early victory to be achieved.