### PR TITLE
Refactor FindTranslationTools.cmake

### DIFF
--- a/cmake/FindTranslationTools.cmake
+++ b/cmake/FindTranslationTools.cmake
@@ -1,18 +1,42 @@
-# - Find the tools needed for updating the potfiles and translations
+#[=======================================================================[.rst:
+FindTranslationTools
+--------------------
+
+Find the tools needed for updating the potfiles and translations.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+	GETTEXT_MSGINIT_EXECUTABLE
+	GETTEXT_XGETTEXT_EXECUTABLE
+	GETTEXT_MSGCAT_EXECUTABLE
+	GETTEXT_MSGATTRIB_EXECUTABLE
+	ASCIIDOC_EXECUTABLE
+	DOS2UNIX_EXECUTABLE
+	PO4A-TRANSLATE_EXECUTABLE
+	PO4A-UPDATEPO_EXECUTABLE
+	PO4A-GETTEXTIZE_EXECUTABLE
+	XSLTPROC_EXECUTABLE
+
+#]=======================================================================]
 
 set(TRANSLATION_TOOLS_FOUND true)
 
-find_program(GETTEXT_MSGINIT_EXECUTABLE msginit)
-if(NOT GETTEXT_MSGINIT_EXECUTABLE)
-	message("msginit not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT GETTEXT_MSGINIT_EXECUTABLE)
+# Try to find the given EXECUTABLE_NAME and set FIND_VARIABLE to its location
+# Sets TRANSLATION_TOOLS_FOUND to false if it can't find the required exe
+macro(_find_translation_tool FIND_VARIABLE EXECUTABLE_NAME)
+	find_program(${FIND_VARIABLE} ${EXECUTABLE_NAME})
+	if(NOT ${FIND_VARIABLE})
+		message("${EXECUTABLE_NAME} not found!")
+		set(TRANSLATION_TOOLS_FOUND false)
+	endif()
+endmacro()
 
-find_program(GETTEXT_XGETTEXT_EXECUTABLE xgettext)
-if(NOT GETTEXT_XGETTEXT_EXECUTABLE)
-	message("xgettext not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT GETTEXT_XGETTEXT_EXECUTABLE)
+_find_translation_tool(GETTEXT_MSGINIT_EXECUTABLE msginit)
+
+_find_translation_tool(GETTEXT_XGETTEXT_EXECUTABLE xgettext)
 set(GETTEXT_XGETTEXT_OPTIONS
 	--force-po
 	--add-comments=TRANSLATORS
@@ -32,70 +56,42 @@ set(GETTEXT_XGETTEXT_OPTIONS
 	--keyword=VNGETTEXT:1,2
 )
 
-find_program(GETTEXT_MSGCAT_EXECUTABLE msgcat)
-if(NOT GETTEXT_MSGCAT_EXECUTABLE )
-	message("msgcat not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT GETTEXT_MSGCAT_EXECUTABLE )
+_find_translation_tool(GETTEXT_MSGCAT_EXECUTABLE msgcat)
 
-find_program(GETTEXT_MSGATTRIB_EXECUTABLE msgattrib)
-if(NOT GETTEXT_MSGATTRIB_EXECUTABLE)
-	message("msgattrib not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT GETTEXT_MSGATTRIB_EXECUTABLE)
+_find_translation_tool(GETTEXT_MSGATTRIB_EXECUTABLE msgattrib)
 
-find_program(ASCIIDOC_EXECUTABLE asciidoc)
+_find_translation_tool(ASCIIDOC_EXECUTABLE asciidoc)
 set(ASCIIDOC_OPTIONS
 	-b docbook
 	-d book
 	-n
 	-a toc
 )
-if(NOT ASCIIDOC_EXECUTABLE)
-	message("asciidoc not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT ASCIIDOC_EXECUTABLE)
 
-find_program(DOS2UNIX_EXECUTABLE dos2unix)
-if(NOT DOS2UNIX_EXECUTABLE)
-	message("dos2unix not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT DOS2UNIX_EXECUTABLE)
+_find_translation_tool(DOS2UNIX_EXECUTABLE dos2unix)
 
-find_program(PO4A-TRANSLATE_EXECUTABLE po4a-translate)
+_find_translation_tool(PO4A-TRANSLATE_EXECUTABLE po4a-translate)
 set(PO4A-TRANSLATE_OPTIONS
 	-f docbook
 	-k 80
 	-M utf-8
 	-L utf-8
 )
-if(NOT PO4A-TRANSLATE_EXECUTABLE)
-	message("po4a-translate not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT PO4A-TRANSLATE_EXECUTABLE)
 
-find_program(PO4A-UPDATEPO_EXECUTABLE po4a-updatepo)
+_find_translation_tool(PO4A-UPDATEPO_EXECUTABLE po4a-updatepo)
 set(PO4A-UPDATEPO_OPTIONS
 	-M utf-8
 )
-if(NOT PO4A-UPDATEPO_EXECUTABLE)
-	message("po4a-updatepo not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT PO4A-UPDATEPO_EXECUTABLE)
 
-find_program(PO4A-GETTEXTIZE_EXECUTABLE po4a-gettextize)
+_find_translation_tool(PO4A-GETTEXTIZE_EXECUTABLE po4a-gettextize)
 set(PO4A-GETTEXTIZE_OPTIONS
 	--copyright-holder "Wesnoth Development Team"
 	-f docbook
 	-M utf-8
 	-L utf-8
 )
-if(NOT PO4A-GETTEXTIZE_EXECUTABLE)
-	message("po4a-gettextize not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT PO4A-GETTEXTIZE_EXECUTABLE)
 
-find_program(XSLTPROC_EXECUTABLE xsltproc)
+_find_translation_tool(XSLTPROC_EXECUTABLE xsltproc)
 set(XSLTPROC_OPTIONS
 	--nonet
 	--stringparam callout.graphics 0
@@ -104,10 +100,6 @@ set(XSLTPROC_OPTIONS
 	--stringparam admon.graphics 0
 	--stringparam html.stylesheet "./styles/manual.css"
 )
-if(NOT XSLTPROC_EXECUTABLE)
-	message("xsltproc not found")
-	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT XSLTPROC_EXECUTABLE)
 
 find_path(ASCIIDOC_DOCBOOK_XSL_PATH
 	xhtml.xsl
@@ -115,12 +107,10 @@ find_path(ASCIIDOC_DOCBOOK_XSL_PATH
 	NO_DEFAULT_PATH
 )
 if(NOT ASCIIDOC_DOCBOOK_XSL_PATH)
-	message("asciidoc DocBook XSL path not found")
+	message(STATUS "asciidoc DocBook XSL path not found!")
 	set(TRANSLATION_TOOLS_FOUND false)
-endif(NOT ASCIIDOC_DOCBOOK_XSL_PATH)
+endif()
 
-if(NOT TRANSLATION_TOOLS_FOUND)
-	if(TranslationTools_FIND_REQUIRED)
-		message(FATAL_ERROR "Not all translation tools are found")
-	endif(TranslationTools_FIND_REQUIRED)
-endif(NOT TRANSLATION_TOOLS_FOUND)
+if(NOT TRANSLATION_TOOLS_FOUND AND TranslationTools_FIND_REQUIRED)
+	message(FATAL_ERROR "Some required translation tools are not found!")
+endif()


### PR DESCRIPTION
Hello!

I've looked into the translation search file and it was finding a bunch of `gettext` tools in the same manner.
Used a macro to factor that code out a bit.

How I've tested: inside a docker container and I've activated the `ENABLE_POT_UPDATE_TARGET` and built like that.
During my testing I've had cmake in very verbose mode to check for the paths and how it set the variables. All LGTM.

All in all seems to work well and the code is shorter and easier to modify if needed.

The CI seems to also do what I've done so fingers crossed!

Please let me know if you'd like me to further test this change.

Thanks!
Andrei