### PR TITLE
1.16 [micro_ai] bottleneck ai

### DIFF
--- a/data/ai/micro_ais/cas/ca_bottleneck_move.lua
+++ b/data/ai/micro_ais/cas/ca_bottleneck_move.lua
@@ -477,7 +477,9 @@ function ca_bottleneck_move:execution(cfg, data)
     else
         -- Don't want full move, as this might be stepping out of the way
         local cfg = { partial_move = true, weapon = BD_level_up_weapon }
-        AH.robust_move_and_attack(ai, BD_unit, BD_hex, BD_level_up_defender, cfg)
+        if BD_unit and BD_hex then
+            AH.robust_move_and_attack(ai, BD_unit, BD_hex, BD_level_up_defender, cfg)
+        end
     end
 
     -- Now delete almost everything


### PR DESCRIPTION
This addresses an error (I'll update if I get a simple way to reproduce)
```error scripting/lua: ai/lua/ai_helper.lua:314: attempt to index a nil value (local 'dst')
stack traceback:
        ai/lua/ai_helper.lua:314: in field 'robust_move_and_attack'
        ai/micro_ais/cas/ca_bottleneck_move.lua:480: in field 'execution'
        [string "local self, params, data, filter_own = ......"]:2: in main chunk
```

I'm not sure this is a proper fix, but it seems to work, so I'll park it here for now.