### PR TITLE
GUI2: made widget initialization process more secure against memory leaks

### DIFF
--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -137,7 +137,7 @@ builder_widget_ptr create_widget_builder(const config& cfg)
 	FAIL("Unknown widget type " + cfg.ordered_begin()->key);
 }
 
-widget* build_single_widget_instance_helper(const std::string& type, const config& cfg)
+widget_ptr build_single_widget_instance_helper(const std::string& type, const config& cfg)
 {
 	const auto& iter = widget_builder_lookup().find(type);
 	VALIDATE(iter != widget_builder_lookup().end(), "Invalid widget type '" + type + "'");
@@ -265,49 +265,21 @@ builder_grid::builder_grid(const config& cfg)
 	DBG_GUI_P << "Window builder: grid has " << rows << " rows and " << cols << " columns.\n";
 }
 
-grid* builder_grid::build() const
+widget_ptr builder_grid::build() const
 {
-	return build(new grid());
+	auto result = std::make_shared<grid>();
+	build(*result);
+	return result;
 }
 
-widget* builder_grid::build(const replacements_map& replacements) const
+widget_ptr builder_grid::build(const replacements_map& replacements) const
 {
-	grid* result = new grid();
+	auto result = std::make_shared<grid>();
 	build(*result, replacements);
 	return result;
 }
 
-grid* builder_grid::build(grid* grid) const
-{
-	grid->set_id(id);
-	grid->set_linked_group(linked_group);
-	grid->set_rows_cols(rows, cols);
-
-	log_scope2(log_gui_general, "Window builder: building grid");
-
-	DBG_GUI_G << "Window builder: grid '" << id << "' has " << rows << " rows and " << cols << " columns.\n";
-
-	for(unsigned x = 0; x < rows; ++x) {
-		grid->set_row_grow_factor(x, row_grow_factor[x]);
-
-		for(unsigned y = 0; y < cols; ++y) {
-			if(x == 0) {
-				grid->set_column_grow_factor(y, col_grow_factor[y]);
-			}
-
-			DBG_GUI_G << "Window builder: adding child at " << x << ',' << y << ".\n";
-
-			const unsigned int i = x * cols + y;
-
-			widget* widget = widgets[i]->build();
-			grid->set_child(widget, x, y, flags[i], border_size[i]);
-		}
-	}
-
-	return grid;
-}
-
-void builder_grid::build(grid& grid, const replacements_map& replacements) const
+void builder_grid::build(grid& grid, optional_replacements replacements) const
 {
 	grid.set_id(id);
 	grid.set_linked_group(linked_group);
@@ -328,7 +300,14 @@ void builder_grid::build(grid& grid, const replacements_map& replacements) const
 			DBG_GUI_G << "Window builder: adding child at " << x << ',' << y << ".\n";
 
 			const unsigned int i = x * cols + y;
-			grid.set_child(widgets[i]->build(replacements), x, y, flags[i], border_size[i]);
+
+			if(replacements) {
+				auto widget = widgets[i]->build(replacements.value());
+				grid.set_child(widget, x, y, flags[i], border_size[i]);
+			} else {
+				auto widget = widgets[i]->build();
+				grid.set_child(widget, x, y, flags[i], border_size[i]);
+			}
 		}
 	}
 }

--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -137,7 +137,7 @@ builder_widget_ptr create_widget_builder(const config& cfg)
 	FAIL("Unknown widget type " + cfg.ordered_begin()->key);
 }
 
-widget_ptr build_single_widget_instance_helper(const std::string& type, const config& cfg)
+std::unique_ptr<widget> build_single_widget_instance_helper(const std::string& type, const config& cfg)
 {
 	const auto& iter = widget_builder_lookup().find(type);
 	VALIDATE(iter != widget_builder_lookup().end(), "Invalid widget type '" + type + "'");
@@ -265,16 +265,16 @@ builder_grid::builder_grid(const config& cfg)
 	DBG_GUI_P << "Window builder: grid has " << rows << " rows and " << cols << " columns.\n";
 }
 
-widget_ptr builder_grid::build() const
+std::unique_ptr<widget> builder_grid::build() const
 {
-	auto result = std::make_shared<grid>();
+	auto result = std::make_unique<grid>();
 	build(*result);
 	return result;
 }
 
-widget_ptr builder_grid::build(const replacements_map& replacements) const
+std::unique_ptr<widget> builder_grid::build(const replacements_map& replacements) const
 {
-	auto result = std::make_shared<grid>();
+	auto result = std::make_unique<grid>();
 	build(*result, replacements);
 	return result;
 }
@@ -303,10 +303,10 @@ void builder_grid::build(grid& grid, optional_replacements replacements) const
 
 			if(replacements) {
 				auto widget = widgets[i]->build(replacements.value());
-				grid.set_child(widget, x, y, flags[i], border_size[i]);
+				grid.set_child(std::move(widget), x, y, flags[i], border_size[i]);
 			} else {
 				auto widget = widgets[i]->build();
-				grid.set_child(widget, x, y, flags[i], border_size[i]);
+				grid.set_child(std::move(widget), x, y, flags[i], border_size[i]);
 			}
 		}
 	}

--- a/src/gui/core/window_builder.hpp
+++ b/src/gui/core/window_builder.hpp
@@ -55,9 +55,9 @@ struct builder_widget
 	{
 	}
 
-	virtual widget_ptr build() const = 0;
+	virtual std::unique_ptr<widget> build() const = 0;
 
-	virtual widget_ptr build(const replacements_map& replacements) const = 0;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const = 0;
 
 	/** Parameters for the widget. */
 	std::string id;
@@ -91,7 +91,7 @@ builder_widget_ptr create_widget_builder(const config& cfg);
  * @returns                       A shared_ptr of the base widget type containing
  *                                the newly built widget.
  */
-widget_ptr build_single_widget_instance_helper(const std::string& type, const config& cfg);
+std::unique_ptr<widget> build_single_widget_instance_helper(const std::string& type, const config& cfg);
 
 /**
  * Builds a single widget instance of the given type with the specified attributes.
@@ -110,9 +110,10 @@ widget_ptr build_single_widget_instance_helper(const std::string& type, const co
  *                                newly build widget.
  */
 template<typename T>
-std::shared_ptr<T> build_single_widget_instance(const config& cfg = {})
+std::unique_ptr<T> build_single_widget_instance(const config& cfg = {})
 {
-	return std::dynamic_pointer_cast<T>(build_single_widget_instance_helper(T::type(), cfg));
+	static_assert(std::is_base_of_v<widget, T>, "Type is not a widget type");
+	return std::unique_ptr<T>{ static_cast<T*>(build_single_widget_instance_helper(T::type(), cfg).release()) };
 }
 
 struct builder_grid : public builder_widget
@@ -136,10 +137,10 @@ struct builder_grid : public builder_widget
 	std::vector<builder_widget_ptr> widgets;
 
 	/** Inherited from @ref builder_widget. */
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	/** Inherited from @ref builder_widget. */
-	virtual widget_ptr build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
 
 	void build(grid& grid, optional_replacements replacements = std::nullopt) const;
 };

--- a/src/gui/core/window_builder/instance.cpp
+++ b/src/gui/core/window_builder/instance.cpp
@@ -30,12 +30,12 @@ builder_instance::builder_instance(const config& cfg)
 {
 }
 
-widget* builder_instance::build() const
+widget_ptr builder_instance::build() const
 {
 	return build(replacements_map());
 }
 
-widget* builder_instance::build(const replacements_map& replacements) const
+widget_ptr builder_instance::build(const replacements_map& replacements) const
 {
 	const replacements_map::const_iterator itor = replacements.find(id);
 	if(itor != replacements.end()) {

--- a/src/gui/core/window_builder/instance.cpp
+++ b/src/gui/core/window_builder/instance.cpp
@@ -30,12 +30,12 @@ builder_instance::builder_instance(const config& cfg)
 {
 }
 
-widget_ptr builder_instance::build() const
+std::unique_ptr<widget> builder_instance::build() const
 {
 	return build(replacements_map());
 }
 
-widget_ptr builder_instance::build(const replacements_map& replacements) const
+std::unique_ptr<widget> builder_instance::build(const replacements_map& replacements) const
 {
 	const replacements_map::const_iterator itor = replacements.find(id);
 	if(itor != replacements.end()) {

--- a/src/gui/core/window_builder/instance.hpp
+++ b/src/gui/core/window_builder/instance.hpp
@@ -29,9 +29,9 @@ struct builder_instance : public builder_widget
 {
 	explicit builder_instance(const config& cfg);
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
-	virtual widget_ptr build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
 
 	/**
 	 * Holds a copy of the cfg parameter in the constructor.

--- a/src/gui/core/window_builder/instance.hpp
+++ b/src/gui/core/window_builder/instance.hpp
@@ -29,9 +29,9 @@ struct builder_instance : public builder_widget
 {
 	explicit builder_instance(const config& cfg);
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
-	virtual widget* build(const replacements_map& replacements) const override;
+	virtual widget_ptr build(const replacements_map& replacements) const override;
 
 	/**
 	 * Holds a copy of the cfg parameter in the constructor.

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -207,14 +207,14 @@ void drop_down_menu::pre_show(window& window)
 				}));
 			}
 
-			mi_grid.swap_child("icon", std::static_pointer_cast<widget>(checkbox), false);
+			mi_grid.swap_child("icon", std::move(checkbox), false);
 		}
 
 		if(entry.image) {
 			auto img = build_single_widget_instance<image>();
 			img->set_label(*entry.image);
 
-			mi_grid.swap_child("label", img, false);
+			mi_grid.swap_child("label", std::move(img), false);
 		}
 	}
 

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -196,7 +196,7 @@ void drop_down_menu::pre_show(window& window)
 		find_widget<toggle_panel>(&new_row, "panel", false).set_tooltip(entry.tooltip);
 
 		if(entry.checkbox) {
-			toggle_button* checkbox = build_single_widget_instance<toggle_button>();
+			auto checkbox = build_single_widget_instance<toggle_button>();
 			checkbox->set_id("checkbox");
 			checkbox->set_value_bool(*entry.checkbox);
 
@@ -207,11 +207,11 @@ void drop_down_menu::pre_show(window& window)
 				}));
 			}
 
-			mi_grid.swap_child("icon", checkbox, false);
+			mi_grid.swap_child("icon", std::static_pointer_cast<widget>(checkbox), false);
 		}
 
 		if(entry.image) {
-			image* img = build_single_widget_instance<image>();
+			auto img = build_single_widget_instance<image>();
 			img->set_label(*entry.image);
 
 			mi_grid.swap_child("label", img, false);

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -643,7 +643,7 @@ void preferences_dialog::post_build(window& window)
 			}
 
 			case avp::avd_type::SLIDER: {
-				slider* setter_widget = build_single_widget_instance<slider>(config {"definition", "minimal"});
+				auto setter_widget = build_single_widget_instance<slider>(config {"definition", "minimal"});
 				setter_widget->set_id("setter");
 				// Maximum must be set first or this will assert
 				setter_widget->set_value_range(option.cfg["min"].to_int(), option.cfg["max"].to_int());
@@ -690,7 +690,7 @@ void preferences_dialog::post_build(window& window)
 					selected = 0;
 				}
 
-				menu_button* setter_widget = build_single_widget_instance<menu_button>();
+				auto setter_widget = build_single_widget_instance<menu_button>();
 				setter_widget->set_id("setter");
 
 				details_grid.swap_child("setter", setter_widget, true);
@@ -713,7 +713,7 @@ void preferences_dialog::post_build(window& window)
 			case avp::avd_type::SPECIAL: {
 				//main_grid->remove_child("setter");
 
-				image* value_widget = build_single_widget_instance<image>();
+				auto value_widget = build_single_widget_instance<image>();
 				value_widget->set_label("icons/arrows/arrows_blank_right_25.png~CROP(3,3,18,18)");
 
 				main_grid->swap_child("value", value_widget, true);

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -649,7 +649,7 @@ void preferences_dialog::post_build(window& window)
 				setter_widget->set_value_range(option.cfg["min"].to_int(), option.cfg["max"].to_int());
 				setter_widget->set_step_size(option.cfg["step"].to_int(1));
 
-				details_grid.swap_child("setter", setter_widget, true);
+				details_grid.swap_child("setter", std::move(setter_widget), true);
 
 				slider& slide = find_widget<slider>(&details_grid, "setter", false);
 
@@ -693,7 +693,7 @@ void preferences_dialog::post_build(window& window)
 				auto setter_widget = build_single_widget_instance<menu_button>();
 				setter_widget->set_id("setter");
 
-				details_grid.swap_child("setter", setter_widget, true);
+				details_grid.swap_child("setter", std::move(setter_widget), true);
 
 				menu_button& menu = find_widget<menu_button>(&details_grid, "setter", false);
 
@@ -716,7 +716,7 @@ void preferences_dialog::post_build(window& window)
 				auto value_widget = build_single_widget_instance<image>();
 				value_widget->set_label("icons/arrows/arrows_blank_right_25.png~CROP(3,3,18,18)");
 
-				main_grid->swap_child("value", value_widget, true);
+				main_grid->swap_child("value", std::move(value_widget), true);
 
 				break;
 			}

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -463,9 +463,9 @@ builder_addon_list::builder_addon_list(const config& cfg)
 	}
 }
 
-widget_ptr builder_addon_list::build() const
+std::unique_ptr<widget> builder_addon_list::build() const
 {
-	auto widget = std::make_shared<addon_list>(*this);
+	auto widget = std::make_unique<addon_list>(*this);
 
 	DBG_GUI_G << "Window builder: placed add-on list '" << id <<
 		"' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -463,9 +463,9 @@ builder_addon_list::builder_addon_list(const config& cfg)
 	}
 }
 
-widget* builder_addon_list::build() const
+widget_ptr builder_addon_list::build() const
 {
-	addon_list* widget = new addon_list(*this);
+	auto widget = std::make_shared<addon_list>(*this);
 
 	DBG_GUI_G << "Window builder: placed add-on list '" << id <<
 		"' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -217,7 +217,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	widget::visibility install_status_visibility_;

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -217,7 +217,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	widget::visibility install_status_visibility_;

--- a/src/gui/widgets/button.cpp
+++ b/src/gui/widgets/button.cpp
@@ -177,9 +177,9 @@ builder_button::builder_button(const config& cfg)
 {
 }
 
-widget_ptr builder_button::build() const
+std::unique_ptr<widget> builder_button::build() const
 {
-	auto widget = std::make_shared<button>(*this);
+	auto widget = std::make_unique<button>(*this);
 
 	widget->set_retval(get_retval(retval_id_, retval_, id));
 

--- a/src/gui/widgets/button.cpp
+++ b/src/gui/widgets/button.cpp
@@ -177,9 +177,9 @@ builder_button::builder_button(const config& cfg)
 {
 }
 
-widget* builder_button::build() const
+widget_ptr builder_button::build() const
 {
-	button* widget = new button(*this);
+	auto widget = std::make_shared<button>(*this);
 
 	widget->set_retval(get_retval(retval_id_, retval_, id));
 

--- a/src/gui/widgets/button.hpp
+++ b/src/gui/widgets/button.hpp
@@ -148,7 +148,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	std::string retval_id_;

--- a/src/gui/widgets/button.hpp
+++ b/src/gui/widgets/button.hpp
@@ -148,7 +148,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	std::string retval_id_;

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -671,9 +671,9 @@ builder_chatbox::builder_chatbox(const config& cfg)
 {
 }
 
-widget* builder_chatbox::build() const
+widget_ptr builder_chatbox::build() const
 {
-	chatbox* widget = new chatbox(*this);
+	auto widget = std::make_shared<chatbox>(*this);
 
 	DBG_GUI_G << "Window builder: placed unit preview pane '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -671,9 +671,9 @@ builder_chatbox::builder_chatbox(const config& cfg)
 {
 }
 
-widget_ptr builder_chatbox::build() const
+std::unique_ptr<widget> builder_chatbox::build() const
 {
-	auto widget = std::make_shared<chatbox>(*this);
+	auto widget = std::make_unique<chatbox>(*this);
 
 	DBG_GUI_G << "Window builder: placed unit preview pane '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -264,7 +264,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 };

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -264,7 +264,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 };

--- a/src/gui/widgets/container_base.cpp
+++ b/src/gui/widgets/container_base.cpp
@@ -267,7 +267,7 @@ void container_base::init_grid(const builder_grid& grid_builder)
 
 	assert(grid_.get_rows() == 0 && grid_.get_cols() == 0);
 
-	grid_builder.build(&grid_);
+	grid_builder.build(grid_);
 }
 
 point container_base::border_space() const

--- a/src/gui/widgets/container_base.hpp
+++ b/src/gui/widgets/container_base.hpp
@@ -199,7 +199,7 @@ public:
 		grid_.set_rows_cols(rows, cols);
 	}
 
-	void set_child(widget* widget,
+	void set_child(widget_ptr widget,
 				   const unsigned row,
 				   const unsigned col,
 				   const unsigned flags,

--- a/src/gui/widgets/container_base.hpp
+++ b/src/gui/widgets/container_base.hpp
@@ -199,13 +199,13 @@ public:
 		grid_.set_rows_cols(rows, cols);
 	}
 
-	void set_child(widget_ptr widget,
+	void set_child(std::unique_ptr<widget> widget,
 				   const unsigned row,
 				   const unsigned col,
 				   const unsigned flags,
 				   const unsigned border_size)
 	{
-		grid_.set_child(widget, row, col, flags, border_size);
+		grid_.set_child(std::move(widget), row, col, flags, border_size);
 	}
 
 	void set_row_grow_factor(const unsigned row, const unsigned factor)

--- a/src/gui/widgets/drawing.cpp
+++ b/src/gui/widgets/drawing.cpp
@@ -118,9 +118,9 @@ builder_drawing::builder_drawing(const config& cfg)
 	assert(!draw.empty());
 }
 
-widget_ptr builder_drawing::build() const
+std::unique_ptr<widget> builder_drawing::build() const
 {
-	auto widget = std::make_shared<drawing>(*this);
+	auto widget = std::make_unique<drawing>(*this);
 
 	const wfl::map_formula_callable& size = get_screen_size_variables();
 

--- a/src/gui/widgets/drawing.cpp
+++ b/src/gui/widgets/drawing.cpp
@@ -118,9 +118,9 @@ builder_drawing::builder_drawing(const config& cfg)
 	assert(!draw.empty());
 }
 
-widget* builder_drawing::build() const
+widget_ptr builder_drawing::build() const
 {
-	drawing* widget = new drawing(*this);
+	auto widget = std::make_shared<drawing>(*this);
 
 	const wfl::map_formula_callable& size = get_screen_size_variables();
 

--- a/src/gui/widgets/drawing.hpp
+++ b/src/gui/widgets/drawing.hpp
@@ -149,7 +149,7 @@ struct builder_drawing : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	/** The width of the widget. */
 	typed_formula<unsigned> width;

--- a/src/gui/widgets/drawing.hpp
+++ b/src/gui/widgets/drawing.hpp
@@ -149,7 +149,7 @@ struct builder_drawing : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	/** The width of the widget. */
 	typed_formula<unsigned> width;

--- a/src/gui/widgets/generator.cpp
+++ b/src/gui/widgets/generator.cpp
@@ -1108,16 +1108,16 @@ static_assert(false, "GUI2/Generator: GENERATE_PLACEMENT already defined!");
 #define GENERATE_PLACEMENT                                                                                             \
 	switch(placement) {                                                                                                \
 	case generator_base::horizontal_list:                                                                              \
-		result = new generator<minimum, maximum, policy::placement::horizontal_list, select_action>;                   \
+		result = std::make_shared<generator<minimum, maximum, policy::placement::horizontal_list, select_action>>();   \
 		break;                                                                                                         \
 	case generator_base::vertical_list:                                                                                \
-		result = new generator<minimum, maximum, policy::placement::vertical_list, select_action>;                     \
+		result = std::make_shared<generator<minimum, maximum, policy::placement::vertical_list, select_action>>();     \
 		break;                                                                                                         \
 	case generator_base::table:                                                                                        \
-		result = new generator<minimum, maximum, policy::placement::table, select_action>;                             \
+		result = std::make_shared<generator<minimum, maximum, policy::placement::table, select_action>>();             \
 		break;                                                                                                         \
 	case generator_base::independent:                                                                                  \
-		result = new generator<minimum, maximum, policy::placement::independent, select_action>;                       \
+		result = std::make_shared<generator<minimum, maximum, policy::placement::independent, select_action>>();       \
 		break;                                                                                                         \
 	default:                                                                                                           \
 		assert(false);                                                                                                 \
@@ -1163,10 +1163,10 @@ static_assert(false, "GUI2/Generator: GENERATE_BODY already defined!");
 	}
 #endif
 
-generator_base* generator_base::build(
+generator_ptr generator_base::build(
 		const bool has_minimum, const bool has_maximum, const placement placement, const bool select)
 {
-	generator_base* result = nullptr;
+	generator_ptr result = nullptr;
 	GENERATE_BODY;
 	return result;
 }

--- a/src/gui/widgets/generator.cpp
+++ b/src/gui/widgets/generator.cpp
@@ -1108,16 +1108,16 @@ static_assert(false, "GUI2/Generator: GENERATE_PLACEMENT already defined!");
 #define GENERATE_PLACEMENT                                                                                             \
 	switch(placement) {                                                                                                \
 	case generator_base::horizontal_list:                                                                              \
-		result = std::make_shared<generator<minimum, maximum, policy::placement::horizontal_list, select_action>>();   \
+		result = std::make_unique<generator<minimum, maximum, policy::placement::horizontal_list, select_action>>();   \
 		break;                                                                                                         \
 	case generator_base::vertical_list:                                                                                \
-		result = std::make_shared<generator<minimum, maximum, policy::placement::vertical_list, select_action>>();     \
+		result = std::make_unique<generator<minimum, maximum, policy::placement::vertical_list, select_action>>();     \
 		break;                                                                                                         \
 	case generator_base::table:                                                                                        \
-		result = std::make_shared<generator<minimum, maximum, policy::placement::table, select_action>>();             \
+		result = std::make_unique<generator<minimum, maximum, policy::placement::table, select_action>>();             \
 		break;                                                                                                         \
 	case generator_base::independent:                                                                                  \
-		result = std::make_shared<generator<minimum, maximum, policy::placement::independent, select_action>>();       \
+		result = std::make_unique<generator<minimum, maximum, policy::placement::independent, select_action>>();       \
 		break;                                                                                                         \
 	default:                                                                                                           \
 		assert(false);                                                                                                 \
@@ -1163,10 +1163,10 @@ static_assert(false, "GUI2/Generator: GENERATE_BODY already defined!");
 	}
 #endif
 
-generator_ptr generator_base::build(
+std::unique_ptr<generator_base>  generator_base::build(
 		const bool has_minimum, const bool has_maximum, const placement placement, const bool select)
 {
-	generator_ptr result = nullptr;
+	std::unique_ptr<generator_base> result = nullptr;
 	GENERATE_BODY;
 	return result;
 }

--- a/src/gui/widgets/generator.hpp
+++ b/src/gui/widgets/generator.hpp
@@ -25,7 +25,10 @@ namespace gui2
 {
 struct builder_grid;
 
+class generator_base;
 class grid;
+
+using generator_ptr = std::shared_ptr<generator_base>;
 
 /**
  * Abstract base class for the generator.
@@ -58,7 +61,7 @@ public:
 	 * @param has_minimum         Does one item need to be selected?
 	 * @param has_maximum         Is one the maximum number of items that can
 	 *                            be selected?
-	 * @param placement           The placement of the grids, see tplacement
+	 * @param placement           The placement of the grids, see placement
 	 *                            for more info.
 	 * @param select              If a grid is selected, what should happen?
 	 *                            If true the grid is selected, if false the
@@ -67,7 +70,7 @@ public:
 	 * @returns                   A pointer to a new object. The caller gets
 	 *                            ownership of the new object.
 	 */
-	static generator_base* build(const bool has_minimum,
+	static generator_ptr build(const bool has_minimum,
 							  const bool has_maximum,
 							  const placement placement,
 							  const bool select);

--- a/src/gui/widgets/generator.hpp
+++ b/src/gui/widgets/generator.hpp
@@ -28,8 +28,6 @@ struct builder_grid;
 class generator_base;
 class grid;
 
-using generator_ptr = std::shared_ptr<generator_base>;
-
 /**
  * Abstract base class for the generator.
  *
@@ -70,7 +68,7 @@ public:
 	 * @returns                   A pointer to a new object. The caller gets
 	 *                            ownership of the new object.
 	 */
-	static generator_ptr build(const bool has_minimum,
+	static std::unique_ptr<generator_base>  build(const bool has_minimum,
 							  const bool has_maximum,
 							  const placement placement,
 							  const bool select);

--- a/src/gui/widgets/generator_private.hpp
+++ b/src/gui/widgets/generator_private.hpp
@@ -735,7 +735,7 @@ public:
 		assert(index == -1 || static_cast<unsigned>(index) <= items_.size());
 
 		child* item = new child;
-		list_builder.build(&item->child_grid);
+		list_builder.build(item->child_grid);
 
 		init(&item->child_grid, item_data, callback);
 

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -67,7 +67,7 @@ unsigned grid::add_row(const unsigned count)
 	return result;
 }
 
-void grid::set_child(widget* widget,
+void grid::set_child(widget_ptr widget,
 					  const unsigned row,
 					  const unsigned col,
 					  const unsigned flags,
@@ -90,16 +90,17 @@ void grid::set_child(widget* widget,
 	cell.set_flags(flags);
 	cell.set_border_size(border_size);
 	cell.set_widget(widget);
-	if(cell.get_widget()) {
-		// make sure the new child is valid before deferring
-		cell.get_widget()->set_parent(this);
+
+	// make sure the new child is valid before deferring
+	if(gui2::widget* w = cell.get_widget()) {
+		w->set_parent(this);
 	}
 }
 
-std::unique_ptr<widget> grid::swap_child(const std::string& id,
-						   widget* w,
-						   const bool recurse,
-						   widget* new_parent)
+widget_ptr grid::swap_child(const std::string& id,
+		widget_ptr w,
+		const bool recurse,
+		widget* new_parent)
 {
 	assert(w);
 
@@ -112,7 +113,7 @@ std::unique_ptr<widget> grid::swap_child(const std::string& id,
 				grid* g = dynamic_cast<grid*>(child.get_widget());
 				if(g) {
 
-					std::unique_ptr<widget> old = g->swap_child(id, w, true);
+					widget_ptr old = g->swap_child(id, w, true);
 					if(old) {
 						return old;
 					}
@@ -123,7 +124,7 @@ std::unique_ptr<widget> grid::swap_child(const std::string& id,
 		}
 
 		// Free widget from cell and validate.
-		std::unique_ptr<widget> old = child.free_widget();
+		widget_ptr old = child.free_widget();
 		assert(old);
 
 		old->set_parent(new_parent);
@@ -1104,7 +1105,7 @@ grid_implementation::cell_request_reduce_width(grid::child& child,
 	child.widget_->request_reduce_width(maximum_width - child.border_space().x);
 }
 
-void set_single_child(grid& grid, widget* widget)
+void set_single_child(grid& grid, widget_ptr widget)
 {
 	grid.set_rows_cols(1, 1);
 	grid.set_child(widget,

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -140,9 +140,9 @@ public:
 	 * @param recurse             Do we want to decent into the child grids.
 	 * @param new_parent          The new parent for the swapped out widget.
 	 *
-	 * returns                    The widget which got removed (the parent of
-	 *                            the widget is cleared). If no widget found
-	 *                            and thus not replace nullptr will returned.
+	 * @returns                   The widget which got removed (the parent of
+	 *                            the widget is cleared), or @ref w if no matching
+	 *                            widget was found.
 	 */
 	std::unique_ptr<widget> swap_child(const std::string& id,
 					std::unique_ptr<widget> w,

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -123,7 +123,7 @@ public:
 	 * @param border_size         The size of the border for the cell, how the
 	 *                            border is applied depends on the flags.
 	 */
-	void set_child(widget* widget,
+	void set_child(widget_ptr widget,
 				   const unsigned row,
 				   const unsigned col,
 				   const unsigned flags,
@@ -144,8 +144,8 @@ public:
 	 *                            the widget is cleared). If no widget found
 	 *                            and thus not replace nullptr will returned.
 	 */
-	std::unique_ptr<widget> swap_child(const std::string& id,
-						widget* w,
+	widget_ptr swap_child(const std::string& id,
+						widget_ptr w,
 						const bool recurse,
 						widget* new_parent = nullptr);
 
@@ -399,16 +399,17 @@ private:
 			return widget_.get();
 		}
 
-		void set_widget(widget* widget)
+		/** Acquires an owning reference to the given widget. */
+		void set_widget(widget_ptr widget)
 		{
-			widget_.reset(widget);
+			widget_ = std::move(widget);
 		}
 
 		/**
 		 * Releases widget from ownership by this child and returns it in the
-		 * form of a new unique_ptr. widget_ will be null after this is called.
+		 * form of a new shared_ptr. widget_ will be null after this is called.
 		 */
-		std::unique_ptr<widget> free_widget()
+		widget_ptr free_widget()
 		{
 			return std::exchange(widget_, nullptr);
 		}
@@ -429,7 +430,7 @@ private:
 		 * Once the widget is assigned to the grid we own the widget and it
 		 * will be destroyed with the grid or @ref free_widget is called.
 		 */
-		std::unique_ptr<widget> widget_;
+		widget_ptr widget_;
 
 		/** Returns the space needed for the border. */
 		point border_space() const;
@@ -450,14 +451,17 @@ public:
 		{
 			return iterator(++itor_);
 		}
+
 		iterator operator--()
 		{
 			return iterator(--itor_);
 		}
+
 		widget* operator->()
 		{
 			return itor_->get_widget();
 		}
+
 		widget* operator*()
 		{
 			return itor_->get_widget();
@@ -558,6 +562,8 @@ private:
 	virtual void impl_draw_children(int x_offset, int y_offset) override;	
 };
 
+using grid_ptr = std::shared_ptr<grid>;
+
 /**
  * Sets the single child in a grid.
  *
@@ -567,6 +573,6 @@ private:
  * @param grid                    The grid to add the child to.
  * @param widget                  The widget to add as child to the grid.
  */
-void set_single_child(grid& grid, widget* widget);
+void set_single_child(grid& grid, widget_ptr widget);
 
 } // namespace gui2

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -123,7 +123,7 @@ public:
 	 * @param border_size         The size of the border for the cell, how the
 	 *                            border is applied depends on the flags.
 	 */
-	void set_child(widget_ptr widget,
+	void set_child(std::unique_ptr<widget> widget,
 				   const unsigned row,
 				   const unsigned col,
 				   const unsigned flags,
@@ -144,10 +144,10 @@ public:
 	 *                            the widget is cleared). If no widget found
 	 *                            and thus not replace nullptr will returned.
 	 */
-	widget_ptr swap_child(const std::string& id,
-						widget_ptr w,
-						const bool recurse,
-						widget* new_parent = nullptr);
+	std::unique_ptr<widget> swap_child(const std::string& id,
+					std::unique_ptr<widget> w,
+					const bool recurse,
+					widget* new_parent = nullptr);
 
 	/**
 	 * Removes and frees a widget in a cell.
@@ -400,7 +400,7 @@ private:
 		}
 
 		/** Acquires an owning reference to the given widget. */
-		void set_widget(widget_ptr widget)
+		void set_widget(std::unique_ptr<widget> widget)
 		{
 			widget_ = std::move(widget);
 		}
@@ -409,7 +409,7 @@ private:
 		 * Releases widget from ownership by this child and returns it in the
 		 * form of a new shared_ptr. widget_ will be null after this is called.
 		 */
-		widget_ptr free_widget()
+		std::unique_ptr<widget> free_widget()
 		{
 			return std::exchange(widget_, nullptr);
 		}
@@ -430,7 +430,7 @@ private:
 		 * Once the widget is assigned to the grid we own the widget and it
 		 * will be destroyed with the grid or @ref free_widget is called.
 		 */
-		widget_ptr widget_;
+		std::unique_ptr<widget> widget_;
 
 		/** Returns the space needed for the border. */
 		point border_space() const;
@@ -559,10 +559,8 @@ private:
 	void layout(const point& origin);
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;	
+	virtual void impl_draw_children(int x_offset, int y_offset) override;
 };
-
-using grid_ptr = std::shared_ptr<grid>;
 
 /**
  * Sets the single child in a grid.
@@ -573,6 +571,6 @@ using grid_ptr = std::shared_ptr<grid>;
  * @param grid                    The grid to add the child to.
  * @param widget                  The widget to add as child to the grid.
  */
-void set_single_child(grid& grid, widget_ptr widget);
+void set_single_child(grid& grid, std::unique_ptr<widget> widget);
 
 } // namespace gui2

--- a/src/gui/widgets/horizontal_scrollbar.cpp
+++ b/src/gui/widgets/horizontal_scrollbar.cpp
@@ -144,9 +144,9 @@ builder_horizontal_scrollbar::builder_horizontal_scrollbar(const config& cfg)
 {
 }
 
-widget* builder_horizontal_scrollbar::build() const
+widget_ptr builder_horizontal_scrollbar::build() const
 {
-	horizontal_scrollbar* widget = new horizontal_scrollbar(*this);
+	auto widget = std::make_shared<horizontal_scrollbar>(*this);
 
 	widget->finalize_setup();
 

--- a/src/gui/widgets/horizontal_scrollbar.cpp
+++ b/src/gui/widgets/horizontal_scrollbar.cpp
@@ -144,9 +144,9 @@ builder_horizontal_scrollbar::builder_horizontal_scrollbar(const config& cfg)
 {
 }
 
-widget_ptr builder_horizontal_scrollbar::build() const
+std::unique_ptr<widget> builder_horizontal_scrollbar::build() const
 {
-	auto widget = std::make_shared<horizontal_scrollbar>(*this);
+	auto widget = std::make_unique<horizontal_scrollbar>(*this);
 
 	widget->finalize_setup();
 

--- a/src/gui/widgets/horizontal_scrollbar.hpp
+++ b/src/gui/widgets/horizontal_scrollbar.hpp
@@ -127,7 +127,7 @@ struct builder_horizontal_scrollbar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/horizontal_scrollbar.hpp
+++ b/src/gui/widgets/horizontal_scrollbar.hpp
@@ -127,7 +127,7 @@ struct builder_horizontal_scrollbar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/image.cpp
+++ b/src/gui/widgets/image.cpp
@@ -122,9 +122,9 @@ builder_image::builder_image(const config& cfg) : builder_styled_widget(cfg)
 {
 }
 
-widget_ptr builder_image::build() const
+std::unique_ptr<widget> builder_image::build() const
 {
-	auto widget = std::make_shared<image>(*this);
+	auto widget = std::make_unique<image>(*this);
 
 	DBG_GUI_G << "Window builder: placed image '" << id << "' with definition '"
 			  << definition << "'.\n";

--- a/src/gui/widgets/image.cpp
+++ b/src/gui/widgets/image.cpp
@@ -122,9 +122,9 @@ builder_image::builder_image(const config& cfg) : builder_styled_widget(cfg)
 {
 }
 
-widget* builder_image::build() const
+widget_ptr builder_image::build() const
 {
-	image* widget = new image(*this);
+	auto widget = std::make_shared<image>(*this);
 
 	DBG_GUI_G << "Window builder: placed image '" << id << "' with definition '"
 			  << definition << "'.\n";

--- a/src/gui/widgets/image.hpp
+++ b/src/gui/widgets/image.hpp
@@ -133,7 +133,7 @@ struct builder_image : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/image.hpp
+++ b/src/gui/widgets/image.hpp
@@ -133,7 +133,7 @@ struct builder_image : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -256,9 +256,9 @@ builder_label::builder_label(const config& cfg)
 {
 }
 
-widget* builder_label::build() const
+widget_ptr builder_label::build() const
 {
-	label* lbl = new label(*this);
+	auto lbl = std::make_shared<label>(*this);
 
 	const auto conf = lbl->cast_config_to<label_definition>();
 	assert(conf);

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -256,9 +256,9 @@ builder_label::builder_label(const config& cfg)
 {
 }
 
-widget_ptr builder_label::build() const
+std::unique_ptr<widget> builder_label::build() const
 {
-	auto lbl = std::make_shared<label>(*this);
+	auto lbl = std::make_unique<label>(*this);
 
 	const auto conf = lbl->cast_config_to<label_definition>();
 	assert(conf);

--- a/src/gui/widgets/label.hpp
+++ b/src/gui/widgets/label.hpp
@@ -252,7 +252,7 @@ struct builder_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	bool wrap;
 

--- a/src/gui/widgets/label.hpp
+++ b/src/gui/widgets/label.hpp
@@ -252,7 +252,7 @@ struct builder_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	bool wrap;
 

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -798,9 +798,9 @@ builder_listbox::builder_listbox(const config& cfg)
 	}
 }
 
-widget* builder_listbox::build() const
+widget_ptr builder_listbox::build() const
 {
-	listbox* widget = new listbox(*this, generator_base::vertical_list, list_builder, has_minimum_, has_maximum_);
+	auto widget = std::make_shared<listbox>(*this, generator_base::vertical_list, list_builder, has_minimum_, has_maximum_);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);
@@ -840,9 +840,9 @@ builder_horizontal_listbox::builder_horizontal_listbox(const config& cfg)
 	}
 }
 
-widget* builder_horizontal_listbox::build() const
+widget_ptr builder_horizontal_listbox::build() const
 {
-	listbox* widget = new listbox(*this, generator_base::horizontal_list, list_builder, has_minimum_, has_maximum_);
+	auto widget = std::make_shared<listbox>(*this, generator_base::horizontal_list, list_builder, has_minimum_, has_maximum_);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);
@@ -882,9 +882,9 @@ builder_grid_listbox::builder_grid_listbox(const config& cfg)
 	}
 }
 
-widget* builder_grid_listbox::build() const
+widget_ptr builder_grid_listbox::build() const
 {
-	listbox* widget = new listbox(*this, generator_base::table, list_builder, has_minimum_, has_maximum_);
+	auto widget = std::make_shared<listbox>(*this, generator_base::table, list_builder, has_minimum_, has_maximum_);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -45,6 +45,7 @@ class listbox : public scrollbar_container
 	friend struct implementation::builder_listbox;
 	friend struct implementation::builder_horizontal_listbox;
 	friend struct implementation::builder_grid_listbox;
+
 	friend class debug_layout_graph;
 
 public:
@@ -67,6 +68,7 @@ public:
 			const bool select = true);
 
 	/***** ***** ***** ***** Row handling. ***** ***** ****** *****/
+
 	/**
 	 * When an item in the list is selected by the user we need to
 	 * update the state. We installed a callback handler which
@@ -363,7 +365,7 @@ private:
 	 * of the scrollbar_container super class and freed when it's grid is
 	 * freed.
 	 */
-	generator_base* generator_;
+	generator_ptr generator_;
 
 	const bool is_horizontal_;
 
@@ -492,7 +494,7 @@ struct builder_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
@@ -540,7 +542,7 @@ struct builder_horizontal_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
@@ -586,7 +588,7 @@ struct builder_grid_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -39,6 +39,8 @@ struct builder_grid_listbox;
 struct builder_styled_widget;
 }
 
+class generator_base;
+
 /** The listbox class. */
 class listbox : public scrollbar_container
 {
@@ -55,17 +57,10 @@ public:
 	 * @param builder             The builder for the appropriate listbox variant.
 	 * @param placement           How are the items placed.
 	 * @param list_builder        Grid builder for the listbox definition grid.
-	 * @param has_minimum         Does the listbox need to have one item selected.
-	 * @param has_maximum         Can the listbox only have one item selected.
-	 * @param select              Select an item when selected. If false it changes
-	 *                            the visible state instead. Default true.
 	 */
 	listbox(const implementation::builder_styled_widget& builder,
 			const generator_base::placement placement,
-			builder_grid_ptr list_builder,
-			const bool has_minimum,
-			const bool has_maximum,
-			const bool select = true);
+			builder_grid_ptr list_builder);
 
 	/***** ***** ***** ***** Row handling. ***** ***** ****** *****/
 
@@ -351,21 +346,23 @@ private:
 	/**
 	 * Finishes the building initialization of the widget.
 	 *
+	 * @param generator           Generator for the list
 	 * @param header              Builder for the header.
 	 * @param footer              Builder for the footer.
 	 * @param list_data           The initial data to fill the listbox with.
 	 */
-	void finalize(builder_grid_const_ptr header,
+	void finalize(std::unique_ptr<generator_base> generator,
+			builder_grid_const_ptr header,
 			builder_grid_const_ptr footer,
 			const std::vector<std::map<std::string, string_map>>& list_data);
+
 	/**
 	 * Contains a pointer to the generator.
 	 *
 	 * The pointer is not owned by this class, it's stored in the content_grid_
-	 * of the scrollbar_container super class and freed when it's grid is
-	 * freed.
+	 * of the scrollbar_container super class and freed when it's grid is freed.
 	 */
-	generator_ptr generator_;
+	generator_base* generator_;
 
 	const bool is_horizontal_;
 
@@ -494,7 +491,7 @@ struct builder_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
@@ -542,7 +539,7 @@ struct builder_horizontal_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
@@ -588,7 +585,7 @@ struct builder_grid_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/matrix.cpp
+++ b/src/gui/widgets/matrix.cpp
@@ -231,9 +231,9 @@ builder_matrix::builder_matrix(const config& cfg)
 	}
 }
 
-widget_ptr builder_matrix::build() const
+std::unique_ptr<widget> builder_matrix::build() const
 {
-	return std::make_shared<matrix>(*this);
+	return std::make_unique<matrix>(*this);
 }
 
 } // namespace implementation

--- a/src/gui/widgets/matrix.cpp
+++ b/src/gui/widgets/matrix.cpp
@@ -88,11 +88,6 @@ matrix::matrix(const implementation::builder_matrix& builder)
 	pane_ = find_widget<pane>(&content_, "pane", false, true);
 }
 
-matrix* matrix::build(const implementation::builder_matrix& builder)
-{
-	return new matrix(builder);
-}
-
 unsigned
 matrix::create_item(const std::map<std::string, string_map>& item_data,
 					 const std::map<std::string, std::string>& tags)
@@ -236,9 +231,9 @@ builder_matrix::builder_matrix(const config& cfg)
 	}
 }
 
-widget* builder_matrix::build() const
+widget_ptr builder_matrix::build() const
 {
-	return matrix::build(*this);
+	return std::make_shared<matrix>(*this);
 }
 
 } // namespace implementation

--- a/src/gui/widgets/matrix.hpp
+++ b/src/gui/widgets/matrix.hpp
@@ -108,11 +108,8 @@ class matrix : public tbase
 {
 	friend class debug_layout_graph;
 
-private:
-	explicit matrix(const implementation::builder_matrix& builder);
-
 public:
-	static matrix* build(const implementation::builder_matrix& builder);
+	explicit matrix(const implementation::builder_matrix& builder);
 
 	/***** ***** ***** ***** Item handling. ***** ***** ****** *****/
 
@@ -265,7 +262,7 @@ struct builder_matrix : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/matrix.hpp
+++ b/src/gui/widgets/matrix.hpp
@@ -262,7 +262,7 @@ struct builder_matrix : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -249,9 +249,9 @@ builder_menu_button::builder_menu_button(const config& cfg)
 	}
 }
 
-widget* builder_menu_button::build() const
+widget_ptr builder_menu_button::build() const
 {
-	menu_button* widget = new menu_button(*this);
+	auto widget = std::make_shared<menu_button>(*this);
 
 	if(!options_.empty()) {
 		widget->set_values(options_);

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -249,9 +249,9 @@ builder_menu_button::builder_menu_button(const config& cfg)
 	}
 }
 
-widget_ptr builder_menu_button::build() const
+std::unique_ptr<widget> builder_menu_button::build() const
 {
-	auto widget = std::make_shared<menu_button>(*this);
+	auto widget = std::make_unique<menu_button>(*this);
 
 	if(!options_.empty()) {
 		widget->set_values(options_);

--- a/src/gui/widgets/menu_button.hpp
+++ b/src/gui/widgets/menu_button.hpp
@@ -186,7 +186,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	std::vector<::config> options_;

--- a/src/gui/widgets/menu_button.hpp
+++ b/src/gui/widgets/menu_button.hpp
@@ -186,7 +186,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	std::vector<::config> options_;

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -249,9 +249,9 @@ builder_minimap::builder_minimap(const config& cfg) : builder_styled_widget(cfg)
 {
 }
 
-widget* builder_minimap::build() const
+widget_ptr builder_minimap::build() const
 {
-	minimap* widget = new minimap(*this);
+	auto widget = std::make_shared<minimap>(*this);
 
 	DBG_GUI_G << "Window builder: placed minimap '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -249,9 +249,9 @@ builder_minimap::builder_minimap(const config& cfg) : builder_styled_widget(cfg)
 {
 }
 
-widget_ptr builder_minimap::build() const
+std::unique_ptr<widget> builder_minimap::build() const
 {
-	auto widget = std::make_shared<minimap>(*this);
+	auto widget = std::make_unique<minimap>(*this);
 
 	DBG_GUI_G << "Window builder: placed minimap '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -128,7 +128,7 @@ struct builder_minimap : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -128,7 +128,7 @@ struct builder_minimap : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/multi_page.cpp
+++ b/src/gui/widgets/multi_page.cpp
@@ -220,9 +220,9 @@ builder_multi_page::builder_multi_page(const config& cfg)
 	}
 }
 
-widget* builder_multi_page::build() const
+widget_ptr builder_multi_page::build() const
 {
-	multi_page* widget = new multi_page(*this);
+	auto widget = std::make_shared<multi_page>(*this);
 
 	widget->set_page_builders(builders);
 

--- a/src/gui/widgets/multi_page.cpp
+++ b/src/gui/widgets/multi_page.cpp
@@ -36,7 +36,7 @@ REGISTER_WIDGET(multi_page)
 
 multi_page::multi_page(const implementation::builder_multi_page& builder)
 	: container_base(builder, type())
-	, generator_(generator_base::build(true, true, generator_base::independent, false))
+	, generator_(nullptr)
 	, page_builders_()
 {
 }
@@ -141,11 +141,14 @@ unsigned multi_page::get_state() const
 	return 0;
 }
 
-void multi_page::finalize(const std::vector<string_map>& page_data)
+void multi_page::finalize(std::unique_ptr<generator_base> generator, const std::vector<string_map>& page_data)
 {
+	// Save our *non-owning* pointer before this gets moved into the grid.
+	generator_ = generator.get();
 	assert(generator_);
-	generator_->create_items(-1, *page_builders_.begin()->second, page_data, nullptr);
-	swap_grid(nullptr, &get_grid(), generator_, "_content_grid");
+
+	generator->create_items(-1, *page_builders_.begin()->second, page_data, nullptr);
+	swap_grid(nullptr, &get_grid(), std::move(generator), "_content_grid");
 }
 
 void multi_page::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
@@ -220,9 +223,9 @@ builder_multi_page::builder_multi_page(const config& cfg)
 	}
 }
 
-widget_ptr builder_multi_page::build() const
+std::unique_ptr<widget> builder_multi_page::build() const
 {
-	auto widget = std::make_shared<multi_page>(*this);
+	auto widget = std::make_unique<multi_page>(*this);
 
 	widget->set_page_builders(builders);
 
@@ -234,7 +237,8 @@ widget_ptr builder_multi_page::build() const
 
 	widget->init_grid(*conf->grid);
 
-	widget->finalize(data);
+	auto generator = generator_base::build(true, true, generator_base::independent, false);
+	widget->finalize(std::move(generator), data);
 
 	return widget;
 }

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -30,7 +30,7 @@ namespace implementation
 struct builder_multi_page;
 }
 
-class generator_base;
+using generator_ptr = std::shared_ptr<class generator_base>;
 
 /**
  * @ingroup GUIWidgetWML
@@ -191,7 +191,7 @@ public:
 private:
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
-	void set_page_builders(const std::map<std::string, builder_grid_const_ptr>& page_builders)
+	void set_page_builders(const builder_grid_map& page_builders)
 	{
 		assert(!page_builders.empty());
 		page_builders_ = page_builders;
@@ -211,10 +211,10 @@ private:
 	 * of the scrollbar_container super class and freed when it's grid is
 	 * freed.
 	 */
-	generator_base* generator_;
+	generator_ptr generator_;
 
 	/** Contains the builder for the new items. */
-	std::map<std::string, builder_grid_const_ptr> page_builders_;
+	builder_grid_map page_builders_;
 
 	/** See @ref widget::impl_draw_background. */
 	virtual void impl_draw_background(int x_offset, int y_offset) override;
@@ -256,9 +256,9 @@ struct builder_multi_page : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
-	std::map<std::string, builder_grid_const_ptr> builders;
+	builder_grid_map builders;
 
 	/**
 	 * Multi page data.

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -30,7 +30,7 @@ namespace implementation
 struct builder_multi_page;
 }
 
-using generator_ptr = std::shared_ptr<class generator_base>;
+class generator_base;
 
 /**
  * @ingroup GUIWidgetWML
@@ -200,18 +200,18 @@ private:
 	/**
 	 * Finishes the building initialization of the widget.
 	 *
+	 * @param generator           Generator for the list
 	 * @param page_data           The initial data to fill the widget with.
 	 */
-	void finalize(const std::vector<string_map>& page_data);
+	void finalize(std::unique_ptr<generator_base> generator, const std::vector<string_map>& page_data);
 
 	/**
 	 * Contains a pointer to the generator.
 	 *
 	 * The pointer is not owned by this class, it's stored in the content_grid_
-	 * of the scrollbar_container super class and freed when it's grid is
-	 * freed.
+	 * of the scrollbar_container super class and freed when it's grid is freed.
 	 */
-	generator_ptr generator_;
+	generator_base* generator_;
 
 	/** Contains the builder for the new items. */
 	builder_grid_map page_builders_;
@@ -256,7 +256,7 @@ struct builder_multi_page : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	builder_grid_map builders;
 

--- a/src/gui/widgets/multimenu_button.cpp
+++ b/src/gui/widgets/multimenu_button.cpp
@@ -273,9 +273,9 @@ builder_multimenu_button::builder_multimenu_button(const config& cfg)
 	}
 }
 
-widget* builder_multimenu_button::build() const
+widget_ptr builder_multimenu_button::build() const
 {
-	multimenu_button* widget = new multimenu_button(*this);
+	auto widget = std::make_shared<multimenu_button>(*this);
 
 	widget->set_max_shown(max_shown_);
 	if(!options_.empty()) {

--- a/src/gui/widgets/multimenu_button.cpp
+++ b/src/gui/widgets/multimenu_button.cpp
@@ -273,9 +273,9 @@ builder_multimenu_button::builder_multimenu_button(const config& cfg)
 	}
 }
 
-widget_ptr builder_multimenu_button::build() const
+std::unique_ptr<widget> builder_multimenu_button::build() const
 {
-	auto widget = std::make_shared<multimenu_button>(*this);
+	auto widget = std::make_unique<multimenu_button>(*this);
 
 	widget->set_max_shown(max_shown_);
 	if(!options_.empty()) {

--- a/src/gui/widgets/multimenu_button.hpp
+++ b/src/gui/widgets/multimenu_button.hpp
@@ -235,7 +235,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	unsigned max_shown_;

--- a/src/gui/widgets/multimenu_button.hpp
+++ b/src/gui/widgets/multimenu_button.hpp
@@ -235,7 +235,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	unsigned max_shown_;

--- a/src/gui/widgets/pane.cpp
+++ b/src/gui/widgets/pane.cpp
@@ -97,7 +97,7 @@ struct pane_implementation
 		{
 
 			if(item.id == id) {
-				return item.item_grid;
+				return item.item_grid.get();
 			}
 		}
 
@@ -118,22 +118,17 @@ pane::pane(const implementation::builder_pane& builder)
 			event::dispatcher::back_pre_child);
 }
 
-pane* pane::build(const implementation::builder_pane& builder)
-{
-	return new pane(builder);
-}
-
 unsigned pane::create_item(const std::map<std::string, string_map>& item_data,
 							const std::map<std::string, std::string>& tags)
 {
-	item item = { item_id_generator_++, tags, item_builder_->build() };
+	item item { item_id_generator_++, tags, std::dynamic_pointer_cast<grid>(item_builder_->build()) };
 
 	item.item_grid->set_parent(this);
 
 	for(const auto & data : item_data)
 	{
 		styled_widget* control
-				= find_widget<styled_widget>(item.item_grid, data.first, false, false);
+				= find_widget<styled_widget>(item.item_grid.get(), data.first, false, false);
 
 		if(control) {
 			control->set_members(data.second);
@@ -381,14 +376,14 @@ builder_pane::builder_pane(const config& cfg)
 	VALIDATE(parallel_items > 0, _("Need at least 1 parallel item."));
 }
 
-widget* builder_pane::build() const
+widget_ptr builder_pane::build() const
 {
 	return build(replacements_map());
 }
 
-widget* builder_pane::build(const replacements_map& /*replacements*/) const
+widget_ptr builder_pane::build(const replacements_map& /*replacements*/) const
 {
-	return pane::build(*this);
+	return std::make_shared<pane>(*this);
 }
 
 } // namespace implementation

--- a/src/gui/widgets/pane.hpp
+++ b/src/gui/widgets/pane.hpp
@@ -47,22 +47,18 @@ class pane : public widget
 public:
 	struct item
 	{
-
 		unsigned id;
 		std::map<std::string, std::string> tags;
 
-		grid* item_grid;
+		grid_ptr item_grid;
 	};
 
 	typedef std::function<bool(const item&, const item&)> compare_functor_t;
 
 	typedef std::function<bool(const item&)> filter_functor_t;
 
-private:
-	explicit pane(const implementation::builder_pane& builder);
-
 public:
-	static pane* build(const implementation::builder_pane& builder);
+	explicit pane(const implementation::builder_pane& builder);
 
 	/**
 	 * Creates a new item.
@@ -203,9 +199,9 @@ struct builder_pane : public builder_widget
 {
 	explicit builder_pane(const config& cfg);
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
-	virtual widget* build(const replacements_map& replacements) const override;
+	virtual widget_ptr build(const replacements_map& replacements) const override;
 
 	grow_direction::type grow_dir;
 

--- a/src/gui/widgets/pane.hpp
+++ b/src/gui/widgets/pane.hpp
@@ -47,10 +47,12 @@ class pane : public widget
 public:
 	struct item
 	{
+		item(item&&) = default;
+
 		unsigned id;
 		std::map<std::string, std::string> tags;
 
-		grid_ptr item_grid;
+		std::unique_ptr<grid> item_grid;
 	};
 
 	typedef std::function<bool(const item&, const item&)> compare_functor_t;
@@ -199,9 +201,9 @@ struct builder_pane : public builder_widget
 {
 	explicit builder_pane(const config& cfg);
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
-	virtual widget_ptr build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
 
 	grow_direction::type grow_dir;
 

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -129,9 +129,9 @@ builder_panel::builder_panel(const config& cfg)
 	grid = std::make_shared<builder_grid>(c);
 }
 
-widget_ptr builder_panel::build() const
+std::unique_ptr<widget> builder_panel::build() const
 {
-	auto widget = std::make_shared<panel>(*this);
+	auto widget = std::make_unique<panel>(*this);
 
 	DBG_GUI_G << "Window builder: placed panel '" << id << "' with definition '"
 			  << definition << "'.\n";

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -129,9 +129,9 @@ builder_panel::builder_panel(const config& cfg)
 	grid = std::make_shared<builder_grid>(c);
 }
 
-widget* builder_panel::build() const
+widget_ptr builder_panel::build() const
 {
-	panel* widget = new panel(*this);
+	auto widget = std::make_shared<panel>(*this);
 
 	DBG_GUI_G << "Window builder: placed panel '" << id << "' with definition '"
 			  << definition << "'.\n";

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -123,7 +123,7 @@ struct builder_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	builder_grid_ptr grid;
 };

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -123,7 +123,7 @@ struct builder_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	builder_grid_ptr grid;
 };

--- a/src/gui/widgets/password_box.cpp
+++ b/src/gui/widgets/password_box.cpp
@@ -121,9 +121,9 @@ builder_password_box::builder_password_box(const config& cfg)
 {
 }
 
-widget_ptr builder_password_box::build() const
+std::unique_ptr<widget> builder_password_box::build() const
 {
-	auto widget = std::make_shared<password_box>(*this);
+	auto widget = std::make_unique<password_box>(*this);
 
 	// A password box doesn't have a label but a text.
 	// It also has no history.

--- a/src/gui/widgets/password_box.cpp
+++ b/src/gui/widgets/password_box.cpp
@@ -121,9 +121,9 @@ builder_password_box::builder_password_box(const config& cfg)
 {
 }
 
-widget* builder_password_box::build() const
+widget_ptr builder_password_box::build() const
 {
-	password_box* widget = new password_box(*this);
+	auto widget = std::make_shared<password_box>(*this);
 
 	// A password box doesn't have a label but a text.
 	// It also has no history.

--- a/src/gui/widgets/password_box.hpp
+++ b/src/gui/widgets/password_box.hpp
@@ -89,7 +89,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	std::string history_;

--- a/src/gui/widgets/password_box.hpp
+++ b/src/gui/widgets/password_box.hpp
@@ -89,7 +89,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	std::string history_;

--- a/src/gui/widgets/progress_bar.cpp
+++ b/src/gui/widgets/progress_bar.cpp
@@ -104,9 +104,9 @@ builder_progress_bar::builder_progress_bar(const config& cfg)
 {
 }
 
-widget_ptr builder_progress_bar::build() const
+std::unique_ptr<widget> builder_progress_bar::build() const
 {
-	auto widget = std::make_shared<progress_bar>(*this);
+	auto widget = std::make_unique<progress_bar>(*this);
 
 	DBG_GUI_G << "Window builder: placed progress bar '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/progress_bar.cpp
+++ b/src/gui/widgets/progress_bar.cpp
@@ -104,9 +104,9 @@ builder_progress_bar::builder_progress_bar(const config& cfg)
 {
 }
 
-widget* builder_progress_bar::build() const
+widget_ptr builder_progress_bar::build() const
 {
-	progress_bar* widget = new progress_bar(*this);
+	auto widget = std::make_shared<progress_bar>(*this);
 
 	DBG_GUI_G << "Window builder: placed progress bar '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/progress_bar.hpp
+++ b/src/gui/widgets/progress_bar.hpp
@@ -111,7 +111,7 @@ struct builder_progress_bar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/progress_bar.hpp
+++ b/src/gui/widgets/progress_bar.hpp
@@ -111,7 +111,7 @@ struct builder_progress_bar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/repeating_button.cpp
+++ b/src/gui/widgets/repeating_button.cpp
@@ -195,9 +195,9 @@ builder_repeating_button::builder_repeating_button(const config& cfg)
 {
 }
 
-widget_ptr builder_repeating_button::build() const
+std::unique_ptr<widget> builder_repeating_button::build() const
 {
-	auto widget = std::make_shared<repeating_button>(*this);
+	auto widget = std::make_unique<repeating_button>(*this);
 
 	DBG_GUI_G << "Window builder: placed repeating button '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/repeating_button.cpp
+++ b/src/gui/widgets/repeating_button.cpp
@@ -195,9 +195,9 @@ builder_repeating_button::builder_repeating_button(const config& cfg)
 {
 }
 
-widget* builder_repeating_button::build() const
+widget_ptr builder_repeating_button::build() const
 {
-	repeating_button* widget = new repeating_button(*this);
+	auto widget = std::make_shared<repeating_button>(*this);
 
 	DBG_GUI_G << "Window builder: placed repeating button '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/repeating_button.hpp
+++ b/src/gui/widgets/repeating_button.hpp
@@ -160,7 +160,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/repeating_button.hpp
+++ b/src/gui/widgets/repeating_button.hpp
@@ -160,7 +160,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/scroll_label.cpp
+++ b/src/gui/widgets/scroll_label.cpp
@@ -200,9 +200,9 @@ builder_scroll_label::builder_scroll_label(const config& cfg)
 {
 }
 
-widget_ptr builder_scroll_label::build() const
+std::unique_ptr<widget> builder_scroll_label::build() const
 {
-	auto widget = std::make_shared<scroll_label>(*this);
+	auto widget = std::make_unique<scroll_label>(*this);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);

--- a/src/gui/widgets/scroll_label.cpp
+++ b/src/gui/widgets/scroll_label.cpp
@@ -200,9 +200,9 @@ builder_scroll_label::builder_scroll_label(const config& cfg)
 {
 }
 
-widget* builder_scroll_label::build() const
+widget_ptr builder_scroll_label::build() const
 {
-	scroll_label* widget = new scroll_label(*this);
+	auto widget = std::make_shared<scroll_label>(*this);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);

--- a/src/gui/widgets/scroll_label.hpp
+++ b/src/gui/widgets/scroll_label.hpp
@@ -166,7 +166,7 @@ struct builder_scroll_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/scroll_label.hpp
+++ b/src/gui/widgets/scroll_label.hpp
@@ -166,7 +166,7 @@ struct builder_scroll_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -769,9 +769,11 @@ void scrollbar_container::finalize_setup()
 	}
 
 	/***** Setup the content *****/
-	content_ = build_single_widget_instance<spacer>();
+	auto content = build_single_widget_instance<spacer>();
+	content_ = content.get();
 
-	content_grid_ = std::dynamic_pointer_cast<grid>(get_grid().swap_child("_content_grid", content_, true));
+	// TODO: possibly move this unique_ptr casting functionality to a helper function.
+	content_grid_.reset(static_cast<grid*>(get_grid().swap_child("_content_grid", std::move(content), true).release()));
 	assert(content_grid_);
 
 	content_grid_->set_parent(this);

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -771,8 +771,7 @@ void scrollbar_container::finalize_setup()
 	/***** Setup the content *****/
 	content_ = build_single_widget_instance<spacer>();
 
-	// TODO: possibly move this unique_ptr casting functionality to a helper function.
-	content_grid_.reset(dynamic_cast<grid*>(get_grid().swap_child("_content_grid", content_, true).release()));
+	content_grid_ = std::dynamic_pointer_cast<grid>(get_grid().swap_child("_content_grid", content_, true));
 	assert(content_grid_);
 
 	content_grid_->set_parent(this);

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -477,10 +477,10 @@ private:
 	scrollbar_base *vertical_scrollbar_, *horizontal_scrollbar_;
 
 	/** The grid that holds the content. */
-	std::unique_ptr<grid> content_grid_;
+	grid_ptr content_grid_;
 
 	/** Dummy spacer to hold the contents location. */
-	spacer* content_;
+	std::shared_ptr<spacer> content_;
 
 	/**
 	 * Cache for the visible area for the content.

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -477,10 +477,10 @@ private:
 	scrollbar_base *vertical_scrollbar_, *horizontal_scrollbar_;
 
 	/** The grid that holds the content. */
-	grid_ptr content_grid_;
+	std::unique_ptr<grid> content_grid_;
 
 	/** Dummy spacer to hold the contents location. */
-	std::shared_ptr<spacer> content_;
+	spacer* content_;
 
 	/**
 	 * Cache for the visible area for the content.

--- a/src/gui/widgets/scrollbar_container_private.hpp
+++ b/src/gui/widgets/scrollbar_container_private.hpp
@@ -66,7 +66,7 @@ struct scrollbar_container_implementation
 		W* result = scrollbar_container.container_base::find_at(coordinate,
 															 must_be_active);
 
-		if(result == scrollbar_container.content_) {
+		if(result == scrollbar_container.content_.get()) {
 			return scrollbar_container.content_grid_->find_at(coordinate,
 															  must_be_active);
 		}

--- a/src/gui/widgets/scrollbar_container_private.hpp
+++ b/src/gui/widgets/scrollbar_container_private.hpp
@@ -66,7 +66,7 @@ struct scrollbar_container_implementation
 		W* result = scrollbar_container.container_base::find_at(coordinate,
 															 must_be_active);
 
-		if(result == scrollbar_container.content_.get()) {
+		if(result == scrollbar_container.content_) {
 			return scrollbar_container.content_grid_->find_at(coordinate,
 															  must_be_active);
 		}

--- a/src/gui/widgets/scrollbar_panel.cpp
+++ b/src/gui/widgets/scrollbar_panel.cpp
@@ -96,9 +96,9 @@ builder_scrollbar_panel::builder_scrollbar_panel(const config& cfg)
 	assert(grid_);
 }
 
-widget_ptr builder_scrollbar_panel::build() const
+std::unique_ptr<widget> builder_scrollbar_panel::build() const
 {
-	auto panel = std::make_shared<scrollbar_panel>(*this);
+	auto panel = std::make_unique<scrollbar_panel>(*this);
 
 	panel->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	panel->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);
@@ -131,7 +131,7 @@ widget_ptr builder_scrollbar_panel::build() const
 			}
 
 			auto widget = grid_->widgets[x * cols + y]->build();
-			content_grid->set_child(widget,
+			content_grid->set_child(std::move(widget),
 									x,
 									y,
 									grid_->flags[x * cols + y],

--- a/src/gui/widgets/scrollbar_panel.cpp
+++ b/src/gui/widgets/scrollbar_panel.cpp
@@ -96,9 +96,9 @@ builder_scrollbar_panel::builder_scrollbar_panel(const config& cfg)
 	assert(grid_);
 }
 
-widget* builder_scrollbar_panel::build() const
+widget_ptr builder_scrollbar_panel::build() const
 {
-	scrollbar_panel* panel = new scrollbar_panel(*this);
+	auto panel = std::make_shared<scrollbar_panel>(*this);
 
 	panel->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	panel->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);
@@ -130,7 +130,7 @@ widget* builder_scrollbar_panel::build() const
 													 grid_->col_grow_factor[y]);
 			}
 
-			widget* widget = grid_->widgets[x * cols + y]->build();
+			auto widget = grid_->widgets[x * cols + y]->build();
 			content_grid->set_child(widget,
 									x,
 									y,

--- a/src/gui/widgets/scrollbar_panel.hpp
+++ b/src/gui/widgets/scrollbar_panel.hpp
@@ -107,7 +107,7 @@ struct builder_scrollbar_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/scrollbar_panel.hpp
+++ b/src/gui/widgets/scrollbar_panel.hpp
@@ -107,7 +107,7 @@ struct builder_scrollbar_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/size_lock.cpp
+++ b/src/gui/widgets/size_lock.cpp
@@ -73,8 +73,10 @@ void size_lock::finalize(const builder_widget& widget_builder)
 {
 	set_rows_cols(1u, 1u);
 
-	widget_ = widget_builder.build();
-	set_child(widget_, 0u, 0u, grid::VERTICAL_GROW_SEND_TO_CLIENT | grid::HORIZONTAL_GROW_SEND_TO_CLIENT, 0u);
+	auto widget = widget_builder.build();
+	widget_ = widget.get();
+
+	set_child(std::move(widget), 0u, 0u, grid::VERTICAL_GROW_SEND_TO_CLIENT | grid::HORIZONTAL_GROW_SEND_TO_CLIENT, 0u);
 }
 
 point size_lock::calculate_best_size() const
@@ -123,9 +125,9 @@ builder_size_lock::builder_size_lock(const config& cfg)
 	content_ = create_widget_builder(cfg.child("widget"));
 }
 
-widget_ptr builder_size_lock::build() const
+std::unique_ptr<widget> builder_size_lock::build() const
 {
-	auto widget = std::make_shared<size_lock>(*this);
+	auto widget = std::make_unique<size_lock>(*this);
 
 	DBG_GUI_G << "Window builder: placed fixed size widget '" << id << "' with definition '" << definition << "'.\n";
 

--- a/src/gui/widgets/size_lock.cpp
+++ b/src/gui/widgets/size_lock.cpp
@@ -123,9 +123,9 @@ builder_size_lock::builder_size_lock(const config& cfg)
 	content_ = create_widget_builder(cfg.child("widget"));
 }
 
-widget* builder_size_lock::build() const
+widget_ptr builder_size_lock::build() const
 {
-	size_lock* widget = new size_lock(*this);
+	auto widget = std::make_shared<size_lock>(*this);
 
 	DBG_GUI_G << "Window builder: placed fixed size widget '" << id << "' with definition '" << definition << "'.\n";
 

--- a/src/gui/widgets/size_lock.hpp
+++ b/src/gui/widgets/size_lock.hpp
@@ -81,7 +81,7 @@ private:
 	 *
 	 * The widget is owned by container_base (the base class).
 	 */
-	widget_ptr widget_;
+	widget* widget_;
 
 	/**
 	 * Finishes the building initialization of the widget.
@@ -127,7 +127,7 @@ struct builder_size_lock : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	typed_formula<unsigned> width_;
 	typed_formula<unsigned> height_;

--- a/src/gui/widgets/size_lock.hpp
+++ b/src/gui/widgets/size_lock.hpp
@@ -81,7 +81,7 @@ private:
 	 *
 	 * The widget is owned by container_base (the base class).
 	 */
-	widget* widget_;
+	widget_ptr widget_;
 
 	/**
 	 * Finishes the building initialization of the widget.
@@ -127,7 +127,7 @@ struct builder_size_lock : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	typed_formula<unsigned> width_;
 	typed_formula<unsigned> height_;

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -339,9 +339,9 @@ builder_slider::builder_slider(const config& cfg)
 	}
 }
 
-widget* builder_slider::build() const
+widget_ptr builder_slider::build() const
 {
-	slider* widget = new slider(*this);
+	auto widget = std::make_shared<slider>(*this);
 
 	widget->set_best_slider_length(best_slider_length_);
 	widget->set_value_range(minimum_value_, maximum_value_);

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -339,9 +339,9 @@ builder_slider::builder_slider(const config& cfg)
 	}
 }
 
-widget_ptr builder_slider::build() const
+std::unique_ptr<widget> builder_slider::build() const
 {
-	auto widget = std::make_shared<slider>(*this);
+	auto widget = std::make_unique<slider>(*this);
 
 	widget->set_best_slider_length(best_slider_length_);
 	widget->set_value_range(minimum_value_, maximum_value_);

--- a/src/gui/widgets/slider.hpp
+++ b/src/gui/widgets/slider.hpp
@@ -275,7 +275,7 @@ struct builder_slider : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	unsigned best_slider_length_;

--- a/src/gui/widgets/slider.hpp
+++ b/src/gui/widgets/slider.hpp
@@ -275,7 +275,7 @@ struct builder_slider : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	unsigned best_slider_length_;

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -127,9 +127,9 @@ builder_spacer::builder_spacer(const config& cfg)
 {
 }
 
-widget* builder_spacer::build() const
+widget_ptr builder_spacer::build() const
 {
-	spacer* widget = new spacer(*this, width_, height_);
+	auto widget = std::make_shared<spacer>(*this, width_, height_);
 
 	DBG_GUI_G << "Window builder: placed spacer '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -127,9 +127,9 @@ builder_spacer::builder_spacer(const config& cfg)
 {
 }
 
-widget_ptr builder_spacer::build() const
+std::unique_ptr<widget> builder_spacer::build() const
 {
-	auto widget = std::make_shared<spacer>(*this, width_, height_);
+	auto widget = std::make_unique<spacer>(*this, width_, height_);
 
 	DBG_GUI_G << "Window builder: placed spacer '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -121,7 +121,7 @@ struct builder_spacer : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	// We store these as strings since they could contain formulas.

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -121,7 +121,7 @@ struct builder_spacer : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	// We store these as strings since they could contain formulas.

--- a/src/gui/widgets/stacked_widget.cpp
+++ b/src/gui/widgets/stacked_widget.cpp
@@ -61,7 +61,7 @@ struct stacked_widget_implementation
 
 stacked_widget::stacked_widget(const implementation::builder_stacked_widget& builder)
 	: container_base(builder, type())
-	, generator_(generator_base::build(false, false, generator_base::independent, false))
+	, generator_(nullptr)
 	, selected_layer_(-1)
 	, find_in_all_layers_(false)
 {
@@ -85,15 +85,17 @@ void stacked_widget::layout_children()
 	}
 }
 
-void stacked_widget::finalize(const std::vector<builder_grid>& widget_builders)
+void stacked_widget::finalize(std::unique_ptr<generator_base> generator, const std::vector<builder_grid>& widget_builders)
 {
+	// Save our *non-owning* pointer before this gets moved into the grid.
+	generator_ = generator.get();
 	assert(generator_);
+
 	string_map empty_data;
-	for(const auto & builder : widget_builders)
-	{
-		generator_->create_item(-1, builder, empty_data, nullptr);
+	for(const auto & builder : widget_builders) {
+		generator->create_item(-1, builder, empty_data, nullptr);
 	}
-	swap_grid(nullptr, &get_grid(), generator_, "_content_grid");
+	swap_grid(nullptr, &get_grid(), std::move(generator), "_content_grid");
 
 	select_layer(-1);
 }
@@ -245,9 +247,9 @@ builder_stacked_widget::builder_stacked_widget(const config& real_cfg)
 	}
 }
 
-widget_ptr builder_stacked_widget::build() const
+std::unique_ptr<widget> builder_stacked_widget::build() const
 {
-	auto widget = std::make_shared<stacked_widget>(*this);
+	auto widget = std::make_unique<stacked_widget>(*this);
 
 	DBG_GUI_G << "Window builder: placed stacked widget '" << id
 			  << "' with definition '" << definition << "'.\n";
@@ -257,7 +259,8 @@ widget_ptr builder_stacked_widget::build() const
 
 	widget->init_grid(*conf->grid);
 
-	widget->finalize(stack);
+	auto generator = generator_base::build(false, false, generator_base::independent, false);
+	widget->finalize(std::move(generator), stack);
 
 	return widget;
 }

--- a/src/gui/widgets/stacked_widget.cpp
+++ b/src/gui/widgets/stacked_widget.cpp
@@ -245,9 +245,9 @@ builder_stacked_widget::builder_stacked_widget(const config& real_cfg)
 	}
 }
 
-widget* builder_stacked_widget::build() const
+widget_ptr builder_stacked_widget::build() const
 {
-	stacked_widget* widget = new stacked_widget(*this);
+	auto widget = std::make_shared<stacked_widget>(*this);
 
 	DBG_GUI_G << "Window builder: placed stacked widget '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/stacked_widget.hpp
+++ b/src/gui/widgets/stacked_widget.hpp
@@ -32,7 +32,7 @@ namespace implementation
 struct builder_stacked_widget;
 }
 
-using generator_ptr = std::shared_ptr<class generator_base>;
+class generator_base;
 
 /**
  * @ingroup GUIWidgetWML
@@ -130,17 +130,16 @@ private:
 	/**
 	 * Finishes the building initialization of the widget.
 	 *
-	 * @param widget_builders     The builder to build the contents of the
-	 *                            widget.
+	 * @param generator           Generator for the list
+	 * @param widget_builders     The builder to build the contents of the widget.
 	 */
-	void finalize(const std::vector<builder_grid>& widget_builders);
+	void finalize(std::unique_ptr<generator_base> generator, const std::vector<builder_grid>& widget_builders);
 
 	/**
 	 * Contains a pointer to the generator.
 	 *
 	 * The pointer is not owned by this class, it's stored in the content_grid_
-	 * of the scrollbar_container super class and freed when its grid is
-	 * freed.
+	 * of the scrollbar_container super class and freed when its grid is freed.
 	 *
 	 * NOTE: the generator is initialized with has_minimum (first arg) as false,
 	 * which seems a little counter-intuitive at first. After all, shouldn't the
@@ -153,7 +152,7 @@ private:
 	 * In that case, the generator would not allow the interim state where no layer
 	 * before the new chosen layer is reached in the loop.
 	 */
-	generator_ptr generator_;
+	generator_base* generator_;
 
 	/**
 	 * The number of the current selected layer.
@@ -215,7 +214,7 @@ struct builder_stacked_widget : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	/** The builders for all layers of the stack .*/
 	std::vector<builder_grid> stack;

--- a/src/gui/widgets/stacked_widget.hpp
+++ b/src/gui/widgets/stacked_widget.hpp
@@ -32,7 +32,7 @@ namespace implementation
 struct builder_stacked_widget;
 }
 
-class generator_base;
+using generator_ptr = std::shared_ptr<class generator_base>;
 
 /**
  * @ingroup GUIWidgetWML
@@ -153,7 +153,7 @@ private:
 	 * In that case, the generator would not allow the interim state where no layer
 	 * before the new chosen layer is reached in the loop.
 	 */
-	generator_base* generator_;
+	generator_ptr generator_;
 
 	/**
 	 * The number of the current selected layer.
@@ -215,7 +215,7 @@ struct builder_stacked_widget : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	/** The builders for all layers of the stack .*/
 	std::vector<builder_grid> stack;

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -607,7 +607,7 @@ builder_styled_widget::builder_styled_widget(const config& cfg)
 			  << "' and definition '" << definition << "'.\n";
 }
 
-widget* builder_styled_widget::build(const replacements_map& /*replacements*/) const
+widget_ptr builder_styled_widget::build(const replacements_map& /*replacements*/) const
 {
 	return build();
 }

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -607,7 +607,7 @@ builder_styled_widget::builder_styled_widget(const config& cfg)
 			  << "' and definition '" << definition << "'.\n";
 }
 
-widget_ptr builder_styled_widget::build(const replacements_map& /*replacements*/) const
+std::unique_ptr<widget> builder_styled_widget::build(const replacements_map& /*replacements*/) const
 {
 	return build();
 }

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -545,7 +545,7 @@ public:
 
 	using builder_widget::build;
 
-	virtual widget_ptr build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
 
 	/** Parameters for the styled_widget. */
 	std::string definition;

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -453,7 +453,7 @@ public:
 	 *
 	 * 2) Having a static type getter allows the type string to be fetched without
 	 *    constructing an instance of the widget. A good example of this usecase is
-	 *    in build_single_widget_and_cast_to.
+	 *    in build_single_widget_instance.
 	 */
 	virtual const std::string& get_control_type() const = 0;
 
@@ -545,7 +545,7 @@ public:
 
 	using builder_widget::build;
 
-	virtual widget* build(const replacements_map& replacements) const override;
+	virtual widget_ptr build(const replacements_map& replacements) const override;
 
 	/** Parameters for the styled_widget. */
 	std::string definition;

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -428,9 +428,9 @@ builder_text_box::builder_text_box(const config& cfg)
 {
 }
 
-widget_ptr builder_text_box::build() const
+std::unique_ptr<widget> builder_text_box::build() const
 {
-	auto widget = std::make_shared<text_box>(*this);
+	auto widget = std::make_unique<text_box>(*this);
 
 	// A textbox doesn't have a label but a text
 	widget->set_value(label_string);

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -428,9 +428,9 @@ builder_text_box::builder_text_box(const config& cfg)
 {
 }
 
-widget* builder_text_box::build() const
+widget_ptr builder_text_box::build() const
 {
-	text_box* widget = new text_box(*this);
+	auto widget = std::make_shared<text_box>(*this);
 
 	// A textbox doesn't have a label but a text
 	widget->set_value(label_string);

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -343,7 +343,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	std::string history;
 

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -343,7 +343,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	std::string history;
 

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -228,9 +228,9 @@ builder_toggle_button::builder_toggle_button(const config& cfg)
 {
 }
 
-widget_ptr builder_toggle_button::build() const
+std::unique_ptr<widget> builder_toggle_button::build() const
 {
-	auto widget = std::make_shared<toggle_button>(*this);
+	auto widget = std::make_unique<toggle_button>(*this);
 
 	widget->set_icon_name(icon_name_);
 	widget->set_retval(get_retval(retval_id_, retval_, id));

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -228,9 +228,9 @@ builder_toggle_button::builder_toggle_button(const config& cfg)
 {
 }
 
-widget* builder_toggle_button::build() const
+widget_ptr builder_toggle_button::build() const
 {
-	toggle_button* widget = new toggle_button(*this);
+	auto widget = std::make_shared<toggle_button>(*this);
 
 	widget->set_icon_name(icon_name_);
 	widget->set_retval(get_retval(retval_id_, retval_, id));

--- a/src/gui/widgets/toggle_button.hpp
+++ b/src/gui/widgets/toggle_button.hpp
@@ -187,7 +187,7 @@ struct builder_toggle_button : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	std::string icon_name_;

--- a/src/gui/widgets/toggle_button.hpp
+++ b/src/gui/widgets/toggle_button.hpp
@@ -187,7 +187,7 @@ struct builder_toggle_button : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	std::string icon_name_;

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -324,9 +324,9 @@ builder_toggle_panel::builder_toggle_panel(const config& cfg)
 	grid = std::make_shared<builder_grid>(c);
 }
 
-widget* builder_toggle_panel::build() const
+widget_ptr builder_toggle_panel::build() const
 {
-	toggle_panel* widget = new toggle_panel(*this);
+	auto widget = std::make_shared<toggle_panel>(*this);
 
 	widget->set_retval(get_retval(retval_id_, retval_, id));
 

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -324,9 +324,9 @@ builder_toggle_panel::builder_toggle_panel(const config& cfg)
 	grid = std::make_shared<builder_grid>(c);
 }
 
-widget_ptr builder_toggle_panel::build() const
+std::unique_ptr<widget> builder_toggle_panel::build() const
 {
-	auto widget = std::make_shared<toggle_panel>(*this);
+	auto widget = std::make_unique<toggle_panel>(*this);
 
 	widget->set_retval(get_retval(retval_id_, retval_, id));
 

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -233,7 +233,7 @@ struct builder_toggle_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	builder_grid_ptr grid;
 

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -233,7 +233,7 @@ struct builder_toggle_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	builder_grid_ptr grid;
 

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -40,7 +40,7 @@ tree_view::tree_view(const implementation::builder_tree_view& builder)
 	, node_definitions_(builder.nodes)
 	, indentation_step_size_(0)
 	, need_layout_(false)
-	, root_node_(new tree_view_node(root_node_id, nullptr, *this, {}))
+	, root_node_(nullptr)
 	, selected_item_(nullptr)
 {
 	connect_signal<event::LEFT_BUTTON_DOWN>(
@@ -62,7 +62,7 @@ tree_view_node& tree_view::add_node(
 
 std::pair<std::shared_ptr<tree_view_node>, int> tree_view::remove_node(tree_view_node* node)
 {
-	assert(node && node != root_node_.get() && node->parent_node_);
+	assert(node && node != root_node_ && node->parent_node_);
 	const point node_size = node->get_size();
 
 	tree_view_node::node_children_vector& siblings = node->parent_node_->children_;
@@ -171,10 +171,13 @@ void tree_view::finalize_setup()
 	// Inherited.
 	scrollbar_container::finalize_setup();
 
+	auto root = std::make_unique<tree_view_node>(root_node_id, nullptr, *this, std::map<std::string, string_map>{});
+	root_node_ = root.get();
+
 	assert(content_grid());
 	content_grid()->set_rows_cols(1, 1);
 	content_grid()->set_child(
-		root_node_, 0, 0, grid::VERTICAL_GROW_SEND_TO_CLIENT | grid::HORIZONTAL_GROW_SEND_TO_CLIENT, 0);
+		std::move(root), 0, 0, grid::VERTICAL_GROW_SEND_TO_CLIENT | grid::HORIZONTAL_GROW_SEND_TO_CLIENT, 0);
 }
 
 void tree_view::signal_handler_left_button_down(const event::ui_event event)
@@ -300,13 +303,13 @@ builder_tree_view::builder_tree_view(const config& cfg)
 	VALIDATE(!nodes.empty(), _("No nodes defined for a tree view."));
 }
 
-widget_ptr builder_tree_view::build() const
+std::unique_ptr<widget> builder_tree_view::build() const
 {
 	/*
 	 *  TODO see how much we can move in the constructor instead of
 	 *  building in several steps.
 	 */
-	auto widget = std::make_shared<tree_view>(*this);
+	auto widget = std::make_unique<tree_view>(*this);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -62,7 +62,7 @@ tree_view_node& tree_view::add_node(
 
 std::pair<std::shared_ptr<tree_view_node>, int> tree_view::remove_node(tree_view_node* node)
 {
-	assert(node && node != root_node_ && node->parent_node_);
+	assert(node && node != root_node_.get() && node->parent_node_);
 	const point node_size = node->get_size();
 
 	tree_view_node::node_children_vector& siblings = node->parent_node_->children_;
@@ -300,13 +300,13 @@ builder_tree_view::builder_tree_view(const config& cfg)
 	VALIDATE(!nodes.empty(), _("No nodes defined for a tree view."));
 }
 
-widget* builder_tree_view::build() const
+widget_ptr builder_tree_view::build() const
 {
 	/*
 	 *  TODO see how much we can move in the constructor instead of
 	 *  building in several steps.
 	 */
-	tree_view* widget = new tree_view(*this);
+	auto widget = std::make_shared<tree_view>(*this);
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -159,7 +159,7 @@ private:
 
 	bool need_layout_;
 
-	std::shared_ptr<tree_view_node> root_node_;
+	tree_view_node* root_node_;
 
 	tree_view_node* selected_item_;
 
@@ -244,7 +244,7 @@ struct builder_tree_view : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -159,7 +159,7 @@ private:
 
 	bool need_layout_;
 
-	tree_view_node* root_node_;
+	std::shared_ptr<tree_view_node> root_node_;
 
 	tree_view_node* selected_item_;
 
@@ -244,7 +244,7 @@ struct builder_tree_view : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -56,7 +56,7 @@ tree_view_node::tree_view_node(const std::string& id,
 	if(const auto opt = get_tree_view().get_node_definition(id)) {
 		const auto& node_definition = **opt;
 
-		node_definition.builder->build(&grid_);
+		node_definition.builder->build(grid_);
 		init_grid(&grid_, data);
 
 		if(parent_node_ && parent_node_->toggle_) {

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -622,9 +622,9 @@ builder_unit_preview_pane::builder_unit_preview_pane(const config& cfg)
 {
 }
 
-widget* builder_unit_preview_pane::build() const
+widget_ptr builder_unit_preview_pane::build() const
 {
-	unit_preview_pane* widget = new unit_preview_pane(*this);
+	auto widget = std::make_shared<unit_preview_pane>(*this);
 
 	DBG_GUI_G << "Window builder: placed unit preview pane '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -622,9 +622,9 @@ builder_unit_preview_pane::builder_unit_preview_pane(const config& cfg)
 {
 }
 
-widget_ptr builder_unit_preview_pane::build() const
+std::unique_ptr<widget> builder_unit_preview_pane::build() const
 {
-	auto widget = std::make_shared<unit_preview_pane>(*this);
+	auto widget = std::make_unique<unit_preview_pane>(*this);
 
 	DBG_GUI_G << "Window builder: placed unit preview pane '" << id
 			  << "' with definition '" << definition << "'.\n";

--- a/src/gui/widgets/unit_preview_pane.hpp
+++ b/src/gui/widgets/unit_preview_pane.hpp
@@ -139,7 +139,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
 private:
 	const std::string image_mods_;

--- a/src/gui/widgets/unit_preview_pane.hpp
+++ b/src/gui/widgets/unit_preview_pane.hpp
@@ -139,7 +139,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
 private:
 	const std::string image_mods_;

--- a/src/gui/widgets/vertical_scrollbar.cpp
+++ b/src/gui/widgets/vertical_scrollbar.cpp
@@ -134,9 +134,9 @@ builder_vertical_scrollbar::builder_vertical_scrollbar(const config& cfg)
 {
 }
 
-widget_ptr builder_vertical_scrollbar::build() const
+std::unique_ptr<widget> builder_vertical_scrollbar::build() const
 {
-	auto widget = std::make_shared<vertical_scrollbar>(*this);
+	auto widget = std::make_unique<vertical_scrollbar>(*this);
 
 	widget->finalize_setup();
 

--- a/src/gui/widgets/vertical_scrollbar.cpp
+++ b/src/gui/widgets/vertical_scrollbar.cpp
@@ -134,9 +134,9 @@ builder_vertical_scrollbar::builder_vertical_scrollbar(const config& cfg)
 {
 }
 
-widget* builder_vertical_scrollbar::build() const
+widget_ptr builder_vertical_scrollbar::build() const
 {
-	vertical_scrollbar* widget = new vertical_scrollbar(*this);
+	auto widget = std::make_shared<vertical_scrollbar>(*this);
 
 	widget->finalize_setup();
 

--- a/src/gui/widgets/vertical_scrollbar.hpp
+++ b/src/gui/widgets/vertical_scrollbar.hpp
@@ -125,7 +125,7 @@ struct builder_vertical_scrollbar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/vertical_scrollbar.hpp
+++ b/src/gui/widgets/vertical_scrollbar.hpp
@@ -125,7 +125,7 @@ struct builder_vertical_scrollbar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/viewport.cpp
+++ b/src/gui/widgets/viewport.cpp
@@ -182,14 +182,14 @@ builder_viewport::builder_viewport(const config& cfg)
 {
 }
 
-widget_ptr builder_viewport::build() const
+std::unique_ptr<widget> builder_viewport::build() const
 {
 	return build(replacements_map());
 }
 
-widget_ptr builder_viewport::build(const replacements_map& replacements) const
+std::unique_ptr<widget> builder_viewport::build(const replacements_map& replacements) const
 {
-	return std::make_shared<viewport>(*this, replacements);
+	return std::make_unique<viewport>(*this, replacements);
 }
 
 } // namespace implementation

--- a/src/gui/widgets/viewport.hpp
+++ b/src/gui/widgets/viewport.hpp
@@ -46,13 +46,9 @@ class viewport : public widget
 {
 	friend struct viewport_implementation;
 
-private:
+public:
 	viewport(const implementation::builder_viewport& builder,
 			  const builder_widget::replacements_map& replacements);
-
-public:
-	static viewport* build(const implementation::builder_viewport& builder,
-							const builder_widget::replacements_map& replacements);
 
 	~viewport();
 
@@ -100,9 +96,7 @@ public:
 	virtual iteration::walker_base* create_walker() override;
 
 private:
-	widget& widget_;
-
-	bool owns_widget_;
+	widget_ptr widget_;
 };
 
 // }---------- BUILDER -----------{
@@ -114,9 +108,9 @@ struct builder_viewport : public builder_widget
 {
 	explicit builder_viewport(const config& cfg);
 
-	virtual widget* build() const override;
+	virtual widget_ptr build() const override;
 
-	virtual widget* build(const replacements_map& replacements) const override;
+	virtual widget_ptr build(const replacements_map& replacements) const override;
 
 	builder_widget_ptr widget_;
 };

--- a/src/gui/widgets/viewport.hpp
+++ b/src/gui/widgets/viewport.hpp
@@ -96,7 +96,7 @@ public:
 	virtual iteration::walker_base* create_walker() override;
 
 private:
-	widget_ptr widget_;
+	std::unique_ptr<widget> widget_;
 };
 
 // }---------- BUILDER -----------{
@@ -108,9 +108,9 @@ struct builder_viewport : public builder_widget
 {
 	explicit builder_viewport(const config& cfg);
 
-	virtual widget_ptr build() const override;
+	virtual std::unique_ptr<widget> build() const override;
 
-	virtual widget_ptr build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
 
 	builder_widget_ptr widget_;
 };

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -814,6 +814,4 @@ public:
 	virtual iteration::walker_base* create_walker() = 0;
 };
 
-using widget_ptr = std::shared_ptr<widget>;
-
 } // namespace gui2

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -814,4 +814,6 @@ public:
 	virtual iteration::walker_base* create_walker() = 0;
 };
 
+using widget_ptr = std::shared_ptr<widget>;
+
 } // namespace gui2

--- a/src/gui/widgets/widget_helpers.cpp
+++ b/src/gui/widgets/widget_helpers.cpp
@@ -22,7 +22,7 @@
 
 namespace gui2
 {
-void swap_grid(grid* g, grid* content_grid,widget_ptr widget, const std::string& id)
+void swap_grid(grid* g, grid* content_grid, std::unique_ptr<widget> widget, const std::string& id)
 {
 	assert(content_grid);
 	assert(widget);
@@ -44,7 +44,7 @@ void swap_grid(grid* g, grid* content_grid,widget_ptr widget, const std::string&
 	assert(parent_grid);
 
 	// Replace the child.
-	auto old = parent_grid->swap_child(id, widget, false);
+	auto old = parent_grid->swap_child(id, std::move(widget), false);
 	assert(old);
 }
 }

--- a/src/gui/widgets/widget_helpers.cpp
+++ b/src/gui/widgets/widget_helpers.cpp
@@ -17,13 +17,12 @@
 
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/grid.hpp"
-#include "gui/widgets/widget.hpp"
 
 #include <cassert>
 
 namespace gui2
 {
-void swap_grid(grid* g, grid* content_grid, widget* widget, const std::string& id)
+void swap_grid(grid* g, grid* content_grid,widget_ptr widget, const std::string& id)
 {
 	assert(content_grid);
 	assert(widget);

--- a/src/gui/widgets/widget_helpers.hpp
+++ b/src/gui/widgets/widget_helpers.hpp
@@ -26,5 +26,5 @@ class grid;
 /**
  * Swaps an item in a grid for another one.
  */
-void swap_grid(grid* g, grid* content_grid, widget_ptr widget, const std::string& id);
+void swap_grid(grid* g, grid* content_grid, std::unique_ptr<widget> widget, const std::string& id);
 }

--- a/src/gui/widgets/widget_helpers.hpp
+++ b/src/gui/widgets/widget_helpers.hpp
@@ -15,15 +15,16 @@
 
 #pragma once
 
+#include "gui/widgets/widget.hpp"
+
 #include <string>
 
 namespace gui2
 {
 class grid;
-class widget;
 
 /**
  * Swaps an item in a grid for another one.
  */
-void swap_grid(grid* g, grid* content_grid, widget* widget, const std::string& id);
+void swap_grid(grid* g, grid* content_grid, widget_ptr widget, const std::string& id);
 }

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -100,7 +100,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget_ptr build() const override
+	virtual std::unique_ptr<widget> build() const override
 	{
 		return nullptr;
 	}
@@ -1138,7 +1138,7 @@ namespace
  */
 void window_swap_grid(grid* g,
 			   grid* content_grid,
-			   widget_ptr widget,
+			   std::unique_ptr<widget> widget,
 			   const std::string& id)
 {
 	assert(content_grid);
@@ -1157,11 +1157,11 @@ void window_swap_grid(grid* g,
 		assert(parent_grid);
 	}
 	if(grid* grandparent_grid = dynamic_cast<grid*>(parent_grid->parent())) {
-		grandparent_grid->swap_child(id, widget, false);
+		grandparent_grid->swap_child(id, std::move(widget), false);
 	} else if(container_base* c
 			  = dynamic_cast<container_base*>(parent_grid->parent())) {
 
-		c->get_grid().swap_child(id, widget, true);
+		c->get_grid().swap_child(id, std::move(widget), true);
 	} else {
 		assert(false);
 	}

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -100,7 +100,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual widget* build() const override
+	virtual widget_ptr build() const override
 	{
 		return nullptr;
 	}
@@ -1138,7 +1138,7 @@ namespace
  */
 void window_swap_grid(grid* g,
 			   grid* content_grid,
-			   widget* widget,
+			   widget_ptr widget,
 			   const std::string& id)
 {
 	assert(content_grid);

--- a/src/tests/gui/fire_event.cpp
+++ b/src/tests/gui/fire_event.cpp
@@ -131,20 +131,24 @@ BOOST_AUTO_TEST_CASE(test_fire_event)
 	grid.set_id("root");
 	connect_signals(sstr, grid);
 
-	auto child_grid = std::make_unique<gui2::grid>(1, 1);
-	add_widget(grid, std::move(child_grid), "level 1", 0, 0);
-	connect_signals(sstr, *child_grid);
+	auto g1 = std::make_unique<gui2::grid>(1, 1);
+	gui2::grid* g1_ptr = g1.get();
 
-	auto child = std::make_unique<gui2::grid>(1, 1);
-	add_widget(*child_grid, std::move(child), "level 2", 0, 0);
-	connect_signals(sstr, *child);
+	add_widget(grid, std::move(g1), "level 1", 0, 0);
+	connect_signals(sstr, *g1_ptr);
+
+	auto g2 = std::make_unique<gui2::grid>(1, 1);
+	gui2::grid* g2_ptr = g2.get();
+
+	add_widget(*g1_ptr, std::move(g2), "level 2", 0, 0);
+	connect_signals(sstr, *g2_ptr);
 
 	/** @todo Add the rest of the events. */
 	sstr.str("");
-	grid.fire(gui2::event::DRAW, *child);
+	grid.fire(gui2::event::DRAW, *g2_ptr);
 	validate_draw(sstr);
 
 	sstr.str("");
-	grid.fire(gui2::event::RIGHT_BUTTON_DOWN, *child);
+	grid.fire(gui2::event::RIGHT_BUTTON_DOWN, *g2_ptr);
 	validate_right_button_down(sstr);
 }

--- a/src/tests/gui/fire_event.cpp
+++ b/src/tests/gui/fire_event.cpp
@@ -76,7 +76,7 @@ static void connect_signals(
 }
 
 static void add_widget(gui2::grid& grid
-		, gui2::widget* widget
+		, std::unique_ptr<gui2::widget> widget
 		, const std::string& id
 		, const unsigned row
 		, const unsigned column)
@@ -84,7 +84,7 @@ static void add_widget(gui2::grid& grid
 	BOOST_REQUIRE_NE(widget, static_cast<gui2::widget*>(nullptr));
 
 	widget->set_id(id);
-	grid.set_child(widget
+	grid.set_child(std::move(widget)
 			, row
 			, column
 			, gui2::grid::VERTICAL_GROW_SEND_TO_CLIENT
@@ -131,12 +131,12 @@ BOOST_AUTO_TEST_CASE(test_fire_event)
 	grid.set_id("root");
 	connect_signals(sstr, grid);
 
-	gui2::grid *child_grid = new gui2::grid(1, 1);
-	add_widget(grid, child_grid, "level 1", 0, 0);
+	auto child_grid = std::make_unique<gui2::grid>(1, 1);
+	add_widget(grid, std::move(child_grid), "level 1", 0, 0);
 	connect_signals(sstr, *child_grid);
 
-	gui2::widget *child = new gui2::grid(1, 1);
-	add_widget(*child_grid, child, "level 2", 0, 0);
+	auto child = std::make_unique<gui2::grid>(1, 1);
+	add_widget(*child_grid, std::move(child), "level 2", 0, 0);
 	connect_signals(sstr, *child);
 
 	/** @todo Add the rest of the events. */

--- a/src/tests/gui/fire_event.cpp
+++ b/src/tests/gui/fire_event.cpp
@@ -81,7 +81,7 @@ static void add_widget(gui2::grid& grid
 		, const unsigned row
 		, const unsigned column)
 {
-	BOOST_REQUIRE_NE(widget, static_cast<gui2::widget*>(nullptr));
+	BOOST_REQUIRE_NE(widget.get(), static_cast<gui2::widget*>(nullptr));
 
 	widget->set_id(id);
 	grid.set_child(std::move(widget)

--- a/src/tests/gui/iterator.cpp
+++ b/src/tests/gui/iterator.cpp
@@ -106,15 +106,15 @@ static std::string bottom_up_t_t_t_result()
 }
 
 static void add_widget(gui2::grid& grid
-		, gui2::widget* widget
+		, std::unique_ptr<gui2::widget> widget
 		, const std::string& id
 		, const unsigned row
 		, const unsigned column)
 {
-	BOOST_REQUIRE_NE(widget, static_cast<gui2::widget*>(nullptr));
+	BOOST_REQUIRE_NE(widget.get(), static_cast<gui2::widget*>(nullptr));
 
 	widget->set_id(id);
-	grid.set_child(widget
+	grid.set_child(std::move(widget)
 			, row
 			, column
 			, gui2::grid::VERTICAL_GROW_SEND_TO_CLIENT
@@ -183,16 +183,18 @@ static void test_grid()
 	gui2::grid grid(2 ,2);
 	grid.set_id("0");
 
-	gui2::grid* g = new gui2::grid(2, 2);
-	add_widget(grid, g, "1", 0, 0);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "2", 1, 0);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "3", 0, 1);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "4", 1, 1);
+	auto g = std::make_unique<gui2::grid>(2, 2);
+	gui2::grid* gptr = g.get();
 
-	add_widget(*g, new gui2::label(gui2::implementation::builder_label(config())), "5", 0, 0);
-	add_widget(*g, new gui2::label(gui2::implementation::builder_label(config())), "6", 1, 0);
-	add_widget(*g, new gui2::label(gui2::implementation::builder_label(config())), "7", 0, 1);
-	add_widget(*g, new gui2::label(gui2::implementation::builder_label(config())), "8", 1, 1);
+	add_widget(grid, std::move(g), "1", 0, 0);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "2", 1, 0);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "3", 0, 1);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "4", 1, 1);
+
+	add_widget(*gptr, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "5", 0, 0);
+	add_widget(*gptr, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "6", 1, 0);
+	add_widget(*gptr, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "7", 0, 1);
+	add_widget(*gptr, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "8", 1, 1);
 
 	{
 		std::stringstream sstr;

--- a/src/tests/gui/visitor.cpp
+++ b/src/tests/gui/visitor.cpp
@@ -26,15 +26,15 @@
 #include <typeinfo>
 
 static void add_widget(gui2::grid& grid
-		, gui2::widget* widget
+		, std::unique_ptr<gui2::widget> widget
 		, const std::string& id
 		, const unsigned row
 		, const unsigned column)
 {
-	BOOST_REQUIRE_NE(widget, static_cast<gui2::widget*>(nullptr));
+	BOOST_REQUIRE_NE(widget.get(), static_cast<gui2::widget*>(nullptr));
 
 	widget->set_id(id);
-	grid.set_child(widget
+	grid.set_child(std::move(widget)
 			, row
 			, column
 			, gui2::grid::VERTICAL_GROW_SEND_TO_CLIENT
@@ -95,10 +95,10 @@ static void test_grid()
 
 	/* Test the child part here. */
 	gui2::grid grid(2 ,2);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "(1,1)", 0, 0);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "(1,2)", 0, 1);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "(2,1)", 1, 0);
-	add_widget(grid, new gui2::label(gui2::implementation::builder_label(config())), "(2,2)", 1, 1);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "(1,1)", 0, 0);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "(1,2)", 0, 1);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "(2,1)", 1, 0);
+	add_widget(grid, std::make_unique<gui2::label>(gui2::implementation::builder_label(config())), "(2,2)", 1, 1);
 
 	const std::unique_ptr<gui2::iteration::walker_base> visitor(grid.create_walker());
 


### PR DESCRIPTION
Pulling this out of the old master branch.

This commit is the followup to a similar one I did regarding window initialization. Instead
of widgets being created on the heap and not being managed by a smart pointer until they're
added to a grid, they are now always managed by a shared_ptr. To that end, this commit covers
bunch of things:

* builder_widget::build (both overloads) and all its overrides (which have now been marked
  as such) now return shared_ptr<widget>.
* The builder_grid::build() override now returns the same instead of grid* since you can't
  use covariant return types with smart pointers.
* The two implementation build helpers in builder_grid have been combined with an optional
  replacement map as the second parameter. Uses of the version that took a grid pointer could
  be easily converted to pass a reference instead.
* The pane, matrix, and viewport build() functions were removed in favor of making the ctor
  public. In case there was a deprecated ctor, that was removed.
* The viewport now keeps a widget shared_ptr instead of a reference that was then deleted
  by address-of. This was both better design and necessary to fix a crash.
* ~~build_single_widget_instance_helper and build_single_widget_instance were renamed to
  build_single_widget and build_single_widget_and_cast_to to better represent their roles
  and to indicate the latter was more a convenience extension for the latter than the other
  way around.~~