### PR TITLE
UtBS S08 OOS and wall-stuck units fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
        * Fast units cannot get stuck on the wall now (issue #6196)
        * Camera now moves to where the charges are blown up (issue #6197)
        * Fixed weird scout AI behaviour (issue #6196)
+     * S08: Fixed OOS error on victory (issue #6267)
      * S09: Rebels joining Kaleh’s side are now loyal (issue #6229 and #6365)
      * The last unit killed to trigger certain events should no longer linger during those events (issue #6341)
      * The Dark Assassin’s race is not revealed until uncloaked (issue #6213)

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -870,7 +870,7 @@
             image_mods={ARMOR_SHIFT_IPF}
         [/move_unit_fake]
 
-        {NAMED_UNIT 2 (Javelineer) 33 44 (Bellerin) ( _ "Bellerin") (upkeep,role,facing=free,human_scout,sw)}
+        {NAMED_UNIT 2 (Javelineer) 33 44 (Bellerin) ( _ "Bellerin") (upkeep,role,facing=free,human_scout,sw)}{PASSABLE_HEX}
 
         [move_unit_fake]
             type=Halberdier
@@ -890,7 +890,7 @@
             image_mods={ARMOR_SHIFT_IPF}
         [/move_unit_fake]
 
-        {NAMED_UNIT 2 {ON_DIFFICULTY (Longbowman) (Longbowman) (Master Bowman)} 34 43 (Othgar) ( _ "Othgar") (upkeep,role,facing=free,human_scout,sw)}
+        {NAMED_UNIT 2 {ON_DIFFICULTY (Longbowman) (Longbowman) (Master Bowman)} 34 43 (Othgar) ( _ "Othgar") (upkeep,role,facing=free,human_scout,sw)}{PASSABLE_HEX}
 
         [message]
             speaker=Durth

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -2116,7 +2116,7 @@
         name=moveto
 
         [filter]
-            x=5-10
+            x=4-10
             y=32-37
             side=1
             [not]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -205,6 +205,12 @@
     # add more dirt at easier difficulties
     # set starting scenario objectives
 
+#define PASSABLE_HEX
+    # Adds passable attribute to a unit
+    [+unit]
+        passable=yes
+    [/unit]
+#enddef
     [event]
         name=prestart
 
@@ -1800,7 +1806,7 @@
             [/not]
 
             [then]
-                {NAMED_UNIT 3 (Ghost) 9 43 (Novice Pior) ( _ "Novice Pior") (upkeep=free)}
+                {NAMED_UNIT 3 (Ghost) 9 43 (Novice Pior) ( _ "Novice Pior") (upkeep=free)}{PASSABLE_HEX}
                 [+unit]
                     animate=yes
                 [/unit]
@@ -1845,21 +1851,21 @@
 
         {CLEAR_VARIABLE explorer}
 
-        {NAMED_UNIT 3 (Skeleton) 15 40 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
-        {NAMED_UNIT 3 (Bone Shooter) 14 36 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Skeleton) 15 40 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
+        {NAMED_UNIT 3 (Bone Shooter) 14 36 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 
 #ifdef HARD
-        {NAMED_UNIT 3 (Deathblade) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Deathblade) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #else
-        {NAMED_UNIT 3 (Revenant) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Revenant) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #endif
 
 #ifdef HARD
-        {NAMED_UNIT 3 (Bone Shooter) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Bone Shooter) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #endif
 
 #ifdef NORMAL
-        {NAMED_UNIT 3 (Skeleton Archer) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Skeleton Archer) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #endif
 
         [message]
@@ -1990,7 +1996,7 @@
 
         {CLEAR_VARIABLE unitstats}
 
-        {NAMED_UNIT 3 (Crab Man) 17 32 (Failed Experiment 1) ( _ "Failed Experiment") (upkeep=free)}
+        {NAMED_UNIT 3 (Crab Man) 17 32 (Failed Experiment 1) ( _ "Failed Experiment") (upkeep=free)}{PASSABLE_HEX}
         {NAMED_UNIT 3 (Young Ogre) 19 32 (Failed Experiment 2) ( _ "Failed Experiment") (upkeep=free)}
 
         [message]
@@ -2179,10 +2185,10 @@
             [redraw]
             [/redraw]
 
-            {NAMED_UNIT 3 (Ixthala Demon) 5 35 (Ancient Guardian 1) ( _ "Ancient Guardian") (upkeep=free)}
-            {NAMED_UNIT 3 (Ixthala Demon) 8 33 (Ancient Guardian 2) ( _ "Ancient Guardian") (upkeep=free)}
+            {NAMED_UNIT 3 (Ixthala Demon) 5 35 (Ancient Guardian 1) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
+            {NAMED_UNIT 3 (Ixthala Demon) 8 33 (Ancient Guardian 2) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
 #ifdef HARD
-            {NAMED_UNIT 3 (Ixthala Demon) 5 33 (Ancient Guardian 3) ( _ "Ancient Guardian") (upkeep=free)}
+            {NAMED_UNIT 3 (Ixthala Demon) 5 33 (Ancient Guardian 3) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
 #endif
             [message]
                 speaker=Ancient Guardian 1
@@ -3502,6 +3508,277 @@
             [/fire_event]
         [/event]
 
+        # child event that can only trigger once Durstrag is defeated
+        [event]
+            name=enemies defeated
+
+            # reveal map in-between starting valley and location elves move to
+            [remove_shroud]
+                x=45-60
+                y=1-6
+                side=1
+            [/remove_shroud]
+
+            [teleport]
+                [filter]
+                    id=Kaleh
+                [/filter]
+                x,y=61,6
+            [/teleport]
+
+            [teleport]
+                [filter]
+                    id=Zhul
+                [/filter]
+                x,y=63,5
+            [/teleport]
+
+            [teleport]
+                [filter]
+                    id=$ally_id
+                [/filter]
+                x,y=60,6
+            [/teleport]
+
+            [store_unit]
+                [filter]
+                    id=Nym
+                [/filter]
+                kill=yes
+                variable=Nymstats
+            [/store_unit]
+
+            {UNIT 1 (Quenoth Fighter) 66 2 (id,upkeep,generate_name=Dummy Unit1,free,no)}
+            {UNIT 1 (Quenoth Fighter) 57 3 (id,upkeep,generate_name=Dummy Unit2,free,no)}
+            {UNIT 1 (Quenoth Scout) 65 3 (id,upkeep,generate_name=Dummy Unit3,free,no)}
+            {UNIT 1 (Quenoth Scout) 59 2 (id,upkeep,generate_name=Dummy Unit4,free,no)}
+            {UNIT 1 (Quenoth Scout) 58 5 (id,upkeep,generate_name=Dummy Unit5,free,no)}
+            {UNIT 1 (Quenoth Mystic) 62 2 (id,upkeep,generate_name=Dummy Unit6,free,no)}
+
+            [scroll_to_unit]
+                id=Kaleh
+            [/scroll_to_unit]
+
+            [delay]
+                time=500
+            [/delay]
+
+            [message]
+                speaker=narrator
+                message= _ "Several hours pass..."
+                image=wesnoth-icon.png
+            [/message]
+
+            {UNIT 1 (Quenoth Scout) 59 2 (id,upkeep,name=Dummy Unit7,free,_ "Jezhar")}
+            {MOVE_UNIT (id=Dummy Unit7) 66 2}
+            [message]
+                speaker=Dummy Unit7
+                message= _ "Eastern scouts, reporting back! If you like sand and hot dust, there’s plenty more out there! No water, or signs of others, we had to turn back."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "No shame in that, Jezhar. Of all the scouts, only Tanstafaal and Nym have yet to return."
+            [/message]
+
+            [message]
+                speaker=Zhul
+                message= _ "And that has me worried. What if-"
+            [/message]
+
+            [move_unit_fake]
+                type=$Nymstats.type
+                gender=female
+                side=1
+                x=51,52,53,54,55,56,57,57,58,59,60,60
+                y=1,1,1,1,1,1,1,2,2,2,2,3
+            [/move_unit_fake]
+
+            [set_variable]
+                name=Nymstats.hitpoints
+                value=12
+            [/set_variable]
+
+            [unstore_unit]
+                variable=Nymstats
+                x,y=60,3
+            [/unstore_unit]
+
+            {CLEAR_VARIABLE Nymstats}
+
+            [message]
+                speaker=Zhul
+                message= _ "In Eloh’s name, Nym, you look terrible. Are you well?"
+            [/message]
+
+            [message]
+                speaker=Nym
+                message= _ "Yes. Just... let me... catch... my breath."
+            [/message]
+
+            [delay]
+                time=100
+            [/delay]
+
+            [move_unit_fake]
+                type=Merman Netcaster
+                side=1
+                x=51,52,53,54,55,56,57,58,59,59,60
+                y=1,1,1,1,2,1,2,2,3,4,4
+            [/move_unit_fake]
+
+            [unit]
+                type=Merman Netcaster
+                id=Esanoo
+                name= _ "Esanoo"
+                hitpoints=10
+                x=60
+                y=4
+                side=1
+                unrenamable=yes
+                [modifications]
+                    {TRAIT_LOYAL}
+                    {TRAIT_RESILIENT}
+                [/modifications]
+            [/unit]
+
+            [delay]
+                time=200
+            [/delay]
+
+            [message]
+                speaker=Esanoo
+                message= _ "Water. Sweet water. By the gods, I thought my scales would fall off."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "What in Uria’s name is that?"
+            [/message]
+
+            [message]
+                speaker=Nym
+                message= _ "Relax, he’s a friend. Just let me explain."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "You’re really beat up, Nym. Are you sure you’re fine?"
+            [/message]
+
+            [message]
+                speaker=Nym
+                message= _ "I’m fine. But I found someone who really wanted to speak with you."
+            [/message]
+
+            [message]
+                speaker=$ally_id
+                message= _ "He looks like a half-man half-fish."
+            [/message]
+
+            [message]
+                speaker=Esanoo
+                message= _ "Indeed. I come from the ocean, and long have I been looking for you."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "The ocean? What are you talking about?"
+            [/message]
+
+            [message]
+                speaker=Nym
+                message= _ "Don’t try to explain, Esanoo. We’ll have to show them instead."
+            [/message]
+
+            # original dialog makes extensive use of "my master" for Esanoo, which might makes sense for a goblin, but seems a bit off here
+            # I went with "wise leader", can probably be improved
+            [message]
+                speaker=Esanoo
+                message= _ "It’s not important. What’s important is that I am an emissary from one who much desires to speak with you, Kaleh. Despite the danger, our wise leader sent me and my brethren to scour the dry land searching for you."
+            [/message]
+
+            [message]
+                speaker=Zhul
+                message= _ "There are more of you? Where are the others?"
+            [/message]
+
+            [message]
+                speaker=Esanoo
+                message= _ "They have been captured by the foul humans. I just barely managed to hide and escape, with the help of your friend."
+            [/message]
+
+            [message]
+                speaker=Zhul
+                message= _ "And why should we trust anything you say?"
+            [/message]
+
+            [message]
+                speaker=Esanoo
+                message= _ "Our leader thought you might be suspicious. She said that what we must talk with you about concerns the fate of your people. Apparently it concerns ‘Yechnagoth’ and ‘Zhangor’. She said that you would understand, Kaleh."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "Hmmmm... Yes, yes I think I do. I don’t know why, but I trust you."
+            [/message]
+
+            [message]
+                speaker=Esanoo
+                message= _ "Thank you, Kaleh. Now I have a favor to ask of you. Our instructions were to find you and to bring you and your people to meet with our wise leader. The problem is that I don’t know where she is hiding."
+            [/message]
+
+            [message]
+                speaker=Zhul
+                message= _ "You don’t know where to find your master?"
+            [/message]
+
+            [message]
+                speaker=Esanoo
+                message= _ "It’s complicated, and I don’t know how much I am allowed to tell you. My people are fighting a desperate war against... against a powerful foe. Many times our enemy has tried to assassinate our wise leader, so she worried that her presence was a danger to the rest of us. So right after she sent us on our mission she went into hiding. I am the youngest member of our group, and so I wasn’t told the location. You must understand, there are spies everywhere. Only the leaders of our group knew, but the rest of them were all captured by those foul humans. They are being held in the settlement to the north. If we are to have any chance of finding our wise leader, we must first rescue them. I would do it myself, but..."
+            [/message]
+
+            [message]
+                speaker=Nym
+                message= _ "...It would be suicide for you to try to rescue them alone. Of course we will help you!"
+            [/message]
+
+            [message]
+                speaker=Esanoo
+                message= _ "Thank you, Nym. I am not very good at fighting on the dry ground."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "With you back, Nym, the only scouts yet to return are Tanstafaal’s group."
+            [/message]
+
+            [message]
+                speaker=Nym
+                message= _ "They were sent due north. From Esanoo’s description it sounds like they were headed right for the human settlement. I hope nothing bad has happened to them."
+            [/message]
+
+            [message]
+                speaker=Kaleh
+                message= _ "Things are coming to a head, Tanstafaal and our new friends are in trouble. Time is of the essence, so let’s move out as soon as possible."
+            [/message]
+
+            [kill]
+                id=Dummy Unit1,Dummy Unit2,Dummy Unit3,Dummy Unit4,Dummy Unit5,Dummy Unit6,Dummy Unit7
+                animate=no
+            [/kill]
+
+            {CLEAR_VARIABLE healing_rune1,healing_rune2}
+
+            {CLEAR_VARIABLE messenger_timer,messengers_incoming}
+
+            {CLEAR_VARIABLE ally_unit}
+            [endlevel]
+                result=victory
+                bonus=yes
+                {NEW_GOLD_CARRYOVER 40}
+            [/endlevel]
+        [/event]
         # change the music playing
         [music]
             name=loyalists.ogg
@@ -4035,12 +4312,6 @@
             speaker=Kaleh
             message= _ "Good, until then we’ll settle around that oasis and set up as good a defense as we can. Until I know what’s out there, I’m not taking any chances."
         [/message]
-
-        [endlevel]
-            result=victory
-            bonus=yes
-            {NEW_GOLD_CARRYOVER 40}
-        [/endlevel]
     [/event]
 
     # Flooding algorithm
@@ -4258,274 +4529,6 @@
             speaker=Kaleh
             message= _ "I can see human reinforcements arriving on the horizon. We’ll surely be overwhelmed now! If only we had moved faster."
         [/message]
-    [/event]
-
-    #victory event
-
-    [event]
-        name=victory
-
-        # reveal map in-between starting valley and location elves move to
-        [remove_shroud]
-            x=45-60
-            y=1-6
-            side=1
-        [/remove_shroud]
-
-        [teleport]
-            [filter]
-                id=Kaleh
-            [/filter]
-            x,y=61,6
-        [/teleport]
-
-        [teleport]
-            [filter]
-                id=Zhul
-            [/filter]
-            x,y=63,5
-        [/teleport]
-
-        [teleport]
-            [filter]
-                id=$ally_id
-            [/filter]
-            x,y=60,6
-        [/teleport]
-
-        [store_unit]
-            [filter]
-                id=Nym
-            [/filter]
-            kill=yes
-            variable=Nymstats
-        [/store_unit]
-
-        {UNIT 1 (Quenoth Fighter) 66 2 (id,upkeep,generate_name=Dummy Unit1,free,no)}
-        {UNIT 1 (Quenoth Fighter) 57 3 (id,upkeep,generate_name=Dummy Unit2,free,no)}
-        {UNIT 1 (Quenoth Scout) 65 3 (id,upkeep,generate_name=Dummy Unit3,free,no)}
-        {UNIT 1 (Quenoth Scout) 59 2 (id,upkeep,generate_name=Dummy Unit4,free,no)}
-        {UNIT 1 (Quenoth Scout) 58 5 (id,upkeep,generate_name=Dummy Unit5,free,no)}
-        {UNIT 1 (Quenoth Mystic) 62 2 (id,upkeep,generate_name=Dummy Unit6,free,no)}
-
-        [scroll_to_unit]
-            id=Kaleh
-        [/scroll_to_unit]
-
-        [delay]
-            time=500
-        [/delay]
-
-        [message]
-            speaker=narrator
-            message= _ "Several hours pass..."
-            image=wesnoth-icon.png
-        [/message]
-
-        {UNIT 1 (Quenoth Scout) 59 2 (id,upkeep,name=Dummy Unit7,free,_ "Jezhar")}
-        {MOVE_UNIT (id=Dummy Unit7) 66 2}
-        [message]
-            speaker=Dummy Unit7
-            message= _ "Eastern scouts, reporting back! If you like sand and hot dust, there’s plenty more out there! No water, or signs of others, we had to turn back."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "No shame in that, Jezhar. Of all the scouts, only Tanstafaal and Nym have yet to return."
-        [/message]
-
-        [message]
-            speaker=Zhul
-            message= _ "And that has me worried. What if-"
-        [/message]
-
-        [move_unit_fake]
-            type=$Nymstats.type
-            gender=female
-            side=1
-            x=51,52,53,54,55,56,57,57,58,59,60,60
-            y=1,1,1,1,1,1,1,2,2,2,2,3
-        [/move_unit_fake]
-
-        [set_variable]
-            name=Nymstats.hitpoints
-            value=12
-        [/set_variable]
-
-        [unstore_unit]
-            variable=Nymstats
-            x,y=60,3
-        [/unstore_unit]
-
-        {CLEAR_VARIABLE Nymstats}
-
-        [message]
-            speaker=Zhul
-            message= _ "In Eloh’s name, Nym, you look terrible. Are you well?"
-        [/message]
-
-        [message]
-            speaker=Nym
-            message= _ "Yes. Just... let me... catch... my breath."
-        [/message]
-
-        [delay]
-            time=100
-        [/delay]
-
-        [move_unit_fake]
-            type=Merman Netcaster
-            side=1
-            x=51,52,53,54,55,56,57,58,59,59,60
-            y=1,1,1,1,2,1,2,2,3,4,4
-        [/move_unit_fake]
-
-        [unit]
-            type=Merman Netcaster
-            id=Esanoo
-            name= _ "Esanoo"
-            hitpoints=10
-            x=60
-            y=4
-            side=1
-            unrenamable=yes
-            [modifications]
-                {TRAIT_LOYAL}
-                {TRAIT_RESILIENT}
-            [/modifications]
-        [/unit]
-
-        [delay]
-            time=200
-        [/delay]
-
-        [message]
-            speaker=Esanoo
-            message= _ "Water. Sweet water. By the gods, I thought my scales would fall off."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "What in Uria’s name is that?"
-        [/message]
-
-        [message]
-            speaker=Nym
-            message= _ "Relax, he’s a friend. Just let me explain."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "You’re really beat up, Nym. Are you sure you’re fine?"
-        [/message]
-
-        [message]
-            speaker=Nym
-            message= _ "I’m fine. But I found someone who really wanted to speak with you."
-        [/message]
-
-        [message]
-            speaker=$ally_id
-            message= _ "He looks like a half-man half-fish."
-        [/message]
-
-        [message]
-            speaker=Esanoo
-            message= _ "Indeed. I come from the ocean, and long have I been looking for you."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "The ocean? What are you talking about?"
-        [/message]
-
-        [message]
-            speaker=Nym
-            message= _ "Don’t try to explain, Esanoo. We’ll have to show them instead."
-        [/message]
-
-        # original dialog makes extensive use of "my master" for Esanoo, which might makes sense for a goblin, but seems a bit off here
-        # I went with "wise leader", can probably be improved
-        [message]
-            speaker=Esanoo
-            message= _ "It’s not important. What’s important is that I am an emissary from one who much desires to speak with you, Kaleh. Despite the danger, our wise leader sent me and my brethren to scour the dry land searching for you."
-        [/message]
-
-        [message]
-            speaker=Zhul
-            message= _ "There are more of you? Where are the others?"
-        [/message]
-
-        [message]
-            speaker=Esanoo
-            message= _ "They have been captured by the foul humans. I just barely managed to hide and escape, with the help of your friend."
-        [/message]
-
-        [message]
-            speaker=Zhul
-            message= _ "And why should we trust anything you say?"
-        [/message]
-
-        [message]
-            speaker=Esanoo
-            message= _ "Our leader thought you might be suspicious. She said that what we must talk with you about concerns the fate of your people. Apparently it concerns ‘Yechnagoth’ and ‘Zhangor’. She said that you would understand, Kaleh."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "Hmmmm... Yes, yes I think I do. I don’t know why, but I trust you."
-        [/message]
-
-        [message]
-            speaker=Esanoo
-            message= _ "Thank you, Kaleh. Now I have a favor to ask of you. Our instructions were to find you and to bring you and your people to meet with our wise leader. The problem is that I don’t know where she is hiding."
-        [/message]
-
-        [message]
-            speaker=Zhul
-            message= _ "You don’t know where to find your master?"
-        [/message]
-
-        [message]
-            speaker=Esanoo
-            message= _ "It’s complicated, and I don’t know how much I am allowed to tell you. My people are fighting a desperate war against... against a powerful foe. Many times our enemy has tried to assassinate our wise leader, so she worried that her presence was a danger to the rest of us. So right after she sent us on our mission she went into hiding. I am the youngest member of our group, and so I wasn’t told the location. You must understand, there are spies everywhere. Only the leaders of our group knew, but the rest of them were all captured by those foul humans. They are being held in the settlement to the north. If we are to have any chance of finding our wise leader, we must first rescue them. I would do it myself, but..."
-        [/message]
-
-        [message]
-            speaker=Nym
-            message= _ "...It would be suicide for you to try to rescue them alone. Of course we will help you!"
-        [/message]
-
-        [message]
-            speaker=Esanoo
-            message= _ "Thank you, Nym. I am not very good at fighting on the dry ground."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "With you back, Nym, the only scouts yet to return are Tanstafaal’s group."
-        [/message]
-
-        [message]
-            speaker=Nym
-            message= _ "They were sent due north. From Esanoo’s description it sounds like they were headed right for the human settlement. I hope nothing bad has happened to them."
-        [/message]
-
-        [message]
-            speaker=Kaleh
-            message= _ "Things are coming to a head, Tanstafaal and our new friends are in trouble. Time is of the essence, so let’s move out as soon as possible."
-        [/message]
-
-        [kill]
-            id=Dummy Unit1,Dummy Unit2,Dummy Unit3,Dummy Unit4,Dummy Unit5,Dummy Unit6,Dummy Unit7
-            animate=no
-        [/kill]
-
-        {CLEAR_VARIABLE healing_rune1,healing_rune2}
-
-        {CLEAR_VARIABLE messenger_timer,messengers_incoming}
-
-        {CLEAR_VARIABLE ally_unit}
     [/event]
 
     # set time for all underground areas to be always night/underground


### PR DESCRIPTION
Addresses my comment on #6428:
> Another thing I found testing is that skeletons in one of the events can get stuck on the wall if you walk to their spawning positions maybe fixable on another PR.

13 units could get stuck in a wall if you knew where they would spawn (and had quick sun sylphs), now they will not (fixed the same way #6357 was fixed, lines 873, 893, etc.). 
Image below is an exaggeration (but was possible with enough sun sylphs).
![wall](https://user-images.githubusercontent.com/30196839/149175043-801d77c0-5cb0-4dbf-b147-4309ee267267.png)

Also you could get past a trigger (without using debug mode line 2119).
Fixed OOS at victory (similar to how #6438 was fixed, lines 3511-3781).

I'll open a PR once this is merged to add {PASSABLE_HEX} to unit-utils and remove it from TRoW S19 and here.

Closes #6267 