### PR TITLE
Attempt to trim down the CI after getting caught in github's automate…

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -14,7 +14,7 @@ jobs:
 
     name: Discord Notification
 
-    needs: [ubuntu-2004-scons-gcc-release-lto, ubuntu-2004-scons-clang-debug, ubuntu-2004-cmake-clang-release, ubuntu-2004-cmake-gcc-debug, steam-runtime, mingw, flatpak, translations, macos-intel-master-release, macos-intel-master-debug, macos-arm-master-release, macos-arm-master-debug, windows-release, windows-debug]
+    needs: [ubuntu-2004-scons-gcc-release-lto, ubuntu-2004-cmake-clang-debug, steam-runtime, mingw, flatpak, translations, macos-intel-master-debug, macos-arm-master-release, windows-release, windows-debug]
     if: always()
 
     steps:
@@ -51,7 +51,7 @@ jobs:
           export CACHE_DIR=/home/wesnoth-CI/build
           ./.github/workflows/ci-scripts/ubuntu.sh
 
-  ubuntu-2004-scons-clang-debug:
+  ubuntu-2004-cmake-clang-debug:
     runs-on: ubuntu-20.04
 
     steps:
@@ -64,7 +64,7 @@ jobs:
           export BRANCH=master
           export IMAGE=2004
           export NLS=false
-          export TOOL=scons
+          export TOOL=cmake
           export CC=clang
           export CXX=clang++
           export CXX_STD=17
@@ -73,49 +73,6 @@ jobs:
           export CACHE_DIR=/home/wesnoth-CI/build
           ./.github/workflows/ci-scripts/ubuntu.sh master
 
-  ubuntu-2004-cmake-clang-release:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "recursive"
-
-      - name: Ubuntu 20.04
-        run: |
-          export BRANCH=master
-          export IMAGE=2004
-          export NLS=false
-          export TOOL=cmake
-          export CC=clang
-          export CXX=clang++
-          export CXX_STD=17
-          export CFG=release
-          export LTO=false
-          export CACHE_DIR=/home/wesnoth-CI/build
-          ./.github/workflows/ci-scripts/ubuntu.sh
-
-  ubuntu-2004-cmake-gcc-debug:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "recursive"
-
-      - name: Ubuntu 20.04
-        run: |
-          export BRANCH=master
-          export IMAGE=2004
-          export NLS=false
-          export TOOL=cmake
-          export CC=gcc
-          export CXX=g++
-          export CXX_STD=17
-          export CFG=debug
-          export LTO=false
-          export CACHE_DIR=/home/wesnoth-CI/build
-          ./.github/workflows/ci-scripts/ubuntu.sh
 
   steam-runtime:
     runs-on: ubuntu-20.04
@@ -220,20 +177,6 @@ jobs:
           export CACHE_DIR=/home/wesnoth-CI/build
           ./.github/workflows/ci-scripts/ubuntu.sh
 
-  macos-intel-master-release:
-    runs-on: macos-10.15
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "recursive"
-
-      - name: macOS Intel Release
-        run: |
-          export CFG=Release
-          export CACHE_DIR=~/build-cache
-          ./.github/workflows/ci-scripts/macos.sh
-
   macos-intel-master-debug:
     runs-on: macos-10.15
 
@@ -262,20 +205,6 @@ jobs:
           export CACHE_DIR=~/build-cache
           ./.github/workflows/ci-scripts/macos.sh
 
-  macos-arm-master-debug:
-    runs-on: macos-11.0
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "recursive"
-
-      - name: macOS ARM Debug
-        run: |
-          export CFG=Debug
-          export CACHE_DIR=~/build-cache
-          ./.github/workflows/ci-scripts/macos.sh
-
 # in the case of needing to recompile the vcpkg-created Windows dependencies, increment the cache-name and key for both Release and Debug
 # this will create a brand new cache and recompile the vcpkg dependencies from scratch
   windows-debug:
@@ -287,13 +216,13 @@ jobs:
           submodules: "recursive"
 
       - name: Cache object files
-        id: windows-master-N007
+        id: windows-master-N009
         uses: actions/cache@v2
         with:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: windows-master-N008
+          key: windows-master-N009
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -302,6 +231,8 @@ jobs:
         shell: cmd
         run: |
           git clone --depth=1 https://github.com/microsoft/vcpkg.git D:/a/wesnoth/vcpkg
+          cd D:/a/wesnoth/vcpkg
+          git checkout cbc22a396c88d098247fe7f79f0913a952e1f77d
           D:/a/wesnoth/vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup cmake
@@ -332,13 +263,13 @@ jobs:
           submodules: "recursive"
 
       - name: Cache object files
-        id: windows-master-N008
+        id: windows-master-N009
         uses: actions/cache@v2
         with:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: windows-master-N007
+          key: windows-master-N009
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -347,6 +278,8 @@ jobs:
         shell: cmd
         run: |
           git clone --depth=1 https://github.com/microsoft/vcpkg.git D:/a/wesnoth/vcpkg
+          cd D:/a/wesnoth/vcpkg
+          git checkout cbc22a396c88d098247fe7f79f0913a952e1f77d
           D:/a/wesnoth/vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup cmake


### PR DESCRIPTION
…d platform abuse tool.

Removed:
* Two linux jobs - now only two combinations of the gcc/clang + scons/cmake matrix are run.
* Two macOS jobs - the Release configuration is now only run on ARM, and the Debug configuration is only run on Intel.

Also pinned vcpkg to a particular commit so it doesn't ignore the cache when new versions of dependencies come out. This does mean though that when dependencies or dependency versions change that the vcpkg commit and the cache ID will need to be manually updated. And while it's *probably* safe to have stable and master share the same vcpkg cache, this may become problematic if their dependencies and/or versions become incompatible.