### PR TITLE
Refactor the backstab unit test

### DIFF
--- a/data/test/scenarios/backstab.cfg
+++ b/data/test/scenarios/backstab.cfg
@@ -1,96 +1,167 @@
 # wmllint: no translatables
+
 # Test that the backstab ability does double-damage, under the correct circumstances
 
-# Given a set of directions, create units on the opposite directions around
-# Bob's starting location. Note: the order that they spawn might not match the
-# order in the ANTIDIRECTIONS argument.
-#
-# The first unit spawned then attacks Bob, and we check that the
-# EXPECTED_DAMAGE was inflicted.
-#
-# Any commands in EXTRA_SETUP can access the new units via the spawn_points
-# array.
-#define TEST_BACKSTAB NAME ANTIDIRECTIONS EXPECTED_DAMAGE EXTRA_SETUP
-{GENERIC_UNIT_TEST {NAME} (
-    [event]
-        # Using this event instead of "start" because units get healed after "start", which makes debugging more confusing
-        name=side 1 turn 1
+#define TEST_BACKSTAB NAME ANTIDIRECTIONS ABILITY_SHOULD_ACTIVATE EXTRA_SETUP
+    # Given a set of directions, create units around Bob.  One of those units
+    # makes an attack, and the damage dealt is compared to the expectation that
+    # the ABILITY_SHOULD_ACTIVATE.
+    #
+    # Note: the directions given are the direction of Bob from the spawn, so
+    # ('n','se','sw') spawns units ('s,'nw','ne') of Bob. The order that the
+    # units spawn might not match the order of the ANTIDIRECTIONS argument.
+    #
+    # Any commands in EXTRA_SETUP are run after spawning the units but before
+    # making the attack. This code can access the new units via the
+    # spawn_points array.
+    #
+    # The unit on hex spawn_points[0] then attacks Bob, and the test asserts
+    # that Bob has the expected number of hit points remaining.
+    {GENERIC_UNIT_TEST {NAME} (
+        [event]
+            # Using this event instead of "start" because units get healed after "start", which makes debugging more confusing
+            name=side 1 turn 1
 
-        # Give Bob enough hitpoints to survive, but put him on bad terrain to give a 100% chance to be hit
-        [modify_unit]
-            [filter]
-                id=bob
-            [/filter]
-            hitpoints=100
-        [/modify_unit]
-        [terrain]
-            location_id=2
-            terrain="Xv"
-        [/terrain]
-
-        # Spawn enemies
-        [store_locations]
-            [filter_adjacent_location]
+            # Give Bob enough hitpoints to survive, but put him on bad terrain to give a 100% chance to be hit
+            [modify_unit]
+                [filter]
+                    id=bob
+                [/filter]
+                hitpoints=100
+            [/modify_unit]
+            [terrain]
                 location_id=2
-                adjacent={ANTIDIRECTIONS}
-            [/filter_adjacent_location]
-            variable=spawn_points
-        [/store_locations]
-        [foreach]
-            array=spawn_points
-            [do]
-                # Use the L2 unit, because a Thief might be killed by Bob's counterattack
-                {NOTRAIT_UNIT 1 Rogue $this_item.x $this_item.y}
-            [/do]
-        [/foreach]
+                terrain="Xv"
+            [/terrain]
 
-        {EXTRA_SETUP}
+            # Spawn enemies
+            [store_locations]
+                [filter_adjacent_location]
+                    location_id=2
+                    adjacent={ANTIDIRECTIONS}
+                [/filter_adjacent_location]
+                variable=spawn_points
+            [/store_locations]
+            [foreach]
+                array=spawn_points
+                [do]
+                    # Use the L2 unit, because a Thief might be killed by Bob's counterattack
+                    {NOTRAIT_UNIT 1 Rogue $this_item.x $this_item.y}
+                [/do]
+            [/foreach]
 
-        [store_locations]
-            location_id=2
-            variable=bob_location
-        [/store_locations]
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x=$spawn_points[0].x
-                    y=$spawn_points[0].y
-                [/source]
-                [destination]
-                    x=$bob_location[0].x
-                    y=$bob_location[0].y
-                [/destination]
-            [/attack]
-        [/do_command]
+            {EXTRA_SETUP}
 
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals "$(100 - {EXPECTED_DAMAGE})"})}
+            [store_locations]
+                location_id=2
+                variable=bob_location
+            [/store_locations]
+            [do_command]
+                [attack]
+                    weapon=0
+                    defender_weapon=0
+                    [source]
+                        x=$spawn_points[0].x
+                        y=$spawn_points[0].y
+                    [/source]
+                    [destination]
+                        x=$bob_location[0].x
+                        y=$bob_location[0].y
+                    [/destination]
+                [/attack]
+            [/do_command]
 
-        {CLEAR_VARIABLE b}
-        {CLEAR_VARIABLE spawn_points}
+            [store_unit]
+                [filter]
+                    id=bob
+                [/filter]
+                variable=b
+            [/store_unit]
 
-        {SUCCEED}
-    [/event]
-)}
+            # Check whether the amount of damage received matches the ability being active or not.
+            # The attacker is a Rogue, so does 6x3 base damage before the ability is applied.
+            {VARIABLE should_activate {ABILITY_SHOULD_ACTIVATE}}
+            [if]
+                {VARIABLE_CONDITIONAL should_activate boolean_equals "yes"}
+                [then]
+                    {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals "$(100 - 6 * 3 * 2)"})}
+                [/then]
+                [else]
+                    {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals "$(100 - 6 * 3)"})}
+                [/else]
+            [/if]
+
+            {CLEAR_VARIABLE b}
+            {CLEAR_VARIABLE should_activate}
+            {CLEAR_VARIABLE spawn_points}
+
+            {SUCCEED}
+        [/event]
+    )}
 #enddef
 
-# The test uses a Rogue to do the attack, which does 6x3 damage before the ability is applied
-{TEST_BACKSTAB "backstab_simple" "n,s" (6 * 3 * 2) ()}
-{TEST_BACKSTAB "backstab_without_enemy_behind" "n,se,sw" (6 * 3 * 1) ()}
-{TEST_BACKSTAB "backstab_with_statue_behind" "n,s" (6 * 3 * 1) (
+#####
+# API(s) being tested: [damage]+[filter_opponent]formula
+##
+# Actions:
+# Bob is made to have 0% defense and given 100 hp.
+# A Rogue is spawned north and south of Bob.
+# A Rogue attacks Bob.
+##
+# Expected end state:
+# The damage shows that Bob was backstabbed.
+# Bob gets hit all three times and ends with 100-(6 * 3 * 2) hp.
+#####
+{TEST_BACKSTAB "backstab_active_with_accomplice_behind_bob" "n,s" yes ()}
+
+#####
+# API(s) being tested: [damage]+[filter_opponent]formula
+##
+# Actions:
+# Bob is made to have 0% defense and given 100 hp.
+# A Rogue is spawned south, northwest and northeast of Bob.
+# A Rogue attacks Bob.
+##
+# Expected end state:
+# The damage shows that the ability was inactive.
+# Bob gets hit all three times and ends with 100-(6 * 3 * 1) hp.
+#####
+{TEST_BACKSTAB "backstab_inactive_with_triangular_formation" "n,se,sw" no ()}
+
+#####
+# API(s) being tested: [damage]+[filter_opponent]formula
+##
+# Actions:
+# Bob is made to have 0% defense and given 100 hp.
+# A Rogue is spawned north, south of Bob.
+# The south Rogue is petrified.
+# The non-petrified Rogue attacks Bob.
+##
+# Expected end state:
+# The damage shows that the ability was inactive.
+# Bob gets hit all three times and ends with 100-(6 * 3 * 1) hp.
+#####
+{TEST_BACKSTAB "backstab_inactive_with_statue_behind_bob" "n,s" no (
     [petrify]
         x=$spawn_points[1].x
         y=$spawn_points[1].y
     [/petrify]
 )}
-{TEST_BACKSTAB "backstab_with_ally_behind" "n,s" (6 * 3 * 1) (
+
+#####
+# API(s) being tested: [damage]+[filter_opponent]formula
+##
+# Actions:
+# Bob is made to have 0% defense and given 100 hp.
+# A Rogue is spawned north, south of Bob.
+# The south Rogue is allied with Bob.
+# The enemy Rogue attacks Bob.
+##
+# Expected end state:
+# The damage shows that the ability was inactive.
+# Bob gets hit all three times and ends with 100-(6 * 3 * 1) hp.
+#####
+{TEST_BACKSTAB "backstab_inactive_with_bobs_ally_behind_bob" "n,s" no (
     [modify_unit]
         [filter]
             x=$spawn_points[1].x

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -255,10 +255,10 @@
 0 test_time_area_prestart
 0 test_berzerk_firststrike
 0 feeding
-0 backstab_simple
-0 backstab_without_enemy_behind
-0 backstab_with_statue_behind
-0 backstab_with_ally_behind
+0 backstab_active_with_accomplice_behind_bob
+0 backstab_inactive_with_triangular_formation
+0 backstab_inactive_with_statue_behind_bob
+0 backstab_inactive_with_bobs_ally_behind_bob
 0 swarm_disables_upgrades
 0 swarm_disables_upgrades_with_abilities
 0 swarm_disables_upgrades_with_abilities_fail


### PR DESCRIPTION
Based on part of Pentarctagon's #6308, and also improving
the encapsulation of the test to take a boolean value for whether
the ability should be active instead of the expected damage total.