### PR TITLE
Workaround a Doxygen bug by naming an anonymous Lua struct

### DIFF
--- a/src/lua/lobject.h
+++ b/src/lua/lobject.h
@@ -145,7 +145,7 @@ typedef struct TValue {
 */
 typedef union StackValue {
   TValue val;
-  struct {
+  struct named_for_doxygen { /* When this is anonymous, Doxygen reports errors in an unrelated anonymous namespace */
     TValuefields;
     unsigned short delta;
   } tbclist;


### PR DESCRIPTION
This change should make no difference at all. However, without it Doxygen reports these warnings, thus making the CI builds fail.
Fixes #6528.

* /home/wesnoth-CI/src/actions/heal.cpp:45: warning: documented symbol 'heal_unit::heal_unit' was not declared or defined.
* /home/wesnoth-CI/src/actions/heal.cpp:66: warning: documented symbol 'POISON_STATUS @8::poison_status' was not declared or defined.
* /home/wesnoth-CI/src/actions/heal.cpp:83: warning: documented symbol 'POISON_STATUS @8::poison_progress' was not declared or defined.
* /home/wesnoth-CI/src/actions/heal.cpp:159: warning: documented symbol 'bool @8::update_healing' was not declared or defined.
* /home/wesnoth-CI/src/actions/heal.cpp:180: warning: documented symbol 'int @8::heal_amount' was not declared or defined.
* /home/wesnoth-CI/src/actions/heal.cpp:234: warning: documented symbol 'void @8::do_heal' was not declared or defined.
* /home/wesnoth-CI/src/actions/heal.cpp:250: warning: documented symbol 'void @8::animate_heals' was not declared or defined.