### PR TITLE
HttT S17: Update to comply with current Wesnoth Lua API specifications

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -716,7 +716,7 @@
             code= <<
                 local ai_helper = wesnoth.require "ai/lua/ai_helper.lua"
                 local delf = wesnoth.units.find_on_map { id = 'Delfador' }[1]
-                local sceptre_loc= wesnoth.special_locations.sceptre
+                local sceptre_loc= wesnoth.current.map.special_locations.sceptre
                 local path = wesnoth.paths.find_path(delf, sceptre_loc[1], sceptre_loc[2], {ignore_units = true, ignore_visibility = true}) -- # wmllint: noconvert
                 _ = wesnoth.textdomain 'wesnoth-httt'
 


### PR DESCRIPTION
Resolves #6517

It might be obvious to experienced Lua API users but it's not a direct translation to `map.special_locations` as per https://wiki.wesnoth.org/LuaAPI/UpdatingFrom14, but rather `wesnoth.current.map.special_locations`.

I tested this in master and believe it can/should be back-ported to 1.16.