### PR TITLE
Add a unit test for [move_unit]location_id with an occupied hex

### DIFF
--- a/data/test/scenarios/test_move_unit_to_occupied_hex.cfg
+++ b/data/test/scenarios/test_move_unit_to_occupied_hex.cfg
@@ -1,0 +1,55 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [move_unit]to_location
+##
+# Actions:
+# Try to move Alice to the hex that Bob already occupies.
+##
+# Expected end state:
+# Bob has not moved and both units are still on the map.
+# Alice is adjacent to Bob.
+#
+# The main "test_move_unit" includes a check that moving to an occupied
+# location by x,y coordinates doesn't overwrite the existing unit. This
+# tests the same, using a location_id.
+#####
+{GENERIC_UNIT_TEST "test_move_unit_to_occupied_location" (
+    [event]
+        name=start
+        {ASSERT (
+            [have_unit]
+                id=alice
+                x=7
+                y=3
+            [/have_unit]
+            [have_unit]
+                id=bob
+                x=13
+                y=3
+            [/have_unit]
+        )}
+
+        [move_unit]
+            id=alice
+            to_location=2
+        [/move_unit]
+
+        # She ends up one hex north-west of Bob instead, for consistency this
+        # tests the exact hex instead of just checking adjacency.
+        {ASSERT (
+            [have_unit]
+                id=alice
+                x=12
+                y=2
+            [/have_unit]
+            [have_unit]
+                id=bob
+                x=13
+                y=3
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -93,6 +93,7 @@
 9 test_move_fail_6
 0 test_move_unit
 0 test_move_unit_in_circle
+0 test_move_unit_to_occupied_location
 0 sighted_on_move
 0 move_skip_no_sighted_no_share_vision
 0 move_skip_ally_sighted_no_share_vision


### PR DESCRIPTION
Just a CI check for the forward-port of #6571.

(cherry picked from commit ba1767f8b90a4ca34cf8ef2abbc03cf98fd488f8)