### PR TITLE
Tutorial S02: Reduce the number of [messages]

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -198,29 +198,7 @@
                 {CONTINUE_MSG}
         [/message]
 
-        [message]
-            speaker=student
-            message= _ "Ho, Galdrad! Has Delfador conjured something else to beat me with? A flock of scarecrows, perhaps?"
-            female_message= _ "female^Ho, Galdrad! Has Delfador conjured something else to beat me with? A flock of scarecrows, perhaps?"
-        [/message]
-
-        {GENDER (
-            [message]
-                speaker=Galdrad
-                message= _ "This is no game, Konrad! Orcs have encamped across the river. This is elven country; they are fools to enter here. We elves are fast and hard to hit in forests. You must defeat their leader so they never threaten us again. I will advise you."
-            [/message]
-        ) (
-            [message]
-                speaker=Galdrad
-                message= _ "This is no game, Li’sar! Orcs have encamped across the river. This is elven country; they are fools to enter here. We elves are fast and hard to hit in forests. You must defeat their leader so they never threaten us again. I will advise you."
-            [/message]
-        )}
-
-        [message]
-            speaker=student
-            message= _ "What should I do?"
-            female_message= _ "female^What should I do?"
-        [/message]
+        # Maybe there should be an intro for Galdrad, but there's a lot of messages in here anyway; it seems better to err on the side of "every message says something useful".
 
         {TALK_ABOUT Dumbo ( _ "First, we will have to deal with the Orcish Grunt stationed in the middle of the river. He should be little trouble.")}
 
@@ -229,27 +207,6 @@
         {TALK_ABOUT_LOC 15,4 ( _ "See this dark blue water? It’s too deep for either side to cross. The orcs could slowly wade through that narrow band of shallow lighter-blue water in the north; but we could stand on the shore and force them to fight us from the water, where they are exposed and we are protected by the forest.")}
 
         {TALK_ABOUT_LOC 17,11 ( _ "The more likely attack, then, is across the bridge. That middle island is the key: it has a village for healing injured units and forests in which we fight so well.")}
-
-        [message]
-            speaker=student
-            message= _ "Let’s go! Attack!"
-            # po: The "us" in "let's" refers to Galdrad and Li'sar.
-            female_message= _ "female^Let’s go! Attack!"
-        [/message]
-
-        {GENDER (
-            [message]
-                speaker=Galdrad
-                # po: Addressing Konrad
-                message= _ "Hang on! You need to gather your forces. Or do you intend to fight the orcs single-handedly?"
-            [/message]
-        ) (
-            [message]
-                speaker=Galdrad
-                # po: Addressing Li'sar
-                message= _ "female^Hang on! You need to gather your forces. Or do you intend to fight the orcs single-handedly?"
-            [/message]
-        )}
 
         [if]
             # Do we have a recall list at all? It’s possible that the player lost all their units in the first scenario
@@ -497,13 +454,6 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
                     message= _ "Each turn, you will gain 2 gold plus one for each village you own. However, <i>upkeep</i> is subtracted from that. You can support as many levels worth of units as the number of villages you own; beyond that, you must pay 1 gold per turn. Be careful, as owning too many units can cause you to have negative income and lose gold each turn!"
                 [/message]
 
-                [message]
-                    speaker=narrator
-                    caption= _ "Status Table"
-                    image=wesnoth-icon.png
-                    message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
-                [/message]
-
                 [allow_end_turn][/allow_end_turn]
 
                 {PRINT (_"End your turn")}
@@ -609,38 +559,7 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
             message= _ "However, keep an eye on that ford. The orcs may try to sneak around behind our forces. It might do to send a few units to defend the banks, and the village there."
         [/message]
 
-        [message]
-            speaker=student
-            message= _ "Alright. The bridge it is, then, but I’ll be careful about the crossing."
-            female_message= _ "female^Alright. The bridge it is, then, but I’ll be careful about the crossing."
-        [/message]
-
         {TALK_ABOUT Dumbo ( _ "That Orcish Grunt is still blocking our path. He has no ranged attacks, so your archers should be able to engage him with little risk. Unfortunately, your units cannot reach him this turn, but you should not let them languish! Move them into position so they can attack next turn. There are also other villages on this side of the river. You should secure them for income and healing.")}
-
-        [message]
-            speaker=narrator
-            caption= _ "Long-distance Movement"
-            image=wesnoth-icon.png
-            message= _ "You can order a unit to move for multiple turns by selecting the unit and clicking on the destination. A number will indicate how many turns it will take to get there."
-        [/message]
-
-        [message]
-            speaker=student
-            message= _ "I think I’ll stick around the keep for now, in order to recruit more units."
-            female_message= _ "female^I think I’ll stick around the keep for now, in order to recruit more units."
-        [/message]
-
-        {GENDER (
-            [message]
-                speaker=Galdrad
-                message= _ "You’ve learned well, Konrad. It is indeed a good idea to keep your leader safe and protected and in range of your keep early in the game. The tide of battle can turn quickly, and you don’t want to find yourself cut off from recruiting reinforcements."
-            [/message]
-        ) (
-            [message]
-                speaker=Galdrad
-                message= _ "You’ve learned well, Li’sar. It is indeed a good idea to keep your leader safe and protected and in range of your keep early in the game. The tide of battle can turn quickly, and you don’t want to find yourself cut off from recruiting reinforcements."
-            [/message]
-        )}
     [/event]
 
     # If the player didn't provide bait for Dumbo, the guardian AI won't move
@@ -763,59 +682,23 @@ Please report the bug."
 
         [event]
             name=attack_end
-            [filter_second]
-                id=Dumbo
-            [/filter_second]
+            first_time_only=no
+            [filter]
+                side=1
+                [not]
+                    id=student
+                [/not]
+            [/filter]
 
-            [if]
-                [variable]
-                    name=unit.id
-                    equals=student
-                [/variable]
-                [then]
-                    [message]
-                        speaker=student
-                        message= _ "I hope I will survive the counter-attack if my units can’t take this grunt out this turn. I should order them to grab more villages if they can and move everyone closer for next turn."
-                    [/message]
-
-                    [message]
-                        speaker=Galdrad
-                        message= _ "If one of your Shamans stands just behind you, she will heal you 4 hitpoints at the beginning of the next turn."
-                    [/message]
-                [/then]
-                [else]
-                    [message]
-                        speaker=student
-                        message= _ "I hope my units will survive the counter-attack if I can’t take this grunt out this turn. I’d better grab more villages if I can and move everyone closer for next turn."
-                    [/message]
-
-                    [message]
-                        speaker=Galdrad
-                        message= _ "If one of your Shamans stands just behind your wounded units, she will heal each of them 4 hitpoints at the beginning of the next turn."
-                    [/message]
-                [/else]
-            [/if]
-
-            [event]
-                name=attack_end
-                first_time_only=no
-                [filter]
-                    side=1
-                    [not]
-                        id=student
-                    [/not]
-                [/filter]
-
-                [fire_event]
-                    name=warn_about_units_with_low_health
-                    [primary_unit]
-                        id=$unit.id
-                    [/primary_unit]
-                    [secondary_unit]
-                        id=$second_unit.id
-                    [/secondary_unit]
-                [/fire_event]
-            [/event]
+            [fire_event]
+                name=warn_about_units_with_low_health
+                [primary_unit]
+                    id=$unit.id
+                [/primary_unit]
+                [secondary_unit]
+                    id=$second_unit.id
+                [/secondary_unit]
+            [/fire_event]
         [/event]
     [/event]
 
@@ -903,7 +786,8 @@ Please report the bug."
         [cancel_action][/cancel_action]
     [/event]
 
-    # Remind them to keep back
+    # Tell the user to stay near the keep, to fit in with the check_income message about them
+    # being able to recruit more units.
     [event]
         name=moveto
         [filter]
@@ -916,6 +800,12 @@ Please report the bug."
                 name=turn_number
                 less_than=8
             [/variable]
+            [have_unit]
+                side=1
+                race=elf
+                count=0-6
+                # The message isn't necessary if they've already recruited extra units.
+            [/have_unit]
         [/filter_condition]
 
         [message]
@@ -1090,6 +980,7 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
         [/filter_condition]
 
         # This uses vision range so that it still triggers even if the player has already put an elf ready to counterattack while the orc is on 20% def, because it's better to trigger it then rather than a couple of turns later when the player is already fighting the orcs.
+        # Using movement range instead wouldn't trigger in that situation, because the elf on the shore would block the movement.
         [store_reachable_locations]
             [filter_location]
                 x,y=10,2


### PR DESCRIPTION
Drop many of the flavortext messages, to focus on the ones that explain
mechanics or tactics to the player.

The message about the Status Table gets removed because the player is unlikely
to benefit from it in this scenario. It might fit near the end as "you can
check how much gold the enemy has, and guess if he'll recruit next turn", but
otherwise it's just "hey, you could look at all the menu items" without any
suggestion about why the player should use it now.

Probably of interest to @max-torch too. The file is the same in 1.16 as master, so
could be backported.