### PR TITLE
Clear dehydration status on victory (resolves #5687)

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/dehydration-utils.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/dehydration-utils.cfg
@@ -303,4 +303,28 @@ Hd, Dd*, Dd^E*, Rd #enddef
             object_id=dehydration_overlay
         [/remove_object]
     [/event]
+
+    [event]
+        name="victory"
+
+        [modify_unit]
+            [filter]
+                status=dehydrated
+            [/filter]
+
+            [status]
+                dehydrated=no
+            [/status]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                status=dehydration_slowed_by_healer
+            [/filter]
+
+            [status]
+                dehydration_slowed_by_healer=no
+            [/status]
+        [/modify_unit]
+    [/event]
 #enddef


### PR DESCRIPTION
Even though units are not dehydrated in subsequent scenarios, the dehydration icon may otherwise still appear in the side-bar without this.