### PR TITLE
Fix single-frame title-screen flicker when loading a game or starting a campaign.

### DIFF
--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -259,6 +259,9 @@ void title_screen::pre_show(window& win)
 	register_button(win, "campaign", hotkey::TITLE_SCREEN__CAMPAIGN, [this, &win]() {
 		try{
 			if(game_.new_campaign()) {
+				// Suspend drawing of the title screen,
+				// so it doesn't flicker in between loading screens.
+				win.set_suspend_drawing(true);
 				win.set_retval(LAUNCH_GAME);
 			}
 		} catch (const config::error& e) {
@@ -277,6 +280,9 @@ void title_screen::pre_show(window& win)
 	//
 	register_button(win, "load", hotkey::HOTKEY_LOAD_GAME, [this, &win]() {
 		if(game_.load_game()) {
+			// Suspend drawing of the title screen,
+			// so it doesn't flicker in between loading screens.
+			win.set_suspend_drawing(true);
 			win.set_retval(LAUNCH_GAME);
 		}
 	});

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -425,6 +425,11 @@ public:
 		callback_next_draw_ = func;
 	}
 
+	void set_suspend_drawing(bool s = true)
+	{
+		suspend_drawing_ = s;
+	}
+
 	enum class show_mode {
 		none,
 		modal,


### PR DESCRIPTION
The title screen was being displayed for a single frame in between loading dialogs when either starting a new campaign or loading a game.

This was giving me an aneurysm.

I just turned off drawing of the title screen after these processes are confirmed. The next time the title screen needs to be drawn, it is recreated from scratch anyway, so the existing instance should never actually need to redraw.