### PR TITLE
SotA S02: Add l10n hints about temple label and bats

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -268,8 +268,8 @@ I decided to hide in the cemetery. That way I could try my experiment to animate
         [/item]
         [label]
             x,y=15,7
-            # This label bled into the two hexes on either side, and obscured
-            # the units there. It's better on two lines. The extra spaces before
+            # po: In English, this label bled into the two hexes on either side, and obscured
+            # the units there, which is why it's split across two lines. The extra spaces before
             # "Temple" are to center that word above the others.
             text= _ "  Temple
 of Healing"
@@ -393,12 +393,14 @@ of Healing"
             [then]
                 [message]
                     speaker=Ardonna
+                    # po: She's speaking to a bat from scenario 1
                     message= _ "Oh, hello friend! I didn’t know you were hiding in there."
                 [/message]
             [/then]
             [else]
                 [message]
                     speaker=Ardonna
+                    # po: She's speaking to a bat that she hasn't met before
                     message= _ "Oh, hello! You’re a handsome one."
                 [/message]
             [/else]


### PR DESCRIPTION
The lines about bats were converted to typographic quotes in 3fcba6aa, so this
could be cherry-picked to the 1.16 branch along with that (but shouldn't be
cherry-picked without it).