### PR TITLE
Only display difficulty for SP campaigns (resolves #5321)

### DIFF
--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -427,8 +427,15 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 		str << _("Scenario start");
 	}
 
-	str << "\n" << _("Difficulty: ")
-		<< difficulty_human_str;
+	// Only makes sense to display difficulty for SP campaigns:
+	try {
+		if (game_classification::CAMPAIGN_TYPE::string_to_enum(campaign_type).v == game_classification::CAMPAIGN_TYPE::SCENARIO) {
+			str << "\n" << _("Difficulty: ") << difficulty_human_str;
+		}
+	}
+	catch (const bad_enum_cast&) {
+		str << campaign_type;
+	}
 
 	if(!cfg_summary["version"].empty()) {
 		str << "\n" << _("Version: ") << cfg_summary["version"];


### PR DESCRIPTION
There are four save game types encoded:
* SP campaigns (internally called 'scenario')
* Multiplayer
* Tutorial
* Test scenario

I think Tutorial type is the old style tutorial from 1.14 and earlier which was treated as separate from SP campaigns. From 1.15 the Tutorial is included in the SP campaigns list and seems to be treated as such because with this change, MP and Test scenario save games will no longer have difficulty displayed in the save game preview of the game load dialogue, but SP campaigns and the Tutorial will.