### PR TITLE
Support macOS 10.8-10.11 SDKs

### DIFF
--- a/src/macosx/SDLMain.mm
+++ b/src/macosx/SDLMain.mm
@@ -22,6 +22,12 @@
 #import "SDLMain.h"
 #include <vector>
 
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 101200
+#define NSEventTypeKeyDown NSKeyDown
+#define NSEventTypeKeyUp NSKeyUp
+#define NSEventModifierFlagCommand NSCommandKeyMask
+#endif
+
 extern "C" int wesnoth_main(int argc, char **argv);
 static std::vector<char*> gArgs;
 


### PR DESCRIPTION
Map new constant names to their previous names after testing the SDK version. Tested against wesnoth 1.16.1.

Patch adapted from https://github.com/macports/macports-ports/pull/13437