### PR TITLE
HttT S04, S05b & S06 Role code enhancement

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -643,16 +643,10 @@
             message= _ "At last, we have freed the merfolk. Go back to the ocean and live in peace."
         [/message]
 #define MERMAN_SPEAKS
-    [role]
-        role=ThankfulMerman
-        search_recall_list=no
-
+    [message]
         type="Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
             "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
             "Merman Fighter,Merman Hunter,Mermaid Initiate"
-    [/role]
-    [message]
-        role=ThankfulMerman
         message= _ "My lord! You may need the help of some of us who have skill in the sea in future. We would like to come with you and offer you help."
     [/message]
 #enddef
@@ -715,17 +709,11 @@
             message= _ "But Delfador! I can’t do it on my own!"
         [/message]
 
-        [role]
-            role=Supporter
-            search_recall_list=no
-
+        [message]
             type="Elvish Sylph,Great Mage,"+
                 "Elvish Marshal,Elvish Champion,Elvish Avenger,Elvish Sharpshooter,Elvish Shyde,Elvish Enchantress,Elvish Outrider,Paladin,Grand Knight,Mage of Light,Arch Mage,Silver Mage,"+
                 "Elvish Captain,Elvish Hero,Elvish Ranger,Elvish Marksman,Elvish Druid,Elvish Sorceress,Elvish Rider,Knight,Lancer,White Mage,Red Mage,"+
                 "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout,Horseman,Mage"
-        [/role]
-        [message]
-            role=Supporter
             message= _ "On your own? My lord! We, your loyal soldiers, will support you!"
         [/message]
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -57,11 +57,8 @@
 
             type="Elvish Sylph,Great Mage," +
                 "Elvish Marshal,Elvish Champion,Elvish Avenger,Elvish Sharpshooter,Elvish Shyde,Elvish Enchantress,Elvish Outrider,Paladin,Grand Knight,Mage of Light,Arch Mage,Silver Mage," +
-                "Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
                 "Elvish Captain,Elvish Hero,Elvish Ranger,Elvish Marksman,Elvish Druid,Elvish Sorceress,Elvish Rider,Knight,Lancer,White Mage,Red Mage," +
-                "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
-                "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout,Horseman,Mage," +
-                "Merman Fighter,Merman Hunter,Mermaid Initiate"
+                "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout,Horseman,Mage"
             [else]
                 [unit]
                     side=1

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -147,6 +147,43 @@
         {UNDERGROUND}
     [/time_area]
 
+#define ADVISOR
+    [role]
+        role=Advisor
+        [auto_recall][/auto_recall]
+
+        type="Elvish Sylph,Great Mage," +
+
+            "Elvish Marshal,Elvish Champion,Elvish Avenger,Elvish Sharpshooter,Elvish Shyde,Elvish Enchantress,Elvish Outrider," +
+            "Paladin,Grand Knight," +
+            "Mage of Light,Arch Mage,Silver Mage," +
+            "Highwayman,Fugitive,Huntsman,Ranger," +
+
+            "Elvish Captain,Elvish Hero,Elvish Ranger,Elvish Marksman,Elvish Druid,Elvish Sorceress,Elvish Rider," +
+            "Knight,Lancer," +
+            "White Mage,Red Mage," +
+            "Bandit,Outlaw,Trapper," +
+
+            "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout," +
+            "Horseman," +
+            "Mage," +
+            "Thug,Footpad,Poacher" +
+
+            # Merfolk at the bottom because they are not as useful as the other options with this castle placement.
+            "Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
+            "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
+            "Merman Fighter,Merman Hunter,Mermaid Initiate," 
+        [else]
+            [unit]
+                side=1
+                type=Elvish Fighter
+                role=Advisor
+                placement=leader
+            [/unit]
+        [/else]
+    [/role]
+#enddef
+
     [event]
         name=prestart
 
@@ -164,40 +201,6 @@
         {STORE_DELFADOR}
         {STORE_KALENZ}
 
-#define ADVISOR
-    [role]
-        role=Advisor
-        [auto_recall][/auto_recall]
-
-        type="Elvish Sylph,Great Mage," +
-
-            "Elvish Marshal,Elvish Champion,Elvish Avenger,Elvish Sharpshooter,Elvish Shyde,Elvish Enchantress,Elvish Outrider," +
-            "Paladin,Grand Knight," +
-            "Mage of Light,Arch Mage,Silver Mage," +
-            "Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
-            "Highwayman,Fugitive,Huntsman,Ranger," +
-
-            "Elvish Captain,Elvish Hero,Elvish Ranger,Elvish Marksman,Elvish Druid,Elvish Sorceress,Elvish Rider," +
-            "Knight,Lancer," +
-            "White Mage,Red Mage," +
-            "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
-            "Bandit,Outlaw,Trapper," +
-
-            "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout," +
-            "Horseman," +
-            "Mage," +
-            "Merman Fighter,Merman Hunter,Mermaid Initiate," +
-            "Thug,Footpad,Poacher"
-        [else]
-            [unit]
-                side=1
-                type=Elvish Fighter
-                role=Advisor
-                placement=leader
-            [/unit]
-        [/else]
-    [/role]
-#enddef
         {ADVISOR}
     [/event]
 

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -167,7 +167,7 @@
             "Elvish Fighter,Elvish Archer,Elvish Shaman,Elvish Scout," +
             "Horseman," +
             "Mage," +
-            "Thug,Footpad,Poacher" +
+            "Thug,Footpad,Poacher," +
 
             # Merfolk at the bottom because they are not as useful as the other options with this castle placement.
             "Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +

--- a/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/06_The_Siege_of_Elensefar.cfg
@@ -172,7 +172,7 @@
             # Merfolk at the bottom because they are not as useful as the other options with this castle placement.
             "Merman Triton,Merman Hoplite,Merman Javelineer,Merman Entangler,Mermaid Diviner,Mermaid Siren," +
             "Merman Warrior,Merman Spearman,Merman Netcaster,Mermaid Priestess,Mermaid Enchantress," +
-            "Merman Fighter,Merman Hunter,Mermaid Initiate," 
+            "Merman Fighter,Merman Hunter,Mermaid Initiate"
         [else]
             [unit]
                 side=1


### PR DESCRIPTION
>S04 assigns a unit as role=Supporter, which is used exactly once, in a [message] immediately after the assignment. The list isn't quite the same as the later scenarios' role=Advisor, as it includes no merfolk (and in S04 it shouldn't), but it seems odd to only use it once.

Now `type` is used inside `[message]` to avoid assigning a role used only once.

> S05a seems okay. It assigns role=Advisor along with [auto_recall][/auto_recall] even though the role hasn't been assigned in a previous scenario; however in this case it's in a prestart event and the [role] tag will search the recall list, so auto_recall makes sense. The type= list includes merfolk, but that's okay as the starting encampment is on a beach.

Agreed, S05a uses it properly.

> S05b also assigns role=Advisor, and again includes merfolk in the type= list. The ISLE_GALLEON_ARRIVE macro will put the Advisor on-board the galleon, even if the Advisor is a merfolk. Worse, if the Advisor is a merfolk then the unit will be killed and not replaced with a copy from iotd_recall_store. If a merfolk gets the role then the player has probably already lost the campaign anyway (army too weak for S06), but while we're testing code changes for this issue then it's something that could be fixed along the way.

Merfolk will now be unable to be the hidden advisors in S05b.

> S06 has #define ADVISOR in the middle of an event. It works, but seems a bad coding style and messes up the indentation. Recalling a merfolk with full moves on turn 1 does give some time to get them in the water, but it still doesn't seem the best choice for the starting encampment.

Moved the define outside, changed the priority list of the advisor (so merfolk will be a last resort).

Closes #6388 

