### PR TITLE
KeyboardInterrupt Handlers for wmltools

### DIFF
--- a/data/tools/wmlindent
+++ b/data/tools/wmlindent
@@ -61,7 +61,7 @@ if there's an indent open at end of file or if a closer occurs with
 indent already zero; these two conditions strongly suggest unbalanced WML.
 """
 
-import sys, os, argparse, filecmp, re, codecs
+import sys, os, argparse, filecmp, re, codecs, signal
 from wesnoth import wmltools3 as wmltools
 
 closer_prefixes = ["{NEXT "]
@@ -299,7 +299,16 @@ def convertor(linefilter, arglist, exclude):
                 print("wmlindent: no WML file found, exiting", file=sys.stderr)
                 sys.exit(1)
 
+def sigint_handler(signal, frame):
+    """This function defines what happens when the SIGINT signal is encountered by pressing ctrl-c during runtime. 
+    When ctrl-c is pressed, a one-line message is displayed and Python exits with Status 0, which refers to successful termination.
+    This overrides Python's default behavior of displaying a traceback when ctrl-c is pressed.
+    """
+    print ('Aborted by pressing ctrl-c')
+    sys.exit(0)
+
 if __name__ == '__main__':
+    signal.signal(signal.SIGINT, sigint_handler)
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter
         )

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -3504,6 +3504,6 @@ In your case, your system interprets your arguments as:
         if failed_any_dirs:
             sys.exit(1)
     except KeyboardInterrupt:
-        print("Aborted")
+        print("Aborted by pressing ctrl-c")
 
 # wmllint ends here

--- a/data/tools/wmlscope
+++ b/data/tools/wmlscope
@@ -552,6 +552,6 @@ directories are given, all files under the current directory are checked.""")
                 xref.unresdump()
                 xref.duplicates(exportonly=True)
     except KeyboardInterrupt:
-        print("wmlscope: aborted.", file=sys.stderr)
+        print("Aborted by pressing ctrl-c", file=sys.stderr)
 
 # wmlscope ends here

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -34,6 +34,7 @@
 import os
 import re
 import sys
+import signal
 import warnings
 import argparse
 from datetime import datetime
@@ -162,6 +163,7 @@ def commandline(args):
 
 
 def main():
+    signal.signal(signal.SIGINT, sigint_handler)
     args = commandline(sys.argv[1:])
     pywmlx.ansi_setEnabled(args.text_col)
     pywmlx.wincol_setEnabled(args.text_col)
@@ -261,6 +263,16 @@ def main():
         outfile.close()
     if args.debugmode:
         fdebug.close()
+
+
+
+def sigint_handler(signal, frame):
+    """This function defines what happens when the SIGINT signal is encountered by pressing ctrl-c during runtime. 
+    When ctrl-c is pressed, a one-line message is displayed and Python exits with Status 0, which refers to successful termination.
+    This overrides Python's default behavior of displaying a traceback when ctrl-c is pressed.
+    """
+    print ('Aborted by pressing ctrl-c')
+    sys.exit(0)
 
 
 


### PR DESCRIPTION
Closes https://github.com/wesnoth/wesnoth/issues/3352.

wmllint and wmlscope already had KeyboardInterrupt Handlers. I just edited their displayed messages for consistency. wmlindent and wmlxgettext did not have interrupt handlers and it had to be defined in their scripts.

wmllint and wmlscope use try-except clauses to define the interrupt routine.
I used a listener, `signal.signal`, to handle the interrupt routine so that I wouldn't have to wrap all the existing code in a try-except clause and change all the indentation.

Approver, please try running all four scripts and then pressing ctrl-c to abort so that you can verify the new behavior.