### PR TITLE
campaignd: Drop removed pbl attributes on upload if applicable

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -525,6 +525,12 @@ public:
 		}
 	}
 
+	/**
+	 * Copies attributes that exist in the source config.
+	 *
+	 * @param from Source config to copy attributes from.
+	 * @param keys Attribute names.
+	 */
 	template<typename... T>
 	void copy_attributes(const config& from, T... keys)
 	{
@@ -532,6 +538,27 @@ public:
 			auto* attr = from.get(key);
 			if(attr) {
 				(*this)[key] = *attr;
+			}
+		}
+	}
+
+	/**
+	 * Copies or deletes attributes to match the source config.
+	 *
+	 * Attributes that do not exist in the source are fully erased rather than
+	 * set to the unspecified/default attribute value.
+	 *
+	 * @param from Source config to copy attributes from.
+	 * @param keys Attribute names.
+	 */
+	template<typename... T>
+	void copy_or_remove_attributes(const config& from, T... keys)
+	{
+		for(const auto& key : {keys...}) {
+			if(from.has_attribute(key)) {
+				(*this)[key] = from[key];
+			} else {
+				remove_attribute(key);
 			}
 		}
 	}

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -1468,9 +1468,10 @@ void server::handle_upload(const server::request& req)
 
 	// Write general metadata attributes
 
-	addon.copy_attributes(upload,
+	addon.copy_or_remove_attributes(upload,
 		"title", "name", "author", "description", "version", "icon",
-		"translate", "dependencies", "core", "type", "tags", "email");
+		"translate", "dependencies", "core", "type", "tags", "email"
+	);
 
 	const std::string& pathstem = "data/" + name;
 	addon["filename"] = pathstem;


### PR DESCRIPTION
This adds a `config::copy_or_remove_attributes()` method with the semantics needed to solve issue #6284 in campaignd, and uses it instead of `config::copy_attributes()` in campaignd. The latter is now unused in the overall codebase, but I'm leaving it intact with new documentation in case it's useful to someone else in the future.