### PR TITLE
De-thread the loading screen. Load in the main thread.

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -470,9 +470,16 @@ static bool remove_on_resize(const SDL_Event& a)
 // TODO: I'm uncertain if this is always safe to call at static init; maybe set in main() instead?
 static const std::thread::id main_thread = std::this_thread::get_id();
 
+// this should probably be elsewhere, but as the main thread is already
+// being tracked here, this went here.
+bool is_in_main_thread()
+{
+	return std::this_thread::get_id() == main_thread;
+}
+
 void pump()
 {
-	if(std::this_thread::get_id() != main_thread) {
+	if(!is_in_main_thread()) {
 		// Can only call this on the main thread!
 		return;
 	}
@@ -868,7 +875,7 @@ void peek_for_resize()
 
 void call_in_main_thread(const std::function<void(void)>& f)
 {
-	if(std::this_thread::get_id() == main_thread) {
+	if(is_in_main_thread()) {
 		// nothing special to do if called from the main thread.
 		f();
 		return;

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -126,6 +126,9 @@ void focus_handler(const sdl_handler* ptr);
 
 bool has_focus(const sdl_handler* ptr, const SDL_Event* event);
 
+// whether the currently executing thread is the main thread.
+bool is_in_main_thread();
+
 void call_in_main_thread(const std::function<void (void)>& f);
 
 //event_context objects control the handler objects that SDL events are sent

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -47,6 +47,8 @@ static lg::log_domain log_config("config");
 #define WRN_CONFIG LOG_STREAM(warn, log_config)
 #define LOG_CONFIG LOG_STREAM(info, log_config)
 
+using gui2::dialogs::loading_screen;
+
 static game_config_manager* singleton;
 
 game_config_manager::game_config_manager(const commandline_options& cmdline_opts)
@@ -416,12 +418,16 @@ void game_config_manager::load_addons_cfg()
 		}
 	}
 
+	loading_screen::spin();
+
 	// Rerun the directory scan using filename only, to get the addon_ids more easily.
 	user_files.clear();
 	user_dirs.clear();
 
 	filesystem::get_files_in_dir(user_campaign_dir, nullptr, &user_dirs,
 		filesystem::name_mode::FILE_NAME_ONLY);
+
+	loading_screen::spin();
 
 	// Load the addons.
 	for(const std::string& addon_id : user_dirs) {
@@ -434,6 +440,8 @@ void game_config_manager::load_addons_cfg()
 		if(!filesystem::file_exists(main_cfg)) {
 			continue;
 		}
+
+		loading_screen::spin();
 
 		// Try to find this addon's metadata. Author publishing info (_server.pbl) is given
 		// precedence over addon sever-generated info (_info.cfg). If neither are found, it
@@ -486,6 +494,8 @@ void game_config_manager::load_addons_cfg()
 				validator->set_create_exceptions(false); // Don't crash if there's an error, just go ahead anyway
 			}
 
+			loading_screen::spin();
+
 			// Load this addon from the cache to a config.
 			config umc_cfg;
 			cache_.get_config(main_cfg, umc_cfg, validator.get());
@@ -511,6 +521,8 @@ void game_config_manager::load_addons_cfg()
 				}
 			}
 
+			loading_screen::spin();
+
 			for(auto& units : umc_cfg.child_range("units")) {
 				for(auto& unit_type : units.child_range("unit_type")) {
 					for(const auto& advancefrom : unit_type.child_range("advancefrom")) {
@@ -529,6 +541,8 @@ void game_config_manager::load_addons_cfg()
 					unit_type.remove_children("advancefrom", [](const config&){return true;});
 				}
 			}
+
+			loading_screen::spin();
 
 			// hardcoded list of 1.14 advancement macros, just used for the error mesage below.
 			static const std::set<std::string> deprecated_defines {
@@ -564,6 +578,8 @@ void game_config_manager::load_addons_cfg()
 				}
 			}
 
+			loading_screen::spin();
+
 			static const std::set<std::string> entry_tags {
 				"era",
 				"modification",
@@ -576,6 +592,8 @@ void game_config_manager::load_addons_cfg()
 			for(const std::string& tagname : entry_tags) {
 				game_config_.append_children_by_move(umc_cfg, tagname);
 			}
+
+			loading_screen::spin();
 
 			addon_cfgs_[addon_id] = std::move(umc_cfg);
 		} catch(const config::error& err) {

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -127,9 +127,14 @@ void loading_screen::progress(loading_stage stage)
 
 void loading_screen::spin()
 {
+	// If we're not showing a loading screen, do nothing.
+	if (!singleton_) {
+		return;
+	}
+
 	// Restrict actual update rate.
 	int elapsed = SDL_GetTicks() - last_spin_;
-	if (singleton_ && (elapsed > 10 || elapsed < 0)) {
+	if (elapsed > 10 || elapsed < 0) {
 		events::raise_draw_event();
 		events::pump();
 		last_spin_ = SDL_GetTicks();

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -132,6 +132,11 @@ void loading_screen::spin()
 		return;
 	}
 
+	// If we're not the main thread, do nothing.
+	if (!events::is_in_main_thread()) {
+		return;
+	}
+
 	// Restrict actual update rate.
 	int elapsed = SDL_GetTicks() - last_spin_;
 	if (elapsed > 10 || elapsed < 0) {

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -67,6 +67,8 @@ static const std::map<loading_stage, std::string> stage_names {
 	{ loading_stage::download_lobby_data, N_("Downloading lobby data") },
 };
 
+namespace { int last_spin_ = 0; }
+
 namespace gui2::dialogs
 {
 REGISTER_DIALOG(loading_screen)
@@ -120,6 +122,17 @@ void loading_screen::progress(loading_stage stage)
 		// Allow display to update, close events to be handled, etc.
 		events::raise_draw_event();
 		events::pump();
+	}
+}
+
+void loading_screen::spin()
+{
+	// Restrict actual update rate.
+	int elapsed = SDL_GetTicks() - last_spin_;
+	if (singleton_ && (elapsed > 10 || elapsed < 0)) {
+		events::raise_draw_event();
+		events::pump();
+		last_spin_ = SDL_GetTicks();
 	}
 }
 

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -99,7 +99,7 @@ private:
 
 	static loading_screen* singleton_;
 
-	std::function<void()> load_func_;
+	std::vector<std::function<void()>> load_funcs_;
 	std::future<void> worker_result_;
 	std::unique_ptr<cursor::setter> cursor_setter_;
 
@@ -113,6 +113,8 @@ private:
 	using stage_map = std::map<loading_stage, t_string>;
 	stage_map visible_stages_;
 	stage_map::const_iterator current_visible_stage_;
+
+	bool running_;
 };
 
 } // namespace dialogs

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -82,7 +82,28 @@ public:
 	static void display(std::function<void()> f);
 	static bool displaying() { return singleton_ != nullptr; }
 
+	/**
+	 * Report what is being loaded to the loading screen.
+	 *
+	 * Also processes any pending events and draw calls.
+	 *
+	 * This should be called before commencing each loading stage.
+	 *
+	 * @param stage     Which loading stage the caller is about to perform.
+	 */
 	static void progress(loading_stage stage = loading_stage::none);
+
+	/**
+	 * Indicate to the player that loading is progressing.
+	 *
+	 * Calling this function is necessary to allow loading screen animations
+	 * to run, and input events to be processed. It should be placed
+	 * inside any loading loops that may take significant time.
+	 *
+	 * There is an internal guard against acting too frequently, so there
+	 * should be little need to limit calls to this function.
+	 */
+	static void spin();
 
 private:
 	virtual const std::string& window_id() const override;

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -102,6 +102,9 @@ public:
 	 *
 	 * There is an internal guard against acting too frequently, so there
 	 * should be little need to limit calls to this function.
+	 *
+	 * If a loading screen is not currently being shown, this function does
+	 * nothing.
 	 */
 	static void spin();
 


### PR DESCRIPTION
The programming interface is still the same. Draw and input events are now processed when the worker function calls loading_screen::progress().

This has two main repercussions:
1. exceptions will no longer be silently eaten by the loading screen,
2. loading screen animations will not update unless progress() is called.

In order to update animations in a timely fashion... well, for me they already update so fast as to be nigh-instant. I'm not really sure what ever takes any significant time to load.

If there are actually sections of loading code that take significant time, some sort of `loading_screen::spin()` function shouild be added, that simply lets the loading screen update the spinner animation. Worker functions should call this periodically while performing long-duration tasks.

An alternate option would be to use a progress bar in stead of a spinner animation. Such that when `loading_screen::progress()` is called, it updates both the name of the loading section and the overall progress amount.

In any case, with this change it becomes the responsibility of the worker function to relinquish control momentarily so that events can be processed. As worker functions were already regularly calling `loading_screen::progress()`, with the changes i made here they do this automatically but with relatively low frequency.

The main thing that is potentially lost here is that if a loading function deadlocks for some reason, it becomes impossible to close the program via the close button. I have no idea if there is actually any chance of this happening, nor if it is really a problem. My OS offers to kill programs that are not responding to input anyway. And if there is a chance of a loading operation deadlocking, it should probably have a time-out attached.

I think doing things this way is preferable to the existing situation, and also to the major architectural overhaul that would be needed to do it properly using threads. I have previously tried four separate solutions to salvage the existing threaded implmentation, and all would be far more work than i am prepared to put in, as well as changing core game systems in dangerous ways, which i do not want to do.