### PR TITLE
Reimplement mingw cross-compile docker image

### DIFF
--- a/utils/dockerbuilds/CI/Dockerfile-base-mingw
+++ b/utils/dockerbuilds/CI/Dockerfile-base-mingw
@@ -8,3 +8,6 @@ RUN pacman-cross -S --noconfirm \
     mingw-w64-x86_64-SDL2_image \
     mingw-w64-x86_64-SDL2_mixer \
     mingw-w64-x86_64-pango
+
+#symlink for compatibility with previous Dockerfiles
+RUN ln -s /msys64 /windows

--- a/utils/dockerbuilds/CI/Dockerfile-base-mingw
+++ b/utils/dockerbuilds/CI/Dockerfile-base-mingw
@@ -1,11 +1,6 @@
-FROM rwgrim/msys2-cross
-ENV DEBIAN_FRONTEND=noninteractive
+FROM wesnoth/wesnoth:msys2-base
 
-RUN apt-get update && \
-    apt-get install -y scons g++-mingw-w64-x86-64 pkg-config python3-pefile expect nsis gettext git && \
-    update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists
+RUN pacman -S --noconfirm scons mingw-w64-gcc pkg-config python-pefile expect nsis git
 
 RUN pacman-cross -S --noconfirm \
     mingw-w64-x86_64-boost \

--- a/utils/dockerbuilds/mingw/Dockerfile
+++ b/utils/dockerbuilds/mingw/Dockerfile
@@ -3,4 +3,4 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 COPY get_dlls.py /scripts/get_dlls.py
 
-ENTRYPOINT cd /output && scons -j `nproc` arch=x86-64 prefix=/windows/mingw64 gtkdir=/windows/mingw64 host=x86_64-w64-mingw32 -Y /wesnoth && python3 /scripts/get_dlls.py && rm -rf packaging && ln -sf /wesnoth/doc /wesnoth/packaging /wesnoth/data /wesnoth/fonts /wesnoth/images /wesnoth/sounds /wesnoth/README.md /wesnoth/copyright /wesnoth/COPYING /wesnoth/changelog.md /wesnoth/cwesnoth.cmd . && scons -Y /wesnoth windows-installer
+ENTRYPOINT cd /output && scons -j `nproc` arch=x86-64 prefix=/msys64/mingw64 gtkdir=/msys64/mingw64 host=x86_64-w64-mingw32 -Y /wesnoth && python3 /scripts/get_dlls.py && rm -rf packaging && ln -sf /wesnoth/doc /wesnoth/packaging /wesnoth/data /wesnoth/fonts /wesnoth/images /wesnoth/sounds /wesnoth/README.md /wesnoth/copyright /wesnoth/COPYING /wesnoth/changelog.md /wesnoth/cwesnoth.cmd . && scons -Y /wesnoth windows-installer

--- a/utils/dockerbuilds/msys2/Dockerfile
+++ b/utils/dockerbuilds/msys2/Dockerfile
@@ -1,0 +1,24 @@
+FROM archlinux
+
+# Add ownstuff third party repository because nsis is unavailable from default archlinux repos
+COPY ownstuff.conf ownstuff.conf
+RUN cat < ownstuff.conf >> /etc/pacman.conf
+
+RUN pacman --noconfirm -Syu && pacman --noconfirm -S wget
+
+# Trust ownstuff repo key to avoid prompts when installing nsis
+RUN pacman-key --init && \
+    pacman-key --recv-keys B9E36A7275FC61B464B67907E06FE8F53CDC6A4C && \
+    pacman-key --lsign-key B9E36A7275FC61B464B67907E06FE8F53CDC6A4C
+
+RUN wget https://github.com/msys2/msys2-installer/releases/download/2022-03-19/msys2-base-x86_64-20220319.tar.xz && \
+    tar xJvf msys2-base-x86_64-20220319.tar.xz && \
+    cp /msys64/etc/pacman.d/* /etc/pacman.d/ && \
+    cp /msys64/usr/share/pacman/keyrings/* /usr/share/pacman/keyrings/
+
+# setup msys2 keys
+RUN pacman-key --populate msys2
+
+RUN pacman --root /msys64 --config /msys64/etc/pacman.conf -Syu
+
+COPY bin/pacman-cross /bin/pacman-cross

--- a/utils/dockerbuilds/msys2/bin/pacman-cross
+++ b/utils/dockerbuilds/msys2/bin/pacman-cross
@@ -1,0 +1,3 @@
+#!/bin/sh
+pacman --root /msys64 --config /msys64/etc/pacman.conf $@
+exit $?

--- a/utils/dockerbuilds/msys2/ownstuff.conf
+++ b/utils/dockerbuilds/msys2/ownstuff.conf
@@ -1,0 +1,3 @@
+[ownstuff]
+Server = https://ftp.f3l.de/~martchus/$repo/os/$arch
+Server = https://martchus.no-ip.biz/repo/arch/$repo/os/$arch


### PR DESCRIPTION
rwgrim/msys2-cross on dockerhub we're currently using is incapable of being updated anymore because of changes in msys2 keyring and rebuilding the image from scratch is hard because it requires manual setup and many things seems to have broken due to changes in pacman and the like. So I made my own variant of it that downloads msys2 as archive, and uses pacman from archlinux base image to download msys2 package updates. rwgrim/msys2-cross uses debian base with pacman-static but I couldn't make this way work since new version of pacman-static seems to depend on some extra config files not existing in debian.