### PR TITLE
SoF: Consistently use lower-case after ellipses

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -509,7 +509,8 @@
         [/message]
         [message]
             speaker=Baglur
-            message= _ "I think it can be sealed up somehow... Yes, look, activating that glyph seems to have closed up the gap."
+            # po: "it" is a side entrance a dwarven fortress
+            message= _ "I think it can be sealed up somehow... yes, look, activating that glyph seems to have closed up the gap."
         [/message]
     [/event]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2p5_Reaching_the_Runecrafter.cfg
@@ -162,7 +162,7 @@
         [/message]
         [message]
             speaker=Pidmer
-            message= _ "Um... Aren’t we needed for the salvage?"
+            message= _ "Um... aren’t we needed for the salvage?"
         [/message]
         [message]
             speaker=Bragdash
@@ -175,7 +175,8 @@
         {MOVE_UNIT id=Rugnur 13 27}
         [message]
             speaker=Rugnur
-            message= _ "... Let’s set up a base here."
+            # po: second part of "Uh, well, we’re not getting through without a fight..."
+            message= _ "... let’s set up a base here."
         [/message]
         [terrain]
             terrain=Ce
@@ -207,7 +208,7 @@
         [/filter]
         [message]
             speaker=unit
-            message= _ "This old cart still rolls smoothly on the track... It’s forged by us dwarves, I shouldn’t be surprised!"
+            message= _ "This old cart still rolls smoothly on the track... it’s forged by us dwarves, I shouldn’t be surprised!"
         [/message]
         [message]
             speaker=narrator
@@ -232,7 +233,7 @@
         [/message]
         [message]
             speaker=unit
-            message= _ "This underground river is choked off with a rotting mess, it’s overgrown with fungus. I can try to see what’s underneath... Whoops!"
+            message= _ "This underground river is choked off with a rotting mess, it’s overgrown with fungus. I can try to see what’s underneath... whoops!"
         [/message]
         {QUAKE "rumble.ogg"}
         [terrain]
@@ -282,7 +283,8 @@
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Och, we ’ave... But our rails are as strong and stout as we are!"
+            # po: "Yes, we have flooded our own tunnel ..."
+            message= _ "Och, we ’ave... but our rails are as strong and stout as we are!"
         [/message]
         [message]
             speaker=Rugnur

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -216,7 +216,7 @@
 
         [message]
             speaker=Alanin
-            message= _ "Now where are we going, anyway? I’ve had to ride down cold, dark, unknown caves... It’s been quite harrowing, this trip had better be worth all that!"
+            message= _ "Now where are we going, anyway? I’ve had to ride down cold, dark, unknown caves... it’s been quite harrowing, this trip had better be worth all that!"
         [/message]
         [message]
             speaker=Baglur
@@ -398,7 +398,7 @@
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Aye, trolls and wolves are closing in... Sure, Krawg, we’ll help you fight them."
+            message= _ "Aye, trolls and wolves are closing in... sure, Krawg, we’ll help you fight them."
         [/message]
         [show_objectives]
         [/show_objectives]
@@ -600,7 +600,7 @@
         [/message]
         [message]
             speaker=Baglur
-            message= _ "Good. Now, there are still wild animals here... We have to get back into the caves."
+            message= _ "Good. Now, there are still wild animals here... we have to get back into the caves."
         [/message]
         {WINTERENEMY 19 30}
         {WINTERENEMY 1 21}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4t_The_Jeweler.cfg
@@ -209,7 +209,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Uh, um, yes, yes, very impressive ruby... Even in this raw form, it has an odd brilliance!"
+            message= _ "Uh, um, yes, yes, very impressive ruby... even in this raw form, it has an odd brilliance!"
         [/message]
         [message]
             speaker=Thursagan
@@ -217,7 +217,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Maybe... maybe... It will be hard, let me see..."
+            message= _ "Maybe... maybe... it will be hard, let me see..."
         [/message]
         [message]
             speaker=Thursagan
@@ -292,7 +292,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Ah, well, uh, no... no... unfortunately... It seems it can’t be cut, or scratched, or damaged at all! At least not by my tools..."
+            message= _ "Ah, well, uh, no... no... unfortunately... it seems it can’t be cut, or scratched, or damaged at all! At least not by my tools..."
         [/message]
         [message]
             speaker=Thursagan
@@ -300,7 +300,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Well... Maybe you can ask the Shorbear clan? They have good tools... chisels made of a metal that could only be worked in the heat of a volcanic forge. I don’t know how true that legend is, but their work is well known among us gem crafters."
+            message= _ "Well... maybe you can ask the Shorbear clan? They have good tools... chisels made of a metal that could only be worked in the heat of a volcanic forge. I don’t know how true that legend is, but their work is well known among us gem crafters."
         [/message]
         [message]
             speaker=Rugnur
@@ -308,7 +308,7 @@
         [/message]
         [message]
             speaker=Theganli
-            message= _ "Another group of dwarves that live south of here... Above ground, if you can believe it! Yes, they’re the best jewelers..."
+            message= _ "Another group of dwarves that live south of here... above ground, if you can believe it! Yes, they’re the best jewelers..."
         [/message]
         [message]
             speaker=Durstorn

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -420,7 +420,8 @@
         [/filter]
         [message]
             speaker=Rugnur
-            message= _ "Look at him fly... If only we could move that fast."
+            # po: he’s a gryphon, "flying" is used in the literal rather than figurative meaning
+            message= _ "Look at him fly... if only we could move that fast."
         [/message]
         [message]
             speaker=Krawg
@@ -494,7 +495,7 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _ "I thought we left the elves behind at the gates way back when... It seems we have two enemies now!"
+            message= _ "I thought we left the elves behind at the gates way back when... it seems we have two enemies now!"
         [/message]
         [message]
             speaker=Glonoin

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -367,7 +367,7 @@
         [/message]
         [message]
             speaker=Glildur
-            message= _ "I see... Well, we will not be fooled by your haggling and false promises. You were very foolish to come out here alone."
+            message= _ "I see... well, we will not be fooled by your haggling and false promises. You were very foolish to come out here alone."
         [/message]
         {REPLACE_SCENARIO_MUSIC frantic.ogg}
         {MOVE_UNIT (id=Glildur) 7 26}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -982,7 +982,7 @@
             [/filter]
             [message]
                 speaker=unit
-                message= _ "This is some sort of notebook... I can’t read the text, but there are drawings showing three arcs spanning what must be the volcano. There are three symbols for these arcs... Well, it must describe the volcano somehow, but I can’t puzzle it out now."
+                message= _ "This is some sort of notebook... I can’t read the text, but there are drawings showing three arcs spanning what must be the volcano. There are three symbols for these arcs... well, it must describe the volcano somehow, but I can’t puzzle it out now."
             [/message]
         [/event]
         [item]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -227,7 +227,7 @@
         [/message]
         [message]
             speaker=Haldric II
-            message= _ "Your advice is grating to my ears, not what I wish to hear... And yet, I see the wisdom in it, and I agree. Alanin, you’ve served in the army long enough to retire, and even if you hadn’t, you’ve seen enough combat. Go back to your village, and I shall see that you and your family live well and enjoy great success."
+            message= _ "Your advice is grating to my ears, not what I wish to hear... and yet, I see the wisdom in it, and I agree. Alanin, you’ve served in the army long enough to retire, and even if you hadn’t, you’ve seen enough combat. Go back to your village, and I shall see that you and your family live well and enjoy great success."
         [/message]
         [message]
             speaker=Alanin


### PR DESCRIPTION
Sadly, this takes the campaign up to 100 string changes between 1.16.2 and 1.16.3. The only one of these that was already going to change for 1.16.3 is S04t's volcanic forge one.

My intention (whether or not this merges) is to send out a mail to the i18n list when Saturday's pot-update is done, identifying the [4 strings that are actual changes](https://r.wesnoth.org/p672656), and saying that all the other fuzzies are just en_US grammar changes.

I think all of these make sense as mid-sentence pauses, but a few were arguably starting a new sentence so the ellipse was acting as both an ellipse and a full stop.

Pings: @max-torch. I'd ping demario if I knew his Github username.