### PR TITLE
Only try to activate required addons after loading all addons present.

### DIFF
--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -118,9 +118,9 @@ std::set<std::string> game_classification::active_addons(const std::string& scen
 	std::set<std::string> loaded_resources;
 	std::set<std::string> res;
 
-	std::transform(active_mods.begin(), active_mods.end(), std::back_inserter(mods),
-		[](const std::string& id) { return modevents_entry("modification", id); }
-	);
+	for(const auto& mod : active_mods) {
+		mods.emplace_back("modification", mod);
+	}
 
 	// We don't want the error message below if there is no era (= if this is a sp game).
 	if(!era_id.empty()) {
@@ -150,8 +150,16 @@ std::set<std::string> game_classification::active_addons(const std::string& scen
 			for (const config& load_res : cfg.child_range("load_resource")) {
 				mods.emplace_back("resource", load_res["id"].str());
 			}
+		} else {
+			ERR_NG << "Unable to find config for content " << current.id << " of type " << current.type;
 		}
 		mods.pop_front( );
 	}
+
+	DBG_NG << "Active content for game set to:" << std::endl;
+	for(const std::string& mod : res) {
+		DBG_NG << mod << std::endl;
+	}
+
 	return res;
 }

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -60,9 +60,9 @@ private:
 	game_config_manager(const game_config_manager&);
 	void operator=(const game_config_manager&);
 
-	void load_game_config(bool reload_everything);
+	void load_game_config(bool reload_everything, const game_classification* classification, const std::string& scenario_id);
 
-	void load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload, std::optional<std::set<std::string>> active_addons = {});
+	void load_game_config_with_loadscreen(FORCE_RELOAD_CONFIG force_reload, const game_classification* classification, const std::string& scenario_id);
 
 	// load_game_config() helper functions.
 	void load_addons_cfg();
@@ -75,7 +75,7 @@ private:
 	game_config_view game_config_view_;
 
 	std::map<std::string, config> addon_cfgs_;
-	std::optional<std::set<std::string>> active_addons_;
+	std::set<std::string> active_addons_;
 
 	preproc_map old_defines_map_;
 


### PR DESCRIPTION
The current issue is that, when loading a replay that requires addons from the main menu, it's checking for which addons can be enabled with game_classification.active_addons(...) before it reloads the cache to contain addons (such as eras) that are behind the #ifdef MULTIPLAYER define. It is of course impossible to find addon content before it has been loaded, which results in things like OOS errors due to unknown unit types.

Fixes #6283