### PR TITLE
CMake: run xgettext on the .cpp file with GETTEXT_DOMAIN "wesnoth"

### DIFF
--- a/cmake/update_pot_source_dependencies.cmake
+++ b/cmake/update_pot_source_dependencies.cmake
@@ -20,23 +20,29 @@ if(DOMAIN STREQUAL ${DEFAULT_DOMAIN})
 	add_custom_command(
 		OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
 
-		# Create an empty new one, to be sure it will exist.
-		COMMAND ${CMAKE_COMMAND}
-				-E touch ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
-
-		# Find all cpp files which are not in a .git directory.
+		# Find all cpp files which are not in a .git directory, check their
+		# textdomain, and write the list of matching files to POTFILES.in.
 		COMMAND find src  -name .git -prune -o -name '*.[hc]pp' -print |
 				sort |
 				while read file\; do
 					# If the file doesn't contain a GETTEXT_DOMAIN
 					# definition it should be added to the default domain.
-					if ! grep \"^\#define  *GETTEXT_DOMAIN\"
+					if ! grep '^\#define  *GETTEXT_DOMAIN'
 							$$file > /dev/null 2>&1\; then
 
-						echo $$file >>
-							${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in \;
+						echo $$file \;
+
+					# While files don't need a GETTEXT_DOMAIN to be included in
+					# the default domain, accept files that contain a
+					# GETTEXT_DOMAIN definition for the default domain too.
+					elif grep '^\#define  *GETTEXT_DOMAIN  *\"${DOMAIN}\"'
+							$$file > /dev/null 2>&1\; then
+
+						echo $$file \;
 					fi
-				done
+				done >|
+					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
+
 
 		DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -50,23 +56,20 @@ else(DOMAIN STREQUAL ${DEFAULT_DOMAIN})
 	add_custom_command(
 		OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
 
-		# Create an empty new one, to be sure it will exist.
-		COMMAND ${CMAKE_COMMAND}
-				-E touch ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
-
-		# Find all cpp files which are not in a .git directory.
+		# Find all cpp files which are not in a .git directory, check their
+		# textdomain, and write the list of matching files to POTFILES.in.
 		COMMAND find src  -name .git -prune -o -name '*cpp' -print |
 				sort |
 				while read file\; do
 					# If the file contains a GETTEXT_DOMAIN definition for
 					# the current domain add it to the domain.
-					if grep \"^\#define  *GETTEXT_DOMAIN  *\\\"${DOMAIN}\\\"\"
+					if grep '^\#define  *GETTEXT_DOMAIN  *\"${DOMAIN}\"'
 							$$file > /dev/null 2>&1\; then
 
-						echo $$file >>
-							${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in \;
+						echo $$file \;
 					fi
-				done
+				done >|
+					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
 
 		DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
 		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
Make the search for translatable strings include install_dependencies.cpp in the POTFILES.in file.

Exactly one (plural) string has been missing from .pot files build by CMake, presumably since 2017.