### PR TITLE
Sync rendering system changes so far

### DIFF
--- a/data/gui/window/wml_message.cfg
+++ b/data/gui/window/wml_message.cfg
@@ -154,7 +154,7 @@ where calculated_width = {__GUI_IMAGE_WIDTH}
 					w = "{__GUI_IMAGE_DISPLAYED_WIDTH}"
 					h = "{__GUI_IMAGE_DISPLAYED_HEIGHT}"
 					name = "(portrait_image)"
-					vertical_mirror = "(portrait_mirror)"
+					mirror = "(portrait_mirror)"
 				[/image]
 
 			[/draw]
@@ -189,7 +189,7 @@ where calculated_width = {__GUI_IMAGE_WIDTH}
 					w = "{__GUI_IMAGE_DISPLAYED_WIDTH}"
 					h = "{__GUI_IMAGE_DISPLAYED_HEIGHT}"
 					name = "(portrait_image)"
-					vertical_mirror = "(portrait_mirror)"
+					mirror = "(portrait_mirror)"
 				[/image]
 
 			[/draw]
@@ -224,7 +224,7 @@ where calculated_width = {__GUI_IMAGE_WIDTH}
 					w = "{__GUI_IMAGE_DISPLAYED_WIDTH}"
 					h = "{__GUI_IMAGE_DISPLAYED_HEIGHT}"
 					name = "(portrait_image)"
-					vertical_mirror = "(portrait_mirror)"
+					mirror = "(portrait_mirror)"
 				[/image]
 
 				[image]
@@ -233,7 +233,7 @@ where calculated_width = {__GUI_IMAGE_WIDTH}
 					w = "{__GUI_IMAGE_DISPLAYED_WIDTH}"
 					h = "{__GUI_IMAGE_DISPLAYED_HEIGHT}"
 					name = "(second_portrait_image)"
-					vertical_mirror = "(second_portrait_mirror)"
+					mirror = "(second_portrait_mirror)"
 				[/image]
 
 			[/draw]

--- a/data/schema/gui.cfg
+++ b/data/schema/gui.cfg
@@ -124,7 +124,7 @@
                         {DEFAULT_KEY "h" f_unsigned 0}
                         {DEFAULT_KEY "name" f_string ""}
                         {DEFAULT_KEY "resize_mode" resize_mode scale}
-                        {DEFAULT_KEY "vertical_mirror" f_bool false}
+                        {DEFAULT_KEY "mirror" f_bool false}
                         {DEFAULT_KEY "w" f_unsigned 0}
                         {DEFAULT_KEY "x" f_unsigned 0}
                         {DEFAULT_KEY "y" f_unsigned 0}

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -823,6 +823,7 @@
 		91A41F901CA22A98008B10D5 /* libreadline.8.1.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = ECA9E7461CA20AA800A947D6 /* libreadline.8.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		91AF556D281101C4007A7652 /* input.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91AF556C281101C3007A7652 /* input.cpp */; };
 		91AF55B02827588B007A7652 /* texture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91AF55AF2827588B007A7652 /* texture.cpp */; };
+		91AF55DF2848472F007A7652 /* draw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91AF55DE2848472F007A7652 /* draw.cpp */; };
 		91B621A21B76A3CC00B00E0F /* build_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91B621A11B76A3CC00B00E0F /* build_info.cpp */; };
 		91B621BA1B76B2C900B00E0F /* version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91B621B91B76B2C900B00E0F /* version.cpp */; };
 		91B6220A1B76C0A600B00E0F /* libcairo.2.dylib in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = B513B2270ED36BFB0006E551 /* libcairo.2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -2138,6 +2139,8 @@
 		91AF556C281101C3007A7652 /* input.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = input.cpp; sourceTree = "<group>"; };
 		91AF55AE2827588B007A7652 /* texture.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = texture.hpp; sourceTree = "<group>"; };
 		91AF55AF2827588B007A7652 /* texture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = texture.cpp; sourceTree = "<group>"; };
+		91AF55DD2848472E007A7652 /* draw.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw.hpp; sourceTree = "<group>"; };
+		91AF55DE2848472F007A7652 /* draw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = draw.cpp; sourceTree = "<group>"; };
 		91B621801B766ED500B00E0F /* buffered_istream.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = buffered_istream.hpp; sourceTree = "<group>"; };
 		91B621811B766F1900B00E0F /* carryover.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = carryover.hpp; sourceTree = "<group>"; };
 		91B621821B766FD200B00E0F /* display_context.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = display_context.hpp; sourceTree = "<group>"; };
@@ -3087,6 +3090,8 @@
 				91B621821B766FD200B00E0F /* display_context.hpp */,
 				B5599A990EC62181008DD061 /* display.cpp */,
 				B5599A980EC62181008DD061 /* display.hpp */,
+				91AF55DE2848472F007A7652 /* draw.cpp */,
+				91AF55DD2848472E007A7652 /* draw.hpp */,
 				B5599FF60EC8FE2E008DD061 /* editor */,
 				B5599A970EC62181008DD061 /* events.cpp */,
 				B5599A960EC62181008DD061 /* events.hpp */,
@@ -5122,6 +5127,7 @@
 				B54AC6E40FEA9EB5006F6FBD /* ai.cpp in Sources */,
 				B5599B830EC62181008DD061 /* animated.cpp in Sources */,
 				F40A13BC1A3A88BA00C4D071 /* apple_notification.mm in Sources */,
+				91AF55DF2848472F007A7652 /* draw.cpp in Sources */,
 				EC218E9C1A1064F4007C910C /* application_lua_kernel.cpp in Sources */,
 				B52EE8CB121359A600CFBDAB /* arrow.cpp in Sources */,
 				B59F96E71034791200A57C1A /* aspect_attacks.cpp in Sources */,

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -72,6 +72,7 @@ desktop/open.cpp
 desktop/paths.cpp
 desktop/version.cpp
 display_chat_manager.cpp
+draw.cpp
 editor/action/action.cpp
 editor/action/action_item.cpp
 editor/action/action_label.cpp

--- a/src/color.hpp
+++ b/src/color.hpp
@@ -245,7 +245,7 @@ inline std::ostream& operator<<(std::ostream& s, const color_t& c)
 	s << static_cast<int>(c.r) << " "
 	  << static_cast<int>(c.g) << " "
 	  << static_cast<int>(c.b) << " "
-	  << static_cast<int>(c.a) << std::endl;
+	  << static_cast<int>(c.a);
 
 	return s;
 }

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -143,12 +143,12 @@ SDL_Cursor* get_cursor(cursor::CURSOR_TYPE type)
 		static const std::string bw_prefix = "cursors-bw/";
 
 		if(use_color) {
-			const surface surf(image::get_image(color_prefix + data.image_color));
+			const surface& surf(image::get_surface(color_prefix + data.image_color));
 
 			// Construct a temporary ptr to provide a new deleter.
 			data.cursor = cursor_ptr_t(SDL_CreateColorCursor(surf, data.hot_x, data.hot_y), SDL_FreeCursor);
 		} else {
-			const surface surf(image::get_image(bw_prefix + data.image_bw));
+			const surface& surf(image::get_surface(bw_prefix + data.image_bw));
 
 			// Construct a temporary ptr to provide a new deleter.
 			data.cursor = cursor_ptr_t(create_cursor(surf), SDL_FreeCursor);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1746,6 +1746,8 @@ void display::draw_minimap()
 		return;
 	}
 
+	// TODO: highdpi - high DPI minimap
+	// TODO: highdpi - is this the best place to convert to texture?
 	if(!minimap_ || minimap_.w() > area.w || minimap_.h() > area.h) {
 		minimap_ = texture(image::getMinimap(area.w, area.h, get_map(),
 			dc_->teams().empty() ? nullptr : &dc_->teams()[currentTeam_],
@@ -1760,21 +1762,17 @@ void display::draw_minimap()
 
 	// Draw the minimap background.
 	draw::fill(area, 31, 31, 23);
-	// The above could be optimized to draw only the non-covered part.
 
-	// Draw the minimap.
-	if (minimap_) {
-		SDL_Rect r = area;
-		r.x += (r.w - minimap_.w())/2;
-		r.y += (r.h - minimap_.h())/2;
-		draw::blit(minimap_, r);
-	}
-
-	//update the minimap location for mouse and units functions
+	// Update the minimap location for mouse and units functions
 	minimap_location_.x = area.x + (area.w - minimap_.w()) / 2;
 	minimap_location_.y = area.y + (area.h - minimap_.h()) / 2;
 	minimap_location_.w = minimap_.w();
 	minimap_location_.h = minimap_.h();
+
+	// Draw the minimap.
+	if (minimap_) {
+		draw::blit(minimap_, minimap_location_);
+	}
 
 	draw_minimap_units();
 
@@ -1809,22 +1807,8 @@ void display::draw_minimap()
 	// no render clipping rectangle set operaton was queued,
 	// so let's not use the render API to draw the rectangle.
 
-	// TODO: highdpi - is the above still relevant?
-
-	const SDL_Rect outline_parts[] = {
-		// top
-		{ outline_rect.x,                      outline_rect.y,                  outline_rect.w, 1              },
-		// bottom
-		{ outline_rect.x,                      outline_rect.y + outline_rect.h, outline_rect.w, 1              },
-		// left
-		{ outline_rect.x,                      outline_rect.y,                  1,              outline_rect.h },
-		// right
-		{ outline_rect.x + outline_rect.w - 1, outline_rect.y,                  1,              outline_rect.h },
-	};
-
-	for(const auto& r : outline_parts) {
-		draw::fill(r, 255, 255, 255);
-	}
+	// TODO: highdpi - is the above still relevant? It doesn't seem to be.
+	draw::rect(outline_rect, 255, 255, 255);
 }
 
 void display::draw_minimap_units()

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1530,7 +1530,8 @@ void display::render_image(int x, int y, const display::drawing_layer drawing_la
 	surface surf(image);
 
 	if(hreverse) {
-		surf = image::reverse_image(surf);
+		// TODO: highdpi - well this will get removed in due process anyway
+		surf = flip_surface(surf);
 	}
 	if(vreverse) {
 		surf = flop_surface(surf);

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -1034,8 +1034,6 @@ private:
 	int invalidated_hexes_;
 	int drawn_hexes_;
 
-	surface map_screenshot_surf_;
-
 	std::vector<std::function<void(display&)>> redraw_observers_;
 
 	/** Debug flag - overlay x,y coords on tiles */

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -756,6 +756,7 @@ protected:
 	std::map<std::string, config> reports_;
 	std::vector<std::shared_ptr<gui::button>> menu_buttons_, action_buttons_;
 	std::set<map_location> invalidated_;
+	// TODO: highdpi - texture
 	surface mouseover_hex_overlay_;
 	// If we're transitioning from one time of day to the next,
 	// then we will use these two masks on top of all hexes when we blit.

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -60,6 +60,7 @@ namespace wb {
 #include "time_of_day.hpp"
 #include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
+#include "sdl/texture.hpp"
 #include "theme.hpp"
 #include "video.hpp"
 #include "widgets/button.hpp"
@@ -590,7 +591,7 @@ public:
 	 * Schedule the minimap for recalculation.
 	 * Useful if any terrain in the map has changed.
 	 */
-	void recalculate_minimap() {minimap_ = nullptr; redrawMinimap_ = true; }
+	void recalculate_minimap() {minimap_.reset(); redrawMinimap_ = true; }
 
 	/**
 	 * Schedule the minimap to be redrawn.
@@ -730,7 +731,7 @@ protected:
 	static unsigned int last_zoom_;
 	const std::unique_ptr<fake_unit_manager> fake_unit_man_;
 	const std::unique_ptr<terrain_builder> builder_;
-	surface minimap_;
+	texture minimap_;
 	SDL_Rect minimap_location_;
 	bool redrawMinimap_;
 	bool redraw_background_;

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -281,8 +281,10 @@ void draw::flipped(const texture& tex, bool flip_h, bool flip_v)
 void draw::tiled(const texture& tex, const SDL_Rect& dst, bool centered,
 	bool mirrored)
 {
-	// TODO: highdpi - should this draw at full res? Or game res? For now it's using game res to ensure consistency of the result.
-	// TODO: highdpi - does this ever need to clip the source texture? It doesn't seem so
+	// TODO: highdpi - should this draw at full res? Or game res? For now it's using game res. To draw in higher res, width and height would have to be specified.
+
+	// Reduce clip to dst.
+	auto clipper = CVideo::get_singleton().reduce_clip(dst);
 
 	const int xoff = centered ? (dst.w - tex.w()) / 2 : 0;
 	const int yoff = centered ? (dst.h - tex.h()) / 2 : 0;

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -129,6 +129,96 @@ void draw::point(int x, int y)
 	SDL_RenderDrawPoint(renderer(), x, y);
 }
 
+void draw::circle(int cx, int cy, int r, const color_t& c, uint8_t octants)
+{
+	draw::set_color(c);
+	draw::circle(cx, cy, r, octants);
+}
+
+void draw::circle(int cx, int cy, int r, uint8_t octants)
+{
+	// Algorithm based on
+	// http://de.wikipedia.org/wiki/Rasterung_von_Kreisen#Methode_von_Horn
+	// version of 2011.02.07.
+	int d = -r;
+	int x = r;
+	int y = 0;
+
+	std::vector<SDL_Point> points;
+
+	while(!(y > x)) {
+		if(octants & 0x04) points.push_back({cx + x, cy + y});
+		if(octants & 0x02) points.push_back({cx + x, cy - y});
+		if(octants & 0x20) points.push_back({cx - x, cy + y});
+		if(octants & 0x40) points.push_back({cx - x, cy - y});
+
+		if(octants & 0x08) points.push_back({cx + y, cy + x});
+		if(octants & 0x01) points.push_back({cx + y, cy - x});
+		if(octants & 0x10) points.push_back({cx - y, cy + x});
+		if(octants & 0x80) points.push_back({cx - y, cy - x});
+
+		d += 2 * y + 1;
+		++y;
+		if(d > 0) {
+			d += -2 * x + 2;
+			--x;
+		}
+	}
+
+	draw::points(points);
+}
+
+void draw::disc(int cx, int cy, int r, const color_t& c, uint8_t octants)
+{
+	draw::set_color(c);
+	draw::disc(cx, cy, r, octants);
+}
+
+void draw::disc(int cx, int cy, int r, uint8_t octants)
+{
+	int d = -r;
+	int x = r;
+	int y = 0;
+
+	while(!(y > x)) {
+		// I use the formula of Bresenham's line algorithm
+		// to determine the boundaries of a segment.
+		// The slope of the line is always 1 or -1 in this case.
+		if(octants & 0x04)
+			// x2 - 1 = y2 - (cy + 1) + cx
+			draw::line(cx + x, cy + y + 1, cx + y + 1, cy + y + 1);
+		if(octants & 0x02)
+			// x2 - 1 = cy - y2 + cx
+			draw::line(cx + x, cy - y, cx + y + 1, cy - y);
+		if(octants & 0x20)
+			// x2 + 1 = (cy + 1) - y2 + (cx - 1)
+			draw::line(cx - x - 1, cy + y + 1, cx - y - 2, cy + y + 1);
+		if(octants & 0x40)
+			// x2 + 1 = y2 - cy + (cx - 1)
+			draw::line(cx - x - 1, cy - y, cx - y - 2, cy - y);
+
+		if(octants & 0x08)
+			// y2 = x2 - cx + (cy + 1)
+			draw::line(cx + y, cy + x + 1, cx + y, cy + y + 1);
+		if(octants & 0x01)
+			// y2 = cx - x2 + cy
+			draw::line(cx + y, cy - x, cx + y, cy - y);
+		if(octants & 0x10)
+			// y2 = (cx - 1) - x2 + (cy + 1)
+			draw::line(cx - y - 1, cy + x + 1, cx - y - 1, cy + y + 1);
+		if(octants & 0x80)
+			// y2 = x2 - (cx - 1) + cy
+			draw::line(cx - y - 1, cy - x, cx - y - 1, cy - y);
+
+		d += 2 * y + 1;
+		++y;
+		if(d > 0) {
+			d += -2 * x + 2;
+			--x;
+		}
+	}
+}
+
 
 /*******************/
 /* texture drawing */

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -1,0 +1,203 @@
+/*
+	Copyright (C) 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#include "draw.hpp"
+
+#include "color.hpp"
+#include "sdl/surface.hpp"
+#include "sdl/texture.hpp"
+#include "video.hpp"
+
+#include <SDL2/SDL_rect.h>
+#include <SDL2/SDL_render.h>
+
+static SDL_Renderer* renderer()
+{
+	return CVideo::get_singleton().get_renderer();
+}
+
+/**************************************/
+/* basic drawing and pixel primatives */
+/**************************************/
+
+void draw::fill(
+	const SDL_Rect& area,
+	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
+	SDL_RenderFillRect(renderer(), &area);
+}
+
+void draw::fill(
+	const SDL_Rect& area,
+	uint8_t r, uint8_t g, uint8_t b)
+{
+	draw::fill(area, r, g, b, SDL_ALPHA_OPAQUE);
+}
+
+void draw::fill(const SDL_Rect& area, const color_t& c)
+{
+	draw::fill(area, c.r, c.g, c.b, c.a);
+}
+
+void draw::fill(const SDL_Rect& area)
+{
+	SDL_RenderFillRect(renderer(), &area);
+}
+
+void draw::set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
+}
+
+void draw::set_color(uint8_t r, uint8_t g, uint8_t b)
+{
+	SDL_SetRenderDrawColor(renderer(), r, g, b, SDL_ALPHA_OPAQUE);
+}
+
+void draw::set_color(const color_t& c)
+{
+	SDL_SetRenderDrawColor(renderer(), c.r, c.g, c.b, c.a);
+}
+
+void draw::rect(const SDL_Rect& rect)
+{
+	SDL_RenderDrawRect(renderer(), &rect);
+}
+
+void draw::rect(const SDL_Rect& rect,
+	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
+	SDL_RenderDrawRect(renderer(), &rect);
+}
+
+void draw::rect(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b)
+{
+	draw::rect(rect, r, g, b, SDL_ALPHA_OPAQUE);
+}
+
+void draw::rect(const SDL_Rect& rect, const color_t& c)
+{
+	draw::rect(rect, c.r, c.g, c.b, c.a);
+}
+
+// TODO: highdpi - canvas previously had code which special cased single-point lines. Is this necessary?
+/* this was the code of draw_line() in canvas.cpp:
+	DBG_GUI_D << "Shape: draw line from " << x1 << ',' << y1
+	          << " to " << x2 << ',' << y2 << ".\n";
+
+	draw::set_color(color);
+
+	if(x1 == x2 && y1 == y2) {
+		// Handle single-pixel lines properly
+		draw::point(x1, y1);
+	} else {
+		draw::line(x1, y1, x2, y2);
+	}
+*/
+
+void draw::line(int from_x, int from_y, int to_x, int to_y)
+{
+	SDL_RenderDrawLine(renderer(), from_x, from_y, to_x, to_y);
+}
+
+void draw::line(int from_x, int from_y, int to_x, int to_y, const color_t& c)
+{
+	SDL_SetRenderDrawColor(renderer(), c.r, c.g, c.b, c.a);
+	SDL_RenderDrawLine(renderer(), from_x, from_y, to_x, to_y);
+}
+
+void draw::points(const std::vector<SDL_Point>& points)
+{
+	SDL_RenderDrawPoints(renderer(), points.data(), points.size());
+}
+
+void draw::point(int x, int y)
+{
+	SDL_RenderDrawPoint(renderer(), x, y);
+}
+
+
+/*******************/
+/* texture drawing */
+/*******************/
+
+
+void draw::blit(const texture& tex, const SDL_Rect& dst, const SDL_Rect& src)
+{
+	SDL_RenderCopy(renderer(), tex, &src, &dst);
+}
+
+void draw::blit(const texture& tex, const SDL_Rect& dst)
+{
+	SDL_RenderCopy(renderer(), tex, nullptr, &dst);
+}
+
+void draw::blit(const texture& tex)
+{
+	SDL_RenderCopy(renderer(), tex, nullptr, nullptr);
+}
+
+
+void draw::flipped(
+	const texture& tex,
+	const SDL_Rect& dst,
+	const SDL_Rect& src,
+	bool flip_h,
+	bool flip_v)
+{
+	SDL_RendererFlip flip =
+		flip_h ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE
+		| flip_v ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
+	SDL_RenderCopyEx(renderer(), tex, &src, &dst, 0.0, nullptr, flip);
+}
+
+void draw::flipped(
+	const texture& tex,
+	const SDL_Rect& dst,
+	bool flip_h,
+	bool flip_v)
+{
+	SDL_RendererFlip flip =
+		flip_h ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE
+		| flip_v ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
+	SDL_RenderCopyEx(renderer(), tex, nullptr, &dst, 0.0, nullptr, flip);
+}
+
+void draw::flipped(const texture& tex, bool flip_h, bool flip_v)
+{
+	SDL_RendererFlip flip =
+		flip_h ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE
+		| flip_v ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
+	SDL_RenderCopyEx(renderer(), tex, nullptr, nullptr, 0.0, nullptr, flip);
+}
+
+
+void draw::tiled(const texture& tex, const SDL_Rect& dst, bool centered)
+{
+	// TODO: highdpi - should this draw at full res? Or game res? For now it's using game res to ensure consistency of the result.
+	// TODO: highdpi - does this ever need to clip the source texture? It doesn't seem so
+
+	const int xoff = centered ? (dst.w - tex.w()) / 2 : 0;
+	const int yoff = centered ? (dst.h - tex.h()) / 2 : 0;
+
+	// Just blit the image however many times is necessary.
+	SDL_Rect t{dst.x - xoff, dst.y - yoff, tex.w(), tex.h()};
+	for (; t.y < dst.y + dst.h; t.y += tex.h()) {
+		for (t.x = dst.x - xoff; t.x < dst.x + dst.w; t.x += tex.w()) {
+			draw::blit(tex, t);
+		}
+	}
+}

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -1,0 +1,262 @@
+/*
+	Copyright (C) 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+/** @file
+ * Drawing functions, for drawing things on the screen.
+ *
+ * This includes pixel drawing for lines, rectangles and circles;
+ * fill and clear routines; and commands to render SDL surfaces and
+ * textures, in full or in part.
+ *
+ * For the most part draw commands take coordinates in what is called
+ * "draw space", or "game-native coordinates". These are the coordinates
+ * that are used in WML, and can be thought of as pixels.
+ *
+ * High-DPI textures and fonts will automatically use their full
+ * resolution when possible, without any extra handling required.
+ */
+
+#include <SDL2/SDL_rect.h>
+#include <vector>
+
+struct color_t;
+class surface;
+class texture;
+
+namespace draw
+{
+
+/**************************************/
+/* basic drawing and pixel primatives */
+/**************************************/
+
+
+/**
+ * Fill an area with the given colour.
+ *
+ * If the alpha component is not specified, it defaults to fully opaque.
+ *
+ * @param rect      The area to fill, in drawing coordinates.
+ * @param r         The red   component of the fill colour, 0-255.
+ * @param g         The green component of the fill colour, 0-255.
+ * @param b         The blue  component of the fill colour, 0-255.
+ * @param a         The alpha component of the fill colour, 0-255.
+ */
+void fill(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+void fill(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b);
+void fill(const SDL_Rect& rect, const color_t& color);
+
+/**
+ * Fill an area.
+ *
+ * Uses the current drawing colour set by set_draw_color().
+ * Coordinates are given in draw space.
+ *
+ * @param rect      The area to fill, in drawing coordinates.
+ */
+void fill(const SDL_Rect& rect);
+
+/**
+ * Set the drawing colour.
+ *
+ * This is the colour used by fill(), line(), points(), etc..
+ *
+ * If the alpha component is not specified, it defaults to fully opaque.
+ *
+ * @param r         The red   component of the drawing colour, 0-255.
+ * @param g         The green component of the drawing colour, 0-255.
+ * @param b         The blue  component of the drawing colour, 0-255.
+ * @param a         The alpha component of the drawing colour, 0-255.
+ */
+void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+void set_color(uint8_t r, uint8_t g, uint8_t b);
+void set_color(const color_t& c);
+
+/**
+ * Draw a rectangle.
+ *
+ * Uses the current drawing colour set by set_color().
+ * Coordinates are given in draw space.
+ *
+ * @param rect      The rectangle to draw, in drawing coordinates.
+ */
+void rect(const SDL_Rect& rect);
+
+/**
+ * Draw a rectangle using the given colour.
+ *
+ * @param rect      The rectangle to draw, in drawing coordinates.
+ * @param r         The red   component of the drawing colour, 0-255.
+ * @param g         The green component of the drawing colour, 0-255.
+ * @param b         The blue  component of the drawing colour, 0-255.
+ * @param a         The alpha component of the drawing colour, 0-255.
+ */
+void rect(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+void rect(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b);
+void rect(const SDL_Rect& rect, const color_t& color);
+
+/**
+ * Draw a line.
+ *
+ * Uses the current drawing colour set by set_color().
+ * Coordinates are given in draw space.
+ *
+ * @param from_x    The X coordinate of the start point, in draw space.
+ * @param from_y    The Y coordinate of the start point, in draw space.
+ * @param to_x      The X coordinate of the end point, in draw space.
+ * @param to_y      The Y coordinate of the end point, in draw space.
+ */
+void line(int from_x, int from_y, int to_x, int to_y);
+
+/**
+ * Draw a line of the given colour.
+ *
+ * @param from_x    The X coordinate of the start point, in draw space.
+ * @param from_y    The Y coordinate of the start point, in draw space.
+ * @param to_x      The X coordinate of the end point, in draw space.
+ * @param to_y      The Y coordinate of the end point, in draw space.
+ * @param c         The RGBA colour of the line.
+ */
+void line(int from_x, int from_y, int to_x, int to_y, const color_t& c);
+
+/** Draw a set of points. */
+void points(const std::vector<SDL_Point>& points);
+
+/** Draw a single point. */
+void point(int x, int y);
+
+
+/*******************/
+/* texture drawing */
+/*******************/
+
+
+/**
+ * Draws an SDL surface at the given location.
+ *
+ * The w and h members of dst are ignored, but will be updated
+ * to reflect the final draw extents including clipping.
+ *
+ * The surface will be rendered in game-native resolution,
+ * and all coordinates are given in this context.
+ *
+ * WARNING: This function will likely be deprecated in the future.
+ * variants using textures should be preferred in all cases.
+ *
+ * @param surf                The surface to draw.
+ * @param dst                 Where to draw the surface. w and h are ignored, but will be updated to reflect the final draw extents including clipping.
+ */
+//void blit(const surface& surf, SDL_Rect* dst);
+
+/**
+ * Draws a surface at the given coordinates.
+ *
+ * The surface will be rendered in game-native resolution, a.k.a.
+ * draw space, and all coordinates are given in this context.
+ *
+ * WARNING: This function will likely be deprecated in the future.
+ * variants using textures should be preferred in all cases.
+ *
+ * @param surf                The surface to draw.
+ * @param x                   The x coordinate of the top-left corner.
+ * @param y                   The y coordinate of the top-left corner.
+ */
+//void blit(const surface& surf, int x, int y);
+
+/**
+ * Draws an area of a surface at the given location.
+ *
+ * The surface will be rendered in game-native resolution,
+ * and all coordinates are given in this context.
+ *
+ * WARNING: This function will likely be deprecated in the future.
+ * variants using textures should be preferred in all cases.
+ *
+ * @param surf                The surface to draw.
+ * @param x                   The x coordinate at which to draw.
+ * @param y                   The y coordinate at which to draw.
+ * @param srcrect             The area of the surface to draw. If null, the entire surface is drawn.
+ * @param clip_rect           The clipping area. If not null, the surface will only be drawn
+ *                            within the bounds of the given rectangle.
+ */
+//void blit(const surface& surf, int x, int y, const SDL_Rect* src, const SDL_Rect* clip);
+
+/**
+ * Draws a texture, or part of a texture, at the given location.
+ *
+ * The portion of the texture to be drawn will be scaled to fill
+ * the target rectangle.
+ *
+ * This version takes coordinates in game-native resolution,
+ * which may be lower than the final output resolution in high-dpi
+ * contexts or if pixel scaling is used. The texture will be copied
+ * in high-resolution if possible.
+ *
+ * @param tex       The texture to be copied / drawn.
+ * @param dst       The target location to copy the texture to,
+ *                  in low-resolution game-native drawing coordinates.
+ *                  If null, this fills the entire render target.
+ * @param src       The portion of the texture to copy.
+ *                  If null, this copies the entire texture.
+ */
+void blit(const texture& tex, const SDL_Rect& dst, const SDL_Rect& src);
+void blit(const texture& tex, const SDL_Rect& dst);
+void blit(const texture& tex);
+
+/**
+ * Draws a texture, or part of a texture, at the given location,
+ * also mirroring/flipping the texture horizontally and/or vertically.
+ *
+ * By default the texture will be flipped horizontally.
+ *
+ * @param tex       The texture to be copied / drawn.
+ * @param dst       The target location to copy the texture to,
+ *                  in low-resolution game-native drawing coordinates.
+ *                  If not given, the entire render target will be filled.
+ * @param src       The portion of the texture to copy.
+ *                  If not given, the entire texture will be copied.
+ * @param flip_h    Whether to flip/mirror the texture horizontally.
+ * @param flip_v    Whether to flip/mirror the texture vertically.
+ */
+void flipped(const texture& tex,
+	const SDL_Rect& dst,
+	const SDL_Rect& src,
+	bool flip_h = true,
+	bool flip_v = false
+);
+void flipped(const texture& tex,
+	const SDL_Rect& dst,
+	bool flip_h = true,
+	bool flip_v = false
+);
+void flipped(const texture& tex, bool flip_h = true, bool flip_v = false);
+
+/**
+ * Tile a texture to fill a region.
+ *
+ * The texture may be aligned either with its center at the center
+ * of the region, or with its top-left corner at the top-left corner
+ * of the region.
+ *
+ * @param tex       The texture to use to fill the region.
+ * @param dst       The region to fill, in draw space.
+ * @param centered  If true the tiled texture will be centered.
+ *                  If false, it will align at the top-left.
+ */
+void tiled(const texture& tex, const SDL_Rect& dst, bool centered = false);
+
+
+} // namespace draw

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -184,7 +184,7 @@ void disc(int x, int y, int r, uint8_t octants = 0xff);
 /*******************/
 
 
-/**
+/*
  * Draws an SDL surface at the given location.
  *
  * The w and h members of dst are ignored, but will be updated
@@ -201,7 +201,7 @@ void disc(int x, int y, int r, uint8_t octants = 0xff);
  */
 //void blit(const surface& surf, SDL_Rect* dst);
 
-/**
+/*
  * Draws a surface at the given coordinates.
  *
  * The surface will be rendered in game-native resolution, a.k.a.
@@ -216,7 +216,7 @@ void disc(int x, int y, int r, uint8_t octants = 0xff);
  */
 //void blit(const surface& surf, int x, int y);
 
-/**
+/*
  * Draws an area of a surface at the given location.
  *
  * The surface will be rendered in game-native resolution,

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -295,8 +295,15 @@ void flipped(const texture& tex, bool flip_h = true, bool flip_v = false);
  * @param dst       The region to fill, in draw space.
  * @param centered  If true the tiled texture will be centered.
  *                  If false, it will align at the top-left.
+ * @param mirrored  If true the texture will be mirrored in such a way that
+ *                  adjacent tiles always share a common edge. This can look
+ *                  better for images that are not perfect tiles.
  */
-void tiled(const texture& tex, const SDL_Rect& dst, bool centered = false);
+void tiled(const texture& tex,
+	const SDL_Rect& dst,
+	bool centered = false,
+	bool mirrored = false
+);
 
 
 } // namespace draw

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -138,6 +138,46 @@ void points(const std::vector<SDL_Point>& points);
 /** Draw a single point. */
 void point(int x, int y);
 
+// TODO: enum for common octant choices - nice but not necessary
+/**
+ * Draw a circle of the given colour.
+ *
+ * Only the outline of the circle is drawn. To draw a filled circle,
+ * use draw::disc().
+ *
+ * The octants bitfield can be used to draw only certain octants
+ * of the circle, resulting in one or more arcs.
+ *
+ * If no colour is specified, the current drawing colour will be used.
+ *
+ * @param x         The x coordinate of the center of the circle.
+ * @param y         The y coordinate of the center of the circle.
+ * @param r         The radius of the circle.
+ * @param c         The colour of the circle.
+ * @param octants   A bitfield indicating which octants to draw,
+ *                  starting at twelve o'clock and moving clockwise.
+ */
+void circle(int x, int y, int r, const color_t& c, uint8_t octants = 0xff);
+void circle(int x, int y, int r, uint8_t octants = 0xff);
+
+/**
+ * Draw a solid disc of the given colour.
+ *
+ * The octants bitfield can be used to draw only certain octants
+ * of the disc, resulting in one or more filled wedges.
+ *
+ * If no colour is specified, the current drawing colour will be used.
+ *
+ * @param x         The x coordinate of the center of the circle.
+ * @param y         The y coordinate of the center of the circle.
+ * @param r         The radius of the circle.
+ * @param c         The colour of the circle.
+ * @param octants   A bitfield indicating which octants to draw,
+ *                  starting at twelve o'clock and moving clockwise.
+ */
+void disc(int x, int y, int r, const color_t& c, uint8_t octants = 0xff);
+void disc(int x, int y, int r, uint8_t octants = 0xff);
+
 
 /*******************/
 /* texture drawing */

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -17,17 +17,16 @@
 
 #include "editor/palette/location_palette.hpp"
 
-#include "gettext.hpp"
-#include "font/sdl_ttf_compat.hpp"
-#include "font/standard_colors.hpp"
-#include "tooltips.hpp"
-
+#include "draw.hpp"
 #include "editor/editor_common.hpp"
 #include "editor/toolkit/editor_toolkit.hpp"
+#include "font/sdl_ttf_compat.hpp"
+#include "font/standard_colors.hpp"
+#include "formula/string_utils.hpp"
+#include "gettext.hpp"
 #include "gui/dialogs/edit_text.hpp"
 #include "gui/dialogs/transient_message.hpp"
-
-#include "formula/string_utils.hpp"
+#include "tooltips.hpp"
 
 #include <boost/regex.hpp>
 
@@ -60,10 +59,10 @@ public:
 	void draw_contents() override
 	{
 		if (state_.mouseover) {
-			sdl::fill_rectangle(location(), {200, 200, 200, 26});
+			draw::fill(location(), 200, 200, 200, 26);
 		}
 		if (state_.selected) {
-			sdl::draw_rectangle(location(), {255, 255, 255, 255});
+			draw::rect(location(), 255, 255, 255, 255);
 		}
 		font::pango_draw_text(&video(), location(), 16, font::NORMAL_COLOR, desc_.empty() ? id_ : desc_, location().x + 2, location().y, 0);
 	}

--- a/src/editor/palette/terrain_palettes.hpp
+++ b/src/editor/palette/terrain_palettes.hpp
@@ -56,6 +56,7 @@ private:
 
 	virtual const std::string& get_id(const t_translation::terrain_code& terrain);
 
+	// TODO: highdpi - texture
 	virtual void draw_item(const t_translation::terrain_code& terrain, surface& item_image, std::stringstream& tooltip_text);
 
 };

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -16,6 +16,7 @@
 #include "floating_label.hpp"
 
 #include "display.hpp"
+#include "draw.hpp"
 #include "font/text.hpp"
 #include "log.hpp"
 #include "video.hpp"
@@ -203,7 +204,7 @@ void floating_label::draw(int time)
 	tex_.set_alpha_mod(get_alpha(time));
 
 	// Apply the label texture to the screen.
-	video.blit_texture(tex_, &draw_rect);
+	draw::blit(tex_, draw_rect);
 }
 
 void floating_label::set_lifetime(int lifetime, int fadeout)
@@ -248,7 +249,7 @@ void floating_label::undraw()
 
 	CVideo& video = CVideo::get_singleton();
 	auto clipper = video.set_clip(clip_rect_);
-	video.blit_texture(buf_, &buf_pos_);
+	draw::blit(buf_, buf_pos_);
 }
 
 int add_floating_label(const floating_label& flabel)

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -332,7 +332,7 @@ bool game_launcher::init_video()
 	video_->set_window_title(game_config::get_default_title_string());
 
 #if !(defined(__APPLE__))
-	surface icon(image::get_image("icons/icon-game.png", image::UNSCALED));
+	surface icon(image::get_surface("icons/icon-game.png", image::UNSCALED));
 	if(icon != nullptr) {
 		video_->set_window_icon(icon);
 	}

--- a/src/gui/auxiliary/typed_formula.hpp
+++ b/src/gui/auxiliary/typed_formula.hpp
@@ -159,7 +159,7 @@ operator()(const wfl::map_formula_callable& variables, wfl::function_symbol_tabl
 	wfl::variant v = wfl::formula(*formula_, functions).evaluate(variables);
 	const T& result = execute(v);
 
-	LOG_GUI_D << "Formula: execute '" << *formula_ << "' result '" << result << "'.\n";
+	DBG_GUI_D << "Formula: execute '" << *formula_ << "' result '" << result << "'.\n";
 
 	return result;
 }

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -157,17 +157,24 @@ void rectangle_shape::draw(
 {
 	const auto rects = calculate_rects(portion_to_draw, variables);
 	if(rects.empty) {
+		DBG_GUI_D << "Rectangle: nothing to draw" << std::endl;
 		return;
 	}
 
 	const color_t fill_color = fill_color_(variables);
+	const color_t border_color = border_color_(variables);
+	SDL_Rect r = rects.unclipped_around_viewport;
+	r.x += draw_location.x;
+	r.y += draw_location.y;
+
+	DBG_GUI_D << "Rectangle: draw at " << r
+		<< " with bounds " << portion_to_draw << std::endl;
 
 	// Fill the background, if applicable
 	if(!fill_color.null()) {
+		DBG_GUI_D << "fill " << fill_color << std::endl;
 		draw::set_color(fill_color);
-		auto area = rects.unclipped_around_viewport;
-		area.x += draw_location.x;
-		area.y += draw_location.y;
+		SDL_Rect area = r;
 		area.x += border_thickness_;
 		area.y += border_thickness_;
 		area.w -= 2 * border_thickness_;
@@ -177,11 +184,11 @@ void rectangle_shape::draw(
 	}
 
 	// Draw the border
-	draw::set_color(border_color_(variables));
+	draw::set_color(border_color);
+	DBG_GUI_D << "border thickness " << border_thickness_
+		<< ", colour " << border_color << std::endl;
 	for(int i = 0; i < border_thickness_; ++i) {
-		auto dimensions = rects.unclipped_around_viewport;
-		dimensions.x += draw_location.x;
-		dimensions.y += draw_location.y;
+		SDL_Rect dimensions = r;
 		dimensions.x += i;
 		dimensions.y += i;
 		dimensions.w -= 2 * i;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -413,26 +413,18 @@ void image_shape::draw(
 
 	// TODO: highdpi - clipping?
 
-	if (mirror_(variables) && (resize_mode_ == resize_mode::tile
-	             || resize_mode_ == resize_mode::tile_center)) {
-		// Not difficult to implement, but will anyone ever use it?
-		WRN_GUI_D << "mirrored tiling images unimplemented" << std::endl;
-	}
-
 	// What to do with the image depends on whether we need to tile it or not.
 	switch (resize_mode_) {
 	case (resize_mode::tile):
-		draw::tiled(tex, adjusted_draw_loc, false);
+		draw::tiled(tex, adjusted_draw_loc, false, mirror_(variables));
 		break;
 	case (resize_mode::tile_center):
-		draw::tiled(tex, adjusted_draw_loc, true);
+		draw::tiled(tex, adjusted_draw_loc, true, mirror_(variables));
 		break;
 	case (resize_mode::stretch):
 	case (resize_mode::scale):
 	case (resize_mode::scale_sharp):
-		// TODO: highdpi - examine the necessity of doing this here. It is better to set the filtering mode per-texture, rather than per-draw.
-		// TODO: highdpi - texture API to set filtering mode, if actually needed
-		// TODO: highdpi - set texture filtering here, if this is desirable
+		// TODO: highdpi - SDL requires that filtering mode be set per-texture, at texture creation. This will require either texture caches according to filtering mode, or an overhaul in how filtering type is requested so that the filter mode is specified as part of image loading, not image drawing.
 		// TODO: highdpi - is there any real difference between scale and stretch?
 		if (mirror_(variables)) {
 			draw::flipped(tex, adjusted_draw_loc);

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -535,8 +535,7 @@ void image_shape::draw(CVideo& video,
 	 * The locator might return a different surface for every call so we can't
 	 * cache the output, also not if no formula is used.
 	 */
-	// TODO: highdpi - get_image should return a texture, not a surface
-	texture tex(image::get_image(image::locator(name)));
+	texture tex(image::get_texture(image::locator(name)));
 
 	// TODO: highdpi - better texture validity check
 	if(tex.w() == 0 || tex.h() == 0) {

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -472,6 +472,7 @@ image_shape::image_shape(const config& cfg, wfl::action_function_symbol_table& f
 	, image_()
 	, image_name_(cfg["name"])
 	, resize_mode_(get_resize_mode(cfg["resize_mode"]))
+	// TODO: highdpi - this is NOT vertical mirroring, but horizontal. rename.
 	, vertical_mirror_(cfg["vertical_mirror"])
 	, actions_formula_(cfg["actions"], &functions)
 {
@@ -586,7 +587,7 @@ void image_shape::draw(CVideo& video,
 	// The clipping area should already be set by canvas::draw(),
 	// so there's no need to set it here.
 
-	// TODO: highdpi - vertical_mirror_ - just needs a RenderCopyEx wrapper in CVideo
+	// TODO: highdpi - vertical_mirror_ - just needs a RenderCopyEx wrapper in CVideo. Also note that it is NOT for vertical mirroring, but horizontal.
 
 	// What to do with the image depends on whether we need to tile it or not.
 	switch (resize_mode_) {

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -27,6 +27,7 @@
 #include "sdl/texture.hpp"
 
 namespace wfl { class variant; }
+class point;
 
 namespace gui2
 {
@@ -97,10 +98,8 @@ public:
 	 * @param area_to_draw        Currently-visible part of the widget, in widget-local coordinates.
 	 *                            Any area outside here won't be blitted to the parent.
 	 * @param draw_location       Where to draw the widget on the screen, in draw coordinates.
-	 * @param force               If the canvas isn't dirty it isn't redrawn
-	 *                            unless force is set to true.
 	 */
-	void draw(const SDL_Rect& area_to_draw, const SDL_Rect& draw_location, const bool force = false);
+	void draw(const SDL_Rect& area_to_draw, const SDL_Rect& draw_location);
 
 	public:
 	/**
@@ -111,7 +110,7 @@ public:
 	 *
 	 * @param rect                Where to blit to, in drawing coordinates.
 	 */
-	void blit(SDL_Rect rect, bool force = false);
+	void blit(SDL_Rect rect);
 
 	/**
 	 * Sets the config.
@@ -135,23 +134,14 @@ public:
 		parse_cfg(cfg);
 	}
 
-	/***** ***** ***** setters / getters for members ***** ****** *****/
+	/** Update WFL size variables. */
+	void update_size_variables();
 
-	void set_width(const unsigned width)
-	{
-		w_ = width;
-		set_is_dirty(true);
-	}
+	/***** ***** ***** setters / getters for members ***** ****** *****/
 
 	unsigned get_width() const
 	{
 		return w_;
-	}
-
-	void set_height(const unsigned height)
-	{
-		h_ = height;
-		set_is_dirty(true);
 	}
 
 	unsigned get_height() const
@@ -159,15 +149,17 @@ public:
 		return h_;
 	}
 
+	void set_size(const point& size);
+
 	void set_variable(const std::string& key, wfl::variant&& value)
 	{
 		variables_.add(key, std::move(value));
-		set_is_dirty(true);
 	}
 
-	void set_is_dirty(const bool is_dirty)
+	// TODO: highdpi - find everywhere that is calling this, and determine why.
+	void set_is_dirty(bool)
 	{
-		is_dirty_ = is_dirty;
+		update_size_variables();
 	}
 
 private:
@@ -198,9 +190,6 @@ private:
 
 	/** Action function definitions for the canvas. */
 	wfl::action_function_symbol_table functions_;
-
-	/** The dirty state of the canvas. */
-	bool is_dirty_;
 
 	/**
 	 * Parses a config object.

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -24,7 +24,6 @@
 #include "config.hpp"
 #include "formula/callable.hpp"
 #include "formula/function.hpp"
-#include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
 
 namespace wfl { class variant; }
@@ -63,15 +62,13 @@ public:
 		/**
 		 * Draws the canvas.
 		 *
-		 * @param video             The current CVideo instance.
 		 * @param portion_to_draw   The portion of the shape to draw, in canvas-local coordinates
 		 * @param draw_location     The location of the canvas on the screen, in draw coordinates.
 		 * @param variables       The canvas can have formulas in it's
 		 *                        definition, this parameter contains the values
 		 *                        for these formulas.
 		 */
-		virtual void draw(CVideo& video,
-		                  const SDL_Rect& portion_to_draw,
+		virtual void draw(const SDL_Rect& portion_to_draw,
 		                  const SDL_Rect& draw_location,
 		                  wfl::map_formula_callable& variables) = 0;
 
@@ -95,8 +92,7 @@ public:
 
 	private:
 	/**
-	 * Internal part of the blit() function - prepares the contents of the internal viewport_
-	 * surface, reallocating that surface if necessary.
+	 * Internal part of the blit() function - does the actual drawing.
 	 *
 	 * @param area_to_draw        Currently-visible part of the widget, in widget-local coordinates.
 	 *                            Any area outside here won't be blitted to the parent.

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -27,7 +27,7 @@
 #include "sdl/texture.hpp"
 
 namespace wfl { class variant; }
-class point;
+struct point;
 
 namespace gui2
 {

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -395,7 +395,7 @@ private:
 	resize_mode resize_mode_;
 
 	/** Mirror the image over the vertical axis. */
-	typed_formula<bool> vertical_mirror_;
+	typed_formula<bool> mirror_;
 
 	// TODO: use a typed_formula?
 	wfl::formula actions_formula_;

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -77,8 +77,7 @@ public:
 	 */
 	explicit line_shape(const config& cfg);
 
-	void draw(CVideo& video,
-	          const SDL_Rect& portion_to_draw,
+	void draw(const SDL_Rect& portion_to_draw,
 	          const SDL_Rect& draw_location,
 	          wfl::map_formula_callable& variables) override;
 
@@ -189,8 +188,7 @@ public:
 	 */
 	explicit rectangle_shape(const config& cfg);
 
-	void draw(CVideo& video,
-	          const SDL_Rect& portion_to_draw,
+	void draw(const SDL_Rect& portion_to_draw,
 	          const SDL_Rect& draw_location,
 	          wfl::map_formula_callable& variables) override;
 
@@ -240,8 +238,7 @@ public:
 	 */
 	explicit round_rectangle_shape(const config& cfg);
 
-	void draw(CVideo& video,
-	          const SDL_Rect& portion_to_draw,
+	void draw(const SDL_Rect& portion_to_draw,
 	          const SDL_Rect& draw_location,
 	          wfl::map_formula_callable& variables) override;
 
@@ -299,8 +296,7 @@ public:
 	 */
 	explicit circle_shape(const config& cfg);
 
-	void draw(CVideo& video,
-	          const SDL_Rect& portion_to_draw,
+	void draw(const SDL_Rect& portion_to_draw,
 	          const SDL_Rect& draw_location,
 	          wfl::map_formula_callable& variables) override;
 
@@ -351,8 +347,7 @@ public:
 	 */
 	image_shape(const config& cfg, wfl::action_function_symbol_table& functions);
 
-	void draw(CVideo& video,
-	          const SDL_Rect& portion_to_draw,
+	void draw(const SDL_Rect& portion_to_draw,
 	          const SDL_Rect& draw_location,
 	          wfl::map_formula_callable& variables) override;
 
@@ -445,8 +440,7 @@ public:
 	 */
 	explicit text_shape(const config& cfg);
 
-	void draw(CVideo& video,
-	          const SDL_Rect& portion_to_draw,
+	void draw(const SDL_Rect& portion_to_draw,
 	          const SDL_Rect& draw_location,
 	          wfl::map_formula_callable& variables) override;
 

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -77,10 +77,10 @@ public:
 	 */
 	explicit line_shape(const config& cfg);
 
-	void draw(surface& canvas,
-			  SDL_Renderer* renderer,
-			  const SDL_Rect& viewport,
-			  wfl::map_formula_callable& variables) override;
+	void draw(CVideo& video,
+	          const SDL_Rect& portion_to_draw,
+	          const SDL_Rect& draw_location,
+	          wfl::map_formula_callable& variables) override;
 
 private:
 	typed_formula<unsigned> x1_, /**< The start x coordinate of the line. */
@@ -189,10 +189,10 @@ public:
 	 */
 	explicit rectangle_shape(const config& cfg);
 
-	void draw(surface& canvas,
-			  SDL_Renderer* renderer,
-			  const SDL_Rect& viewport,
-			  wfl::map_formula_callable& variables) override;
+	void draw(CVideo& video,
+	          const SDL_Rect& portion_to_draw,
+	          const SDL_Rect& draw_location,
+	          wfl::map_formula_callable& variables) override;
 
 private:
 	/**
@@ -240,10 +240,10 @@ public:
 	 */
 	explicit round_rectangle_shape(const config& cfg);
 
-	void draw(surface& canvas,
-			  SDL_Renderer* renderer,
-			  const SDL_Rect& viewport,
-			  wfl::map_formula_callable& variables) override;
+	void draw(CVideo& video,
+	          const SDL_Rect& portion_to_draw,
+	          const SDL_Rect& draw_location,
+	          wfl::map_formula_callable& variables) override;
 
 private:
 	typed_formula<int> r_; /**< The radius of the corners. */
@@ -299,10 +299,10 @@ public:
 	 */
 	explicit circle_shape(const config& cfg);
 
-	void draw(surface& canvas,
-			  SDL_Renderer* renderer,
-			  const SDL_Rect& viewport,
-			  wfl::map_formula_callable& variables) override;
+	void draw(CVideo& video,
+	          const SDL_Rect& portion_to_draw,
+	          const SDL_Rect& draw_location,
+	          wfl::map_formula_callable& variables) override;
 
 private:
 	typed_formula<unsigned> x_, /**< The center x coordinate of the circle. */
@@ -351,10 +351,10 @@ public:
 	 */
 	image_shape(const config& cfg, wfl::action_function_symbol_table& functions);
 
-	void draw(surface& canvas,
-			  SDL_Renderer* renderer,
-			  const SDL_Rect& viewport,
-			  wfl::map_formula_callable& variables) override;
+	void draw(CVideo& video,
+	          const SDL_Rect& portion_to_draw,
+	          const SDL_Rect& draw_location,
+	          wfl::map_formula_callable& variables) override;
 
 private:
 	typed_formula<unsigned> x_, /**< The x coordinate of the image. */
@@ -362,11 +362,13 @@ private:
 			w_,			   /**< The width of the image. */
 			h_;			   /**< The height of the image. */
 
+	// TODO: highdpi - none of these cached items are ever used. Why is this here?
+
 	/** Contains the size of the image. */
 	SDL_Rect src_clip_;
 
 	/** The image is cached in this surface. */
-	surface image_;
+	texture image_;
 
 	/**
 	 * Name of the image.
@@ -443,10 +445,10 @@ public:
 	 */
 	explicit text_shape(const config& cfg);
 
-	void draw(surface& canvas,
-			  SDL_Renderer* renderer,
-			  const SDL_Rect& viewport,
-			  wfl::map_formula_callable& variables) override;
+	void draw(CVideo& video,
+	          const SDL_Rect& portion_to_draw,
+	          const SDL_Rect& draw_location,
+	          wfl::map_formula_callable& variables) override;
 
 private:
 	/** The text font family. */

--- a/src/gui/dialogs/terrain_layers.cpp
+++ b/src/gui/dialogs/terrain_layers.cpp
@@ -45,7 +45,7 @@ terrain_layers::terrain_layers(display_t& disp, const map_location& loc)
 
 void terrain_layers::pre_show(window& window)
 {
-    //
+	//
 	// List terrain flags
 	//
 	std::vector<std::string> flags(tile_->flags.begin(), tile_->flags.end());
@@ -84,6 +84,7 @@ void terrain_layers::pre_show(window& window)
 		const int tz = game_config::tile_size;
 		SDL_Rect r {0,0,tz,tz};
 
+		// TODO: highdpi - maybe this needs width and height accessors? The surface here isn't even used.
 		surface surf = image::get_image(img.get_filename());
 
 		// calculate which part of the image the terrain engine uses

--- a/src/gui/widgets/image.cpp
+++ b/src/gui/widgets/image.cpp
@@ -44,6 +44,7 @@ image::image(const implementation::builder_image& builder)
 
 point image::calculate_best_size() const
 {
+	// TODO: highdpi - image width / height accessors. The surface is unnecessary.
 	surface image(::image::get_image(::image::locator(get_label())));
 
 	if(!image) {

--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -57,11 +57,12 @@ void update_screen_size_variables()
 	screen_width = rect.w;
 	screen_height = rect.h;
 
+	// TODO: highdpi - remove usage
 	// Use of screen_pitch_microns should probably be deprecated, as physical
 	// DPI is not an accurate method of determining perceptual pixel size.
-	auto [scalew, scaleh] = video.get_dpi_scale_factor();
-	float avgscale = (scalew + scaleh)/2;
-	screen_pitch_microns = MICRONS_PER_INCH / (avgscale * MAGIC_DPI_MATCH_VIDEO);
+	//auto [scalew, scaleh] = video.get_dpi_scale_factor();
+	//float avgscale = (scalew + scaleh)/2;
+	//screen_pitch_microns = MICRONS_PER_INCH / (avgscale * MAGIC_DPI_MATCH_VIDEO);
 
 	gamemap_width = screen_width;
 	gamemap_height = screen_height;

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -268,8 +268,7 @@ void styled_widget::place(const point& origin, const point& size)
 	// resize canvasses
 	for(auto & canvas : canvases_)
 	{
-		canvas.set_width(size.x);
-		canvas.set_height(size.y);
+		canvas.set_size(size);
 	}
 
 	// Note we assume that the best size has been queried but otherwise it
@@ -437,7 +436,7 @@ void styled_widget::impl_draw_background(int x_offset, int y_offset)
 	DBG_GUI_D << LOG_HEADER << " label '" << debug_truncate(label_) << "' size "
 			  << get_rectangle() << ".\n";
 
-	get_canvas(get_state()).blit(calculate_blitting_rectangle(x_offset, y_offset), get_is_dirty());
+	get_canvas(get_state()).blit(calculate_blitting_rectangle(x_offset, y_offset));
 }
 
 void styled_widget::impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -29,6 +29,7 @@
 #include "gui/widgets/window.hpp"
 #include "hotkey/hotkey_item.hpp"
 #include "sdl/rect.hpp"
+#include "video.hpp"
 #include "wml_exception.hpp"
 #include <functional>
 
@@ -436,7 +437,7 @@ void styled_widget::impl_draw_background(int x_offset, int y_offset)
 	DBG_GUI_D << LOG_HEADER << " label '" << debug_truncate(label_) << "' size "
 			  << get_rectangle() << ".\n";
 
-	get_canvas(get_state()).blit(calculate_blitting_rectangle(x_offset, y_offset));
+	get_canvas(get_state()).blit(calculate_blitting_rectangle(x_offset, y_offset), get_is_dirty());
 }
 
 void styled_widget::impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)
@@ -455,6 +456,11 @@ point styled_widget::get_best_text_size(point minimum_size, point maximum_size) 
 		? text_maximum_width_
 		: maximum_size.x;
 
+	// Fonts will be rendered at full output resolution,
+	// so the pixel scale multiplier must be taken into account.
+	CVideo& video = CVideo::get_singleton();
+	const int pixel_scale = video.get_pixel_scale();
+
 	/*
 	 * NOTE: text rendering does *not* happen here. That happens in the text_shape
 	 * canvas class. Instead, this just leverages the pango text rendering engine to
@@ -464,10 +470,10 @@ point styled_widget::get_best_text_size(point minimum_size, point maximum_size) 
 		.set_link_aware(get_link_aware())
 		.set_link_color(get_link_color())
 		.set_family_class(config_->text_font_family)
-		.set_font_size(get_text_font_size())
+		.set_font_size(get_text_font_size() * pixel_scale)
 		.set_font_style(config_->text_font_style)
 		.set_alignment(text_alignment_)
-		.set_maximum_width(maximum_width)
+		.set_maximum_width(maximum_width * pixel_scale)
 		.set_ellipse_mode(get_text_ellipse_mode())
 		.set_characters_per_line(get_characters_per_line())
 		.set_text(label_, use_markup_);
@@ -491,19 +497,25 @@ point styled_widget::get_best_text_size(point minimum_size, point maximum_size) 
 		<< "renderer size: " << renderer_.get_size() << "\n\n"
 		<< std::noboolalpha;
 
-	const point border(config_->text_extra_width, config_->text_extra_height);
+	const point border(config_->text_extra_width * pixel_scale,
+	                   config_->text_extra_height * pixel_scale);
 
 	// If doesn't fit try the maximum.
 	if(renderer_.is_truncated() && !can_wrap()) {
 		// FIXME if maximum size is defined we should look at that
 		// but also we don't adjust for the extra text space yet!!!
-		maximum_size = point(config_->max_width, config_->max_height);
+		maximum_size = point(config_->max_width * pixel_scale,
+		                     config_->max_height * pixel_scale);
 
 		renderer_.set_maximum_width(maximum_size.x ? maximum_size.x - border.x : -1);
 	}
 
 	// Get the resulting size.
 	point size = renderer_.get_size() + border;
+
+	// Translate it back to draw space, rounding up.
+	size.x = (size.x + pixel_scale - 1) / pixel_scale;
+	size.y = (size.y + pixel_scale - 1) / pixel_scale;
 
 	if(size.x < minimum_size.x) {
 		size.x = minimum_size.x;

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -15,6 +15,7 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
+#include "draw.hpp"
 #include "gui/widgets/grid.hpp"
 #include "gui/widgets/settings.hpp"
 #include "gui/widgets/window.hpp"
@@ -529,11 +530,11 @@ void widget::draw_debug_border()
 			/* DO NOTHING */
 			break;
 		case debug_border::outline:
-			sdl::draw_rectangle(r, debug_border_color_);
+			draw::rect(r, debug_border_color_);
 			break;
 
 		case debug_border::fill:
-			sdl::fill_rectangle(r, debug_border_color_);
+			draw::fill(r, debug_border_color_);
 			break;
 
 		default:
@@ -554,11 +555,11 @@ widget::draw_debug_border(int x_offset, int y_offset)
 			break;
 
 		case debug_border::outline:
-			sdl::draw_rectangle(r, debug_border_color_);
+			draw::rect(r, debug_border_color_);
 			break;
 
 		case debug_border::fill:
-			sdl::fill_rectangle(r, debug_border_color_);
+			draw::fill(r, debug_border_color_);
 			break;
 
 		default:

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -24,6 +24,7 @@
 
 #include "config.hpp"
 #include "cursor.hpp"
+#include "draw.hpp"
 #include "events.hpp"
 #include "floating_label.hpp"
 #include "formula/callable.hpp"
@@ -579,8 +580,7 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 
 		// restore area
 		if(restore_) {
-			SDL_Rect rect = get_rectangle();
-			video_.blit_texture(restorer_, &rect);
+			draw::blit(restorer_, get_rectangle());
 			font::undraw_floating_labels();
 		}
 		throw;
@@ -590,8 +590,7 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 
 	// restore area
 	if(restore_) {
-		SDL_Rect rect = get_rectangle();
-		video_.blit_texture(restorer_, &rect);
+		draw::blit(restorer_, get_rectangle());
 		font::undraw_floating_labels();
 	}
 
@@ -616,8 +615,7 @@ void window::draw()
 		// since all will be redrawn when needed with dirty rects. Since that
 		// doesn't work yet we need to undraw the window.
 		if(restore_ && restorer_) {
-			SDL_Rect rect = get_rectangle();
-			video_.blit_texture(restorer_, &rect);
+			draw::blit(restorer_, get_rectangle());
 		}
 
 		layout();
@@ -732,8 +730,7 @@ void window::draw()
 
 		// Restore.
 		if(restore_) {
-			SDL_Rect rect = get_rectangle();
-			video_.blit_texture(restorer_, &rect);
+			draw::blit(restorer_, get_rectangle());
 		}
 
 		// Background.
@@ -776,8 +773,7 @@ void window::draw()
 void window::undraw()
 {
 	if(restore_ && restorer_) {
-		SDL_Rect rect = get_rectangle();
-		video_.blit_texture(restorer_, &rect);
+		draw::blit(restorer_, get_rectangle());
 	}
 }
 

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -247,7 +247,7 @@ bool halo_impl::effect::render()
 
 void halo_impl::effect::unrender()
 {
-	if (tex_ == nullptr || buffer_ == nullptr) {
+	if (tex_ || buffer_) {
 		return;
 	}
 

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -248,7 +248,7 @@ bool halo_impl::effect::render()
 
 void halo_impl::effect::unrender()
 {
-	if (tex_ || buffer_) {
+	if (!tex_ || !buffer_) {
 		return;
 	}
 

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -201,10 +201,8 @@ bool halo_impl::effect::render()
 	if(!tex_) {
 		return false;
 	}
-	// TODO: highdpi - better access to texture width and height
-	auto texinfo = tex_.get_info();
-	w_ = texinfo.w;
-	h_ = texinfo.h;
+	w_ = tex_.w();
+	h_ = tex_.h();
 
 	const int screenx = disp->get_location_x(map_location::ZERO());
 	const int screeny = disp->get_location_y(map_location::ZERO());

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -197,7 +197,7 @@ bool halo_impl::effect::render()
 
 	images_.update_last_draw_time();
 	// TODO: highdpi - no prescaling
-	tex_ = texture(image::get_image(current_image(),image::SCALED_TO_ZOOM));
+	tex_ = image::get_texture(current_image(),image::SCALED_TO_ZOOM);
 	if(!tex_) {
 		return false;
 	}

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -21,6 +21,7 @@
 
 #include "animated.hpp"
 #include "display.hpp"
+#include "draw.hpp"
 #include "preferences/game.hpp"
 #include "halo.hpp"
 #include "log.hpp"
@@ -235,14 +236,11 @@ bool halo_impl::effect::render()
 	buffer_ = disp->video().read_texture(&buffer_pos_);
 
 	if (orientation_ == NORMAL) {
-		disp->video().blit_texture(tex_, &rect);
+		draw::blit(tex_, rect);
 	} else {
-		disp->video().blit_texture_flipped(
-			tex_,
+		draw::flipped(tex_, rect,
 			orientation_ == HREVERSE || orientation_ == HVREVERSE,
-			orientation_ == VREVERSE || orientation_ == HVREVERSE,
-			&rect
-		);
+			orientation_ == VREVERSE || orientation_ == HVREVERSE);
 	}
 
 	return true;
@@ -277,7 +275,7 @@ void halo_impl::effect::unrender()
 	buffer_pos_.x += xpos - rect_.x;
 	buffer_pos_.y += ypos - rect_.y;
 
-	disp->video().blit_texture(buffer_, &buffer_pos_);
+	draw::blit(buffer_, buffer_pos_);
 }
 
 bool halo_impl::effect::on_location(const std::set<map_location>& locations) const

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -24,6 +24,7 @@
 #include "log.hpp"                      // for LOG_STREAM, log_domain, etc
 #include "preferences/general.hpp"              // for font_scaled
 #include "sdl/rect.hpp"                 // for draw_rectangle, etc
+#include "sdl/texture.hpp"              // for texture
 #include "serialization/parser.hpp"     // for read, write
 #include "video.hpp"                    // for CVideo
 
@@ -72,11 +73,11 @@ void help_text_area::show_topic(const topic &t)
 }
 
 
-help_text_area::item::item(surface surface, int x, int y, const std::string& _text,
+help_text_area::item::item(const texture& _tex, int x, int y, const std::string& _text,
 						   const std::string& reference_to, bool _floating,
 						   bool _box, ALIGNMENT alignment) :
 	rect(),
-	surf(surface),
+	tex(_tex),
 	text(_text),
 	ref_to(reference_to),
 	floating(_floating), box(_box),
@@ -84,14 +85,14 @@ help_text_area::item::item(surface surface, int x, int y, const std::string& _te
 {
 	rect.x = x;
 	rect.y = y;
-	rect.w = box ? surface->w + box_width * 2 : surface->w;
-	rect.h = box ? surface->h + box_width * 2 : surface->h;
+	rect.w = box ? tex.w() + box_width * 2 : tex.w();
+	rect.h = box ? tex.h() + box_width * 2 : tex.h();
 }
 
-help_text_area::item::item(surface surface, int x, int y, bool _floating,
+help_text_area::item::item(const texture& _tex, int x, int y, bool _floating,
 						   bool _box, ALIGNMENT alignment) :
 	rect(),
-	surf(surface),
+	tex(_tex),
 	text(""),
 	ref_to(""),
 	floating(_floating),
@@ -99,8 +100,8 @@ help_text_area::item::item(surface surface, int x, int y, bool _floating,
 {
 	rect.x = x;
 	rect.y = y;
-	rect.w = box ? surface->w + box_width * 2 : surface->w;
-	rect.h = box ? surface->h + box_width * 2 : surface->h;
+	rect.w = box ? tex.w() + box_width * 2 : tex.w();
+	rect.h = box ? tex.h() + box_width * 2 : tex.h();
 }
 
 void help_text_area::set_items()
@@ -113,9 +114,11 @@ void help_text_area::set_items()
 	// Add the title item.
 	const std::string show_title =
 		font::pango_line_ellipsize(shown_topic_->title, title_size, inner_location().w);
-	surface surf = font::pango_render_text(show_title, title_size, font::NORMAL_COLOR, font::pango_text::STYLE_BOLD);
-	if (surf != nullptr) {
-		add_item(item(surf, 0, 0, show_title));
+	// TODO: highdpi - pango textures
+	texture tex(font::pango_render_text(show_title, title_size,
+		font::NORMAL_COLOR, font::pango_text::STYLE_BOLD));
+	if (tex) {
+		add_item(item(tex, 0, 0, show_title));
 		curr_loc_.second = title_spacing_;
 		contents_height_ = title_spacing_;
 		down_one_line();
@@ -351,9 +354,13 @@ void help_text_area::add_text_item(const std::string& text, const std::string& r
 			down_one_line();
 		}
 		else {
-			surface surf = font::pango_render_text(first_part, scaled_font_size, color, font::pango_text::FONT_STYLE(state));
-			if (surf)
-				add_item(item(surf, curr_loc_.first, curr_loc_.second, first_part, ref_dst));
+			// TODO: highdpi - pango textures
+			texture tex(font::pango_render_text(first_part,
+				scaled_font_size, color, font::pango_text::FONT_STYLE(state)));
+			if (tex) {
+				add_item(item(tex, curr_loc_.first, curr_loc_.second,
+					first_part, ref_dst));
+			}
 		}
 		if (parts.size() > 1) {
 
@@ -383,15 +390,15 @@ void help_text_area::add_text_item(const std::string& text, const std::string& r
 void help_text_area::add_img_item(const std::string& path, const std::string& alignment,
 								  const bool floating, const bool box)
 {
-	surface surf(image::get_image(path));
-	if (!surf)
+	texture tex(image::get_texture(path));
+	if (!tex)
 		return;
 	ALIGNMENT align = str_to_align(alignment);
 	if (align == HERE && floating) {
 		WRN_DP << "Floating image with align HERE, aligning left." << std::endl;
 		align = LEFT;
 	}
-	const int width = surf->w + (box ? box_width * 2 : 0);
+	const int width = tex.w() + (box ? box_width * 2 : 0);
 	int xpos;
 	int ypos = curr_loc_.second;
 	int text_width = inner_location().w;
@@ -422,7 +429,7 @@ void help_text_area::add_img_item(const std::string& path, const std::string& al
 		else {
 			ypos = get_y_for_floating_img(width, xpos, ypos);
 		}
-		add_item(item(surf, xpos, ypos, floating, box, align));
+		add_item(item(tex, xpos, ypos, floating, box, align));
 	}
 }
 
@@ -557,12 +564,13 @@ void help_text_area::draw_contents()
 					// surface's clipping rectangle being overridden even if
 					// no render clipping rectangle set operaton was queued,
 					// so let's not use the render API to draw the rectangle.
+					// TODO: highdpi - is the above still relevant?
 					video().fill(draw_rect, 0, 0, 0, 0);
 					++dst.x;
 					++dst.y;
 				}
 			}
-			video().blit_surface(it->surf, &dst);
+			video().blit_texture(it->tex, &dst);
 		}
 	}
 }

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -16,13 +16,14 @@
 #include "help/help_text_area.hpp"
 
 #include "config.hpp"                   // for config, etc
-#include "game_config.hpp"              // for debug
+#include "draw.hpp"                     // for blit, fill
 #include "font/sdl_ttf_compat.hpp"
+#include "game_config.hpp"              // for debug
 #include "help/help_impl.hpp"           // for parse_error, box_width, etc
 #include "lexical_cast.hpp"
-#include "picture.hpp"                    // for get_image
 #include "log.hpp"                      // for LOG_STREAM, log_domain, etc
-#include "preferences/general.hpp"              // for font_scaled
+#include "picture.hpp"                  // for get_image
+#include "preferences/general.hpp"      // for font_scaled
 #include "sdl/rect.hpp"                 // for draw_rectangle, etc
 #include "sdl/texture.hpp"              // for texture
 #include "serialization/parser.hpp"     // for read, write
@@ -565,12 +566,12 @@ void help_text_area::draw_contents()
 					// no render clipping rectangle set operaton was queued,
 					// so let's not use the render API to draw the rectangle.
 					// TODO: highdpi - is the above still relevant?
-					video().fill(draw_rect, 0, 0, 0, 0);
+					draw::fill(draw_rect, 0, 0, 0, 0);
 					++dst.x;
 					++dst.y;
 				}
 			}
-			video().blit_texture(it->tex, &dst);
+			draw::blit(it->tex, dst);
 		}
 	}
 }

--- a/src/help/help_text_area.hpp
+++ b/src/help/help_text_area.hpp
@@ -19,7 +19,7 @@
 #include <string>                       // for string
 #include <utility>                      // for pair
 #include "font/standard_colors.hpp"     // for NORMAL_COLOR
-#include "sdl/surface.hpp"                // for surface
+#include "sdl/texture.hpp"              // for texture
 #include "widgets/scrollarea.hpp"       // for scrollarea
 class CVideo;
 class config;
@@ -59,17 +59,17 @@ private:
 	 */
 	struct item {
 
-		item(surface surface, int x, int y, const std::string& text="",
+		item(const texture& tex, int x, int y, const std::string& text="",
 			 const std::string& reference_to="", bool floating=false,
 			 bool box=false, ALIGNMENT alignment=HERE);
 
-		item(surface surface, int x, int y,
+		item(const texture& tex, int x, int y,
 			 bool floating, bool box=false, ALIGNMENT=HERE);
 
 		/** Relative coordinates of this item. */
 		SDL_Rect rect;
 
-		surface surf;
+		texture tex;
 
 		// If this item contains text, this will contain that text.
 		std::string text;

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -1023,7 +1023,7 @@ REGISTER_MOD_PARSER(BLIT, args)
 	message << "~BLIT():";
 	if(!check_image(img, message))
 		return nullptr;
-	surface surf = get_image(img);
+	surface surf = get_surface(img);
 
 	return new blit_modification(surf, x, y);
 }
@@ -1056,7 +1056,7 @@ REGISTER_MOD_PARSER(MASK, args)
 	message << "~MASK():";
 	if(!check_image(img, message))
 		return nullptr;
-	surface surf = get_image(img);
+	surface surf = get_surface(img);
 
 	return new mask_modification(surf, x, y);
 }
@@ -1069,7 +1069,7 @@ REGISTER_MOD_PARSER(L, args)
 		return nullptr;
 	}
 
-	surface surf = get_image(args);
+	surface surf = get_surface(args);
 
 	return new light_modification(surf);
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -283,7 +283,7 @@ void scope_logger::do_log_exit() noexcept
 	auto output = debug()(domain_, false, true);
 	output.set_indent(indent);
 	if(timestamp) output.enable_timestamp();
-	output | formatter() << "} END: " << str_ << " (took " << ticks << "ms)\n";
+	output | formatter() << "} END: " << str_ << " (took " << ticks << "us)\n";
 }
 
 std::stringstream& log_to_chat()

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -677,7 +677,7 @@ bool locator::file_exists() const
 		: !filesystem::get_binary_file_location("images", val_.filename_).empty();
 }
 
-surface load_from_disk(const locator& loc)
+static surface load_from_disk(const locator& loc)
 {
 	switch(loc.get_type()) {
 	case locator::FILE:

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -177,8 +177,6 @@ std::map<std::string, bool> image_existence_map;
 // directories where we already cached file existence
 std::set<std::string> precached_dirs;
 
-std::map<surface, surface> reversed_images_;
-
 int red_adjust = 0, green_adjust = 0, blue_adjust = 0;
 
 unsigned int zoom = tile_size;
@@ -236,7 +234,6 @@ void flush_cache()
 		mini_terrain_cache.clear();
 		mini_fogged_terrain_cache.clear();
 		mini_highlighted_terrain_cache.clear();
-		reversed_images_.clear();
 		image_existence_map.clear();
 		precached_dirs.clear();
 	}
@@ -712,7 +709,6 @@ void set_color_adjustment(int r, int g, int b)
 		brightened_images_.flush();
 		lit_images_.flush();
 		lit_scaled_images_.flush();
-		reversed_images_.clear();
 	}
 }
 
@@ -722,7 +718,6 @@ void set_zoom(unsigned int amount)
 		zoom = amount;
 		tod_colored_images_.flush();
 		brightened_images_.flush();
-		reversed_images_.clear();
 
 		// We keep these caches if:
 		// we use default zoom (it doesn't need those)
@@ -998,28 +993,6 @@ bool is_empty_hex(const locator& i_locator)
 	}
 
 	return i_locator.locate_in_cache(is_empty_hex_);
-}
-
-surface reverse_image(const surface& surf)
-{
-	if(surf == nullptr) {
-		return surface(nullptr);
-	}
-
-	const auto itor = reversed_images_.find(surf);
-	if(itor != reversed_images_.end()) {
-		// sdl_add_ref(itor->second);
-		return itor->second;
-	}
-
-	const surface rev(flip_surface(surf));
-	if(rev == nullptr) {
-		return surface(nullptr);
-	}
-
-	reversed_images_.emplace(surf, rev);
-	// sdl_add_ref(rev);
-	return rev;
 }
 
 bool exists(const image::locator& i_locator)

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -30,6 +30,7 @@
 #include "serialization/base64.hpp"
 #include "serialization/string_utils.hpp"
 #include "sdl/rect.hpp"
+#include "sdl/texture.hpp"
 
 #include <SDL2/SDL_image.h>
 
@@ -495,7 +496,7 @@ static surface load_image_file(const image::locator& loc)
 	if(!res && !name.empty()) {
 		ERR_DP << "could not open image '" << name << "'" << std::endl;
 		if(game_config::debug && name != game_config::images::missing)
-			return get_image(game_config::images::missing, UNSCALED);
+			return get_surface(game_config::images::missing, UNSCALED);
 	}
 
 	return res;
@@ -503,7 +504,7 @@ static surface load_image_file(const image::locator& loc)
 
 static surface load_image_sub_file(const image::locator& loc)
 {
-	surface surf = get_image(loc.get_filename(), UNSCALED);
+	surface surf = get_surface(loc.get_filename(), UNSCALED);
 	if(surf == nullptr) {
 		return nullptr;
 	}
@@ -733,7 +734,7 @@ void set_zoom(unsigned int amount)
 
 static surface get_hexed(const locator& i_locator)
 {
-	surface image(get_image(i_locator, UNSCALED));
+	surface image(get_surface(i_locator, UNSCALED));
 	// hex cut tiles, also check and cache if empty result
 	bool is_empty = false;
 	surface res = mask_surface(image, get_hexmask(), &is_empty, i_locator.get_filename());
@@ -743,7 +744,7 @@ static surface get_hexed(const locator& i_locator)
 
 static surface get_scaled_to_hex(const locator& i_locator)
 {
-	surface img = get_image(i_locator, HEXED);
+	surface img = get_surface(i_locator, HEXED);
 	// return scale_surface(img, zoom, zoom);
 
 	if(img) {
@@ -756,7 +757,7 @@ static surface get_scaled_to_hex(const locator& i_locator)
 
 static surface get_tod_colored(const locator& i_locator)
 {
-	surface img = get_image(i_locator, SCALED_TO_HEX);
+	surface img = get_surface(i_locator, SCALED_TO_HEX);
 	return adjust_surface_color(img, red_adjust, green_adjust, blue_adjust);
 }
 
@@ -765,7 +766,7 @@ static surface get_scaled_to_zoom(const locator& i_locator)
 	assert(zoom != tile_size);
 	assert(tile_size != 0);
 
-	surface res(get_image(i_locator, UNSCALED));
+	surface res(get_surface(i_locator, UNSCALED));
 	// For some reason haloes seems to have invalid images, protect against crashing
 	if(res) {
 		return scale_surface_nn(res, ((res->w * zoom) / tile_size), ((res->h * zoom) / tile_size));
@@ -776,7 +777,7 @@ static surface get_scaled_to_zoom(const locator& i_locator)
 
 static surface get_brightened(const locator& i_locator)
 {
-	surface image(get_image(i_locator, TOD_COLORED));
+	surface image(get_surface(i_locator, TOD_COLORED));
 	return brighten_image(image, floating_to_fixed_point(game_config::hex_brightening));
 }
 
@@ -822,7 +823,7 @@ static TYPE simplify_type(const image::locator& i_locator, TYPE type)
 	return type;
 }
 
-surface get_image(const image::locator& i_locator, TYPE type)
+surface get_surface(const image::locator& i_locator, TYPE type)
 {
 	surface res;
 
@@ -895,6 +896,18 @@ surface get_image(const image::locator& i_locator, TYPE type)
 	return res;
 }
 
+// TODO: highdpi - actually implement this. Will require determining what needs to retain only surface caches, what needs to keep both surface and texture caches, and what needs to keep only texture handles.
+texture get_texture(const image::locator& i_locator, TYPE type)
+{
+	// This is obviously not ideal.
+	return texture(get_surface(i_locator, type));
+}
+
+surface get_image(const image::locator& i_locator, TYPE type)
+{
+	return get_surface(i_locator, type);
+}
+
 surface get_lighted_image(const image::locator& i_locator, const light_string& ls, TYPE type)
 {
 	surface res;
@@ -929,7 +942,7 @@ surface get_lighted_image(const image::locator& i_locator, const light_string& l
 	// not cached yet, generate it
 	switch(type) {
 	case HEXED:
-		res = get_image(i_locator, HEXED);
+		res = get_surface(i_locator, HEXED);
 		res = apply_light(res, ls);
 		break;
 	case SCALED_TO_HEX:
@@ -950,7 +963,7 @@ surface get_lighted_image(const image::locator& i_locator, const light_string& l
 surface get_hexmask()
 {
 	static const image::locator terrain_mask(game_config::images::terrain_mask);
-	return get_image(terrain_mask, UNSCALED);
+	return get_surface(terrain_mask, UNSCALED);
 }
 
 bool is_in_hex(const locator& i_locator)
@@ -960,7 +973,7 @@ bool is_in_hex(const locator& i_locator)
 		if(i_locator.in_cache(in_hex_info_)) {
 			result = i_locator.locate_in_cache(in_hex_info_);
 		} else {
-			const surface image(get_image(i_locator, UNSCALED));
+			const surface image(get_surface(i_locator, UNSCALED));
 
 			bool res = in_mask_surface(image, get_hexmask());
 
@@ -979,7 +992,7 @@ bool is_in_hex(const locator& i_locator)
 bool is_empty_hex(const locator& i_locator)
 {
 	if(!i_locator.in_cache(is_empty_hex_)) {
-		const surface surf = get_image(i_locator, HEXED);
+		const surface surf = get_surface(i_locator, HEXED);
 		// emptiness of terrain image is checked during hex cut
 		// so, maybe in cache now, let's recheck
 		if(!i_locator.in_cache(is_empty_hex_)) {
@@ -1067,7 +1080,7 @@ bool precached_file_exists(const std::string& file)
 
 save_result save_image(const locator& i_locator, const std::string& filename)
 {
-	return save_image(get_image(i_locator), filename);
+	return save_image(get_surface(i_locator), filename);
 }
 
 save_result save_image(const surface& surf, const std::string& filename)

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 class surface;
+class texture;
 
 /**
  * Functions to load and save images from/to disk.
@@ -240,12 +241,36 @@ enum TYPE
 };
 
 /**
- * Caches and returns an image.
+ * [DEPRECATED] Caches and returns an image.
+ *
+ * This function is deprecated. Use get_texture or get_surface in stead.
  *
  * @param i_locator            Image path.
  * @param type                 Rendering format.
  */
 surface get_image(const locator& i_locator, TYPE type = UNSCALED);
+
+/**
+ * Returns an image surface suitable for software manipulation.
+ *
+ * The equivalent get_texture() function should generally be preferred.
+ *
+ * @param i_locator            Image path.
+ * @param type                 Rendering format.
+ */
+surface get_surface(const locator& i_locator, TYPE type = UNSCALED);
+
+/**
+ * Returns an image texture suitable for hardware-accelerated rendering.
+ *
+ * Texture pointers are not unique, and will be cached and retained
+ * until no longer needed. Users of the returned texture do not have to
+ * worry about texture management.
+ *
+ * @param i_locator            Image path.
+ * @param type                 Rendering format.
+ */
+texture get_texture(const locator& i_locator, TYPE type = UNSCALED);
 
 /**
  * Caches and returns an image with a lightmap applied to it.

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -208,8 +208,7 @@ struct manager
  *
  * In particular this affects TOD_COLORED and BRIGHTENED images, as well as
  * images with lightmaps applied. Changing the previous values automatically
- * invalidates all cached images of those types. It also invalidates the
- * internal cache used by reverse_image() (FIXME?).
+ * invalidates all cached images of those types.
  */
 void set_color_adjustment(int r, int g, int b);
 
@@ -274,14 +273,6 @@ bool is_in_hex(const locator& i_locator);
  * the hex-masked version if necessary.
  */
 bool is_empty_hex(const locator& i_locator);
-
-/**
- * Horizontally flips an image.
- *
- * The input MUST have originally been returned from an image namespace function.
- * Returned images have the same semantics as those obtained from get_image().
- */
-surface reverse_image(const surface& surf);
 
 /**
  * Returns @a true if the given image actually exists, without loading it.

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -150,8 +150,6 @@ private:
 	value val_;
 };
 
-surface load_from_disk(const locator& loc);
-
 typedef cache_type<surface> image_cache;
 typedef cache_type<bool> bool_cache;
 

--- a/src/scripting/lua_fileops.cpp
+++ b/src/scripting/lua_fileops.cpp
@@ -45,6 +45,7 @@ static int intf_get_image_size(lua_State *L)
 	char const *m = luaL_checkstring(L, 1);
 	image::locator img(m);
 	if(!img.file_exists()) return 0;
+	// TODO: highdpi - image width/height accessor
 	surface s = get_image(img);
 	lua_pushinteger(L, s->w);
 	lua_pushinteger(L, s->h);

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -55,6 +55,8 @@ SDL_Rect union_rects(const SDL_Rect& rect1, const SDL_Rect& rect2)
 	return res;
 }
 
+// TODO: highdpi - remove drawing functions from here. This file should deal with rectangles, not drawing.
+
 void draw_rectangle(const SDL_Rect& rect, const color_t& color)
 {
 	SDL_Renderer* renderer = *CVideo::get_singleton().get_window();

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -55,24 +55,6 @@ SDL_Rect union_rects(const SDL_Rect& rect1, const SDL_Rect& rect2)
 	return res;
 }
 
-// TODO: highdpi - remove drawing functions from here. This file should deal with rectangles, not drawing.
-
-void draw_rectangle(const SDL_Rect& rect, const color_t& color)
-{
-	SDL_Renderer* renderer = *CVideo::get_singleton().get_window();
-
-	SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
-	SDL_RenderDrawRect(renderer, &rect);
-}
-
-void fill_rectangle(const SDL_Rect& rect, const color_t& color)
-{
-	SDL_Renderer* renderer = *CVideo::get_singleton().get_window();
-
-	SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
-	SDL_RenderFillRect(renderer, &rect);
-}
-
 } // namespace sdl
 
 bool operator==(const SDL_Rect& a, const SDL_Rect& b)

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -90,22 +90,6 @@ SDL_Rect intersect_rects(const SDL_Rect& rect1, const SDL_Rect& rect2);
 SDL_Rect union_rects(const SDL_Rect &rect1, const SDL_Rect &rect2);
 
 /**
- * Draw a rectangle outline.
- *
- * @param rect                    The dimensions of the rectangle.
- * @param color                   The color of the rectangle.
- */
-void draw_rectangle(const SDL_Rect& rect, const color_t& color);
-
-/**
- * Draws a filled rectangle.
- *
- * @param rect                    The dimensions of the rectangle.
- * @param color                   The color of the rectangle.
- */
-void fill_rectangle(const SDL_Rect& rect, const color_t& color);
-
-/**
  * Fill a rectangle on a given surface. Alias for SDL_FillRect.
  *
  * @param dst                     The surface to operate on.

--- a/src/sdl/render_utils.hpp
+++ b/src/sdl/render_utils.hpp
@@ -24,36 +24,9 @@
 #include <cassert>
 #include <functional>
 
-/**
- * Sets the renderer output target to the specified texture.
- */
-class render_target_setter
-{
-public:
-	explicit render_target_setter(texture& t)
-		: renderer_(CVideo::get_singleton().get_renderer())
-		, last_target_(nullptr)
-	{
-		if(renderer_) {
-			// Validate we can render to this texture.
-			assert(t.get_info().access == SDL_TEXTUREACCESS_TARGET);
-
-			last_target_ = SDL_GetRenderTarget(renderer_);
-			SDL_SetRenderTarget(renderer_, t);
-		}
-	}
-
-	~render_target_setter()
-	{
-		if(renderer_) {
-			SDL_SetRenderTarget(renderer_, last_target_);
-		}
-	}
-
-private:
-	SDL_Renderer* renderer_;
-	SDL_Texture* last_target_; // TODO: use the texture wrapper?
-};
+// The render_target_setter class has been moved to CVideo.
+// To obtain one, use CVideo::set_render_target().
+//class render_target_setter
 
 using sdl_rect_getter = void (*)(SDL_Renderer*, SDL_Rect*);
 using sdl_rect_setter = int (*)(SDL_Renderer*, const SDL_Rect*);

--- a/src/sdl/texture.cpp
+++ b/src/sdl/texture.cpp
@@ -54,6 +54,10 @@ texture::texture(SDL_Texture* txt)
 texture::texture(const surface& surf)
 	: texture()
 {
+	if (!surf) {
+		return;
+	}
+
 	if (surf->w == 0 && surf->h == 0) {
 		return;
 	}

--- a/src/sdl/texture.hpp
+++ b/src/sdl/texture.hpp
@@ -58,6 +58,12 @@ public:
 		return info(*this);
 	}
 
+	/** The width of the texture, in pixels. */
+	int w() const { return w_; }
+
+	/** The height of the texture, in pixels. */
+	int h() const { return h_; }
+
 	/** Sets the texture's alpha modifier. */
 	void set_alpha_mod(uint8_t alpha);
 
@@ -65,7 +71,7 @@ public:
 	void reset();
 
 	/** Releases ownership of the managed texture and creates a new one. */
-	void reset(int w, int h, SDL_TextureAccess access);
+	void reset(int width, int height, SDL_TextureAccess access);
 
 	/** Replaces ownership of the managed texture with the given one. */
 	void assign(SDL_Texture* t);
@@ -89,4 +95,5 @@ private:
 	void finalize();
 
 	std::shared_ptr<SDL_Texture> texture_;
+	int w_, h_;
 };

--- a/src/sdl/texture.hpp
+++ b/src/sdl/texture.hpp
@@ -80,9 +80,9 @@ public:
 		return texture_.get();
 	}
 
-	bool null() const
+	explicit operator bool() const
 	{
-		return texture_ == nullptr;
+		return texture_ != nullptr;
 	}
 
 private:

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -22,7 +22,6 @@
 #include "sdl/rect.hpp"
 #include "color.hpp"
 #include "xBRZ/xbrz.hpp"
-#include "video.hpp" // only needed for draw_centered_on_background, consider removing
 
 #include <algorithm>
 #include <cassert>
@@ -2245,21 +2244,6 @@ SDL_Rect get_non_transparent_portion(const surface &surf)
 	res.w = nsurf->w - res.x - n;
 
 	return res;
-}
-
-void draw_centered_on_background(surface& surf, const SDL_Rect& rect, const color_t& color, CVideo& video)
-{
-	auto clipper = video.set_clip(rect);
-
-	//TODO: only draw background outside the image
-	SDL_Rect r = rect;
-	video.fill(r, color.r, color.g, color.b, color.a);
-
-	if (surf != nullptr) {
-		r.x = rect.x + (rect.w-surf->w)/2;
-		r.y = rect.y + (rect.h-surf->h)/2;
-		video.blit_surface(surf, &r);
-	}
 }
 
 SDL_Color color_t::to_sdl() const {

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -324,7 +324,3 @@ SDL_Rect get_non_transparent_portion(const surface &surf);
 void put_pixel(const surface& surf, surface_lock& surf_lock, int x, int y, uint32_t pixel);
 uint32_t get_pixel(const surface& surf, const const_surface_lock& surf_lock, int x, int y);
 
-// blit the image on the center of the rectangle
-// and a add a colored background
-void draw_centered_on_background(surface& surf, const SDL_Rect& rect,
-	const color_t& color, CVideo& video);

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -87,16 +87,16 @@ dialog_frame::dialog_frame(CVideo& video, const std::string& title,
 	restorer_(nullptr),
 	auto_restore_(auto_restore),
 	dim_(),
-	top_(image::get_image("dialogs/" + dialog_style_.panel + "-border-top.png")),
-	bot_(image::get_image("dialogs/" + dialog_style_.panel + "-border-bottom.png")),
-	left_(image::get_image("dialogs/" + dialog_style_.panel + "-border-left.png")),
-	right_(image::get_image("dialogs/" + dialog_style_.panel + "-border-right.png")),
-	top_left_(image::get_image("dialogs/" + dialog_style_.panel + "-border-topleft.png")),
-	bot_left_(image::get_image("dialogs/" + dialog_style_.panel + "-border-botleft.png")),
-	top_right_(image::get_image("dialogs/" + dialog_style_.panel + "-border-topright.png")),
-	bot_right_(image::get_image("dialogs/" + dialog_style_.panel + "-border-botright.png")),
-	bg_(image::get_image("dialogs/" + dialog_style_.panel + "-background.png")),
-	have_border_(top_ != nullptr && bot_ != nullptr && left_ != nullptr && right_ != nullptr),
+	top_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-top.png")),
+	bot_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-bottom.png")),
+	left_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-left.png")),
+	right_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-right.png")),
+	top_left_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-topleft.png")),
+	bot_left_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-botleft.png")),
+	top_right_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-topright.png")),
+	bot_right_(image::get_texture("dialogs/" + dialog_style_.panel + "-border-botright.png")),
+	bg_(image::get_texture("dialogs/" + dialog_style_.panel + "-background.png")),
+	have_border_(top_ && bot_ && left_ && right_),
 	dirty_(true)
 {
 }
@@ -110,14 +110,16 @@ dialog_frame::dimension_measurements::dimension_measurements() :
 	interior(sdl::empty_rect), exterior(sdl::empty_rect), title(sdl::empty_rect), button_row(sdl::empty_rect)
 {}
 
-dialog_frame::dimension_measurements dialog_frame::layout(const SDL_Rect& rect) {
+dialog_frame::dimension_measurements dialog_frame::layout(const SDL_Rect& rect)
+{
 	return layout(rect.x, rect.y, rect.w, rect.h);
 }
 
-int dialog_frame::top_padding() const {
+int dialog_frame::top_padding() const
+{
 	int padding = 0;
 	if(have_border_) {
-		padding += top_->h;
+		padding += top_.h();
 	}
 	if(!title_.empty()) {
 		padding += font::get_max_height(font::SIZE_TITLE) + 2*dialog_frame::title_border_h;
@@ -125,12 +127,13 @@ int dialog_frame::top_padding() const {
 	return padding;
 }
 
-void dialog_frame::set_dirty(bool dirty) {
+void dialog_frame::set_dirty(bool dirty)
+{
 	dirty_ = dirty;
 }
 
-void dialog_frame::handle_window_event(const SDL_Event& event) {
-
+void dialog_frame::handle_window_event(const SDL_Event& event)
+{
 	if (event.type == SDL_WINDOWEVENT) {
 		switch (event.window.event) {
 		case SDL_WINDOWEVENT_RESIZED:
@@ -142,8 +145,8 @@ void dialog_frame::handle_window_event(const SDL_Event& event) {
 	}
 }
 
-void dialog_frame::handle_event(const SDL_Event& event) {
-
+void dialog_frame::handle_event(const SDL_Event& event)
+{
 	if (event.type == DRAW_ALL_EVENT) {
 		set_dirty();
 
@@ -167,7 +170,7 @@ int dialog_frame::bottom_padding() const {
 		}
 	}
 	if(have_border_) {
-		padding += bot_->h;
+		padding += bot_.h();
 	}
 	return padding;
 }
@@ -204,10 +207,10 @@ dialog_frame::dimension_measurements dialog_frame::layout(int x, int y, int w, i
 
 	SDL_Rect bounds = video_.draw_area();
 	if(have_border_) {
-		bounds.x += left_->w;
-		bounds.y += top_->h;
-		bounds.w -= left_->w;
-		bounds.h -= top_->h;
+		bounds.x += left_.w();
+		bounds.y += top_.h();
+		bounds.w -= left_.w();
+		bounds.h -= top_.h();
 	}
 	if(x < bounds.x) {
 		w += x;
@@ -232,10 +235,10 @@ dialog_frame::dimension_measurements dialog_frame::layout(int x, int y, int w, i
 	dim_.interior.w = w;
 	dim_.interior.h = h;
 	if(have_border_) {
-		dim_.exterior.x = dim_.interior.x - left_->w;
-		dim_.exterior.y = dim_.interior.y - top_->h;
-		dim_.exterior.w = dim_.interior.w + left_->w + right_->w;
-		dim_.exterior.h = dim_.interior.h + top_->h + bot_->h;
+		dim_.exterior.x = dim_.interior.x - left_.w();
+		dim_.exterior.y = dim_.interior.y - top_.h();
+		dim_.exterior.w = dim_.interior.w + left_.w() + right_.w();
+		dim_.exterior.h = dim_.interior.h + top_.h() + bot_.h();
 	} else {
 		dim_.exterior = dim_.interior;
 	}
@@ -250,38 +253,62 @@ void dialog_frame::draw_border()
 		return;
 	}
 
-	surface top_image(scale_surface(top_, dim_.interior.w, top_->h));
+	// Too much typing is bad for you.
+	const SDL_Rect& i = dim_.interior;
+	const SDL_Rect& e = dim_.exterior;
 
-	if(top_image != nullptr) {
-		video_.blit_surface(dim_.interior.x, dim_.exterior.y, top_image);
+	SDL_Rect dest;
+
+	if(top_) {
+		dest = {i.x, e.y, i.w, top_.h()};
+		video_.blit_texture(top_, &dest);
 	}
 
-	surface bot_image(scale_surface(bot_, dim_.interior.w, bot_->h));
-
-	if(bot_image != nullptr) {
-		video_.blit_surface(dim_.interior.x, dim_.interior.y + dim_.interior.h, bot_image);
+	if(bot_) {
+		dest = {i.x, i.y + i.h, i.w, bot_.h()};
+		video_.blit_texture(bot_, &dest);
 	}
 
-	surface left_image(scale_surface(left_, left_->w, dim_.interior.h));
-
-	if(left_image != nullptr) {
-		video_.blit_surface(dim_.exterior.x, dim_.interior.y, left_image);
+	if(left_) {
+		dest = {e.x, i.y, left_.w(), i.h};
+		video_.blit_texture(left_, &dest);
 	}
 
-	surface right_image(scale_surface(right_, right_->w, dim_.interior.h));
-
-	if(right_image != nullptr) {
-		video_.blit_surface(dim_.interior.x + dim_.interior.w, dim_.interior.y, right_image);
+	if(right_) {
+		dest = {i.x + i.w, i.y, right_.w(), i.h};
+		video_.blit_texture(right_, &dest);
 	}
 
-	if(top_left_ == nullptr || bot_left_ == nullptr || top_right_ == nullptr || bot_right_ == nullptr) {
+	if(!top_left_ || !bot_left_ || !top_right_ || !bot_right_) {
 		return;
 	}
 
-	video_.blit_surface(dim_.interior.x - left_->w, dim_.interior.y - top_->h, top_left_);
-	video_.blit_surface(dim_.interior.x - left_->w, dim_.interior.y + dim_.interior.h + bot_->h - bot_left_->h, bot_left_);
-	video_.blit_surface(dim_.interior.x + dim_.interior.w + right_->w - top_right_->w, dim_.interior.y - top_->h, top_right_);
-	video_.blit_surface(dim_.interior.x + dim_.interior.w + right_->w - bot_right_->w, dim_.interior.y + dim_.interior.h + bot_->h - bot_right_->h, bot_right_);
+	dest = {i.x - left_.w(), i.y - top_.h(), top_left_.w(), top_left_.h()};
+	video_.blit_texture(top_left_, &dest);
+
+	dest = {
+		i.x - left_.w(),
+		i.y + i.h + bot_.h() - bot_left_.h(),
+		bot_left_.w(),
+		bot_left_.h()
+	};
+	video_.blit_texture(bot_left_, &dest);
+
+	dest = {
+		i.x + i.w + right_.w() - top_right_.w(),
+		i.y - top_.h(),
+		top_right_.w(),
+		top_right_.h(),
+	};
+	video_.blit_texture(top_right_, &dest);
+
+	dest = {
+		i.x + i.w + right_.w() - bot_right_.w(),
+		i.y + i.h + bot_.h() - bot_right_.h(),
+		bot_right_.w(),
+		bot_right_.h()
+	};
+	video_.blit_texture(bot_right_, &dest);
 }
 
 void dialog_frame::clear_background()
@@ -304,19 +331,21 @@ void dialog_frame::draw_background()
 		video_.blit_surface(surf, &r);
 	}
 
-	if(bg_ == nullptr) {
+	if (!bg_) {
 		ERR_DP << "could not find dialog background '" << dialog_style_.panel << "'" << std::endl;
 		return;
 	}
-	for(int i = 0; i < dim_.interior.w; i += bg_->w) {
-		for(int j = 0; j < dim_.interior.h; j += bg_->h) {
+
+	auto clipper = video_.set_clip(dim_.interior);
+	for(int i = 0; i < dim_.interior.w; i += bg_.w()) {
+		for(int j = 0; j < dim_.interior.h; j += bg_.h()) {
 			SDL_Rect src {0,0,0,0};
-			src.w = std::min(dim_.interior.w - i, bg_->w);
-			src.h = std::min(dim_.interior.h - j, bg_->h);
+			src.w = std::min(dim_.interior.w - i, bg_.w());
+			src.h = std::min(dim_.interior.h - j, bg_.h());
 			SDL_Rect dst = src;
 			dst.x = dim_.interior.x + i;
 			dst.y = dim_.interior.y + j;
-			video_.blit_surface(dst.x, dst.y, bg_, &src, nullptr);
+			video_.blit_texture(bg_, &dst);
 		}
 	}
 }

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -17,6 +17,7 @@
 
 #include "show_dialog.hpp"
 
+#include "draw.hpp"
 #include "floating_label.hpp"
 #include "picture.hpp"
 #include "gettext.hpp"
@@ -257,58 +258,49 @@ void dialog_frame::draw_border()
 	const SDL_Rect& i = dim_.interior;
 	const SDL_Rect& e = dim_.exterior;
 
-	SDL_Rect dest;
-
 	if(top_) {
-		dest = {i.x, e.y, i.w, top_.h()};
-		video_.blit_texture(top_, &dest);
+		draw::blit(top_, {i.x, e.y, i.w, top_.h()});
 	}
 
 	if(bot_) {
-		dest = {i.x, i.y + i.h, i.w, bot_.h()};
-		video_.blit_texture(bot_, &dest);
+		draw::blit(bot_, {i.x, i.y + i.h, i.w, bot_.h()});
 	}
 
 	if(left_) {
-		dest = {e.x, i.y, left_.w(), i.h};
-		video_.blit_texture(left_, &dest);
+		draw::blit(left_, {e.x, i.y, left_.w(), i.h});
 	}
 
 	if(right_) {
-		dest = {i.x + i.w, i.y, right_.w(), i.h};
-		video_.blit_texture(right_, &dest);
+		draw::blit(right_, {i.x + i.w, i.y, right_.w(), i.h});
 	}
 
 	if(!top_left_ || !bot_left_ || !top_right_ || !bot_right_) {
 		return;
 	}
 
-	dest = {i.x - left_.w(), i.y - top_.h(), top_left_.w(), top_left_.h()};
-	video_.blit_texture(top_left_, &dest);
+	draw::blit(top_left_,
+		{i.x - left_.w(), i.y - top_.h(), top_left_.w(), top_left_.h()});
 
-	dest = {
+	draw::blit(bot_left_, {
 		i.x - left_.w(),
 		i.y + i.h + bot_.h() - bot_left_.h(),
 		bot_left_.w(),
 		bot_left_.h()
-	};
-	video_.blit_texture(bot_left_, &dest);
+	});
 
-	dest = {
+	draw::blit(top_right_, {
 		i.x + i.w + right_.w() - top_right_.w(),
 		i.y - top_.h(),
 		top_right_.w(),
 		top_right_.h(),
-	};
-	video_.blit_texture(top_right_, &dest);
+	});
 
-	dest = {
+	draw::blit(bot_right_, {
 		i.x + i.w + right_.w() - bot_right_.w(),
 		i.y + i.h + bot_.h() - bot_right_.h(),
 		bot_right_.w(),
 		bot_right_.h()
-	};
-	video_.blit_texture(bot_right_, &dest);
+	});
 }
 
 void dialog_frame::clear_background()
@@ -345,7 +337,7 @@ void dialog_frame::draw_background()
 			SDL_Rect dst = src;
 			dst.x = dim_.interior.x + i;
 			dst.y = dim_.interior.y + j;
-			video_.blit_texture(bg_, &dst);
+			draw::blit(bg_, dst);
 		}
 	}
 }

--- a/src/show_dialog.hpp
+++ b/src/show_dialog.hpp
@@ -105,7 +105,7 @@ private:
 	surface_restorer* restorer_;
 	bool auto_restore_;
 	dimension_measurements dim_;
-	surface top_, bot_, left_, right_, top_left_, bot_left_, top_right_, bot_right_, bg_;
+	texture top_, bot_, left_, right_, top_left_, bot_left_, top_right_, bot_right_, bg_;
 	bool have_border_;
 	bool dirty_;
 };

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -67,7 +67,7 @@ private:
 
 	/** Sets up the paths later used to load images
 	 *
-	 * This is required by all the modifications that use image::get_image
+	 * This is required by all the modifications that use image::get_surface
 	 * to load images from disk
 	 */
 	void set_up_image_paths()

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -41,6 +41,7 @@
 static lg::log_domain log_display("display");
 #define LOG_DP LOG_STREAM(info, log_display)
 #define ERR_DP LOG_STREAM(err, log_display)
+#define WRN_DP LOG_STREAM(warn, log_display)
 #define DBG_DP LOG_STREAM(debug, log_display)
 
 CVideo* CVideo::singleton_ = nullptr;
@@ -478,6 +479,10 @@ SDL_Rect CVideo::draw_area() const
 
 SDL_Rect CVideo::input_area() const
 {
+	if(!window) {
+		WRN_DP << "requesting input area with no window" << std::endl;
+		return draw_area();
+	}
 	// This should always match draw_area.
 	SDL_Point p(window->get_logical_size());
 	return {0, 0, p.x, p.y};
@@ -538,6 +543,9 @@ void CVideo::force_clip(const SDL_Rect& clip)
 		SDL_SetClipRect(drawingSurface, &clip);
 	}
 	// and on the render target.
+	if (!window) {
+		return;
+	}
 	if (SDL_RenderSetClipRect(get_renderer(), &clip)) {
 		throw error("Failed to set render clip rect");
 	}
@@ -545,6 +553,10 @@ void CVideo::force_clip(const SDL_Rect& clip)
 
 SDL_Rect CVideo::get_clip() const
 {
+	if (!window) {
+		return sdl::empty_rect;
+	}
+
 	SDL_Rect clip;
 	SDL_RenderGetClipRect(*window, &clip);
 
@@ -572,6 +584,10 @@ SDL_Rect CVideo::to_output(const SDL_Rect& r) const
 // TODO: highdpi - deprecate
 void CVideo::render_low_res()
 {
+	if (!window) {
+		WRN_DP << "trying to render with no window" << std::endl;
+		return;
+	}
 	if (!drawingSurface) {
 		throw error("Trying to render with no drawingSurface");
 	}
@@ -599,6 +615,10 @@ void CVideo::render_low_res()
 // TODO: highdpi - deprecate
 void CVideo::render_low_res(SDL_Rect* src_rect)
 {
+	if (!window) {
+		WRN_DP << "trying to render with no window" << std::endl;
+		return;
+	}
 	if (!drawingSurface) {
 		throw error("Trying to render with no drawingSurface");
 	}
@@ -671,6 +691,10 @@ void CVideo::render_screen()
 
 surface CVideo::read_pixels(SDL_Rect* r)
 {
+	if (!window) {
+		WRN_DP << "trying to read pixels with no window" << std::endl;
+		return surface();
+	}
 	SDL_Rect d = draw_area();
 	SDL_Rect r_clipped = d;
 	if (r) {
@@ -694,6 +718,10 @@ surface CVideo::read_pixels(SDL_Rect* r)
 
 surface CVideo::read_pixels_low_res(SDL_Rect* r)
 {
+	if (!window) {
+		WRN_DP << "trying to read pixels with no window" << std::endl;
+		return surface();
+	}
 	surface s = read_pixels(r);
 	if (r) {
 		return scale_surface(s, r->w, r->h);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -187,6 +187,41 @@ int CVideo::fill(
 	}
 }
 
+int CVideo::fill(const SDL_Rect& area)
+{
+	return SDL_RenderFillRect(*window, &area);
+}
+
+void CVideo::set_draw_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	SDL_SetRenderDrawColor(*window, r, g, b, a);
+}
+
+void CVideo::set_draw_color(color_t c)
+{
+	SDL_SetRenderDrawColor(*window, c.r, c.g, c.b, c.a);
+}
+
+void CVideo::draw_line(int from_x, int from_y, int to_x, int to_y)
+{
+	SDL_RenderDrawLine(*window, from_x, from_y, to_x, to_y);
+}
+
+void CVideo::draw_points(const std::vector<SDL_Point>& points)
+{
+	SDL_RenderDrawPoints(*window, points.data(), points.size());
+}
+
+void CVideo::draw_point(int x, int y)
+{
+	SDL_RenderDrawPoint(*window, x, y);
+}
+
+void CVideo::draw_rect(const SDL_Rect& rect)
+{
+	SDL_RenderDrawRect(*window, &rect);
+}
+
 void CVideo::blit_surface(const surface& surf, SDL_Rect* dst)
 {
 	// Ensure alpha gets transferred as well
@@ -225,7 +260,7 @@ void CVideo::blit_surface(int x, int y, const surface& surf, const SDL_Rect* src
 	SDL_SetSurfaceBlendMode(surf, b);
 }
 
-void CVideo::blit_texture(texture& tex, const SDL_Rect* dst_rect, const SDL_Rect* src_rect)
+void CVideo::blit_texture(const texture& tex, const SDL_Rect* dst_rect, const SDL_Rect* src_rect)
 {
 	SDL_RenderCopy(*window.get(), tex, src_rect, dst_rect);
 }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -267,6 +267,19 @@ void CVideo::blit_texture(const texture& tex, const SDL_Rect* dst_rect, const SD
 	SDL_RenderCopy(*window.get(), tex, src_rect, dst_rect);
 }
 
+void CVideo::blit_texture_flipped(
+	const texture& tex,
+	bool flip_horizontal,
+	bool flip_vertical,
+	const SDL_Rect* dst_rect,
+	const SDL_Rect* src_rect)
+{
+	SDL_RendererFlip flip =
+		flip_horizontal ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE
+		| flip_vertical ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
+	SDL_RenderCopyEx(*window, tex, src_rect, dst_rect, 0.0, nullptr, flip);
+}
+
 void CVideo::make_fake()
 {
 	fake_screen_ = true;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -187,6 +187,8 @@ int CVideo::fill(
 	}
 }
 
+// TODO: highdpi - move all these drawing functions to a separate interface
+
 int CVideo::fill(const SDL_Rect& area)
 {
 	return SDL_RenderFillRect(*window, &area);
@@ -552,6 +554,8 @@ void CVideo::delay(unsigned int milliseconds)
 	}
 }
 
+// TODO: highdpi - separate drawing interface should also handle clipping
+
 CVideo::clip_setter CVideo::set_clip(const SDL_Rect& clip)
 {
 	return CVideo::clip_setter(*this, clip);
@@ -593,6 +597,7 @@ SDL_Rect CVideo::to_output(const SDL_Rect& r) const
 	return {s*r.x, s*r.y, s*r.w, s*r.h};
 }
 
+// TODO: highdpi - deprecate
 void CVideo::render_low_res()
 {
 	if (!drawingSurface) {
@@ -619,6 +624,7 @@ void CVideo::render_low_res()
 	SDL_RenderCopy(*window.get(), drawing_texture_, nullptr, nullptr);
 }
 
+// TODO: highdpi - deprecate
 void CVideo::render_low_res(SDL_Rect* src_rect)
 {
 	if (!drawingSurface) {
@@ -667,6 +673,10 @@ void CVideo::render_screen()
 	if(fake_screen_ || flip_locked_ > 0) {
 		return;
 	}
+
+	// Note: this is not thread-safe.
+	// Drawing functions should not be called while this is active.
+	// SDL renderer usage is not thread-safe anyway, so this is fine.
 
 	if(window) {
 		// Reset the render target to the window.

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -175,55 +175,6 @@ void CVideo::video_event_handler::handle_window_event(const SDL_Event& event)
 	}
 }
 
-int CVideo::fill(
-	const SDL_Rect& area,
-	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	int e = SDL_SetRenderDrawColor(*window, r, g, b, a);
-	if (e == 0) {
-		return SDL_RenderFillRect(*window, &area);
-	} else {
-		return e;
-	}
-}
-
-// TODO: highdpi - move all these drawing functions to a separate interface
-
-int CVideo::fill(const SDL_Rect& area)
-{
-	return SDL_RenderFillRect(*window, &area);
-}
-
-void CVideo::set_draw_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	SDL_SetRenderDrawColor(*window, r, g, b, a);
-}
-
-void CVideo::set_draw_color(color_t c)
-{
-	SDL_SetRenderDrawColor(*window, c.r, c.g, c.b, c.a);
-}
-
-void CVideo::draw_line(int from_x, int from_y, int to_x, int to_y)
-{
-	SDL_RenderDrawLine(*window, from_x, from_y, to_x, to_y);
-}
-
-void CVideo::draw_points(const std::vector<SDL_Point>& points)
-{
-	SDL_RenderDrawPoints(*window, points.data(), points.size());
-}
-
-void CVideo::draw_point(int x, int y)
-{
-	SDL_RenderDrawPoint(*window, x, y);
-}
-
-void CVideo::draw_rect(const SDL_Rect& rect)
-{
-	SDL_RenderDrawRect(*window, &rect);
-}
-
 void CVideo::blit_surface(const surface& surf, SDL_Rect* dst)
 {
 	// Ensure alpha gets transferred as well
@@ -260,24 +211,6 @@ void CVideo::blit_surface(int x, int y, const surface& surf, const SDL_Rect* src
 
 	// Reset the input surface blend mode to whatever it originally was
 	SDL_SetSurfaceBlendMode(surf, b);
-}
-
-void CVideo::blit_texture(const texture& tex, const SDL_Rect* dst_rect, const SDL_Rect* src_rect)
-{
-	SDL_RenderCopy(*window.get(), tex, src_rect, dst_rect);
-}
-
-void CVideo::blit_texture_flipped(
-	const texture& tex,
-	bool flip_horizontal,
-	bool flip_vertical,
-	const SDL_Rect* dst_rect,
-	const SDL_Rect* src_rect)
-{
-	SDL_RendererFlip flip =
-		flip_horizontal ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE
-		| flip_vertical ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE;
-	SDL_RenderCopyEx(*window, tex, src_rect, dst_rect, 0.0, nullptr, flip);
 }
 
 void CVideo::make_fake()

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -534,6 +534,16 @@ CVideo::clip_setter CVideo::set_clip(const SDL_Rect& clip)
 	return CVideo::clip_setter(*this, clip);
 }
 
+CVideo::clip_setter CVideo::reduce_clip(const SDL_Rect& clip)
+{
+	SDL_Rect c = get_clip();
+	if (c == sdl::empty_rect) {
+		return CVideo::clip_setter(*this, clip);
+	} else {
+		return CVideo::clip_setter(*this, sdl::intersect_rects(clip, c));
+	}
+}
+
 void CVideo::force_clip(const SDL_Rect& clip)
 {
 	// Set the clipping area both on the drawing surface,

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -27,6 +27,7 @@ class surface;
 class texture;
 struct point;
 struct SDL_Texture;
+struct color_t;
 
 namespace sdl
 {
@@ -251,6 +252,50 @@ public:
 	int fill(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 	/**
+	 * Fill an area.
+	 *
+	 * Uses the current drawing colour set by set_draw_color().
+	 * Coordinates are given in draw space.
+	 *
+	 * @param rect      The area to fill, in drawing coordinates.
+	 * @returns         0 on success, a negative SDL error code on failure.
+	 */
+	int fill(const SDL_Rect& rect);
+
+	/**
+	 * Draw a rectangle.
+	 *
+	 * Uses the current drawing colour set by set_draw_color().
+	 * Coordinates are given in draw space.
+	 *
+	 * @param rect      The rectangle to draw, in drawing coordinates.
+	 */
+	void draw_rect(const SDL_Rect& rect);
+
+	/**
+	 * Draw a line.
+	 *
+	 * Uses the current drawing colour set by set_draw_color().
+	 * Coordinates are given in draw space.
+	 *
+	 * @param from_x    The X coordinate of the start point, in draw space.
+	 * @param from_y    The Y coordinate of the start point, in draw space.
+	 * @param to_x      The X coordinate of the end point, in draw space.
+	 * @param to_y      The Y coordinate of the end point, in draw space.
+	 */
+	void draw_line(int from_x, int from_y, int to_x, int to_y);
+
+	/** Draw a set of points. */
+	void draw_points(const std::vector<SDL_Point>& points);
+
+	/** Draw a single point. */
+	void draw_point(int x, int y);
+
+	/** Set the draw colour used by for draw_line(), draw_points(), etc. */
+	void set_draw_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+	void set_draw_color(color_t c);
+
+	/**
 	 * Draws a surface at the given location.
 	 *
 	 * The w and h members of dst are ignored, but will be updated
@@ -309,7 +354,7 @@ public:
 	 * @param srcrect       The portion of the texture to copy.
 	 *                      If null, this copies the entire texture.
 	 */
-	void blit_texture(texture& tex, const SDL_Rect* dstrect = nullptr, const SDL_Rect* srcrect = nullptr);
+	void blit_texture(const texture& tex, const SDL_Rect* dstrect = nullptr, const SDL_Rect* srcrect = nullptr);
 
 	/**
 	 * Render a portion of the low-resolution drawing surface.

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -416,6 +416,14 @@ public:
 	clip_setter set_clip(const SDL_Rect& clip);
 
 	/**
+	 * Set the clipping area to the intersection of the current clipping
+	 * area and the given rectangle.
+	 *
+	 * Otherwise acts as set_clip().
+	 */
+	clip_setter reduce_clip(const SDL_Rect& clip);
+
+	/**
 	 * Set the clipping area, without any provided way of setting it back.
 	 *
 	 * @param clip          The clipping area, in draw-space coordinates.

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -357,6 +357,29 @@ public:
 	void blit_texture(const texture& tex, const SDL_Rect* dstrect = nullptr, const SDL_Rect* srcrect = nullptr);
 
 	/**
+	 * Draws a texture, or part of a texture, at the given location,
+	 * also mirroring/flipping the texture horizontally and/or vertically.
+	 *
+	 * Calling this function with no explicit parameters will flip the
+	 * texture horizontally.
+	 *
+	 * @param tex               The texture to be copied / drawn.
+	 * @param flip_horizontal   Whether to flip/mirror the texture horizontally.
+	 * @param flip_vertical     Whether to flip/mirror the texture vertically.
+	 * @param dstrect           The target location to copy the texture to,
+	 *                          in low-resolution game-native drawing coordinates.
+	 *                          If null, this fills the entire render target.
+	 * @param srcrect           The portion of the texture to copy.
+	 *                          If null, this copies the entire texture.
+	 */
+	void blit_texture_flipped(
+		const texture& tex,
+		bool flip_horizontal = true,
+		bool flip_vertical = false,
+		const SDL_Rect* dst_rect = nullptr,
+		const SDL_Rect* src_rect = nullptr);
+
+	/**
 	 * Render a portion of the low-resolution drawing surface.
 	 *
 	 * @param src_rect      The portion of the drawing surface to render, in draw-space coordinates. If null, the entire drawing surface is rendered.

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -239,64 +239,9 @@ public:
 
 	/***** ***** ***** ***** Drawing functions ***** ***** ****** *****/
 
-	/**
-	 * Fills an area with the given colour.
-	 *
-	 * @param rect      The area to fill, in drawing coordinates.
-	 * @param r         The red   component of the fill colour, 0-255.
-	 * @param g         The green component of the fill colour, 0-255.
-	 * @param b         The blue  component of the fill colour, 0-255.
-	 * @param a         The alpha component of the fill colour, 0-255.
-	 * @returns         0 on success, a negative SDL error code on failure.
-	 */
-	int fill(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 	/**
-	 * Fill an area.
-	 *
-	 * Uses the current drawing colour set by set_draw_color().
-	 * Coordinates are given in draw space.
-	 *
-	 * @param rect      The area to fill, in drawing coordinates.
-	 * @returns         0 on success, a negative SDL error code on failure.
-	 */
-	int fill(const SDL_Rect& rect);
-
-	/**
-	 * Draw a rectangle.
-	 *
-	 * Uses the current drawing colour set by set_draw_color().
-	 * Coordinates are given in draw space.
-	 *
-	 * @param rect      The rectangle to draw, in drawing coordinates.
-	 */
-	void draw_rect(const SDL_Rect& rect);
-
-	/**
-	 * Draw a line.
-	 *
-	 * Uses the current drawing colour set by set_draw_color().
-	 * Coordinates are given in draw space.
-	 *
-	 * @param from_x    The X coordinate of the start point, in draw space.
-	 * @param from_y    The Y coordinate of the start point, in draw space.
-	 * @param to_x      The X coordinate of the end point, in draw space.
-	 * @param to_y      The Y coordinate of the end point, in draw space.
-	 */
-	void draw_line(int from_x, int from_y, int to_x, int to_y);
-
-	/** Draw a set of points. */
-	void draw_points(const std::vector<SDL_Point>& points);
-
-	/** Draw a single point. */
-	void draw_point(int x, int y);
-
-	/** Set the draw colour used by for draw_line(), draw_points(), etc. */
-	void set_draw_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
-	void set_draw_color(color_t c);
-
-	/**
-	 * Draws a surface at the given location.
+	 * [DEPRECATED] Draws a surface at the given location.
 	 *
 	 * The w and h members of dst are ignored, but will be updated
 	 * to reflect the final draw extents including clipping.
@@ -304,16 +249,22 @@ public:
 	 * The surface will be rendered in game-native resolution,
 	 * and all coordinates are given in this context.
 	 *
+	 * WARNING: This function is deprecated and will be removed.
+	 * Use draw::blit() in stead.
+	 *
 	 * @param surf                The surface to draw.
 	 * @param dst                 Where to draw the surface. w and h are ignored, but will be updated to reflect the final draw extents including clipping.
 	 */
 	void blit_surface(const surface& surf, SDL_Rect* dst);
 
 	/**
-	 * Draws a surface at the given coordinates.
+	 * [DEPRECATED] Draws a surface at the given coordinates.
 	 *
 	 * The surface will be rendered in game-native resolution,
 	 * and all coordinates are given in this context.
+	 *
+	 * WARNING: This function is deprecated and will be removed.
+	 * Use draw::blit() in stead.
 	 *
 	 * @param x                   The x coordinate at which to draw.
 	 * @param y                   The y coordinate at which to draw.
@@ -322,10 +273,13 @@ public:
 	void blit_surface(int x, int y, const surface& surf);
 
 	/**
-	 * Draws an area of a surface at the given location.
+	 * [DEPRECATED] Draws an area of a surface at the given location.
 	 *
 	 * The surface will be rendered in game-native resolution,
 	 * and all coordinates are given in this context.
+	 *
+	 * WARNING: This function is deprecated and will be removed.
+	 * Use draw::blit() in stead.
 	 *
 	 * @param x                   The x coordinate at which to draw.
 	 * @param y                   The y coordinate at which to draw.
@@ -335,49 +289,6 @@ public:
 	 *                            within the bounds of the given rectangle.
 	 */
 	void blit_surface(int x, int y, const surface& surf, const SDL_Rect* srcrect, const SDL_Rect* clip_rect);
-
-	/**
-	 * Draws a texture, or part of a texture, at the given location.
-	 *
-	 * The portion of the texture to be drawn will be scaled to fill
-	 * the target rectangle.
-	 *
-	 * This version takes coordinates in game-native resolution,
-	 * which may be lower than the final output resolution in high-dpi
-	 * contexts or if pixel scaling is used. The texture will be copied
-	 * in high-resolution if possible.
-	 *
-	 * @param tex           The texture to be copied / drawn.
-	 * @param dstrect       The target location to copy the texture to,
-	 *                      in low-resolution game-native drawing coordinates.
-	 *                      If null, this fills the entire render target.
-	 * @param srcrect       The portion of the texture to copy.
-	 *                      If null, this copies the entire texture.
-	 */
-	void blit_texture(const texture& tex, const SDL_Rect* dstrect = nullptr, const SDL_Rect* srcrect = nullptr);
-
-	/**
-	 * Draws a texture, or part of a texture, at the given location,
-	 * also mirroring/flipping the texture horizontally and/or vertically.
-	 *
-	 * Calling this function with no explicit parameters will flip the
-	 * texture horizontally.
-	 *
-	 * @param tex               The texture to be copied / drawn.
-	 * @param flip_horizontal   Whether to flip/mirror the texture horizontally.
-	 * @param flip_vertical     Whether to flip/mirror the texture vertically.
-	 * @param dstrect           The target location to copy the texture to,
-	 *                          in low-resolution game-native drawing coordinates.
-	 *                          If null, this fills the entire render target.
-	 * @param srcrect           The portion of the texture to copy.
-	 *                          If null, this copies the entire texture.
-	 */
-	void blit_texture_flipped(
-		const texture& tex,
-		bool flip_horizontal = true,
-		bool flip_vertical = false,
-		const SDL_Rect* dst_rect = nullptr,
-		const SDL_Rect* src_rect = nullptr);
 
 	/**
 	 * Render a portion of the low-resolution drawing surface.

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -17,6 +17,7 @@
 
 #include "widgets/button.hpp"
 
+#include "draw.hpp"
 #include "filesystem.hpp"
 #include "game_config.hpp"
 #include "game_errors.hpp"
@@ -360,7 +361,7 @@ void button::draw_contents()
 	}
 	*/
 
-	video().blit_texture(image, &dest);
+	draw::blit(image, dest);
 
 	if (overlayImage_) {
 		texture& overlay = enabled() ? overlayImage_ : overlayDisabledImage_;
@@ -385,7 +386,7 @@ void button::draw_contents()
 		// TODO: highdpi - should this be the whole button? Like... WTF? Previously these weren't scaled at all, so... maybe? Or maybe not? IT IS A MYSTERY
 		dest.w = overlay.w();
 		dest.h = overlay.h();
-		video().blit_texture(overlay, &dest);
+		draw::blit(overlay, dest);
 	}
 
 	if (type_ != TYPE_IMAGE){

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -99,13 +99,20 @@ void button::load_images() {
 			break;
 	}
 
-	surface button_image(image::get_image(button_image_name_ + ".png" + button_image_path_suffix_));
-	surface pressed_image(image::get_image(button_image_name_ + "-pressed.png"+ button_image_path_suffix_));
-	surface active_image(image::get_image(button_image_name_ + "-active.png"+ button_image_path_suffix_));
-	surface disabled_image;
-	if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + "-disabled.png"))
-		disabled_image = image::get_image(button_image_name_ + "-disabled.png"+ button_image_path_suffix_);
-	surface pressed_disabled_image, pressed_active_image, touched_image;
+	image_ = image::get_texture(
+		button_image_name_ + ".png" + button_image_path_suffix_);
+	pressedImage_ = image::get_texture(
+		button_image_name_ + "-pressed.png" + button_image_path_suffix_);
+	activeImage_ = image::get_texture(
+		button_image_name_ + "-active.png" + button_image_path_suffix_);
+	// TODO: highdpi - why is this checking if the path exists? There should be no problem even if it doesn't.
+	if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + "-disabled.png")) {
+		disabledImage_ = image::get_texture(
+			button_image_name_ + "-disabled.png" + button_image_path_suffix_);
+	} else {
+		// TODO: highdpi - this was not previously reset. Is this function only ever run once, or can it be run multiple times?
+		disabledImage_.reset();
+	}
 
 	if (!button_overlay_image_name_.empty()) {
 
@@ -114,51 +121,64 @@ void button::load_images() {
 			button_overlay_image_name_.resize(button_overlay_image_name_.length() - size_postfix.length());
 		}
 
-		overlayImage_ = image::get_image(button_overlay_image_name_ + size_postfix + ".png"+ button_image_path_suffix_);
-		overlayPressedImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-pressed.png"+ button_image_path_suffix_);
+		overlayImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + ".png"+ button_image_path_suffix_);
+		overlayPressedImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + "-pressed.png"+ button_image_path_suffix_);
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_overlay_image_name_ + size_postfix + "-active.png"))
-			overlayActiveImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-active.png"+ button_image_path_suffix_);
+			overlayActiveImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + "-active.png"+ button_image_path_suffix_);
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_overlay_image_name_ + size_postfix + "-disabled.png"))
-			overlayDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-disabled.png"+ button_image_path_suffix_);
+			overlayDisabledImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + "-disabled.png"+ button_image_path_suffix_);
 		if (!overlayDisabledImage_)
-			overlayDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + ".png~GS()" + button_image_path_suffix_);
+			overlayDisabledImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + ".png~GS()" + button_image_path_suffix_);
 
 		if (filesystem::file_exists(game_config::path + "/images/" + button_overlay_image_name_ + size_postfix + "-disabled-pressed.png"))
-			overlayPressedDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-disabled-pressed.png"+ button_image_path_suffix_);
+			overlayPressedDisabledImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + "-disabled-pressed.png"+ button_image_path_suffix_);
 		if (!overlayPressedDisabledImage_)
-			overlayPressedDisabledImage_ = image::get_image(button_overlay_image_name_ + size_postfix + "-pressed.png~GS()"+ button_image_path_suffix_);
+			overlayPressedDisabledImage_ = image::get_texture(button_overlay_image_name_ + size_postfix + "-pressed.png~GS()"+ button_image_path_suffix_);
 	} else {
-		overlayImage_ = nullptr;
+		overlayImage_.reset();
 	}
 
-	if (disabled_image == nullptr) {
-		disabled_image = image::get_image(button_image_name_ + ".png~GS()" + button_image_path_suffix_);
+	if (!disabledImage_) {
+		disabledImage_ = image::get_texture(
+			button_image_name_ + ".png~GS()" + button_image_path_suffix_);
 	}
 
-	if (!pressed_image)
-		pressed_image = button_image;
+	if (!pressedImage_) {
+		pressedImage_ = image_;
+	}
 
-	if (!active_image)
-		active_image = button_image;
+	if (!activeImage_) {
+		activeImage_ = image_;
+	}
 
 	if (type_ == TYPE_CHECK || type_ == TYPE_RADIO) {
-		touched_image = image::get_image(button_image_name_ + "-touched.png"+ button_image_path_suffix_);
-		if (!touched_image)
-			touched_image = pressed_image;
+		touchedImage_ = image::get_texture(
+			button_image_name_ + "-touched.png"+ button_image_path_suffix_);
+		if (!touchedImage_) {
+			touchedImage_ = pressedImage_;
+		}
 
-		pressed_active_image = image::get_image(button_image_name_ + "-active-pressed.png"+ button_image_path_suffix_);
-		if (!pressed_active_image)
-			pressed_active_image = pressed_image;
+		pressedActiveImage_ = image::get_texture(
+			button_image_name_ + "-active-pressed.png"+ button_image_path_suffix_);
+		if (!pressedActiveImage_) {
+			pressedActiveImage_ = pressedImage_;
+		}
 
-		if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + size_postfix + "-disabled-pressed.png"))
-			pressed_disabled_image = image::get_image(button_image_name_ + "-disabled-pressed.png"+ button_image_path_suffix_);
-		if (!pressed_disabled_image)
-			pressed_disabled_image = image::get_image(button_image_name_ + "-pressed.png~GS()"+ button_image_path_suffix_);
+		// TODO: highdpi - why is this check necessary? How does this work?
+		if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + size_postfix + "-disabled-pressed.png")) {
+			pressedDisabledImage_ = image::get_texture(
+				button_image_name_ + "-disabled-pressed.png"+ button_image_path_suffix_);
+		}
+		if (!pressedDisabledImage_) {
+			pressedDisabledImage_ = image::get_texture(
+				button_image_name_ + "-pressed.png~GS()"+ button_image_path_suffix_);
+		}
 	}
 
-	if (!button_image) {
+	// TODO: highdpi - why is this check HERE? Why not back at the start? WTF is even going on in this function? And if checks like this work, WHY do we need all these filesystem::exists checks!?
+	if (!image_) {
 		std::string err_msg = "error initializing button images! file name: ";
 		err_msg += button_image_name_;
 		err_msg += ".png";
@@ -166,28 +186,11 @@ void button::load_images() {
 		throw game::error(err_msg);
 	}
 
-	base_height_ = button_image->h;
-	base_width_ = button_image->w;
+	base_height_ = image_.h();
+	base_width_ = image_.w();
 
 	if (type_ != TYPE_IMAGE) {
 		set_label(label_text_);
-	}
-
-	if(type_ == TYPE_PRESS || type_ == TYPE_TURBO) {
-		image_ = scale_surface(button_image,location().w,location().h);
-		pressedImage_ = scale_surface(pressed_image,location().w,location().h);
-		activeImage_ = scale_surface(active_image,location().w,location().h);
-		disabledImage_ = scale_surface(disabled_image,location().w,location().h);
-	} else {
-		image_ = scale_surface(button_image,button_image->w,button_image->h);
-		activeImage_ = scale_surface(active_image,button_image->w,button_image->h);
-		disabledImage_ = scale_surface(disabled_image,button_image->w,button_image->h);
-		pressedImage_ = scale_surface(pressed_image,button_image->w,button_image->h);
-		if (type_ == TYPE_CHECK || type_ == TYPE_RADIO) {
-			pressedDisabledImage_ = scale_surface(pressed_disabled_image,button_image->w,button_image->h);
-			pressedActiveImage_ = scale_surface(pressed_active_image, button_image->w, button_image->h);
-			touchedImage_ = scale_surface(touched_image, button_image->w, button_image->h);
-		}
 	}
 
 	if (type_ == TYPE_IMAGE){
@@ -203,8 +206,8 @@ void button::calculate_size()
 {
 	if (type_ == TYPE_IMAGE){
 		SDL_Rect loc_image = location();
-		loc_image.h = image_->h;
-		loc_image.w = image_->w;
+		loc_image.h = image_.h();
+		loc_image.w = image_.w();
 		set_location(loc_image);
 		return;
 	}
@@ -285,8 +288,7 @@ void button::enable(bool new_val)
 
 void button::draw_contents()
 {
-	surface image = image_;
-	const int image_w = image_->w;
+	texture& image = image_;
 
 	int offset = 0;
 	switch(state_) {
@@ -309,22 +311,21 @@ void button::draw_contents()
 		break;
 	}
 
-	const SDL_Rect& loc = location();
+	SDL_Rect loc = location();
 	SDL_Rect clipArea = loc;
 	const int texty = loc.y + loc.h / 2 - textRect_.h / 2 + offset;
 	int textx;
 
-	if (type_ != TYPE_CHECK && type_ != TYPE_RADIO && type_ != TYPE_IMAGE)
-		textx = loc.x + image->w / 2 - textRect_.w / 2 + offset;
-	else {
-		clipArea.w += image_w + checkbox_horizontal_padding_;
-		textx = loc.x + image_w + checkbox_horizontal_padding_ / 2;
+	if (type_ != TYPE_CHECK && type_ != TYPE_RADIO && type_ != TYPE_IMAGE) {
+		textx = loc.x + image.w() / 2 - textRect_.w / 2 + offset;
+	} else {
+		clipArea.w += image.w() + checkbox_horizontal_padding_;
+		textx = loc.x + image.w() + checkbox_horizontal_padding_ / 2;
 	}
 
 	color_t button_color = font::BUTTON_COLOR;
 
 	if (!enabled()) {
-
 		if (state_ == PRESSED || state_ == PRESSED_ACTIVE)
 			image = pressedDisabledImage_;
 		else image = disabledImage_;
@@ -332,33 +333,61 @@ void button::draw_contents()
 		button_color = font::GRAY_COLOR;
 	}
 
-	if (overlayImage_) {
+	// TODO: highdpi - previous code was so much of a mess, i am not sure if this is doing anything like the correct thing.
+	SDL_Rect dest = loc;
+	if(type_ != TYPE_PRESS && type_ != TYPE_TURBO) {
+		// Scale other button types to match the base image?
+		dest.w = image_.w();
+		dest.h = image_.h();
+	}
+	// PREVIOUS HORRIBLE CODE FROM ELSEWHERE, FOR REFERENCE:
+	/*
+	if(type_ == TYPE_PRESS || type_ == TYPE_TURBO) {
+		image_ = scale_surface(button_image,location().w,location().h);
+		pressedImage_ = scale_surface(pressed_image,location().w,location().h);
+		activeImage_ = scale_surface(active_image,location().w,location().h);
+		disabledImage_ = scale_surface(disabled_image,location().w,location().h);
+	} else {
+		image_ = scale_surface(button_image,button_image->w,button_image->h);
+		activeImage_ = scale_surface(active_image,button_image->w,button_image->h);
+		disabledImage_ = scale_surface(disabled_image,button_image->w,button_image->h);
+		pressedImage_ = scale_surface(pressed_image,button_image->w,button_image->h);
+		if (type_ == TYPE_CHECK || type_ == TYPE_RADIO) {
+			pressedDisabledImage_ = scale_surface(pressed_disabled_image,button_image->w,button_image->h);
+			pressedActiveImage_ = scale_surface(pressed_active_image, button_image->w, button_image->h);
+			touchedImage_ = scale_surface(touched_image, button_image->w, button_image->h);
+		}
+	}
+	*/
 
-		surface* noverlay = enabled() ? &overlayImage_ : &overlayDisabledImage_;
+	video().blit_texture(image, &dest);
+
+	if (overlayImage_) {
+		texture& overlay = enabled() ? overlayImage_ : overlayDisabledImage_;
 
 		if (overlayPressedImage_) {
 			switch (state_) {
 			case ACTIVE:
 				if (overlayActiveImage_)
-					noverlay = &overlayActiveImage_;
+					overlay = overlayActiveImage_;
 				break;
 			case PRESSED:
 			case PRESSED_ACTIVE:
 			case TOUCHED_NORMAL:
 			case TOUCHED_PRESSED:
-				noverlay = enabled() ? &overlayPressedImage_ : &overlayPressedDisabledImage_;
+				overlay = enabled() ? overlayPressedImage_ : overlayPressedDisabledImage_;
 				break;
 			default:
 				break;
 			}
 		}
 
-		surface nimage = image.clone();
-		sdl_blit(*noverlay, nullptr, nimage, nullptr);
-		image = nimage;
+		// TODO: highdpi - should this be the whole button? Like... WTF? Previously these weren't scaled at all, so... maybe? Or maybe not? IT IS A MYSTERY
+		dest.w = overlay.w();
+		dest.h = overlay.h();
+		video().blit_texture(overlay, &dest);
 	}
 
-	video().blit_surface(loc.x, loc.y, image);
 	if (type_ != TYPE_IMAGE){
 		clipArea.x += offset;
 		clipArea.y += offset;

--- a/src/widgets/button.hpp
+++ b/src/widgets/button.hpp
@@ -19,6 +19,7 @@
 
 #include "exceptions.hpp"
 
+#include "sdl/texture.hpp"
 
 namespace gui {
 
@@ -99,7 +100,7 @@ private:
 
 	std::string label_text_;
 
-	surface image_, pressedImage_, activeImage_, pressedActiveImage_,
+	texture image_, pressedImage_, activeImage_, pressedActiveImage_,
 		touchedImage_, disabledImage_, pressedDisabledImage_,
 		overlayImage_, overlayPressedImage_, overlayPressedDisabledImage_, overlayDisabledImage_,
 		overlayActiveImage_;

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -17,6 +17,7 @@
 
 #include "widgets/menu.hpp"
 
+#include "draw.hpp"
 #include "game_config.hpp"
 #include "font/standard_colors.hpp"
 #include "language.hpp"
@@ -799,7 +800,7 @@ void menu::style::draw_row_bg(menu& menu_ref, const std::size_t /*row_index*/, c
 	color_t c((rgb & 0xff0000) >> 16, (rgb & 0xff00) >> 8, rgb & 0xff);
 	c.a = 255 * alpha;
 
-	sdl::fill_rectangle(rect, c);
+	draw::fill(rect, c);
 }
 
 void menu::style::draw_row(menu& menu_ref, const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE type)
@@ -889,9 +890,9 @@ void menu::draw_row(const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE 
 			};
 
 			if(highlight_heading_ == int(i)) {
-				sdl::fill_rectangle(draw_rect, {255,255,255,77});
+				draw::fill(draw_rect, {255,255,255,77});
 			} else if(sortby_ == int(i)) {
-				sdl::fill_rectangle(draw_rect, {255,255,255,26});
+				draw::fill(draw_rect, {255,255,255,26});
 			}
 		}
 
@@ -936,7 +937,7 @@ void menu::draw_row(const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE 
 						const int sort_x = xpos + widths[i] - sort_tex.w() - padding;
 						const int sort_y = rect.y + rect.h/2 - sort_tex.h()/2;
 						SDL_Rect dest = {sort_x, sort_y, sort_tex.w(), sort_tex.h()};
-						video().blit_texture(sort_tex, &dest);
+						draw::blit(sort_tex, dest);
 					}
 				}
 

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -24,6 +24,7 @@
 #include "picture.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "sdl/rect.hpp"
+#include "sdl/texture.hpp"
 #include "sound.hpp"
 #include "utils/general.hpp"
 #include "video.hpp"
@@ -929,12 +930,13 @@ void menu::draw_row(const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE 
 					(type == HEADING_ROW ? xpos+padding : xpos), y);
 
 				if(type == HEADING_ROW && sortby_ == int(i)) {
-					const surface sort_img = image::get_image(sortreversed_ ? "buttons/sliders/slider_arrow_blue.png" :
-					                                   "buttons/sliders/slider_arrow_blue.png~ROTATE(180)");
-					if(sort_img != nullptr && sort_img->w <= widths[i] && sort_img->h <= rect.h) {
-						const std::size_t sort_x = xpos + widths[i] - sort_img->w - padding;
-						const std::size_t sort_y = rect.y + rect.h/2 - sort_img->h/2;
-						video().blit_surface(sort_x,sort_y,sort_img);
+					const texture sort_tex(image::get_texture(sortreversed_ ? "buttons/sliders/slider_arrow_blue.png" :
+					                                   "buttons/sliders/slider_arrow_blue.png~ROTATE(180)"));
+					if(sort_tex && sort_tex.w() <= widths[i] && sort_tex.h() <= rect.h) {
+						const int sort_x = xpos + widths[i] - sort_tex.w() - padding;
+						const int sort_y = rect.y + rect.h/2 - sort_tex.h()/2;
+						SDL_Rect dest = {sort_x, sort_y, sort_tex.w(), sort_tex.h()};
+						video().blit_texture(sort_tex, &dest);
 					}
 				}
 

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -16,6 +16,7 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
+#include "draw.hpp"
 #include "widgets/scrollbar.hpp"
 #include "picture.hpp"
 #include "sdl/input.hpp" // get_mouse_state
@@ -205,17 +206,17 @@ void scrollbar::draw_contents()
 
 	// Draw scrollbar "groove"
 	const color_t c{0, 0, 0, uint8_t(255 * 0.35)};
-	sdl::fill_rectangle(groove, c);
+	draw::fill(groove, c);
 
 	// Draw scrollbar "grip"
 	SDL_Rect dest{grip.x, grip.y, top_img.w(), top_img.h()};
-	video().blit_texture(top_img, &dest);
+	draw::blit(top_img, dest);
 
 	dest = {dest.x, dest.y + top_img.h(), mid_img.w(), mid_height};
-	video().blit_texture(mid_img, &dest);
+	draw::blit(mid_img, dest);
 
 	dest = {dest.x, dest.y + mid_height, bot_img.w(), bot_img.h()};
-	video().blit_texture(bot_img, &dest);
+	draw::blit(bot_img, dest);
 }
 
 void scrollbar::handle_event(const SDL_Event& event)

--- a/src/widgets/scrollbar.hpp
+++ b/src/widgets/scrollbar.hpp
@@ -75,7 +75,6 @@ protected:
 
 private:
 	SDL_Rect grip_area() const;
-	surface mid_scaled_, groove_scaled_;
 
 	enum STATE { UNINIT, NORMAL, ACTIVE, DRAGGED };
 	STATE state_;

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -19,6 +19,7 @@
 
 #include "cursor.hpp"
 #include "desktop/clipboard.hpp"
+#include "draw.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "log.hpp"
 #include "sdl/rect.hpp"
@@ -185,7 +186,7 @@ void textbox::draw_cursor(int pos) const
 				, location().h
 		};
 
-		sdl::fill_rectangle(rect, {255, 255, 255, 255});
+		draw::fill(rect, 255, 255, 255, 255);
 	}
 }
 
@@ -198,7 +199,7 @@ void textbox::draw_contents()
 	double& alpha = focus(nullptr) ? alpha_focus_ : alpha_;
 	c.a = 255 * alpha;
 
-	sdl::fill_rectangle(loc, c);
+	draw::fill(loc, c);
 
 	SDL_Rect src;
 
@@ -235,10 +236,10 @@ void textbox::draw_contents()
 						, right - startx
 						, line_height_);
 
+				// TODO: highdpi - this seems excessive
 				auto clipper = video().set_clip(loc);
 
-				color_t c2(0, 0, 160, 140);
-				sdl::fill_rectangle(rect, c2);
+				draw::fill(rect, 0, 0, 160, 140);
 
 				starty += int(line_height_);
 				startx = 0;


### PR DESCRIPTION
Primary visible changes:
* high-DPI fonts now work for all GUI2 items - so most of the UI. It's very nice.
* some images are also rendered in high-dpi, notably the title screen background
* the previous physical-DPI-based scaling has been disabled. Pixel scale is used exclusively for now. The old UI scaling code is still there, for future use.

Architectural changes:
* There is a new API for drawing things to the screen. It can be found in `draw.cpp/hpp`. Usage is straightforward, `draw::line(from, to)` draws a line, for example. `draw::flipped(tex, where)` draws a mirrored texture (by default horizontally, but with optional explicit direction flags). All functions drawing to the screen have been updated to use this new API. The code was consolidated from several places.
* The image cache has a stub for returning textures rather than surfaces. It doesn't actually cache textures yet, but it eventually will. This is just to assist conversion. `get_image` has been deprecated in favour of `get_surface` and `get_texture` to explicitly request that type of image storage. Where it was obvious, i have updated calls to use one or the other. Some calls to `get_image` remain, where they will be overhauled later anyway, or where the choice wasn't obvious.
* Some things have been changed from using separate mirrored or scaled textures to mirroring and scaling on-the-fly. More work remains to be done changing things over.
* GUI2 elements now draw directly to the screen, in stead of caching their canvas as a separate SDL surface.

What remains to be done:
* game display still needs to be converted
* GUI1 also needs some more converting
* image cache needs to be updated to manage textures
* there should probably be some sort of cache for rendered text, especially calculated sizes
* a new system for handling redraws without surface restorers / screen reads needs to be put in place
* a lot more

Oh, i also reimplemented map screenshots. But that will still remain broken until the game display is converted over to the new hardware accelerated rendering system, as it doesn't mix well with the old drawing system in this specific case.