### PR TITLE
wmlxgettext: sort-by-filename before processing files

### DIFF
--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -211,6 +211,7 @@ def main():
     # if args.recursive is True and args.filelist is None:
     else:
         startPath, filelist = pywmlx.autof.autoscan(startPath)
+    filelist.sort()
     for fileno, fx in enumerate(filelist):
         fname = os.path.join(startPath, os.path.normpath(fx))
         is_file = os.path.isfile(fname)


### PR DESCRIPTION
Add a sort inside wmlxgettext so that the order of filenames on the command
line doesn't affect the output. The sort is run unconditionally, because I
don't see a usecase for not enabling it. For consistency with xgettext and
msgcat, if there was an option to enable it then it would be called
`--sort-by-file`.

The aim of this change is to reduce the number of changes in .po files caused
by a pot-update. When multiple comments refer to the same translatable string,
separate runs of pot-update could generate them in a random order. If I've
understood the root cause correctly, wmlxgettext itself was deterministic, but
the order of the files on wmlxgettext's command line was not deterministic.

For testing, I tried reversing the sort order; the resulting reordering hit
lines that commonly swap order during pot-updates.

This affects the ordering of the lines beginning `#.` that are generated from
`#po:` comments and also those auto-generated from `[message]speaker=`, etc.

@AncientLich, it's only a one-liner, but it seems polite to ask you first.

Fixes #5989.