### PR TITLE
Get the scenario_id from the addon content list sent by the server if it's not otherwise available.

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -146,7 +146,7 @@ bool map_includes(const preproc_map& general, const preproc_map& special)
 } // end anonymous namespace
 
 void game_config_manager::load_game_config_with_loadscreen(
-	FORCE_RELOAD_CONFIG force_reload, game_classification const*, std::optional<std::set<std::string>> active_addons)
+	FORCE_RELOAD_CONFIG force_reload, std::optional<std::set<std::string>> active_addons)
 {
 	if(!lg::info().dont_log(log_config)) {
 		auto out = formatter();
@@ -703,7 +703,7 @@ void game_config_manager::load_game_config_for_game(
 	}
 
 	try {
-		load_game_config_with_loadscreen(NO_FORCE_RELOAD, &classification, classification.active_addons(scenario_id));
+		load_game_config_with_loadscreen(NO_FORCE_RELOAD, classification.active_addons(scenario_id));
 	} catch(const game::error&) {
 		cache_.clear_defines();
 

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -62,8 +62,7 @@ private:
 
 	void load_game_config(bool reload_everything);
 
-	void load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload,
-		game_classification const* classification = nullptr, std::optional<std::set<std::string>> active_addons = {});
+	void load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload, std::optional<std::set<std::string>> active_addons = {});
 
 	// load_game_config() helper functions.
 	void load_addons_cfg();

--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -134,7 +134,19 @@ bool mp_join_game::fetch_game_config()
 		state_.classification() = game_classification(level_);
 
 		// Make sure that we have the same config as host, if possible.
-		game_config_manager::get()->load_game_config_for_game(state_.classification(), state_.get_scenario_id());
+		std::string scenario_id = state_.get_scenario_id();
+		// since add-ons are now only enabled when used, the scenario ID may still not be known
+		// so check in the MP info sent from the server for the scenario ID if that's the case
+		if(scenario_id == "") {
+			for(const auto& addon : level_.child("multiplayer").child_range("addon")) {
+				for(const auto& content : addon.child_range("content")) {
+					if(content["type"] == "scenario") {
+						scenario_id = content["id"].str();
+					}
+				}
+			}
+		}
+		game_config_manager::get()->load_game_config_for_game(state_.classification(), scenario_id);
 	}
 
 	game_config::add_color_info(game_config_view::wrap(get_scenario()));

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -1760,9 +1760,9 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		g.level().root().apply_diff(*scenario_diff);
 		const simple_wml::node* cfg_change = scenario_diff->child("change_child");
 
-		// it is very likeley that the diff changes a side so this check isn't that important.
+		// it is very likely that the diff changes a side so this check isn't that important.
 		// Note that [side] is not at toplevel but inside [scenario] or [snapshot]
-		if(cfg_change /** && cfg_change->child("side") */) {
+		if(cfg_change) {
 			g.update_side_data();
 		}
 


### PR DESCRIPTION
Fixes #6285