### PR TITLE
[1.16] SoF S09: A few extra translation hints

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -509,7 +509,7 @@
         [/message]
         [message]
             speaker=Baglur
-            # po: "it" is a side entrance a dwarven fortress
+            # po: "it" is a side entrance of a dwarven fortress
             message= _ "I think it can be sealed up somehow... yes, look, activating that glyph seems to have closed up the gap."
         [/message]
     [/event]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -449,6 +449,7 @@
         [/unit]
         [message]
             speaker=narrator
+            # po: The mount is a gryphon.
             message= _ "A brave dwarf ran out, grabbed it by the sturdy neck-feathers, and hauled himself up over its back. The big animal was friendly, took it all in stride, and seemed to understand what the pats and strokes of the dwarf’s hands meant."
             image=wesnoth-icon.png
         [/message]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -793,6 +793,7 @@
                     [/message]
                     [message]
                         speaker=Thursagan
+                        # po: "smash it" refers to a stone tablet, not the Sceptre.
                         message= _ "Durstorn and Glildur have both convinced me that the time is not right for the Sceptre of Fire, best that it rests with us for a while. Now, smash it!"
                     [/message]
                     [message]
@@ -958,6 +959,7 @@
                 [then]
                     [message]
                         speaker=narrator
+                        # po: Krawg survives in both variants of this paragraph, but this one has an extra sentence to explain the gryhon riders’ fate. Surrounding events imply that flying units can escape, but the plot requires all dwarves to die.
                         message= _ "Once the magic seal capping the throat of the volcano was removed, lava and toxic gas exploded upward, killing everyone inside and sealing them in a tomb of hot, flowing rock. Krawg and the gryphon riders flew towards a hole in the roof but it was only Krawg who managed to outrun the explosion and emerge as the sole survivor. The Sceptre of Fire would wait, unharmed by the lava, until some day far in the future."
                         image=wesnoth-icon.png
                     [/message]
@@ -965,6 +967,7 @@
                 [else]
                     [message]
                         speaker=narrator
+                        # po: Krawg survives in both variants of this paragraph, this one is shown if the player didn’t have any gryphon riders. Surrounding events imply that flying units can escape, and in this variant Krawg is the only flying unit.
                         message= _ "Once the magic seal capping the throat of the volcano was removed, lava and toxic gas exploded upward, killing everyone inside and sealing them in a tomb of hot, flowing rock. The Sceptre of Fire would wait, unharmed by the lava, until some day far in the future."
                         image=wesnoth-icon.png
                     [/message]


### PR DESCRIPTION
Also an idea for the translators' changelog: put a paragraph starting with `po:` in the commit message, so that someone can generate the translators' changelog from the Git changelog.

Example covering this and 2581ab6c87f24abc92c1933d790324cc22cc20e3 / f82079bcc0eb2a24fa0e0ee6559fb390480a77d7 :
```
po: In SoF S09, many strings involving Krawg (a gryphon) assumed that Krawg was
the only flying unit. Similar texts have been added that are used when the player
has gryphon riders too; most of these will be marked as fuzzy versions of the
Krawg-only strings.