### PR TITLE
Print which campaign is causing the extra_defines warning

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -568,7 +568,7 @@ void game_config_manager::load_addons_cfg()
 						//      it before also didn't work in all cases (see #4402)
 						//      i don't think it is worth it.
 						deprecated_message(
-							"extra_defines=" + str,
+							"campaign id='" + campaign["id"].str() + "' has extra_defines=" + str,
 							DEP_LEVEL::REMOVED,
 							{1, 15, 4},
 							_("instead, use the macro with the same name in the [campaign] tag")


### PR DESCRIPTION
Forward-port of #6375. Just running the CI and will then merge.

Whether or not it's the campaign being played, this warning
gets printed if any add-on has a [campaign]extra_defines=
attribute with one of the deprecated strings (a hardcoded
list about 20 lines above the line that's changed here).

(cherry picked from commit c1499e06b55eb109502f6ae4272f16ca6661181b)