### PR TITLE
SoF: explain the Shorbear tools as products of the volcanic forge

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
@@ -300,7 +300,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Well... Maybe you can ask the Shorbear clan? They have good tools... chisels made of some rare mineral. I don’t know what mineral it is or how they got it, but their work is well known among us gem crafters."
+            message= _ "Well... Maybe you can ask the Shorbear clan? They have good tools... chisels made of a metal that could only be worked in the heat of a volcanic forge. I don’t know how true that legend is, but their work is well known among us gem crafters."
         [/message]
         [message]
             speaker=Rugnur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -1069,7 +1069,7 @@
         [/message]
         [message]
             speaker=Thursagan
-            message= _ "Look up! if this were a normal volcano, you’d see stars and sky. Instead, there’s a high ceiling, shaped like a cone. This means that something must be holding back the volcano’s lava flow. This thing, if it exists, could be our chance to trigger an eruption. The first place I would consider investigating would be the center of this chamber."
+            message= _ "Look up! If this were a normal volcano, you’d see stars and sky. Instead, there’s a high ceiling, shaped like a cone. This means that something must be holding back the volcano’s lava flow. This thing, if it exists, could be our chance to trigger an eruption. The first place I would consider investigating would be the center of this chamber."
         [/message]
         [message]
             speaker=Rugnur


### PR DESCRIPTION
I don't like the explanation of the tools being made of unobtainium, so changed
it to use a convenient plot device. I think this also solves a plot hole about
the forge; instead of it being near the Shorbear Caves by random chance, this
gives a reason for the Shorbear Clan to live there (even if they haven't been
in there in living memory).

@max-torch I'd appreciate a review please, but I can't add you in Github's UI.