### PR TITLE
Potential fix for flickering and corrupted graphics on master branch.

### DIFF
--- a/src/video.hpp
+++ b/src/video.hpp
@@ -493,6 +493,9 @@ private:
 	/** The drawing texture. */
 	SDL_Texture* drawing_texture_;
 
+	/** The current offscreen render target. */
+	SDL_Texture* render_texture_;
+
 	/** Initializes the SDL video subsystem. */
 	void initSDL();
 


### PR DESCRIPTION
Changed to render everything to an offscreen texture rather than allowing SDL to do whatever it wants.

This isn't all that undesirable anyway.

From my earlier research, the only thing that doesn't support rendering to texture is some very very old graphics hardware. So likely these days, nothing.