### PR TITLE
wmllint: add missing monster ID changes

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -969,6 +969,11 @@ linechanges = (
         ("Naga Slasher", "Naga Dirkfang"),
         ("Naga Bladewhirler", "Naga Ophidian"),
 
+        # monster unit ID changes during 1.15.x cycle
+        ("Gorer", "Woodland Boar"),
+        ("Tusklet", "Piglet"),
+        ("Giant Stoat", "Frost Stoat"),
+
         # Changed in 1.15.0: separate portrait for leader
         ("portraits/orcs/leader.png", "portraits/orcs/ruler.png"),
         ("portraits/orcs/leader-2.png", "portraits/orcs/ruler-2.png"),

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -970,8 +970,6 @@ linechanges = (
         ("Naga Bladewhirler", "Naga Ophidian"),
 
         # monster unit ID changes during 1.15.x cycle
-        ("Gorer", "Woodland Boar"),
-        ("Tusklet", "Piglet"),
         ("Giant Stoat", "Frost Stoat"),
 
         # Changed in 1.15.0: separate portrait for leader


### PR DESCRIPTION
Context:

1. Gorer and Tusklet were added as is, and clashed with UMC units, so ID was changed during 1.15 cycle. Wmllint was not notified of this. Some addons using Gorer/Tusklet that time were not updated so I got Lua unknown unit bug. Also, I think better to not have these 2 lines since UMC still use IDs for this. Any comments? (#5662)

2. Giant Stoat and Frost Stoat was quickly renamed but wmllint was never notified. This might be worth adding to wmllint. (#5344) Some UMC still use deprecated Giant Stoat and aren't aware unless they see deprecated message.