### PR TITLE
Show the id in the "[race] '' is missing a plural_name" warning

### DIFF
--- a/src/units/race.cpp
+++ b/src/units/race.cpp
@@ -80,13 +80,9 @@ unit_race::unit_race(const config& cfg) :
 		help_taxonomy_(cfg["help_taxonomy"])
 
 {
-	if (id_.empty()) {
-		lg::log_to_chat() << "[race] '" << cfg["name"] << "' is missing an id field.\n";
-		ERR_WML << "[race] '" << cfg["name"] << "' is missing an id field.";
-	}
 	if (plural_name_.empty()) {
-		lg::log_to_chat() << "[race] '" << cfg["name"] << "' is missing a plural_name field.\n";
-		ERR_WML << "[race] '" << cfg["name"] << "' is missing a plural_name field.";
+		lg::log_to_chat() << "[race] id='" << id_ << "' is missing a plural_name field.\n";
+		ERR_WML << "[race] id='" << id_ << "' is missing a plural_name field.\n";
 		plural_name_ = (cfg["name"]);
 	}
 
@@ -98,6 +94,13 @@ unit_race::unit_race(const config& cfg) :
 	name_[FEMALE] = cfg["female_name"];
 	if(name_[FEMALE].empty()) {
 		name_[FEMALE] = (cfg["name"]);
+	}
+	if(std::any_of(name_.begin(), name_.end(), [](const auto& n) { return n.empty(); })) {
+		lg::log_to_chat()
+			<< "[race] id='" << id_
+			<< "' is missing a singular name field (either 'name' or both 'male_name' and 'female_name').\n";
+		ERR_WML << "[race] id'" << id_
+				<< "' is missing a singular name field (either 'name' or both 'male_name' and 'female_name').\n";
 	}
 
 	name_generator_factory generator_factory = name_generator_factory(cfg, {"male", "female"});


### PR DESCRIPTION
In 1.16 with Ageless Era 4.28.0, the message `[race] '' is missing a
plural_name` is printed to the chat area. The message is not useful even to
add-on developers, because it only identifies which race is affected by
`[race]name`, and in the affected races the `name` attribute is also missing.

An unfortunate side-effect of making the warnings more useful is that more of
them are shown in-game - these messages go through the logging mechanism that
discards duplicate messages. Making them useful also makes them unique,
they are no longer duplicates.

Also log if a race lacks either a male or female singular name. This warning
will not trigger if the race has a non-empty `name`, as both gender-specific
options are documented to fall back to `name`.

Remove the warning about races that have a `name` but no `id`. Prior to 1.3.8,
[race]name= was the identifier, and there wasn't a [race]id= attribute. The
compatibility code for that change was removed in 1.7.6 (commit 160000a40), so
it seems unnecessary to keep the logging for missing ids.

I'm unsure about backporting this to 1.16, as it increases the number of messages
printed to the chat area. Keeping it as a tool on the master branch only seems reasonable.
The newly-traceable issues have been logged as ProditorMagnus/Ageless-for-1-14#28 and
ProditorMagnus/Ageless-for-1-14#29. At the time of writing it's possible to use the master
branch's binary with 1.16's data and Ageless; but Ageless 4.28.0 isn't compatible with master's
data (due to the removal of the SPECIAL_NOTES macro).