### PR TITLE
Used std::any, except on MacOS

### DIFF
--- a/src/formula/variant.cpp
+++ b/src/formula/variant.cpp
@@ -68,7 +68,7 @@ variant_iterator::variant_iterator()
 {
 }
 
-variant_iterator::variant_iterator(const variant_value_base* value, const boost::any& iter)
+variant_iterator::variant_iterator(const variant_value_base* value, const utils::any& iter)
 	: type_(value->get_type())
 	, container_(value)
 	, iter_(iter)

--- a/src/formula/variant.hpp
+++ b/src/formula/variant.hpp
@@ -205,7 +205,7 @@ public:
 	 * @param value   A pointer to a variant value representing the container.
 	 * @param iter    An underlying iterator for the underlying container.
 	 */
-	variant_iterator(const variant_value_base* value, const boost::any& iter);
+	variant_iterator(const variant_value_base* value, const utils::any& iter);
 
 	variant operator*() const;
 	variant_iterator& operator++();
@@ -217,7 +217,7 @@ public:
 private:
 	formula_variant::type type_;
 	const variant_value_base* container_;
-	boost::any iter_;
+	utils::any iter_;
 };
 
 }

--- a/src/formula/variant_value.cpp
+++ b/src/formula/variant_value.cpp
@@ -26,7 +26,7 @@ boost::iterator_range<variant_iterator> variant_value_base::make_iterator() cons
 	return {variant_iterator(), variant_iterator()};
 }
 
-variant variant_value_base::deref_iterator(const boost::any& /*iter*/) const
+variant variant_value_base::deref_iterator(const utils::any& /*iter*/) const
 {
 	return variant();
 }
@@ -166,23 +166,23 @@ boost::iterator_range<variant_iterator> variant_callable::make_iterator() const
 	return {variant_iterator(this, inputs.cbegin()), variant_iterator(this, inputs.cend())};
 }
 
-variant variant_callable::deref_iterator(const boost::any& iter) const
+variant variant_callable::deref_iterator(const utils::any& iter) const
 {
 	if(!callable_) {
 		return variant();
 	}
 
-	return callable_->query_value(boost::any_cast<const formula_input_vector::const_iterator&>(iter)->name);
+	return callable_->query_value(utils::any_cast<const formula_input_vector::const_iterator&>(iter)->name);
 }
 
-void variant_callable::iterator_inc(boost::any& iter) const
+void variant_callable::iterator_inc(utils::any& iter) const
 {
-	++boost::any_cast<formula_input_vector::const_iterator&>(iter);
+	++utils::any_cast<formula_input_vector::const_iterator&>(iter);
 }
 
-void variant_callable::iterator_dec(boost::any& iter) const
+void variant_callable::iterator_dec(utils::any& iter) const
 {
-	--boost::any_cast<formula_input_vector::const_iterator&>(iter);
+	--utils::any_cast<formula_input_vector::const_iterator&>(iter);
 }
 
 std::string variant_string::get_serialized_string() const
@@ -270,21 +270,21 @@ boost::iterator_range<variant_iterator> variant_container<T>::make_iterator() co
 }
 
 template<typename T>
-void variant_container<T>::iterator_inc(boost::any& iter) const
+void variant_container<T>::iterator_inc(utils::any& iter) const
 {
-	++boost::any_cast<typename T::const_iterator&>(iter);
+	++utils::any_cast<typename T::const_iterator&>(iter);
 }
 
 template<typename T>
-void variant_container<T>::iterator_dec(boost::any& iter) const
+void variant_container<T>::iterator_dec(utils::any& iter) const
 {
-	--boost::any_cast<typename T::const_iterator&>(iter);
+	--utils::any_cast<typename T::const_iterator&>(iter);
 }
 
 template<typename T>
-bool variant_container<T>::iterator_equals(const boost::any& first, const boost::any& second) const
+bool variant_container<T>::iterator_equals(const utils::any& first, const utils::any& second) const
 {
-	return boost::any_cast<typename T::const_iterator>(first) == boost::any_cast<typename T::const_iterator>(second);
+	return utils::any_cast<typename T::const_iterator>(first) == utils::any_cast<typename T::const_iterator>(second);
 }
 
 // Force compilation of the following template instantiations
@@ -341,9 +341,9 @@ bool variant_list::less_than(variant_value_base& other) const
 	return num_elements() < other.num_elements();
 }
 
-variant variant_list::deref_iterator(const boost::any& iter) const
+variant variant_list::deref_iterator(const utils::any& iter) const
 {
-	return *boost::any_cast<const variant_vector::const_iterator&>(iter);
+	return *utils::any_cast<const variant_vector::const_iterator&>(iter);
 }
 
 std::string variant_map::to_string_detail(const variant_map_raw::value_type& container_val, mod_func_t mod_func) const
@@ -367,9 +367,9 @@ bool variant_map::less_than(variant_value_base& other) const
 	return get_container() < value_ref_cast<variant_map>(other).get_container();
 }
 
-variant variant_map::deref_iterator(const boost::any& iter) const
+variant variant_map::deref_iterator(const utils::any& iter) const
 {
-	const variant_map_raw::value_type& p = *boost::any_cast<const variant_map_raw::const_iterator&>(iter);
+	const variant_map_raw::value_type& p = *utils::any_cast<const variant_map_raw::const_iterator&>(iter);
 	auto the_pair = std::make_shared<key_value_pair>(p.first, p.second);
 	return variant(the_pair);
 }

--- a/src/formula/variant_value.hpp
+++ b/src/formula/variant_value.hpp
@@ -17,6 +17,7 @@
 #include "exceptions.hpp"
 #include "formula/callable_fwd.hpp"
 #include "formula_variant.hpp"
+#include "utils/any.hpp"
 #include "utils/general.hpp"
 
 #include <functional>
@@ -27,7 +28,6 @@
 #include <utility>
 #include <vector>
 #include <boost/range/iterator_range.hpp>
-#include <boost/any.hpp>
 
 namespace wfl
 {
@@ -143,7 +143,7 @@ public:
 	/**
 	 * Creates an iterator pair that can be used for iteration.
 	 * For an iterable type, it should use the two-argument constructor of variant-iterator,
-	 * passing the underlying iterator as the boost::any parameter.
+	 * passing the underlying iterator as the utils::any parameter.
 	 *
 	 * This creates both the begin and end iterator, but the variant implementation
 	 * discards one of the two.
@@ -156,7 +156,7 @@ public:
 	 *
 	 * @param iter The opaque reference that was passed to the variant_iterator by @ref make_iterator.
 	 */
-	virtual variant deref_iterator(const boost::any& iter) const;
+	virtual variant deref_iterator(const utils::any& iter) const;
 
 	/**
 	 * Implements the increment functionality of variant_iterator
@@ -164,7 +164,7 @@ public:
 	 *
 	 * The parameter is an opaque reference that was passed to the variant_iterator by @ref make_iterator.
 	 */
-	virtual void iterator_inc(boost::any&) const {}
+	virtual void iterator_inc(utils::any&) const {}
 
 	/**
 	 * Implements the decrement functionality of variant_iterator
@@ -172,7 +172,7 @@ public:
 	 *
 	 * The parameter is an opaque reference that was passed to the variant_iterator by @ref make_iterator.
 	 */
-	virtual void iterator_dec(boost::any&) const {}
+	virtual void iterator_dec(utils::any&) const {}
 
 	/**
 	 * Implements the equality functionality of variant_iterator
@@ -183,7 +183,7 @@ public:
 	 * The first parameter is an opaque reference that was passed to the variant_iterator by @ref make_iterator.
 	 * The second parameter is an opaque reference that was passed to the variant_iterator by @ref make_iterator.
 	 */
-	virtual bool iterator_equals(const boost::any& /*first*/, const boost::any& /*second*/) const
+	virtual bool iterator_equals(const utils::any& /*first*/, const utils::any& /*second*/) const
 	{
 		return true;
 	}
@@ -340,11 +340,11 @@ public:
 	}
 
 	virtual boost::iterator_range<variant_iterator> make_iterator() const override;
-	virtual variant deref_iterator(const boost::any& iter) const override;
+	virtual variant deref_iterator(const utils::any& iter) const override;
 
-	virtual void iterator_inc(boost::any& iter) const override;
-	virtual void iterator_dec(boost::any& iter) const override;
-	virtual bool iterator_equals(const boost::any& /*first*/, const boost::any& /*second*/) const override
+	virtual void iterator_inc(utils::any& iter) const override;
+	virtual void iterator_dec(utils::any& iter) const override;
+	virtual bool iterator_equals(const utils::any& /*first*/, const utils::any& /*second*/) const override
 	{
 		return true; // TODO: implement
 	}
@@ -467,9 +467,9 @@ public:
 	// specializations and leave the deref function to the derived classes.
 	virtual boost::iterator_range<variant_iterator> make_iterator() const override;
 
-	virtual void iterator_inc(boost::any&) const override;
-	virtual void iterator_dec(boost::any&) const override;
-	virtual bool iterator_equals(const boost::any& first, const boost::any& second) const override;
+	virtual void iterator_inc(utils::any&) const override;
+	virtual void iterator_dec(utils::any&) const override;
+	virtual bool iterator_equals(const utils::any& first, const utils::any& second) const override;
 
 protected:
 	using mod_func_t = std::function<std::string(const variant&)>;
@@ -510,7 +510,7 @@ public:
 		return type;
 	}
 
-	virtual variant deref_iterator(const boost::any&) const override;
+	virtual variant deref_iterator(const utils::any&) const override;
 
 private:
 	virtual std::string to_string_detail(const variant_vector::value_type& container_val, mod_func_t mod_func) const override
@@ -536,7 +536,7 @@ public:
 		return type;
 	}
 
-	virtual variant deref_iterator(const boost::any&) const override;
+	virtual variant deref_iterator(const utils::any&) const override;
 
 private:
 	virtual std::string to_string_detail(const variant_map_raw::value_type& container_val, mod_func_t mod_func) const override;

--- a/src/utils/any.hpp
+++ b/src/utils/any.hpp
@@ -1,0 +1,48 @@
+/*
+	Copyright (C) 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+/**
+ * @file
+ *
+ * MacOS doesn't support std::any_cast when targing MacOS < 10.14 (currently we target 10.11).
+ * This provides a wrapper around the STL variant API on all platforms except MacOS, which
+ * instead utilizes boost::any.
+ */
+
+#ifdef __APPLE__
+#define USING_BOOST_ANY
+#endif
+
+#ifndef USING_BOOST_ANY
+#include <any>
+#else
+#include <boost/any.hpp>
+#endif
+
+namespace utils
+{
+#ifndef USING_BOOST_ANY
+
+using std::any;
+using std::any_cast;
+
+#else
+
+using boost::any;
+using boost::any_cast;
+
+#endif
+} // namespace utils


### PR DESCRIPTION
For CI.

There's one remaining use of boost::any in commandline_options.cpp that cannot be converted since boost::program_options
excepted custom validator functions to take boost::any as their first argument.

