### PR TITLE
UtBS S8 fixed wallstuck units on and moved PASSABLE_HEX macro to core

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
  ### Campaigns
    * Sceptre of Fire
      * S9: Allow Grypon Riders to complete the scenario (issue #6332)
+   * Under the Burning Suns
+     * S8: Spawned units will now be unable to be blocked into walls (PR #6677)
  ### Editor
  ### Multiplayer
  ### Lua API
@@ -21,6 +23,7 @@
    * The `--stringfreeze` (`-Z`) command line flag has been removed from wmllint.
    * The checks for the old special notes system have been removed from wmllint; the `notecheck off`, `notecheck on` and `match <ability> with <note>` magic comments no longer have any effect.
    * Resolved title screen flashing during the loading screen (issue #2395)
+   * Added the {PASSABLE_HEX} macro to core and deleted it from TRoW S19 (PR #6677)
 
 ## Version 1.17.3
  ### Add-ons client

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/19_The_Vanguard.cfg
@@ -149,13 +149,6 @@
         [/ai]
     [/side]
 
-#define PASSABLE_HEX
-    # Adds passable attribute
-    [+unit]
-        passable=yes
-    [/unit]
-#enddef
-
     [event]
         name=prestart
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -888,7 +888,7 @@
             image_mods={ARMOR_SHIFT_IPF}
         [/move_unit_fake]
 
-        {NAMED_UNIT 2 (Javelineer) 33 44 (Bellerin) ( _ "Bellerin") (upkeep,role,facing=free,human_scout,sw)}
+        {NAMED_UNIT 2 (Javelineer) 33 44 (Bellerin) ( _ "Bellerin") (upkeep,role,facing=free,human_scout,sw)}{PASSABLE_HEX}
 
         [move_unit_fake]
             type=Halberdier
@@ -908,7 +908,7 @@
             image_mods={ARMOR_SHIFT_IPF}
         [/move_unit_fake]
 
-        {NAMED_UNIT 2 {ON_DIFFICULTY (Longbowman) (Longbowman) (Master Bowman)} 34 43 (Othgar) ( _ "Othgar") (upkeep,role,facing=free,human_scout,sw)}
+        {NAMED_UNIT 2 {ON_DIFFICULTY (Longbowman) (Longbowman) (Master Bowman)} 34 43 (Othgar) ( _ "Othgar") (upkeep,role,facing=free,human_scout,sw)}{PASSABLE_HEX}
 
         [message]
             speaker=Durth
@@ -1844,7 +1844,7 @@
             [/not]
 
             [then]
-                {NAMED_UNIT 3 (Ghost) 9 43 (Novice Pior) ( _ "Novice Pior") (upkeep=free)}
+                {NAMED_UNIT 3 (Ghost) 9 43 (Novice Pior) ( _ "Novice Pior") (upkeep=free)}{PASSABLE_HEX}
                 [+unit]
                     animate=yes
                 [/unit]
@@ -1889,21 +1889,21 @@
 
         {CLEAR_VARIABLE explorer}
 
-        {NAMED_UNIT 3 (Skeleton) 15 40 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
-        {NAMED_UNIT 3 (Bone Shooter) 14 36 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Skeleton) 15 40 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
+        {NAMED_UNIT 3 (Bone Shooter) 14 36 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 
 #ifdef HARD
-        {NAMED_UNIT 3 (Deathblade) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Deathblade) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #else
-        {NAMED_UNIT 3 (Revenant) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Revenant) 13 39 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #endif
 
 #ifdef HARD
-        {NAMED_UNIT 3 (Bone Shooter) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Bone Shooter) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #endif
 
 #ifdef NORMAL
-        {NAMED_UNIT 3 (Skeleton Archer) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}
+        {NAMED_UNIT 3 (Skeleton Archer) 17 37 () ( _ "Restless Dead") (upkeep,animate=free,yes)}{PASSABLE_HEX}
 #endif
 
         [message]
@@ -2034,7 +2034,7 @@
 
         {CLEAR_VARIABLE unitstats}
 
-        {NAMED_UNIT 3 (Crab Man) 17 32 (Failed Experiment 1) ( _ "Failed Experiment") (upkeep=free)}
+        {NAMED_UNIT 3 (Crab Man) 17 32 (Failed Experiment 1) ( _ "Failed Experiment") (upkeep=free)}{PASSABLE_HEX}
         {NAMED_UNIT 3 (Young Ogre) 19 32 (Failed Experiment 2) ( _ "Failed Experiment") (upkeep=free)}
 
         [message]
@@ -2154,7 +2154,7 @@
         name=moveto
 
         [filter]
-            x=5-10
+            x=4-10
             y=32-37
             side=1
             [not]
@@ -2244,10 +2244,10 @@
             [redraw]
             [/redraw]
 
-            {NAMED_UNIT 3 (Ixthala Demon) 5 35 (Ancient Guardian 1) ( _ "Ancient Guardian") (upkeep=free)}
-            {NAMED_UNIT 3 (Ixthala Demon) 8 33 (Ancient Guardian 2) ( _ "Ancient Guardian") (upkeep=free)}
+            {NAMED_UNIT 3 (Ixthala Demon) 5 35 (Ancient Guardian 1) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
+            {NAMED_UNIT 3 (Ixthala Demon) 8 33 (Ancient Guardian 2) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
 #ifdef HARD
-            {NAMED_UNIT 3 (Ixthala Demon) 5 33 (Ancient Guardian 3) ( _ "Ancient Guardian") (upkeep=free)}
+            {NAMED_UNIT 3 (Ixthala Demon) 5 33 (Ancient Guardian 3) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
 #endif
             [message]
                 speaker=Ancient Guardian 1

--- a/data/core/macros/unit-utils.cfg
+++ b/data/core/macros/unit-utils.cfg
@@ -198,6 +198,14 @@
     [/unit]
 #enddef
 
+#define PASSABLE_HEX
+    # Meant to be used as a suffix to a unit-generating macro call.
+    # Makes sure the generated unit is in a passable hex
+    [+unit]
+        passable=yes
+    [/unit]
+#enddef
+
 #define STORE_UNIT_VAR FILTER VAR TO_VAR_NAME
     # Stores an attribute of a unit to the given variable.
     #


### PR DESCRIPTION
Half of #6439 Moves the macro first used in #6357 and uses it to fix the possibility of wall-stuck units in UtBS S8.

Test photos:
![test_utbs_s8](https://user-images.githubusercontent.com/30196839/166459065-528f6032-320e-45d6-8bbd-ea82d6327fcf.png)
![test_trow_s19](https://user-images.githubusercontent.com/30196839/166459074-7625afab-8ccf-4c4f-a782-465a0e93eac4.png)
