### PR TITLE
Editor: document the magenta D and the special terrain overlays

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -11,7 +11,7 @@
 [section]
     id=editor_mode_terrain
     title= _ "Terrain Editor"
-    topics=..editor_mode_terrain, editor_palette, editor_masks, editor_tool_paint, editor_tool_fill, editor_tool_select, editor_tool_paste, editor_tool_starting
+    topics=..editor_mode_terrain, editor_palette, editor_masks, editor_tool_paint, editor_tool_fill, editor_tool_select, editor_tool_paste, editor_tool_starting, editor_terrain_overlays, editor_deprecated_overlay
     sort_topics=no
 [/section]
 
@@ -121,6 +121,63 @@ Named locations can be accessed from WML using the Standard Location Filter’s 
 • Control+mouse click on a hex that already has a location: select that location for placing with a subsequent mouse click, as if it was selected in the editor palette."
 [/topic]
 # wmllint: markcheck on
+
+[topic]
+    id=editor_terrain_overlays
+    title= _ "Editor Terrain-Overlay Graphics"
+    text= _ "editor^Maps generally look similar in the editor to their appearance in the game. There are a few exceptions, where different graphics are used in the editor; all the overlays described here are found in the terrain palette’s “special” group." + "
+
+" +
+        # po: The images here have text, while they could be translated I assume editor-only images won’t be.
+        # po: In English the text is “IO” for impassable and “UO” for unwalkable.
+        _ "editor^<bold>text='Movement Overlays'</bold>
+
+<img>src='terrain/grass/green.png~BLIT(terrain/impassable-editor.png~O(0.5))' align=here box=yes</img> <img>src='terrain/grass/green.png~BLIT(terrain/unwalkable-editor.png~O(0.5))' align=here box=yes</img> Impassable and Unwalkable
+
+While easily noticeable in the editor, these are invisible in the game, so the mixed terrains created by them look like the base terrain. They create a mixed terrain with the movement costs set to “impassable” or “unwalkable” respectively." + "
+
+" +
+        # po: The images here have text, while they could be translated I assume editor-only images won’t be.
+        # po: In English these images are the literal text “Castle overlay” and “Keep overlay”.
+        _ "editor^<bold>text='Castle Overlays'</bold>
+
+<img>src='terrain/grass/green.png~BLIT(terrain/castle/castle-overlay-editor.png~O(0.5))' align=here box=yes</img> <img>src='terrain/grass/green.png~BLIT(terrain/castle/keep-overlay-editor.png~O(0.5))' align=here box=yes</img>
+
+Adding either of these overlays to a passable hex allows units to be recruited onto a hex. The keep also allows a leader to recruit from there.
+
+These can be added to an impassable hex to connect a castle to a visually-separate keep through an impassable wall. It’s also possible to create a castle that seems to have grassland between the keep and towers, however this requires the connecting hexes to be occupied or blocked to prevent units being recruited onto them." + "
+
+" +
+        # po: The image here has text, while it could be translated I assume editor-only images won’t be.
+        # po: In English this image is the literal text “Village overlay”.
+        _ "editor^<bold>text='Village Overlay'</bold>
+
+<img>src='terrain/grass/green.png~BLIT(terrain/village/village-overlay-editor.png~O(0.5))' align=here box=yes</img>
+
+This turns any base terrain into a village, providing income and healing." + "
+
+" +
+        # po: The image is an “S” on a solid black background.
+        _ "editor^<bold>text='Fake Shroud'</bold>
+
+<img>src=terrain/void/shroud-editor.png align=left box=yes</img>
+
+Fake Shroud looks like an unexplored area, even in scenarios that have shroud disabled and even when the player’s units can see the hex."
+[/topic]
+
+[topic]
+    id=editor_deprecated_overlay
+    title= _ "Deprecated Terrain"
+    # po: The main reason for choosing “D” is that the hole in the middle of the letter makes it easier to see which terrain is underneath it. This uses a hardcoded image and doesn’t expect the image to be translated.
+    # po: The Xol and ^Efs terrains’ help pages aren’t given hyperlinks, because they both have hide_help enabled. Even when on a map with Xol on it, ctrl+t will show the hidden page but the ref still won’t link to it.
+    text= _ "editor^<img>src='terrain/grass/green.png~BLIT(terrain/deprecated-editor.png)' align=left box=yes</img>The magenta ‘D’ (for “Deprecated”).
+
+This is shown in the editor over deprecated terrain codes. Examples are:
+• the <ref>dst='terrain_fungus_grove_old' text='“^Uf” mushroom terrain'</ref>,
+• the “Xol” Lit Stone Wall, which is deprecated because several wall terrains now support the “^Efs” Sconce embellishment.
+
+The help pages for these terrains may have additional text that’s only shown in the editor, describing the deprecation and the recommended replacements."
+[/topic]
 
 # wmllint: markcheck off
 # wmllint: unbalanced-on


### PR DESCRIPTION
This adds help documentation for:
* The deprecated terrain marker
* XO and UO movement overlays
* Castle, keep and village overlays
* Fake Shroud
![deprecated_terrain](https://user-images.githubusercontent.com/101462/150808377-d2eeaeea-de6c-4217-8c09-7e1d9898b975.png)
![terrain_overlays](https://user-images.githubusercontent.com/101462/150808384-decec315-c7c4-44d1-82d7-c76c59c850eb.png)

