### PR TITLE
Temporarily re-introduce the SPECIAL_NOTES macro

### DIFF
--- a/data/core/macros/special-notes.cfg
+++ b/data/core/macros/special-notes.cfg
@@ -109,6 +109,12 @@ _"This unit has a defense cap on certain terrain types — it cannot achieve a h
 
 # Deprecated versions here
 
+#define SPECIAL_NOTES
+#deprecated 4 Use [special_note]note= tags instead to apply special notes, or use the {NOTE_*} macros (note the singular).
+    "
+
+"+_"Special Notes:"#enddef
+
 #define SPECIAL_NOTES_SPIRIT
 #deprecated 2 1.17 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SPIRIT}#enddef


### PR DESCRIPTION
While this will be deleted before 1.18, at the moment UMC authors
are still working on 1.16. While the 1.17 branch is being used for
new development in the engine, I think it's more useful to be able
to run 1.16 UMCs that test engine edge cases rather than force the
UMCs to be upgraded for 1.18's macros.

There's currently circa 1200 units using `{SPECIAL_NOTES}` in
Ageless Era, probably requiring manual checks to update them.
Another option would be to `#define SPECIAL_NOTES` in the UMC
itself, but that would likely also mean that the warning was
silenced when running on 1.16, and few of the 1200 units would
get fixed during the 1.16 cycle.

This reverts part of commit 61fa3627818c1a3fb5181a21fc651b67d17b133a.