### PR TITLE
Make tutorial hint messages persistent

### DIFF
--- a/data/campaigns/tutorial/_main.cfg
+++ b/data/campaigns/tutorial/_main.cfg
@@ -42,7 +42,10 @@
 [/units]
 
 [lua]
-    code="wesnoth.require 'campaigns/tutorial/lua/character_selection.lua'"
+    code=<<
+        wesnoth.require 'campaigns/tutorial/lua/character_selection'
+        wesnoth.require 'campaigns/tutorial/lua/hint_message'
+    >>
 [/lua]
 
 {campaigns/tutorial/utils}

--- a/data/campaigns/tutorial/lua/hint_message.lua
+++ b/data/campaigns/tutorial/lua/hint_message.lua
@@ -1,0 +1,24 @@
+
+local hint_message = {valid = false}
+function wesnoth.wml_actions.hint_message(cfg)
+    if hint_message.valid then
+        hint_message:remove()
+    end
+    if cfg.message and not cfg.remove then
+        local text = cfg.message
+        if cfg.caption and cfg.caption ~= "" then
+            text = "<b><big>" .. cfg.caption .. "</big></b>\n" .. cfg.message
+        else
+            text = cfg.message
+        end
+        hint_message = wesnoth.interface.add_overlay_text(text, {
+            size = 18,
+            location = {5,5},
+            color = {255, 255, 255},
+            duration = "unlimited",
+            max_width = "40%",
+            valign = "top",
+            halign = "left"
+        })
+    end
+end

--- a/data/campaigns/tutorial/lua/hint_message.lua
+++ b/data/campaigns/tutorial/lua/hint_message.lua
@@ -9,8 +9,6 @@ function wesnoth.wml_actions.hint_message(cfg)
         hint_text = cfg.message
         if cfg.caption and cfg.caption ~= "" then
             hint_text = "<b><big>" .. cfg.caption .. "</big></b>\n" .. hint_text
-        else
-            hint_text = cfg.message
         end
         hint_message = wesnoth.interface.add_overlay_text(hint_text, {
             size = 18,

--- a/data/campaigns/tutorial/lua/hint_message.lua
+++ b/data/campaigns/tutorial/lua/hint_message.lua
@@ -1,17 +1,18 @@
 
 local hint_message = {valid = false}
+local hint_text = ""
 function wesnoth.wml_actions.hint_message(cfg)
     if hint_message.valid then
         hint_message:remove()
     end
     if cfg.message and not cfg.remove then
-        local text = cfg.message
+        hint_text = cfg.message
         if cfg.caption and cfg.caption ~= "" then
-            text = "<b><big>" .. cfg.caption .. "</big></b>\n" .. cfg.message
+            hint_text = "<b><big>" .. cfg.caption .. "</big></b>\n" .. hint_text
         else
-            text = cfg.message
+            hint_text = cfg.message
         end
-        hint_message = wesnoth.interface.add_overlay_text(text, {
+        hint_message = wesnoth.interface.add_overlay_text(hint_text, {
             size = 18,
             location = {5,5},
             color = {255, 255, 255},
@@ -22,3 +23,10 @@ function wesnoth.wml_actions.hint_message(cfg)
         })
     end
 end
+
+wesnoth.persistent_tags.hint_message.read = wesnoth.wml_actions.hint_message
+
+function wesnoth.persistent_tags.hint_message.write(add)
+    add{message = hint_text}
+end
+    

--- a/data/campaigns/tutorial/lua/hint_message.lua
+++ b/data/campaigns/tutorial/lua/hint_message.lua
@@ -29,4 +29,4 @@ wesnoth.persistent_tags.hint_message.read = wesnoth.wml_actions.hint_message
 function wesnoth.persistent_tags.hint_message.write(add)
     add{message = hint_text}
 end
-    
+

--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -357,14 +357,12 @@
         {GENDER (
             [hint_message]
                 caption= _ "Movement"
-                message= _ "When you hover over or select a unit, in this case Konrad, the places he can move to are highlighted. All units have a certain number of <i>movement points</i>, which dictate how many hexes that unit can move per turn. Normally, moving one hex on flat terrain uses one movement point. To move, simply click on Konrad and then your destination. (You can press <b>u</b> to undo a move if you move to the wrong place.)" +
-                    {CONTINUE_MSG}
+                message= _ "When you hover over or select a unit, in this case Konrad, the places he can move to are highlighted. All units have a certain number of <i>movement points</i>, which dictate how many hexes that unit can move per turn. Normally, moving one hex on flat terrain uses one movement point. To move, simply click on Konrad and then your destination. (You can press <b>u</b> to undo a move if you move to the wrong place.)"
             [/hint_message]
         ) (
             [hint_message]
                 caption= _ "Movement"
-                message= _ "When you hover over or select a unit, in this case Li’sar, the places she can move to are highlighted. All units have a certain number of <i>movement points</i>, which dictate how many hexes that unit can move per turn. Normally, moving one hex on flat terrain uses one movement point. To move, simply click on Li’sar and then your destination. (You can press <b>u</b> to undo a move if you move to the wrong place.)" +
-                    {CONTINUE_MSG}
+                message= _ "When you hover over or select a unit, in this case Li’sar, the places she can move to are highlighted. All units have a certain number of <i>movement points</i>, which dictate how many hexes that unit can move per turn. Normally, moving one hex on flat terrain uses one movement point. To move, simply click on Li’sar and then your destination. (You can press <b>u</b> to undo a move if you move to the wrong place.)"
             [/hint_message]
         )}
 

--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -355,21 +355,17 @@
         {CLEAR_PRINT}
 
         {GENDER (
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Movement"
-                image=wesnoth-icon.png
                 message= _ "When you hover over or select a unit, in this case Konrad, the places he can move to are highlighted. All units have a certain number of <i>movement points</i>, which dictate how many hexes that unit can move per turn. Normally, moving one hex on flat terrain uses one movement point. To move, simply click on Konrad and then your destination. (You can press <b>u</b> to undo a move if you move to the wrong place.)" +
                     {CONTINUE_MSG}
-            [/message]
+            [/hint_message]
         ) (
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Movement"
-                image=wesnoth-icon.png
                 message= _ "When you hover over or select a unit, in this case Li’sar, the places she can move to are highlighted. All units have a certain number of <i>movement points</i>, which dictate how many hexes that unit can move per turn. Normally, moving one hex on flat terrain uses one movement point. To move, simply click on Li’sar and then your destination. (You can press <b>u</b> to undo a move if you move to the wrong place.)" +
                     {CONTINUE_MSG}
-            [/message]
+            [/hint_message]
         )}
 
         # [message]speaker=narrator deselects the unit, so reselect it now
@@ -508,19 +504,15 @@
         )}
 
         {GENDER (
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _"Attacking"
-                image=wesnoth-icon.png
                 message= _ "To attack the quintain, first select the attacker (Konrad), then the target (the quintain). You will see an attack description. Click <b>Attack</b> when you’re ready."
-            [/message]
+            [/hint_message]
         ) (
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _"Attacking"
-                image=wesnoth-icon.png
                 message= _"To attack the quintain, first select the attacker (Li’sar), then the target (the quintain). You will see an attack description. Click <b>Attack</b> when you’re ready."
-            [/message]
+            [/hint_message]
         )}
 
         [disallow_end_turn]
@@ -558,19 +550,15 @@
         [/message]
 
         {GENDER (
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Crowns"
-                image=wesnoth-icon.png
                 message= _ "The tiny golden crown above your leader (Konrad) indicates he is a side leader. In most scenarios, you will lose if your leader is killed. Be sure to keep him safe!"
-            [/message]
+            [/hint_message]
         ) (
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Crowns"
-                image=wesnoth-icon.png
                 message= _ "The tiny golden crown above your leader (Li’sar) indicates she is a side leader. In most scenarios, you will lose if your leader is killed. Be sure to keep her safe!"
-            [/message]
+            [/hint_message]
         )}
 
         # Check where Delfador is, to set the remaining moves accordingly
@@ -611,12 +599,10 @@
 
         [allow_end_turn][/allow_end_turn]
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Turns"
-            image=wesnoth-icon.png
             message= _ "Every turn, each side in a scenario gets a chance to make their move. Once you’ve completed everything you wish to do this turn, click on the <b>End Turn</b> button in the bottom right of the screen. The other sides, whether controlled by the AI or other human players, will then make their move. Some scenarios must be completed in a certain number of turns. You can see what turn it is, and any applicable turn limit, next to the flag icon at the top of the screen."
-        [/message]
+        [/hint_message]
 
         {PRINT (_"End your turn")}
     [/event]
@@ -689,12 +675,10 @@
 
             {CLEAR_PRINT}
 
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Villages"
-                image=wesnoth-icon.png
                 message= _"You have captured a village! It now flies your colors and has been added to your total village count (the house icon at the top of the screen shows how many villages you currently control). Villages provide the gold needed to recruit units. Each turn, you gain 2 gold, plus 1 for every village you own."
-            [/message]
+            [/hint_message]
 
             [allow_end_turn][/allow_end_turn]
 
@@ -770,12 +754,10 @@
                 side=1
             [/set_recruit]
 
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Recruiting"
-                image=wesnoth-icon.png
                 message= _ "Whenever you’re on a <i>keep</i>, you can <i>recruit</i> units on the castle tiles around it by right-clicking and selecting <b>Recruit</b>. Note that newly recruited units cannot act the turn you recruit them; you will be able to use them next turn. For this scenario, you have only one type of unit to choose from: the Elvish Fighter."
-            [/message]
+            [/hint_message]
 
             {PRINT (_"Recruit two Elvish Fighters")}
         [/event]
@@ -794,12 +776,10 @@
 
             {CLEAR_PRINT}
 
-            [message]
-                speaker=narrator
+            [hint_message]
                 caption= _ "Traits"
-                image=wesnoth-icon.png
                 message= _"Be sure to examine the <i>traits</i> of your new recruits. They are listed under its race in the sidebar. Traits can subtly affect how you use your troops. For example, units with the <i>quick</i> trait can move an extra hex each turn, and units with the <i>intelligent</i> trait require 20% less experience to level up."
-            [/message]
+            [/hint_message]
 
             # Allow our hero to move freely until next turn without undo messages now that the recruiting is done
             {VARIABLE enable_undo_messages no}
@@ -1009,36 +989,30 @@
             [/show_if]
         [/message]
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Unit Descriptions"
-            image=wesnoth-icon.png
             message= _ "You can right-click on a unit to see a detailed <b>Unit Description</b>."
-        [/message]
+        [/hint_message]
     [/event]
 
     # TURN 7: protect your troops
     [event]
         name=turn 7
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Protect Your Troops"
-            image=wesnoth-icon.png
             message= _ "Remember to pull back wounded units into villages and recruit more if needed. Take special care of units with the highest <i>experience points (XP)</i> so they can gain levels and become more powerful."
-        [/message]
+        [/hint_message]
     [/event]
 
     # TURN 8: support
     [event]
         name=turn 8
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Support"
-            image=wesnoth-icon.png
             message= _"Each village you control will <i>support</i> one unit for free. After that, each unit costs you one gold per turn."
-        [/message]
+        [/hint_message]
     [/event]
 
     # TURN 9: advancement
@@ -1055,25 +1029,21 @@
             [/show_if]
         [/message]
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Advancement"
-            image=wesnoth-icon.png
             message= _ "When a unit gains enough experience points (the <i>experience bar</i>, if present, is on the <b>right</b> of the <i>hitpoints bar</i>), it will gain a level. Elvish Fighters have two advancement options, and you will be able to choose which one you want. However, second level units cost twice as much to support as first level units."
-        [/message]
+        [/hint_message]
     [/event]
 
     # TURN 10: defenses
     [event]
         name=turn 10
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Defenses"
-            image=wesnoth-icon.png
             # wmllint: local spelling quintains
             message= _ "Whenever one of your units is selected, you’ll see varying percentages as you move the mouse over the map. The higher the percentage, the more <i>defense</i> that unit has in that kind of terrain. For example, most units have good defenses in castles and villages but poor defenses in rivers. Some units, like these quintains, have a <i>magical</i> attack, which always has a 70% chance of hitting no matter what terrain their targets occupy."
-        [/message]
+        [/hint_message]
     [/event]
 
     [event]
@@ -1239,12 +1209,10 @@
     [event]
         name=victory
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Victory"
-            image=wesnoth-icon.png
             message= _ "After your victory notice, the map will be grayed out to indicate that the scenario is over; this is called <i>linger mode</i>. You will still be able to examine the final positions and state of your troops and any surviving enemies. When you’re finished, click the <b>End Scenario</b> button to go on to the next scenario in the campaign."
-        [/message]
+        [/hint_message]
     [/event]
 
     [event]

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -912,7 +912,7 @@ Please report the bug."
 
         {UNDO_REMINDER}
     [/event]
-    
+
     [event]
         name=turn 4
         [hint_message]
@@ -947,7 +947,7 @@ Please report the bug."
 
     [event]
         name=turn 6
-        
+
         [hint_message]
             remove=yes
         [/hint_message]
@@ -986,7 +986,7 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
             name=check_income
         [/fire_event]
     [/event]
-    
+
     [event]
         name=turn 8
 

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -288,9 +288,7 @@
         [/if]
 
         [hint_message]
-            speaker=narrator
             caption= _ "Recalling"
-            image=wesnoth-icon.png
             message= _ "In addition to recruiting new units each scenario, you can also <i>recall</i> your experienced veterans from previous scenarios, for the cost of 20 gold each. This allows you to build up a formidable army over the course of multiple scenarios by recalling your highest leveled troops or those with good combinations of traits and abilities. To recall a unit, right-click while your leader stands on a keep and select the <i>Recall</i> option. Remember to also recruit new troops in addition to recalling old ones."
         [/hint_message]
 

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -287,12 +287,12 @@
             [/else]
         [/if]
 
-        [message]
+        [hint_message]
             speaker=narrator
             caption= _ "Recalling"
             image=wesnoth-icon.png
             message= _ "In addition to recruiting new units each scenario, you can also <i>recall</i> your experienced veterans from previous scenarios, for the cost of 20 gold each. This allows you to build up a formidable army over the course of multiple scenarios by recalling your highest leveled troops or those with good combinations of traits and abilities. To recall a unit, right-click while your leader stands on a keep and select the <i>Recall</i> option. Remember to also recruit new troops in addition to recalling old ones."
-        [/message]
+        [/hint_message]
 
         [message]
             speaker=Galdrad
@@ -490,19 +490,10 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
                     message= _ "Excellent! As Delfador mentioned earlier, each captured village will support one unit and provide you with 1 extra gold per turn."
                 [/message]
 
-                [message]
-                    speaker=narrator
+                [hint_message]
                     caption= _ "Income and Upkeep"
-                    image=wesnoth-icon.png
                     message= _ "Each turn, you will gain 2 gold plus one for each village you own. However, <i>upkeep</i> is subtracted from that. You can support as many levels worth of units as the number of villages you own; beyond that, you must pay 1 gold per turn. Be careful, as owning too many units can cause you to have negative income and lose gold each turn!"
-                [/message]
-
-                [message]
-                    speaker=narrator
-                    caption= _ "Status Table"
-                    image=wesnoth-icon.png
-                    message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
-                [/message]
+                [/hint_message]
 
                 [allow_end_turn][/allow_end_turn]
 
@@ -617,12 +608,10 @@ If either Shaman advances to become a Druid, then she’ll be able to heal adjac
 
         {TALK_ABOUT Dumbo ( _ "That Orcish Grunt is still blocking our path. He has no ranged attacks, so your archers should be able to engage him with little risk. Unfortunately, your units cannot reach him this turn, but you should not let them languish! Move them into position so they can attack next turn. There are also other villages on this side of the river. You should secure them for income and healing.")}
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Long-distance Movement"
-            image=wesnoth-icon.png
             message= _ "You can order a unit to move for multiple turns by selecting the unit and clicking on the destination. A number will indicate how many turns it will take to get there."
-        [/message]
+        [/hint_message]
 
         [message]
             speaker=student
@@ -721,12 +710,10 @@ Please report the bug."
     [event]
         name=turn 3
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Tracking Enemy Movement"
-            image=wesnoth-icon.png
             message= _ "You can see where an enemy can reach by moving the mouse over them. You can see all possible enemy moves at once with the <b>Show Enemy Moves</b> command from the <b>Actions</b> menu."
-        [/message]
+        [/hint_message]
 
         {TALK_ABOUT_LOC 15,11 ( _ "We must occupy that island before the Wolf Riders reach it!")}
 
@@ -925,6 +912,13 @@ Please report the bug."
 
         {UNDO_REMINDER}
     [/event]
+    
+    [event]
+        name=turn 4
+        [hint_message]
+            message= _ "When moving a unit, the percentages shown are the unit’s defense on that hex. The higher the number, the less likely they are to get hit."
+        [/hint_message]
+    [/event]
 
     [event]
         name=turn 4
@@ -945,16 +939,18 @@ Please report the bug."
 
         {TALK_ABOUT_LOC 16,9 ( _ "Careful! It is now nighttime. Orcs are <i>chaotic</i>, which means their attacks are now 25% stronger. By day, their attacks are 25% weaker, which is a noticeable difference. You are <i>lawful</i>: stronger by day and weaker at night. Your elvish warriors are <i>neutral</i>: unaffected by the time of day.")}
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Time of Day"
-            image=wesnoth-icon.png
             message= _ "During a scenario, the time of day will shift as turns pass. There are four <i>alignments</i> a unit may be: Lawful, Neutral, Chaotic, or Liminal. Each alignment gets a different bonus or handicap depending on the time of day. You can hover over the sky image below the minimap on the right to see the current time of day and who has the advantage."
-        [/message]
+        [/hint_message]
     [/event]
 
     [event]
         name=turn 6
+        
+        [hint_message]
+            remove=yes
+        [/hint_message]
 
         [fire_event]
             name=check_income
@@ -990,38 +986,50 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
             name=check_income
         [/fire_event]
     [/event]
+    
+    [event]
+        name=turn 8
+
+        [hint_message]
+            caption= _ "Long-distance Movement"
+            message= _ "You can order a unit to move for multiple turns by selecting the unit and clicking on the destination. A number will indicate how many turns it will take to get there."
+        [/hint_message]
+    [/event]
 
     [event]
         name=turn 9
 
-        [message]
-            speaker=narrator
+        [hint_message]
             caption= _ "Tracking Unused Units"
-            image=wesnoth-icon.png
             message= _ "You can ensure you use all your troops by pressing <b>n</b> to step from one unit to the next. If you press <b>space</b>, you can mark the currently selected unit as having finished its turn, which stops you moving it by accident later on. When <b>n</b> no longer selects a new unit, it’s safe to end your turn."
-        [/message]
+        [/hint_message]
     [/event]
 
     [event]
         name=turn 10
 
-        [message]
-            speaker=narrator
-            caption= _ "Victory Conditions"
-            image=wesnoth-icon.png
-            message= _ "In this scenario, you only need to defeat the orc leader to win. Victory conditions for a scenario are given under <b>Objectives</b> in the <b>Menu</b> menu."
-        [/message]
+        [hint_message]
+            caption= _ "Status Table"
+            message= _ "The Status Table details the sides’ current status and starting conditions. Fog and shroud will affect what you can see in this table, and occasionally a side may be hidden; however, it is still useful to check this table when a scenario begins. You can access it in the <b>Menu</b> menu."
+        [/hint_message]
+    [/event]
+
+    [event]
+        name=turn 11
+
+        [hint_message]
+            caption= _ "Speeding Up Animations"
+            message= _ "Holding down <b>shift</b> will make the animations for moving and fighting quicker. The <b>acceleration factor</b> can be set, and turned on by default, in the <b>Preferences</b> menu’s <b>General</b> tab."
+        [/hint_message]
     [/event]
 
     [event]
         name=turn 12
 
-        [message]
-            speaker=narrator
-            caption= _ "Speeding Up Animations"
-            image=wesnoth-icon.png
-            message= _ "Holding down <b>shift</b> will make the animations for moving and fighting quicker. The <b>acceleration factor</b> can be set, and turned on by default, in the <b>Preferences</b> menu’s <b>General</b> tab."
-        [/message]
+        [hint_message]
+            caption= _ "Victory Conditions"
+            message= _ "In this scenario, you only need to defeat the orc leader to win. Victory conditions for a scenario are given under <b>Objectives</b> in the <b>Menu</b> menu."
+        [/hint_message]
     [/event]
 
     [event]
@@ -1066,12 +1074,10 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
                     message= _ "Good idea!"
                 [/message]
 
-                [message]
-                    speaker=narrator
+                [hint_message]
                     caption= _ "Recruit the Right Units"
-                    image=wesnoth-icon.png
                     message= _ "Remember to recruit troops useful for the situation. Archers are particularly effective against Grunts, Wolf Riders and the orcish leader."
-                [/message]
+                [/hint_message]
             [/then]
         [/if]
 


### PR DESCRIPTION
Based on @stevecotton's #6615, this moves many of the tutorial hint messages into persistent overlay text. I played through the tutorial with these changes and I think it seems pretty good, but it probably needs a little refinement.