### PR TITLE
SoF: Fix for Thursagan's Arcanister advancement breaking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
    * Delfador’s Memoirs
      * S11: Finding Chantal will now share her side’s vision with the player, as originally intended.
      * S14: Smoother appearance of enemies and added dialogue (#6176)
+   * Sceptre of Fire
+     * Fixed Thursagan's Arcanister advancement being "lost" after dismounting a minecart. 
    * The Rise of Wesnoth
      * S22: Fixed the possibility of a missplaced dialogue when a bridge was broken (issue #6376)
    * Under the Burning Suns

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -513,11 +513,33 @@
             name= _ "Thursagan"
             unrenamable=yes
             profile=portraits/thursagan.png
-            advances_to=Dwarvish Arcanister
-            max_experience=210
             [modifications]
                 {TRAIT_LOYAL_HERO}
                 {TRAIT_STRONG}
+                [object]
+                    [effect]
+                        [filter]
+                            type=Dwarvish Runemaster
+                        [/filter]
+                        apply_to=remove_advancement
+                        amlas=amla_default
+                    [/effect]
+                    [effect]
+                        [filter]
+                            type=Dwarvish Runemaster
+                        [/filter]
+                        apply_to=new_advancement
+                        replace=yes
+                        types=Dwarvish Arcanister
+                    [/effect]
+                    [effect]
+                        [filter]
+                            type=Dwarvish Runemaster
+                        [/filter]
+                        apply_to=max_experience
+                        set=210
+                    [/effect]
+                [/object]
             [/modifications]
         [/unit]
         [message]


### PR DESCRIPTION
Same as #6484 but for the 1.16.x branch. A backport.