### PR TITLE
map-diff: fix missing permission

### DIFF
--- a/.github/workflows/map-diff.yml
+++ b/.github/workflows/map-diff.yml
@@ -1,7 +1,7 @@
 name: Map Diff
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
     - '**.map'
 


### PR DESCRIPTION
The `Map Diff` action failed on this PR: https://github.com/wesnoth/wesnoth/pull/6704

<img width="940" alt="image" src="https://user-images.githubusercontent.com/9501115/168476924-afb87aac-e6a7-47d1-a963-a788386a6409.png">

Following [the documentation](https://github.com/peter-evans/create-or-update-comment/tree/v1.4.5), we should replace `pull_request` with `pull_request_target` - and this PR does it