### PR TITLE
TRoW S22 Fixed the possibility of a missplaced dialogue when a bridge was broken

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
      * S08: The appearance of Naga is now smoother (issue #6140)
      * S19: The troll’s gold is automatically collected upon victory if not already obtained (issue #6141)
      * S19: Avoid units spawning over chasms
+     * S22: Fixed the possibility of a missplaced dialogue when a bridge was broken (issue #6376)
      * Remove time-runs-out lose condition for final scenario (issue #6109)
    * Under the Burning Suns
      * Avoid a few possibilities where the Dust Devil could speak (issue #4892)

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/22_The_Rise_of_Wesnoth.cfg
@@ -1282,14 +1282,37 @@
                 [redraw]
                 [/redraw]
 
-                [message]
-                    side=1
-                    [filter_location]
-                        x,y=42,30
-                        radius=8
-                    [/filter_location]
-                    message= _ "Our advance is thwarted, that monster has destroyed the bridge!"
-                [/message]
+                # Test for units to be north of the bridge in that moment. If there are none, it does not make sense
+                # to say their advance is thwarted, but it does make sense to say their retreat is.
+                [if]
+                    [have_unit]
+                        side=1
+                        [filter_location]
+                            x,y=43,24
+                            radius=6
+                        [/filter_location]
+                    [/have_unit]
+                    [then]
+                        [message]
+                            side=1
+                            [filter_location]
+                                x,y=42,30
+                                radius=8
+                            [/filter_location]
+                            message= _ "Our advance is thwarted, that monster has destroyed the bridge!"
+                        [/message]
+                    [/then]
+                    [else]
+                        [message]
+                            side=1
+                            [filter_location]
+                                x,y=42,30
+                                radius=8
+                            [/filter_location]
+                            message= _ "Our retreat is thwarted, that monster has destroyed the bridge!"
+                        [/message]
+                    [/else]
+                [/if]
 
                 [delay]
                     time=500


### PR DESCRIPTION
**New behaviour:**
When no units are in the "island" north of the bridge, "retreat" is said instead of "advance".
![advance](https://user-images.githubusercontent.com/30196839/148776235-b01b92a5-5591-41e7-ae6f-d47cb2516710.png)
![retreat](https://user-images.githubusercontent.com/30196839/148776243-c817b1ef-5c68-41af-bba2-42b79f86b6de.png)

If there are units on both sides of the bridge, (even if it is only one, minor level 1 unit) the word advance takes priority over retreat. As stated on the issue, it is such a minor possibility that it does not matter if the condition is simple, as long as it does not feel weird when the dialogue is triggered (at least, that is my opinion).

Also remember string freeze if backported.

Closes #6376