### PR TITLE
Pinnacle rock map label covered during dialog fix

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -294,7 +294,7 @@
         [/message]
 
         [scroll_to]
-            x,y=19,6
+            x,y=22,9
         [/scroll_to]
 
         [message]


### PR DESCRIPTION
Issue #6125 - UtBS S2 Across the Harsh Sands Pinnacle Rock is covered during dialog fix. Now the camera will scroll to the tile where the "Pinnacle Rock" map label is.