### PR TITLE
Display Difficulty as em dash when it is not valid (resolves #5321)

### DIFF
--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -444,19 +444,19 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 				}
 			}
 			else {
-				str << _("N/A");
+				str << "—";
 			}
 
 			break;
 		}
 		case game_classification::CAMPAIGN_TYPE::TUTORIAL:
 		case game_classification::CAMPAIGN_TYPE::TEST:
-			str << _("N/A");
+			str << "—";
 			break;
 		}
 	}
 	catch (const bad_enum_cast&) {
-		str << _("N/A");
+		str << "—";
 	}
 
 	if(!cfg_summary["version"].empty()) {

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -353,7 +353,6 @@ void game_load::filter_text_changed(const std::string& text)
 
 void game_load::evaluate_summary_string(std::stringstream& str, const config& cfg_summary)
 {
-	std::string difficulty_human_str = string_table[cfg_summary["difficulty"]];
 	if(cfg_summary["corrupt"].to_bool()) {
 		str << "\n<span color='#f00'>" << _("(Invalid)") << "</span>";
 		// \todo: this skips the catch() statement in display_savegame. Low priority, as the
@@ -364,26 +363,15 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 	}
 
 	const std::string& campaign_type = cfg_summary["campaign_type"];
+	const std::string campaign_id = cfg_summary["campaign"];
 
 	try {
 		switch(game_classification::CAMPAIGN_TYPE::string_to_enum(campaign_type).v) {
 			case game_classification::CAMPAIGN_TYPE::SCENARIO: {
-				const std::string campaign_id = cfg_summary["campaign"];
-
 				const config* campaign = nullptr;
 				if(!campaign_id.empty()) {
 					if(const config& c = cache_config_.find_child("campaign", "id", campaign_id)) {
 						campaign = &c;
-					}
-				}
-
-				if (campaign != nullptr) {
-					try {
-						const config &difficulty = campaign->find_child("difficulty", "define", cfg_summary["difficulty"]);
-						std::ostringstream ss;
-						ss << difficulty["label"] << " (" << difficulty["description"] << ")";
-						difficulty_human_str = ss.str();
-					} catch(const config::error&) {
 					}
 				}
 
@@ -427,8 +415,47 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 		str << _("Scenario start");
 	}
 
-	str << "\n" << _("Difficulty: ")
-		<< difficulty_human_str;
+	str << "\n" << _("Difficulty: ");
+	try {
+		switch (game_classification::CAMPAIGN_TYPE::string_to_enum(campaign_type).v) {
+		case game_classification::CAMPAIGN_TYPE::SCENARIO:
+		case game_classification::CAMPAIGN_TYPE::MULTIPLAYER: {
+			const config* campaign = nullptr;
+			if (!campaign_id.empty()) {
+				if (const config& c = cache_config_.find_child("campaign", "id", campaign_id)) {
+					campaign = &c;
+				}
+			}
+
+			// 'SCENARIO' or SP should only ever be campaigns
+			// 'MULTIPLAYER' may be a campaign with difficulty or single scenario without difficulty
+			// For the latter do not show the difficulty - even though it will be listed as
+			// NORMAL -> Medium in the save file it should not be considered valid (GitHub Issue #5321)
+			if (campaign != nullptr) {
+				try {
+					const config& difficulty = campaign->find_child("difficulty", "define", cfg_summary["difficulty"]);
+					std::ostringstream ss;
+					ss << difficulty["label"] << " (" << difficulty["description"] << ")";
+					str << ss.str();
+				}
+				catch (const config::error&) {
+				}
+			}
+			else {
+				str << _("N/A");
+			}
+
+			break;
+		}
+		case game_classification::CAMPAIGN_TYPE::TUTORIAL:
+		case game_classification::CAMPAIGN_TYPE::TEST:
+			str << _("N/A");
+			break;
+		}
+	}
+	catch (const bad_enum_cast&) {
+		str << _("N/A");
+	}
 
 	if(!cfg_summary["version"].empty()) {
 		str << "\n" << _("Version: ") << cfg_summary["version"];

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -439,6 +439,8 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 					str << ss.str();
 				}
 				catch (const config::error&) {
+					// fall back to standard difficulty string in case of exception
+					str << string_table[cfg_summary["difficulty"]];
 				}
 			}
 			else {


### PR DESCRIPTION
Second attempt at resolving #5321 after first (naïve) attempt in #6092.

Also shows campaign-specific difficulty for MP games.

* Test scenario: No difficulty -> —
* Pre-1.15 Tutorial: No difficulty -> —
* SP Campaigns: Custom difficulty -> no change
* MP Campaigns: Plain difficulty -> Custom difficulty
* MP Scenario: No difficulty -> —

```
Save Game                Before              After
---------                ------              -----
Test scenario            Medium              —
Tutorial (1.14 Tutorial) Medium              —
Tutorial (1.17 Campaign) Tutorial (Beginner) Tutorial (Beginner)

MP single scenario       Medium              —

SP campaign (HttT)       Commander (Normal)  Commander (Normal)
MP campaign (HttT)       Medium              Commander (Normal)
SP campaign (LoW)        Lord (Challenging)  Lord (Challenging)
MP campaign (LoW)        Medium              Lord (Challenging)
```

~Unfortunately, because it introduces the string `N/A`, it needs to wait till after 1.16.0 release before back-porting.~