### PR TITLE
[new feature 1.17] create a filter_distant for detect unit distant and test if enemy or not( more simple what filter_location)

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -137,21 +137,15 @@
     [/dummy]
 #enddef
 
-#define ABILITY_SHADOW_VEIL_HELPER SIDE
+#define ABILITY_SHADOW_VEIL_HELPER
     [hides]
         id=did_shadow_veil_helper
         [filter]
-            [filter_location]
+            [filter_distant]
                 radius=5
-                [filter]
-                    ability=did_shadow_veil
-                    [filter_side]
-                        [allied_with]
-                            side={SIDE}
-                        [/allied_with]
-                    [/filter_side]
-                [/filter]
-            [/filter_location]
+                is_enemy=no
+                ability=did_shadow_veil
+            [/filter_distant]
         [/filter]
     [/hides]
 #enddef
@@ -189,7 +183,7 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $unit.side}
+                        {ABILITY_SHADOW_VEIL_HELPER}
                     [/abilities]
                 [/effect]
             [/object]
@@ -224,7 +218,7 @@
                 [effect]
                     apply_to=new_ability
                     [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $this_unit.side}
+                        {ABILITY_SHADOW_VEIL_HELPER}
                     [/abilities]
                 [/effect]
             [/object]

--- a/data/schema/filters/unit.cfg
+++ b/data/schema/filters/unit.cfg
@@ -44,6 +44,7 @@
 	{FILTER_TAG "has_attack" weapon ()}
 	{FILTER_TAG "filter_vision" vision ()}
 	{FILTER_TAG "filter_adjacent" adjacent ()}
+	{FILTER_TAG "filter_distant" distant ()}
 	{FILTER_TAG "filter_location" location ()}
 	{FILTER_TAG "filter_side" side ()}
 	{FILTER_BOOLEAN_OPS unit}
@@ -55,5 +56,14 @@
 	super="$filter_unit"
 	{SIMPLE_KEY count s_range_list}
 	{SIMPLE_KEY adjacent dir_list}
+	{SIMPLE_KEY is_enemy s_bool}
+[/tag]
+
+[tag]
+	name="$filter_distant"
+	max=0
+	super="$filter_unit"
+	{SIMPLE_KEY radius s_int}
+	{SIMPLE_KEY count s_range_list}
 	{SIMPLE_KEY is_enemy s_bool}
 [/tag]


### PR DESCRIPTION


use a "filter_distant" equivalent ot "filter_adjacent" is simplest to write and more dynamic what [filter_location] because is it no more necessary to specifie side of unit.

More intessting for encode events in unit_type or [+abilities] with presence of allies or enemies unit in radius.