### PR TITLE
Unit tests: make separate files for each starting position

### DIFF
--- a/data/test/macros/start_position_common_keep_a_b_c_d.cfg
+++ b/data/test/macros/start_position_common_keep_a_b_c_d.cfg
@@ -1,0 +1,65 @@
+#textdomain wesnoth-test
+
+##
+# Starting state:
+#
+# Side 1 leader Alice (Orcish Grunt)
+# Side 2 leader Bob (Orcish Grunt)
+# Side 3 leader Charlie (Orcish Grunt)
+# Side 4 leader Dave (Orcish Grunt)
+#
+# All four leaders are on a single keep, with Alice and Bob already in position to attack any of the other units. None of the sides are allied.
+#
+# There is no free castle hex to recruit onto.
+##
+#define COMMON_KEEP_A_B_C_D_UNIT_TEST NAME CONTENT
+    [test]
+        name=_ "Unit Test " + {NAME}
+        map_file=test/maps/4p_single_castle.map
+        turns=unlimited
+        id={NAME}
+        random_start_time=no
+        is_unit_test=yes
+
+        {DAWN}
+
+        [side]
+            side=1
+            controller=human
+            [leader]
+                name = _ "Alice"
+                type = Orcish Grunt
+                id=alice
+            [/leader]
+        [/side]
+        [side]
+            side=2
+            controller=human
+            [leader]
+                name = _ "Bob"
+                type = Orcish Grunt
+                id=bob
+            [/leader]
+        [/side]
+        [side]
+            side=3
+            controller=human
+            [leader]
+                name = _ "Charlie"
+                type = Orcish Grunt
+                id=charlie
+            [/leader]
+        [/side]
+        [side]
+            side=4
+            controller=human
+            [leader]
+                name = _ "Dave"
+                type = Orcish Grunt
+                id=dave
+            [/leader]
+        [/side]
+
+        {CONTENT}
+    [/test]
+#enddef

--- a/data/test/macros/start_position_generic.cfg
+++ b/data/test/macros/start_position_generic.cfg
@@ -1,0 +1,59 @@
+#textdomain wesnoth-test
+
+##
+# Starting state:
+# Side 1 leader Alice (Elvish Archer)
+# Side 2 leader Bob (Orcish Grunt)
+#
+# Both leaders are on keeps separated by a few hexes, close enough for either
+# of them to move next to the other leader in a single turn for an attack.
+#
+# Both keeps have space to recruit a single unit.
+##
+#define GENERIC_UNIT_TEST NAME CONTENT
+#arg SIDE1_CONTROLLER
+human#endarg
+#arg SIDE2_CONTROLLER
+human#endarg
+#arg TURNS
+-1#endarg
+#arg SIDE1_RECRUIT
+#endarg
+#arg SIDE1_GOLD
+100#endarg
+#arg SIDE1_LEADER
+Elvish Archer#endarg
+
+    [test]
+        name = _ "Unit Test " + {NAME}
+        map_file=test/maps/generic_unit_test.map
+        turns = {TURNS}
+        id = {NAME}
+        is_unit_test = yes
+
+        {DAWN}
+
+        [side]
+            side=1
+            controller={SIDE1_CONTROLLER}
+            recruit={SIDE1_RECRUIT}
+            gold={SIDE1_GOLD}
+            [leader]
+                name = _ "Alice"
+                type = {SIDE1_LEADER}
+                id=alice
+            [/leader]
+        [/side]
+        [side]
+            side=2
+            controller={SIDE2_CONTROLLER}
+            [leader]
+                name = _ "Bob"
+                type = Orcish Grunt
+                id=bob
+            [/leader]
+        [/side]
+
+        {CONTENT}
+    [/test]
+#enddef

--- a/data/test/macros/wml_unit_test_macros.cfg
+++ b/data/test/macros/wml_unit_test_macros.cfg
@@ -56,59 +56,6 @@
     [/if]
 #enddef
 
-##
-# Starting state:
-# Side 1 leader Alice (Elvish Archer)
-# Side 2 leader Bob (Orcish Grunt)
-##
-#define GENERIC_UNIT_TEST NAME CONTENT
-#arg SIDE1_CONTROLLER
-human#endarg
-#arg SIDE2_CONTROLLER
-human#endarg
-#arg TURNS
--1#endarg
-#arg SIDE1_RECRUIT
-#endarg
-#arg SIDE1_GOLD
-100#endarg
-#arg SIDE1_LEADER
-Elvish Archer#endarg
-
-    [test]
-        name = _ "Unit Test " + {NAME}
-        map_file=test/maps/generic_unit_test.map
-        turns = {TURNS}
-        id = {NAME}
-        is_unit_test = yes
-
-        {DAWN}
-
-        [side]
-            side=1
-            controller={SIDE1_CONTROLLER}
-            recruit={SIDE1_RECRUIT}
-            gold={SIDE1_GOLD}
-            [leader]
-                name = _ "Alice"
-                type = {SIDE1_LEADER}
-                id=alice
-            [/leader]
-        [/side]
-        [side]
-            side=2
-            controller={SIDE2_CONTROLLER}
-            [leader]
-                name = _ "Bob"
-                type = Orcish Grunt
-                id=bob
-            [/leader]
-        [/side]
-
-        {CONTENT}
-    [/test]
-#enddef
-
 #define FAIL
     {RETURN ([false][/false])}
 #enddef
@@ -118,13 +65,13 @@ Elvish Archer#endarg
 #enddef
 
 #define FAIL_IF_NOT FLAG NOT_EQUALS
-[if]
-    [variable]
-        name={FLAG}
-        not_equals={NOT_EQUALS}
-    [/variable]
-    [then]
-        {FAIL}
-    [/then]
-[/if]
+    [if]
+        [variable]
+            name={FLAG}
+            not_equals={NOT_EQUALS}
+        [/variable]
+        [then]
+            {FAIL}
+        [/then]
+    [/if]
 #enddef

--- a/data/test/scenarios/firststrike_and_laststrike.cfg
+++ b/data/test/scenarios/firststrike_and_laststrike.cfg
@@ -22,52 +22,7 @@
 # Two units that both have firststrike act the same as neither having it.
 # Two units that both have laststrike act the same as neither having it.
 #####
-[test]
-    name = _ "Unit Test firststrike_and_laststrike"
-    map_file=test/maps/4p_single_castle.map
-    turns = unlimited
-    id = firststrike_and_laststrike
-    is_unit_test = yes
-
-    {DAWN}
-
-    [side]
-        side=1
-        controller=human
-        [leader]
-            name = _ "Alice"
-            type = Orcish Grunt
-            id=alice
-        [/leader]
-    [/side]
-    [side]
-        side=2
-        controller=human
-        [leader]
-            name = _ "Bob"
-            type = Orcish Grunt
-            id=bob
-        [/leader]
-    [/side]
-    [side]
-        side=3
-        controller=human
-        [leader]
-            name = _ "Charlie"
-            type = Orcish Grunt
-            id=charlie
-        [/leader]
-    [/side]
-    [side]
-        side=4
-        controller=human
-        [leader]
-            name = _ "Dave"
-            type = Orcish Grunt
-            id=dave
-        [/leader]
-    [/side]
-
+{COMMON_KEEP_A_B_C_D_UNIT_TEST firststrike_and_laststrike (
     [event]
         name=start
 
@@ -200,4 +155,4 @@
 
         {SUCCEED}
     [/event]
-[/test]
+)}


### PR DESCRIPTION
Turn the 4 side setup of the `firststrike_and_laststrike` test into a macro
called `COMMON_KEEP_A_B_C_D`for reuse in other tests.

The comment for `GENERIC_UNIT_TEST` gets a couple of extra paragraphs.

All the files get wmlindent run on them, which reindents `FAIL_IF_NOT`.

The main reason for having these is separate files is Git's fuzzy-patch
matching when merging and rebasing. Having large blocks of identical text
in `wml_unit_test_macros.cfg` can mean the wrong section gets patched.