### PR TITLE
map-diff: fix event name

### DIFF
--- a/.github/workflows/map-diff.yml
+++ b/.github/workflows/map-diff.yml
@@ -30,8 +30,8 @@ jobs:
         cd ./utils/wesnoth-map-diff
 
         ## Get maps changed
-        git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
-        mapfile -t map_paths < <(git diff --name-only HEAD ${{ github.event.pull_request.base.sha }} | grep '\.map$')
+        git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+        mapfile -t map_paths < <(git diff --name-only HEAD ${{ github.event.pull_request.head.sha }} | grep '\.map$')
 
         for map_path in "${map_paths[@]}"
         do


### PR DESCRIPTION
On the previous PR (https://github.com/wesnoth/wesnoth/pull/6709), I forgot to change orders when fetching the map files.

Since now it's running using the base branch, it should now use `github.event.pull_request.head.sha`.

I tested it on my test repository and it worked: https://github.com/macabeus/wesnoth/pull/9