### PR TITLE
Refactor FindHistory.cmake

### DIFF
--- a/cmake/FindHistory.cmake
+++ b/cmake/FindHistory.cmake
@@ -1,11 +1,37 @@
-# Locale GNU history library
+#[=======================================================================[.rst:
+FindHistory
+-----------
+
+Find the GNU History includes and library.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines the `IMPORTED` target ``History::History``, if
+History has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+	HISTORY_FOUND         - True if history found.
+	HISTORY_INCLUDE_DIR   - Where to find readline/history.h.
+	HISTORY_LIBRARY       - Library when using history.
+
+#]=======================================================================]
 
 find_path(HISTORY_INCLUDE_DIR readline/history.h)
-
 find_library(HISTORY_LIBRARY history)
 
-# handle the QUIETLY and REQUIRED arguments and set XXX_FOUND to TRUE if all listed variables are TRUE
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(History DEFAULT_MSG HISTORY_LIBRARY HISTORY_INCLUDE_DIR)
+# handle the QUIETLY and REQUIRED arguments and set HISTORY_FOUND to TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(History DEFAULT_MSG HISTORY_LIBRARY HISTORY_INCLUDE_DIR)
 
 mark_as_advanced(HISTORY_INCLUDE_DIR HISTORY_LIBRARY)
+
+if(HISTORY_FOUND AND (NOT TARGET History::History))
+	add_library(History::History UNKNOWN IMPORTED)
+	set_target_properties(History::History PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${HISTORY_INCLUDE_DIR}")
+	set_target_properties(History::History PROPERTIES IMPORTED_LOCATION "${HISTORY_LIBRARY}")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT MSVC)
 endif()
 
 if(HISTORY_FOUND)
-	set(game-external-libs ${game-external-libs} ${HISTORY_LIBRARY})
+	set(game-external-libs ${game-external-libs} History::History)
 endif()
 
 # get source lists


### PR DESCRIPTION
Hello!

I was super excited to look into `wesnoth`! Amazing work!

While I was getting to know the project I've read through some of the `cmake` finders and thought I may help with some modernization.

I've made `FindHistory.cmake` use lower caps keywords, added an `IMPORTED` target for it and some documentation that looks like the standard `cmake` docs.

Please let me know if this kind of stuff is interesting to you as I'll probably also look into the other `cmake` files during my journey.

Thanks and keep up the great work!
Andrei

EDIT: my editor was configured with `spaces`. I noticed all other cmake finders use tabs. I'll update accordingly