### PR TITLE
Refactor find vorbis file cmake

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ later, or a version of Clang with equivalent support.
 You'll need to have these libraries and their development headers installed in
 order to build Wesnoth:
 
- * Boost libraries             >= 1.65.0
+ * Boost libraries             >= 1.66.0
      Most headers plus the following binary libs:
    * Filesystem
    * Locale
@@ -56,7 +56,7 @@ The following build systems are fully supported for compiling Wesnoth on Linux,
 *BSD, and other Unix-like platforms:
 
  * SCons >= 0.98.3
- * CMake >= 2.8.5
+ * CMake >= 3.14
 
 You will also need to have a working installation of GNU gettext to build the
 translations.

--- a/cmake/FindVorbisFile.cmake
+++ b/cmake/FindVorbisFile.cmake
@@ -1,14 +1,39 @@
-# Locate VorbisFile
-# This module defines XXX_FOUND, XXX_INCLUDE_DIRS and XXX_LIBRARIES standard variables
-#
-# $VORBISDIR is an environment variable that would
-# correspond to the ./configure --prefix=$VORBISDIR
-# used in building Vorbis.
+#[=======================================================================[.rst:
+FindVorbisFile
+--------------
 
-# Copied from
-# http://code.google.com/p/osgaudio/source/browse/trunk/CMakeModules/FindVorbisFile.cmake
+Find the VorbisFile includes and library.
 
-SET(VORBISFILE_SEARCH_PATHS
+Environment
+^^^^^^^^^^^
+
+$ENV{VORBISDIR} is an environment variable that would correspond to
+the `./configure --prefix=$VORBISDIR` used in building Vorbis.
+
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines the `IMPORTED` target ``VorbisFile::VorbisFile``, if
+VorbisFile has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+	VORBISFILE_FOUND         - True if VorbisFile found.
+	VORBISFILE_INCLUDE_DIR   - Where to find vorbis/vorbisfile.h.
+	VORBISFILE_LIBRARIES     - Libraries when using VorbisFile.
+
+Inspiration
+^^^^^^^^^^^
+
+http://code.google.com/p/osgaudio/source/browse/trunk/CMakeModules/FindVorbisFile.cmake
+
+#]=======================================================================]
+
+set(VORBISFILE_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
     /usr/local
@@ -19,78 +44,103 @@ SET(VORBISFILE_SEARCH_PATHS
 	/opt
 )
 
-SET(MSVC_YEAR_NAME)
-IF (MSVC_VERSION GREATER 1599)		# >= 1600
-	SET(MSVC_YEAR_NAME VS2010)
-ELSEIF(MSVC_VERSION GREATER 1499)	# >= 1500
-	SET(MSVC_YEAR_NAME VS2008)
-ELSEIF(MSVC_VERSION GREATER 1399)	# >= 1400
-	SET(MSVC_YEAR_NAME VS2005)
-ELSEIF(MSVC_VERSION GREATER 1299)	# >= 1300
-	SET(MSVC_YEAR_NAME VS2003)
-ELSEIF(MSVC_VERSION GREATER 1199)	# >= 1200
-	SET(MSVC_YEAR_NAME VS6)
-ENDIF()
+# Map MSVC version to the installation folder name
+set(MSVC_YEAR_NAME)
+if(MSVC_VERSION GREATER 1599)		# >= 1600
+	set(MSVC_YEAR_NAME VS2010)
+elseif(MSVC_VERSION GREATER 1499)	# >= 1500
+	set(MSVC_YEAR_NAME VS2008)
+elseif(MSVC_VERSION GREATER 1399)	# >= 1400
+	set(MSVC_YEAR_NAME VS2005)
+elseif(MSVC_VERSION GREATER 1299)	# >= 1300
+	set(MSVC_YEAR_NAME VS2003)
+elseif(MSVC_VERSION GREATER 1199)	# >= 1200
+	set(MSVC_YEAR_NAME VS6)
+endif()
 
-FIND_PATH(VORBISFILE_INCLUDE_DIR
+find_path(VORBISFILE_INCLUDE_DIR
 	NAMES vorbis/vorbisfile.h
 	HINTS
-	$ENV{VORBISFILEDIR}
-	$ENV{VORBISFILE_PATH}
-	$ENV{VORBISDIR}
-	$ENV{VORBIS_PATH}
-	PATH_SUFFIXES include
-	PATHS ${VORBISFILE_SEARCH_PATHS}
-)
-
-FIND_LIBRARY(VORBISFILE_LIBRARY
-	NAMES vorbisfile libvorbisfile
-	HINTS
-	$ENV{VORBISFILEDIR}
-	$ENV{VORBISFILE_PATH}
-	$ENV{VORBISDIR}
-	$ENV{VORBIS_PATH}
-	PATH_SUFFIXES lib lib64 win32/VorbisFile_Dynamic_Release "Win32/${MSVC_YEAR_NAME}/x64/Release" "Win32/${MSVC_YEAR_NAME}/Win32/Release"
-	PATHS ${VORBISFILE_SEARCH_PATHS}
-)
-
-# First search for d-suffixed libs
-FIND_LIBRARY(VORBISFILE_LIBRARY_DEBUG
-	NAMES vorbisfiled vorbisfile_d libvorbisfiled libvorbisfile_d
-	HINTS
-	$ENV{VORBISFILEDIR}
-	$ENV{VORBISFILE_PATH}
-	$ENV{VORBISDIR}
-	$ENV{VORBIS_PATH}
-	PATH_SUFFIXES lib lib64 win32/VorbisFile_Dynamic_Debug "Win32/${MSVC_YEAR_NAME}/x64/Debug" "Win32/${MSVC_YEAR_NAME}/Win32/Debug"
-	PATHS ${VORBISFILE_SEARCH_PATHS}
-)
-
-IF(NOT VORBISFILE_LIBRARY_DEBUG)
-	# Then search for non suffixed libs if necessary, but only in debug dirs
-	FIND_LIBRARY(VORBISFILE_LIBRARY_DEBUG
-		NAMES vorbisfile libvorbisfile
-		HINTS
 		$ENV{VORBISFILEDIR}
 		$ENV{VORBISFILE_PATH}
 		$ENV{VORBISDIR}
 		$ENV{VORBIS_PATH}
-		PATH_SUFFIXES win32/VorbisFile_Dynamic_Debug "Win32/${MSVC_YEAR_NAME}/x64/Debug" "Win32/${MSVC_YEAR_NAME}/Win32/Debug"
+	PATH_SUFFIXES include
+	PATHS ${VORBISFILE_SEARCH_PATHS}
+)
+
+find_library(VORBISFILE_LIBRARY
+	NAMES vorbisfile libvorbisfile
+	HINTS
+		$ENV{VORBISFILEDIR}
+		$ENV{VORBISFILE_PATH}
+		$ENV{VORBISDIR}
+		$ENV{VORBIS_PATH}
+	PATH_SUFFIXES
+		lib
+		lib64
+		win32/VorbisFile_Dynamic_Release
+		"Win32/${MSVC_YEAR_NAME}/x64/Release"
+		"Win32/${MSVC_YEAR_NAME}/Win32/Release"
+	PATHS ${VORBISFILE_SEARCH_PATHS}
+)
+
+# First search for d-suffixed libs
+find_library(VORBISFILE_LIBRARY_DEBUG
+	NAMES vorbisfiled vorbisfile_d libvorbisfiled libvorbisfile_d
+	HINTS
+		$ENV{VORBISFILEDIR}
+		$ENV{VORBISFILE_PATH}
+		$ENV{VORBISDIR}
+		$ENV{VORBIS_PATH}
+	PATH_SUFFIXES
+		lib
+		lib64
+		win32/VorbisFile_Dynamic_Debug
+		"Win32/${MSVC_YEAR_NAME}/x64/Debug"
+		"Win32/${MSVC_YEAR_NAME}/Win32/Debug"
+	PATHS ${VORBISFILE_SEARCH_PATHS}
+)
+
+if(NOT VORBISFILE_LIBRARY_DEBUG)
+	# Then search for non suffixed libs if necessary, but only in debug dirs
+	find_library(VORBISFILE_LIBRARY_DEBUG
+		NAMES vorbisfile libvorbisfile
+		HINTS
+			$ENV{VORBISFILEDIR}
+			$ENV{VORBISFILE_PATH}
+			$ENV{VORBISDIR}
+			$ENV{VORBIS_PATH}
+		PATH_SUFFIXES
+			win32/VorbisFile_Dynamic_Debug
+			"Win32/${MSVC_YEAR_NAME}/x64/Debug"
+			"Win32/${MSVC_YEAR_NAME}/Win32/Debug"
 		PATHS ${VORBISFILE_SEARCH_PATHS}
 	)
-ENDIF()
+endif()
 
 
-IF(VORBISFILE_LIBRARY)
-	IF(VORBISFILE_LIBRARY_DEBUG)
-		SET(VORBISFILE_LIBRARIES optimized "${VORBISFILE_LIBRARY}" debug "${VORBISFILE_LIBRARY_DEBUG}")
-	ELSE()
-		SET(VORBISFILE_LIBRARIES "${VORBISFILE_LIBRARY}")		# Could add "general" keyword, but it is optional
-	ENDIF()
-ENDIF()
+if(VORBISFILE_LIBRARY)
+	if(VORBISFILE_LIBRARY_DEBUG)
+		set(VORBISFILE_LIBRARIES optimized "${VORBISFILE_LIBRARY}" debug "${VORBISFILE_LIBRARY_DEBUG}")
+	else()
+		set(VORBISFILE_LIBRARIES "${VORBISFILE_LIBRARY}") # Could add "general" keyword, but it is optional
+	endif()
+endif()
 
-# handle the QUIETLY and REQUIRED arguments and set XXX_FOUND to TRUE if all listed variables are TRUE
-INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(VorbisFile DEFAULT_MSG VORBISFILE_LIBRARIES VORBISFILE_INCLUDE_DIR)
+# handle the QUIETLY and REQUIRED arguments and set VORBISFILE_FOUND to TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(VorbisFile DEFAULT_MSG VORBISFILE_LIBRARIES VORBISFILE_INCLUDE_DIR)
 
 mark_as_advanced(VORBISFILE_INCLUDE_DIR VORBISFILE_LIBRARIES VORBISFILE_LIBRARY VORBISFILE_LIBRARY_DEBUG)
+
+if(VORBISFILE_FOUND AND (NOT TARGET VorbisFile::VorbisFile))
+	add_library(VorbisFile::VorbisFile UNKNOWN IMPORTED)
+	set_target_properties(VorbisFile::VorbisFile PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${VORBISFILE_INCLUDE_DIR}")
+	if(VORBISFILE_LIBRARY_DEBUG)
+		set_target_properties(VorbisFile::VorbisFile PROPERTIES IMPORTED_LOCATION_DEBUG "${VORBISFILE_LIBRARY_DEBUG}")
+		set_target_properties(VorbisFile::VorbisFile PROPERTIES IMPORTED_LOCATION_RELEASE "${VORBISFILE_LIBRARY}")
+	else()
+		set_target_properties(VorbisFile::VorbisFile PROPERTIES IMPORTED_LOCATION "${VORBISFILE_LIBRARY}")
+	endif()
+endif()

--- a/cmake/FindVorbisFile.cmake
+++ b/cmake/FindVorbisFile.cmake
@@ -36,27 +36,13 @@ http://code.google.com/p/osgaudio/source/browse/trunk/CMakeModules/FindVorbisFil
 set(VORBISFILE_SEARCH_PATHS
 	~/Library/Frameworks
 	/Library/Frameworks
-    /usr/local
+	/usr/local
 	/usr
 	/sw # Fink
 	/opt/local # DarwinPorts
 	/opt/csw # Blastwave
 	/opt
 )
-
-# Map MSVC version to the installation folder name
-set(MSVC_YEAR_NAME)
-if(MSVC_VERSION GREATER 1599)		# >= 1600
-	set(MSVC_YEAR_NAME VS2010)
-elseif(MSVC_VERSION GREATER 1499)	# >= 1500
-	set(MSVC_YEAR_NAME VS2008)
-elseif(MSVC_VERSION GREATER 1399)	# >= 1400
-	set(MSVC_YEAR_NAME VS2005)
-elseif(MSVC_VERSION GREATER 1299)	# >= 1300
-	set(MSVC_YEAR_NAME VS2003)
-elseif(MSVC_VERSION GREATER 1199)	# >= 1200
-	set(MSVC_YEAR_NAME VS6)
-endif()
 
 find_path(VORBISFILE_INCLUDE_DIR
 	NAMES vorbis/vorbisfile.h
@@ -79,9 +65,6 @@ find_library(VORBISFILE_LIBRARY
 	PATH_SUFFIXES
 		lib
 		lib64
-		win32/VorbisFile_Dynamic_Release
-		"Win32/${MSVC_YEAR_NAME}/x64/Release"
-		"Win32/${MSVC_YEAR_NAME}/Win32/Release"
 	PATHS ${VORBISFILE_SEARCH_PATHS}
 )
 
@@ -96,9 +79,6 @@ find_library(VORBISFILE_LIBRARY_DEBUG
 	PATH_SUFFIXES
 		lib
 		lib64
-		win32/VorbisFile_Dynamic_Debug
-		"Win32/${MSVC_YEAR_NAME}/x64/Debug"
-		"Win32/${MSVC_YEAR_NAME}/Win32/Debug"
 	PATHS ${VORBISFILE_SEARCH_PATHS}
 )
 
@@ -111,14 +91,9 @@ if(NOT VORBISFILE_LIBRARY_DEBUG)
 			$ENV{VORBISFILE_PATH}
 			$ENV{VORBISDIR}
 			$ENV{VORBIS_PATH}
-		PATH_SUFFIXES
-			win32/VorbisFile_Dynamic_Debug
-			"Win32/${MSVC_YEAR_NAME}/x64/Debug"
-			"Win32/${MSVC_YEAR_NAME}/Win32/Debug"
 		PATHS ${VORBISFILE_SEARCH_PATHS}
 	)
 endif()
-
 
 if(VORBISFILE_LIBRARY)
 	if(VORBISFILE_LIBRARY_DEBUG)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 include_directories(SYSTEM ${PANGOCAIRO_INCLUDE_DIRS})
 include_directories(SYSTEM ${GETTEXT_INCLUDE_DIR})
 include_directories(SYSTEM ${LIBDBUS_INCLUDE_DIRS})
-include_directories(SYSTEM ${VORBISFILE_INCLUDE_DIR})
 if(NOT MSVC)
 	include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
 	include_directories(SYSTEM ${SDL2IMAGE_INCLUDE_DIRS})
@@ -54,7 +53,7 @@ set(game-external-libs
 	${common-external-libs}
 	${PANGOCAIRO_LIBRARIES}
 	${LIBDBUS_LIBRARIES}
-	${VORBISFILE_LIBRARIES}
+	VorbisFile::VorbisFile
 )
 
 if(NOT MSVC)


### PR DESCRIPTION
A couple of changes for consistency with the other modules + a small commit to state the minimum requirements for Boost and CMake which were a bit behind.

As always, tested as much I could, the `link.txt` file is looking good, same as `compile_commands.json`.

I was thinking, would it be interesting to move the `FindXXX` files in a `cmake/modules` folder? That way they're separate from other cmake utilities.

Also, since I've embarked in this journey, and haven't yet seen the whole history of the project, have there been efforts to unite the SDL2 find? I'm thinking about unifying windows/*nix finders with a couple of tricks but I'd like to see if there have been other efforts. Of course, it's fine even if there weren't and it may actually be impossible, but I'd like to try.

Thanks!