### PR TITLE
Remove support for writing BMP screenshots

### DIFF
--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -189,7 +189,7 @@ EXIT_STATUS editor_controller::main_loop()
 void editor_controller::status_table() {
 }
 
-void editor_controller::do_screenshot(const std::string& screenshot_filename /* = "map_screenshot.bmp" */)
+void editor_controller::do_screenshot(const std::string& screenshot_filename /* = "map_screenshot.png" */)
 {
 	try {
 		surface screenshot = gui().screenshot(true);

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -88,7 +88,7 @@ class editor_controller : public controller_base,
 		EXIT_STATUS main_loop();
 
 		/** Takes a screenshot **/
-		void do_screenshot(const std::string& screenshot_filename = "map_screenshot.bmp");
+		void do_screenshot(const std::string& screenshot_filename = "map_screenshot.png");
 
 		/** Process a hotkey quit command */
 		void hotkey_quit();

--- a/src/editor/editor_main.cpp
+++ b/src/editor/editor_main.cpp
@@ -28,7 +28,7 @@ lg::log_domain log_editor("editor");
 namespace editor {
 
 EXIT_STATUS start(const std::string& filename /* = "" */,
-	bool take_screenshot /* = false */, const std::string& screenshot_filename /* = "map_screenshot.bmp" */)
+	bool take_screenshot /* = false */, const std::string& screenshot_filename /* = "map_screenshot.png" */)
 {
 	EXIT_STATUS e = EXIT_ERROR;
 	try {

--- a/src/editor/editor_main.hpp
+++ b/src/editor/editor_main.hpp
@@ -34,6 +34,6 @@ enum EXIT_STATUS {
  *          go back to the titlescreen or quit to desktop altogether)
  */
 
-EXIT_STATUS start(const std::string& filename = "", bool take_screenshot = false, const std::string& screenshot_filename = "map_screenshot.bmp");
+EXIT_STATUS start(const std::string& filename = "", bool take_screenshot = false, const std::string& screenshot_filename = "map_screenshot.png");
 
 } //end namespace editor

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -656,7 +656,7 @@ bool game_launcher::play_render_image_mode()
 	}
 
 	// A default output filename
-	std::string outfile = "wesnoth_image.bmp";
+	std::string outfile = "wesnoth_image.png";
 
 	// If a output path was given as an argument, use that instead
 	if(cmdline_opts_.render_image_dst) {

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -1103,12 +1103,6 @@ save_result save_image(const surface& surf, const std::string& filename)
 		return err == 0 ? save_result::success : save_result::save_failed;
 	}
 
-	if(filesystem::ends_with(filename, ".bmp")) {
-		LOG_DP << "Writing a BMP image to " << filename << std::endl;
-		const int err = SDL_SaveBMP(surf, filename.c_str()) == 0;
-		return err == 0 ? save_result::success : save_result::save_failed;
-	}
-
 	return save_result::unsupported_format;
 }
 


### PR DESCRIPTION
This is redundant now that PNG support is part of SDL_image and therefore always available to us on supported configurations. BMP files are horribly expensive to store and offer no advantages for this use case, to the point people are way more familiarized with the existence of PNGs than BMPs these days.