### PR TITLE
TRoW S19 Chest is automatically collected at the end of the scenario

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -318,12 +318,14 @@
 
     [event]
         name=get chest
+
         [sound]
             name=open-chest.wav
         [/sound]
         [store_unit]
             [filter]
                 x,y=$xx1,$yy1
+                side=1
             [/filter]
             variable=chest_unit_temp
         [/store_unit]
@@ -331,6 +333,7 @@
             speaker=$chest_unit_temp.id
             message= _ "I’ve found the orcs’ chest! It’s filled with gold."
         [/message]
+
         {CLEAR_VARIABLE chest_unit_temp}
 
         [remove_item]
@@ -701,17 +704,16 @@
                 equals=no
             [/variable]
             [then]
-                [move_unit]
-                    id=Prince Haldric
-                    to_x=$xx1
-                    to_y=$yy1
-                [/move_unit]
+                [message]
+                    speaker=Prince Haldric
+                    message= _ "Grab the troll’s gold and get moving!"
+                [/message]
                 [fire_event]
                     name=get chest
                 [/fire_event]
             [/then]
         [/if]
-
+        
         {CLEAR_VARIABLE xx1,yy1,chest_obtained}
     [/event]
 [/scenario]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -697,7 +697,7 @@
 
     [event]
         name=victory
-        
+
         [if]
             [variable]
                 name=chest_obtained
@@ -713,7 +713,7 @@
                 [/fire_event]
             [/then]
         [/if]
-        
+
         {CLEAR_VARIABLE xx1,yy1,chest_obtained}
     [/event]
 [/scenario]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -162,6 +162,7 @@
 
         {VARIABLE xx1 $possible_chest_locs[$random].x}
         {VARIABLE yy1 $possible_chest_locs[$random].y}
+        {VARIABLE chest_obtained no}
 
         {CLEAR_VARIABLE possible_chest_locs,random}
 
@@ -310,15 +311,27 @@
             x=$xx1
             y=$yy1
         [/filter]
+        [fire_event]
+            name=get chest
+        [/fire_event]
+    [/event]
 
+    [event]
+        name=get chest
         [sound]
             name=open-chest.wav
         [/sound]
-
+        [store_unit]
+            [filter]
+                x,y=$xx1,$yy1
+            [/filter]
+            variable=chest_unit_temp
+        [/store_unit]
         [message]
-            speaker=unit
+            speaker=$chest_unit_temp.id
             message= _ "I’ve found the orcs’ chest! It’s filled with gold."
         [/message]
+        {CLEAR_VARIABLE chest_unit_temp}
 
         [remove_item]
             x,y=$x1,$y1
@@ -327,6 +340,10 @@
         {PLACE_IMAGE (items/chest-plain-open.png) $xx1 $yy1}
 
         {LOOT {ON_DIFFICULTY 125 100 75} 1}
+        [set_variable]
+            name=chest_obtained
+            value=yes
+        [/set_variable]
     [/event]
 
     # When an enemy side has less than half of its units left, some undead
@@ -639,7 +656,6 @@
         [/message]
 
         {CLEAR_VARIABLE side_2_undead_backup_triggered,side_3_undead_backup_triggered,side_4_undead_backup_triggered,undead_spawns_so_far}
-        {CLEAR_VARIABLE xx1,yy1}
 
         [endlevel]
             result=victory
@@ -674,5 +690,28 @@
             speaker=Burin the Lost
             message= _ "Ahh, it’s great to be home! I’m not much for the politics, but it’s great to be home!"
         [/message]
+    [/event]
+
+    [event]
+        name=victory
+        
+        [if]
+            [variable]
+                name=chest_obtained
+                equals=no
+            [/variable]
+            [then]
+                [move_unit]
+                    id=Prince Haldric
+                    to_x=$xx1
+                    to_y=$yy1
+                [/move_unit]
+                [fire_event]
+                    name=get chest
+                [/fire_event]
+            [/then]
+        [/if]
+
+        {CLEAR_VARIABLE xx1,yy1,chest_obtained}
     [/event]
 [/scenario]


### PR DESCRIPTION
The S19's gold chest close to the troll enemy leader will now be collected at the end of the scenario if the player misses it (which is unlikely but could happen). A new dialogue may be necessary in line 704.

The expected behaviour of the changes is:

- If the player moves a unit during the scenario to the chest, it opens and cannot be opened again and at the end of the scenario nothing will happen.
- If the player misses the chest, Haldric (Or the closest ally unit, if that is ever wanted to be implemented) moves to the chest and opens it, and the scenario ends.

(Closes #6141)