### PR TITLE
Remove apply_to = opponent from the opponent's attack prediction window

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -889,7 +889,7 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 	const unit_map& units = display::get_singleton()->get_units();
 	if(self_){
 		for (const config::any_child &sp : self_->abilities().all_children_range()){
-			const bool active = check_self_abilities(sp.cfg, sp.key);
+			const bool active = check_self_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, self_loc_, AFFECT_SELF, sp.key);
 			add_name(weapon_abilities, active, sp, checking_name, false);
 		}
 		const auto adjacent = get_adjacent_tiles(self_loc_);
@@ -900,7 +900,7 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 			if(&*it == self_.get())
 				continue;
 			for (const config::any_child &sp : it->abilities().all_children_range()){
-				const bool active = check_adj_abilities(sp.cfg, sp.key, i, *it);
+				const bool active = check_adj_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, *it, i, self_loc_, AFFECT_SELF, sp.key);
 				add_name(weapon_abilities, active, sp, checking_name, true);
 			}
 		}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -839,7 +839,7 @@ std::vector<std::pair<t_string, t_string>> attack_type::special_tooltips(
  * @param[in] sp reference to ability to check
  * @param[in,out] checking_name the reference for checking if @name already added
  */
-static void add_name(std::string& weapon_abilities, bool active, const config::any_child sp, std::set<std::string>& checking_name)
+static void add_name(std::string& weapon_abilities, bool active, const config::any_child sp, std::set<std::string>& checking_name, bool affect_adjacent)
 {
 	if (active) {
 		const std::string& name = sp.cfg["name"].str();
@@ -847,7 +847,11 @@ static void add_name(std::string& weapon_abilities, bool active, const config::a
 		if (!name.empty() && checking_name.count(name) == 0) {
 			checking_name.insert(name);
 			if (!weapon_abilities.empty()) weapon_abilities += ", ";
-			weapon_abilities += font::span_color(font::BUTTON_COLOR, name);
+			if (affect_adjacent) {
+				weapon_abilities += sp.cfg["affect_enemies"].to_bool() ? font::span_color(font::BAD_COLOR, name) : font::span_color(font::GOOD_COLOR, name);
+			} else {
+				weapon_abilities += font::span_color(font::BUTTON_COLOR, name);
+			}
 		}
 	}
 }
@@ -885,9 +889,8 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 	const unit_map& units = display::get_singleton()->get_units();
 	if(self_){
 		for (const config::any_child &sp : self_->abilities().all_children_range()){
-			const bool active = check_self_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, self_loc_, AFFECT_SELF, sp.key);
-
-			add_name(weapon_abilities, active, sp, checking_name);
+			const bool active = check_self_abilities(sp.cfg, sp.key);
+			add_name(weapon_abilities, active, sp, checking_name, false);
 		}
 		const auto adjacent = get_adjacent_tiles(self_loc_);
 		for(unsigned i = 0; i < adjacent.size(); ++i) {
@@ -897,30 +900,8 @@ std::string attack_type::weapon_specials(bool only_active, bool is_backstab) con
 			if(&*it == self_.get())
 				continue;
 			for (const config::any_child &sp : it->abilities().all_children_range()){
-				const bool active = check_adj_abilities_impl(shared_from_this(), other_attack_, sp.cfg, self_, *it, i, self_loc_, AFFECT_SELF, sp.key);
-
-				add_name(weapon_abilities, active, sp, checking_name);
-			}
-		}
-	}
-
-	if(other_){
-		for (const config::any_child &sp : other_->abilities().all_children_range()){
-			const bool active = check_self_abilities_impl(other_attack_, shared_from_this(), sp.cfg, other_, other_loc_, AFFECT_OTHER, sp.key);
-
-			add_name(weapon_abilities, active, sp, checking_name);
-		}
-		const auto adjacent = get_adjacent_tiles(other_loc_);
-		for(unsigned i = 0; i < adjacent.size(); ++i) {
-			const unit_map::const_iterator it = units.find(adjacent[i]);
-			if (it == units.end() || it->incapacitated())
-				continue;
-			if(&*it == other_.get())
-				continue;
-			for (const config::any_child &sp : it->abilities().all_children_range()){
-				const bool active = check_adj_abilities_impl(other_attack_, shared_from_this(), sp.cfg, other_, *it, i, other_loc_, AFFECT_OTHER, sp.key);
-
-				add_name(weapon_abilities, active, sp, checking_name);
+				const bool active = check_adj_abilities(sp.cfg, sp.key, i, *it);
+				add_name(weapon_abilities, active, sp, checking_name, true);
 			}
 		}
 	}


### PR DESCRIPTION
Showing the names of the abilities that apply to the opposing side with that opponent's attack is more confusing than anything else.