### PR TITLE
Doxygen: fix mainpage links with Doxygen 1.9.1

### DIFF
--- a/doc/doxygen/doxygen.cpp
+++ b/doc/doxygen/doxygen.cpp
@@ -14,34 +14,34 @@
 
 @mainpage Developer Documentation
 
-	<table border="0">
-	<tr>
-	<td valign="top">
-		@image html wesnoth-icon.png
-	</td>
-	<td>
-		<h3>Howto</h3>
-		@li @ref get_involved
-		@li @ref howto_document
+<table border="0">
+<tr>
+<td valign="top">
+	@image html wesnoth-icon.png
+</td>
+<td>
+	<h3>Howto</h3>
+	@li @ref get_involved
+	@li @ref howto_document
 
-	</td>
-	</tr>
+</td>
+</tr>
 
-	<tr>
-	<td valign="top">
-		@image html portraits/humans/mage.png
-	</td>
-	<td>
-		<h3>Reference</h3>
-		@li <a href="namespaces.html">Namespaces</a>
-		@li @ref unnamed_namespace
-		@li <a href="hierarchy.html">Classes</a>
-		@li <a href="files.html">Source Files</a>
-		@li <a href="todo.html">Todo</a>
-		@li <a href="deprecated.html">Deprecated</a>
-	</td>
-	</tr>
-	</table>
+<tr>
+<td valign="top">
+	@image html portraits/humans/mage.png
+</td>
+<td>
+	<h3>Reference</h3>
+	@li <a href="namespaces.html">Namespaces</a>
+	@li @ref unnamed_namespace
+	@li <a href="hierarchy.html">Classes</a>
+	@li <a href="files.html">Source Files</a>
+	@li <a href="todo.html">Todo</a>
+	@li <a href="deprecated.html">Deprecated</a>
+</td>
+</tr>
+</table>
 
 */
 


### PR DESCRIPTION
The extra indentation on these lines caused Doxygen in my local builds
to treat them as a block of preformatted text, and to escape all the HTML.

Locally I'm building with Debian Unstable, which has Doxygen 1.9.1. The
bug isn't present in the CI built docs on https://devdocs.wesnoth.org/
which were built with Doxygen 1.8.13.