### PR TITLE
Put translation contribution info into CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,9 @@ private:
 };
 ```
 
+## Translations
+For specific information on how to update and submit translations, see [here](https://wiki.wesnoth.org/WesnothTranslationsHowTo).
+
 ## Bug Reports
 
 Please report any bugs here on GitHub (preferred) or on the forums.


### PR DESCRIPTION
---

This would be a replacement to https://wiki.wesnoth.org/WesnothTranslations, just in a place people are more likely to see that contributing to translations is a thing they can do.  After merging, that wiki page would be replaced with a redirect to this section of CONTRIBUTING.md.

Translations listed with a maintainer of None were determined by there being no updates to that language for over 5 years, or if a language was added more recently but has not received any meaningful updates since.