### PR TITLE
Support [foreach]array=this_item, nested loops using the default name

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/ConditionalActionsWML/nested_foreach.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/ConditionalActionsWML/nested_foreach.cfg
@@ -1,0 +1,49 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [foreach],[foreach]array=this_item
+#
+# The [foreach] loop implements local-scoping for the variables this_item and i.
+# This tests the behavior when looping over an array that is itself called this_item.
+##
+# Actions:
+# Simulate storing a unit with heals+4 to a variable.
+# Boost the strength of the healing ability.
+##
+# Expected end state:
+# The unit's healing ability is heals+8.
+#####
+{GENERIC_UNIT_TEST foreach_mutate_nested (
+    [event]
+        name=start
+
+        # A small subset of the result of storing a unit to a variable
+        {VARIABLE u.abilities[0].regenerate.value 4}
+        {VARIABLE u.abilities[1].heals.value 4}
+
+        # This makes the length of the inner this_item different to that of
+        # the outer this_item, to test that the sanity check for external
+        # modification isn't triggered by the matching names.
+        {VARIABLE u.abilities[1].heals.test_attribute 4}
+
+        [foreach]
+            array=u.abilities
+            [do]
+                [foreach]
+                    array=this_item.heals
+                    [do]
+                        [set_variable]
+                            name=this_item.value
+                            value=8
+                        [/set_variable]
+                    [/do]
+                [/foreach]
+            [/do]
+        [/foreach]
+
+        {ASSERT ({VARIABLE_CONDITIONAL u.abilities[0].regenerate.value equals 4})}
+        {ASSERT ({VARIABLE_CONDITIONAL u.abilities[1].heals.value equals 8})}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -398,6 +398,7 @@
 0 for_end2_step2
 0 for_end-2
 0 for_end-2_step-2
+0 foreach_mutate_nested
 # AI Config Parsing tests
 0 test_basic_simplified_aspect
 0 test_basic_abbreviated_aspect


### PR DESCRIPTION
Since a0ee38a49, the inner this_item was still in scope when the inner loop
writes changed data back to the outer loop's variable, which meant that
changes were silently ignored.

A lot of the changes in wml-flow.lua are just indentation because of the
extra block.

Extend the unit test for scoped variables, which includes fixing the mixed
tab-and-space indentation in that file.

Fixes #6305. I'm dithering about whether to say it's a bugfix and should go
in 1.16, or say that it's unimportant enough to only go in 1.17.