### PR TITLE
[1.16] Fix tooltips on the sidebar

### DIFF
--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -132,7 +132,7 @@ void clear_tooltips(const SDL_Rect& rect)
 			if (i==current_tooltip) {
 				clear_tooltip();
 			}
-			tips.erase(i++);
+			i = tips.erase(i);
 			current_tooltip = tips.end();
 		} else {
 			++i;
@@ -175,13 +175,7 @@ void remove_tooltip(int id)
 
 int add_tooltip(const SDL_Rect& rect, const std::string& message, const std::string& action, bool use_markup, const surface& foreground)
 {
-	for(std::map<int, tooltip>::iterator it = tips.begin(); it != tips.end();) {
-		if(sdl::rects_overlap(it->second.rect,rect)) {
-			tips.erase(it++);
-		} else {
-			++it;
-		}
-	}
+	clear_tooltips(rect);
 
 	int id = tooltip_id++;
 


### PR DESCRIPTION
Fix iterator-use-after-invalidation in tooltips
---

It's undefined behavior to access an iterator after calling std::map::erase(),
the correct method is to use the new iterator that erase() returns instead.

Fix pango_text::set_maximum_height
---

Change back to handling the height in our code instead of expecting Pango to
handle it. Pango is still expected to handle the maximum width, as Pango needs
to handle the word-wrapping.

While writing f282eb7, I had noticed that set_maximum_height called
PangoLayout's pango_layout_set_height, and removed the apparently unnecessary
enforcement of the maximum height from our wrapper code. The documentation
added in this commit explains why that was incorrect.

Fixes #6007 and #6096, both issues that some tooltips on the sidebar stopped
working. The text on that sidebar is densely packed, and while this commit
makes no visual change, it removes a few blank pixels of padding below the
text. That extra padding was sufficient for the next line's area to overlap,
making tooltips::add_tooltip remove the previously-added tooltip.