### PR TITLE
Expand the reduce function to both fold and reduce

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -14,4 +14,4 @@ global=false
 unused=false
 -- excluded files due to using lua 5.4 syntax that currently gets flagged as a syntax error
 -- clear out once a newer Ubuntu LTS base is used for our docker images, which would then also have a newer luacheck available
-exclude_files={"data/lua/core/wml.lua","data/lua/wml-flow.lua","data/lua/wml/find_path.lua","data/lua/wml/harm_unit.lua","data/lua/wml/modify_unit.lua","data/lua/wml/random_placement.lua"}
+exclude_files={"data/lua/core/wml.lua","data/lua/wml-flow.lua","data/lua/wml/find_path.lua","data/lua/wml/harm_unit.lua","data/lua/wml/modify_unit.lua","data/lua/wml/random_placement.lua","data/lua/functional.lua"}

--- a/data/lua/functional.lua
+++ b/data/lua/functional.lua
@@ -126,15 +126,40 @@ local known_operators = {
 	['or'] = function(a, b) return a or b end,
 }
 
-function functional.reduce(input, operator, identity)
+-- If operator is a string, return the corresponding function. Otherwise, return
+-- operator.
+local function check_operator(operator)
 	if type(operator) == 'string' then
-		operator = known_operators[operator]
+		return known_operators[operator]
 	end
-	local result = identity or 0
-	for _, v in ipairs(input) do
-		result = operator(result, v)
+	return operator
+end
+
+-- Fold starting from the given index.
+local function fold_from_i(t, f, init, i)
+	local value <const> = t[i]
+	if value == nil then
+		return init
 	end
-	return result
+	return fold_from_i(t, f, f(init, value), i + 1)
+end
+
+-- Fold the elements of array t into a single value. operator is called as
+-- 'operator(accumulator, element)' for every element in t, where init is the
+-- initial accumulator. operator may be a function or a binary Lua operator as a
+-- string.
+function functional.fold(t, operator, init)
+	return fold_from_i(t, check_operator(operator), init, 1)
+end
+
+-- Like fold, but if t is not empty, ignore the identity argument. The first
+-- operator call will be on the first two elements.
+function functional.reduce(t, operator, identity)
+	local first <const> = t[1]
+	if first == nil then
+		return identity
+	end
+	return fold_from_i(t, check_operator(operator), first, 2)
 end
 
 function functional.take_while(input, condition)

--- a/data/lua/functional.lua
+++ b/data/lua/functional.lua
@@ -126,13 +126,13 @@ local known_operators = {
 	['or'] = function(a, b) return a or b end,
 }
 
--- Reduce the elements of array t into a single value. operator is called as
--- 'operator(accumulator, element)' for every element in t. If a 3rd argument is
--- provided, which may be nil, it will be used as the accumulator when calling
--- operator on the first element. If there is no 3rd argument, the first
--- operator call will be on the first two elements. If there is no 3rd argument
--- and the array is empty, return nil. operator may be a function or a binary
--- Lua operator as a string.
+--- Reduce the elements of array t into a single value. operator is called as
+--- 'operator(accumulator, element)' for every element in t. If a 3rd argument
+--- is provided, which may be nil, it will be used as the accumulator when
+--- calling operator on the first element. If there is no 3rd argument, the
+--- first operator call will be on the first two elements. If there is no 3rd
+--- argument and the array is empty, return nil. operator may be a function or a
+--- binary Lua operator as a string.
 function functional.reduce(t, operator, ...)
 	local f <const> = known_operators[operator] or operator
 

--- a/data/test/scenarios/lua_functional.cfg
+++ b/data/test/scenarios/lua_functional.cfg
@@ -1,0 +1,29 @@
+#textdomain wesnoth-test
+
+# Tests for the functional.lua library
+{GENERIC_UNIT_TEST "lua_functional" (
+    [event]
+        name = start
+        [lua]
+            code = <<
+                local fp <const> = wesnoth.require'lua/functional'
+
+                unit_test.assert_equal(
+                    fp.reduce({}, function() end),
+                    nil,
+                    "reduce with empty array and no init doesn't return nil.")
+
+                unit_test.assert(
+                    not fp.reduce({false, false}, 'or', false),
+                    "reduce with false elements and 'or' operator returns a truthy value.")
+
+                unit_test.assert_equal(
+                    fp.reduce({4, 5, 2}, '+', 0),
+                    11,
+                    "reduce does not calculate a sum correctly.")
+
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -351,6 +351,7 @@
 9 unknown_scenario_1_0
 
 # Lua API tests
+0 lua_functional
 0 lua_map_find
 0 mapgen_filter_range
 0 mapgen_filter_terrain


### PR DESCRIPTION
The file `data/lua/functional.lua` contains a `reduce` function which, when receiving a falsey `identity` argument, changes it to `0`. This makes it impossible to initialize the calculation with `nil` or `false`. `functional.reduce(t, 'or', false)` will always return `0`.

While changing the function to accept any 3rd argument, I decided to rewrite it to `fold`, which always includes the init value in the calculation, and `reduce`, which only looks at the identity value if the array is empty.