### PR TITLE
[Campaign] [DiD] [Liberty] Fix background image paths

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/_main.cfg
+++ b/data/campaigns/Descent_Into_Darkness/_main.cfg
@@ -9,7 +9,7 @@
     rank=100
     year="389 YW"
     icon="data/campaigns/Descent_Into_Darkness/images/units/dark-mage.png~RC(magenta>red)"
-    background="data/campaigns/The_Rise_Of_Wesnoth/images/story/trow_intro_03.jpg"
+    background="data/campaigns/The_Rise_Of_Wesnoth/images/story/trow_intro_03.webp"
     name= _ "Descent into Darkness"
     abbrev= _ "DiD"
     define=CAMPAIGN_DESCENT

--- a/data/campaigns/Liberty/_main.cfg
+++ b/data/campaigns/Liberty/_main.cfg
@@ -14,7 +14,7 @@
     first_scenario=01_The_Raid
     define=CAMPAIGN_LIBERTY
     icon="units/human-outlaws/fugitive.png~RC(magenta>red)"
-    background="data/campaigns/The_Rise_Of_Wesnoth/images/story/trow_intro_02.jpg"
+    background="data/campaigns/The_Rise_Of_Wesnoth/images/story/trow_intro_02.webp"
 
     {CAMPAIGN_DIFFICULTY EASY   "units/human-peasants/peasant.png~RC(magenta>red)" ( _ "Peasant") ( _ "Easy")}
     {CAMPAIGN_DIFFICULTY NORMAL "units/human-outlaws/outlaw.png~RC(magenta>red)" ( _ "Outlaw") ( _ "Normal")} {DEFAULT_DIFFICULTY}


### PR DESCRIPTION
- [x]  Descent into Darkness
- [x] Liberty

After conversion to webp, their images for backgrounds were not being shown.

![image](https://user-images.githubusercontent.com/5283677/166120771-e3d35df6-ad28-4598-844b-30020b1ca145.png)
