### PR TITLE
UtBS Changed and documented the change of XP bar color to blue

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Dust_Devil.cfg
@@ -79,6 +79,10 @@
         id=Dust1
         max_times=4
         description= _ "a stronger Dust Devil"
+
+        # Make the XP bar blue instead of purple.
+        major_amla=yes
+
         [effect]
             apply_to=attack
             range=melee
@@ -98,6 +102,7 @@
         id=Dust2
         max_times=2
         description= _ "a taller Dust Devil"
+        major_amla=yes
         [effect]
             apply_to=attack
             range=ranged

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -12,6 +12,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
 "+{NYM_DESCRIPTION}#enddef
 
 #define HEAL_EFFECTS
+    # Make the XP bar blue instead of purple.
     major_amla=yes
     [effect]
         apply_to=hitpoints


### PR DESCRIPTION
Effect ingame:
If the Dust devil still has the "Taller" and "Stronger" AMLAs available, the XP is blue.
![still has good amlas](https://user-images.githubusercontent.com/30196839/144433476-8aae9f93-96ef-44a2-91ff-b43ff7c51f92.png)
If it reaches all major AMLAs, it turns purple so the player does not waste XP on him.
![reaches all major amlas](https://user-images.githubusercontent.com/30196839/144433486-d5aa5239-7a6d-457b-beda-1a680e234021.png)

Also documented the changes in the files, so it is easier to understand, for future reference, why the XP bar is blue.

(Closes #6212)