### PR TITLE
VS+Clang

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -73,7 +73,6 @@ jobs:
           export CACHE_DIR=/home/wesnoth-CI/build
           ./.github/workflows/ci-scripts/ubuntu.sh
 
-
   steam-runtime:
     runs-on: ubuntu-20.04
 
@@ -216,13 +215,13 @@ jobs:
           submodules: "recursive"
 
       - name: Cache object files
-        id: windows-N009
+        id: windows-N010
         uses: actions/cache@v2
         with:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: windows-N009
+          key: windows-N010
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -243,7 +242,7 @@ jobs:
       - name: Use cmake
         run: |
           cmake --version
-          cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_MYSQL=false -DENABLE_NLS=false -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=D:/a/wesnoth/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64 -G "Visual Studio 16 2019" .
+          cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_MYSQL=false -DENABLE_NLS=false -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=D:/a/wesnoth/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64 -G "Visual Studio 16 2019" -T ClangCL .
 
 # delete buildtrees directory to free up space after cmake invokes vcpkg to build the dependencies
 # otherwise the job was failing when trying to write a .obj file
@@ -263,13 +262,13 @@ jobs:
           submodules: "recursive"
 
       - name: Cache object files
-        id: windows-N009
+        id: windows-N010
         uses: actions/cache@v2
         with:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: windows-N009
+          key: windows-N010
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -289,7 +288,7 @@ jobs:
 
       - name: Use cmake
         run: |
-          cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_MYSQL=false -DENABLE_NLS=false -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=D:/a/wesnoth/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64 -G "Visual Studio 16 2019" .
+          cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_MYSQL=false -DENABLE_NLS=false -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=D:/a/wesnoth/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64 -G "Visual Studio 16 2019" -T ClangCL .
 
 # delete buildtrees directory to free up space after cmake invokes vcpkg to build the dependencies
 # otherwise the job was failing when trying to write a .obj file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(NOT WIN32)
 # End setting profiler build options
 # #
 else()
-	set(CMAKE_CXX_FLAGS "/W3 /WX /wd4503 /wd4351 /wd4250 /wd4244 /wd4267 /we4239 /wd4275 /EHsc /utf-8" CACHE STRING "Global flags used by the CXX compiler during all builds." FORCE)
+	set(CMAKE_CXX_FLAGS "/W3 /WX /wd4503 /wd4351 /wd4250 /wd4244 /wd4267 /we4239 /wd4275 /EHsc /utf-8 -Wno-microsoft -Wno-deprecated-declarations -Wno-unused-private-field -Wno-unused-variable -Wno-unused-lambda-capture -Wno-return-std-move" CACHE STRING "Global flags used by the CXX compiler during all builds." FORCE)
 	add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN7 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -DNOMINMAX)
 
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_LUA")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,7 @@ endif()
 if(ENABLE_GAME)
 	if(WIN32)
 		add_executable(wesnoth WIN32 wesnoth.cpp ../packaging/windows/wesnoth.rc)
-		target_link_options(wesnoth PRIVATE /WX /WHOLEARCHIVE:wesnoth-widgets)
+		target_link_options(wesnoth PRIVATE /WX /LIBPATH:\"D:\\a\\wesnoth\\wesnoth\\src\\${CMAKE_BUILD_TYPE}\" /WHOLEARCHIVE:wesnoth-widgets.lib)
 	elseif(APPLE)
 		add_executable(wesnoth wesnoth.cpp macosx/SDLMain.mm)
 	else()
@@ -196,7 +196,7 @@ if(ENABLE_TESTS)
 	add_executable(boost_unit_tests ${boost_tests_sources})
 
 	if(WIN32)
-		target_link_options(boost_unit_tests PRIVATE /WX /WHOLEARCHIVE:wesnoth-widgets)
+		target_link_options(boost_unit_tests PRIVATE /LIBPATH:\"D:\\a\\wesnoth\\wesnoth\\src\\${CMAKE_BUILD_TYPE}\" /WHOLEARCHIVE:wesnoth-widgets.lib)
 	endif()
 
 	target_link_libraries(boost_unit_tests

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -381,7 +381,7 @@ std::string os_version()
 			}
 	}
 
-	if(v.szCSDVersion && *v.szCSDVersion) {
+	if(*v.szCSDVersion) {
 		version += " ";
 		version += unicode_cast<std::string>(std::wstring(v.szCSDVersion));
 	}


### PR DESCRIPTION
---

Not necessarily something I'm saying we should definitely do, but opening the PR to start a discussion about using Clang with Visual Studio on Windows rather than MSVC. The main idea being that it would mean we'd only need to deal with Clang and GCC rather than Clang, GCC, and MSVC, and that we'd be able to build with Clang on all the platforms we support.