### PR TITLE
[1.16] For a [message] with options, zero-initialise the default selection int

### DIFF
--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -77,7 +77,7 @@ int show_message_dialog(lua_State* L)
 	input.maximum_length = txt_cfg["max_length"].to_int(256);
 	input.text_input_was_specified = has_input;
 
-	gui2::dialogs::wml_message_options options;
+	auto options = gui2::dialogs::wml_message_options {};
 	if(!lua_isnoneornil(L, 2)) {
 		luaL_checktype(L, 2, LUA_TTABLE);
 		std::size_t n = lua_rawlen(L, 2);


### PR DESCRIPTION
@virtualghetto, please would you test this?

I can't reproduce the issue (it selects the first option by default for me even without this), but this probably fixes #6038 "When you have a long list of [message][option], it will default to highlighting the 3rd entry for some reason."

Adding @Vultraz as a reviewer, please would you say whether this is the best coding style for doing this?