### PR TITLE
TRoW Proofread Pass

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/01_A_Summer_of_Storms.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/01_A_Summer_of_Storms.cfg
@@ -144,7 +144,7 @@
         name=start
         [message]
             speaker=narrator
-            message= _ "The trouble seems to have finally reached to the heart of the Isle, to the isolated lands of King Eldaric IV."
+            message= _ "The trouble seems to have finally reached the heart of the Isle, to the isolated lands of King Eldaric IV."
             image=wesnoth-icon.png
         [/message]
         [message]
@@ -157,7 +157,7 @@
         [/message]
         [message]
             speaker=King Eldaric IV
-            message= _ "You’re showing initiative, son! I’m proud of you! Yes, you may lead our forces to battle, it is time — but I’ll stay near to keep an eye on you. There is more to this raid than meets the eye, I think."
+            message= _ "You’re showing initiative, son! I’m proud of you! Yes, you may lead our forces in battle, it is time — but I’ll stay near to keep an eye on you. There is more to this raid than meets the eye, I think."
         [/message]
         [message]
             speaker=Prince Haldric

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/04a_The_Swamp_of_Esten.cfg
@@ -370,7 +370,7 @@
         [/unit]
         [message]
             speaker=Minister Edren
-            message= _ "Back you vile— Oh, sorry I thought you were undead. When are those goofs in Clearwater Port going to clear the swamp again?"
+            message= _ "Back you vile— Oh, sorry, I thought you were undead. When are those goofs in Clearwater Port going to clear the swamp again?"
         [/message]
         [message]
             speaker=Prince Haldric
@@ -577,7 +577,7 @@ Enter at Your Own Risk!"
 
         [message]
             speaker=Sir Ruddry
-            message= _ "As far as I know, Sir. We have a large army, and they were pressing all able bodied men and boys into service when I left. That orcish army is huge, but they haven’t met the main body of our forces yet."
+            message= _ "As far as I know, Sir. We have a large army, and they were pressing all able-bodied men and boys into service when I left. That orcish army is huge, but they haven’t met the main body of our forces yet."
         [/message]
 
         [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/06_Temple_in_the_Deep.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/06_Temple_in_the_Deep.cfg
@@ -205,7 +205,7 @@
             [then]
                 [message]
                     speaker=narrator
-                    message= _ "You already have the Fire Ruby."
+                    message= _ "Haldric already has the Ruby of Fire."
                     image=wesnoth-icon.png
                 [/message]
 
@@ -229,7 +229,7 @@
 
                         [message]
                             speaker=narrator
-                            message= _ "As you open the chest you see it, the Ruby of Fire. It is the size of an apple, and burns with an internal fire, which is refracted through its faces. You can feel the power flowing from it..."
+                            message= _ "As Haldric opens the chest he sees it, the Ruby of Fire. It is the size of an apple, and burns with an internal fire, which is refracted through its faces. He can feel the power flowing from it..."
                             image=wesnoth-icon.png
                         [/message]
 
@@ -289,7 +289,7 @@
         name=victory
         [message]
             speaker=Prince Haldric
-            message= _ "I’m glad that’s over! We have the Ruby of Fire, and that Lich-Lord is now a pile of dust, let’s get out of these catacombs!"
+            message= _ "I’m glad that’s over! We have the Ruby of Fire, and that Lich-Lord is now a pile of dust. Let’s get out of these catacombs!"
         [/message]
         {CLEAR_VARIABLE Have_Ruby}
     [/event]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
@@ -117,7 +117,7 @@
         [/message]
         [message]
             speaker=Prince Haldric
-            message= _ "Yes, it was a tough battle, but we prevailed. Now, I’m having a problem. I know not what I should do next."
+            message= _ "Yes, it was a tough battle, but we prevailed. Now, I have a problem. I know not what I should do next."
         [/message]
         [message]
             speaker=Prince Haldric

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
@@ -918,7 +918,7 @@
         name=victory
         [message]
             speaker=Prince Haldric
-            message= _ "We’ve escaped from the orcs before we were trapped by the ice! Now, on to Southbay."
+            message= _ "We’ve escaped from the orcs before getting trapped by the ice! Now, on to Southbay."
         [/message]
 
         [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/09_Fallen_Lich_Point.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/09_Fallen_Lich_Point.cfg
@@ -244,7 +244,7 @@
 
         [message]
             speaker=narrator
-            message= _ "Prince Haldric has arrived at Fallen Lich Point, to retrieve the Lich-Lord Caror’s Book of Fire and Darkness, and flee into the sewers of Southbay."
+            message= _ "Prince Haldric has arrived at Fallen Lich Point, to retrieve Lich-Lord Caror’s Book of Fire and Darkness, and flee into the sewers of Southbay."
             image=wesnoth-icon.png
         [/message]
 
@@ -344,7 +344,7 @@
         [/filter]
         [message]
             speaker=narrator
-            message= _ "This monolith was erected by me, ― (<i>chipped away</i>), first Mage of the good people of the Green Isle. By its power the Lich-Lord is bound in stone. To end the spell a noble of the line of Kings should utter the following..."
+            message= _ "This monolith was erected by me, ― (<i>chipped away</i>), first Mage of the good people of the Green Isle. By its power, the Lich-Lord is bound in stone. To end the spell, a noble of the line of Kings should utter the following..."
             image=wesnoth-icon.png
         [/message]
 
@@ -388,7 +388,7 @@
 
                                     [message]
                                         speaker=Prince Haldric
-                                        message= _ "The lich is free! Let’s bash him and grab that book. That sounds like a job for you, Lady Jessene!"
+                                        message= _ "The lich is free! Let’s bash him and grab that book. This sounds like a job for you, Lady Jessene!"
                                     [/message]
                                     [message]
                                         speaker=Lady Jessene

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/11_Southbay_in_Winter.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/11_Southbay_in_Winter.cfg
@@ -182,7 +182,7 @@
         [/message]
         [message]
             speaker=King Addroran IX
-            message= _ "Hmm. There is wisdom in your words, and my end should be in this place. We can hold out for the rest of the winter here. When the orcs last came it was fall and the harvest was in. We can hunt the great schools of fish that live under the ice. You might even be able to depart in well provisioned ships!"
+            message= _ "Hmm. There is wisdom in your words, and my end should be in this place. We can hold out for the rest of the winter here. When the orcs last came it was fall and the harvest was in. We can hunt the great schools of fish that live under the ice. You might even be able to depart in well-provisioned ships!"
         [/message]
         [message]
             speaker=Lady Jessene
@@ -190,7 +190,7 @@
         [/message]
         [message]
             speaker=King Addroran IX
-            message= _ "No. Flee, and flee east. It is my duty to hold this city as long as I can for the sake of all who can be evacuated. That means that it shall fall on Haldric and you to lead the evacuation."
+            message= _ "No. Flee, and flee east. It is my duty to hold this city as long as I can for the sake of all who can be evacuated. This means that it shall fall on Haldric and you to lead the evacuation."
         [/message]
         [message]
             speaker=Prince Haldric

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/16_The_Kalian.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/16_The_Kalian.cfg
@@ -227,7 +227,7 @@
 
 #define ISLE
     [option]
-        label= _ "Let’s put those souls to rest on the cursed isle!"
+        label= _ "Let’s put those souls on the cursed isle to rest!"
 
         [show_if]
             [variable]
@@ -313,7 +313,7 @@
         [then]
             [message]
                 speaker="Lord El'Isomithir"
-                message= _ "Long ago a clan of elves on the Isle of Tears fell under the sway of a dark curse. Their souls still haunt that place and no elf will go there. You should clear this isle, and put their souls to rest."
+                message= _ "Long ago, a clan of elves on the Isle of Tears fell under the sway of a dark curse. Their souls still haunt that place and no elf will go there. You should clear this isle, and put their souls to rest."
             [/message]
         [/then]
     [/if]
@@ -341,7 +341,7 @@
             value="Isle"
             [message]
                 speaker="Lord El'Isomithir"
-                message= _ "Finally the souls of our poor kin may rest. Thank you."
+                message= _ "Finally, the souls of our poor kin may rest. Thank you."
             [/message]
         [/case]
         [case]
@@ -433,7 +433,7 @@
                 [/message]
                 [message]
                     speaker=Lord Aryad
-                    message= _ "Well then, human. Each of us lords has a specific quest for you. If you complete them all you will be granted all of the plains in our domain and the hills south of the Great River, if not you will be forced to depart. So which quest do you wish to undertake first?"
+                    message= _ "Well then, human. Each of us lords has a specific quest for you. If you complete them all you will be granted all of the plains in our domain and the hills south of the Great River, if not you will be forced to depart. So, which quest do you wish to undertake first?"
                 [/message]
                 {QUESTS}
 

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/18_A_Spy_in_the_Woods.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/18_A_Spy_in_the_Woods.cfg
@@ -117,7 +117,7 @@
 
         [message]
             speaker=Lord Logalmier
-            message= _ "So a doom has followed them here from their old home. My Outriders have reported that orcs have made landfall. Orcs! The tree-killers of our most ancient legends. Some thought them only a nightmare to frighten children, and never real at all."
+            message= _ "So, a doom has followed them here from their old home. My Outriders have reported that orcs have made landfall. Orcs! The tree-killers of our most ancient legends. Some thought them only a nightmare to frighten children, and never real at all."
         [/message]
         [message]
             speaker=Lady Dionli

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/21_The_Plan.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/21_The_Plan.cfg
@@ -109,11 +109,11 @@
 
         [message]
             speaker=Lady Jessene
-            message= _ "So what is your plan?"
+            message= _ "So, what is your plan?"
         [/message]
         [message]
             speaker=Prince Haldric
-            message= _ "We’re going to convince Jevyan that we gave the elves the Ruby of Fire to secure our place in this new land. Then if the orcs return, hopefully they’ll go looking for our not-so-loyal elven allies first."
+            message= _ "We’re going to convince Jevyan that we gave the elves the Ruby of Fire to secure our place in this new land. Then, if the orcs return, hopefully they’ll go looking for our not-so-loyal elven allies first."
         [/message]
         [message]
             speaker=Lady Jessene

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/23_Epilogue.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/23_Epilogue.cfg
@@ -309,7 +309,7 @@
         [/message]
         [message]
             speaker=narrator
-            message= _ "It was never said afterwards that the marriage of Haldric and Jessene was exactly tranquil. But it was also said that neither could long stand to be separated from the other, and she bore him strong children that mingled the blood of their diverse ancestries. Many followed their example, and the two refugee peoples from the Green Isles became fused into one in the new kingdom."
+            message= _ "It was never said afterwards that the marriage of Haldric and Jessene was exactly tranquil. But it was also said that neither could long stand to be separated from the other, and she bore him strong children that mingled the blood of their diverse ancestries. Many followed their example, and the two refugee peoples from the Green Isle became fused into one in the new kingdom."
             image=wesnoth-icon.png
         [/message]
         [message]

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Leader.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Leader.cfg
@@ -19,7 +19,7 @@
     {AMLA_DEFAULT}
     cost=60
     usage=mixed fighter
-    description= _ "Born in the Wesfolk aristocracy, she and her people were excluded from society by their lords, who betrayed their loyalty when a war against Haldric’s people was being lost. This outcast still conserves her nobleness in her veins and on the battlefield she has earned valuable experience, which continues increasing with time, as does her natural leadership."
+    description= _ "Born in the Wesfolk aristocracy, she and her people were excluded from society by their lords, who betrayed their loyalty when a war against Haldric’s people was being lost. This outcast still conserves her nobleness in her veins, and on the battlefield she has earned valuable experience, which continues to increase with time, as does her natural leadership."
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     [defend]
         hits=miss

--- a/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Outcast.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/units/Wesfolk_Outcast.cfg
@@ -18,7 +18,7 @@
     advances_to=Wesfolk Lady
     cost=18
     usage=mixed fighter
-    description= _ "Born in the Wesfolk aristocracy, she and her people were excluded from society by their lords, who betrayed their loyalty when a war against Haldric’s people was being lost. This outcast still conserves her nobleness in her veins and on the battlefield she has earned valuable experience, which she can lend to her people for turning a fight in their favor."
+    description= _ "Born in the Wesfolk aristocracy, she and her people were excluded from society by their lords, who betrayed their loyalty when a war against Haldric’s people was being lost. This outcast still conserves her nobleness in her veins, and on the battlefield she has earned valuable experience, which she can lend to her people for turning a fight in their favor."
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}
     [defend]
         hits=miss

--- a/data/campaigns/The_Rise_Of_Wesnoth/utils/trow-nlmsg.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/utils/trow-nlmsg.cfg
@@ -87,7 +87,7 @@
         [then]
             [message]
                 speaker=Lady Jessene
-                message= _ "Haldric, just before we arrived here I got word that the your ‘third of a fleet’ has departed for our old home, the Green Isle."
+                message= _ "Haldric, just before we arrived here I got word that your ‘third of a fleet’ has departed for our old home, the Green Isle."
             [/message]
             [message]
                 speaker=Prince Haldric


### PR DESCRIPTION
For the campaign The Rise of Wesnoth. For Approval. Minor edits and proofreads. `wmlxgettext` was used so as to ensure all text was reviewed.