### PR TITLE
Fix potential for OOS errors due to wrong viewing side in vision_path

### DIFF
--- a/src/pathfind/pathfind.cpp
+++ b/src/pathfind/pathfind.cpp
@@ -582,7 +582,8 @@ vision_path::vision_path(const unit& viewer, const map_location& loc,
 
 	// The three nullptr parameters indicate (in order):
 	// ignore units, ignore ZoC (no effect), and don't build a cost_map.
-	const team& viewing_team = resources::gameboard->teams()[display::get_singleton()->viewing_team()];
+	// The viewing team needs to be the unit's team here.
+	const team& viewing_team = resources::gameboard->get_team(viewer.side());
 	find_routes(loc, viewer.movement_type().get_vision(),
 	            viewer.get_state(unit::STATE_SLOWED), sight_range, sight_range,
 	            0, destinations, &edges, &viewer, nullptr, nullptr, &viewing_team, &jamming_map, nullptr, true);
@@ -607,8 +608,9 @@ vision_path::vision_path(const movetype::terrain_costs & view_costs, bool slowed
 {
 	// The three nullptr parameters indicate (in order):
 	// ignore units, ignore ZoC (no effect), and don't build a cost_map.
-	const team& viewing_team = resources::gameboard->teams()[display::get_singleton()->viewing_team()];
 	const unit_map::const_iterator u = resources::gameboard->units().find(loc);
+	// The viewing team needs to be the unit's team here.
+	const team& viewing_team = resources::gameboard->get_team(u->side());
 	find_routes(loc, view_costs, slowed, sight_range, sight_range, 0,
 	            destinations, &edges, u.valid() ? &*u : nullptr, nullptr, nullptr, &viewing_team, &jamming_map, nullptr, true);
 }


### PR DESCRIPTION
When finding the vision path for a unit, that unit's team's vision needs to be used.  This had the potential of causing OOS errors in rare cases on maps with tunnels and at least three sides that do not share vision.