### PR TITLE
TRoW S19 Fix for the flying chocobones issue

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -149,6 +149,21 @@
         [/ai]
     [/side]
 
+#define LOYAL_UNIT_PASS SIDE TYPE X Y
+    # Creates a unit with the Loyal trait and who can walk on where it is created
+    [unit]
+        type={TYPE}
+        side={SIDE}
+        x={X}
+        y={Y}
+        generate_name=yes
+        [modifications]
+            {TRAIT_LOYAL}
+        [/modifications]
+        passable=yes
+    [/unit]
+#enddef
+
     [event]
         name=prestart
 
@@ -512,9 +527,9 @@
 
                                     {NAMED_LOYAL_UNIT 5 Deathblade $|spawn_x $|spawn_y Norte _"Norte"}
 
-                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
 #ifndef EASY
-                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
 #endif
 
                                     {CLEAR_FOG 1 $|possible_undead_locs[$|undead_loc_i].x $|possible_undead_locs[$|undead_loc_i].y 2}
@@ -530,10 +545,10 @@
 
                                     {NAMED_LOYAL_UNIT 5 Banebow $|spawn_x $|spawn_y Rabbin _"Rabbin"}
 
-                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}
-                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
 #ifdef HARD
-                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
 #endif
 
                                     {CLEAR_FOG 1 $|possible_undead_locs[$|undead_loc_i].x $|possible_undead_locs[$|undead_loc_i].y 2}
@@ -558,11 +573,11 @@
                                         profile="portraits/undead/draug-2.png"
                                     [/unit]
 
-                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}
-                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
 #ifdef HARD
-                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}
-                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
 #endif
 
                                     {CLEAR_FOG 1 $|possible_undead_locs[$|undead_loc_i].x $|possible_undead_locs[$|undead_loc_i].y 2}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -149,17 +149,9 @@
         [/ai]
     [/side]
 
-#define LOYAL_UNIT_PASS SIDE TYPE X Y
-    # Creates a unit with the Loyal trait and who can walk on where it is created
-    [unit]
-        type={TYPE}
-        side={SIDE}
-        x={X}
-        y={Y}
-        generate_name=yes
-        [modifications]
-            {TRAIT_LOYAL}
-        [/modifications]
+#define PASSABLE_HEX
+    # Adds passable attribute
+    [+unit]
         passable=yes
     [/unit]
 #enddef
@@ -527,9 +519,9 @@
 
                                     {NAMED_LOYAL_UNIT 5 Deathblade $|spawn_x $|spawn_y Norte _"Norte"}
 
-                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
 #ifndef EASY
-                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
 #endif
 
                                     {CLEAR_FOG 1 $|possible_undead_locs[$|undead_loc_i].x $|possible_undead_locs[$|undead_loc_i].y 2}
@@ -545,10 +537,10 @@
 
                                     {NAMED_LOYAL_UNIT 5 Banebow $|spawn_x $|spawn_y Rabbin _"Rabbin"}
 
-                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
-                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
+                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
 #ifdef HARD
-                                    {LOYAL_UNIT_PASS 5 (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT 5 (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
 #endif
 
                                     {CLEAR_FOG 1 $|possible_undead_locs[$|undead_loc_i].x $|possible_undead_locs[$|undead_loc_i].y 2}
@@ -573,11 +565,11 @@
                                         profile="portraits/undead/draug-2.png"
                                     [/unit]
 
-                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
-                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
+                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
 #ifdef HARD
-                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
-                                    {LOYAL_UNIT_PASS 5  (Chocobone) $|spawn_x $|spawn_y}
+                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
+                                    {LOYAL_UNIT 5  (Chocobone) $|spawn_x $|spawn_y}{PASSABLE_HEX}
 #endif
 
                                     {CLEAR_FOG 1 $|possible_undead_locs[$|undead_loc_i].x $|possible_undead_locs[$|undead_loc_i].y 2}
@@ -731,4 +723,5 @@
 
         {CLEAR_VARIABLE xx1,yy1,chest_obtained}
     [/event]
+#undef PASSABLE_HEX
 [/scenario]


### PR DESCRIPTION
Fixed a bug reported on discord by @Konrad22 which made the chocobones spawn over a chasm as can be seen:
![Flycobones](https://user-images.githubusercontent.com/30196839/144759710-023c6271-eca7-43f9-950f-2e605b1c926e.png)
Using passable=yes, and with the previous code implementation, no undead should spawn over a chasm.
![No flybones](https://user-images.githubusercontent.com/30196839/144759741-09e7b42e-0a60-4a1b-945e-7b2d065af3ff.png)