### PR TITLE
Add command suggestions

### DIFF
--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -357,9 +357,9 @@ std::string vngettext_impl(const char* domain,
 	return msg;
 }
 
-int approximate_string_distance(const std::string &str_1, const std::string &str_2)
+int edit_distance_approx(const std::string &str_1, const std::string &str_2)
 {
-    int approximate_distance = 0;
+    int edit_distance = 0;
     if(str_1.length() == 0) {
         return str_2.length();
     }
@@ -367,32 +367,31 @@ int approximate_string_distance(const std::string &str_1, const std::string &str
         return str_1.length();
     }
     else {
-        int Lmax = 0;
         int j = 0;
-        Lmax = std::max(str_1.length(),str_2.length());
-        for(int i = 0 ; i < Lmax ; i++) {
+        int len_max = std::max(str_1.length(), str_2.length());
+        for(int i = 0; i < len_max; i++) {
             if(str_1[i] != str_2[j]){
                 //SWAP
-                if(str_1[i+1] == str_2[j] && str_1[i] == str_2[j+1]){
+                if(str_1[i+1] == str_2[j] && str_1[i] == str_2[j+1]) {
                     // No need to test the next letter
                     i++;j++;
                 }
                 //ADDITION
-                else if (str_1[i+1] == str_2[j]){
+                else if (str_1[i+1] == str_2[j]) {
                     j--;
                 }
                 //DELETION
-                else if (str_1[i] == str_2[j+1]){
+                else if (str_1[i] == str_2[j+1]) {
                     i--;
                 }
                 // CHANGE (no need to do anything, next letter MAY be successful).
-                approximate_distance++;
-                if(approximate_distance*100/std::min(str_1.length(),str_2.length()) > 33){
+                edit_distance++;
+                if(edit_distance * 100 / std::min(str_1.length(), str_2.length()) > 33) {
                     break;
                 }
             }
             j++;
         }
     }
-    return approximate_distance;
+    return edit_distance;
 }

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -356,3 +356,38 @@ std::string vngettext_impl(const char* domain,
 	const std::string msg = utils::interpolate_variables_into_string(orig, &symbols);
 	return msg;
 }
+
+int approximate_string_distance(const std::string &str_1, const std::string &str_2)
+{
+    int approximate_distance = 0;
+    if(str_1.length() == 0) {
+        return str_2.length();
+    }
+    else if(str_2.length() == 0) {
+        return str_1.length();
+    }
+    else {
+        int Lmax = std::max(str_1.length(),str_2.length());
+        int j = 0;
+        for(int i = 0 ; i < Lmax ; i++) {
+            if(str_1[i] != str_2[j]){
+                //SWAP
+                if(str_1[i+1] == str_2[j] && str_1[i] == str_2[j+1]){
+                    // No need to test the next letter
+                    i++;j++;
+                }
+                //ADDITION
+                else if (str_1[i+1] == str_2[j]){
+                    j--;
+                }
+                //DELETION
+                else if (str_1[i] == str_2[j+1]){
+                    i--;
+                }
+                // CHANGE (no need to do anything, next letter MAY be successful).
+                approximate_distance++;
+            }
+        }
+    }
+    return approximate_distance;
+}

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -386,6 +386,9 @@ int approximate_string_distance(const std::string &str_1, const std::string &str
                 }
                 // CHANGE (no need to do anything, next letter MAY be successful).
                 approximate_distance++;
+                if(approximate_distance > 2){
+                    break;
+                }
             }
         }
     }

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -367,8 +367,14 @@ int approximate_string_distance(const std::string &str_1, const std::string &str
         return str_1.length();
     }
     else {
-        int Lmax = std::max(str_1.length(),str_2.length());
+        int Lmax = 0;
         int j = 0;
+        if (str_1.length() >= str_2.length()){
+            Lmax = str_1.length();
+        }
+        else{
+            Lmax = str_2.length();
+        }
         for(int i = 0 ; i < Lmax ; i++) {
             if(str_1[i] != str_2[j]){
                 //SWAP
@@ -390,6 +396,7 @@ int approximate_string_distance(const std::string &str_1, const std::string &str
                     break;
                 }
             }
+            j++;
         }
     }
     return approximate_distance;

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -369,12 +369,7 @@ int approximate_string_distance(const std::string &str_1, const std::string &str
     else {
         int Lmax = 0;
         int j = 0;
-        if (str_1.length() >= str_2.length()){
-            Lmax = str_1.length();
-        }
-        else{
-            Lmax = str_2.length();
-        }
+        Lmax = std::max(str_1.length(),str_2.length());
         for(int i = 0 ; i < Lmax ; i++) {
             if(str_1[i] != str_2[j]){
                 //SWAP
@@ -392,7 +387,7 @@ int approximate_string_distance(const std::string &str_1, const std::string &str
                 }
                 // CHANGE (no need to do anything, next letter MAY be successful).
                 approximate_distance++;
-                if(approximate_distance > 2){
+                if(approximate_distance*100/std::min(str_1.length(),str_2.length()) > 33){
                     break;
                 }
             }

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -359,39 +359,39 @@ std::string vngettext_impl(const char* domain,
 
 int edit_distance_approx(const std::string &str_1, const std::string &str_2)
 {
-    int edit_distance = 0;
-    if(str_1.length() == 0) {
-        return str_2.length();
-    }
-    else if(str_2.length() == 0) {
-        return str_1.length();
-    }
-    else {
-        int j = 0;
-        int len_max = std::max(str_1.length(), str_2.length());
-        for(int i = 0; i < len_max; i++) {
-            if(str_1[i] != str_2[j]) {
-                //SWAP
-                if(str_1[i+1] == str_2[j] && str_1[i] == str_2[j+1]) {
-                    // No need to test the next letter
-                    i++;j++;
-                }
-                //ADDITION
-                else if(str_1[i+1] == str_2[j]) {
-                    j--;
-                }
-                //DELETION
-                else if(str_1[i] == str_2[j+1]) {
-                    i--;
-                }
-                // CHANGE (no need to do anything, next letter MAY be successful).
-                edit_distance++;
-                if(edit_distance * 100 / std::min(str_1.length(), str_2.length()) > 33) {
-                    break;
-                }
-            }
-            j++;
-        }
-    }
-    return edit_distance;
+	int edit_distance = 0;
+	if(str_1.length() == 0) {
+		return str_2.length();
+	}
+	else if(str_2.length() == 0) {
+		return str_1.length();
+	}
+	else {
+		int j = 0;
+		int len_max = std::max(str_1.length(), str_2.length());
+		for(int i = 0; i < len_max; i++) {
+			if(str_1[i] != str_2[j]) {
+				//SWAP
+				if(str_1[i+1] == str_2[j] && str_1[i] == str_2[j+1]) {
+					// No need to test the next letter
+					i++;j++;
+				}
+				//ADDITION
+				else if(str_1[i+1] == str_2[j]) {
+					j--;
+				}
+				//DELETION
+				else if(str_1[i] == str_2[j+1]) {
+					i--;
+				}
+				// CHANGE (no need to do anything, next letter MAY be successful).
+				edit_distance++;
+				if(edit_distance * 100 / std::min(str_1.length(), str_2.length()) > 33) {
+					break;
+				}
+			}
+			j++;
+		}
+	}
+	return edit_distance;
 }

--- a/src/formula/string_utils.cpp
+++ b/src/formula/string_utils.cpp
@@ -370,18 +370,18 @@ int edit_distance_approx(const std::string &str_1, const std::string &str_2)
         int j = 0;
         int len_max = std::max(str_1.length(), str_2.length());
         for(int i = 0; i < len_max; i++) {
-            if(str_1[i] != str_2[j]){
+            if(str_1[i] != str_2[j]) {
                 //SWAP
                 if(str_1[i+1] == str_2[j] && str_1[i] == str_2[j+1]) {
                     // No need to test the next letter
                     i++;j++;
                 }
                 //ADDITION
-                else if (str_1[i+1] == str_2[j]) {
+                else if(str_1[i+1] == str_2[j]) {
                     j--;
                 }
                 //DELETION
-                else if (str_1[i] == str_2[j+1]) {
+                else if(str_1[i] == str_2[j+1]) {
                     i--;
                 }
                 // CHANGE (no need to do anything, next letter MAY be successful).

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -138,7 +138,10 @@ std::string vngettext_impl(const char* domain,
  *
  * The consequence is that the function gets "lost"
  * after two consecutive differences.
+ *
+ * @param str_1 First string to compare
+ * @param str_2 Second string to compare
  */
 
-int approximate_string_distance(const std::string &str_1, const std::string &str_2);
+int edit_distance_approx(const std::string &str_1, const std::string &str_2);
 

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -129,3 +129,16 @@ std::string vngettext_impl(const char* domain,
 
 #define VNGETTEXT(msgid, msgid_plural, count, ...) \
 	vngettext_impl(GETTEXT_DOMAIN, msgid, msgid_plural, count, __VA_ARGS__)
+
+/**
+ * Approximately calculates the distance between two strings
+ *
+ * Inspired in the Levenshtein distance, but made simpler
+ * to avoid using recursion and wasting resources.
+ *
+ * The consequence is that the function gets "lost"
+ * after two consecutive differences.
+ */
+
+int approximate_string_distance(const std::string &str_1, const std::string &str_2);
+

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -207,7 +207,7 @@ public:
                     break;
                 }
                 else{
-                    symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first + " " +std::to_string(distance_);
+                    symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first + " " + std::to_string(distance_);
                     print("help", VGETTEXT("DEBUG: $DEBUG_STRINGS.", symbols));
                 }
             }

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -207,7 +207,7 @@ public:
                     break;
                 }
                 else{
-                    symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first;
+                    symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first + " " +std::to_string(distance_);
                     print("help", VGETTEXT("DEBUG: $DEBUG_STRINGS.", symbols));
                 }
             }

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -200,11 +200,11 @@ public:
             int distance_ = 0;
             // Compare the input with every command (excluding alias)
             for (typename command_map::value_type i : command_map_) {
-                // No need to test cases that would fail
-                if((string_user_.length() <= i.first.length() + 2) && (string_user_.length() >= i.first.length() - 2) && is_enabled(i.second)) {
+                // No need to test commands that are not enabled
+                if(is_enabled(i.second)) {
                     distance_ = approximate_string_distance(string_user_, i.first);
-                    // Maximum of two errors for any word, maximum of one error until six letter-words.
-                    if ((distance_ < 2 && string_user_.length() < 6) || distance_ < 3){
+                    // Maximum of a third of the letters are wrong
+                    if (distance_*100/std::min(string_user_.length(),i.first.length()) < 34){
                         symbols["command_proposal"] = " did you mean '" + i.first + "'?";
                         // If a good enough candidate is found, exit the loop.
                         break;

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -191,20 +191,18 @@ public:
 		else if (help_on_unknown_) {
 			utils::string_map symbols;
 		    // Get the input command on a string
-            std::string string_user_ = get_cmd();
-            // Get all commands (even if disallowed)
-            std::vector<std::string> command_list_ = get_commands_list();
+            std::string string_user = get_cmd();
             // Initialize the distance and the command_proposal symbol so it
             // does not appear if no candidate is found.
             symbols["command_proposal"] = "";
-            int distance_ = 0;
+            int distance = 0;
             // Compare the input with every command (excluding alias)
-            for (typename command_map::value_type i : command_map_) {
+            for(typename command_map::value_type i : command_map_) {
                 // No need to test commands that are not enabled
                 if(is_enabled(i.second)) {
-                    distance_ = approximate_string_distance(string_user_, i.first);
+                    distance = edit_distance_approx(string_user, i.first);
                     // Maximum of a third of the letters are wrong
-                    if (distance_*100/std::min(string_user_.length(),i.first.length()) < 34){
+                    if (distance * 100 / std::min(string_user.length(), i.first.length()) < 34){
                         symbols["command_proposal"] = " did you mean '" + i.first + "'?";
                         // If a good enough candidate is found, exit the loop.
                         break;

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -190,18 +190,27 @@ public:
 		}
 		else if (help_on_unknown_) {
 			utils::string_map symbols;
-			// Get the input command on a string
+			// Get the input command on a string.
 			std::string string_user = get_cmd();
-			// Initialize the distance and the command proposal bool
+			// Initialize the variables.
+			// Edit distance variable.
 			int distance = 0;
+			// Minimum length of the two compared strings.
+			int len_min = 0;
+			// Bool used to show the command proposal if it exists.
 			bool has_command_proposal = false;
-			// Compare the input with every command (excluding alias)
+			// Compare the input with every command (excluding alias).
 			for(typename command_map::value_type i : command_map_) {
-				// No need to test commands that are not enabled
+				// No need to test commands that are not enabled.
 				if(is_enabled(i.second)) {
+                    // Get the edit distance between input and each command.
 					distance = edit_distance_approx(string_user, i.first);
-					// Maximum of a third of the letters are wrong
-					if(distance * 100 / std::min(string_user.length(), i.first.length()) < 34) {
+                    // Get the minimum length between the strings.
+                    len_min = std::min(string_user.length(), i.first.length());
+					// Maximum of a third of the letters are wrong. The ratio
+					// between the edit distance and the minimum length, multiplied
+					// by a hundred gives us the  percentage of errors.
+					if(distance * 100 / len_min < 34) {
 						symbols["command_proposal"] = i.first;
 						has_command_proposal = true;
 						// If a good enough candidate is found, exit the loop.

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -190,22 +190,16 @@ public:
 		}
 		else if (help_on_unknown_) {
 			utils::string_map symbols;
-			// Get the input command on a string.
 			std::string string_user = get_cmd();
-			// Initialize the variables.
-			// Edit distance variable.
 			int distance = 0;
 			// Minimum length of the two compared strings.
 			int len_min = 0;
-			// Bool used to show the command proposal if it exists.
 			bool has_command_proposal = false;
 			// Compare the input with every command (excluding alias).
 			for(const auto& [key, index] : command_map_) {
 				// No need to test commands that are not enabled.
 				if(is_enabled(index)) {
-					// Get the edit distance between input and each command.
 					distance = edit_distance_approx(string_user, key);
-					// Get the minimum length between the strings.
 					len_min = std::min(string_user.length(), key.length());
 					// Maximum of a third of the letters are wrong. The ratio
 					// between the edit distance and the minimum length, multiplied

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -189,23 +189,28 @@ public:
 			}
 		}
 		else if (help_on_unknown_) {
+			utils::string_map symbols;
 		    // Get the input command on a string
-            std::string string_user = get_cmd();
+            std::string string_user_ = get_cmd();
+            // Get all commands (even if disallowed)
+            std::vector<std::string> command_list_ = get_commands_list();
             // Initiate the command_proposal symbol so it does not appear if no
             // candidate is found.
             symbols["command_proposal"] = "";
-            // Recursively compare the input with every command (including alias)
-            for (int i = 0; i < command_alias_map_.length; i++) {
-                int distance = 0; // string_approximate_distance(string_user, command_alias_map_[i]);
-                int string_length = max(string_user.length, command_alias_map_[i].length);
+            // Compare the input with every command (excluding alias)
+            for (typename command_map::value_type i : command_map_) {
+                int distance_ = 10; // string_approximate_distance(string_user_, command_list_[i]);
                 // A third of the letters or less are wrong (e.g. 1 in a 4 letter cmd, 2 in a 6 letter cmd).
-                if (distance*100/string_length < 34){
-                    symbols["command_proposal"] = " did you mean" + command_alias_map_[i] + "?";
+                if (distance_*100/string_user_.length() < 34){
+                    symbols["command_proposal"] = " did you mean" + i.first + "?";
                     // If a good enough candidate is found, exit the loop.
                     break;
                 }
+                else{
+                    symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first;
+                    print("help", VGETTEXT("DEBUG: $DEBUG_STRINGS.", symbols));
+                }
             }
-			utils::string_map symbols;
 			symbols["command"] = get_cmd();
 			symbols["help_command"] = cmd_prefix_ + "help";
 			print("help", VGETTEXT("Unknown command '$command',$command_proposal try $help_command "

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -192,18 +192,18 @@ public:
 			utils::string_map symbols;
 		    // Get the input command on a string
             std::string string_user = get_cmd();
-            // Initialize the distance and the command_proposal symbol so it
-            // does not appear if no candidate is found.
-            symbols["command_proposal"] = "";
+            // Initialize the distance and the command proposal bool
             int distance = 0;
+            bool has_command_proposal = false;
             // Compare the input with every command (excluding alias)
             for(typename command_map::value_type i : command_map_) {
                 // No need to test commands that are not enabled
                 if(is_enabled(i.second)) {
                     distance = edit_distance_approx(string_user, i.first);
                     // Maximum of a third of the letters are wrong
-                    if (distance * 100 / std::min(string_user.length(), i.first.length()) < 34){
-                        symbols["command_proposal"] = " did you mean '" + i.first + "'?";
+                    if(distance * 100 / std::min(string_user.length(), i.first.length()) < 34) {
+                        symbols["command_proposal"] = i.first;
+                        has_command_proposal = true;
                         // If a good enough candidate is found, exit the loop.
                         break;
                     }
@@ -211,8 +211,15 @@ public:
             }
 			symbols["command"] = get_cmd();
 			symbols["help_command"] = cmd_prefix_ + "help";
-			print("help", VGETTEXT("Unknown command '$command',$command_proposal try $help_command "
-				"for a list of available commands.", symbols));
+			// If a proposal for a command is found, print it
+			if(has_command_proposal) {
+                print("help", VGETTEXT("Unknown command '$command', did you mean '$command_proposal'? try $help_command "
+                    "for a list of available commands.", symbols));
+			}
+			else {
+                print("help", VGETTEXT("Unknown command '$command', try $help_command "
+                    "for a list of available commands.", symbols));
+			}
 		}
 	}
 

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -205,13 +205,9 @@ public:
                     distance_ = approximate_string_distance(string_user_, i.first);
                     // Maximum of two errors for any word, maximum of one error until six letter-words.
                     if ((distance_ < 2 && string_user_.length() < 6) || distance_ < 3){
-                        symbols["command_proposal"] = " did you mean " + i.first + "?";
+                        symbols["command_proposal"] = " did you mean '" + i.first + "'?";
                         // If a good enough candidate is found, exit the loop.
                         break;
-                    }
-                    else{
-                        symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first + " " + std::to_string(distance_);
-                        print("help", VGETTEXT("DEBUG: $DEBUG_STRINGS.", symbols));
                     }
                 }
             }

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -190,35 +190,35 @@ public:
 		}
 		else if (help_on_unknown_) {
 			utils::string_map symbols;
-		    // Get the input command on a string
-            std::string string_user = get_cmd();
-            // Initialize the distance and the command proposal bool
-            int distance = 0;
-            bool has_command_proposal = false;
-            // Compare the input with every command (excluding alias)
-            for(typename command_map::value_type i : command_map_) {
-                // No need to test commands that are not enabled
-                if(is_enabled(i.second)) {
-                    distance = edit_distance_approx(string_user, i.first);
-                    // Maximum of a third of the letters are wrong
-                    if(distance * 100 / std::min(string_user.length(), i.first.length()) < 34) {
-                        symbols["command_proposal"] = i.first;
-                        has_command_proposal = true;
-                        // If a good enough candidate is found, exit the loop.
-                        break;
-                    }
-                }
-            }
+			// Get the input command on a string
+			std::string string_user = get_cmd();
+			// Initialize the distance and the command proposal bool
+			int distance = 0;
+			bool has_command_proposal = false;
+			// Compare the input with every command (excluding alias)
+			for(typename command_map::value_type i : command_map_) {
+				// No need to test commands that are not enabled
+				if(is_enabled(i.second)) {
+					distance = edit_distance_approx(string_user, i.first);
+					// Maximum of a third of the letters are wrong
+					if(distance * 100 / std::min(string_user.length(), i.first.length()) < 34) {
+						symbols["command_proposal"] = i.first;
+						has_command_proposal = true;
+						// If a good enough candidate is found, exit the loop.
+						break;
+					}
+				}
+			}
 			symbols["command"] = get_cmd();
 			symbols["help_command"] = cmd_prefix_ + "help";
 			// If a proposal for a command is found, print it
 			if(has_command_proposal) {
-                print("help", VGETTEXT("Unknown command '$command', did you mean '$command_proposal'? try $help_command "
-                    "for a list of available commands.", symbols));
+				print("help", VGETTEXT("Unknown command '$command', did you mean '$command_proposal'? try $help_command "
+					"for a list of available commands.", symbols));
 			}
 			else {
-                print("help", VGETTEXT("Unknown command '$command', try $help_command "
-                    "for a list of available commands.", symbols));
+				print("help", VGETTEXT("Unknown command '$command', try $help_command "
+					"for a list of available commands.", symbols));
 			}
 		}
 	}

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -189,10 +189,26 @@ public:
 			}
 		}
 		else if (help_on_unknown_) {
+		    // Get the input command on a string
+            std::string string_user = get_cmd();
+            // Initiate the command_proposal symbol so it does not appear if no
+            // candidate is found.
+            symbols["command_proposal"] = "";
+            // Recursively compare the input with every command (including alias)
+            for (int i = 0; i < command_alias_map_.length; i++) {
+                int distance = 0; // string_approximate_distance(string_user, command_alias_map_[i]);
+                int string_length = max(string_user.length, command_alias_map_[i].length);
+                // A third of the letters or less are wrong (e.g. 1 in a 4 letter cmd, 2 in a 6 letter cmd).
+                if (distance*100/string_length < 34){
+                    symbols["command_proposal"] = " did you mean" + command_alias_map_[i] + "?";
+                    // If a good enough candidate is found, exit the loop.
+                    break;
+                }
+            }
 			utils::string_map symbols;
 			symbols["command"] = get_cmd();
 			symbols["help_command"] = cmd_prefix_ + "help";
-			print("help", VGETTEXT("Unknown command '$command', try $help_command "
+			print("help", VGETTEXT("Unknown command '$command',$command_proposal try $help_command "
 				"for a list of available commands.", symbols));
 		}
 	}

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -194,24 +194,25 @@ public:
             std::string string_user_ = get_cmd();
             // Get all commands (even if disallowed)
             std::vector<std::string> command_list_ = get_commands_list();
-            // Initiate the command_proposal symbol so it does not appear if no
-            // candidate is found.
+            // Initialize the distance and the command_proposal symbol so it
+            // does not appear if no candidate is found.
             symbols["command_proposal"] = "";
+            int distance_ = 0;
             // Compare the input with every command (excluding alias)
             for (typename command_map::value_type i : command_map_) {
                 // No need to test cases that would fail
-                if((string_user_.length() - i.first.length() < 2) && (string_user_.length() - i.first.length() > -2)) {
-                    int distance_ = approximate_string_distance(string_user_, i.first);
-                }
-                // Maximum of two errors for any word, maximum of one error until six letter-words.
-                if (distance_ < 2 && string_user_.length() < 6 || distance_ < 3){
-                    symbols["command_proposal"] = " did you mean" + i.first + "?";
-                    // If a good enough candidate is found, exit the loop.
-                    break;
-                }
-                else{
-                    symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first + " " + std::to_string(distance_);
-                    print("help", VGETTEXT("DEBUG: $DEBUG_STRINGS.", symbols));
+                if((string_user_.length() <= i.first.length() + 2) && (string_user_.length() >= i.first.length() - 2) && is_enabled(i.second)) {
+                    distance_ = approximate_string_distance(string_user_, i.first);
+                    // Maximum of two errors for any word, maximum of one error until six letter-words.
+                    if ((distance_ < 2 && string_user_.length() < 6) || distance_ < 3){
+                        symbols["command_proposal"] = " did you mean " + i.first + "?";
+                        // If a good enough candidate is found, exit the loop.
+                        break;
+                    }
+                    else{
+                        symbols["DEBUG_STRINGS"] = string_user_ + " " + i.first + " " + std::to_string(distance_);
+                        print("help", VGETTEXT("DEBUG: $DEBUG_STRINGS.", symbols));
+                    }
                 }
             }
 			symbols["command"] = get_cmd();

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -199,9 +199,12 @@ public:
             symbols["command_proposal"] = "";
             // Compare the input with every command (excluding alias)
             for (typename command_map::value_type i : command_map_) {
-                int distance_ = 10; // string_approximate_distance(string_user_, command_list_[i]);
-                // A third of the letters or less are wrong (e.g. 1 in a 4 letter cmd, 2 in a 6 letter cmd).
-                if (distance_*100/string_user_.length() < 34){
+                // No need to test cases that would fail
+                if((string_user_.length() - i.first.length() < 2) && (string_user_.length() - i.first.length() > -2)) {
+                    int distance_ = approximate_string_distance(string_user_, i.first);
+                }
+                // Maximum of two errors for any word, maximum of one error until six letter-words.
+                if (distance_ < 2 && string_user_.length() < 6 || distance_ < 3){
                     symbols["command_proposal"] = " did you mean" + i.first + "?";
                     // If a good enough candidate is found, exit the loop.
                     break;

--- a/src/map_command_handler.hpp
+++ b/src/map_command_handler.hpp
@@ -200,18 +200,18 @@ public:
 			// Bool used to show the command proposal if it exists.
 			bool has_command_proposal = false;
 			// Compare the input with every command (excluding alias).
-			for(typename command_map::value_type i : command_map_) {
+			for(const auto& [key, index] : command_map_) {
 				// No need to test commands that are not enabled.
-				if(is_enabled(i.second)) {
-                    // Get the edit distance between input and each command.
-					distance = edit_distance_approx(string_user, i.first);
-                    // Get the minimum length between the strings.
-                    len_min = std::min(string_user.length(), i.first.length());
+				if(is_enabled(index)) {
+					// Get the edit distance between input and each command.
+					distance = edit_distance_approx(string_user, key);
+					// Get the minimum length between the strings.
+					len_min = std::min(string_user.length(), key.length());
 					// Maximum of a third of the letters are wrong. The ratio
 					// between the edit distance and the minimum length, multiplied
 					// by a hundred gives us the  percentage of errors.
 					if(distance * 100 / len_min < 34) {
-						symbols["command_proposal"] = i.first;
+						symbols["command_proposal"] = key;
 						has_command_proposal = true;
 						// If a good enough candidate is found, exit the loop.
 						break;


### PR DESCRIPTION
Makes suggestions when a command is misspelled as seen below.

![untitled](https://user-images.githubusercontent.com/30196839/167211125-655eeb0d-ebdd-455c-bf40-b5d3bc63f6bd.png)
*works in mp chats too.

Explanation:

Other commands will be recommended when a third or less of the letters (of the shortest string, either player input or actual command) are wrong. Additions, deletions, swaps and changes all count as 1 error (1 wrong letter).

- Writing 'hlep' recommends 'help' because there is only one error and the word is four letters (1/4 <= 1/3, one swap, string_utils.cpp Line 375)
- Writing 'hel' recommends 'help' because there is only one error and the word is three letters (1/3 <= 1/3, one deletion)
- Writing 'hello' does not recommend 'help' because there are two errors and the word is four letters (2/3 > 1/3, an addition and a change)
- Writing 'aawhiteboard' does not recommend 'whiteboard', even if there are only two errors out of eleven letters (2/11 <= 1/3) because the implementation is approximated and gets "lost" after two consecutive (non-swap) errors (string_utils.hpp Line 139)

The change comes from https://github.com/wesnoth/wesnoth/pull/6421#issuecomment-1015416479 which comes from #1018

Needless to say that the implementation and thresholds are not set in stone, I even pushed all the commits so anyone can follow along the development to better understand my decisions.