### PR TITLE
DM S14 Smooth undead appearance and add dialogue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
      * The mercenary will now spawn in a less sudden way (issue #6183)
    * Delfador’s Memoirs
      * S07: Clarified objectives (issue #5608) and remove End Turn being required to trigger victory (issue #6173)
+     * S14: Smoother appearance of enemies and added dialogue (#6176)
    * Descent into Darkness
      * S08: Prevent possibility of Darken Volk advancing to Lich (issue #6351)
    * Heir to the Throne

--- a/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
@@ -328,10 +328,19 @@
             [/not]
         [/filter_condition]
 
-        # do not allow an elvish victory before Delfador shows up
-
-        {NAMED_UNIT 2 (Draug)   42 3 Krumful _"Krumful" (facing=sw)}
-        {NAMED_UNIT 2 (Spectre) 42 2 Unhul _"Unhul" (facing=sw)}
+        # try to impede an elvish victory before Delfador shows up
+        [message]
+            speaker=Rudimil
+            message= _ "They are too close, Krumful, Unhul, arise!"
+        [/message]
+        {NAMED_UNIT 2 (Draug)   46 2 Krumful _"Krumful" (facing=sw)}
+        [+unit]
+            animate=yes
+        [/unit]
+        {NAMED_UNIT 2 (Spectre) 44 2 Unhul _"Unhul" (facing=sw)}
+        [+unit]
+            animate=yes
+        [/unit]
     [/event]
 
     [event]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/14_Shadows.cfg
@@ -331,7 +331,7 @@
         # try to impede an elvish victory before Delfador shows up
         [message]
             speaker=Rudimil
-            message= _ "They are too close, Krumful, Unhul, arise!"
+            message= _ "The elves have advanced much further than anticipated; Krumful, Unhul, arise!"
         [/message]
         {NAMED_UNIT 2 (Draug)   46 2 Krumful _"Krumful" (facing=sw)}
         [+unit]


### PR DESCRIPTION
Please add postponed label due to string freeze.

**Changes:**
Changed the event comment (as beating the enemy leader is allowed and accounted for on lines 349+) (Line 331).
Added a dialogue to explain a bit why they are being spawned (Lines 332-335) (string could be changed before merging)
And added `animate=yes` to enemy spawning (Lines 337-339, 341-343)

Closes #6176 
