### PR TITLE
Scroll at a consistent speed.

### DIFF
--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -189,6 +189,12 @@ protected:
 	bool scroll_down_;
 	bool scroll_left_;
 	bool scroll_right_;
+	/* When the last scroll tick was processed */
+	uint32_t last_scroll_tick_;
+	/* Sub-pixel movement left over from a previous scroll tick.
+	 * This is added to the next scroll tick, if scrolling continues. */
+	double scroll_carry_x_;
+	double scroll_carry_y_;
 
 private:
 	/* A separate class for listening key-up events.


### PR DESCRIPTION
Fixes #3607

The `controller_base::handle_scroll` function is being called inside a loop that doesn't seem to be limited by anything. So if processing is fast, it loops and scrolls a lot, and if processing is slow, it doesn't.

I made it scroll by an amount proportional to the amount of time between calls to `handle_scroll`.