### PR TITLE
NR S01 Solve OOS by moving code to synced event

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -341,15 +341,6 @@
     [event]
         name=enemies defeated
 
-        [endlevel]
-            bonus=yes
-            {NEW_GOLD_CARRYOVER 40}
-        [/endlevel]
-    [/event]
-
-    [event]
-        name=victory
-
         [message]
             speaker=Tallin
             message= _ "<i>Yes</i>! We did it! We are free!"
@@ -392,6 +383,11 @@
         [/move_unit_fake]
 
         [redraw][/redraw]
+
+        [endlevel]
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 40}
+        [/endlevel]
     [/event]
 
     # Death events


### PR DESCRIPTION
[This](https://wiki.wesnoth.org/EventWML#Multiplayer_safety) says the victory event is unsynced so I just moved the code to the enemies defeated event. Tested that everything works the same and replay goes all the way without OOSs.

Closes #6268 