### PR TITLE
UtBS S8: Avoid counting encounters with the 'Cloaked Figure'

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -2357,7 +2357,7 @@
         [/message]
     [/event]
 
-    # Event 13: Encounter Cloaked Figure for a third time
+    # Event 13: Encounter Cloaked Figure for (potentially) a third time
 
     [event]
         name=moveto
@@ -2397,7 +2397,7 @@
 
         [message]
             speaker=Kaleh
-            message= _ "In Eloh’s name, not you again. Must I fight you a third time?"
+            message= _ "In Eloh’s name, not you again. Must I fight you another time?"
         [/message]
 
         [message]


### PR DESCRIPTION
Resolves #6355.

The 'Cloaked Figure' that hounds Kaleh and friends can be encountered up to three times:
* S4 - guaranteed as his appearance is triggered by Kaleh entering the cave which is a scenario requirement.
* S5 - appearance is at a random turn during the battle between the dwarves and the trolls.
* S8 - final appearance is triggered when moving through the narrow passage.

It is possible to miss the encounter in S5 due to the randomised turn mechanic. Thus, it can be confusing when Kaleh says 'third time'. This is just a quick work-around - another option may be to make the appearance in S5 more deterministic.