### PR TITLE
Add a "special notes" section to terrain help pages

### DIFF
--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -18,6 +18,7 @@
 #include "help/help_topic_generators.hpp"
 
 #include "font/sdl_ttf_compat.hpp"
+#include "formula/string_utils.hpp"     // for VNGETTEXT
 #include "game_config.hpp"              // for debug, menu_contract, etc
 #include "preferences/game.hpp"         // for encountered_terrains, etc
 #include "gettext.hpp"                  // for _, gettext, N_
@@ -153,6 +154,42 @@ std::string terrain_topic_generator::operator()() const {
 		return ss.str();
 	}
 
+	// Special notes are generated from the terrain's properties - at the moment there's no way for WML authors
+	// to add their own via a [special_note] tag.
+	std::vector<std::string> special_notes;
+
+	if(type_.is_village()) {
+		special_notes.push_back(_("Villages allow any unit stationed therein to heal, or to be cured of poison."));
+	} else if(type_.gives_healing() > 0) {
+		auto symbols = utils::string_map{{"amount", std::to_string(type_.gives_healing())}};
+		// TRANSLATORS: special note for terrains such as the oasis; the only terrain in core with this property heals 8 hp just like a village.
+		// For the single-hitpoint variant, the wording is different because I assume the player will be more interested in the curing-poison part than the minimal healing.
+		auto message = VNGETTEXT("This terrain allows units to be cured of poison, or to heal a single hitpoint.",
+			"This terrain allows units to heal $amount hitpoints, or to be cured of poison, as if stationed in a village.",
+			type_.gives_healing(), symbols);
+		special_notes.push_back(std::move(message));
+	}
+
+	if(type_.is_castle()) {
+		special_notes.push_back(_("This terrain is a castle — units can be recruited on to it from a connected keep."));
+	}
+	if(type_.is_keep() && type_.is_castle()) {
+		// TRANSLATORS: The "this terrain is a castle" note will also be shown directly above this one.
+		special_notes.push_back(_("This terrain is a keep — a leader can recruit from this hex on to connected castle hexes."));
+	} else if(type_.is_keep() && !type_.is_castle()) {
+		// TRANSLATORS: Special note for a terrain, but none of the terrains in mainline do this.
+		special_notes.push_back(_("This unusual keep allows a leader to recruit while standing on it, but does not allow a leader on a connected keep to recruit onto this hex."));
+	}
+
+	if(!special_notes.empty()) {
+		ss << "\n" << _("Special Notes:") << '\n';
+		for(const auto& note : special_notes) {
+			ss << font::unicode_bullet << " " << note << '\n';
+		}
+	}
+
+	// Almost all terrains will show the data in this conditional block. The ones that don't are the
+	// archetypes used in [movetype]'s subtags such as [movement_costs].
 	if (!type_.is_indivisible()) {
 		ss << "\n" << _("Base Terrain: ");
 
@@ -564,7 +601,7 @@ std::string unit_topic_generator::operator()() const {
 	if(const auto notes = type_.special_notes(); !notes.empty()) {
 		ss << "\n\n" << _("Special Notes:") << '\n';
 		for(const auto& note : notes) {
-			ss << "• " << note << '\n';
+			ss << font::unicode_bullet << " " << note << '\n';
 		}
 	}
 


### PR DESCRIPTION
The notes are automatically added based on the terrain's properties, there isn't a way to add or remove them in WML.

As-is, this fixes #6394. Issue #4417 mentions some other possibilities too, but I want to postpone these:
* income is complex about upkeep, and the values can be specific to the map and the side
* illumination would need to handle min and max lighting caps too
* defense caps would entangle this with the units on the map, I don't intend to add that at all

Any questions about negative values for gives_healing() are issue #4232; this PR simply doesn't add a special note for that.

![keep_in_800x600](https://user-images.githubusercontent.com/101462/147358571-0b0e310c-0c3a-49e4-8962-c5e0081072db.png)
![desert_village](https://user-images.githubusercontent.com/101462/147358569-cac459ff-d91d-463f-adb7-f5fbe5df2426.png)

The next image is what's shown when choosing the terrain in the help browser's list. The main reasoning for this PR is that the "A welcome sight" line doesn't appear when right-clicking on an oasis on the map and choosing the "terrain description" menu option.
![oasis](https://user-images.githubusercontent.com/101462/147358574-2c22d417-265d-4907-a440-9e906e960100.png)

Right-clicking on an oasis on the map leads to a page similar to this one. This wording is only used for 1 hp; for 2 hp or more the wording is similar to the 8 hp one shown above (that logic may vary by language, it's the language's pluralisation rules that force two wordings for en_US).
![oasis_1hp](https://user-images.githubusercontent.com/101462/147358575-7bb37e33-3d6b-4af6-a3ae-16a6975f73df.png)

Another terrain that doesn't appear in mainline, but seemed better to handle than not to.
![keep_no_recruit_onto](https://user-images.githubusercontent.com/101462/147358573-d5b79ccd-7c44-4291-830d-72d7e761804b.png)