### PR TITLE
DM S11: Correct vision sharing when Delfador finds Chantal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
  ### Add-ons server
  ### Campaigns
    * Delfador’s Memoirs
+     * S11: Finding Chantal will now share her side’s vision with the player, as originally intended.
      * S14: Smoother appearance of enemies and added dialogue (#6176)
    * The Rise of Wesnoth
      * S22: Fixed the possibility of a missplaced dialogue when a bridge was broken (issue #6376)
@@ -46,7 +47,7 @@
      * Remove the “formation” ability from the attack predictions dialog, as it was in a confusing location; its effect is still shown in the calculations and chance-to-hit percentage (PR #6326)
      * S02: Pinnacle Rock is now shown during dialogue (issue #6125)
      * S04: Improve dialogue about dark underground tunnels (PR #6345)
-     * S06b: 
+     * S06b:
        * Account for non-elvish units encountering Dwarf Sergeant (issue #6196)
        * Grog will not die as quick now (issue #6196 & #6197)
        * Hermit dialogue cannot be accidentally skipped now (issue #6196)

--- a/data/campaigns/Delfadors_Memoirs/scenarios/11_Wasteland.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/11_Wasteland.cfg
@@ -55,6 +55,9 @@
         side=3
         controller=ai
         hidden=yes
+        # Shroud is required for share_maps to have the intended effect in the event where the player finds Chantal.
+        shroud=yes
+        share_maps=no
         recruit=Elvish Ranger,Elvish Rider
         {GOLD 120 110 100}
         team_name=allies


### PR DESCRIPTION
Partial back-port of #6498 (second and final commit in that PR, as at time of writing). Originally @stevecotton's findings.