### PR TITLE
Added ability to add setter callbacks on preferences

### DIFF
--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -53,6 +53,7 @@ bool no_preferences_save = false;
 bool fps = false;
 
 config prefs;
+std::map<std::string, std::function<void(const config::attribute_value&)>> callbacks {};
 }
 
 namespace preferences {
@@ -158,29 +159,19 @@ void write_preferences()
 #endif
 }
 
-void set(const std::string &key, bool value)
+void _set_impl(const std::string& key, config::attribute_value& value)
 {
-	prefs[key] = value;
+	auto& ref = prefs[key];
+	ref = value;
+
+	if(const auto iter = callbacks.find(key); iter != callbacks.end()) {
+		std::invoke(iter->second, ref);
+	}
 }
 
-void set(const std::string &key, int value)
+void add_setter_callback(const std::string& key, std::function<void(const config::attribute_value&)> func)
 {
-	prefs[key] = value;
-}
-
-void set(const std::string &key, char const *value)
-{
-	prefs[key] = value;
-}
-
-void set(const std::string &key, const std::string &value)
-{
-	prefs[key] = value;
-}
-
-void set(const std::string &key, const config::attribute_value &value)
-{
-	prefs[key] = value;
+	callbacks[key] = func;
 }
 
 void clear(const std::string& key)

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -46,11 +46,18 @@ namespace preferences {
 
 	void write_preferences();
 
-	void set(const std::string& key, const std::string &value);
-	void set(const std::string& key, char const *value);
-	void set(const std::string& key, bool value);
-	void set(const std::string& key, int value);
-	void set(const std::string& key, const config::attribute_value& value);
+	void _set_impl(const std::string& key, config::attribute_value& value);
+
+	template<typename T>
+	void set(const std::string& key, T value)
+	{
+		config::attribute_value nv{};
+		nv = value;
+		_set_impl(key, nv);
+	}
+
+	void add_setter_callback(const std::string& key, std::function<void(const config::attribute_value&)> func);
+
 	void clear(const std::string& key);
 	void set_child(const std::string& key, const config& val);
 	const config &get_child(const std::string &key);

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -56,7 +56,25 @@ namespace preferences {
 		_set_impl(key, nv);
 	}
 
-	void add_setter_callback(const std::string& key, std::function<void(const config::attribute_value&)> func);
+	using setter_callback = std::function<void(const config::attribute_value&)>;
+
+	/** Registers a callback to be called when the given preference is @ref set. This will replace any existing callback. */
+	void set_callback(const std::string& key, setter_callback func);
+
+	/**
+	 * RAII helper to temporarily register a setter callback.
+	 * On being destroyed, the previous callback for the given key is restored.
+	 */
+	class temp_callback
+	{
+	public:
+		temp_callback(const std::string& key, setter_callback cb);
+		~temp_callback();
+
+	private:
+		setter_callback& old_f;
+		setter_callback new_f;
+	};
 
 	void clear(const std::string& key);
 	void set_child(const std::string& key, const config& val);


### PR DESCRIPTION
A simple callback interface for pref setters required by @irydacea. This could honestly be used to replace functions like `set_music`, allowing one to simply call `set` and having the callback handle the side effects.