### PR TITLE
TRoW S08 - Add a way of smoothing the appearance of Naga in the map in case the player premoves a unit.

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/08_Clearwater_Port.cfg
@@ -411,6 +411,9 @@
         {LOYAL_UNIT 3 (Naga Fighter) 30 31}
         {LOYAL_UNIT 3 (Naga Fighter) 27 33}
 #endif
+        [delay]
+            time=1000
+        [/delay]
     [/event]
 
     [event]


### PR DESCRIPTION
Delay time can be changed. One second felt okey imo tho (sorry for the quality of the attached file).
Fix for issue #6140

https://user-images.githubusercontent.com/30196839/135730846-952fe630-27b9-4bfb-828e-78e3b04150db.mp4

