### PR TITLE
[1.16] Update to Flatpak 21.08

### DIFF
--- a/packaging/flatpak/org.wesnoth.Wesnoth.json
+++ b/packaging/flatpak/org.wesnoth.Wesnoth.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.wesnoth.Wesnoth",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",

--- a/utils/dockerbuilds/CI/Dockerfile-base-flatpak
+++ b/utils/dockerbuilds/CI/Dockerfile-base-flatpak
@@ -5,4 +5,4 @@ RUN apt update
 RUN apt install -y flatpak flatpak-builder jq
 RUN flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
 # install runtime
-RUN flatpak install -y flathub org.freedesktop.Platform/x86_64/20.08 org.freedesktop.Sdk/x86_64/20.08
+RUN flatpak install -y flathub org.freedesktop.Platform/x86_64/21.08 org.freedesktop.Sdk/x86_64/21.08


### PR DESCRIPTION
Since the CI was updated to build 1.17 with Flatpak 21.08, the 1.16 builds have failed because they're lacking 20.08.

This cherry-picks c6f9a96a09e3eda6e1e43ccdaabe8a5442a40b2a and 35211181b4ba6e08ff67d9a1b9ee3cdd2e311990. I haven't done local testing, just want to run a build to check that the CI is currently fully set up if we upgrade 1.16 to 21.08.
