### PR TITLE
Hotkeys: refactored how hotkey_commands are stored and managed (WML hotkeys only)

### DIFF
--- a/src/game_events/menu_item.hpp
+++ b/src/game_events/menu_item.hpp
@@ -21,7 +21,10 @@
 #pragma once
 
 #include "config.hpp"
+#include "hotkey/hotkey_command.hpp"
 #include "variable.hpp"
+
+#include <optional>
 
 class filter_context;
 class game_data;
@@ -103,10 +106,10 @@ public:
 	void fire_event(const map_location& event_hex, const game_data& data) const;
 
 	/** Removes the implicit event handler for an inlined [command]. */
-	void finish_handler() const;
+	void finish_handler();
 
 	/** Initializes the implicit event handler for an inlined [command]. */
-	void init_handler() const;
+	void init_handler();
 
 	/**
 	 * The text to put in a menu for this item.
@@ -149,6 +152,9 @@ private:
 
 	/** The id for this item's hotkey; based on the item's id. */
 	const std::string hotkey_id_;
+
+	/** Controls the lifetime of the associate hotkey's hotkey_command. */
+	std::optional<hotkey::wml_hotkey_record> hotkey_record_;
 
 	/** The image to display in the menu next to this item's description. */
 	std::string image_;

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -795,7 +795,7 @@ listbox& preferences_dialog::setup_hotkey_list()
 	const std::string eh = "<span color='#0f0'>" + _("editor_hotkeys^E") + "</span>";
 	const std::string mh = "<span color='#0f0'>" + _("mainmenu_hotkeys^M") + "</span>";
 
-	for(const auto& hotkey_item : hotkey::get_hotkey_commands()) {
+	for(const auto& [id, hotkey_item] : hotkey::get_hotkey_commands()) {
 		if(hotkey_item.hidden) {
 			continue;
 		}

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -394,13 +394,14 @@ wml_hotkey_record::wml_hotkey_record(const std::string& id, const t_string& desc
 		return;
 	}
 
-	const auto& [iter, inserted] = registered_hotkeys.insert_or_assign(
-		id, hotkey_command{hotkey::HOTKEY_WML, id, description, false, false, scope_game, HKCAT_CUSTOM, t_string("")});
+	const auto& [iter, inserted] = registered_hotkeys.try_emplace(
+		id, hotkey::HOTKEY_WML, id, description, false, false, scope_game, HKCAT_CUSTOM, t_string(""));
 
 	if(inserted) {
 		DBG_G << "Added wml hotkey with id = '" << id << "' and description = '" << description << "'.\n";
 	} else {
-		LOG_G << "Hotkey with id '" << id << "' already exists and was reassigned.\n";
+		LOG_G << "Hotkey with id '" << id << "' already exists.\n";
+		return;
 	}
 
 	if(!default_hotkey.empty() && !has_hotkey_item(id)) {
@@ -417,6 +418,13 @@ wml_hotkey_record::wml_hotkey_record(const std::string& id, const t_string& desc
 
 	// Record the cleanup handler
 	cleanup_ = [i = iter] { registered_hotkeys.erase(i); };
+}
+
+wml_hotkey_record::~wml_hotkey_record()
+{
+	if(cleanup_) {
+		cleanup_();
+	}
 }
 
 hotkey_command::hotkey_command(const hotkey_command_temp& temp_command)

--- a/src/hotkey/hotkey_command.hpp
+++ b/src/hotkey/hotkey_command.hpp
@@ -19,6 +19,7 @@
 #include "tstring.hpp"
 
 #include <bitset>
+#include <functional>
 #include <list>
 #include <map>
 #include <vector>
@@ -292,7 +293,7 @@ private:
  * returns a container that contains all currently active hotkey_commands.
  * everything that wants a hotkey, must be in this container
  */
-const std::vector<hotkey_command>& get_hotkey_commands();
+const std::map<std::string_view, hotkey::hotkey_command>& get_hotkey_commands();
 
 /** returns the hotkey_command with the given name */
 const hotkey_command& get_hotkey_command(const std::string& command);
@@ -308,23 +309,30 @@ bool is_scope_active(hk_scopes s);
 
 bool has_hotkey_command(const std::string& id);
 
-/**
- * adds a new wml hotkey to the list, but only if there is no hotkey with that id yet on the list.
- * the object that is created here will be deleted in "delete_all_wml_hotkeys()"
- */
-void add_wml_hotkey(const std::string& id, const t_string& description, const config& default_hotkey);
+class wml_hotkey_record
+{
+public:
+	wml_hotkey_record() = default;
 
-/** deletes all wml hotkeys, should be called after a game has ended */
-void delete_all_wml_hotkeys();
-/** removes a wml hotkey with the given id, returns true if the deletion was successful */
-bool remove_wml_hotkey(const std::string& id);
+	/** Registers (or reassigns, if one already exists) a hotkey_command for a WML hotkey with the given ID. */
+	wml_hotkey_record(const std::string& id, const t_string& description, const config& default_hotkey);
+
+	~wml_hotkey_record()
+	{
+		if(cleanup_) {
+			cleanup_();
+		}
+	}
+
+private:
+	/** Handles removing the associated hotkey_command on this object's destruction. */
+	std::function<void()> cleanup_{};
+};
 
 const std::string& get_description(const std::string& command);
 const std::string& get_tooltip(const std::string& command);
 
 void init_hotkey_commands();
-
-void clear_hotkey_commands();
 
 /** returns get_hotkey_command(command).id */
 HOTKEY_COMMAND get_id(const std::string& command);

--- a/src/hotkey/hotkey_manager.cpp
+++ b/src/hotkey/hotkey_manager.cpp
@@ -33,9 +33,7 @@ void manager::init()
 
 void manager::wipe()
 {
-	clear_hotkey_commands();
 	clear_hotkeys();
-	delete_all_wml_hotkeys();
 }
 
 manager::~manager()

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -201,7 +201,6 @@ play_controller::play_controller(const config& level, saved_game& state_of_game,
 play_controller::~play_controller()
 {
 	unit_types.remove_scenario_fixes();
-	hotkey::delete_all_wml_hotkeys();
 	clear_resources();
 }
 


### PR DESCRIPTION
This encompasses two closely related changes. First, we now store hotkey_commands in a map instead of
a vector with accompanying index map. Most code did not rely on the command container being contiguous,
and since the commonly used get_hotkey_command was already performing a lookup in the index map, there
wasn't much need to use a separate container. Associative storage makes the most sense here.

The one place that did rely on the command container being contiguous was remove_wml_hotkey. I realized,
however, that it would be much cleaner to eliminate the manual bookkeeping. To this end, I added a new
wml_hotkey_record RAII class. It registers a hotkey_command when created and removes it on destruction.
Using a map for the commands made this even easier, since it doesn't invalidate other iterators or
require other commands to be moved to keep the container contiguous. In addition, removing the secondary
index map means we no longer need to recreate that every time a wml hotkey is removed!

Switching to this RAII-based system means delete_all_wml_hotkeys could also be removed, since all WML
hotkeys should now be handled by wml_hotkey_record and clean themselves up on destruction.

clear_hotkey_commands was also removed, since it was both misleading and now unnecessary. It only cleared
the index map, not the actual list of hotkey_commands! Given that init_hotkey_commands actually set up
the command list, this was doubly confusing.