### PR TITLE
Make the adhoc add-on download check more detailed.

### DIFF
--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -19,6 +19,7 @@
 #include "addon/client.hpp"
 #include "addon/info.hpp"
 #include "addon/manager.hpp"
+#include "config_cache.hpp"
 #include "filesystem.hpp"
 #include "formula/string_utils.hpp"
 #include "preferences/game.hpp"
@@ -38,6 +39,7 @@ static lg::log_domain log_filesystem("filesystem");
 static lg::log_domain log_addons_client("addons-client");
 
 #define ERR_CFG LOG_STREAM(err,   log_config)
+#define INFO_CFG LOG_STREAM(info, log_config)
 
 #define ERR_NET LOG_STREAM(err,   log_network)
 
@@ -276,11 +278,31 @@ bool ad_hoc_addon_fetch_session(const std::vector<std::string>& addon_ids)
 			addons_list::const_iterator it = addons.find(addon_id);
 			if(it != addons.end()) {
 				const addon_info& addon = it->second;
-				// don't redownload in case it was already downloaded for being another add-on's dependency
-				if(!filesystem::file_exists(filesystem::get_addons_dir()+"/"+addon_id)) {
-					addons_client::install_result res = client.install_addon_with_checks(addons, addon);
-					return_value = return_value && (res.outcome == addons_client::install_outcome::success);
+				const std::string addon_dir = filesystem::get_addons_dir()+"/"+addon_id;
+				const std::string info_cfg = addon_dir+"/_info.cfg";
+
+				// no _info.cfg, so either there's a _server.pbl or there's no version information available at all, so this add-on can be skipped
+				if(filesystem::file_exists(addon_dir) && !filesystem::file_exists(info_cfg)) {
+					INFO_CFG << "No _info.cfg exists for '" << addon_id << "', skipping update.\n";
+					continue;
 				}
+
+				// if _info.cfg exists, compare the local vs remote add-on versions to determine whether a download is needed
+				if(filesystem::file_exists(info_cfg)) {
+					game_config::config_cache& cache = game_config::config_cache::instance();
+					config info;
+					cache.get_config(info_cfg, info);
+					version_info installed_addon_version(info.child_or_empty("info")["version"]);
+
+					// if the installed version is outdated, download the most recent version from the add-ons server
+					if(installed_addon_version >= addon.current_version) {
+						continue;
+					}
+				}
+
+				// if the add-on exists locally and needs to be updated, or it doesn't exist and needs to be downloaded
+				addons_client::install_result res = client.install_addon_with_checks(addons, addon);
+				return_value = return_value && (res.outcome == addons_client::install_outcome::success);
 			} else {
 				if(!return_value) {
 					os << ", ";


### PR DESCRIPTION
Originally this simply checked for whether the add-on's directory existed to avoid downloading the same add-on multiple times when migrating from one major release to another. However this then causes add-ons to not get updated when joining a multiplayer game where to person joining has the add-on (so the directory exists) but needs an updated version of it.

Fixes #6383