### PR TITLE
Show team village owner name when hovering

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1573,10 +1573,9 @@ REPORT_GENERATOR(terrain, rc)
 			str << map.get_terrain_info(terrain).income_description();
 		} else if (owner == viewing_side) {
 			str << map.get_terrain_info(terrain).income_description_own();
-		} else if (viewing_team.is_enemy(owner)) {
-			str << map.get_terrain_info(terrain).income_description_enemy();
 		} else {
-			str << map.get_terrain_info(terrain).income_description_ally();
+			const team &owner_team = rc.teams()[owner - 1];
+			str << VGETTEXT("$village_owner's village", {{ "village_owner", owner_team.team_name() }});
 		}
 
 		const std::string& underlying_desc = map.get_underlying_terrain_string(terrain);

--- a/src/terrain/terrain.cpp
+++ b/src/terrain/terrain.cpp
@@ -56,8 +56,6 @@ terrain_type::terrain_type() :
 		min_light_(0),
 		heals_(0),
 		income_description_(),
-		income_description_ally_(),
-		income_description_enemy_(),
 		income_description_own_(),
 		editor_group_(),
 		village_(false),
@@ -95,8 +93,6 @@ terrain_type::terrain_type(const config& cfg) :
 		min_light_(cfg["min_light"].to_int(light_modification_)),
 		heals_(cfg["heals"]),
 		income_description_(),
-		income_description_ally_(),
-		income_description_enemy_(),
 		income_description_own_(),
 		editor_group_(cfg["editor_group"]),
 		village_(cfg["gives_income"].to_bool()),
@@ -188,16 +184,6 @@ terrain_type::terrain_type(const config& cfg) :
 			income_description_ = _("Village");
 		}
 
-		income_description_ally_ = cfg["income_description_ally"];
-		if(income_description_ally_.empty()) {
-			income_description_ally_ = _("Allied village");
-		}
-
-		income_description_enemy_ = cfg["income_description_enemy"];
-		if(income_description_enemy_.empty()) {
-			income_description_enemy_ = _("Enemy village");
-		}
-
 		income_description_own_ = cfg["income_description_own"];
 		if(income_description_own_.empty()) {
 			income_description_own_ = _("Owned village");
@@ -229,8 +215,6 @@ terrain_type::terrain_type(const terrain_type& base, const terrain_type& overlay
 	min_light_(std::min(base.min_light_, overlay.min_light_)),
 	heals_(std::max<int>(base.heals_, overlay.heals_)),
 	income_description_(),
-	income_description_ally_(),
-	income_description_enemy_(),
 	income_description_own_(),
 	editor_group_(),
 	village_(base.village_ || overlay.village_),
@@ -281,14 +265,10 @@ terrain_type::terrain_type(const terrain_type& base, const terrain_type& overlay
 	//mouse over message are only shown on villages
 	if(base.village_) {
 		income_description_ = base.income_description_;
-		income_description_ally_ = base.income_description_ally_;
-		income_description_enemy_ = base.income_description_enemy_;
 		income_description_own_ = base.income_description_own_;
 	}
 	else if (overlay.village_) {
 		income_description_ = overlay.income_description_;
-		income_description_ally_ = overlay.income_description_ally_;
-		income_description_enemy_ = overlay.income_description_enemy_;
 		income_description_own_ = overlay.income_description_own_;
 	}
 

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -145,8 +145,6 @@ public:
 	//these descriptions are shown for the terrain in the mouse over
 	//depending on the owner or the village
 	const t_string& income_description() const { return income_description_; }
-	const t_string& income_description_ally() const { return income_description_ally_; }
-	const t_string& income_description_enemy() const { return income_description_enemy_; }
 	const t_string& income_description_own() const { return income_description_own_; }
 
 	const std::string& editor_group() const { return editor_group_; }
@@ -226,8 +224,6 @@ private:
 	int heals_;
 
 	t_string income_description_;
-	t_string income_description_ally_;
-	t_string income_description_enemy_;
 	t_string income_description_own_;
 
 	std::string editor_group_;


### PR DESCRIPTION
Solves https://github.com/wesnoth/wesnoth/issues/4344

Show on the side menu the village owner's name, as proposed on the above issue.

BUT I'm not sure if it's the best way to solve it because there is a little space on the side menu, so the description could be dropped frequently.

<img src="https://user-images.githubusercontent.com/9501115/150705774-d5c64e89-78af-4302-9f8c-7ca0d4f66736.png" height="300px" />
