### PR TITLE
UtBS S06b hermit enhancement and tentacle fix.

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1246,19 +1246,7 @@
 
 #define CREATE_TENTACLE
     {RANDOM 1..$locs.length}
-#ifdef DEBUG_MODE
-    [message]
-        speaker=narrator
-        message= _ "Random number selected: $random"
-    [/message]
-#endif
     {VARIABLE_OP random sub 1}
-#ifdef DEBUG_MODE
-    [message]
-        speaker=narrator
-        message= _ "Random number selected after operation: $random"
-    [/message]
-#endif
     [unit]
         type=Tentacle of the Deep
         side=5
@@ -1272,12 +1260,6 @@
         [/modifications]
         role=large_tentacles
     [/unit]
-#ifdef DEBUG_MODE
-    [message]
-        speaker=narrator
-        message= _ "Spawning tentacle at $locs[$random].x $locs[$random].y"
-    [/message]
-#endif
 #enddef
 
     # create a bunch of tentacles every time a side 1 unit is in area
@@ -1298,21 +1280,6 @@
                 less_than=3
             [/variable]
         [/filter_condition]
-#ifdef DEBUG_MODE
-        [message]
-            speaker=narrator
-            message= _ "Possible spawning locations:"
-        [/message]
-        [for]
-            end=$locs.length
-            [do]
-                [message]
-                    speaker=narrator
-                    message= _ "$locs[$i].x $locs[$i].y"
-                [/message]
-            [/do]
-        [/for]
-#endif
 
         {CREATE_TENTACLE}
         {CREATE_TENTACLE}
@@ -1380,7 +1347,6 @@
 
                     #once all the tentacles have been killed, locs is no longer needed
                     {CLEAR_VARIABLE locs}
-
 
                     [modify_side]
                         side=4
@@ -1546,7 +1512,7 @@
 
     # DWARF EASTER EGG EVENTS
 
-    # Event(s) 19: Hermit Intro and Death events (sighted intro version disabled)
+    # Event 19: Hermit Intro and Death events (sighted intro version disabled)
 
     # Hermit lives alone on island in the lake, guarding his amulet
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -287,6 +287,8 @@
             value=0
         [/set_variable]
 
+        {VARIABLE hermit_trigger no}
+
         # Pre-set units
 
         # Event 2.1
@@ -1503,13 +1505,13 @@
 
     # DWARF EASTER EGG EVENTS
 
-    # Event 19: Hermit Intro and Death events (sighted intro version disabled)
+    # Event(s) 19: Hermit Intro and Death events (sighted intro version disabled)
 
     # Hermit lives alone on island in the lake, guarding his amulet
 
-    [event]
-        #name=sighted
+    # The two following events are mutually exclusive
 
+    [event]
         name=moveto
 
         [filter]
@@ -1517,10 +1519,41 @@
             side=1
         [/filter]
 
-        [message]
-            speaker=Dwarf Hermit
-            message= _ "They’ve come for my precious. It’s mine, yes it is. They shan’t have it, no they shan’t. We shall kill them all, yes, yes we will."
-        [/message]
+        [if]
+            [variable]
+                name=hermit_trigger
+                equals=no
+            [/variable]
+            [then]
+                [message]
+                    speaker=Dwarf Hermit
+                    message= _ "They’ve come for my precious. It’s mine, yes it is. They shan’t have it, no they shan’t. We shall kill them all, yes, yes we will."
+                [/message]
+                {CLEAR_VARIABLE hermit_trigger}
+            [/then]
+        [/if]
+    [/event]
+
+    [event]
+        name=attack
+
+        [filter]
+            id=Dwarf Hermit
+        [/filter]
+
+        [if]
+            [variable]
+                name=hermit_trigger
+                equals=no
+            [/variable]
+            [then]
+                [message]
+                    speaker=Dwarf Hermit
+                    message= _ "They’ve come for my precious. It’s mine, yes it is. They shan’t have it, no they shan’t. We shall kill them all, yes, yes we will."
+                [/message]
+                {CLEAR_VARIABLE hermit_trigger}
+            [/then]
+        [/if]
     [/event]
 
     [event]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -198,9 +198,9 @@ This ability will not cure an affected unit of poison, however, only delay its e
         cumulative=no
         name= _ "leadership"
         female_name= _ "female^leadership"
-        description= _ "This unit can lead your own units that are next to it, making them fight better.
+        description= _ "This unit can lead other troops in battle.
 
-Adjacent own units of lower level will do more damage in battle. When a unit adjacent to, of a lower level than, and on the same side as a unit with Leadership engages in combat, its attacks do 25% more damage times the difference in their levels."
+All adjacent lower-level units from the same side deal 25% more damage for each difference in level."
         special_note={INTERNAL:SPECIAL_NOTES_LEADERSHIP}
         affect_self=no
         [affect_adjacent]


### PR DESCRIPTION
Two fixes have been bundled in this PR:

1. Tentacle spawning rework.

Previously, the tentacle spawning event would search for a suitable location to spawn the tentacles (and it would search for just the one location) so if it failed to find a Ww* or Wo* (shallow or deep water) tile then the location array (locs) would be empty and lowering the random variable by one (which is defined between 1 and the length of locs) would cause it to be below zero (-1) as seen in my comment in #6196 (Erased Lines 1268-1276). TL;DR [store_locations] would not store all matching locations.

The expected behaviour now is:

At the start of the scenario, in the prestart event, all the intended possible locations for spawn are stored in locs (Lines 293-306).
When tentacles have to be spawned, a random number is selected the same way as it was before (Lines 1248-1249).
The location variable is cleared when every tentacle is killed (Lines 1348-1349).

Note: I removed the #ifdef DEBUG_MODE lines I added for debug purposes in commit 2cc4457 in case someone wants to have a look at them.

Image used as demonstration:
![Nodebug](https://user-images.githubusercontent.com/30196839/137625576-923f70a4-4879-4361-ad3d-6cd49957ddd4.png)

2. Fix for hermit dialogue not triggering when he is lured into the water.

Previously the only way for the Dwarf Hermit's dialogue to trigger was to step on his island, but it makes way more sense for him to say it if you step on his island or if he engages in combat with side 1.

The expected behaviour now is:

A hermit_trigger variable is initialized at line 291.
If the player sets foot on the island before being attacked by the hermit the first event (Lines 1529-1542) and the variable is cleared, locking the other event (Lines 1544-1563) and vice versa.

Image used as demonstration:

![Hermit dialogue fix](https://user-images.githubusercontent.com/30196839/137625553-481d199e-c8df-4bd8-a092-0ab9c0815a68.png)

