### PR TITLE
add tooltip to unit_attack dialogs

### DIFF
--- a/data/gui/widget/window_tooltip_large.cfg
+++ b/data/gui/widget/window_tooltip_large.cfg
@@ -46,8 +46,51 @@
 
 [window_definition]
 
-	id = tooltip
+	id = tooltip_transparent
 	description = "The window to show a large tooltip."
+
+	[resolution]
+
+		left_border = 15
+		right_border = 15
+		top_border = 15
+		bottom_border = 15
+
+		[background]
+
+			[draw]
+
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+
+					fill_color = "0, 0, 0, 192"
+					border_thickness = 1
+					border_color = "0, 0, 0, 255"
+
+				[/rectangle]
+
+			[/draw]
+
+		[/background]
+
+		[foreground]
+
+			[draw]
+			[/draw]
+
+		[/foreground]
+
+	[/resolution]
+
+[/window_definition]
+
+[window_definition]
+
+	id = tooltip
+	description = "The window to show a floating tooltip."
 
 	[resolution]
 

--- a/data/gui/window/tooltip_floating.cfg
+++ b/data/gui/window/tooltip_floating.cfg
@@ -141,7 +141,7 @@ def reevaluate_best_size(w, s)
 
 [window]
 	id = "tooltip"
-	description = "The tooltip popup window with large tooltips, eg in the main menu."
+	description = "The tooltip popup window with floating tooltips."
 
 	[resolution]
 		definition = "tooltip"
@@ -164,6 +164,57 @@ def reevaluate_best_size(w, s)
 
 		[helptip]
 			id = "tooltip"
+		[/helptip]
+
+		[grid]
+
+			[row]
+
+				[column]
+
+					[label]
+						id = "label"
+						definition = "default_small"
+
+						use_markup = true
+						wrap = true
+					[/label]
+
+				[/column]
+
+			[/row]
+
+		[/grid]
+
+	[/resolution]
+
+[/window]
+
+[window]
+	id = "tooltip_transparent"
+	description = "The tooltip popup window with floating tooltips, and transparent background."
+
+	[resolution]
+		definition = "tooltip_transparent"
+
+		automatic_placement = false
+
+		functions = "{__GUI_WINDOW_FUNCTIONS}"
+
+		x = "{__GUI_WINDOW_X}"
+		y = "{__GUI_WINDOW_Y}"
+		width = "{__GUI_WINDOW_WIDTH}"
+		height = "{__GUI_WINDOW_HEIGHT}"
+		reevaluate_best_size = "{__GUI_WINDOW_REEVALUATE_BEST_SIZE}"
+
+		# TODO tooltips in this window make little sense.
+		# Have to think of a nice solution.
+		[tooltip]
+			id = "tooltip_transparent"
+		[/tooltip]
+
+		[helptip]
+			id = "tooltip_transparent"
 		[/helptip]
 
 		[grid]

--- a/data/gui/window/unit_attack.cfg
+++ b/data/gui/window/unit_attack.cfg
@@ -282,11 +282,11 @@
 		[/linked_group]
 
 		[tooltip]
-			id = "tooltip"
+			id = "tooltip_transparent"
 		[/tooltip]
 
 		[helptip]
-			id = "tooltip"
+			id = "tooltip_transparent"
 		[/helptip]
 
 		[grid]

--- a/src/gui/dialogs/unit_attack.cpp
+++ b/src/gui/dialogs/unit_attack.cpp
@@ -115,19 +115,51 @@ void unit_attack::pre_show(window& window)
 			attacker_itor_->get_location(), false, attacker.weapon
 		);
 
-		std::string attw_specials = attacker_weapon.weapon_specials(true, attacker.backstab_pos);
+		const std::set<std::string> checking_tags_other = {"disable", "berserk", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
+		std::string attw_specials = attacker_weapon.weapon_specials(true);
+		std::string attw_specials_dmg = attacker_weapon.weapon_specials_value({"leadership", "damage"}, true);
+		std::string attw_specials_atk = attacker_weapon.weapon_specials_value({"attacks", "swarm"}, true);
+		std::string attw_specials_cth = attacker_weapon.weapon_specials_value({"chance_to_hit"}, true);
+		std::string attw_specials_others = attacker_weapon.weapon_specials_value(checking_tags_other, true);
 		bool defender_attack = !(defender_weapon.name().empty() && defender_weapon.damage() == 0 && defender_weapon.num_attacks() == 0 && defender.chance_to_hit == 0);
 		std::string defw_specials = defender_attack ? defender_weapon.weapon_specials(true) : "";
+		std::string defw_specials_dmg = defender_attack ? defender_weapon.weapon_specials_value({"leadership", "damage"}, true) : "";
+		std::string defw_specials_atk = defender_attack ? defender_weapon.weapon_specials_value({"attacks", "swarm"}, true) : "";
+		std::string defw_specials_cth = defender_attack ? defender_weapon.weapon_specials_value({"chance_to_hit"}, true) : "";
+		std::string defw_specials_others = defender_attack ? defender_weapon.weapon_specials_value(checking_tags_other, true) : "";
 
 		if(!attw_specials.empty()) {
 			attw_specials = " " + attw_specials;
 		}
-
+		if(!attw_specials_dmg.empty()) {
+			attw_specials_dmg = " " + attw_specials_dmg;
+		}
+		if(!attw_specials_atk.empty()) {
+			attw_specials_atk = " " + attw_specials_atk;
+		}
+		if(!attw_specials_cth.empty()) {
+			attw_specials_cth = " " + attw_specials_cth;
+		}
+		if(!attw_specials_others.empty()) {
+			attw_specials_others = "\n" + translation::dsgettext("wesnoth", "Other: ") + attw_specials_others;
+		}
 		if(!defw_specials.empty()) {
 			defw_specials = " " + defw_specials;
 		}
+		if(!defw_specials_dmg.empty()) {
+			defw_specials_dmg = " " + defw_specials_dmg;
+		}
+		if(!defw_specials_atk.empty()) {
+			defw_specials_atk = " " + defw_specials_atk;
+		}
+		if(!defw_specials_cth.empty()) {
+			defw_specials_cth = " " + defw_specials_cth;
+		}
+		if(!defw_specials_others.empty()) {
+			defw_specials_others = "\n" + translation::dsgettext("wesnoth", "Other: ") + defw_specials_others;
+		}
 
-		std::stringstream attacker_stats, defender_stats;
+		std::stringstream attacker_stats, defender_stats, attacker_tooltip, defender_tooltip;
 
 		// Use attacker/defender.num_blows instead of attacker/defender_weapon.num_attacks() because the latter does not consider the swarm weapon special
 		attacker_stats << "<b>" << attw_name << "</b>" << "\n"
@@ -135,10 +167,22 @@ void unit_attack::pre_show(window& window)
 			<< attw_specials << "\n"
 			<< font::span_color(a_cth_color) << attacker.chance_to_hit << "%</span>";
 
+		attacker_tooltip << translation::dsgettext("wesnoth", "Weapon: ") << "<b>" << attw_name << "</b>" << "\n"
+			<< translation::dsgettext("wesnoth", "Damage: ") << attacker.damage <<  "<i>" << attw_specials_dmg <<  "</i>" << "\n"
+			<< translation::dsgettext("wesnoth", "Attacks: ") << attacker.num_blows <<  "<i>" << attw_specials_atk <<  "</i>" << "\n"
+			<< translation::dsgettext("wesnoth", "Chance to hit: ") << font::span_color(a_cth_color) << attacker.chance_to_hit << "%</span>"<<  "<i>" << attw_specials_cth << "</i>"
+			<< "<i>" << attw_specials_others << "</i>";
+
 		defender_stats << "<b>" << defw_name << "</b>" << "\n"
 			<< defender.damage << font::weapon_numbers_sep << defender.num_blows
 			<< defw_specials << "\n"
 			<< font::span_color(d_cth_color) << defender.chance_to_hit << "%</span>";
+
+		defender_tooltip << translation::dsgettext("wesnoth", "Weapon: ") << "<b>" << defw_name << "</b>" << "\n"
+			<< translation::dsgettext("wesnoth", "Damage: ") << defender.damage << "<i>" << defw_specials_dmg << "</i>" << "\n"
+			<< translation::dsgettext("wesnoth", "Attacks: ") << defender.num_blows <<  "<i>" << defw_specials_atk <<  "</i>" << "\n"
+			<< translation::dsgettext("wesnoth", "Chance to hit: ") << font::span_color(d_cth_color) << defender.chance_to_hit << "%</span>"<<  "<i>" << defw_specials_cth << "</i>"
+			<< "<i>" << defw_specials_others << "</i>";
 
 		std::map<std::string, string_map> data;
 		string_map item;
@@ -148,15 +192,19 @@ void unit_attack::pre_show(window& window)
 		item["label"] = attacker_weapon.icon();
 		data.emplace("attacker_weapon_icon", item);
 
+		item["tooltip"] = attacker_tooltip.str();
 		item["label"] = attacker_stats.str();
 		data.emplace("attacker_weapon", item);
+		item["tooltip"] = "";
 
 		item["label"] = "<span color='#a69275'>" + font::unicode_em_dash + " " + range + " " + font::unicode_em_dash + "</span>";
 		data.emplace("range", item);
 
+		item["tooltip"] = defender_attack ? defender_tooltip.str() : "";
 		item["label"] = defender_stats.str();
 		data.emplace("defender_weapon", item);
 
+		item["tooltip"] = "";
 		item["label"] = defender_weapon.icon();
 		data.emplace("defender_weapon_icon", item);
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -83,6 +83,7 @@ public:
 	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials(bool only_active=false, bool is_backstab=false) const;
+	std::string weapon_specials_value(const std::set<std::string> checking_tags, bool only_active=false, bool is_backstab=false) const;
 
 	/** Calculates the number of attacks this weapon has, considering specials. */
 	void modified_attacks(bool is_backstab, unsigned & min_attacks,
@@ -150,6 +151,33 @@ private:
 	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool include_backstab=true, const std::string& filter_self ="filter_self") const;
 
+	std::string weapon_specials_impl(bool only_active, bool is_backstab = false, const std::set<std::string> checking_tags= {}, bool is_tooltip = false) const;
+	static void weapon_specials_impl_self(
+		std::string& weapon_abilities,
+		unit_const_ptr self,
+		const_attack_ptr self_attack,
+		const_attack_ptr other_attack,
+		const map_location& self_loc,
+		AFFECTS whom,
+		std::set<std::string>& checking_name,
+		const std::set<std::string> checking_tags,
+		bool is_tooltip,
+		bool leader_bool=false
+	);
+
+	static void weapon_specials_impl_adj(
+		std::string& weapon_abilities,
+		unit_const_ptr self,
+		const_attack_ptr self_attack,
+		const_attack_ptr other_attack,
+		const map_location& self_loc,
+		AFFECTS whom,
+		std::set<std::string>& checking_name,
+		const std::set<std::string> checking_tags,
+		const std::string& affect_adjacents,
+		bool is_tooltip,
+		bool leader_bool = false
+	);
 	/** check_self_abilities_impl : return an boolean value for checking of activities of abilities used like weapon
 	 * @return True if the special @a tag_name is active.
 	 * @param self_attack the attack used by unit checked in this function.
@@ -169,7 +197,7 @@ private:
 		const map_location& loc,
 		AFFECTS whom,
 		const std::string& tag_name,
-		bool leader_bool=false
+		bool leader_bool = false
 	);
 
 


### PR DESCRIPTION
with this way, weapon abilities applied to stats of attacks showed in tooltips same if from opponent but only if modify damage num of attack or chance to hit stats.

i cannot capture the windows with tooltip this time.