### PR TITLE
[1.16] Warning when share_view or share_maps overrides share_vision

### DIFF
--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -87,3 +87,18 @@ std::string deprecated_message(
 
 	return message;
 }
+
+void unsupported_combo_message(const std::string& elem_name, const std::string& modern_name) {
+	if(lg::err().dont_log(log_deprecate)) {
+		return;
+	}
+
+	utils::string_map msg_params {{"elem", elem_name}, {"modern", modern_name}};
+	// TRANSLATORS: For example, "[side]share_view= ... with [side]share_vision="
+	std::string message = VGETTEXT("$elem has been deprecated, and can’t be used with $modern.", msg_params);
+
+	FORCE_LOG_TO(lg::err(), log_deprecate) << message << '\n';
+	if(preferences::get("show_deprecation", game_config::wesnoth_version.is_dev_version())) {
+		lg::log_to_chat() << message << '\n';
+	}
+}

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -21,7 +21,8 @@ enum class DEP_LEVEL : uint8_t { INDEFINITE = 1, PREEMPTIVE, FOR_REMOVAL, REMOVE
 
 /**
  * Prints a message to the deprecation log domain informing players that a given feature
- * has been deprecated.
+ * has been deprecated. May show the error in the in-game chat area, but has a mechanism
+ * to avoid repeatedly showing in-game messages to players who can't fix the issue.
  *
  * @param elem_name    The name of the feature to be deprecated.
  * @param level        The deprecation level. This indicates how long the feature will
@@ -43,3 +44,17 @@ std::string deprecated_message(const std::string& elem_name,
 		DEP_LEVEL level,
 		const class version_info& version,
 		const std::string& detail = "");
+
+/**
+ * Prints a message to the deprecation log domain informing players that a deprecated
+ * feature has been used along with a new feature, and that the compatibility code
+ * doesn't support that combination.
+ *
+ * For example, if a WML tag contains both a deprecated attribute and its replacement,
+ * the compatibilty code might use one, ignore the other, and log a message.
+ *
+ * @param elem_name    The name of the feature that's deprecated.
+ * @param modern_name  The new feature that can't be used with the deprecated one.
+ */
+void unsupported_combo_message(const std::string& elem_name,
+		const std::string& modern_name);

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -22,6 +22,7 @@
 
 #include "ai/manager.hpp"
 #include "color.hpp"
+#include "deprecation.hpp"
 #include "formula/string_utils.hpp"     // for VGETTEXT
 #include "game_data.hpp"
 #include "game_events/pump.hpp"
@@ -268,6 +269,20 @@ void team::team_info::read(const config& cfg)
 
 void team::team_info::handle_legacy_share_vision(const config& cfg)
 {
+	// Either legacy setting overrides share_vision - it was that way in 1.13.1, and the eventual
+	// fix will be to remove the deprecated attributes, along with removing this legacy support.
+
+	// This block is just to show a warning if the old and new attributes are used together.
+	if(cfg.has_attribute("share_vision")) {
+		if(cfg.has_attribute("share_view")) {
+			unsupported_combo_message("[side]share_view=", "[side]share_vision=");
+		}
+		if(cfg.has_attribute("share_maps")) {
+			unsupported_combo_message("[side]share_maps=", "[side]share_vision=");
+		}
+	}
+
+	// Share_view and share_maps can't both be enabled, so share_view overrides share_maps.
 	if(cfg.has_attribute("share_view") || cfg.has_attribute("share_maps")) {
 		if(cfg["share_view"].to_bool()) {
 			share_vision = team::SHARE_VISION::ALL;


### PR DESCRIPTION
Add a new type of deprecation warning, used when a deprecated WML attribute is used alongside its replacement. Use that to log a deprecation warning if a [side] has share_vision overridden by share_view or share_maps.

While share_view and share_maps are deprecated on the Wiki, they don't trigger deprecation warnings on their own. I intend to make them trigger warnings in 1.17, but they map cleanly to the share_vision enum so the wrapper is easy to support indefinitely.

All SP uses of the deprecated attributes were removed from mainline in f983a998a2 on the 1.17 branch, which was backported to 1.16 as 80c9263003.

On 1.16, WC still has one [side]share_view=, in WC's side_definitions.lua; this has been replaced in 35aa0d1893 on the master branch. It won't trigger this warning, because it isn't used in the same tag as [side]share_vision=.

The branch name is no longer accurate, as some feature-creep has been removed.