### PR TITLE
Add-ons manager: handle the selected add-on changing in small-screen mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ## Version 1.17.0+dev
  ### Add-ons client
+   * Fixed: using the up or down arrow keys in small-screen mode returned to the title screen (issue #6485)
  ### Add-ons server
  ### Campaigns
    * Delfador’s Memoirs


### PR DESCRIPTION
Forward-port of #6490, intending to merge after the CI finishes.
Fixes #6485.

Fix another instance of issue #3059, where code assumes that all parts of the
add-ons manager's UI are accessible, an assumption that fails when the dialog
uses a stacked widget to handle small window sizes.

The up and down arrow keys select the previous or next add-on in the list,
even when the small-window layout is hiding the list. That feels like a feature
rather than a bug, as it's useful and an understandable UX; however it needs
the fix in this commit so that on_addon_select() doesn't throw an exception
and close the dialog. The new code is the same as the fix that 050feb623b
applied to on_selected_version_change, traversing the stacked widget to get the
info.

(cherry picked from commit 6a72b2e5114619e7736de97d47a1407254f8fa8a)