### PR TITLE
UtBS S8: Ensure humans are removed from display during their 'die' event

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -994,7 +994,7 @@
 
         # Vary dialogue depending on what kind of sea life the humans originally
         # mentioned. Also if last human died from drowning instead of being killed
-        # have Kaleh as the question, instead of the victorious unit.
+        # have Kaleh ask the question, instead of the victorious unit.
 
         # Set speaker before checking for dialog
         [if]
@@ -1013,6 +1013,11 @@
                 [/set_variable]
             [/else]
         [/if]
+
+        # Ensure all humans are removed from display
+        [kill]
+            role=human_scout
+        [/kill]
 
         [message]
             speaker=$speaking_unit.id


### PR DESCRIPTION
There appears to be another situation as with #6341, but for the human attackers:
![human](https://user-images.githubusercontent.com/13679322/144736016-be04f277-fb26-41e1-b8c5-e375f81adca8.png)

I tested this change directly in my current save file and it seemed to resolve the issue.

I also remove redundant phrasing and correct a commentary typo. @nemaara Please advise if you object to the former - I just find the phrasing of 'Hurry up already!' to be too modern (and redundant) compared with just 'Hurry up!'