### PR TITLE
Editor: Add some missing terrain groupings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
    * Sceptre of Fire
      * S9: Allow Grypon Riders to complete the scenario (issue #6332)
  ### Editor
+   * Added some missing terrain groupings (issue #6643)
  ### Multiplayer
  ### Lua API
  ### Packaging

--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -472,7 +472,7 @@ Most units receive 20 to 40% defense in sand."
     string=^Efs
     aliasof=_bas
     light=25
-    editor_group=embellishments
+    editor_group=embellishments, cave
 [/terrain_type]
 
 [terrain_type]

--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -261,7 +261,7 @@
     editor_name= _ "Desert Cobbles"
     string=Rrd
     aliasof=Gt
-    editor_group=flat
+    editor_group=flat, desert
 [/terrain_type]
 
 [terrain_type]
@@ -407,7 +407,7 @@ Most units receive 20 to 40% defense in sand."
     editor_name= _ "Snowbits"
     string=^Esa
     aliasof=_bas
-    editor_group=embellishments
+    editor_group=embellishments, frozen
 [/terrain_type]
 
 [terrain_type]
@@ -2165,7 +2165,7 @@ Merfolk and nagas have 60% defense in submerged villages, whereas land based uni
     aliasof=Ct
     unit_height_adjust=3
     recruit_onto=yes
-    editor_group=castle
+    editor_group=castle, frozen
 [/terrain_type]
 
 [terrain_type]


### PR DESCRIPTION
Resolves #6643.

I'm not overly familiar with the myriad of terrains but this seems to make sense to me (I tested the changes too). I tried to review everything but it's possible there could be more groupings that could be added.