### PR TITLE
SoF Finale: Allow for Gryphon Riders to trigger an event on the final runic tablet

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -658,7 +658,6 @@
         [event]
             name=moveto
             [filter]
-                id=Krawg
                 x,y=29,31
             [/filter]
             [filter_condition]
@@ -672,14 +671,58 @@
                     [/have_unit]
                 [/or]
             [/filter_condition]
+            [if]
+                # Only flying units can reach this location and the only flying units the player should have access to besides Krawg is the Gryphon Rider line
+                [variable]
+                    name=unit.id
+                    equals=Krawg
+                [/variable]
+                [then]
+                    [message]
+                        speaker=Krawg
+                        message= _ "Wha’?"
+                    [/message]
+                    [message]
+                        speaker=narrator
+                        message= _ "Krawg puzzled over a stone tile sitting loose on the small mesa. Beneath a spattering of bat guano, there was a glowing rune. Krawg didn’t know what to make of it, so the gryphon left it for now."
+                        image=wesnoth-icon.png
+                    [/message]
+                [/then]
+                [else]
+                    [message]
+                        speaker=$unit.id
+                        message= _ "Well, what do we have here? Looks suspiciously important. We should probably come back here after exploring some more..."
+                    [/message]
+                [/else]
+            [/if]
+        [/event]
+        [event]
+            name=moveto
+            [filter]
+                x,y=29,31
+            [/filter]
+            [filter_condition]
+                [not]
+                    [variable]
+                        name=gathor_tablet
+                        equals=whole
+                    [/variable]
+                    [or]
+                        [have_unit]
+                            id=Toomak
+                        [/have_unit]
+                    [/or]
+                [/not]
+                [and]
+                    [variable]
+                       name=unit.id
+                       not_equals=Krawg
+                    [/variable]
+                [/and]
+            [/filter_condition]
             [message]
-                speaker=Krawg
-                message= _ "Wha’?"
-            [/message]
-            [message]
-                speaker=narrator
-                message= _ "Krawg puzzled over a stone tile sitting loose on the small mesa. Beneath a spattering of bat guano, there was a glowing rune. Krawg didn’t know what to make of it, so the gryphon left it for now."
-                image=wesnoth-icon.png
+                speaker=$unit.id
+                message= _ "It seems that something special will happen if Krawg flies here. Why do you get to be the special one, Krawg? You lucky beast, you. Must be plot armour, or somethin’..."
             [/message]
         [/event]
         [event]


### PR DESCRIPTION
Draft: needs actual dialogue that makes sense from a story perspective, explaining why it has to be Krawg to destroy the final tablet.

Relates to #6332.

Either Krawg or a Gryphon Rider/Master may trigger the first event, finding the tablet before the other two are destroyed. After they have been destroyed, Krawg and a Gryphon Rider/Master may trigger their respective event independently, though of course if Krawg goes first that's the end of the scenario.

Alternative is to trigger victory irrespective of who reaches the final tablet, but then dialogue needs to be rewritten for a Gryphon Rider/Master instead of Krawg.