### PR TITLE
[1.16] Revert MP string changes, as string freeze is still in effect

### DIFF
--- a/data/gui/window/mp_faction_select.cfg
+++ b/data/gui/window/mp_faction_select.cfg
@@ -203,7 +203,7 @@
 
 							[label]
 								definition = "gold"
-								label = _ "Recruits"
+								label = _ "Recruits:"
 								linked_group = "details_label"
 							[/label]
 
@@ -294,7 +294,7 @@
 
 								[label]
 									definition = "title"
-									label = _ "Choose Your Leader"
+									label = _ "Choose Your Faction"
 								[/label]
 
 							[/column]


### PR DESCRIPTION
This reverts 100045c0, "Revert "Revert this for 1.16.1"", which in the end
reverts the string changes from b765c0be66c0f43e2eeedb0c1015a1f0ee81a7dd.