### PR TITLE
Fix building with GCC 13.

### DIFF
--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 /** See https://wiki.wesnoth.org/CompatibilityStandards for more info. */

--- a/src/serialization/base64.hpp
+++ b/src/serialization/base64.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
Fixes the following issue:
`base64.hpp:23:49: error: 'uint8_t' was not declared in this scope`

and:
`deprecation.hpp:20:22: error: found ':' in nested-name-specifier, expected '::'`