### PR TITLE
i18n: Fix dsngettext() not stripping caret annotations from plural forms

### DIFF
--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -411,15 +411,33 @@ std::string dsgettext (const char * domainname, const char *msgid)
 	return msgval;
 }
 
+namespace {
+
+inline const char* is_unlocalized_string2(const std::string& str, const char* singular, const char* plural)
+{
+	if (str == singular) {
+		return singular;
+	}
+
+	if (str == plural) {
+		return plural;
+	}
+
+	return nullptr;
+}
+
+}
+
 std::string dsngettext (const char * domainname, const char *singular, const char *plural, int n)
 {
 	//TODO: only the next line needs to be in the lock.
 	std::scoped_lock lock(get_mutex());
 	std::string msgval = bl::dngettext(domainname, singular, plural, n, get_manager().get_locale());
-	if (msgval == singular) {
-		const char* firsthat = std::strchr (singular, '^');
+	auto original = is_unlocalized_string2(msgval, singular, plural);
+	if (original) {
+		const char* firsthat = std::strchr (original, '^');
 		if (firsthat == nullptr)
-			msgval = singular;
+			msgval = original;
 		else
 			msgval = firsthat + 1;
 	}


### PR DESCRIPTION
This affects operation of `dsngettext()` and its users (e.g. `_n()` and `VNGETTEXT()`) specifically when the plural version of a string is chosen.

Apparently back in 2007 in commit 4852283ab3e1916c66d7d6660d61f9dc2cae38c6, this function and its late sibling were made to only strip carets from singular forms under the probable assumption that disambiguation won't be needed for plurals because of the way GNU gettext pairs them with their singular msgid under a single unique entry. Like everything else related to our gettext functionality, this wasn't documented in the C++ code.

However, there's no guarantee that this will remain the case forever if we some day decide to replace the GNU gettext format with something without this guarantee. It's also likely to confuse more people later down the line (especially now that the Lua API exposes this functionality).

Closes #6093.