### PR TITLE
map-diff: fix get new map

### DIFF
--- a/.github/workflows/map-diff.yml
+++ b/.github/workflows/map-diff.yml
@@ -37,7 +37,7 @@ jobs:
         do
           ## Get old map version
           map_filename=${map_path##*/}
-          git show ${{ github.event.pull_request.base.sha }}:"$map_path" > "$map_filename"
+          git show ${{ github.event.pull_request.head.sha }}:"$map_path" > "$map_filename"
 
           ## Run map diff
           diff_image=${map_filename%.map}.png

--- a/.github/workflows/map-diff.yml
+++ b/.github/workflows/map-diff.yml
@@ -54,10 +54,17 @@ jobs:
         done
 
         echo "::set-output name=COMMENT_BODY::$comment_body"
+    - name: Find comment
+      uses: peter-evans/find-comment@v2
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
     - name: Add comment
       uses: peter-evans/create-or-update-comment@v1.4.5
       with:
         issue-number: ${{ github.event.pull_request.number }}
+        comment-id: ${{ steps.fc.outputs.comment-id }}
         edit-mode: replace
         body: |
           ${{ steps.get-maps-diff.outputs.COMMENT_BODY }}


### PR DESCRIPTION
Fix again the `map-diff` action, as reported [in this comment](https://github.com/wesnoth/wesnoth/pull/6711#issuecomment-1127240999).

This PR also adds a step to get the previous comment to update it to avoid flooding the PR.

I tested it on my test repository and it's working: https://github.com/macabeus/wesnoth/pull/9
<img width="826" alt="image" src="https://user-images.githubusercontent.com/9501115/168691617-1e02e543-2c87-40f8-8ad1-a75e60ff03d9.png">
We can see the difference on the fire position and on the farm.

And the comment was updated:
<img width="920" alt="image" src="https://user-images.githubusercontent.com/9501115/168691671-3c9f9801-45ec-49c6-8ebd-f64526360a92.png">