### PR TITLE
Main menu language button v3

### DIFF
--- a/data/gui/widget/button_title_screen_small.cfg
+++ b/data/gui/widget/button_title_screen_small.cfg
@@ -1,0 +1,136 @@
+#textdomain wesnoth-lib
+
+#define _GUI_BUTTON_FONT_SIZE
+{GUI_FONT_SIZE_TINY} #enddef
+
+#define _GUI_BUTTON_TEXT FONT_SIZE FONT_STYLE FONT_COLOR
+	[text]
+		x = 30 # 10 px padding left + 20 px image width
+		y = "(max((height - text_height - 2) / 2, 0))"
+		w = "(width - 40)" # 10 px padding right
+		h = "(text_height)"
+		maximum_width = "(width - 40)" # 10 px padding right
+		font_size = {FONT_SIZE}
+		font_style = {FONT_STYLE}
+		color = {FONT_COLOR}
+		text = "(text)"
+		text_markup = "(text_markup)"
+		text_alignment = "right"
+	[/text]
+#enddef
+
+#define _GUI_BUTTON_ICON IMAGE_FILESTEM IPF
+	[image]
+		x = 5
+		y = "(max(pos, 0) where pos = floor((height - image_height) / 2))"
+
+		w = "(min(width,  image_original_width))"
+		h = "(min(height, image_original_height))"
+
+		name = {IMAGE_FILESTEM} + ".png{IPF}"
+	[/image]
+#enddef
+
+#define _GUI_RESOLUTION RESOLUTION MIN_WIDTH DEFAULT_WIDTH HEIGHT EXTRA_WIDTH EXTRA_HEIGHT FONT_SIZE ICON IPF ALPHA
+	[resolution]
+
+		{RESOLUTION}
+
+		min_width = {MIN_WIDTH}
+		min_height = {HEIGHT}
+
+		default_width = {DEFAULT_WIDTH}
+		default_height = {HEIGHT}
+
+		max_width = 0
+		max_height = {HEIGHT}
+
+		text_extra_width = {EXTRA_WIDTH}
+		text_extra_height = {EXTRA_HEIGHT}
+		text_font_size = {FONT_SIZE}
+
+		[state_enabled]
+
+			[draw]
+
+				{GUI__BUTTON_NORMAL_FRAME "buttons/button_normal/background"
+					({GUI__BORDER_COLOR      ALPHA={ALPHA}})
+					({GUI__BORDER_COLOR_DARK ALPHA={ALPHA}}) ("21, 79, 109, 255") {IPF}}
+
+				{_GUI_BUTTON_ICON {ICON} {IPF}}
+
+				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
+
+			[/draw]
+
+		[/state_enabled]
+
+		[state_disabled]
+
+			[draw]
+
+				{GUI__BUTTON_NORMAL_FRAME "buttons/button_normal/background"
+					({GUI__FONT_COLOR_DISABLED__DEFAULT ALPHA={ALPHA}})
+					("89,  89,  89,  {ALPHA}")
+					("60,  60,  60, 255") "~GS(){IPF}"}
+
+				{_GUI_BUTTON_ICON {ICON} "~GS(){IPF}"}
+
+				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_DISABLED__TITLE})}
+
+			[/draw]
+
+		[/state_disabled]
+
+		[state_pressed]
+
+			[draw]
+
+				{GUI__BUTTON_NORMAL_FRAME "buttons/button_normal/background-pressed"
+					({GUI__BORDER_COLOR      ALPHA={ALPHA}})
+					({GUI__BORDER_COLOR_DARK ALPHA={ALPHA}}) ("1, 10, 16, 255") {IPF}}
+
+				{_GUI_BUTTON_ICON {ICON}-pressed {IPF}}
+
+				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
+
+			[/draw]
+
+		[/state_pressed]
+
+		[state_focused]
+
+			[draw]
+
+				{GUI__BUTTON_NORMAL_FRAME "buttons/button_normal/background-active"
+					({GUI__BORDER_COLOR      ALPHA={ALPHA}})
+					({GUI__BORDER_COLOR_DARK ALPHA={ALPHA}}) ("12, 108, 157, 255") {IPF}}
+
+				{_GUI_BUTTON_ICON {ICON}-active {IPF}}
+
+				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
+
+			[/draw]
+
+		[/state_focused]
+
+	[/resolution]
+#enddef
+
+[button_definition]
+
+	id = "titlescreen_language"
+	description = "Language button used on the main menu."
+
+	{_GUI_RESOLUTION () 40 80 16 43 14 ({_GUI_BUTTON_FONT_SIZE}) icons/action/language_25 () 255}
+	{_GUI_RESOLUTION ({GUI_BIG_RESOLUTION})
+			 50 80 20 46 16
+			 ({GUI_SCALE_RESOLUTION {_GUI_BUTTON_FONT_SIZE}})
+			 icons/action/language_25 () 255}
+
+[/button_definition]
+
+#undef _GUI_RESOLUTION
+#undef _GUI_BUTTON_ICON
+#undef _GUI_BUTTON_TEXT
+#undef _GUI_BUTTON_FONT_SIZE

--- a/data/gui/window/title_screen.cfg
+++ b/data/gui/window/title_screen.cfg
@@ -480,7 +480,7 @@ where
 								horizontal_alignment = "right"
 								[button]
 									id = "language"
-									definition = "action_language"
+									definition = "titlescreen_language"
 									label = _ "Language"
 									tooltip = _ "Change the language"
 								[/button]

--- a/data/gui/window/title_screen.cfg
+++ b/data/gui/window/title_screen.cfg
@@ -449,6 +449,8 @@ where
 				[column]
 					horizontal_grow = true
 					vertical_alignment = "bottom"
+					border = "bottom,left,right"
+					border_size = 10
 
 					[grid]
 

--- a/data/languages/en@shaw.cfg
+++ b/data/languages/en@shaw.cfg
@@ -1,6 +1,6 @@
 [locale]
     name="·𐑖𐑭𐑝𐑾𐑯 ·𐑰𐑙𐑜𐑤𐑦𐑖 (Shavian English)"
-    sort_name = "English [·𐑖𐑭𐑝𐑾𐑯]"
+    sort_name = "English (·𐑖𐑭𐑝𐑾𐑯)"
     locale=en@shaw
     alternates=en_AG@shaw, en_AU@shaw, en_CA@shaw, en_BW@shaw, en_DK@shaw, en_GB@shaw, en_HK@shaw, en_IE@shaw, en_IN@shaw, en_NG@shaw, en_NZ@shaw, en_PH@shaw, en_SG@shaw, en_US@shaw, en_ZA@shaw, en_ZW@shaw
     percent=33

--- a/data/languages/en_GB.cfg
+++ b/data/languages/en_GB.cfg
@@ -1,5 +1,5 @@
 [locale]
-    name="English [GB]"
+    name="English (GB)"
     locale=en_GB
     alternates=en_AG, en_AU, en_BW, en_IE, en_IN, en_NG, en_NZ, en_SG, en_ZA, en_ZW
     percent=98

--- a/data/languages/en_US.cfg
+++ b/data/languages/en_US.cfg
@@ -1,5 +1,5 @@
 [locale]
-    name="English [US]"
+    name="English (US)"
     locale=en_US
     alternates=C, en_PH
 [/locale]

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -38,6 +38,7 @@
 #include "gui/dialogs/preferences_dialog.hpp"
 #include "gui/dialogs/screenshot_notification.hpp"
 #include "gui/dialogs/simple_item_selector.hpp"
+#include "language.hpp"
 #include "log.hpp"
 #include "preferences/game.hpp"
 //#define DEBUG_TOOLTIP
@@ -58,6 +59,8 @@
 
 #include <algorithm>
 #include <functional>
+
+#include <boost/algorithm/string/erase.hpp>
 
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
@@ -310,6 +313,23 @@ void title_screen::pre_show(window& win)
 			gui2::show_error_message(e.what());
 		}
 	});
+
+	if(auto* lang_button = find_widget<button>(&win, "language", false, false); lang_button) {
+		const auto& locale = translation::get_effective_locale_info();
+		const auto& langs = get_languages(true);
+
+		auto lang_def = std::find_if(langs.begin(), langs.end(), [&](language_def const& lang) {
+			// Just assume everything is UTF-8 (it should be as long as we're called Wesnoth)
+			// and strip the charset from the Boost locale identifier.
+			const auto& boost_name = boost::algorithm::erase_first_copy(locale.name(), ".UTF-8");
+			// std::cerr << lang.localename << '/' << boost_name << '\n';
+			return lang.localename == boost_name;
+		});
+
+		// If somehow the locale doesn't match a known translation, use the
+		// locale identifier as a last resort
+		lang_button->set_label(lang_def != langs.end() ? lang_def->language.str() : locale.name());
+	}
 
 	//
 	// Preferences


### PR DESCRIPTION
Since @stevecotton expressed interest in the iteration of the Language button I mentioned [in the middle of the discussion in #4531](https://github.com/wesnoth/wesnoth/issues/4531#issuecomment-842665100), I decided to package that and that alone into a PR that could potentially be merged into 1.16 without any string changes whatsoever.

![Screenshot_20210923_120951](https://user-images.githubusercontent.com/489895/134533823-66d33645-ff3e-42d1-a49d-2856857ed36b.png)

This new iteration of the button displays the name of the currently selected (or *guessed*, if it's System Default) language as its label, while retaining the icon for aesthetic purposes. It also increases the bottom and edge margins for that UI grid row to make it slightly more elegant than the previous "everything stuck in the corner" approach. There are otherwise no changes in functionalityhere.

![image](https://user-images.githubusercontent.com/489895/134534232-d9dd2fb9-b75c-4fe4-8637-bc36ab0dee15.png)

![image](https://user-images.githubusercontent.com/489895/134534286-da1572da-5431-4624-8fad-1d58b6f0f550.png)

![image](https://user-images.githubusercontent.com/489895/134534499-d9c395ef-fd88-47fe-ae9a-b05add0ece2b.png)

(Paging @Vultraz and @nemaara as well.)

CC #4531