### PR TITLE
Fix sidebar abilities leaking shrouded information

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -342,7 +342,8 @@ std::vector<std::tuple<std::string, t_string, t_string, t_string>> unit::ability
 
 	for (const config::any_child ab : this->abilities_.all_children_range())
 	{
-		bool active = ability_active(ab.key, ab.cfg, loc);
+		bool loc_is_unshrouded = display::get_singleton()->shrouded(loc) == false;
+		bool active = loc_is_unshrouded && ability_active(ab.key, ab.cfg, loc);
 		if (add_ability_tooltip(ab, gender_, res, active))
 		{
 			active_list.push_back(active);


### PR DESCRIPTION
Fixes https://github.com/wesnoth/wesnoth/issues/4456

Now when you focus on a shrouded tile, all abilities will be shown as inactive.

I tried to make it only for abilities that depend on a specific tile, but I can't find a parameter to check it. If there is one, we can improve that.

![image](https://user-images.githubusercontent.com/9501115/151673482-267ccde8-eb77-463a-9e0c-a9af97b73030.png)

![image](https://user-images.githubusercontent.com/9501115/151673487-0161b7e6-63ef-4b6b-8007-99eee83def2a.png)

![image](https://user-images.githubusercontent.com/9501115/151673491-03866628-474c-4c95-b0ee-a3625c0c9fe5.png)
