### PR TITLE
UtBS S02 Ogre now dissappears before Nym starts moving or talking

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -708,6 +708,12 @@
             message= _ "That’s the last of them. This looks like a hunting party, they must have a camp around here somewhere."
         [/message]
 
+        # Move Nym adjacent to the bottle. During a die event, $unit is still blocking the hex, so killing it with wml is needed.
+        [kill]
+            role="Hunting Ogre"
+            animate=no
+        [/kill]
+
         [item]
             x=$x1
             y=$y1
@@ -722,10 +728,7 @@
             message=_"Hey! Look there, they dropped something... A stone bottle, sealed. I wonder what’s inside..."
         [/message]
 
-        # Move Nym adjacent to the bottle. During a die event, $unit is still blocking the hex, so
-        # Nym probably ends up running to the hex north-west of $x1,$y1.
-        #
-        # Don't move her if she's already adjacent to it - if she landed the killing blow, moving
+        # Don't move Nym if she's already adjacent to the Ogre - if she landed the killing blow, moving
         # her now means that she doesn't get the XP. Also, the unit still has ZoC, and she'll take a
         # longer route to avoid it, which looks particularly obvious if Nym was adjacent the ogre.
         [if]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -726,7 +726,7 @@
             message=_"Hey! Look there, they dropped something... A stone bottle, sealed. I wonder what’s inside..."
         [/message]
 
-        # Move Nym adjacent to the bottle, but don't move her if she's already adjacent to it
+        # Move Nym to the bottle, but don't move her if she's already adjacent to it
         # if she landed the killing blow, moving her now means that she doesn't get the XP.
 
         [if]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -703,16 +703,12 @@
             [/have_unit]
         [/filter_condition]
 
-        [message]
-            speaker=Kaleh
-            message= _ "That’s the last of them. This looks like a hunting party, they must have a camp around here somewhere."
-        [/message]
-
-        # Move Nym adjacent to the bottle. During a die event, $unit is still blocking the hex, so killing it with wml is needed.
         [kill]
             role="Hunting Ogre"
-            animate=no
         [/kill]
+
+        [redraw]
+        [/redraw]
 
         [item]
             x=$x1
@@ -720,24 +716,27 @@
             image=items/potion-grey.png
         [/item]
 
-        [redraw]
-        [/redraw]
+        [message]
+            speaker=Kaleh
+            message= _ "That’s the last of them. This looks like a hunting party, they must have a camp around here somewhere."
+        [/message]
 
         [message]
             speaker=Nym
             message=_"Hey! Look there, they dropped something... A stone bottle, sealed. I wonder what’s inside..."
         [/message]
 
-        # Don't move Nym if she's already adjacent to the Ogre - if she landed the killing blow, moving
-        # her now means that she doesn't get the XP. Also, the unit still has ZoC, and she'll take a
-        # longer route to avoid it, which looks particularly obvious if Nym was adjacent the ogre.
+        # Move Nym adjacent to the bottle, but don't move her if she's already adjacent to it
+        # if she landed the killing blow, moving her now means that she doesn't get the XP.
+
         [if]
             [not]
                 [have_unit]
                     id=Nym
-                    [filter_adjacent]
-                        id=$unit.id
-                    [/filter_adjacent]
+                    [filter_location]
+                        x,y=$x1,$y1
+                        radius=1
+                    [/filter_location]
                 [/have_unit]
             [/not]
             [then]


### PR DESCRIPTION
As said in the comments, a die event makes the unit linger. Applied what is said in https://wiki.wesnoth.org/Eventwml#die

> Note: The primary unit is not removed from the game until the end of this event. The primary unit can still be manipulated, will block other units from taking its hex, and will still be found by standard unit filters (except [have_unit]). To prevent this behavior, you can use [kill] to remove the unit immediately.

(Closes #6341)