### PR TITLE
editor: Add "Map Screenshot" item to menu

### DIFF
--- a/data/themes/editor.cfg
+++ b/data/themes/editor.cfg
@@ -61,7 +61,7 @@
             title= _ "File"
             type=turbo
             font_size=9
-            items=editor-scenario-edit,statustable,unitlist,editor-map-new,editor-scenario-new,editor-map-load,menu-editor-recent,editor-map-revert,editor-map-save,editor-map-save-as,editor-scenario-save-as,editor-map-save-all,preferences,help,editor-close-map,quit,quit-to-desktop
+            items=editor-scenario-edit,statustable,unitlist,editor-map-new,editor-scenario-new,editor-map-load,menu-editor-recent,editor-map-revert,editor-map-save,editor-map-save-as,mapscreenshot,editor-scenario-save-as,editor-map-save-all,preferences,help,editor-close-map,quit,quit-to-desktop
             ref=top-panel
             rect="=,=+1,+100,+20"
             xanchor=fixed


### PR DESCRIPTION
I think we should add the `Map Screenshot` item to the menu so it's easier to discover. (See #6386)

Not sure where it fits best. I've put it below "Save Map As". The map menu could be another option.