### PR TITLE
[1.16] Only show planned moves to self and allies in multiplayer

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -895,6 +895,7 @@ void menu_handler::move_unit_to_loc(const unit_map::iterator& ui,
 		actions::move_unit_and_record(route.steps, &pc_.get_undo_stack(), continue_move);
 	}
 
+	mousehandler.deselect_hex();
 	gui_->set_route(nullptr);
 	gui_->invalidate_game_status();
 }

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -160,6 +160,15 @@ private:
 	const team& viewing_team() const;
 	team &current_team();
 
+	// Some common code from mouse_motion and touch_motion.
+	/**
+	 * Highlight the hexes that a unit can move to.
+	 *
+	 * Based on the currently selected hex, selected unit and what's being moused-over,
+	 * conditionally draw any planned moves for the unit passed as an argument.
+	 */
+	void show_reach_for_unit(const unit_ptr& un);
+
 	game_display* gui_;
 	play_controller & pc_;
 


### PR DESCRIPTION
Two commits. The first one unifies some common code from mouse_handler::mouse_motion and mouse_handler::touch_motion.

For changelog.md
---

``` 
 ### Multiplayer
   * Fixed the originally planned move becoming visible to enemies when an "enemy sighted" event interrupts a multi-turn move (issue #6292)
   * Made planned multi-turn moves consistently visible to allies.

 ### User interface
   * Fixed "enemy sighted, press t to continue" also activating a feature that showed units' route to where the move started (issue #6292)
```


Only show planned moves to self and allies
---

Fixes #6292, that the planned final destination from multi-turn moves and
interrupted moves was visible to enemies. There are three side-numbers involved
in this logic, listed below; the GUI code was checking whether the move should
be visible to the player whose turn it is, rather to the viewing team.

* un->side(), the owner of the unit
* mouse_handler::side_num_, the side whose turn it is
* viewing_team(), the side of the player whose computer this wesnoth-client is
  running on, thus which side's shroud and fog should be applied.

The plans are still hidden for units belonging to local AI sides, to hide any
goto_x,goto_y settings by campaign authors. The edge case in multiplayer of
allied network AI sides isn't tested here, but I think it's a trivial matter
whether or not those plans are shown.

Don't leave a hex selected when using 't' to continue a move
---

Fixes the minor part of issue #6292, that functionality showing the path
to a selected hex was active after continuing an interrupted move. That
feature is completely separate to the main bug of #6292, but it looks
confusingly similar in testing. The intended way to activate this feature is
via the "Select Hex" hotkey, which doesn't have any keybinding by default, so
should only be reachable by people who want the feature.

It would be good to refactor the movement handling so that it's not split
between mouse-handling and menu-handling files, but it would also need a lot of
work and would be out-of-scope for backporting to 1.16.
