### PR TITLE
Fixes for broken gui.get_user_choice() function

### DIFF
--- a/data/lua/core/gui.lua
+++ b/data/lua/core/gui.lua
@@ -35,10 +35,20 @@ function gui.get_user_choice(attr, options)
 		msg[k] = attr[k]
 	end
 	for k,v in ipairs(options) do
-		table.insert(msg, wml.tag.option { message = v,
-			wml.tag.command { wml.tag.lua {
-				code = string.format("gui.__user_choice_helper(%d)", k)
-			}}})
+		if type(v) == "table" or type(v) == "userdata" then
+			table.insert(msg, wml.tag.option { image = v.image,
+				label = v.label,
+				description = v.description,
+				default = v.default,
+				wml.tag.command { wml.tag.lua {
+					code = string.format("gui.__user_choice_helper(%d)", k)
+				}}})
+		elseif type(v) == "string" then
+			table.insert(msg, wml.tag.option { message = v,
+				wml.tag.command { wml.tag.lua {
+					code = string.format("gui.__user_choice_helper(%d)", k)
+				}}})
+		end
 	end
 	wesnoth.wml_actions.message(msg)
 	gui.__user_choice_helper = nil

--- a/data/lua/core/gui.lua
+++ b/data/lua/core/gui.lua
@@ -35,8 +35,8 @@ function gui.get_user_choice(attr, options)
 		msg[k] = attr[k]
 	end
 	for k,v in ipairs(options) do
-		table.insert(msg, wml.tag.option, { message = v,
-			wml.tag.command, { wml.tag.lua, {
+		table.insert(msg, wml.tag.option { message = v,
+			wml.tag.command { wml.tag.lua {
 				code = string.format("gui.__user_choice_helper(%d)", k)
 			}}})
 	end

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -2562,13 +2562,13 @@ Also, 0..9 = $below_ten, one,two,three = $ascii and the bonus answer is $mixed."
                 wesnoth.interface.add_chat_message(string.format("Unit moved from %d,%d to %d,%d", ec.x2, ec.y2, ec.x1, ec.y1))
                 local result = gui.get_user_choice(
                     { speaker = "unit", message = "Pick your poison" },
-                    { "&items/potion-red.png=Something red=Take a sip and enjoy",
-                      "*&items/potion-blue.png=Nice blue=Surely you’ll like that one",
-                      "&items/potion-yellow.png=<span color='yellow'>Oh noes yellow</span>=Oh I’m sure you’ll love that one",
-                      "&scenery/well.png=A nice well=Grab a bucket and fetch some water",
-                      "&items/holy-water.png=Oh nice bottle=Feel the divinity",
-                      -- Should have an empty first column and a second column on two lines.
-                      "=Well a nice and black drink.\nToo dark too see?=Take a sip and pass the bottle along" })
+                      { {image="items/potion-red.png", label="Something red", description="Take a sip and enjoy"},
+                        {image="items/potion-blue.png", label="Nice blue", description="Surely you’ll like that one", default=true},
+                        {image="items/potion-yellow.png", label="<span color='yellow'>Oh noes yellow</span>", description="Oh I’m sure you’ll love that one"},
+                        {image="scenery/well.png", label="A nice well", description="Grab a bucket and fetch some water"},
+                        {image="items/holy-water.png", label="Oh nice bottle", description="Feel the divinity"},
+                        -- Should have an empty first column and a second column on two lines.
+                        {label="Well a nice and black drink.\nToo dark too see?", description="Take a sip and pass the bottle along"} })
                 wesnoth.interface.add_chat_message(string.format("User selected choice %d.", result))
             >>
         [/lua]


### PR DESCRIPTION
While updating the Wesnoth Lua Pack for the 1.16 series, I noticed that the `gui.get_user_choice()` function is unusable: all it does is throwing the following error.

    error scripting/lua: lua/core/gui.lua:38: bad argument #2 to 'insert' (number expected, got function)

This is caused by three commas that shouldn't be there, so the first commit of this PR removes them.
After having fixed this, I checked the function with the test scenario: while it was supposed to show an image column and two text columns, it still used the old syntax (the one with `&` and `=`, to be clear), instead of the current `image`, `label`, `description` and `default` keys used by `[option]` tags. Since support for the old syntax has been removed, the text shown to the user was just like this:

    *&items/potion-blue.png=Nice blue=Surely you’ll like that one

The second and third commit of this PR add support for the currently used keys (which can be in a table or vconfig object) and update the test scenario, respectively.