### PR TITLE
Avoid using unit IDs that are no longer valid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
  ### WML Engine
  ### Miscellaneous and Bug Fixes
    * Reduced the size of Isar's Cross map background images.
+   * Resolve crash on systems using musl implementation of libc (issue #6603)
 
 ## Version 1.17.2
  ### Add-ons client

--- a/src/recall_list_manager.cpp
+++ b/src/recall_list_manager.cpp
@@ -56,8 +56,10 @@ unit_const_ptr recall_list_manager::find_if_matches_id(const std::string &unit_i
  */
 void recall_list_manager::erase_if_matches_id(const std::string &unit_id)
 {
+	// using unit_id as reference has potential to cause a crash if the underlying unit becomes invald
+	// https://github.com/wesnoth/wesnoth/issues/6603
 	recall_list_.erase(std::remove_if(recall_list_.begin(), recall_list_.end(),
-		[&unit_id](const unit_ptr & ptr) { return ptr->id() == unit_id; }),
+		[unit_id](const unit_ptr & ptr) { return ptr->id() == unit_id; }),
 	                       recall_list_.end());
 }
 


### PR DESCRIPTION
Patch originally from @stevecotton. Aiming to merge before 1.16.3 is tagged (supposedly scheduled for 17th April 2022).

Resolves #6603 (crash with musl implementation of libc)