### PR TITLE
Add test scenario for teacher-based weapon specials

### DIFF
--- a/data/test/maps/5p_single_castle.map
+++ b/data/test/maps/5p_single_castle.map
@@ -1,0 +1,8 @@
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, 1 Cvr, 3 Cvr, 4 Co, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, 5 Cdr, 2 Co, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg

--- a/data/test/scenarios/test_teachers_and_specials.cfg
+++ b/data/test/scenarios/test_teachers_and_specials.cfg
@@ -1,0 +1,237 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: TODO weapon-special related formulas; mainly exists as a manual test for the attack-prediction tooltips
+##
+# Actions:
+# Alice is allied with Charlie (side 3)
+# Bob is allied with Dave (side 4)
+# Eve (side 5) is an enemy of both Alice and Bob.
+# Everybody gets the formation special, and all attacks get the shock weapon special.
+# Everybody gets a self+allies leadership ability, with a value equal to their side number at the start of the scenario (it doesn't change if debug mode is used to change their side).
+# The dwarves (Bob and Dave) get an extra self+allies ability.
+# Eve gets an ability that gives adjacent enemies (but not allies) a charge-like special.
+##
+# Expected end state:
+# A workbench for manually checking the UI presentation, for example the UI of the attack predictions dialog.
+#####
+
+# Copy of the special from UtBS
+#define TEST_WEAPON_SPECIAL_SHOCK
+    # Canned definition of the Shock ability to be included in a
+    # [specials] clause.
+    [attacks]
+        id=shock
+        name= _ "shock"
+        description= _ "When this attack is used on offense, the opponent will retaliate with one less strike than normally, to a minimum of one strike."
+        sub=1
+        active_on=offense
+        apply_to=opponent
+        [filter_base_value]
+            greater_than=1
+        [/filter_base_value]
+    [/attacks]
+#enddef
+
+# Copy of the special from UtBS, having only the 1-ally and 2-ally forms and with lower limits for the minimum chance to hit.
+# The original in UtBS can lower it to a minimum of 30% CTH, this can lower it down to zero.
+# Unlike the original, the mechanism behind it is visible (in UtBS it's 5 abilities, of which 4 are unnamed).
+#define TEST_ABILITY_FORMATION
+    [chance_to_hit]
+        id=formation1
+        name= _ "formation1"
+        female_name= _ "female^formation1"
+        description= _ "This unit gains a +10% bonus to defense when another unit with the same ability is adjacent to it. However, this cannot raise the unit’s defense above 70%."
+        special_note=_"Groups of units of this type are able to shield each other in combat."
+        apply_to=opponent
+        sub=10
+        [filter_base_value]
+            greater_than_equal_to=10
+        [/filter_base_value]
+        [filter]
+            [filter_adjacent]
+                ability=formation1
+                is_enemy=no
+                count=1-5
+            [/filter_adjacent]
+        [/filter]
+    [/chance_to_hit]
+    [chance_to_hit]
+        id=formation2
+        name= _ "formation2"
+        female_name= _ "female^formation2"
+        apply_to=opponent
+        sub=10
+        [filter_base_value]
+            greater_than_equal_to=20
+        [/filter_base_value]
+        [filter_self]
+            [filter_adjacent]
+                is_enemy=no
+                count=2-5
+                # The next line can use either formation1 or formation2, as exactly the same set of units have both abilities.
+                ability=formation1
+            [/filter_adjacent]
+        [/filter_self]
+    [/chance_to_hit]
+#enddef
+
+[test]
+    name = _ "Unit Test teachers and specials"
+    map_file=test/maps/5p_single_castle.map
+    turns = 3
+    id = teachers_and_specials
+    random_start_time = no
+    is_unit_test = yes
+
+    {DAWN}
+
+    [side]
+        side=1
+        controller=human
+        name = _ "Alice"
+        type = Elvish Archer
+        id=alice
+        fog=no
+        team_name=West
+    [/side]
+    [side]
+        side=2
+        controller=human
+        name = _ "Bob"
+        type = Dwarvish Guardsman
+        id=bob
+        fog=no
+        team_name=East
+        # Has ABILITY_STEADFAST from the unit type
+    [/side]
+    [side]
+        side=3
+        controller=human
+        name= _ "Charlie"
+        type = Elvish Sorceress
+        id=charlie
+        fog=no
+        team_name=West
+    [/side]
+    [side]
+        side=4
+        controller=human
+        name = _ "Dave"
+        type = Dwarvish Fighter
+        id=dave
+        fog=no
+        team_name=East
+    [/side]
+    [side]
+        side=5
+        controller=human
+        name = _ "Eve"
+        type = Dune Explorer
+        id=eve
+        fog=no
+        team_name=South
+    [/side]
+
+    [event]
+        name=prestart
+        [store_unit]
+            [filter]
+            [/filter]
+            variable=leaders
+        [/store_unit]
+        [foreach]
+            array=leaders
+            [do]
+                [object]
+                    [filter]
+                        id=$this_item.id
+                    [/filter]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            {TEST_ABILITY_FORMATION}
+                        [/abilities]
+                    [/effect]
+                    [effect]
+                        apply_to=attack
+                        [set_specials]
+                            mode=append
+                            {TEST_WEAPON_SPECIAL_SHOCK}
+                        [/set_specials]
+                    [/effect]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            [leadership]
+                                id="led_by_$this_item.id"
+                                add=$this_item.side
+                                name="led_by_$this_item.name"
+                                affect_self=yes
+                                affect_allies=yes
+                                affect_enemies=no
+                                [affect_adjacent]
+                                [/affect_adjacent]
+                            [/leadership]
+                        [/abilities]
+                    [/effect]
+                [/object]
+                [switch]
+                    variable=this_item.id
+                    [case]
+                        # The dwarves get some affects-allies ability with a metal name
+                        value=bob,dave
+                        [object]
+                            [filter]
+                                id=$this_item.id
+                            [/filter]
+                            [effect]
+                                apply_to=new_ability
+                                [abilities]
+                                    [leadership]
+                                        id="raw_iron_$this_item.id"
+                                        add=$this_item.side
+                                        name="raw_iron_$this_item.name"
+                                        affect_self=yes
+                                        affect_allies=yes
+                                        affect_enemies=no
+                                        [affect_adjacent]
+                                        [/affect_adjacent]
+                                    [/leadership]
+                                [/abilities]
+                            [/effect]
+                        [/object]
+                    [/case]
+                    [case]
+                        value=eve
+                        [object]
+                            [filter]
+                                id=$this_item.id
+                            [/filter]
+                            [effect]
+                                apply_to=new_ability
+                                [abilities]
+                                    [damage]
+                                        id="others_charge"
+                                        add=$this_item.side
+                                        name=_ "others_charge"
+                                        description=_ "Encourages adjacent enemies to risk more, they gain the equivalent of “charge” on all their weapons."
+                                        affect_self=no
+                                        affect_allies=no
+                                        affect_enemies=yes
+                                        apply_to=both
+                                        [affect_adjacent]
+                                        [/affect_adjacent]
+                                    [/damage]
+                                [/abilities]
+                            [/effect]
+                        [/object]
+                    [/case]
+                [/switch]
+            [/do]
+        [/foreach]
+    [/event]
+[/test]
+
+#undef TEST_ABILITY_FORMATION
+#undef TEST_WEAPON_SPECIAL_SHOCK


### PR DESCRIPTION
This is intended for manual testing, the reason for writing it is to
test tooltips in the attack-predictions dialog. It has a new map, with
five sides packed into adjacent hexes.

Everyone gets a self+allies leadership based on their side number, with
their name in the ability's id and ability's name for tracking whose buffs
are affecting who.

I'm expecting to do more changes to it before considering whether it should
be merged as a standalone test, added to data/scenario-test.cfg, or discarded.

[ci skip]