### PR TITLE
Replace std::regex by boost to temporary workaround for Mingw-w64's bug

### DIFF
--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -29,7 +29,7 @@
 
 #include "formula/string_utils.hpp"
 
-#include <regex>
+#include <boost/regex.hpp>
 
 static bool is_positive_integer(const std::string& str) {
 	return str != "0" && std::find_if(str.begin(), str.end(), [](char c) { return !std::isdigit(c); }) == str.end();
@@ -264,8 +264,8 @@ void location_palette::adjust_size(const SDL_Rect& target)
 		button_add_.reset(new location_palette_button(video(), SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Add"), [this]() {
 			std::string newid;
 			if (gui2::dialogs::edit_text::execute(_("New Location Identifier"), "", newid)) {
-				static const std::regex valid_id("[a-zA-Z0-9_]+");
-				if(std::regex_match(newid, valid_id)) {
+				static const boost::regex valid_id("[a-zA-Z0-9_]+");
+				if(boost::regex_match(newid, valid_id)) {
 					add_item(newid);
 				}
 				else {

--- a/src/utils/parse_network_address.cpp
+++ b/src/utils/parse_network_address.cpp
@@ -15,15 +15,15 @@
 
 #include "utils/parse_network_address.hpp"
 
-#include <regex>
+#include <boost/regex.hpp>
 #include <string>
 
 std::pair<std::string, std::string> parse_network_address(const std::string& address, const std::string& default_port)
 {
-	const char* address_re = "\\[([[:xdigit:]:]*)\\](:([[:alnum:]]*))?|([[:alnum:]-_\\.]{1,253})(:([[:alnum:]]*))?";
+	const char* address_re = "\\[([[:xdigit:]:]*)\\](:([[:alnum:]]*))?|([[:alnum:]\\-_\\.]{1,253})(:([[:alnum:]]*))?";
 
-	std::smatch m;
-	std::regex_match(address, m, std::regex(address_re));
+	boost::smatch m;
+	boost::regex_match(address, m, boost::regex(address_re));
 
 	if(!m[1].str().empty()) {
 		return { m[1], m[3].str().empty() ? default_port : m[3] };


### PR DESCRIPTION
Temporary workaround for #6291.

It is an upstream bug but seems to take a long time to fundamental resolve, such as fix the bug at the upstream or move release toolchain to MSVC.