### PR TITLE
Proof of concept: Convert the tutorial's wall of text [message]s into overlay text

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -198,29 +198,7 @@
                 {CONTINUE_MSG}
         [/message]
 
-        [message]
-            speaker=student
-            message= _ "Ho, Galdrad! Has Delfador conjured something else to beat me with? A flock of scarecrows, perhaps?"
-            female_message= _ "female^Ho, Galdrad! Has Delfador conjured something else to beat me with? A flock of scarecrows, perhaps?"
-        [/message]
-
-        {GENDER (
-            [message]
-                speaker=Galdrad
-                message= _ "This is no game, Konrad! Orcs have encamped across the river. This is elven country; they are fools to enter here. We elves are fast and hard to hit in forests. You must defeat their leader so they never threaten us again. I will advise you."
-            [/message]
-        ) (
-            [message]
-                speaker=Galdrad
-                message= _ "This is no game, Li’sar! Orcs have encamped across the river. This is elven country; they are fools to enter here. We elves are fast and hard to hit in forests. You must defeat their leader so they never threaten us again. I will advise you."
-            [/message]
-        )}
-
-        [message]
-            speaker=student
-            message= _ "What should I do?"
-            female_message= _ "female^What should I do?"
-        [/message]
+        # Maybe there should be an intro for Galdrad, but there's a lot of messages in here anyway; it seems better to err on the side of "every message says something useful".
 
         {TALK_ABOUT Dumbo ( _ "First, we will have to deal with the Orcish Grunt stationed in the middle of the river. He should be little trouble.")}
 
@@ -229,27 +207,6 @@
         {TALK_ABOUT_LOC 15,4 ( _ "See this dark blue water? It’s too deep for either side to cross. The orcs could slowly wade through that narrow band of shallow lighter-blue water in the north; but we could stand on the shore and force them to fight us from the water, where they are exposed and we are protected by the forest.")}
 
         {TALK_ABOUT_LOC 17,11 ( _ "The more likely attack, then, is across the bridge. That middle island is the key: it has a village for healing injured units and forests in which we fight so well.")}
-
-        [message]
-            speaker=student
-            message= _ "Let’s go! Attack!"
-            # po: The "us" in "let's" refers to Galdrad and Li'sar.
-            female_message= _ "female^Let’s go! Attack!"
-        [/message]
-
-        {GENDER (
-            [message]
-                speaker=Galdrad
-                # po: Addressing Konrad
-                message= _ "Hang on! You need to gather your forces. Or do you intend to fight the orcs single-handedly?"
-            [/message]
-        ) (
-            [message]
-                speaker=Galdrad
-                # po: Addressing Li'sar
-                message= _ "female^Hang on! You need to gather your forces. Or do you intend to fight the orcs single-handedly?"
-            [/message]
-        )}
 
         [if]
             # Do we have a recall list at all? It’s possible that the player lost all their units in the first scenario
@@ -497,13 +454,6 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
                     message= _ "Each turn, you will gain 2 gold plus one for each village you own. However, <i>upkeep</i> is subtracted from that. You can support as many levels worth of units as the number of villages you own; beyond that, you must pay 1 gold per turn. Be careful, as owning too many units can cause you to have negative income and lose gold each turn!"
                 [/message]
 
-                [message]
-                    speaker=narrator
-                    caption= _ "Status Table"
-                    image=wesnoth-icon.png
-                    message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
-                [/message]
-
                 [allow_end_turn][/allow_end_turn]
 
                 {PRINT (_"End your turn")}
@@ -609,38 +559,7 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
             message= _ "However, keep an eye on that ford. The orcs may try to sneak around behind our forces. It might do to send a few units to defend the banks, and the village there."
         [/message]
 
-        [message]
-            speaker=student
-            message= _ "Alright. The bridge it is, then, but I’ll be careful about the crossing."
-            female_message= _ "female^Alright. The bridge it is, then, but I’ll be careful about the crossing."
-        [/message]
-
         {TALK_ABOUT Dumbo ( _ "That Orcish Grunt is still blocking our path. He has no ranged attacks, so your archers should be able to engage him with little risk. Unfortunately, your units cannot reach him this turn, but you should not let them languish! Move them into position so they can attack next turn. There are also other villages on this side of the river. You should secure them for income and healing.")}
-
-        [message]
-            speaker=narrator
-            caption= _ "Long-distance Movement"
-            image=wesnoth-icon.png
-            message= _ "You can order a unit to move for multiple turns by selecting the unit and clicking on the destination. A number will indicate how many turns it will take to get there."
-        [/message]
-
-        [message]
-            speaker=student
-            message= _ "I think I’ll stick around the keep for now, in order to recruit more units."
-            female_message= _ "female^I think I’ll stick around the keep for now, in order to recruit more units."
-        [/message]
-
-        {GENDER (
-            [message]
-                speaker=Galdrad
-                message= _ "You’ve learned well, Konrad. It is indeed a good idea to keep your leader safe and protected and in range of your keep early in the game. The tide of battle can turn quickly, and you don’t want to find yourself cut off from recruiting reinforcements."
-            [/message]
-        ) (
-            [message]
-                speaker=Galdrad
-                message= _ "You’ve learned well, Li’sar. It is indeed a good idea to keep your leader safe and protected and in range of your keep early in the game. The tide of battle can turn quickly, and you don’t want to find yourself cut off from recruiting reinforcements."
-            [/message]
-        )}
     [/event]
 
     # If the player didn't provide bait for Dumbo, the guardian AI won't move
@@ -763,59 +682,23 @@ Please report the bug."
 
         [event]
             name=attack_end
-            [filter_second]
-                id=Dumbo
-            [/filter_second]
+            first_time_only=no
+            [filter]
+                side=1
+                [not]
+                    id=student
+                [/not]
+            [/filter]
 
-            [if]
-                [variable]
-                    name=unit.id
-                    equals=student
-                [/variable]
-                [then]
-                    [message]
-                        speaker=student
-                        message= _ "I hope I will survive the counter-attack if my units can’t take this grunt out this turn. I should order them to grab more villages if they can and move everyone closer for next turn."
-                    [/message]
-
-                    [message]
-                        speaker=Galdrad
-                        message= _ "If one of your Shamans stands just behind you, she will heal you 4 hitpoints at the beginning of the next turn."
-                    [/message]
-                [/then]
-                [else]
-                    [message]
-                        speaker=student
-                        message= _ "I hope my units will survive the counter-attack if I can’t take this grunt out this turn. I’d better grab more villages if I can and move everyone closer for next turn."
-                    [/message]
-
-                    [message]
-                        speaker=Galdrad
-                        message= _ "If one of your Shamans stands just behind your wounded units, she will heal each of them 4 hitpoints at the beginning of the next turn."
-                    [/message]
-                [/else]
-            [/if]
-
-            [event]
-                name=attack_end
-                first_time_only=no
-                [filter]
-                    side=1
-                    [not]
-                        id=student
-                    [/not]
-                [/filter]
-
-                [fire_event]
-                    name=warn_about_units_with_low_health
-                    [primary_unit]
-                        id=$unit.id
-                    [/primary_unit]
-                    [secondary_unit]
-                        id=$second_unit.id
-                    [/secondary_unit]
-                [/fire_event]
-            [/event]
+            [fire_event]
+                name=warn_about_units_with_low_health
+                [primary_unit]
+                    id=$unit.id
+                [/primary_unit]
+                [secondary_unit]
+                    id=$second_unit.id
+                [/secondary_unit]
+            [/fire_event]
         [/event]
     [/event]
 
@@ -903,7 +786,8 @@ Please report the bug."
         [cancel_action][/cancel_action]
     [/event]
 
-    # Remind them to keep back
+    # Tell the user to stay near the keep, to fit in with the check_income message about them
+    # being able to recruit more units.
     [event]
         name=moveto
         [filter]
@@ -916,6 +800,12 @@ Please report the bug."
                 name=turn_number
                 less_than=8
             [/variable]
+            [have_unit]
+                side=1
+                race=elf
+                count=0-6
+                # The message isn't necessary if they've already recruited extra units.
+            [/have_unit]
         [/filter_condition]
 
         [message]
@@ -1090,6 +980,7 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
         [/filter_condition]
 
         # This uses vision range so that it still triggers even if the player has already put an elf ready to counterattack while the orc is on 20% def, because it's better to trigger it then rather than a couple of turns later when the player is already fighting the orcs.
+        # Using movement range instead wouldn't trigger in that situation, because the elf on the shore would block the movement.
         [store_reachable_locations]
             [filter_location]
                 x,y=10,2

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -7,6 +7,10 @@
     turns=36
     experience_modifier=100
 
+    [load_resource]
+        id=hint_message_support
+    [/load_resource]
+
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC       battle-epic.ogg}
@@ -221,9 +225,9 @@
                     message= _ "I see you have veteran troops from your training! You should <i>recall</i> them so as to start off the battle with more experienced units. Think carefully, though; if a unit has too little experience, it might be better to recruit a new one."
                 [/message]
 
-                # It's impossible to have a lvl 3 unit by now, and rare to even have a lvl 2, but let's mention it anyway
                 [message]
                     speaker=Galdrad
+                    # po: It's impossible to have a lvl 3 unit by now, and rare to even have a lvl 2, but let's mention it anyway
                     message= _ "Some of your units have also managed to level up. They’re even more formidable, so you should recall them as well."
                     [show_if]
                         [have_unit]
@@ -236,9 +240,9 @@
                 [/message]
             [/then]
             [else]
-                # Unlikely in any case
                 [message]
                     speaker=Galdrad
+                    # po: This is extremely unlikely
                     message= _ "Unfortunately, none of your troops survived your training, so you will have to recruit new units. If you had any veteran troops, you could have <i>recalled</i> them to battle this scenario. More experienced units would have been of help against these orcs."
                 [/message]
             [/else]
@@ -253,6 +257,7 @@
 
         [message]
             speaker=Galdrad
+            # TODO: this one should probably become a [hint_message], but that means a new string
             message= _ "You also have two new types of units to recruit this scenario: Elvish Archers and Elvish Shamans. I’ll tell you more about them when you recruit them. Personally, I would recommend a balanced force of two archers, two fighters, and a shaman."
         [/message]
 
@@ -447,12 +452,13 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
                     message= _ "Excellent! As Delfador mentioned earlier, each captured village will support one unit and provide you with 1 extra gold per turn."
                 [/message]
 
-                [message]
+                [hint_message]
                     speaker=narrator
                     caption= _ "Income and Upkeep"
                     image=wesnoth-icon.png
+                    # TODO: This suggests that negative gold is something to be avoided, rather than a standard part of the game.
                     message= _ "Each turn, you will gain 2 gold plus one for each village you own. However, <i>upkeep</i> is subtracted from that. You can support as many levels worth of units as the number of villages you own; beyond that, you must pay 1 gold per turn. Be careful, as owning too many units can cause you to have negative income and lose gold each turn!"
-                [/message]
+                [/hint_message]
 
                 [allow_end_turn][/allow_end_turn]
 
@@ -545,6 +551,7 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
 
         [message]
             speaker=student
+            # TODO: this doesn't fit the map layout - even if there was a bridge there, it would still be a longer route to the enemy keep, and either route would approach the keep from the same path.
             message= _ "Galdrad, if I go by the ford, I could sneak up near his keep and dispatch him quickly."
             female_message= _ "female^Galdrad, if I go by the ford, I could sneak up near his keep and dispatch him quickly."
         [/message]
@@ -558,6 +565,11 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
             speaker=Galdrad
             message= _ "However, keep an eye on that ford. The orcs may try to sneak around behind our forces. It might do to send a few units to defend the banks, and the village there."
         [/message]
+
+        [hint_message]
+            # po: This hint is shown when the player's attention is directed to the first orcish grunt, the one on the bridge.
+            message= _ "You can see where an enemy can reach by moving the mouse over them. Don’t be afraid of putting a unit where the enemy can have the first attack, if that will leave the enemy in a bad position afterwards."
+        [/hint_message]
 
         {TALK_ABOUT Dumbo ( _ "That Orcish Grunt is still blocking our path. He has no ranged attacks, so your archers should be able to engage him with little risk. Unfortunately, your units cannot reach him this turn, but you should not let them languish! Move them into position so they can attack next turn. There are also other villages on this side of the river. You should secure them for income and healing.")}
     [/event]
@@ -640,12 +652,13 @@ Please report the bug."
     [event]
         name=turn 3
 
-        [message]
+        # The previous turn gave a hint specifically about the first enemy's movement, now expand it to the whole enemy side.
+        [hint_message]
             speaker=narrator
             caption= _ "Tracking Enemy Movement"
             image=wesnoth-icon.png
             message= _ "You can see where an enemy can reach by moving the mouse over them. You can see all possible enemy moves at once with the <b>Show Enemy Moves</b> command from the <b>Actions</b> menu."
-        [/message]
+        [/hint_message]
 
         {TALK_ABOUT_LOC 15,11 ( _ "We must occupy that island before the Wolf Riders reach it!")}
 
@@ -792,7 +805,7 @@ Please report the bug."
         name=moveto
         [filter]
             id=student
-            x=8-20
+            x=12-20
             y=1-20
         [/filter]
         [filter_condition]
@@ -810,28 +823,38 @@ Please report the bug."
 
         [message]
             speaker=Galdrad
+            # TODO: Is this message useful? Maybe rephrase as "You’ll soon have enough gold to recruit more units, consider staying near the keep a couple more turns."
             message= _ "You’re venturing away from your keep. You might need to recruit more units, and I doubt the orc leader will let you use his! Careful!"
         [/message]
 
         {UNDO_REMINDER}
     [/event]
 
+    # Dusk - time to set up for defending the island during the night.
     [event]
         name=turn 4
-        [filter_condition]
+
+        [hint_message]
+            message= _ "When moving a unit, the percentages shown are the unit’s defense on that hex. The higher the number, the less likely they are to get hit."
+        [/hint_message]
+
+        [if]
             [have_location]
                 x,y=16,9
                 [not]
                     owner_side=1
                 [/not]
             [/have_location]
-        [/filter_condition]
-
-        {TALK_ABOUT_LOC 16,9 ( _ "We need to occupy that village, otherwise they will take it soon! Move a unit into the village to stop the orcs capturing it. Whichever unit you choose will benefit from the village’s healing, too.")}
+            [then]
+                {TALK_ABOUT_LOC 16,9 ( _ "We need to occupy that village, otherwise they will take it soon! Move a unit into the village to stop the orcs capturing it. Whichever unit you choose will benefit from the village’s healing, too.")}
+            [/then]
+        [/if]
     [/event]
 
     [event]
         name=turn 5
+
+        # Leave the hint_message about defense numbers from turn 4, it's relevant here too.
 
         {TALK_ABOUT_LOC 16,9 ( _ "Careful! It is now nighttime. Orcs are <i>chaotic</i>, which means their attacks are now 25% stronger. By day, their attacks are 25% weaker, which is a noticeable difference. You are <i>lawful</i>: stronger by day and weaker at night. Your elvish warriors are <i>neutral</i>: unaffected by the time of day.")}
 
@@ -845,6 +868,11 @@ Please report the bug."
 
     [event]
         name=turn 6
+
+        # Clear the hint from turn 4 about defense stats
+        [hint_message]
+            message=""
+        [/hint_message]
 
         [fire_event]
             name=check_income
@@ -882,36 +910,61 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
     [/event]
 
     [event]
+        name=turn 8
+
+        # No particular reason for putting this on turn 8; there may be a couple of units finishing healing on villages, and the unit that's guarding the ford should probably cross the river about now.
+        [hint_message]
+            speaker=narrator
+            caption= _ "Long-distance Movement"
+            image=wesnoth-icon.png
+            message= _ "You can order a unit to move for multiple turns by selecting the unit and clicking on the destination. A number will indicate how many turns it will take to get there."
+        [/hint_message]
+    [/event]
+
+    [event]
         name=turn 9
 
-        [message]
+        [hint_message]
             speaker=narrator
             caption= _ "Tracking Unused Units"
             image=wesnoth-icon.png
             message= _ "You can ensure you use all your troops by pressing <b>n</b> to step from one unit to the next. If you press <b>space</b>, you can mark the currently selected unit as having finished its turn, which stops you moving it by accident later on. When <b>n</b> no longer selects a new unit, it’s safe to end your turn."
-        [/message]
+        [/hint_message]
     [/event]
 
     [event]
-        name=turn 10
+        name=turn 11
 
-        [message]
+        # TODO: Should this just be dropped? It used to be in the turn 1 event, but even as a late hint_message, it's talking about concepts that don't appear in the tutorial.
+        [hint_message]
             speaker=narrator
-            caption= _ "Victory Conditions"
+            caption= _ "Status Table"
             image=wesnoth-icon.png
-            message= _ "In this scenario, you only need to defeat the orc leader to win. Victory conditions for a scenario are given under <b>Objectives</b> in the <b>Menu</b> menu."
-        [/message]
+            message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
+        [/hint_message]
     [/event]
 
     [event]
         name=turn 12
 
-        [message]
+        [hint_message]
             speaker=narrator
             caption= _ "Speeding Up Animations"
             image=wesnoth-icon.png
             message= _ "Holding down <b>shift</b> will make the animations for moving and fighting quicker. The <b>acceleration factor</b> can be set, and turned on by default, in the <b>Preferences</b> menu’s <b>General</b> tab."
-        [/message]
+        [/hint_message]
+    [/event]
+
+    [event]
+        name=turn 13
+
+        # This would fit as the final hint.
+        [hint_message]
+            speaker=narrator
+            caption= _ "Victory Conditions"
+            image=wesnoth-icon.png
+            message= _ "In this scenario, you only need to defeat the orc leader to win. Victory conditions for a scenario are given under <b>Objectives</b> in the <b>Menu</b> menu."
+        [/hint_message]
     [/event]
 
     [event]
@@ -923,6 +976,10 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
         [/message]
     [/event]
 
+    # On turn 6 or turn 7, suggest recruiting more units
+    # TODO: the hint_message about recruiting the right units is appropriate for this turn
+    # This is also around the time that a hint_message about rotating injured troops would be
+    # appropriate, so maybe the logic should show on one of turn 6 or 7 too.
     [event]
         name=check_income
         first_time_only=no
@@ -956,12 +1013,12 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
                     message= _ "Good idea!"
                 [/message]
 
-                [message]
+                [hint_message]
                     speaker=narrator
                     caption= _ "Recruit the Right Units"
                     image=wesnoth-icon.png
                     message= _ "Remember to recruit troops useful for the situation. Archers are particularly effective against Grunts, Wolf Riders and the orcish leader."
-                [/message]
+                [/hint_message]
             [/then]
         [/if]
 

--- a/data/campaigns/tutorial/utils/utils.cfg
+++ b/data/campaigns/tutorial/utils/utils.cfg
@@ -15,6 +15,76 @@
     [/print]
 #enddef
 
+[resource]
+    id=hint_message_support
+    # Adds the tag [hint_message] which puts the text at the edge (top or bottom) of the screen.
+    # Used in the tutorial for info that can be left for reading until another hint is triggered,
+    # and unlike [message] does not block the user until they dismiss the text.
+    #
+    # There is no interaction between PRINT_STRING and [hint_message] - they don't cancel each
+    # other's messages.
+    [event]
+        name=preload
+        first_time_only=no
+        [lua]
+            # Intended implementation, requires PR 5873's add_overlay_text() function.
+            code=<<
+                if wesnoth.interface.add_overlay_text == nil then
+                    return {}
+                end
+
+                hint_label = {valid = false}
+                -- Takes 'caption' and 'message' arguments, similar to [message]
+                function wesnoth.wml_actions.hint_message(cfg)
+                    if hint_label.valid then
+                        hint_label:remove()
+                    end
+                    if cfg.message and cfg.message ~= "" then
+                        local text
+                        if cfg.caption and cfg.caption ~= "" then
+                            text = "<b>" .. cfg.caption .. "</b>\n" .. cfg.message
+                        else
+                            text = cfg.message
+                        end
+                        hint_label = wesnoth.interface.add_overlay_text(text, {
+                            size = 18,
+                            color = {255, 255, 255},
+                            duration = "unlimited",
+                            valign = "top"
+                        })
+                    end
+                end
+            >>
+        [/lua]
+        [lua]
+            # Fallback for discussing tutorial changes separately to the add_overlay_text() feature.
+            # Dumps the text into the chat log instead.
+            code=<<
+                if wesnoth.interface.add_overlay_text ~= nil then
+                    return {}
+                end
+
+                local _ = wesnoth.textdomain 'wesnoth-tutorial'
+                wesnoth.interface.add_chat_message(_("hint_message^Tip"), _("This is meant to be used with PR 5873’s add_overlay_text mechanism. Please imagine that only the most recently added message is shown, but a nice UI and with markup support."))
+
+                -- Takes 'caption' and 'message' arguments, however markup is not supported
+                function wesnoth.wml_actions.hint_message(cfg)
+                    if cfg.message and cfg.message ~= "" then
+                        local text
+                        if cfg.caption and cfg.caption ~= "" then
+                            text = cfg.caption .. ": " .. cfg.message
+                        else
+                            text = cfg.message
+                        end
+                        local _ = wesnoth.textdomain 'wesnoth-tutorial'
+                        wesnoth.interface.add_chat_message(_("hint_message^Tip"), text)
+                    end
+                end
+            >>
+        [/lua]
+    [/event]
+[/resource]
+
 #define GENDER MALE_WML FEMALE_WML
     [if]
         [have_unit]

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -663,6 +663,17 @@
 		[/tag]
 	[/tag]
 	[tag]
+		# TODO: this is just prototyping in the tutorial
+		name="hint_message"
+		max=infinite
+		{INSERT_TAG}
+		{SIMPLE_KEY message s_t_string}
+		{SIMPLE_KEY caption s_t_string}
+		# TODO: ignored, but makes it easy to switch between [message] and [hint_message]
+		{SIMPLE_KEY speaker string}
+		{SIMPLE_KEY image string}
+	[/tag]
+	[tag]
 		name="objectives"
 		max=infinite
 		super="$filter_side"


### PR DESCRIPTION
The reason for opening this is to ask if it's a direction that the UI should go in.

Adds the implementation of a prototype [hint_message] tag, either using PR #5837's add_overlay_text feature, or a fallback of outputting them to the chat log. This means a few less dialogs for the user to click through, but mainly means that about one hint per turn stays visible even when skipping through the dialogs.

The first of the two commits is PR #6614.

Turn 1's hint about upkeep appears near the end, when the player captures a village.

Turn 2's hint appears in the start-of-turn dialogue, when commenting on the orc blocking the bridge.

Turn 3 onwards appear at the start of each turn.

Initially I tried the bottom of the screen, but that overlaps with the area for `[message]`s.

With PR #5873 merged too:
![tutorial_add_overlay](https://user-images.githubusercontent.com/101462/161870949-4c7ad2de-9ddd-44fc-b5c6-f8e8d32de990.png)

Without that PR:
![tutorial_without_add_overlay](https://user-images.githubusercontent.com/101462/162079527-7232bbfc-5445-4321-97a4-20d729c098e9.png)