### PR TITLE
Fix [store_unit]'s stored coordinates for recalls

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -402,7 +402,7 @@ function wml_actions.store_unit(cfg)
 			ucfg.x = 'recall'
 			ucfg.y = 'recall'
 		end
-		utils.vwriter.write(writer, u.__cfg)
+		utils.vwriter.write(writer, ucfg)
 		if kill_units then u:erase() end
 	end
 end

--- a/data/test/scenarios/put_to_recall_and_modify.cfg
+++ b/data/test/scenarios/put_to_recall_and_modify.cfg
@@ -1,10 +1,11 @@
 #textdomain wesnoth-test
 
 #####
-# API(s) being tested: [modify_unit] on the recall list, [role][auto_recall]
+# API(s) being tested: [put_to_recall_list], [modify_unit], [role][auto_recall]
 ##
 # Actions:
-# Create Charlie, belonging to side 1, on the recall list.
+# Create Charlie, belonging to side 1, on the map.
+# Repose Charlie on the recall list.
 # Assign Charlie to side 2.
 # Recall Charlie next to his side's leader.
 ##
@@ -12,27 +13,16 @@
 # Charlie is on the map next to side 2's leader.
 #####
 
-# In 1.14 and before, the implementation of [modify_unit] always stored and
-# unstored the unit. 1.15.0 introduced a "fast-path" which optimised setting
-# some attributes, but which changed the behavior of the API in some edge
-# cases; 1.16.0 disabled that fast-path.
-#
-# The store and unstore also ensured that the animation code noticed the
-# change, and the fast path meant that changes for facing or low hitpoints
-# failed to change the animation (issue 4978). However, that's a UI issue which
-# doesn't affect the API, can't be automatically tested via the WML test
-# framework, and which could be fixed during a stable branch.
-
-# In this test, changing the side of a unit on a side's recall list needs to
-# have the side-effect of moving it to the correct side's recall list.
-{GENERIC_UNIT_TEST "modify_unit_which_recall_list" (
+# This is almost the same as the modify_unit_which_recall_list test, except that
+# creating Charlie on the map can leave an on-map x,y pair in Charlie's data,
+# which needs to be handled within the WML API.
+{GENERIC_UNIT_TEST "put_to_recall_and_modify" (
     [event]
         name = start
 
-        # Create a unit on the recall list of side 1
+        # Create a unit on the map, belonging to side 1.
         [unit]
-            x=recall
-            y=recall
+            x,y=2,2
             type=Orcish Grunt
             side=1
             id=Charlie
@@ -40,6 +30,21 @@
             role=TestSubject
             canrecruit=no
         [/unit]
+
+        [put_to_recall_list]
+            id=Charlie
+        [/put_to_recall_list]
+
+        # Check Charlie has moved to the recall list. Using count=0 is equivalent to putting a
+        # [not] around the [have_unit] - using two different but equivalent syntaxes makes it
+        # easier to work out which of the two asserts failed.
+        {ASSERT (
+            [have_unit]
+                count=0
+                id=Charlie
+                search_recall_list=no
+            [/have_unit]
+        )}
 
         [modify_unit]
             side=2

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -109,6 +109,7 @@
 0 replace_schedule_prestart
 0 modify_unit_facing
 0 modify_unit_which_recall_list
+0 put_to_recall_and_modify
 0 event_handlers_in_events_1
 0 event_handlers_in_events_3
 0 event_handlers_in_events_2


### PR DESCRIPTION
Forward-port of #6296, just doing a CI run before merging.
Fixes #6295
Fixes #6315

Units on the recall list might have x,y coordinates that are on the map, which
therefore need to be replaced with "recall,recall" within [store_unit]. The
existing code created a temporary variable, changed the coordinates, and then
returned the unchanged original instead of the temporary.

Add a new test that `[put_to_recall_list]` followed by `[modify_unit]`
doesn't move the unit back to the map.

(cherry picked from commit 096d8aba1474e9c6583d240e7eedbcd66957f327)