### PR TITLE
Treat all 1.17 builds as dev versions, including non-canonical ones

### DIFF
--- a/src/game_version.cpp
+++ b/src/game_version.cpp
@@ -172,7 +172,7 @@ bool version_info::is_canonical() const {
 }
 
 bool version_info::is_dev_version() const {
-	return is_canonical() && is_odd(minor_version());
+	return is_odd(minor_version());
 }
 
 namespace {


### PR DESCRIPTION
This controls whether the "show deprecation warnings" preference defaults to
on or off. It seemed odd to have that default to on for the official 1.17.x
releases, yet default to off for local builds which developers are fixing.