### PR TITLE
[1.16] Error handling for corrupt .mo files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
    * Don't display the locale API identifier on the Language button (issue #6205).
  ### WML Engine
  ### Miscellaneous and Bug Fixes
+   * Fix the engine exiting immediately due to a corrupt .mo file (issue #6194)
 
 ## Version 1.15.18
  ### Campaigns


### PR DESCRIPTION
Fixes #6194

Previously, a corrupt .mo file caused the game to exit immediately. This meant
that a broken add-on could stop the user from reaching the main menu, a
situation that could only be recovered by editing the preferences file or by
deleting the add-on with a file browser.

The engine generates the locale 3 times:
* once with no .mo files loaded
* once with only the mainline .mo files loaded
* once with all .mo files loaded

This means that:
* starting Wesnoth with a corrupt .mo file in mainline will make the engine run
  showing en_US text
* changing language with a corrupt .mo file in mainline will make the engine
  stay in whatever language it had successfully loaded
* a corrupt .mo file in an add-on will disable .mo files in all add-ons, but
  leave mainline translations active, and will let the user play the game