### PR TITLE
Refactor handling of allies in Sceptre of Fire

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/07a_Dealing_with_Dwarves.cfg
@@ -144,14 +144,14 @@
 
             [then]
                 [set_variable]
-                    name=ally_name
+                    name=ally_id
                     value=Rogrimir
                 [/set_variable]
             [/then]
 
             [else]
                 [set_variable]
-                    name=ally_name
+                    name=ally_id
                     value=Jarl
                 [/set_variable]
 
@@ -363,26 +363,11 @@
             message= _ "That I may be able to help you with. We haven’t sent anyone to the surface in years, but we do know of a passage that leads to the ancient northern gate. Several generations ago we used to trade heavily with humans that lived north of the mountains, but then some new human came to power and decreed that all contact with us should be cut off. We sent messengers to find out why, but they never returned."
         [/message]
 
-        [if]
-            [variable]
-                name=ally_name
-                equals=Rogrimir
-            [/variable]
-
-            [then]
-                [message]
-                    speaker=King Thurongar
-                    message= _ "But dwarves are excellent delvers, and we keep meticulous maps of all the tunnels we have explored. We should still have maps of the tunnels leading back to the surface. Of course I doubt you would be able to understand them, so, Rogrimir here has volunteered to lead you to the surface."
-                [/message]
-            [/then]
-
-            [else]
-                [message]
-                    speaker=King Thurongar
-                    message= _ "But dwarves are excellent delvers, and we keep meticulous maps of all the tunnels we have explored. We should still have maps of the tunnels leading back to the surface. Of course I doubt you would be able to understand them, so, Jarl here has volunteered to lead you to the surface."
-                [/message]
-            [/else]
-        [/if]
+        {SET_ALLY_UNIT}
+        [message]
+            speaker=King Thurongar
+            message= _ "But dwarves are excellent delvers, and we keep meticulous maps of all the tunnels we have explored. We should still have maps of the tunnels leading back to the surface. Of course I doubt you would be able to understand them, so, $ally_unit.name here has volunteered to lead you to the surface."
+        [/message]
 
         [if]
             [variable]
@@ -404,33 +389,18 @@
 
             [else]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "You did a great service for my brothers. In exchange, as much as I hate the light, I am the one who knows the upper tunnels the best, so I’ll be your guide."
                 [/message]
             [/else]
         [/if]
         {CLEAR_VARIABLE saved_rogrimir}
 
-        [if]
-            [variable]
-                name=ally_name
-                equals=Rogrimir
-            [/variable]
-
-            [then]
-                [message]
-                    speaker=Kaleh
-                    message= _ "Thank you very much for your help. We were worried about getting lost in all these twisting tunnels. And we would be honored to have you come with us, Rogrimir."
-                [/message]
-            [/then]
-
-            [else]
-                [message]
-                    speaker=Kaleh
-                    message= _ "Thank you very much for your help. We were worried about getting lost in all these twisting tunnels. And we would be honored to have you come with us, Jarl."
-                [/message]
-            [/else]
-        [/if]
+        [message]
+            speaker=Kaleh
+            message= _ "Thank you very much for your help. We were worried about getting lost in all these twisting tunnels. And we would be honored to have you come with us, $ally_unit.name."
+        [/message]
+        {CLEAR_VARIABLE ally_unit}
 
         [if]
             [have_unit]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/07b_Talking_with_Trolls.cfg
@@ -142,14 +142,14 @@
 
             [then]
                 [set_variable]
-                    name=ally_name
+                    name=ally_id
                     value=Grog
                 [/set_variable]
             [/then]
 
             [else]
                 [set_variable]
-                    name=ally_name
+                    name=ally_id
                     value=Nog
                 [/set_variable]
 
@@ -356,26 +356,11 @@
             message= _ "Darmog has never been above ground, but Darmog understand your story. A leader must protect and care for his people. Every people deserve to find their own home. If we can help you we will."
         [/message]
 
-        [if]
-            [variable]
-                name=ally_name
-                equals=Grog
-            [/variable]
-
-            [then]
-                [message]
-                    speaker=Spiritual Advisor
-                    message= _ "We may be able to help you find a way back to the sunlit lands. In our temples we do keep records of the past. We have not walked above the earth for many many generations, not since the darkness drove us underground. But we are masters of the underground lands, and we have explored many tunnels. Recently one of our scouts found a path that leads north back to the sunlit lands, I think it may be the way you are trying to go. In reward for your achievements, we will help you. Grog has volunteered to protect you and lead you back to the sunlight lands."
-                [/message]
-            [/then]
-
-            [else]
-                [message]
-                    speaker=Spiritual Advisor
-                    message= _ "We may be able to help you find a way back to the sunlit lands. In our temples we do keep records of the past. We have not walked above the earth for many many generations, not since the darkness drove us underground. But we are masters of the underground lands, and we have explored many tunnels. Recently one of our scouts found a path that leads north back to the sunlit lands, I think it may be the way you are trying to go. In reward for your achievements, we will help you. Nog has volunteered to protect you and lead you back to the sunlight lands."
-                [/message]
-            [/else]
-        [/if]
+        {SET_ALLY_UNIT}
+        [message]
+            speaker=Spiritual Advisor
+            message= _ "We may be able to help you find a way back to the sunlit lands. In our temples we do keep records of the past. We have not walked above the earth for many many generations, not since the darkness drove us underground. But we are masters of the underground lands, and we have explored many tunnels. Recently one of our scouts found a path that leads north back to the sunlit lands, I think it may be the way you are trying to go. In reward for your achievements, we will help you. $ally_unit.name has volunteered to protect you and lead you back to the sunlight lands."
+        [/message]
 
         [if]
             [variable]
@@ -404,26 +389,11 @@
         [/if]
         {CLEAR_VARIABLE saved_grog}
 
-        [if]
-            [variable]
-                name=ally_name
-                equals=Grog
-            [/variable]
-
-            [then]
-                [message]
-                    speaker=Kaleh
-                    message= _ "Thank you very much for your help. We were worried about getting lost in all these twisting tunnels. And we would be honored to have you come with us, Grog."
-                [/message]
-            [/then]
-
-            [else]
-                [message]
-                    speaker=Kaleh
-                    message= _ "Thank you very much for your help. We were worried about getting lost in all these twisting tunnels. And we would be honored to have you come with us, Nog."
-                [/message]
-            [/else]
-        [/if]
+        [message]
+            speaker=Kaleh
+            message= _ "Thank you very much for your help. We were worried about getting lost in all these twisting tunnels. And we would be honored to have you come with us, $ally_unit.name."
+        [/message]
+        {CLEAR_VARIABLE ally_unit}
 
         [if]
             [have_unit]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -318,7 +318,7 @@
 
         # recall dwarf/troll ally
         [recall]
-            id=$ally_name
+            id=$ally_id
             x,y=51,43
         [/recall]
 
@@ -329,7 +329,7 @@
 
         # put hero icon on troll/dwarf ally
         [unit_overlay]
-            id=$ally_name
+            id=$ally_id
             image=misc/hero-icon.png
         [/unit_overlay]
 
@@ -387,6 +387,7 @@
 #endif
 
         # set starting scenario objectives
+        {SET_ALLY_UNIT}
         [objectives]
             [objective]
                 description= _ "Escape the caves"
@@ -431,34 +432,9 @@
                 condition=lose
             [/objective]
             [objective]
-                description= _ "Death of Grog"
+                description= _ "Death of $ally_unit.name"
                 condition=lose
                 [show_if]
-                    {VARIABLE_CONDITIONAL ally_name equals "Grog"}
-                    {VARIABLE_CONDITIONAL ally_must_live boolean_equals yes}
-                [/show_if]
-            [/objective]
-            [objective]
-                description= _ "Death of Nog"
-                condition=lose
-                [show_if]
-                    {VARIABLE_CONDITIONAL ally_name equals "Nog"}
-                    {VARIABLE_CONDITIONAL ally_must_live boolean_equals yes}
-                [/show_if]
-            [/objective]
-            [objective]
-                description= _ "Death of Rogrimir"
-                condition=lose
-                [show_if]
-                    {VARIABLE_CONDITIONAL ally_name equals "Rogrimir"}
-                    {VARIABLE_CONDITIONAL ally_must_live boolean_equals yes}
-                [/show_if]
-            [/objective]
-            [objective]
-                description= _ "Death of Jarl"
-                condition=lose
-                [show_if]
-                    {VARIABLE_CONDITIONAL ally_name equals "Jarl"}
                     {VARIABLE_CONDITIONAL ally_must_live boolean_equals yes}
                 [/show_if]
             [/objective]
@@ -492,7 +468,7 @@
         name=start
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "We’ve come far and we’re almost to the surface. But first we should stop and rest here for a while."
         [/message]
 
@@ -509,14 +485,14 @@
 
             [then]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Yes, this time of year the snow melts from the mountains, and rivers like this often go deep underground. Sometimes the rivers break through and flood caverns, a deadly accident that has occasionally befallen my kind."
                 [/message]
             [/then]
 
             [else]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Deep and dark are the waters that flow in our caves. Sometimes raging waters flood tunnels without warning. A stream can sustain a village, a sudden flood can destroy it."
                 [/message]
             [/else]
@@ -708,7 +684,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Quick, the southern passage!"
         [/message]
 
@@ -800,7 +776,7 @@
             # The ally has not seen the first set of ants, so has a different reaction.
             [variable]
                 name=unit.id
-                equals=$ally_name
+                equals=$ally_id
             [/variable]
             [then]
                 [message]
@@ -1050,7 +1026,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Curses, the water is rising too fast. That tunnel those humans were fleeing down was the fastest way out of here, but it’s already flooding."
         [/message]
 
@@ -1060,7 +1036,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "There might be, but I don’t—"
         [/message]
 
@@ -1070,7 +1046,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Fine. Just keep going west, but be careful."
         [/message]
     [/event]
@@ -1095,7 +1071,7 @@
         [if]
             [variable]
                 name=unit.id
-                not_equals=$ally_name
+                not_equals=$ally_id
             [/variable]
 
             [then]
@@ -1107,14 +1083,14 @@
                 {CLEAR_VARIABLE explorer}
 
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "This is an ancient fortress. Who lived here I do not know, but it has been long since abandoned."
                 [/message]
             [/then]
 
             [else]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Behold, we come now to an ancient fortress. Who lived here I do not know, but it has been long since abandoned."
                 [/message]
             [/else]
@@ -1126,7 +1102,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Yes, but I didn’t explore very far. This foul place is still protected by wards and guards. It reeks of dark magic."
         [/message]
 
@@ -1136,7 +1112,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Wait. The chamber in front of us is probably trapped and well guarded. There is another way. When I explored here before, I found a secret passage that bypassed the main gate. Search along the southern wall of this cave and you should find it. The only problem is that the passage is long and windy, and it will cost us precious minutes. With the water rising that may be time we don’t have to spend. I leave the final decision up to you, Kaleh."
         [/message]
     [/event]
@@ -1158,7 +1134,7 @@
         [if]
             [have_unit]
                 x,y=$x1,$y1
-                id=$ally_name
+                id=$ally_id
             [/have_unit]
 
             [then]
@@ -1180,7 +1156,7 @@
                 [/message]
 
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Good, that should be the entrance to the secret tunnel. Now just push hard inwards."
                 [/message]
 
@@ -1218,7 +1194,7 @@
         [if]
             [have_unit]
                 x,y=$x1,$y1
-                id=$ally_name
+                id=$ally_id
             [/have_unit]
 
             [then]
@@ -1240,7 +1216,7 @@
                 [/message]
 
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "You didn’t expect the other end to be left wide open did you? There should be another secret door hidden right in front of you."
                 [/message]
 
@@ -1422,38 +1398,17 @@
         [if]
             [variable]
                 name=unit.id
-                not_equals=$ally_name
+                not_equals=$ally_id
             [/variable]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "This cave seems pretty empty, except for those two glowing runes in the center. This fort must have once been heavily occupied because countless feet have left well worn paths leading in several directions. Grog, which way should we go?"
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "This cave seems pretty empty, except for those two glowing runes in the center. This fort must have once been heavily occupied because countless feet have left well worn paths leading in several directions. Nog, which way should we go?"
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "This cave seems pretty empty, except for those two glowing runes in the center. This fort must have once been heavily occupied because countless feet have left well worn paths leading in several directions. Rogrimir, which way should we go?"
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "This cave seems pretty empty, except for those two glowing runes in the center. This fort must have once been heavily occupied because countless feet have left well worn paths leading in several directions. Jarl, which way should we go?"
-                    [/message]
-                )}
+                [message]
+                    speaker=unit
+                    message= _ "This cave seems pretty empty, except for those two glowing runes in the center. This fort must have once been heavily occupied because countless feet have left well worn paths leading in several directions. $ally_unit.name, which way should we go?"
+                [/message]
 
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "I don’t know. When I last came this way I got scared by all the runes and things moving in the shadows, and I explored no further."
                 [/message]
             [/then]
@@ -2170,7 +2125,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "I don’t like the smell of this place."
         [/message]
 
@@ -2179,34 +2134,13 @@
             message= _ "I feel some sort of presence... Ugh... it makes my skin crawl."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Nym
-                message= _ "Grog, I thought you said that you’d been here before? Where are we supposed to go from here?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nym
-                message= _ "Nog, I thought you said that you’d been here before? Where are we supposed to go from here?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nym
-                message= _ "Rogrimir, I thought you said that you’d been here before? Where are we supposed to go from here?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nym
-                message= _ "Jarl, I thought you said that you’d been here before? Where are we supposed to go from here?"
-            [/message]
-        )}
+        [message]
+            speaker=Nym
+            message= _ "$ally_unit.name, I thought you said that you’d been here before? Where are we supposed to go from here?"
+        [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "I never explored this deep into the complex. But every lair has to have a back door somewhere."
         [/message]
 
@@ -2413,7 +2347,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "We’re in luck, a fissure has opened up a crack in the northern wall. We may be able to escape that way."
         [/message]
     [/event]
@@ -2882,7 +2816,7 @@
             # remove hero icon from troll/dwarf ally
 
             [remove_unit_overlay]
-                id=$ally_name
+                id=$ally_id
                 image=misc/hero-icon.png
             [/remove_unit_overlay]
         [/event]
@@ -2923,91 +2857,56 @@
     [event]
         name=ally_conversation
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Grog, thank you so much for leading us out of the caves. We never would have found our way without your help. But with the tunnels flooded, how are you going to find your way back to your people?"
-            [/message]
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
 
-            [message]
-                speaker=Grog
-                message= _ "Grog proud of little elves too. He would not have made it this far without all your help. Grog is surprised by your bravery and strength."
-            [/message]
+            [then]
+                [message]
+                    speaker=Kaleh
+                    message= _ "$ally_unit.name, I want to thank you so much for guiding us out of the caves. We never would have found our way without your help. But with the tunnels flooded, how are you going to find your way back to your people?"
+                [/message]
 
-            [message]
-                speaker=Grog
-                message= _ "Truth is that Grog not know much of sunlight lands. Sun and stars are scary, everything is open, exposed, no safe places to hide. But Grog cannot go back through all that water. And Grog doesn’t know where to find other tunnels back to his home. He is as lost as elves are."
-            [/message]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Och, it is I who should be congratulating you, laddie. I showed you the way, but it was you and your people who defeated the many perils and obstacles to your escape. In all my years such bravery and courage I have rarely seen."
+                [/message]
 
-            [message]
-                speaker=Grog
-                message= _ "But Grog not afraid. Great leader told Grog to guide and protect elves, and Grog will keep his oath. Grog will follow elves wherever they may go and protect them from danger as best he can. Maybe later, Grog will find another way back down to the caves of his people. But for now, Grog will continue to serve and protect you."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Nog, thank you so much for leading us out of the caves. We never would have found our way without your help. But with the tunnels flooded, how are you going to find your way back to your people?"
-            [/message]
+                [message]
+                    speaker=$ally_id
+                    message= _ "But truly I cannot return the way I came and even if there are other tunnels which lead back down to my homeland, I do not know where to search for them. I know as little about the land above ground as you do."
+                [/message]
 
-            [message]
-                speaker=Nog
-                message= _ "Nog proud of little elves too. He would not have made it this far without all your help. Nog is surprised by your bravery and strength."
-            [/message]
+                [message]
+                    speaker=$ally_id
+                    message= _ "But my king told me to protect you from all dangers, and I plan to keep that oath. I do not like the above ground, it is too open and exposed; I feel that I could be attacked from any direction. But an oath is an oath and so I will follow you and your people wherever you may go and protect you as best I can. The tunnels cannot stay flooded forever; later perhaps if am able to return this way, I may be able to find my way back to my homeland. But for now I am yours to command."
+                [/message]
+            [/then]
 
-            [message]
-                speaker=Nog
-                message= _ "Truth is that Nog not know much of sunlight lands. Sun and stars are scary, everything is open, exposed, no safe places to hide. But Nog cannot go back through all that water. And Nog doesn’t know where to find other tunnels back to his home. He is as lost as elves are."
-            [/message]
+            [else]
+                [message]
+                    speaker=Kaleh
+                    message= _ "$ally_unit.name, thank you so much for leading us out of the caves. We never would have found our way without your help. But with the tunnels flooded, how are you going to find your way back to your people?"
+                [/message]
 
-            [message]
-                speaker=Nog
-                message= _ "But Nog not afraid. Great leader told Nog to guide and protect elves, and Nog will keep his oath. Nog will follow elves wherever they may go and protect them from danger as best he can. Maybe later, Nog will find another way back down to the caves of his people. But for now, Nog will continue to serve and protect you."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Rogrimir, I want to thank you so much for guiding us out of the caves. We never would have found our way without your help. But with the tunnels flooded, how are you going to find your way back to your people?"
-            [/message]
+                [message]
+                    speaker=$ally_id
+                    message= _ "$ally_unit.name proud of little elves too. He would not have made it this far without all your help. $ally_unit.name is surprised by your bravery and strength."
+                [/message]
 
-            [message]
-                speaker=Rogrimir
-                message= _ "Och, it is I who should be congratulating you, laddie. I showed you the way, but it was you and your people who defeated the many perils and obstacles to your escape. In all my years such bravery and courage I have rarely seen."
-            [/message]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Truth is that $ally_unit.name not know much of sunlight lands. Sun and stars are scary, everything is open, exposed, no safe places to hide. But $ally_unit.name cannot go back through all that water. And $ally_unit.name doesn’t know where to find other tunnels back to his home. He is as lost as elves are."
+                [/message]
 
-            [message]
-                speaker=Rogrimir
-                message= _ "But truly I cannot return the way I came and even if there are other tunnels which lead back down to my homeland, I do not know where to search for them. I know as little about the land above ground as you do."
-            [/message]
-
-            [message]
-                speaker=Rogrimir
-                message= _ "But my king told me to protect you from all dangers, and I plan to keep that oath. I do not like the above ground, it is too open and exposed; I feel that I could be attacked from any direction. But an oath is an oath and so I will follow you and your people wherever you may go and protect you as best I can. The tunnels cannot stay flooded forever; later perhaps if am able to return this way, I may be able to find my way back to my homeland. But for now I am yours to command."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Jarl, I want to thank you so much for guiding us out of the caves. We never would have found our way without your help. But with the tunnels flooded, how are you going to find your way back to your people?"
-            [/message]
-
-            [message]
-                speaker=Jarl
-                message= _ "Och, it is I who should be congratulating you, laddie. I showed you the way, but it was you and your people who defeated the many perils and obstacles to your escape. In all my years such bravery and courage I have rarely seen."
-            [/message]
-
-            [message]
-                speaker=Jarl
-                message= _ "But truly I cannot return the way I came and even if there are other tunnels which lead back down to my homeland, I do not know where to search for them. I know as little about the land above ground as you do."
-            [/message]
-
-            [message]
-                speaker=Jarl
-                message= _ "But my king told me to protect you from all dangers, and I plan to keep that oath. I do not like the above ground, it is too open and exposed; I feel that I could be attacked from any direction. But an oath is an oath and so I will follow you and your people wherever you may go and protect you as best I can. The tunnels cannot stay flooded forever; later perhaps if am able to return this way, I may be able to find my way back to my homeland. But for now I am yours to command."
-            [/message]
-        )}
+                [message]
+                    speaker=$ally_id
+                    message= _ "But $ally_unit.name not afraid. Great leader told $ally_unit.name to guide and protect elves, and $ally_unit.name will keep his oath. $ally_unit.name will follow elves wherever they may go and protect them from danger as best he can. Maybe later, $ally_unit.name will find another way back down to the caves of his people. But for now, $ally_unit.name will continue to serve and protect you."
+                [/message]
+            [/else]
+        [/if]
 
         [message]
             speaker=Kaleh
@@ -3117,35 +3016,30 @@
         [if]
             [have_unit]
                 x,y=$x1,$y1
-                id=$ally_name
+                id=$ally_id
             [/have_unit]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "We made it. Outside look strange to Grog, Grog not used to big open spaces."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "We made it. Outside look strange to Nog, Nog not used to big open spaces."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "I think we finally made it outside. I’d forgotten how big the sky is and how windy it can be."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=unit
-                        message= _ "I think we finally made it outside. I’d forgotten how big the sky is and how windy it can be."
-                    [/message]
-                )}
+                [if]
+                    [variable]
+                        name=ally_race
+                        equals=dwarf
+                    [/variable]
+
+                    [then]
+                        [message]
+                            speaker=unit
+                            message= _ "I think we finally made it outside. I’d forgotten how big the sky is and how windy it can be."
+                        [/message]
+                    [/then]
+
+                    [else]
+                        [message]
+                            speaker=unit
+                            message= _ "We made it. Outside look strange to $ally_unit.name, $ally_unit.name not used to big open spaces."
+                        [/message]
+                    [/else]
+                [/if]
             [/then]
         [/if]
 
@@ -3303,38 +3197,17 @@
 
         #troll/dwarf ally teleports to just outside of cave
 
-        {MOVE_UNIT (id=$ally_name) 21 23}
+        {MOVE_UNIT (id=$ally_id) 21 23}
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Kaleh, a quick question—"
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Not now Grog, I’m busy."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Not now Nog, I’m busy."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Not now Rogrimir, I’m busy."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Kaleh
-                message= _ "Not now Jarl, I’m busy."
-            [/message]
-        )}
+        [message]
+            speaker=Kaleh
+            message= _ "Not now $ally_unit.name, I’m busy."
+        [/message]
 
         [message]
             speaker=Eloh
@@ -3409,7 +3282,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "Well, actually they were fleeing from—"
         [/message]
 
@@ -3571,31 +3444,26 @@
 
         {MOVE_UNIT (id=Kaleh) 18 19}
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Grog no like humans either. They mean. But they sound great when they go squish."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Nog no like humans either. They mean. But they sound great when they go squish."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "I never liked humans much anyway. I’ll be glad to be fighting something besides undead."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "I never liked humans much anyway. I’ll be glad to be fighting something besides undead."
-            [/message]
-        )}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "I never liked humans much anyway. I’ll be glad to be fighting something besides undead."
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "$ally_unit.name no like humans either. They mean. But they sound great when they go squish."
+                [/message]
+            [/else]
+        [/if]
 
         [modify_side]
             side=2
@@ -4410,7 +4278,7 @@
 
         [teleport]
             [filter]
-                id=$ally_name
+                id=$ally_id
             [/filter]
             x,y=60,6
         [/teleport]
@@ -4547,7 +4415,7 @@
         [/message]
 
         [message]
-            speaker=$ally_name
+            speaker=$ally_id
             message= _ "He looks like a half-man half-fish."
         [/message]
 
@@ -4646,6 +4514,8 @@
         {CLEAR_VARIABLE healing_rune1,healing_rune2}
 
         {CLEAR_VARIABLE messenger_timer,messengers_incoming}
+
+        {CLEAR_VARIABLE ally_unit}
     [/event]
 
     # set time for all underground areas to be always night/underground

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -289,7 +289,7 @@
 
         # recall dwarf/troll
         [recall]
-            id=$ally_name
+            id=$ally_id
         [/recall]
         # wmllint: recognize Grog
         # wmllint: recognize Nog
@@ -399,31 +399,27 @@
             message= _ "And yet these trees seem different, the forest seems darker, somehow. I prefer to stay out in the open where I can see my enemies coming."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Trees look big and strong, like trolls. Dark, too. Grog tired of walking under hot sun."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Trees look big and strong, like trolls. Dark, too. Nog tired of walking under hot sun."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "It looks nice and dark under the trees, less exposed to that blazing sun. I’m exhausted after walking across all that harsh sand."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "It looks nice and dark under the trees, less exposed to that blazing sun. I’m exhausted after walking across all that harsh sand."
-            [/message]
-        )}
+        {SET_ALLY_UNIT}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "It looks nice and dark under the trees, less exposed to that blazing sun. I’m exhausted after walking across all that harsh sand."
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Trees look big and strong, like trolls. Dark, too. $ally_unit.name tired of walking under hot sun."
+                [/message]
+            [/else]
+        [/if]
 
         [message]
             speaker=Esanoo
@@ -1842,31 +1838,27 @@
             message= _ "Forgive me, Kaleh. I do not know what to believe. I... I have to ponder this."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Great Leader told Grog to serve you, and so Grog will still follow your command. But other elves must be out on a separate island. How will we cross deep water?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Great Leader told Nog to serve you, and so Nog will still follow your command. But other elves must be out on a separate island. How will we cross deep water?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "The chieftain told me to serve you, and it will take more than this to shatter my confidence in you, lad. But those elves must be out on a different island, how will we cross the deep water?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "The chieftain told me to serve you, and it will take more than this to shatter my confidence in you, lad. But those elves must be out on a different island, how will we cross the deep water?"
-            [/message]
-        )}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "The chieftain told me to serve you, and it will take more than this to shatter my confidence in you, lad. But those elves must be out on a different island, how will we cross the deep water?"
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Great Leader told $ally_unit.name to serve you, and so $ally_unit.name will still follow your command. But other elves must be out on a separate island. How will we cross deep water?"
+                [/message]
+            [/else]
+        [/if]
+
         # merfolk offer to help
 
         [message]
@@ -2519,31 +2511,27 @@
             message= _ "Very well. You have not led us astray so far, I will not leave you now."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Grog scared of big water and bright sun, but Grog will not dishonor Great Leader. Great Leader say follow Kaleh, and Grog will do so."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Nog scared of big water and bright sun, but Nog will not dishonor Great Leader. Great Leader say follow Kaleh, and Nog will do so."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "Ouch, being stuck between the water and the sun is a terrible place to be, but where you go I will follow."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "Ouch, being stuck between the water and the sun is a terrible place to be, but where you go I will follow."
-            [/message]
-        )}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Ouch, being stuck between the water and the sun is a terrible place to be, but where you go I will follow."
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "$ally_unit.name scared of big water and bright sun, but $ally_unit.name will not dishonor Great Leader. Great Leader say follow Kaleh, and $ally_unit.name will do so."
+                [/message]
+            [/else]
+        [/if]
+        {CLEAR_VARIABLE ally_unit}
 
         [message]
             race=merman

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg
@@ -75,7 +75,7 @@
         [/recall]
 
         [recall]
-            id=$ally_name
+            id=$ally_id
             x,y=13,15
         [/recall]
 
@@ -167,55 +167,36 @@
 
         [if]
             [have_unit]
-                id=$ally_name
+                id=$ally_id
             [/have_unit]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=Melusand
-                        message= _ "No, you don’t have to introduce yourselves. I already know who you are and why you have been journeying all this way. And I must say, Grog, that your recent actions and indeed your presence with these fine folk speaks well for your people."
-                    [/message]
+                {SET_ALLY_UNIT}
+                [message]
+                    speaker=Melusand
+                    message= _ "No, you don’t have to introduce yourselves. I already know who you are and why you have been journeying all this way. And I must say, $ally_unit.name, that your recent actions and indeed your presence with these fine folk speaks well for your people."
+                [/message]
 
-                    [message]
-                        speaker=Grog
-                        message= _ "Grog says thank you."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Melusand
-                        message= _ "No, you don’t have to introduce yourselves. I already know who you are and why you have been journeying all this way. And I must say, Nog, that your recent actions and indeed your presence with these fine folk speaks well for your people."
-                    [/message]
+                [if]
+                    [variable]
+                        name=ally_race
+                        equals=dwarf
+                    [/variable]
 
-                    [message]
-                        speaker=Nog
-                        message= _ "Nog says thank you."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Melusand
-                        message= _ "No, you don’t have to introduce yourselves. I already know who you are and why you have been journeying all this way. And I must say, Rogrimir, that your recent actions and indeed your presence with these fine folk speaks well for your people."
-                    [/message]
+                    [then]
+                        [message]
+                            speaker=$ally_id
+                            message= _ "Thank you for your kindness."
+                        [/message]
+                    [/then]
 
-                    [message]
-                        speaker=Rogrimir
-                        message= _ "Thank you for your kindness."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Melusand
-                        message= _ "No, you don’t have to introduce yourselves. I already know who you are and why you have been journeying all this way. And I must say, Jarl, that your recent actions and indeed your presence with these fine folk speaks well for your people."
-                    [/message]
-
-                    [message]
-                        speaker=Jarl
-                        message= _ "Thank you for your kindness."
-                    [/message]
-                )}
+                    [else]
+                        [message]
+                            speaker=$ally_id
+                            message= _ "$ally_unit.name says thank you."
+                        [/message]
+                    [/else]
+                [/if]
             [/then]
 
             [else]
@@ -415,31 +396,27 @@
             message= _ "I’m not sure what to think. It’s all so much information."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Grog not sure if he trust fish lady. What if she just want you elves to fight her war for her?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Nog not sure if he trust fish lady. What if she just want you elves to fight her war for her?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "I’m still not sure I trust her. What if she’s just trying to get you all to fight her war for her?"
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "I’m still not sure I trust her. What if she’s just trying to get you all to fight her war for her?"
-            [/message]
-        )}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "I’m still not sure I trust her. What if she’s just trying to get you all to fight her war for her?"
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "$ally_unit.name not sure if he trust fish lady. What if she just want you elves to fight her war for her?"
+                [/message]
+            [/else]
+        [/if]
+
         [message]
             speaker=Kaleh
             message= _ "The point is, it’s not her fight, it’s our fight too. I for one believe her tale. With all the power that Melusand says Yechnagoth has, how do we know that Yechnagoth wasn’t the one who rained those rocks down upon our village all those weeks ago? What if this is all just part of a plot to turn our people into a group of mindless followers?"
@@ -495,14 +472,14 @@
 
             [then]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Yes, remember boy, the fight is not yet lost while we still draw breath."
                 [/message]
             [/then]
 
             [else]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Do not give up yet, little one. The battle is not yet lost while we still fight."
                 [/message]
             [/else]
@@ -523,31 +500,28 @@
             message= _ "As strange as it may sound, there are some things in this world that are more important than the fate of our people. Years from now the suns shall rise anew, a seed will grow into a flower, a child will be born. And I believe that if Yechnagoth is victorious then all that is good and beautiful will be corrupted and twisted and destroyed. This is a harsh world that we live in, but there is beauty and goodness in it, and no matter what may happen to us, I would gladly give my life to see that beauty and goodness survive."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Even in deepest tunnels my people could not escape Yechnagoth’s power forever if she is not stopped. Against such evil I am sure the Great Leader would give you whole army of trolls, but I am afraid you only have Grog. Still, Grog will do what he can to see her destroyed."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Even in deepest tunnels my people could not escape Yechnagoth’s power forever if she is not stopped. Against such evil I am sure the Great Leader would give you whole army of trolls, but I am afraid you only have Nog. Still, Nog will do what he can to see her destroyed."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "Even in the deepest tunnels underground we could not forever escape Yechnagoth’s power if she remains unchecked. Against such evil I am sure my king would give you a whole army of dwarves, but I am afraid you only have me. Still, I will do what I can to see her destroyed."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "Even in the deepest tunnels underground we could not forever escape Yechnagoth’s power if she remains unchecked. Against such evil I am sure my king would give you a whole army of dwarves, but I am afraid you only have me. Still, I will do what I can to see her destroyed."
-            [/message]
-        )}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Even in the deepest tunnels underground we could not forever escape Yechnagoth’s power if she remains unchecked. Against such evil I am sure my king would give you a whole army of dwarves, but I am afraid you only have me. Still, I will do what I can to see her destroyed."
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Even in deepest tunnels my people could not escape Yechnagoth’s power forever if she is not stopped. Against such evil I am sure the Great Leader would give you whole army of trolls, but I am afraid you only have $ally_unit.name. Still, $ally_unit.name will do what he can to see her destroyed."
+                [/message]
+            [/else]
+            {CLEAR_VARIABLE ally_unit}
+        [/if]
+
         [message]
             speaker=Kaleh
             message= _ "Then it is decided. Still in this matter we cannot speak for all our people. Those who go on this quest may never return, and this battle is certainly no place for the young or the elderly. Let all who are afraid or cannot fight stay behind with the merfolk. I will ask Melusand to arrange that if we fail, they be taken far away from here, that they might live out their lives in what peace they can find."

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
@@ -329,7 +329,7 @@
 
         # recall dwarf/troll
         [recall]
-            id=$ally_name
+            id=$ally_id
         [/recall]
 
         # wmllint: recognize Grog
@@ -1401,31 +1401,28 @@
             id=Zhul
         [/hide_unit]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Grog not going to just sit here while Kaleh does all the fighting. Kaleh will need strong fighter like Grog. Other elves may be scared, but Grog fear no dark place. Grog just hope there still something to smash when he gets there."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Nog not going to just sit here while Kaleh does all the fighting. Kaleh will need strong fighter like Nog. Other elves may be scared, but Nog fear no dark place. Nog just hope there still something to smash when he gets there."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "I’ve followed that boy this far, I’m not going to just let him march in there without me. Besides, whoever heard of a dwarf being afraid of going underground? I just hope they save some of the fighting for me."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "I’ve followed that boy this far, I’m not going to just let him march in there without me. Besides, whoever heard of a dwarf being afraid of going underground? I just hope they save some of the fighting for me."
-            [/message]
-        )}
+        {SET_ALLY_UNIT}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "I’ve followed that boy this far, I’m not going to just let him march in there without me. Besides, whoever heard of a dwarf being afraid of going underground? I just hope they save some of the fighting for me."
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "$ally_unit.name not going to just sit here while Kaleh does all the fighting. Kaleh will need strong fighter like $ally_unit.name. Other elves may be scared, but $ally_unit.name fear no dark place. $ally_unit.name just hope there still something to smash when he gets there."
+                [/message]
+            [/else]
+        [/if]
+        {CLEAR_VARIABLE ally_unit}
 
         {CLEAR_VARIABLE found_door}
         {CLEAR_VARIABLE keep_reached}

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
@@ -90,7 +90,7 @@
             [goal]
                 name=target
                 [criteria]
-                    id=$ally_name
+                    id=$ally_id
                 [/criteria]
                 value=3
             [/goal]
@@ -138,7 +138,7 @@
             [goal]
                 name=target
                 [criteria]
-                    id=$ally_name
+                    id=$ally_id
                 [/criteria]
                 value=3
             [/goal]
@@ -188,7 +188,7 @@
             [goal]
                 name=target
                 [criteria]
-                    id=$ally_name
+                    id=$ally_id
                 [/criteria]
                 value=3
             [/goal]
@@ -225,7 +225,7 @@
 
         # recall dwarf/troll
         [recall]
-            id=$ally_name
+            id=$ally_id
             x,y=9,17
         [/recall]
 
@@ -340,7 +340,7 @@
 
         # Ally runs to Kaleh's side
 
-        {MOVE_UNIT id=$ally_name 9 14}
+        {MOVE_UNIT id=$ally_id 9 14}
 
         [delay]
             time=300
@@ -354,14 +354,14 @@
 
             [then]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "Aye, there’s still life in the boy. But where is the foul creature that did this to him?"
                 [/message]
             [/then]
 
             [else]
                 [message]
-                    speaker=$ally_name
+                    speaker=$ally_id
                     message= _ "The little one is not dead yet. But where is evil lady that did this to him?"
                 [/message]
             [/else]
@@ -411,36 +411,15 @@
 
         [if]
             [have_unit]
-                id=$ally_name
+                id=$ally_id
             [/have_unit]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=Kaleh
-                        message= _ "Nym, Zhul, Grog, you shouldn’t have."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        message= _ "Nym, Zhul, Nog, you shouldn’t have."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        message= _ "Nym, Zhul, Rogrimir, you shouldn’t have."
-                    [/message]
-                )
-
-                (
-                    [message]
-                        speaker=Kaleh
-                        message= _ "Nym, Zhul, Jarl, you shouldn’t have."
-                    [/message]
-                )}
+                {SET_ALLY_UNIT}
+                [message]
+                    speaker=Kaleh
+                    message= _ "Nym, Zhul, $ally_unit.name, you shouldn’t have."
+                [/message]
             [/then]
 
             [else]
@@ -1522,35 +1501,31 @@
             message= _ "Behold, the pretender has been defeated. Eloh’s might has prevailed."
         [/message]
 
-        {MESSAGE_DEPEND_ON_ALLY
-        (
-            [message]
-                speaker=Grog
-                message= _ "Ugh. Grog is covered in blood and guts and nasty blue goo. Whatever creature was, she doesn’t smell any better dead than she did alive."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Nog
-                message= _ "Ugh. Nog is covered in blood and guts and nasty blue goo. Whatever creature was, she doesn’t smell any better dead than she did alive."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Rogrimir
-                message= _ "Ugh. I’m covered in blood and guts, and this nasty blue stuff. I don’t know what in the nine hells we were fighting, but she doesn’t smell any better dead than she did alive."
-            [/message]
-        )
-        (
-            [message]
-                speaker=Jarl
-                message= _ "Ugh. I’m covered in blood and guts, and this nasty blue stuff. I don’t know what in the nine hells we were fighting, but she doesn’t smell any better dead than she did alive."
-            [/message]
-        )}
+        [if]
+            [variable]
+                name=ally_race
+                equals=dwarf
+            [/variable]
+
+            [then]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Ugh. I’m covered in blood and guts, and this nasty blue stuff. I don’t know what in the nine hells we were fighting, but she doesn’t smell any better dead than she did alive."
+                [/message]
+            [/then]
+
+            [else]
+                [message]
+                    speaker=$ally_id
+                    message= _ "Ugh. $ally_unit.name is covered in blood and guts and nasty blue goo. Whatever creature was, she doesn’t smell any better dead than she did alive."
+                [/message]
+            [/else]
+        [/if]
+        {CLEAR_VARIABLE ally_unit}
 
         [if]
             [have_unit]
-                id=Nym,Zhul,$ally_name
+                id=Nym,Zhul,$ally_id
             [/have_unit]
 
             [then]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg
@@ -93,6 +93,7 @@
 
         # if only 1 friend dies, then have 3 different texts depending on who died
 
+        {SET_ALLY_UNIT}
         [if]
             [variable]
                 name=allies_killed
@@ -145,47 +146,14 @@
                     [/variable]
 
                     [then]
-                        {MESSAGE_DEPEND_ON_ALLY
-                        (
-                            [message]
-                                speaker=Kaleh
-                                message= _ "If you had told me at the start of our journey the price I was to pay in blood, I do not know if I would have had the strength to take that first step. I suppose I should have known that my friends would not let me confront Yechnagoth alone. But I would gladly give up my life today if I could bring Grog back. He left his homeland to fight faithfully by my side, and then to lose him at the end... I wish I could go back and do it all over again."
-                            [/message]
-                            [message]
-                                speaker=Kaleh
-                                message= _ "Although I believe that our battle in the black citadel was our finest hour, I am still haunted by the death of Grog in that dark place. And so every morning at sunrise I come out to the southeastern tip of the island and look out upon the waters, upon the world that we sacrificed so much to preserve. I remind myself what Zhul said, and they all believed, that despite all the death and fighting we saw in our journey, this world was a beautiful and good enough place that Grog was willing to sacrifice his life to save it. Looking out over the waters, and back upon the prosperity of my people, I tell myself it was worth it. But when I think of the desperate war that his people are probably still fighting underground, it seems a small consolation."
-                            [/message]
-                        )
-                        (
-                            [message]
-                                speaker=Kaleh
-                                message= _ "If you had told me at the start of our journey the price I was to pay in blood, I do not know if I would have had the strength to take that first step. I suppose I should have known that my friends would not let me confront Yechnagoth alone. But I would gladly give up my life today if I could bring Nog back. He left his homeland to fight faithfully by my side, and then to lose him at the end... I wish I could go back and do it all over again."
-                            [/message]
-                            [message]
-                                speaker=Kaleh
-                                message= _ "Although I believe that our battle in the black citadel was our finest hour, I am still haunted by the death of Nog in that dark place. And so every morning at sunrise I come out to the southeastern tip of the island and look out upon the waters, upon the world that we sacrificed so much to preserve. I remind myself what Zhul said, and they all believed, that despite all the death and fighting we saw in our journey, this world was a beautiful and good enough place that Nog was willing to sacrifice his life to save it. Looking out over the waters, and back upon the prosperity of my people, I tell myself it was worth it. But when I think of the desperate war that his people are probably still fighting underground, it seems a small consolation."
-                            [/message]
-                        )
-                        (
-                            [message]
-                                speaker=Kaleh
-                                message= _ "If you had told me at the start of our journey the price I was to pay in blood, I do not know if I would have had the strength to take that first step. I suppose I should have known that my friends would not let me confront Yechnagoth alone. But I would gladly give up my life today if I could bring Rogrimir back. He left his homeland to fight faithfully by my side, and then to lose him at the end... I wish I could go back and do it all over again."
-                            [/message]
-                            [message]
-                                speaker=Kaleh
-                                message= _ "Although I believe that our battle in the black citadel was our finest hour, I am still haunted by the death of Rogrimir in that dark place. And so every morning at sunrise I come out to the southeastern tip of the island and look out upon the waters, upon the world that we sacrificed so much to preserve. I remind myself what Zhul said, and they all believed, that despite all the death and fighting we saw in our journey, this world was a beautiful and good enough place that Rogrimir was willing to sacrifice his life to save it. Looking out over the waters, and back upon the prosperity of my people, I tell myself it was worth it. But when I think of the desperate war that his people are probably still fighting underground, it seems a small consolation."
-                            [/message]
-                        )
-                        (
-                            [message]
-                                speaker=Kaleh
-                                message= _ "If you had told me at the start of our journey the price I was to pay in blood, I do not know if I would have had the strength to take that first step. I suppose I should have known that my friends would not let me confront Yechnagoth alone. But I would gladly give up my life today if I could bring Jarl back. He left his homeland to fight faithfully by my side, and then to lose him at the end... I wish I could go back and do it all over again."
-                            [/message]
-                            [message]
-                                speaker=Kaleh
-                                message= _ "Although I believe that our battle in the black citadel was our finest hour, I am still haunted by the death of Jarl in that dark place. And so every morning at sunrise I come out to the southeastern tip of the island and look out upon the waters, upon the world that we sacrificed so much to preserve. I remind myself what Zhul said, and they all believed, that despite all the death and fighting we saw in our journey, this world was a beautiful and good enough place that Jarl was willing to sacrifice his life to save it. Looking out over the waters, and back upon the prosperity of my people, I tell myself it was worth it. But when I think of the desperate war that his people are probably still fighting underground, it seems a small consolation."
-                            [/message]
-                        )}
+                        [message]
+                            speaker=Kaleh
+                            message= _ "If you had told me at the start of our journey the price I was to pay in blood, I do not know if I would have had the strength to take that first step. I suppose I should have known that my friends would not let me confront Yechnagoth alone. But I would gladly give up my life today if I could bring $ally_unit.name back. He left his homeland to fight faithfully by my side, and then to lose him at the end... I wish I could go back and do it all over again."
+                        [/message]
+                        [message]
+                            speaker=Kaleh
+                            message= _ "Although I believe that our battle in the black citadel was our finest hour, I am still haunted by the death of $ally_unit.name in that dark place. And so every morning at sunrise I come out to the southeastern tip of the island and look out upon the waters, upon the world that we sacrificed so much to preserve. I remind myself what Zhul said, and they all believed, that despite all the death and fighting we saw in our journey, this world was a beautiful and good enough place that $ally_unit.name was willing to sacrifice his life to save it. Looking out over the waters, and back upon the prosperity of my people, I tell myself it was worth it. But when I think of the desperate war that his people are probably still fighting underground, it seems a small consolation."
+                        [/message]
                     [/then]
                 [/if]
             [/then]
@@ -250,35 +218,28 @@
             [/variable]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/trolls/troll-hero-alt.png
-                        message= _ "I am saddened by the death of Grog, but by saving my life in the end he did fulfill his life debt to me. I think he also would have been glad to have died in battle. I considered leading an expedition to go back and return his body to his people, but my fellow elves have been weakened by our long journey and I do not want to risk losing any more. Instead I searched all across the islands and at last in the rocky outcroppings to the northwest I found a series of caves. They were not as deep as his homeland but I thought Grog would have appreciated being laid to rest under some solid rock. And so we buried him with much honor and will long remember the service that his kind has done for our people."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/trolls/troll-hero-alt.png
-                        message= _ "I am saddened by the death of Nog, but by saving my life in the end he did fulfill his life debt to me. I think he also would have been glad to have died in battle. I considered leading an expedition to go back and return his body to his people, but my fellow elves have been weakened by our long journey and I do not want to risk losing any more. Instead I searched all across the islands and at last in the rocky outcroppings to the northwest I found a series of caves. They were not as deep as his homeland but I thought Nog would have appreciated being laid to rest under some solid rock. And so we buried him with much honor and will long remember the service that his kind has done for our people."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/dwarves/fighter-2.png
-                        message= _ "I am saddened by the death of Rogrimir, but by saving my life in the end he did fulfill his life debt to me. I think he also would have been glad to have died in battle. I considered leading an expedition to go back and return his body to his people, but my fellow elves have been weakened by our long journey and I do not want to risk losing any more. Instead I searched all across the islands and at last in the rocky outcroppings to the northwest I found a series of caves. They were not as deep as his homeland but I thought Rogrimir would have appreciated being laid to rest under some solid rock. And so we buried him with much honor and will long remember the service that his kind has done for our people."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/dwarves/fighter-2.png
-                        message= _ "I am saddened by the death of Jarl, but by saving my life in the end he did fulfill his life debt to me. I think he also would have been glad to have died in battle. I considered leading an expedition to go back and return his body to his people, but my fellow elves have been weakened by our long journey and I do not want to risk losing any more. Instead I searched all across the islands and at last in the rocky outcroppings to the northwest I found a series of caves. They were not as deep as his homeland but I thought Jarl would have appreciated being laid to rest under some solid rock. And so we buried him with much honor and will long remember the service that his kind has done for our people."
-                    [/message]
-                )}
+                [if]
+                    [variable]
+                        name=ally_race
+                        equals=dwarf
+                    [/variable]
+
+                    [then]
+                        [message]
+                            speaker=Kaleh
+                            image=portraits/dwarves/fighter-2.png
+                            message= _ "I am saddened by the death of $ally_unit.name, but by saving my life in the end he did fulfill his life debt to me. I think he also would have been glad to have died in battle. I considered leading an expedition to go back and return his body to his people, but my fellow elves have been weakened by our long journey and I do not want to risk losing any more. Instead I searched all across the islands and at last in the rocky outcroppings to the northwest I found a series of caves. They were not as deep as his homeland but I thought $ally_unit.name would have appreciated being laid to rest under some solid rock. And so we buried him with much honor and will long remember the service that his kind has done for our people."
+                        [/message]
+                    [/then]
+
+                    [else]
+                        [message]
+                            speaker=Kaleh
+                            image=portraits/trolls/troll-hero-alt.png
+                            message= _ "I am saddened by the death of $ally_unit.name, but by saving my life in the end he did fulfill his life debt to me. I think he also would have been glad to have died in battle. I considered leading an expedition to go back and return his body to his people, but my fellow elves have been weakened by our long journey and I do not want to risk losing any more. Instead I searched all across the islands and at last in the rocky outcroppings to the northwest I found a series of caves. They were not as deep as his homeland but I thought $ally_unit.name would have appreciated being laid to rest under some solid rock. And so we buried him with much honor and will long remember the service that his kind has done for our people."
+                        [/message]
+                    [/else]
+                [/if]
             [/then]
         [/if]
 
@@ -317,47 +278,40 @@
         # if ally doesn't die
         [if]
             [have_unit]
-                id=$ally_name
+                id=$ally_id
                 search_recall_list=yes
             [/have_unit]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/trolls/troll-hero-alt.png
-                        message= _ "By saving my life, Grog fulfilled his life debt to me, but we convinced him to hang around for a while and revel in the celebrations that we held after our great victory. We celebrated for days and days, thanking Eloh and the merfolk’s god, and delighting in the bounty and beauty of our new home. And afterwards we set to work building new dwellings for our people. Grog stayed to help us with the construction, he was the hardest worker among us. But after a while he came to me and told me that he had to return to his own people. Grog said his time with us had been like a wonderful dream, and he promised he would remember us always, but his people needed him and he had to go back home. He said that someday he would return and visit us again, but I doubt I shall ever see him again in life. All the same I treasure the memory of him and his kind, and I will long remember his steadfast loyalty and all that he did to aid us in our struggle."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/trolls/troll-hero-alt.png
-                        message= _ "By saving my life, Nog fulfilled his life debt to me, but we convinced him to hang around for a while and revel in the celebrations that we held after our great victory. We celebrated for days and days, thanking Eloh and the merfolk’s god, and delighting in the bounty and beauty of our new home. And afterwards we set to work building new dwellings for our people. Nog stayed to help us with the construction, he was the hardest worker among us. But after a while he came to me and told me that he had to return to his own people. Nog said his time with us had been like a wonderful dream, and he promised he would remember us always, but his people needed him and he had to go back home. He said that someday he would return and visit us again, but I doubt I shall ever see him again in life. All the same I treasure the memory of him and his kind, and I will long remember his steadfast loyalty and all that he did to aid us in our struggle."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/dwarves/fighter-2.png
-                        message= _ "By saving my life, Rogrimir fulfilled his life debt to me, but we convinced him to hang around for a while and revel in the celebrations that we held after our great victory. We celebrated for days and days, thanking Eloh and the merfolk’s god, and delighting in the bounty and beauty of our new home. Afterwards we set to work building new dwellings for our people. Rogrimir stayed to help us with the construction, he was the hardest worker among us. But after a while he came to me and told me that he had to return to his own people. Rogrimir said his time with us had been like a wonderful dream, and he promised he would remember us always, but his people needed him and he had to go back home. He said that someday he would return and visit us again, but I doubt I shall ever see him again in life. All the same I treasure the memory of him and his kind, and I will long remember his steadfast loyalty and all that he did to aid us in our struggle."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/dwarves/fighter-2.png
-                        message= _ "By saving my life, Jarl fulfilled his life debt to me, but we convinced him to hang around for a while and revel in the celebrations that we held after our great victory. We celebrated for days and days, thanking Eloh and the merfolk’s god, and delighting in the bounty and beauty of our new home. Afterwards we set to work building new dwellings for our people. Jarl stayed to help us with the construction, he was the hardest worker among us. But after a while he came to me and told me that he had to return to his own people. Jarl said his time with us had been like a wonderful dream, and he promised he would remember us always, but his people needed him and he had to go back home. He said that someday he would return and visit us again, but I doubt I shall ever see him again in life. All the same I treasure the memory of him and his kind, and I will long remember his steadfast loyalty and all that he did to aid us in our struggle."
-                    [/message]
-                )}
+                [if]
+                    [variable]
+                        name=ally_race
+                        equals=dwarf
+                    [/variable]
+
+                    [then]
+                        [message]
+                            speaker=Kaleh
+                            image=portraits/dwarves/fighter-2.png
+                            message= _ "By saving my life, $ally_unit.name fulfilled his life debt to me, but we convinced him to hang around for a while and revel in the celebrations that we held after our great victory. We celebrated for days and days, thanking Eloh and the merfolk’s god, and delighting in the bounty and beauty of our new home. Afterwards we set to work building new dwellings for our people. $ally_unit.name stayed to help us with the construction, he was the hardest worker among us. But after a while he came to me and told me that he had to return to his own people. $ally_unit.name said his time with us had been like a wonderful dream, and he promised he would remember us always, but his people needed him and he had to go back home. He said that someday he would return and visit us again, but I doubt I shall ever see him again in life. All the same I treasure the memory of him and his kind, and I will long remember his steadfast loyalty and all that he did to aid us in our struggle."
+                        [/message]
+                    [/then]
+
+                    [else]
+                        [message]
+                            speaker=Kaleh
+                            image=portraits/trolls/troll-hero-alt.png
+                            message= _ "By saving my life, $ally_unit.name fulfilled his life debt to me, but we convinced him to hang around for a while and revel in the celebrations that we held after our great victory. We celebrated for days and days, thanking Eloh and the merfolk’s god, and delighting in the bounty and beauty of our new home. And afterwards we set to work building new dwellings for our people. $ally_unit.name stayed to help us with the construction, he was the hardest worker among us. But after a while he came to me and told me that he had to return to his own people. $ally_unit.name said his time with us had been like a wonderful dream, and he promised he would remember us always, but his people needed him and he had to go back home. He said that someday he would return and visit us again, but I doubt I shall ever see him again in life. All the same I treasure the memory of him and his kind, and I will long remember his steadfast loyalty and all that he did to aid us in our struggle."
+                        [/message]
+                    [/else]
+                [/if]
             [/then]
         [/if]
 
         # if ally died before the final battle
         [if]
             [have_unit]
-                id=$ally_name
+                id=$ally_id
                 search_recall_list=yes
                 count=0
             [/have_unit]
@@ -368,37 +322,31 @@
             [/variable]
 
             [then]
-                {MESSAGE_DEPEND_ON_ALLY
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/trolls/troll-hero-alt.png
-                        message= _ "And I will always remember Grog who died along our journey. A braver warrior I have never seen, and though he was taken from us too soon, I am glad for the short time that I knew him."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/trolls/troll-hero-alt.png
-                        message= _ "And I will always remember Nog who died along our journey. A braver warrior I have never seen, and though he was taken from us too soon, I am glad for the short time that I knew him."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/dwarves/fighter-2.png
-                        message= _ "And I will always remember Rogrimir who died along our journey. A braver warrior I have never seen, and though he was taken from us too soon, I am glad for the short time that I knew him."
-                    [/message]
-                )
-                (
-                    [message]
-                        speaker=Kaleh
-                        image=portraits/dwarves/fighter-2.png
-                        message= _ "And I will always remember Jarl who died along our journey. A braver warrior I have never seen, and though he was taken from us too soon, I am glad for the short time that I knew him."
-                    [/message]
-                )}
+                [if]
+                    [variable]
+                        name=ally_race
+                        equals=dwarf
+                    [/variable]
+
+                    [then]
+                        [message]
+                            speaker=Kaleh
+                            image=portraits/dwarves/fighter-2.png
+                            message= _ "And I will always remember $ally_unit.name who died along our journey. A braver warrior I have never seen, and though he was taken from us too soon, I am glad for the short time that I knew him."
+                        [/message]
+                    [/then]
+
+                    [else]
+                        [message]
+                            speaker=Kaleh
+                            image=portraits/trolls/troll-hero-alt.png
+                            message= _ "And I will always remember $ally_unit.name who died along our journey. A braver warrior I have never seen, and though he was taken from us too soon, I am glad for the short time that I knew him."
+                        [/message]
+                    [/else]
+                [/if]
             [/then]
         [/if]
+        {CLEAR_VARIABLE ally_unit}
 
         [message]
             speaker=Kaleh

--- a/data/campaigns/Under_the_Burning_Suns/utils/dialog-macros.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/dialog-macros.cfg
@@ -35,6 +35,7 @@
         [/else]
     [/if]
 #enddef
+
 # for second_unit
 #define CHECK_SPEAKER
     [if]
@@ -70,27 +71,13 @@
     [/if]
 #enddef
 
-#define MESSAGE_DEPEND_ON_ALLY GROG_WML NOG_WML ROGRIMIR_WML JARL_WML
-    [switch]
-        variable=ally_name
-        [case]
-            value=Grog
-            {GROG_WML}
-        [/case]
-
-        [case]
-            value=Nog
-            {NOG_WML}
-        [/case]
-
-        [case]
-            value=Rogrimir
-            {ROGRIMIR_WML}
-        [/case]
-
-        [case]
-            value=Jarl
-            {JARL_WML}
-        [/case]
-    [/switch]
+# Avoid duplication of dialogue by using an ally unit to extract translated ally name
+#define SET_ALLY_UNIT
+    [store_unit]
+        variable=ally_unit
+        kill=no
+        [filter]
+            id=$ally_id
+        [/filter]
+    [/store_unit]
 #enddef


### PR DESCRIPTION
With four potential allies in the campaign, there is a lot of dialogue duplication. This refactoring attempts to consolidate the text. Additionally, the ally ID was recorded in the variable `ally_name` which can be confusing (it was to me, at least), so I renamed it to `ally_id` instead.

Unless I made a mistake somewhere, the dialogue itself should not be changed, this is just to avoid redundant duplication. Please keep in mind I'm still very much a novice with WML so be gentle in pointing out any errors. Thanks.

PS I tested a little bit but haven't done a thorough checking of S7b (where `ally_id` is introduced) onwards, for all four allies.