### PR TITLE
Add Objective Note for Thursagan's Rune Mechanic

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -661,6 +661,8 @@
                 condition=lose
             [/objective]
 
+            {RUNE_MECHANIC_NOTE}
+
             {TURNS_RUN_OUT}
 
             [gold_carryover]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -200,6 +200,8 @@
                 condition=lose
             [/objective]
 
+            {RUNE_MECHANIC_NOTE}
+
             {TURNS_RUN_OUT}
 
             [gold_carryover]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -238,6 +238,8 @@
                 [/show_if]
             [/objective]
 
+            {RUNE_MECHANIC_NOTE}
+
             {TURNS_RUN_OUT}
 
             [gold_carryover]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/8_The_Dragon.cfg
@@ -195,6 +195,8 @@
                 [/show_if]
             [/objective]
 
+            {RUNE_MECHANIC_NOTE}
+
             [gold_carryover]
                 carryover_percentage=0
             [/gold_carryover]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -1008,6 +1008,8 @@
                 condition=lose
             [/objective]
 
+            {RUNE_MECHANIC_NOTE}
+
             {IS_LAST_SCENARIO}
         [/objectives]
     [/event]

--- a/data/campaigns/Sceptre_of_Fire/utils/utils.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/utils.cfg
@@ -102,3 +102,9 @@ profile="portraits/elves/captain.png~CHAN(
 )"
 #enddef
 # wmlindent: stop ignoring
+
+#define RUNE_MECHANIC_NOTE
+    [note]
+        description= _ "Thursagan's Rune Mastery: while Thursagan is on a keep, selecting an adjacent dwarf opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
+    [/note]
+#enddef


### PR DESCRIPTION
Resolves #6153 
Adds an objective note to scenarios where Thursagan can upgrade units. This implementation is consistent with the design style set forth by Son of the Black Eye for its "Great Horde" mechanic, which displays an objective note for half of the scenarios in that campaign.

### Screenshot
SoF Thursagan's Rune Mastery:
![image](https://user-images.githubusercontent.com/41433185/137685133-7a40d7b1-65bf-42c2-b444-2ff0bfac280b.png)

### SotBE Comparison
SotBE Great Horde:
![image](https://user-images.githubusercontent.com/41433185/137684546-f91e2fdc-adcb-41b1-bcd8-7a1b49213b86.png)



