### PR TITLE
Store add-on passwords in the credentials file as well.

### DIFF
--- a/data/gui/window/addon_auth.cfg
+++ b/data/gui/window/addon_auth.cfg
@@ -96,6 +96,26 @@
 			[/row]
 
 			[row]
+				grow_factor = 1
+
+				[column]
+					grow_factor = 1
+					horizontal_alignment = "left"
+					border = "all"
+					border_size = 5
+
+					[toggle_button]
+						id = "remember_password"
+						definition = "default"
+
+						label = _ "Save password locally (encrypted)"
+					[/toggle_button]
+
+				[/column]
+
+			[/row]
+
+			[row]
 				grow_factor = 0
 
 				[column]

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -27,6 +27,7 @@
 #include "gui/dialogs/message.hpp"
 #include "gui/widgets/retval.hpp"
 #include "log.hpp"
+#include "preferences/credentials.hpp"
 #include "random.hpp"
 #include "serialization/parser.hpp"
 #include "serialization/string_utils.hpp"
@@ -276,13 +277,16 @@ bool addons_client::delete_remote_addon(const std::string& id, std::string& resp
 	config request_buf, response_buf;
 	config& request_body = request_buf.add_child("delete");
 
-	// the passphrase isn't provided, prompt for it
+	// if the passphrase isn't provided from the _server.pbl, try to pre-populate it from the preferences before prompting for it
 	if(cfg["passphrase"].empty()) {
+		cfg["passphrase"] = preferences::password(host_, cfg["author"]);
 		if(!gui2::dialogs::addon_auth::execute(cfg)) {
 			config dummy;
 			config& error = dummy.add_child("error");
 			error["message"] = "Password not provided.";
 			return !update_last_error(dummy);
+		} else {
+			preferences::set_password(host_, cfg["author"], cfg["passphrase"]);
 		}
 	}
 

--- a/src/gui/dialogs/addon/addon_auth.cpp
+++ b/src/gui/dialogs/addon/addon_auth.cpp
@@ -21,6 +21,7 @@
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/password_box.hpp"
 #include "gui/widgets/window.hpp"
+#include "preferences/credentials.hpp"
 
 namespace gui2::dialogs
 {
@@ -30,12 +31,16 @@ REGISTER_DIALOG(addon_auth)
 addon_auth::addon_auth(config& cfg)
 	: cfg_(cfg)
 {
-
+	register_bool("remember_password", false,
+		&preferences::remember_password,
+		&preferences::set_remember_password);
 }
 
 void addon_auth::pre_show(window& win)
 {
-	win.add_to_tab_order(find_widget<password_box>(&win, "password", false, true));
+	text_box* pwd = find_widget<text_box>(&win, "password", false, true);
+	win.add_to_tab_order(pwd);
+	pwd->set_value(cfg_["passphrase"].str(""));
 }
 
 void addon_auth::post_show(window& win)

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -45,6 +45,8 @@
 #include "gui/widgets/toggle_button.hpp"
 #include "gui/widgets/text_box.hpp"
 #include "gui/widgets/window.hpp"
+#include "preferences/credentials.hpp"
+#include "preferences/game.hpp"
 #include "serialization/string_utils.hpp"
 #include "formula/string_utils.hpp"
 #include "picture.hpp"
@@ -854,10 +856,13 @@ void addon_manager::publish_addon(const addon_info& addon)
 		}
 	}
 
-	// the passphrase isn't provided, prompt for it
+	// if the passphrase isn't provided from the _server.pbl, try to pre-populate it from the preferences before prompting for it
 	if(cfg["passphrase"].empty()) {
+		cfg["passphrase"] = preferences::password(preferences::campaign_server(), cfg["author"]);
 		if(!gui2::dialogs::addon_auth::execute(cfg)) {
 			return;
+		} else {
+			preferences::set_password(preferences::campaign_server(), cfg["author"], cfg["passphrase"]);
 		}
 	}
 


### PR DESCRIPTION
This allows storing add-on passwords for uploading in the same credentials file as is currently used by the client when connecting to a multiplayer server. For add-on authors that don't keep their passwords as plaintext in their _server.pbl, this removes the need for them to manually enter their password each time they upload an add-on.