### PR TITLE
UtBS S08 Kromph and Dust Devil able to trigger Eloh's event

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
        * Fast units cannot get stuck on the wall now (issue #6196)
        * Camera now moves to where the charges are blown up (issue #6197)
        * Fixed weird scout AI behaviour (issue #6196)
+     * S08: Kromph and the Dust devil now trigger a critical event (issue #6211)
      * S09: Rebels joining Kaleh’s side are now loyal (issue #6229 and #6365)
      * The last unit killed to trigger certain events should no longer linger during those events (issue #6341)
      * The Dark Assassin’s race is not revealed until uncloaked (issue #6213)

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -3011,7 +3011,8 @@
                 type=Dust Devil,Flesh Golem
             [/have_unit]
             [then]
-                # if the player only has Zhul and Kaleh, a new unit has to be recalled or respawned, else reassign. Counting Nym aswell to make sure
+                # if the player only has Zhul and Kaleh, a new unit has to be recalled or respawned, else reassign. Nym should never be
+                # on the map when this is triggered but is being counted anyway to prevent future problems.
                 [role]
                     race=quenoth,elf
                     [not]
@@ -3052,7 +3053,7 @@
                     [/else]
                 [/role]
 
-                # There will always be a talker role unit here, wheter it has been recalled or "recruited"
+                # There will always be a talker role unit here, whether it has been recalled or "recruited"
                 [store_unit]
                     [filter]
                         role=talker

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -3022,6 +3022,7 @@
                     [else]
                         [if]
                             [have_unit]
+                                search_recall_list=yes
                                 x,y=recall,recall
                                 level=1
                                 race=elf,quenoth
@@ -3033,12 +3034,19 @@
                                     level=1
                                 [/recall]
                                 [role]
-                                    x,y=19,20
+                                    race=elf,quenoth
+                                    level=1
+                                    [not]
+                                        id=Zhul,Nym,Kaleh
+                                    [/not]
                                     role=talker
                                 [/role]
                             [/then]
                             [else]
                                 {UNIT 1 (Quenoth Fighter) 19 20 (role=talker)}
+                                [+unit]
+                                    passable=yes
+                                [/unit]
                             [/else]
                         [/if]
                     [/else]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -3002,10 +3002,68 @@
             x=25-50
             y=19-31
             side=1
-            [not]
-                type=Dust Devil,Flesh Golem
-            [/not]
         [/filter]
+
+        # in case Kromph or the dust devil trigger the event the unit variable is set to track a different unit
+        [if]
+            [have_unit]
+                x,y=$x1,$y1
+                type=Dust Devil,Flesh Golem
+            [/have_unit]
+            [then]
+                # if the player only has Zhul and Kaleh, a new unit has to be recalled or respawned, else reassign. Counting Nym aswell to make sure
+                [role]
+                    race=quenoth,elf
+                    [not]
+                        id=Zhul,Nym,Kaleh
+                    [/not]
+                    search_recall_list=no
+                    role=talker
+                    [else]
+                        [if]
+                            [have_unit]
+                                x,y=recall,recall
+                                level=1
+                                race=elf,quenoth
+                            [/have_unit]
+                            [then]
+                                [recall]
+                                    race=elf,quenoth
+                                    x,y=19,20
+                                    level=1
+                                [/recall]
+                                [role]
+                                    x,y=19,20
+                                    role=talker
+                                [/role]
+                            [/then]
+                            [else]
+                                {UNIT 1 (Quenoth Fighter) 19 20 (role=talker)}
+                            [/else]
+                        [/if]
+                    [/else]
+                [/role]
+
+                # There will always be a talker role unit here, wheter it has been recalled or "recruited"
+                [store_unit]
+                    [filter]
+                        role=talker
+                    [/filter]
+                    variable=talking_unit
+                [/store_unit]
+                {VARIABLE reassigned yes}
+            [/then]
+            [else]
+                # If the unit that triggers the event is not the Dust devil nor Flesh golem (e.g. any elf)
+                [store_unit]
+                    [filter]
+                        x,y=$x1,$y1
+                    [/filter]
+                    variable=talking_unit
+                [/store_unit]
+                {VARIABLE reassigned no}
+            [/else]
+        [/if]
 
         [if]
             [have_unit]
@@ -3057,11 +3115,28 @@
             x,y=12-23,15-20
             side=1
             race=quenoth,elf
+            [not]
+                id=$talking_unit.id
+            [/not]
             message= _ "Can you see very far? Do you have any idea where we are?"
         [/message]
 
+        [if]
+            [variable]
+                name=reassigned
+                equals=yes
+            [/variable]
+            [then]
+                [move_unit]
+                    role=talker
+                    to_x=24
+                    to_y=22
+                [/move_unit]
+            [/then]
+        [/if]
+
         [message]
-            speaker=unit
+            speaker=$talking_unit.id
             message= _ "We’ve come out on the side of a mountain, overlooking a large valley. The land seems to be much the same as the foothills south of the mountains. The valley is filled with sand dunes, though the center is flat. There seems to be some sort of settlement in the center of the valley. And far to the north I can see something sparkling on the horizon, but I don’t know what it is."
         [/message]
 
@@ -3166,7 +3241,7 @@
 
             [then]
                 [message]
-                    speaker=unit
+                    speaker=$talking_unit.id
                     message= _ "Kaleh, who are you talking to?"
                 [/message]
 
@@ -3177,7 +3252,7 @@
 
                 [message]
                     speaker=Kaleh
-                    message= _ "$unit.name|, be quiet, I’ll explain it all later."
+                    message= _ "$talking_unit.name, be quiet, I’ll explain it all later."
                 [/message]
             [/then]
 
@@ -3507,6 +3582,8 @@
             name=loyalists.ogg
             immediate=yes
         [/music]
+        # Clear unnecesary variables
+        {CLEAR_VARIABLE talking_unit,reassigned,2}
     [/event]
 
     # Event 16: Nym returns


### PR DESCRIPTION
The variable talking_unit is used instead of unit to set the speaker in many messages.

The talking unit that talks on behalf of the monsters can be, in this order: An elf in the map, a recalled elf, a forcedly spawned elf (Lines 3007-3067)

That unit will move to the dunes to fit the dialogue (Lines 3124-3137)

EDIT: fixed on 061a42b:

I found that code at line 3024 was not searching for units on the recall list
Also if a unit was on 19 20 previously, it would get the talker role, even if it was not intended.
Also the unit which gets created in case everything else fails could get stuck in a wall

Another thing I found testing is that skeletons in one of the events can get stuck on the wall if you walk to their spawning positions maybe fixable on another PR.

Closes #6211 