### PR TITLE
Replace deprecated placement=map_overwrite

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/08_The_Princess_of_Wesnoth.cfg
@@ -313,7 +313,8 @@
             x,y=$x1,$y1
             side=2
             type=$unit.type
-            placement=map_overwrite
+            placement=map
+            overwrite=yes
             moves=0
             attacks_left=0
             [modifications]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg
@@ -309,7 +309,8 @@ Not far inside the cave was a ruined castle built in a style I did not recognize
         [unit]
             type=SotA Skeleton
             side=1
-            placement=map_overwrite
+            placement=map
+            overwrite=yes
             x,y=8,4
             id=skeleton
             facing=se

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/07_Return_to_Oldwood.cfg
@@ -268,7 +268,8 @@
             variation=unmasked
             side=1
             x,y=$lady_store.x,$lady_store.y
-            placement=map_overwrite
+            placement=map
+            overwrite=yes
             facing=$lady_store.facing
             experience=$lady_store.experience
             random_traits=no


### PR DESCRIPTION
I think deprecation notifications are only being shown in 1.17 but not 1.16. I noticed the `map_overwrite` deprecation message when testing the former.

I checked the change in SotA S17, no apparent regressions. I don't see any other instances of `map_overwrite`.

Info: https://wiki.wesnoth.org/SingleUnitWML#placement