### PR TITLE
Fix MINGW build on Windows by splitting MSVC and WIN32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,19 +79,8 @@ find_package(Gettext)
 find_package(X11)
 
 if(NOT WIN32)
-	# needed to get some SDL2 defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
-	if(NOT MINGW)
-		set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
-		exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
-		add_definitions(${SDL2_CFLAGS})
-	else()
-		# equivalent to sdl2-config --cflags --libs
-		# since cmake cannot execute sdl2-config in msys2 shell
-		set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -I/mingw64/include/SDL2 -Dmain=SDL_main -L/mingw64/lib -lmingw32 -lSDL2main -lSDL2 -mwindows)
-	endif()
-
-		# Use the safer `mkstemp' instead of `tmpnam' on POSIX systems.
-		add_definitions(-DLUA_USE_POSIX)
+	# Use the safer `mkstemp' instead of `tmpnam' on POSIX systems.
+	add_definitions(-DLUA_USE_POSIX)
 endif()
 
 #check for some compiler/arch specific things and export defines accordingly...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ set(BINARY_PREFIX "" CACHE STRING "Prefix in front of all binaries")
 
 ### Set the environment compiler flags.
 
-if(NOT WIN32)
+if(NOT MSVC)
 	if(NOT DEFINED CXX_FLAGS_USER)
 
 		MESSAGE(STATUS "Environment compiler flags set to »${CXX_FLAGS_USER}«")
@@ -260,6 +260,8 @@ if(NOT WIN32)
 
 		if(APPLE)
 			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -Wl,-pie")
+		elseif(WIN32 AND MINGW)
+			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie")
 		else()
 			set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie -Wl,-z,relro,-z,now")
 		endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,10 +38,10 @@ link_directories(
 )
 
 set(common-external-libs ${ICU_DATA_LIBRARY} ${ICU_I18N_LIBRARY} ${ICU_UC_LIBRARY})
-if(WIN32)
+if(MSVC)
 	set(common-external-libs ${common-external-libs} shlwapi.lib winmm.lib crypt32.lib)
 elseif(MINGW)
-	set(common-external-libs ${common-external-libs} wsock32 ws2_32 shlwapi winmm)
+	set(common-external-libs ${common-external-libs} wsock32 ws2_32 shlwapi winmm crypt32)
 elseif(APPLE)
 	set(common-external-libs ${common-external-libs} ${IOKIT_LIBRARY} ${SECURITY_LIBRARY})
 endif()
@@ -80,7 +80,9 @@ set_source_files_properties(${lua_sources} PROPERTIES OBJECT_DEPENDS ${wesnoth_l
 if(WIN32)
 	set(wesnoth_core_sources ${wesnoth_core_sources} log_windows.cpp)
 	set(wesnoth_game_sources ${wesnoth_game_sources} desktop/windows_tray_notification.cpp desktop/windows_battery_info.cpp)
+endif()
 	
+if(MSVC)
 	set_source_files_properties(${lua_sources} PROPERTIES COMPILE_FLAGS "/FI\"${wesnoth_lua_config}\"")
 	# silence an implicit bitshift conversion warning
 	set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " /wd4334")
@@ -142,7 +144,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 	add_library(wesnoth-widgets STATIC ${wesnoth_widget-sources})
 	if(APPLE)
 		set(WIDGETS_LIB -Wl,-force_load wesnoth-widgets)
-	elseif(NOT WIN32)
+	elseif(NOT MSVC)
 		set(WIDGETS_LIB -Wl,--whole-archive wesnoth-widgets -Wl,--no-whole-archive)
 	else()
 		# handled by /WHOLEARCHIVE below
@@ -153,7 +155,9 @@ endif()
 if(ENABLE_GAME)
 	if(WIN32)
 		add_executable(wesnoth WIN32 wesnoth.cpp ../packaging/windows/wesnoth.rc)
-		target_link_options(wesnoth PRIVATE /WX /WHOLEARCHIVE:wesnoth-widgets)
+		if(MSVC)
+			target_link_options(wesnoth PRIVATE /WX /WHOLEARCHIVE:wesnoth-widgets)
+		endif()
 	elseif(APPLE)
 		add_executable(wesnoth wesnoth.cpp macosx/SDLMain.mm)
 	else()
@@ -195,7 +199,7 @@ if(ENABLE_TESTS)
 	GetSources("boost_unit_tests" boost_tests_sources)
 	add_executable(boost_unit_tests ${boost_tests_sources})
 
-	if(WIN32)
+	if(MSVC)
 		target_link_options(boost_unit_tests PRIVATE /WX /WHOLEARCHIVE:wesnoth-widgets)
 	endif()
 
@@ -258,7 +262,7 @@ if(ENABLE_SERVER)
 		Boost::locale
 		Boost::filesystem
 	)
-	if(WIN32)
+	if(MSVC)
 		target_link_options(wesnothd PRIVATE /WX)
 	endif()
 
@@ -300,7 +304,7 @@ if(ENABLE_CAMPAIGN_SERVER)
 		Boost::locale
 		Boost::filesystem
 	)
-	if(WIN32)
+	if(MSVC)
 		target_link_options(campaignd PRIVATE /WX)
 	endif()
 


### PR DESCRIPTION
Fixes the MINGW build in the MSYS2 environment on Windows.

I've seen the previous PR #4728, but a more recent change to the CMakeLists-files introduced MSVC-specific compile and link flags for all WIN32 targets.
This PR splits `WIN32` and `MSVC` and keeps the `gcc`-flags if MSVC is not used.
With this I was able to build and run wesnoth in the UCRT64-environment of MSYS2 using CMake.

There is one more occurrence of `NOT WIN32` where I'm not sure if the section should apply for MSYS2.
~~I will try to add an inline comment for the relevant section.~~
Since there are no changes to this section a inline comment is not possible.
Here is a link to the section in question: [CMakeLists.txt line 81-95](https://github.com/wesnoth/wesnoth/blob/9d5271b98aebdb39631b98089f22f15d80c75a5a/CMakeLists.txt#L81-L95)
The POSIX-definition in line 94 breaks the build for me if applied on Windows.
I'm not sure if the other SDL-flags (line 90) are necessary. For me the build also worked without them.