### PR TITLE
Ardonna should only call her own bats 'my pet'

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
@@ -362,6 +362,13 @@
                 name=zombies[0].allow_recruit
                 boolean_equals=no
             [/variable]
+            [and]
+                # Only makes sense for Ardonna to call her own bats 'my pet'.
+                [variable]
+                    name=side
+                    equals=1
+                [/variable]
+            [/and]
         [/filter_condition]
         [message]
             speaker=Ardonna


### PR DESCRIPTION
It's possible, however unlikely, for none of Ardonna's bats to have died before killing the hostile bats in 'Following the Shadow'. In such a case, when the 'You can now raise bat corpses!' event triggers, Ardonna will still refer to the enemy bat as her 'pet' so add this condition to avoid it.