### PR TITLE
ui: Fix 800x600 theme's sidebar tooltips

### DIFF
--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -557,7 +557,7 @@
         [change]
             id=unit-description
             font_size={DEFAULT_FONT_SMALL}
-            rect="=,+0,+140,+{DEFAULT_FONT_SMALL_HEIGHT}"
+            rect="=,+1,+128,+{DEFAULT_FONT_SMALL_HEIGHT}"
         [/change]
         [change]
             id=unit-type


### PR DESCRIPTION
Forward-port of #6304, intending to merge without further review after the CI run.

Two changes in the theme config for 1024x600, which is inherited by the config
for 800x600. Both are the same line but otherwise only loosely related to each
other; together these fix issue #6264, which was that trigger areas for some
tooltips overlapped.

Reduce the width for the unit's name, thus giving the side-flag and side-number
(which get the remaining horizontal space) enough space to display themselves.
128 pixels wide is the same as the name gets in larger themes, even though
those larger themes use larger font sizes. This means that the side number
doesn't get ellipsed, at least for games with up to 9 sides, with the
side-effect that the tooltip can be displayed when hovering over the flag.

Move the name, and thus the flag and side-number down by 1 pixel, so that they
don't overlap with the tooltip trigger areas for movement points and terrain
defense. The name's location is based on the placement of `unit-box-botleft`;
the theme for larger screen-sizes similarly adds 5 pixels of padding because
the `unit-box` is only 72x72 for the image, and the text areas for movement
points and defense go lower than that.

(cherry picked from commit 0d4854d5ffdcf265065d9519e2537dce14c8406e)