### PR TITLE
Allow enabling the VSync hint on SDL's software renderer

### DIFF
--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -270,6 +270,20 @@
 			horizontal_alignment = "left"
 
 			[toggle_button]
+				id = "vsync"
+				label = _ "VSync"
+				tooltip = _ "Reduces tearing by synchronizing rendering with the screen refresh rate (requires restart to take effect)"
+			[/toggle_button]
+		[/column]
+	[/row]
+
+	[row]
+		[column]
+			border = "all"
+			border_size = 5
+			horizontal_alignment = "left"
+
+			[toggle_button]
 				id = "fps_limiter"
 				label = _ "Limit FPS"
 				tooltip = _ "Disabling this increases CPU usage, but may slightly improve performance (requires restart to take effect)"

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -454,6 +454,12 @@ void preferences_dialog::post_build(window& window)
 	register_bool("fps_limiter", true,
 		[]() { return draw_delay() != 0; }, [](bool v) { set_draw_delay(v ? -1 : 0); });
 
+	/* VSYNC */
+	register_bool("vsync", true, vsync, set_vsync);
+	if(!CVideo::get_singleton().supports_vsync()) {
+		find_widget<widget>(&window, "vsync", false).set_visible(gui2::widget::visibility::invisible);
+	}
+
 	/* SELECT THEME */
 	connect_signal_mouse_left_click(
 			find_widget<button>(&window, "choose_theme", false),

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -416,6 +416,11 @@ bool fullscreen()
 	return get("fullscreen", true);
 }
 
+bool vsync()
+{
+	return get("vsync", true);
+}
+
 void _set_resolution(const point& res)
 {
 	preferences::set("xresolution", std::to_string(res.x));
@@ -430,6 +435,11 @@ void _set_maximized(bool ison)
 void _set_fullscreen(bool ison)
 {
 	prefs["fullscreen"] = ison;
+}
+
+void set_vsync(bool ison)
+{
+	prefs["vsync"] = ison;
 }
 
 bool turbo()

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -81,6 +81,9 @@ namespace preferences {
 	bool fullscreen();
 	void _set_fullscreen(bool ison);
 
+	bool vsync();
+	void set_vsync(bool ison);
+
 	bool turbo();
 	void _set_turbo(bool ison);
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -220,8 +220,14 @@ void CVideo::init_window()
 		window_flags |= SDL_WINDOW_MAXIMIZED;
 	}
 
+	uint32_t renderer_flags = SDL_RENDERER_SOFTWARE;
+	if(supports_vsync() && preferences::vsync()) {
+		LOG_DP << "VSYNC on\n";
+		renderer_flags |= SDL_RENDERER_PRESENTVSYNC;
+	}
+
 	// Initialize window
-	window.reset(new sdl::window("", x, y, w, h, window_flags, SDL_RENDERER_SOFTWARE));
+	window.reset(new sdl::window("", x, y, w, h, window_flags, renderer_flags));
 
 	std::cerr << "Setting mode to " << w << "x" << h << std::endl;
 
@@ -493,6 +499,11 @@ point CVideo::current_resolution()
 bool CVideo::is_fullscreen() const
 {
 	return (window->get_flags() & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0;
+}
+
+bool CVideo::supports_vsync() const
+{
+	return sdl_get_version() >= version_info{2, 0, 17};
 }
 
 int CVideo::set_help_string(const std::string& str)

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -105,6 +105,8 @@ public:
 
 	bool is_fullscreen() const;
 
+	bool supports_vsync() const;
+
 	bool set_resolution(const unsigned width, const unsigned height);
 
 	/**


### PR DESCRIPTION
Adds a VSync option to Preferences -> Display above Limit FPS. Requires SDL 2.0.17 or later. If an earlier version of SDL 2 is detected at runtime, the option in Preferences is hidden and ignored entirely.

Requires restarting the game because it necessitates recreating the window.

CC #5018