### PR TITLE
1.16 - Added attack icon to the nightblade's kick

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
    * Implemented delayed translation option for gettext plurals (issue #6036, PR #6097).
  ### Units
    * Added attack image for the Bone Knight’s trample
+   * Added attack image for the Nightblade’s kick
  ### User interface
    * Improved translatability of MP ban durations (issue #6036, PR #6097).
  ### WML Engine

--- a/data/core/units/orcs/Nightblade.cfg
+++ b/data/core/units/orcs/Nightblade.cfg
@@ -32,7 +32,7 @@
     [attack]
         name=kick
         description=_"kick"
-        icon=attacks/blank-attack.png
+        icon=attacks/foot-boot.png
         type=impact
         range=melee
         damage=11


### PR DESCRIPTION
Grabbed the image from #6339 solves #4145 partly.