### PR TITLE
remove Utbs 'formation' name of attack prediction windows(master)

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -165,17 +165,12 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
 #enddef
 
 #define ABILITY_FORMATION
-    [chance_to_hit]
+    [dummy]
         id=formation
         name= _ "formation"
         female_name= _ "female^formation"
         description= _ "This unit gains a +10% bonus to defense when another unit with the same ability is adjacent to it. However, this cannot raise the unit’s defense above 70%."
         special_note=_"Groups of units of this type are able to shield each other in combat."
-        apply_to=opponent
-        sub=10
-        [filter_base_value]
-            greater_than_equal_to=40
-        [/filter_base_value]
         [filter]
             [filter_adjacent]
                 ability=formation
@@ -183,7 +178,8 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
                 count=1-5
             [/filter_adjacent]
         [/filter]
-    [/chance_to_hit]
+    [/dummy]
+    {FORMATION formation1 40 1-5}
     {FORMATION formation2 50 2-5}
     {FORMATION formation3 60 3-5}
     {FORMATION formation4 70 4-5}


### PR DESCRIPTION
Like description of Utbs formation abilities is opposite of what suggest name in attack prediction windows, it best to remove that.