### PR TITLE
Add debug for "[event] is missing name or id"

### DIFF
--- a/src/game_events/manager_impl.cpp
+++ b/src/game_events/manager_impl.cpp
@@ -34,6 +34,7 @@ static lg::log_domain log_event_handler("event_handler");
 
 static lg::log_domain log_wml("wml");
 #define ERR_WML LOG_STREAM(err, log_wml)
+#define DBG_WML LOG_STREAM(debug, log_wml)
 
 namespace game_events
 {
@@ -115,7 +116,8 @@ void event_handlers::add_event_handler(const config& cfg, bool is_menu_item)
 
 	if(name.empty() && id.empty()) {
 		lg::log_to_chat() << "[event] is missing name or id field\n";
-		ERR_WML << "[event] is missing name or id field";
+		ERR_WML << "[event] is missing name or id field\n";
+		DBG_WML << "Content of that event:\n" << cfg.debug() << "\n";
 		return;
 	}
 


### PR DESCRIPTION
The problem with this warning was that it didn't include any clue about what
had triggered it - just that there's a broken event somewhere, and it could be
in a scenario, macro, unit_type or even from another add-on if you're using a
non-default era.

When run with `--log-debug=wml`, this makes Wesnoth print out whatever the
contents of the affected [event] tag are.

See https://r.wesnoth.org/t55584 for more details.