### PR TITLE
SunOS 5.11/OpenIndiana build fixes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -637,6 +637,9 @@ for env in [test_env, client_env, env]:
         env.Append(FRAMEWORKS = "IOKit")            # IOKit
         env.Append(FRAMEWORKS = "CoreGraphics")     # CoreGraphics
 
+    if env["PLATFORM"] == 'sunos':
+        env.Append(LINKFLAGS = "-lsocket")
+
 if not env['static_test']:
     test_env.Append(CPPDEFINES = "BOOST_TEST_DYN_LINK")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,10 @@ elseif(APPLE)
 	set(common-external-libs ${common-external-libs} ${IOKIT_LIBRARY} ${SECURITY_LIBRARY})
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+	set(common-external-libs ${common-external-libs} socket)
+endif()
+
 set(game-external-libs
 	${common-external-libs}
 	${SDL2_LIBRARY}

--- a/src/desktop/version.cpp
+++ b/src/desktop/version.cpp
@@ -217,7 +217,8 @@ std::map<std::string, std::string> parse_fdo_osrelease(const std::string& path)
 std::string os_version()
 {
 #if defined(__APPLE__) || defined(_X11)
-	utsname u;
+	// Some systems, e.g. SunOS, need "struct" here
+	struct utsname u;
 
 	if(uname(&u) != 0) {
 		ERR_DU << "os_version: uname error (" << strerror(errno) << ")\n";


### PR DESCRIPTION
With these changes, Wesnoth builds and runs on SunOS 5.11, tested on OpenIndiana 2021.10.