### PR TITLE
[1.16] wmlxgettext: add a --no-sort-by-file option

### DIFF
--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -49,7 +49,7 @@ def commandline(args):
                    [--directory=START_PATH]
                    [--recursive] [--initialdomain=INITIAL_DOMAIN]
                    [--package-version=PACKAGE_VERSION]
-                   [--no-text-colors] [--fuzzy] [--warnall]
+                   [--no-sort-by-file] [--no-text-colors] [--fuzzy] [--warnall]
                    FILE1 FILE2 ... FILEN'''
     )
     parser.add_argument(
@@ -101,6 +101,16 @@ def commandline(args):
         help=('Version number of your wesnoth add-on. You don\'t actually '
               'require to set this option since you can directly edit the '
               'po file produced by wmlxgettext.')
+    )
+    parser.add_argument(
+        '--no-sort-by-file',
+        action='store_false',
+        default=True,
+        dest='sort_by_file',
+        help=("By default the list of input files is sorted so that they "
+              "are processed in a deterministic order. Use this flag to "
+              "process the files in the order that they're named on the "
+              "command line.")
     )
     parser.add_argument(
         '--no-text-colors',
@@ -211,7 +221,8 @@ def main():
     # if args.recursive is True and args.filelist is None:
     else:
         startPath, filelist = pywmlx.autof.autoscan(startPath)
-    filelist.sort()
+    if args.sort_by_file:
+        filelist.sort()
     for fileno, fx in enumerate(filelist):
         fname = os.path.join(startPath, os.path.normpath(fx))
         is_file = os.path.isfile(fname)


### PR DESCRIPTION
Some users of wmlxgettext have scripts that already provide the file list in
a deterministic order, and the sorting added in 2adcb92fab was choosing a
different order to the one desired.

This doesn't affect mainline's .pot files - `scons pot-update` will have the same
output with or without this change.

@cooljeanius here you go.