### PR TITLE
fix weapon abilities showed in void attack in attack dialog window

### DIFF
--- a/src/gui/dialogs/unit_attack.cpp
+++ b/src/gui/dialogs/unit_attack.cpp
@@ -116,7 +116,8 @@ void unit_attack::pre_show(window& window)
 		);
 
 		std::string attw_specials = attacker_weapon.weapon_specials(true, attacker.backstab_pos);
-		std::string defw_specials = defender_weapon.weapon_specials(true);
+		bool defender_attack = !(defender_weapon.name().empty() && defender_weapon.damage() == 0 && defender_weapon.num_attacks() == 0 && defender.chance_to_hit == 0);
+		std::string defw_specials = defender_attack ? defender_weapon.weapon_specials(true) : "";
 
 		if(!attw_specials.empty()) {
 			attw_specials = " " + attw_specials;


### PR DESCRIPTION
if by example, formation affect a dark Adept, and he is defender, then formation name appear in defender attack.(if name and description of formation in chance_to_hit abilities)