### PR TITLE
Have cmake also execute the conftests.

### DIFF
--- a/.github/workflows/ci-scripts/docker.sh
+++ b/.github/workflows/ci-scripts/docker.sh
@@ -99,8 +99,9 @@ else
 
         cmake -DCMAKE_BUILD_TYPE="$CFG" -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_NLS="$NLS" \
               -DEXTRA_FLAGS_CONFIG="-pipe" -DENABLE_STRICT_COMPILATION=true -DENABLE_LTO="$LTO" -DLTO_JOBS=2 -DENABLE_MYSQL=true \
-              -DCXX_STD="$CXX_STD" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache . && \
-              make VERBOSE=1 -j2
+              -DCXX_STD="$CXX_STD" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache . || exit 1
+        make conftests || exit 1
+        make VERBOSE=1 -j2
         EXIT_VAL=$?
 
         ccache -s

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,15 @@ uninstall.cmake
 CMakeCache.txt
 install_manifest.txt
 out/**/*
+CTestTestfile.cmake
+DartConfiguration.tcl
+Testing/*
+doc/CTestTestfile.cmake
+doc/design/CTestTestfile.cmake
+doc/man/CTestTestfile.cmake
+doc/manual/CTestTestfile.cmake
+src/CTestTestfile.cmake
+src/Testing/
 
 # scons
 .scons-option-cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.14)
 project(wesnoth)
 
 include(CheckCXXCompilerFlag)
+include(CTest)
 
 # use our own version of FindBoost.cmake and other Find* scripts
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/SConstruct
+++ b/SConstruct
@@ -350,9 +350,9 @@ if env["prereqs"]:
 
     def have_sdl_other():
         return \
-            conf.CheckSDL(require_version = '2.0.8') & \
-            conf.CheckSDL("SDL2_mixer", header_file = "SDL_mixer") & \
-            conf.CheckSDL("SDL2_image", header_file = "SDL_image")
+            conf.CheckSDL2('2.0.8') & \
+            conf.CheckSDL2Mixer() & \
+            conf.CheckSDL2Image()
 
     if sys.platform == "msys":
         env["PKG_CONFIG_FLAGS"] = "--dont-define-prefix"

--- a/scons/sdl.py
+++ b/scons/sdl.py
@@ -1,151 +1,117 @@
 # vi: syntax=python:et:ts=4
 import os
+import os.path
 from SCons.Script import *
 from config_check_utils import *
 from os import environ
 from SCons.Util import PrependPath
 
-def CheckSDL(context, sdl_lib = "SDL", require_version = None, header_file = None):
-    if require_version:
-        version = require_version.split(".", 2)
-        major_version = int(version[0])
-        minor_version = int(version[1])
-        try:
-            patchlevel    = int(version[2])
-        except (ValueError, IndexError):
-            patch_level = 0
-
-    if header_file:
-        sdl_header = header_file
-    else:
-        sdl_header = sdl_lib
-
+def CheckSDL2(context, require_version):
+    version = require_version.split(".", 2)
+    major_version = version[0]
+    minor_version = version[1]
+    patchlevel = version[2]
     backup = backup_env(context.env, ["CPPPATH", "LIBPATH", "LIBS"])
-
     sdldir = context.env.get("sdldir", "")
-    if sdl_lib == "SDL":
-        if require_version:
-            context.Message("Checking for Simple DirectMedia Layer library version >= %d.%d.%d... " % (major_version, minor_version, patchlevel))
-        else:
-            context.Message("Checking for Simple DirectMedia Layer library... ")
-        if major_version == 2:
-            sdl_config_name = "sdl2-config"
-            sdl_include_dir = "include/SDL2"
-            sdl_lib_name = "SDL2"
-            sdl_lib_name_pkgconfig = "sdl2"
-            sdlmain_name = "SDL2main"
-        else:
-            sdl_config_name = "sdl-config"
-            sdl_include_dir = "include/SDL"
-            sdl_lib_name = "SDL"
-            sdl_lib_name_pkgconfig = "sdl"
-            sdlmain_name = "SDLmain"
-        env = context.env
+    context.Message("Checking for Simple DirectMedia Layer library version >= %s.%s.%s... " % (major_version, minor_version, patchlevel))
+
+    env = context.env
+    if sdldir:
+        env["ENV"]["PATH"] = PrependPath(environ["PATH"], join(sdldir, "bin"))
+        env["ENV"]["PKG_CONFIG_PATH"] = PrependPath(environ.get("PKG_CONFIG_PATH", ""), join(sdldir, "lib/pkgconfig"))
+
+    if env["PLATFORM"] != "win32" or sys.platform == "msys":
+        for foo_config in [
+            "pkg-config --cflags --libs $PKG_CONFIG_FLAGS sdl2",
+            "sdl2-config --cflags --libs"
+            ]:
+            try:
+                env.ParseConfig(foo_config)
+            except OSError:
+                pass
+            else:
+                break
+    else:
         if sdldir:
-            env["ENV"]["PATH"] = PrependPath(environ["PATH"], join(sdldir, "bin"))
-            env["ENV"]["PKG_CONFIG_PATH"] = PrependPath(environ.get("PKG_CONFIG_PATH", ""), join(sdldir, "lib/pkgconfig"))
-        if env["PLATFORM"] != "win32" or sys.platform == "msys":
-            for foo_config in [
-                "pkg-config --cflags --libs $PKG_CONFIG_FLAGS %s" % sdl_lib_name_pkgconfig,
-                "%s --cflags --libs" % sdl_config_name
-                ]:
-                try:
-                    env.ParseConfig(foo_config)
-                except OSError:
-                    pass
-                else:
-                    break
+            env.AppendUnique(CPPPATH = [os.path.join(sdldir, "include/SDL2")], LIBPATH = [os.path.join(sdldir, "lib")])
+        env.AppendUnique(CCFLAGS = ["-D_GNU_SOURCE"])
+        env.AppendUnique(LIBS = Split("mingw32 SDL2main SDL2"))
+        env.AppendUnique(LINKFLAGS = ["-mwindows"])
+
+    cpp_file = File("src/conftests/sdl2.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2.cpp"
+
+    with open(cpp_file, 'r') as file:
+        test_program = file.read().replace("argv[1]", "\""+major_version+"\"").replace("argv[2]", "\""+minor_version+"\"").replace("argv[3]", "\""+patchlevel+"\"")
+
+        if context.TryLink(test_program, ".cpp"):
+            context.Result("yes")
+            return True
         else:
-            if sdldir:
-                env.AppendUnique(CPPPATH = [os.path.join(sdldir, sdl_include_dir)], LIBPATH = [os.path.join(sdldir, "lib")])
-            env.AppendUnique(CCFLAGS = ["-D_GNU_SOURCE"])
-            env.AppendUnique(LIBS = Split("mingw32 %s %s" % (sdlmain_name, sdl_lib_name)))
-            env.AppendUnique(LINKFLAGS = ["-mwindows"])
-    else:
-        if require_version:
-            context.Message("Checking for %s library version >= %d.%d.%d... " % (sdl_lib, major_version, minor_version, patchlevel))
+            context.Result("no")
+            restore_env(context.env, backup)
+            return False
+
+def CheckSDL2Image(context):
+    backup = backup_env(context.env, ["CPPPATH", "LIBPATH", "LIBS"])
+    context.Message("Checking for SDL2_image library... ")
+    context.env.AppendUnique(LIBS = ["SDL2_image"])
+
+    cpp_file = File("src/conftests/sdl2_image.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2_image.cpp"
+
+    with open(cpp_file, 'r') as file:
+        test_program = file.read()
+
+        if context.TryLink(test_program, ".cpp"):
+            context.Result("yes")
+            return True
         else:
-            context.Message("Checking for %s library... " % sdl_lib)
-        context.env.AppendUnique(LIBS = [sdl_lib])
-    test_program = """
-        #include <%s.h>
-        \n""" % sdl_header
-    if require_version:
-        test_program += "#if SDL_VERSIONNUM(%s, %s, %s) < SDL_VERSIONNUM(%d, %d, %d)\n#error Library is too old!\n#endif\n" % \
-            (sdl_lib.upper() + "_MAJOR_VERSION", \
-             sdl_lib.upper() + "_MINOR_VERSION", \
-             sdl_lib.upper() + "_PATCHLEVEL", \
-             major_version, minor_version, patchlevel)
-    test_program += """
-        int main(int argc, char** argv)
-        {
-            SDL_Init(0);
-            SDL_Quit();
-        }
-        \n"""
-    if context.TryLink(test_program, ".c"):
-        context.Result("yes")
-        return True
-    else:
-        context.Result("no")
-        restore_env(context.env, backup)
-        return False
+            context.Result("no")
+            restore_env(context.env, backup)
+            return False
+
+def CheckSDL2Mixer(context):
+    backup = backup_env(context.env, ["CPPPATH", "LIBPATH", "LIBS"])
+    context.Message("Checking for SDL2_mixer library... ")
+    context.env.AppendUnique(LIBS = ["SDL2_mixer"])
+
+    cpp_file = File("src/conftests/sdl2_mixer.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2_mixer.cpp"
+
+    with open(cpp_file, 'r') as file:
+        test_program = file.read()
+
+        if context.TryLink(test_program, ".cpp"):
+            context.Result("yes")
+            return True
+        else:
+            context.Result("no")
+            restore_env(context.env, backup)
+            return False
 
 def CheckOgg(context):
-    test_program = '''
-#include <stdlib.h>
-#include <stdio.h>
-
-#include <SDL.h>
-#include <SDL_mixer.h>
-
-int main(int argc, char ** argv)
-{
-    if (SDL_Init(SDL_INIT_AUDIO) < 0) {
-        fprintf(stdout, "Cannot initialize SDL Audio: %s\\n", SDL_GetError());
-        return (EXIT_FAILURE);
-    }
-
-    if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {
-        fprintf(stdout, "Cannot initialize SDL Mixer: %s\\n", Mix_GetError());
-        return (EXIT_FAILURE);
-    }
-
-    if (Mix_Init(MIX_INIT_OGG) != MIX_INIT_OGG) {
-        fprintf(stdout, "Cannot initialize OGG codec: %s\\n", Mix_GetError());
-        Mix_CloseAudio();
-        return (EXIT_FAILURE);
-    }
-
-    Mix_Music* music = Mix_LoadMUS("$TESTFILE");
-    if (music == NULL) {
-        fprintf(stdout, "Cannot load music file: %s\\n", Mix_GetError());
-        Mix_CloseAudio();
-        return (EXIT_FAILURE);
-    }
-
-    fprintf(stdout, "Success\\n");
-    Mix_FreeMusic(music);
-    Mix_CloseAudio();
-    return (EXIT_SUCCESS);
-}
-\n
-'''
-    nodepath = File("data/core/music/main_menu.ogg").rfile().abspath.replace("\\", "\\\\")
-    test_program1 = context.env.Clone(TESTFILE = nodepath).subst(test_program)
-    #context.env.AppendUnique(LIBS = "SDL_mixer")
-    context.Message("Checking for Ogg Vorbis support in SDL... ")
-    if context.env["host"]:
-        context.Result("n/a (cross-compile)")
-        return True
     context.env["ENV"]["SDL_AUDIODRIVER"] = "dummy"
-    (result, output) = context.TryRun(test_program1, ".c")
-    if result:
-        context.Result("yes")
-        return True
-    else:
-        test_program2 = context.env.Clone(TESTFILE = "data/core/music/main_menu.ogg").subst(test_program)
-        (result, output) = context.TryRun(test_program2, ".c")
+
+    cpp_file = File("src/conftests/sdl2_audio.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2_audio.cpp"
+
+    ogg_file = File("data/core/music/main_menu.ogg").rfile().abspath
+    if not os.path.isfile(ogg_file):
+        ogg_file = "data/core/music/main_menu.ogg"
+
+    with open(cpp_file, 'r') as file:
+        test_program = file.read().replace("argv[1]", "\""+ogg_file+"\"")
+
+        context.Message("Checking for audio support in SDL... ")
+        if context.env["host"]:
+            context.Result("n/a (cross-compile)")
+            return True
+        (result, output) = context.TryRun(test_program, ".cpp")
         if result:
             context.Result("yes")
             return True
@@ -154,36 +120,22 @@ int main(int argc, char ** argv)
             return False
 
 def CheckPNG(context):
-    test_program = '''
-    #include <SDL_image.h>
-    #include <stdlib.h>
+    cpp_file = File("src/conftests/sdl2_png.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2_png.cpp"
 
-    int main(int argc, char **argv)
-    {
-            SDL_RWops *src;
-            char *testimage = "$TESTFILE";
+    img_file = File("data/core/images/scons_conftest_images/end-n.png").rfile().abspath
+    if not os.path.isfile(img_file):
+        img_file = "data/core/images/scons_conftest_images/end-n.png"
 
-            src = SDL_RWFromFile(testimage, "rb");
-            if (src == NULL) {
-                    exit(2);
-            }
-            exit(!IMG_isPNG(src));
-    }
-\n
-'''
-    nodepath = File("data/core/images/scons_conftest_images/end-n.png").rfile().abspath.replace("\\", "\\\\")
-    test_program1 = context.env.Clone(TESTFILE = nodepath).subst(test_program)
-    context.Message("Checking for PNG support in SDL... ")
-    if context.env["host"]:
-        context.Result("n/a (cross-compile)")
-        return True
-    (result, output) = context.TryRun(test_program1, ".c")
-    if result:
-        context.Result("yes")
-        return True
-    else:
-        test_program2 = context.env.Clone(TESTFILE = "data/core/images/scons_conftest_images/end-n.png").subst(test_program)
-        (result, output) = context.TryRun(test_program2, ".c")
+    with open(cpp_file, 'r') as file:
+        test_program = file.read().replace("argv[1]", "\""+img_file+"\"")
+
+        context.Message("Checking for PNG support in SDL... ")
+        if context.env["host"]:
+            context.Result("n/a (cross-compile)")
+            return True
+        (result, output) = context.TryRun(test_program, ".cpp")
         if result:
             context.Result("yes")
             return True
@@ -192,36 +144,22 @@ def CheckPNG(context):
             return False
 
 def CheckWebP(context):
-    test_program = '''
-    #include <SDL_image.h>
-    #include <stdlib.h>
+    cpp_file = File("src/conftests/sdl2_webp.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2_webp.cpp"
 
-    int main(int argc, char **argv)
-    {
-            SDL_RWops *src;
-            char *testimage = "$TESTFILE";
+    img_file = File("data/core/images/scons_conftest_images/end-n.webp").rfile().abspath
+    if not os.path.isfile(img_file):
+        img_file = "data/core/images/scons_conftest_images/end-n.webp"
 
-            src = SDL_RWFromFile(testimage, "rb");
-            if (src == NULL) {
-                    exit(2);
-            }
-            exit(!IMG_isWEBP(src));
-    }
-\n
-'''
-    nodepath = File("data/core/images/scons_conftest_images/end-n.webp").rfile().abspath.replace("\\", "\\\\")
-    test_program1 = context.env.Clone(TESTFILE = nodepath).subst(test_program)
-    context.Message("Checking for WebP support in SDL... ")
-    if context.env["host"]:
-        context.Result("n/a (cross-compile)")
-        return True
-    (result, output) = context.TryRun(test_program1, ".c")
-    if result:
-        context.Result("yes")
-        return True
-    else:
-        test_program2 = context.env.Clone(TESTFILE = "data/core/images/scons_conftest_images/end-n.webp").subst(test_program)
-        (result, output) = context.TryRun(test_program2, ".c")
+    with open(cpp_file, 'r') as file:
+        test_program = file.read().replace("argv[1]", "\""+img_file+"\"")
+
+        context.Message("Checking for WEBP support in SDL... ")
+        if context.env["host"]:
+            context.Result("n/a (cross-compile)")
+            return True
+        (result, output) = context.TryRun(test_program, ".cpp")
         if result:
             context.Result("yes")
             return True
@@ -230,36 +168,22 @@ def CheckWebP(context):
             return False
 
 def CheckJPG(context):
-    test_program = '''
-    #include <SDL_image.h>
-    #include <stdlib.h>
+    cpp_file = File("src/conftests/sdl2_jpg.cpp").rfile().abspath
+    if not os.path.isfile(cpp_file):
+        cpp_file = "src/conftests/sdl2_jpg.cpp"
 
-    int main(int argc, char **argv)
-    {
-            SDL_RWops *src;
-            char *testimage = "$TESTFILE";
+    img_file = File("data/core/images/scons_conftest_images/end-n.jpg").rfile().abspath
+    if not os.path.isfile(img_file):
+        img_file = "data/core/images/scons_conftest_images/end-n.jpg"
 
-            src = SDL_RWFromFile(testimage, "rb");
-            if (src == NULL) {
-                    exit(2);
-            }
-            exit(!IMG_isJPG(src));
-    }
-\n
-'''
-    nodepath = File("data/core/images/scons_conftest_images/end-n.jpg").rfile().abspath.replace("\\", "\\\\")
-    test_program1 = context.env.Clone(TESTFILE = nodepath).subst(test_program)
-    context.Message("Checking for JPG support in SDL... ")
-    if context.env["host"]:
-        context.Result("n/a (cross-compile)")
-        return True
-    (result, output) = context.TryRun(test_program1, ".c")
-    if result:
-        context.Result("yes")
-        return True
-    else:
-        test_program2 = context.env.Clone(TESTFILE = "data/core/images/scons_conftest_images/end-n.jpg").subst(test_program)
-        (result, output) = context.TryRun(test_program2, ".c")
+    with open(cpp_file, 'r') as file:
+        test_program = file.read().replace("argv[1]", "\""+img_file+"\"")
+
+        context.Message("Checking for JPG support in SDL... ")
+        if context.env["host"]:
+            context.Result("n/a (cross-compile)")
+            return True
+        (result, output) = context.TryRun(test_program, ".cpp")
         if result:
             context.Result("yes")
             return True
@@ -267,7 +191,9 @@ def CheckJPG(context):
             context.Result("no")
             return False
 
-config_checks = { 'CheckSDL' : CheckSDL,
+config_checks = { 'CheckSDL2Image' : CheckSDL2Image,
+                  'CheckSDL2Mixer' : CheckSDL2Mixer,
+                  'CheckSDL2': CheckSDL2,
                   'CheckOgg' : CheckOgg,
                   'CheckPNG' : CheckPNG,
                   'CheckJPG' : CheckJPG,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,65 @@ if(ENABLE_DISPLAY_REVISION)
 	set_source_files_properties(game_config.cpp PROPERTIES COMPILE_DEFINITIONS "LOAD_REVISION")
 endif()
 
+########### Conf Tests ###########
+
+if(NOT MSVC)
+	# test for SDL2
+	add_executable(sdl2 conftests/sdl2.cpp)
+	set_target_properties(sdl2 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2 ${game-external-libs})
+	# cmake checks the version elsewhere already, but scons uses this, which is why the three arguments for major.minor.patchlevel are 0 here
+	add_test(NAME SDL2_SUPPORT COMMAND sdl2 0 0 0)
+
+	# test for SDL2_image
+	add_executable(sdl2_image conftests/sdl2_image.cpp)
+	set_target_properties(sdl2_image PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2_image ${game-external-libs})
+	add_test(NAME SDL2_IMAGE_SUPPORT COMMAND sdl2_image)
+
+	# test for SDL2_mixer
+	add_executable(sdl2_mixer conftests/sdl2_mixer.cpp)
+	set_target_properties(sdl2_mixer PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2_mixer ${game-external-libs})
+	add_test(NAME SDL2_MIXER_SUPPORT COMMAND sdl2_mixer)
+
+	# test for JPG support in SDL2
+	add_executable(sdl2_jpg conftests/sdl2_jpg.cpp)
+	set_target_properties(sdl2_jpg PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2_jpg ${game-external-libs})
+	add_test(NAME SDL2_JPG_SUPPORT COMMAND sdl2_jpg "${CMAKE_SOURCE_DIR}/data/core/images/scons_conftest_images/end-n.jpg")
+
+	# test for PNG support in SDL2
+	add_executable(sdl2_png conftests/sdl2_png.cpp)
+	set_target_properties(sdl2_png PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2_png ${game-external-libs})
+	add_test(NAME SDL2_PNG_SUPPORT COMMAND sdl2_png "${CMAKE_SOURCE_DIR}/data/core/images/scons_conftest_images/end-n.png")
+
+	# test for WEBP support in SDL2
+	add_executable(sdl2_webp conftests/sdl2_webp.cpp)
+	set_target_properties(sdl2_webp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2_webp ${game-external-libs})
+	add_test(NAME SDL2_WEBP_SUPPORT COMMAND sdl2_webp "${CMAKE_SOURCE_DIR}/data/core/images/scons_conftest_images/end-n.webp")
+
+	# test for audio support in SDL2
+	add_executable(sdl2_audio conftests/sdl2_audio.cpp)
+	set_target_properties(sdl2_audio PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/Testing)
+	target_link_libraries(sdl2_audio ${game-external-libs})
+	add_test(NAME SDL2_AUDIO_SUPPORT COMMAND sdl2_audio "${CMAKE_SOURCE_DIR}/data/core/music/main_menu.ogg")
+
+	add_custom_target(conftests
+		COMMAND ${CMAKE_COMMAND} -E env "SDL_AUDIODRIVER=dummy" ${CMAKE_CTEST_COMMAND}
+		DEPENDS
+			sdl2
+			sdl2_image
+			sdl2_mixer
+			sdl2_jpg
+			sdl2_png
+			sdl2_webp
+			sdl2_audio
+	)
+endif()
+
 ########### Wesnoth ###############
 
 add_library(wesnoth-common STATIC ${wesnoth_core_sources})

--- a/src/conftests/sdl2.cpp
+++ b/src/conftests/sdl2.cpp
@@ -1,0 +1,19 @@
+#include <SDL2/SDL.h>
+#include <stdlib.h>
+#include <string>
+
+int main(int, char** argv)
+{
+    int major = std::stoi(argv[1]);
+    int minor = std::stoi(argv[2]);
+    int patchlevel = std::stoi(argv[3]);
+
+    if(!SDL_VERSION_ATLEAST(major, minor, patchlevel)) {
+        exit(1);
+    }
+
+    SDL_Init(0);
+    SDL_Quit();
+
+    return 0;
+}

--- a/src/conftests/sdl2_audio.cpp
+++ b/src/conftests/sdl2_audio.cpp
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
+
+int main(int, char** argv)
+{
+    if (SDL_Init(SDL_INIT_AUDIO) < 0) {
+        fprintf(stdout, "Cannot initialize SDL Audio: %s\\n", SDL_GetError());
+        return (EXIT_FAILURE);
+    }
+
+    if (Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 1024) == -1) {
+        fprintf(stdout, "Cannot initialize SDL Mixer: %s\\n", Mix_GetError());
+        return (EXIT_FAILURE);
+    }
+
+    if (Mix_Init(MIX_INIT_OGG) != MIX_INIT_OGG) {
+        fprintf(stdout, "Cannot initialize OGG codec: %s\\n", Mix_GetError());
+        Mix_CloseAudio();
+        return (EXIT_FAILURE);
+    }
+
+    Mix_Music* music = Mix_LoadMUS(argv[1]);
+    if (music == NULL) {
+        fprintf(stdout, "Cannot load music file: %s\\n", Mix_GetError());
+        Mix_CloseAudio();
+        return (EXIT_FAILURE);
+    }
+
+    fprintf(stdout, "Success\\n");
+    Mix_FreeMusic(music);
+    Mix_CloseAudio();
+    return (EXIT_SUCCESS);
+}

--- a/src/conftests/sdl2_image.cpp
+++ b/src/conftests/sdl2_image.cpp
@@ -1,0 +1,10 @@
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+
+int main(int, char**)
+{
+    SDL_Init(0);
+    SDL_Quit();
+
+    return 0;
+}

--- a/src/conftests/sdl2_jpg.cpp
+++ b/src/conftests/sdl2_jpg.cpp
@@ -1,0 +1,11 @@
+#include <SDL2/SDL_image.h>
+#include <stdlib.h>
+
+int main(int, char** argv)
+{
+    SDL_RWops *src = SDL_RWFromFile(argv[1], "rb");
+    if (src == NULL) {
+        exit(2);
+    }
+    exit(!IMG_isJPG(src));
+}

--- a/src/conftests/sdl2_mixer.cpp
+++ b/src/conftests/sdl2_mixer.cpp
@@ -1,0 +1,10 @@
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
+
+int main(int, char**)
+{
+    SDL_Init(0);
+    SDL_Quit();
+
+    return 0;
+}

--- a/src/conftests/sdl2_png.cpp
+++ b/src/conftests/sdl2_png.cpp
@@ -1,0 +1,11 @@
+#include <SDL2/SDL_image.h>
+#include <stdlib.h>
+
+int main(int, char** argv)
+{
+    SDL_RWops *src = SDL_RWFromFile(argv[1], "rb");
+    if (src == NULL) {
+        exit(2);
+    }
+    exit(!IMG_isPNG(src));
+}

--- a/src/conftests/sdl2_webp.cpp
+++ b/src/conftests/sdl2_webp.cpp
@@ -1,0 +1,11 @@
+#include <SDL2/SDL_image.h>
+#include <stdlib.h>
+
+int main(int, char** argv)
+{
+    SDL_RWops *src = SDL_RWFromFile(argv[1], "rb");
+    if (src == NULL) {
+        exit(2);
+    }
+    exit(!IMG_isWEBP(src));
+}


### PR DESCRIPTION
---

This moves the scons conf tests into their own cpp files rather than being embedded in the scons python scripts, and also has them be executed by cmake before building.