### PR TITLE
UtBS S06b Fix Dwarf Sergeant confusing a dust devil or human for a troll

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -694,7 +694,7 @@
                 value=human
                 [message]
                     x,y=10,34
-                    message= _ "No, It’s a... human?"
+                    message= _ "No, it’s a... human?"
                 [/message]
                 [modify_unit]
                     [filter]
@@ -712,7 +712,7 @@
                 [message]
                     x,y=10,34
                     #po: "it" is referring to the dust devil
-                    message= _ "No, It’s a... what is that?"
+                    message= _ "No, it’s a... what is that?"
                 [/message]
                 [modify_unit]
                     [filter]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -654,18 +654,10 @@
             message= _ "Oh let me guess, a big nasty troll, right? And when I turn around you flee like the cowards you are. Do you think I’m stupid enough to fall for that one?"
         [/message]
 
-        [if]
-            [variable]
-                name=unit.race
-                equals=quenoth
-            [/variable]
-            [or]
-                [variable]
-                    name=unit.race
-                    equals=elf
-                [/variable]
-            [/or]
-            [then]
+        [switch]
+            variable=unit.race
+            [case]
+                value=quenoth
                 [message]
                     x,y=9,36
                     message= _ "No, it’s an elf!"
@@ -680,8 +672,9 @@
                     id=Dwarf Sergeant
                     message= _ "What...?! Right... First task, boys, kill the intruder!"
                 [/message]
-            [/then]
-            [else]
+            [/case]
+            [case]
+                value=troll
                 [message]
                     x,y=9,36
                     message= _ "I’m too young to die, save me!"
@@ -696,8 +689,58 @@
                     speaker=Dwarf Sergeant
                     message= _ "Oh, grow a backbone... Huh? Hey, for once the runt was telling the truth. Come on, boys, kill the intruder!"
                 [/message]
+            [/case]
+            [case]
+                value=human
+                [message]
+                    x,y=10,34
+                    message= _ "No, It's a... human?"
+                [/message]
+                [modify_unit]
+                    [filter]
+                        id=Dwarf Sergeant
+                    [/filter]
+                    facing=se
+                [/modify_unit]
+                [message]
+                    speaker=Dwarf Sergeant
+                    message= _ "What is a human doing here? Come on, boys, kill the intruder!"
+                [/message]
+            [/case]
+            [case]
+                value=monster
+                [message]
+                    x,y=10,34
+                    message= _ "No, It's a... what is that?"
+                [/message]
+                [modify_unit]
+                    [filter]
+                        id=Dwarf Sergeant
+                    [/filter]
+                    facing=se
+                [/modify_unit]
+                [message]
+                    speaker=Dwarf Sergeant
+                    message= _ "What in the Earth's Guts is that? Kill it!"
+                [/message]
+            [/case]
+            [else]
+                [message]
+                    x,y=9,36
+                    message= _ "No, look behind you!"
+                [/message]
+                [modify_unit]
+                    [filter]
+                        id=Dwarf Sergeant
+                    [/filter]
+                    facing=se
+                [/modify_unit]
+                [message]
+                    id=Dwarf Sergeant
+                    message= _ "What...?! Right... First task, boys, kill the intruder!"
+                [/message]
             [/else]
-        [/if]
+        [/switch]
     [/event]
 
     # funny death message from one of the conscripts

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -657,7 +657,7 @@
         [switch]
             variable=unit.race
             [case]
-                value=quenoth
+                value=quenoth, elf
                 [message]
                     x,y=9,36
                     message= _ "No, it’s an elf!"
@@ -694,7 +694,7 @@
                 value=human
                 [message]
                     x,y=10,34
-                    message= _ "No, It's a... human?"
+                    message= _ "No, It’s a... human?"
                 [/message]
                 [modify_unit]
                     [filter]
@@ -711,6 +711,7 @@
                 value=monster
                 [message]
                     x,y=10,34
+                    #po: "it" is referring to the dust devil
                     message= _ "No, It's a... what is that?"
                 [/message]
                 [modify_unit]
@@ -721,7 +722,8 @@
                 [/modify_unit]
                 [message]
                     speaker=Dwarf Sergeant
-                    message= _ "What in the Earth's Guts is that? Kill it!"
+                    #po: "it" is referring to the dust devil
+                    message= _ "What in the Earth’s Guts is that? Kill it!"
                 [/message]
             [/case]
             [else]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -712,7 +712,7 @@
                 [message]
                     x,y=10,34
                     #po: "it" is referring to the dust devil
-                    message= _ "No, It's a... what is that?"
+                    message= _ "No, It’s a... what is that?"
                 [/message]
                 [modify_unit]
                     [filter]


### PR DESCRIPTION
Fix for one of the tasks in Issue #6196. Used a [switch] instead of [if]-[elses] for clarity. **⚠New strings have been added ⚠** and have to be revisioned, make sure string freeze is lifted before merging/backporting.

Dust devil (monster) string: 

![Dust devil 1](https://user-images.githubusercontent.com/30196839/137592103-c9693961-547f-4dd7-ae7b-b053cb7945a5.png)
![Dust devil 2](https://user-images.githubusercontent.com/30196839/137592105-376b7454-24b1-4791-bd2e-46f778544a6c.png)

Elyssa (human) string:

![Human 1](https://user-images.githubusercontent.com/30196839/137592131-ee2d356e-2c0c-4753-98e9-3b71a5be5138.png)
![Human 2](https://user-images.githubusercontent.com/30196839/137592133-01c56a20-0522-4123-862f-5d0119652a7f.png)

In case other race is added to previous scenarios in the future:

![Other 1](https://user-images.githubusercontent.com/30196839/137592186-fc20e1ac-d4d7-4cf4-baad-125be2a5f80d.png)
![Other 2](https://user-images.githubusercontent.com/30196839/137592191-f676ed9b-efd3-4b0a-b95a-00e8ffa74cab.png)

Troll and Quenoth elf strings are unchanged.

