### PR TITLE
Add set_cost and set_advances_to to modify_unit_type schema

### DIFF
--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -158,7 +158,9 @@
 		{REQUIRED_KEY type string}
 		{SIMPLE_KEY add_advancement string}
 		{SIMPLE_KEY remove_advancement string}
+		{SIMPLE_KEY set_advances_to string_list}
 		{SIMPLE_KEY set_experience int}
+		{SIMPLE_KEY set_cost int}
 	[/tag]
 	{DATA_TAG "world_conquest_data" 0 1 any}
 [/tag]


### PR DESCRIPTION
The proposed schema update is based on the documented attributes
on the wiki https://wiki.wesnoth.org/ModificationWML (of 2021/01/09).

The new attributes are documented as applicable since version 1.15.2.

# Issue

This is tested against the following test case:

$ cat ./modify_unit_type.cfg

    [modification]
        [modify_unit_type]
            type=Peasant
            set_experience=30
            set_cost=10
            set_advances_to=Thief,Footpad
            add_advancement=Spearman
            remove_advancement=Footpad
        [/modify_unit_type]
    [/modification]

Before commit the test fails with the output:

$ ./wesnoth --data-dir=. --validate=./modify_unit_type.cfg
Battle for Wesnoth v1.16.1+dev x86_64
Started on Sun Jan  9 14:56:33 2022

Automatically found a possible data directory at /opt/wesnoth/wesnoth.git.master/build/..
Overriding data directory with /opt/wesnoth/wesnoth.git.master
Validating ./modify_unit_type.cfg against schema /opt/wesnoth/wesnoth.git.master/data/schema/game_config.cfg
Error (strict mode, strict_level = 0): wesnoth reported on channel error validation
20220109 14:56:33 error validation: Invalid key 'set_cost=' in tag [modify_unit_type]
at ./modify_unit_type.cfg:5
20220109 14:56:33 error validation: Invalid key 'set_advances_to=' in tag [modify_unit_type]
at ./modify_unit_type.cfg:6
validation failed

# Fix

After the changes, the WML is validated ok:

$ ./wesnoth --data-dir=. --validate=./modify_unit_type.cfg
[...]
Validating ./modify_unit_type.cfg against schema /opt/wesnoth/wesnoth.git.master/data/schema/game_config.cfg
validation succeeded