### PR TITLE
[1.16] Fix a typo in the editor-help

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -341,7 +341,7 @@ To load a map that was created in the scenario editor, use “Load Map” from t
 
 " + _ "<header>text='The files: .map and .cfg'</header>
 
-The map editor saves exactly one file, either a .map (for terrain mode) or a .cfg (for scenario mode). In scenario mode the terrain map is saved inside the .cfg file; there is no separate .map file. If you start editing in terrain mode and then switch to scenaro mode then an old .map file might remain, but this is not updated by the scenario editor.
+The map editor saves exactly one file, either a .map (for terrain mode) or a .cfg (for scenario mode). In scenario mode the terrain map is saved inside the .cfg file; there is no separate .map file. If you start editing in terrain mode and then switch to scenario mode then an old .map file might remain, but this is not updated by the scenario editor.
 
 Loading a .cfg file has different results depending on the contents of the .cfg file. For .cfg files that were created by the scenario editor, it will open the .cfg in the scenario editor. However, for .cfg files that use a separate .map file (which can't be created by the scenario editor), the editor may follow the link and open the corresponding .map in terrain-only mode, as if the .map file was chosen in the file selector."
 [/topic]


### PR DESCRIPTION
po: in wesnoth-help's `<header>text='The files: .map and .cfg' ...`,
the change is just a spelling correction of "scenaro" to "scenario".

Reported by Antro in https://forums.wesnoth.org/viewtopic.php?t=55696

I think string-freeze will be tonight, so planning to merge before that.