### PR TITLE
Omit line-numbers from the .po files

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -96,6 +96,7 @@ if(ENABLE_POT_UPDATE_TARGET)
 
 			COMMAND ${GETTEXT_MSGCAT_EXECUTABLE}
 				--sort-by-file
+				--add-location=file
 					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
 					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.wml.pot
 				--output ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.pot

--- a/po/SConscript
+++ b/po/SConscript
@@ -80,15 +80,15 @@ if "pot-update" in COMMAND_LINE_TARGETS:
         if cfgs and sources:
             env.Command(new_pot, [source_pot, wml_pot],
                 [
-                    "msgcat --sort-by-file $SOURCES -o $TARGET",
+                    "msgcat --sort-by-file --add-location=file $SOURCES -o $TARGET",
                     Delete(wml_pot),
                     Delete(source_pot)
                 ]
             )
         elif cfgs:
-            env.Command(new_pot, wml_pot, ["msgcat --sort-by-file $SOURCES -o $TARGET", Delete(wml_pot)])
+            env.Command(new_pot, wml_pot, ["msgcat --sort-by-file --add-location=file $SOURCES -o $TARGET", Delete(wml_pot)])
         else:
-            env.Command(new_pot, source_pot, ["msgcat --sort-by-file $SOURCES -o $TARGET", Delete(source_pot)])
+            env.Command(new_pot, source_pot, ["msgcat --sort-by-file --add-location=file $SOURCES -o $TARGET", Delete(source_pot)])
         env.Command(pot, new_pot, Action(update_pot))
 
     env.Alias("pot-update", "../translations", "python3 utils/po_stat.py --update-cfg --textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units")


### PR DESCRIPTION
The aim of this change is to reduce the number of changes in .po files caused
by a pot-update. For example, changes elsewhere in .cpp and .cfg files added
lots of changes just to change the line numbers.

This change is done on the final stage of creating the .pot files, so that the
same stage's `msgcat --sort-by-file` sorting still works as before, sorting by
both file and line.

Note: although the aim is reduce the number of changes in the long term, it
creates a huge diff on the very first pot-update. There are slightly more
deletions than insertions, as files with the same translatable string repeated
on multiple lines are now only listed once.

Estimated sizes for pot-update at the start of 1.16.2's string freeze. This
pot-update introduces (across all languages) 13438 new fuzzy strings, circa
60000 of the insertions are those fuzzies:

* 1.16.2 without this: 214795 insertions(+), 135146 deletions(-)
* 1.16.2 with this: 1283834 insertions(+), 1339266 deletions(-)
* 1.16.2 if this was in 1.16.1: 130824 insertions(+), 52728 deletions(-)

Estimates for master:

* 1.17.0 without this: 448590 insertions(+), 369170 deletions(-)
* 1.17.0 with this: 1356682 insertions(+), 1411589 deletions(-)