### PR TITLE
Fix #6389.

### DIFF
--- a/src/addon/state.cpp
+++ b/src/addon/state.cpp
@@ -51,7 +51,11 @@ addon_tracking_info get_addon_tracking_info(const addon_info& addon)
 		} else {
 			// We normally use the _info.cfg version instead.
 			t.installed_version = get_addon_version_info(id);
-			t.remote_version = *addon.versions.begin();
+			if(addon.versions.size() > 0) {
+				t.remote_version = *addon.versions.begin();
+			} else {
+				t.remote_version = version_info(0,0,0);
+			}
 		}
 
 		if(t.remote_version == t.installed_version) {


### PR DESCRIPTION
Previously this code assumed that all add-ons would have a _server.pbl or an _info.cfg. When neither was the case, it tried to dereference the begin() of an empty set, causing the crash.