### PR TITLE
Fix Issue 5743 surronding unit checksum code caring about weapon spec…

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2734,6 +2734,9 @@ std::string get_checksum(const unit& u)
 			config& child_spec = child.add_child("specials", spec);
 
 			child_spec.recursive_clear_value("description");
+			child_spec.recursive_clear_value("description_inactive");
+			child_spec.recursive_clear_value("name");
+			child_spec.recursive_clear_value("name_inactive");
 		}
 	}
 


### PR DESCRIPTION
…ial names, which causes OOS when changed locally; fix issue by clearing out respective values by following later code.