### PR TITLE
Refactor handling of allies in UtBS (plus compatibility)

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -317,6 +317,7 @@
         [/recall]
 
         # recall dwarf/troll ally
+        {ALLY_NAME_COMPATIBILITY}
         [recall]
             id=$ally_id
             x,y=51,43

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -288,6 +288,7 @@
         [/recall]
 
         # recall dwarf/troll
+        {ALLY_NAME_COMPATIBILITY}
         [recall]
             id=$ally_id
         [/recall]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/10_Speaking_with_the_Fishes.cfg
@@ -74,6 +74,7 @@
             x,y=15,15
         [/recall]
 
+        {ALLY_NAME_COMPATIBILITY}
         [recall]
             id=$ally_id
             x,y=13,15

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
@@ -328,6 +328,7 @@
         [/recall]
 
         # recall dwarf/troll
+        {ALLY_NAME_COMPATIBILITY}
         [recall]
             id=$ally_id
         [/recall]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
@@ -195,6 +195,15 @@
         [/ai]
     [/side]
 
+    # Only running pre-load event to accommodate compatibility macro (since it can affect [ai][goal][criteria])
+
+    [event]
+        name=preload
+        first_time_only=no
+
+        {ALLY_NAME_COMPATIBILITY}
+    [/event]
+
     # Prestart functions:
     # insert items onto map
     # place item images on map
@@ -224,7 +233,6 @@
         # wmllint: unwho ALL
 
         # recall dwarf/troll
-        {ALLY_NAME_COMPATIBILITY}
         [recall]
             id=$ally_id
             x,y=9,17

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
@@ -224,6 +224,7 @@
         # wmllint: unwho ALL
 
         # recall dwarf/troll
+        {ALLY_NAME_COMPATIBILITY}
         [recall]
             id=$ally_id
             x,y=9,17

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/13_Epilogue.cfg
@@ -93,6 +93,7 @@
 
         # if only 1 friend dies, then have 3 different texts depending on who died
 
+        {ALLY_NAME_COMPATIBILITY}
         {SET_ALLY_UNIT}
         [if]
             [variable]

--- a/data/campaigns/Under_the_Burning_Suns/utils/dialog-macros.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/dialog-macros.cfg
@@ -81,3 +81,22 @@
         [/filter]
     [/store_unit]
 #enddef
+
+# Accommodate ally_name -> ally_id variable name change potentially occurring in between scenarios for a campaign in progress across major versions
+#define ALLY_NAME_COMPATIBILITY
+    [if]
+        [variable]
+            name=ally_name
+            # $null is not supposed to represent anything here
+            not_equals=$null
+        [/variable]
+
+        [then]
+            [set_variable]
+                name=ally_id
+                value=$ally_name
+            [/set_variable]
+            {CLEAR_VARIABLE ally_name}
+        [/then]
+    [/if]
+#enddef


### PR DESCRIPTION
Depends on / is super-set of #6165, which refactors ally dialogue, and attempts to (but incompletely) handle the variable name correction from `$ally_name` to `$ally_id`. The original variable name was confusing because the values it held referred to the `id` of the ally, not the `name`.

Outstanding issue: The final scenario does not work properly because the variable `$ally_id` is used in the `[side]` declaration.