### PR TITLE
Make wmltools Forest avoid version control subdirectories

### DIFF
--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -14,6 +14,7 @@ map_extensions   = ("map", "mask")
 image_extensions = ("png", "jpg", "jpeg")
 sound_extensions = ("ogg", "wav")
 vc_directories = (".git", ".svn")
+misc_files_extensions = ("-bak", ".DS_Store", "Thumbs.db")
 l10n_directories = ("l10n",)
 resource_extensions = map_extensions + image_extensions + sound_extensions
 image_reference = r"[A-Za-z0-9{}.][A-Za-z0-9_/+{}.\-\[\]~\*,]*\.(png|jpe?g)(?=(~.*)?)"
@@ -225,15 +226,15 @@ class Forest:
             subtree = sorted(maincfgs) + sorted(rest)
             self.forest.append(subtree)
         for i in range(len(self.forest)):
-            # Ignore version-control subdirectories, Emacs tempfiles, and Apple Store files
+            # Ignore version-control subdirectories, Emacs tempfiles, and other files and extensions
             for dirkind in vc_directories + l10n_directories:
                 self.forest[i] = [x for x in self.forest[i] if dirkind not in x]
             self.forest[i] = [x for x in self.forest[i] if '.#' not in x]
             self.forest[i] = [x for x in self.forest[i] if not os.path.isdir(x)]
             if exclude:
                 self.forest[i] = [x for x in self.forest[i] if not re.search(exclude, x)]
-            self.forest[i] = [x for x in self.forest[i] if not x.endswith("-bak")]
-            self.forest[i] = [x for x in self.forest[i] if not x.endswith(".DS_Store")]
+            for each in misc_files_extensions:
+                self.forest[i] = [x for x in self.forest[i] if not x.endswith(each)]
         # Compute cliques (will be used later for visibility checks)
         self.clique = {}
         counter = 0

--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -224,15 +224,15 @@ class Forest:
             rest = [elem for elem in subtree if not elem.endswith("_main.cfg")]
             subtree = sorted(maincfgs) + sorted(rest)
             self.forest.append(subtree)
-        for i in self.forest:
+        for i in range(len(self.forest)):
             # Ignore version-control subdirectories and Emacs tempfiles
             for dirkind in vc_directories + l10n_directories:
-                i = [x for x in i if dirkind not in x]
-            i = [x for x in i if '.#' not in x]
-            i = [x for x in i if not os.path.isdir(x)]
+                self.forest[i] = [x for x in self.forest[i] if dirkind not in x]
+            self.forest[i] = [x for x in self.forest[i] if '.#' not in x]
+            self.forest[i] = [x for x in self.forest[i] if not os.path.isdir(x)]
             if exclude:
-                i = [x for x in i if not re.search(exclude, x)]
-            i = [x for x in i if not x.endswith("-bak")]
+                self.forest[i] = [x for x in self.forest[i] if not re.search(exclude, x)]
+            self.forest[i] = [x for x in self.forest[i] if not x.endswith("-bak")]
         # Compute cliques (will be used later for visibility checks)
         self.clique = {}
         counter = 0

--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -225,7 +225,7 @@ class Forest:
             subtree = sorted(maincfgs) + sorted(rest)
             self.forest.append(subtree)
         for i in range(len(self.forest)):
-            # Ignore version-control subdirectories and Emacs tempfiles
+            # Ignore version-control subdirectories, Emacs tempfiles, and Apple Store files
             for dirkind in vc_directories + l10n_directories:
                 self.forest[i] = [x for x in self.forest[i] if dirkind not in x]
             self.forest[i] = [x for x in self.forest[i] if '.#' not in x]
@@ -233,6 +233,7 @@ class Forest:
             if exclude:
                 self.forest[i] = [x for x in self.forest[i] if not re.search(exclude, x)]
             self.forest[i] = [x for x in self.forest[i] if not x.endswith("-bak")]
+            self.forest[i] = [x for x in self.forest[i] if not x.endswith(".DS_Store")]
         # Compute cliques (will be used later for visibility checks)
         self.clique = {}
         counter = 0

--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -14,7 +14,7 @@ map_extensions   = ("map", "mask")
 image_extensions = ("png", "jpg", "jpeg")
 sound_extensions = ("ogg", "wav")
 vc_directories = (".git", ".svn")
-misc_files_extensions = ("-bak", ".DS_Store", "Thumbs.db")
+misc_files_extensions = ("-bak", ".DS_Store", "Thumbs.db") # These files and extensions should be included in the `default_blacklist` in filesystem.hpp.
 l10n_directories = ("l10n",)
 resource_extensions = map_extensions + image_extensions + sound_extensions
 image_reference = r"[A-Za-z0-9{}.][A-Za-z0-9_/+{}.\-\[\]~\*,]*\.(png|jpe?g)(?=(~.*)?)"


### PR DESCRIPTION
Resolves #5949.

Seems more like a bug fix than a feature enhancement. The original code had a for loop that tried to modify the contents of `Forest.forest` but never actually updated it.

Tested by using wmlscope on a check out of A New Order:
Here's the output of `wmlscope --collision` before the fix:
[beforefix.txt](https://github.com/wesnoth/wesnoth/files/7428240/beforefix.txt)
And here's the output after. No more looking inside of .git:
[afterfix.txt](https://github.com/wesnoth/wesnoth/files/7428244/afterfix.txt)

So far this only makes wmlscope and anything else that uses the Forest class object inside wmltools actually avoid version control subdirectories. In #5949 there is also mention of other "pesky" subdirectories such as 
`.DS_Store`

Do we want to specifically also include `.DS_Store`, and do we want to also include all hidden folders?
Those things can be a separate commit since it expands existing functionality, while this can be its own commit since it fixes a bug/existing intended behavior.