### PR TITLE
SoF Add Rune Chest Objective Notes

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -252,7 +252,7 @@
                 condition=lose
             [/objective]
             [note]
-                description= _ "Moving a dwarf to rune chest beside the keep opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
+                description= _ "Moving a dwarf to a rune chest beside the keep opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
             [/note]
 
             {TURNS_RUN_OUT}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -251,6 +251,9 @@
                 description= _ "Loss of a caravan"
                 condition=lose
             [/objective]
+            [note]
+                description= _ "Moving a dwarf to rune chest beside the keep opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
+            [/note]
 
             {TURNS_RUN_OUT}
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -149,6 +149,9 @@
                 description= _ "Death of Baglur"
                 condition=lose
             [/objective]
+            [note]
+                description= _ "Moving a dwarf to rune chest north of the keep opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
+            [/note]
 
             {TURNS_RUN_OUT}
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -150,7 +150,7 @@
                 condition=lose
             [/objective]
             [note]
-                description= _ "Moving a dwarf to rune chest north of the keep opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
+                description= _ "Moving a dwarf to a rune chest north of the keep opens a dialog for obtaining temporary upgrades which last until the end of the scenario."
             [/note]
 
             {TURNS_RUN_OUT}


### PR DESCRIPTION
Resolves #6160 
Objective Notes are added to inform the player about the available rune chests that can be used to purchase rune upgrades.