### PR TITLE
Make the team Eryssa leads (if alive) have consistent colour

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/12a_Get_the_Gold.cfg
@@ -273,6 +273,7 @@
         {GOLD 400 350 300}
         team_name=knalgans
         user_team_name= _ "Alliance"
+        color=teal
         {FLAG_VARIANT wood-elvish}
     [/side]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/13a_Showdown.cfg
@@ -334,6 +334,7 @@
         controller=human
         no_leader=yes
         defeat_condition=never # changed in prestart
+        color=teal
         {FLAG_VARIANT wood-elvish}
         # passive_leader=yes, if his death causes the scenario to be lost
     [/side]


### PR DESCRIPTION
Resolves #5375.

I tested this as per the above request and it works as intended. I can't think of how it could cause any, but not sure if there could be any unintended side-effects