### PR TITLE
UtBS S4: Restrict who remarks about the dark underground tunnels

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg
@@ -752,6 +752,11 @@
                 time_of_day_id=underground
             [/filter_location]
             side=1
+            race=quenoth
+            [not]
+                # Exclude Kaleh lest he potentially talks to himself if he is the first to enter the cave
+                id=Kaleh
+            [/not]
         [/filter]
 
         [allow_undo]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg
@@ -752,7 +752,7 @@
                 time_of_day_id=underground
             [/filter_location]
             side=1
-            race=quenoth
+            race=quenoth,elf
             [not]
                 # Exclude Kaleh lest he potentially talks to himself if he is the first to enter the cave
                 id=Kaleh
@@ -762,12 +762,10 @@
         [allow_undo]
         [/allow_undo]
 
-        {CHECK_EXPLORER}
         [message]
-            speaker=$explorer.id
+            speaker=$unit.id
             message= _ "Ugh! These tunnels are pitch black! It’s as bad as fighting in a moonless night, and it stinks of orc filth. I can hardly think of a place I would less like to go into."
         [/message]
-        {CLEAR_VARIABLE explorer}
 
         [message]
             speaker=Kaleh


### PR DESCRIPTION
By happenstance, Elyssa was my first unit to enter the caves. It sounded really weird for her to complain about the darkness and then say that she can use her fireballs to defeat the orcs.

As per the code commentary, it seemed the intention was to have this dialogue be for the elves:
https://github.com/wesnoth/wesnoth/blob/4248738a3894df4a551debd4ff6afff4e68ffe49/data/campaigns/Under_the_Burning_Suns/scenarios/04_Descending_into_Darkness.cfg#L746

So I added `race=quenoth` to exclude Elyssa and focus on the elves as per the original intention.

Unfortunately - or perhaps fortunately - Kaleh was my next unit in line to enter the caves, and it sounded really bad for him to complain about the darkness and then tell himself 'we have no choice'. So I added `[not]id=Kaleh[/not]` to cover that case.

Potentially we could exclude Zhul as well, but it sounds fine to me if she complains about the darkness and then reminds Kaleh about the elves' disadvantage fighting in that environment.