### PR TITLE
Fix Winged Sceptre bug in WC

### DIFF
--- a/data/campaigns/World_Conquest/lua/game_mechanics/effects.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/effects.lua
@@ -92,7 +92,7 @@ function wesnoth.effects.wc2_min_defense(u, cfg)
 	local defense_new = {}
 	local defense_old = wml.parsed(wml.get_child(cfg, "defense"))
 	for k,v in pairs(defense_old) do
-		if type(k) == "string" and type(v) == "number" and wesnoth.units.defense_on(u, terrain_map[k] or "") >= v then
+		if type(k) == "string" and type(v) == "number" and wesnoth.units.chance_to_be_hit(u, terrain_map[k] or "") >= v then
 			defense_new[k] = v
 		end
 	end


### PR DESCRIPTION
In the old WC here there was wesnoth.unit_defense function, so it should be wesnoth.units.chance_to_be_hit. In the current code it's wesnoth.units.defense_on which returns actual defense (50,60,40, etc), so the code checked if the defense of the unit is better than given by the artifact and worsened it.