### PR TITLE
Fix the po stats script to recognise "es_419"

### DIFF
--- a/utils/po_stat.py
+++ b/utils/po_stat.py
@@ -103,7 +103,7 @@ def write_percentage_wml(wml_file, percent):
 
 
 def get_wml_cfg(wml_dir, locale):
-    match = re.match(r'([a-z]+)(_([A-Z]+))?(@([a-z]+))?', locale)
+    match = re.match(r'([a-z]+)(_([A-Z0-9]+))?(@([a-z]+))?', locale)
     if not match:
         return None
 


### PR DESCRIPTION
The failure mode caused it to overwrite the es_ES stats
with the es_419 ones. Skipping the CI step, as this script
is only run by the pot-update targets.

[ci_skip]