### PR TITLE
macOS: Link with AppKit and Foundation frameworks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(OpenSSL 1.0 REQUIRED)
 
 if(APPLE)
+	find_library(APPKIT_LIBRARY AppKit REQUIRED)
+	find_library(FOUNDATION_LIBRARY Foundation REQUIRED)
 	find_library(IOKIT_LIBRARY IOKit REQUIRED)
 	find_library(SECURITY_LIBRARY Security REQUIRED)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,7 @@ if(MSVC)
 elseif(MINGW)
 	set(common-external-libs ${common-external-libs} wsock32 ws2_32 shlwapi winmm crypt32)
 elseif(APPLE)
-	set(common-external-libs ${common-external-libs} ${IOKIT_LIBRARY} ${SECURITY_LIBRARY})
+	set(common-external-libs ${common-external-libs} ${APPKIT_LIBRARY} ${FOUNDATION_LIBRARY} ${IOKIT_LIBRARY} ${SECURITY_LIBRARY})
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")


### PR DESCRIPTION
Building wesnoth 1.16.3 with the cmake build system fails for me on macOS 10.15:

```
Undefined symbols for architecture x86_64:
  "_CFArrayGetCount", referenced from:
      network_asio::load_tls_root_certs(boost::asio::ssl::context&) in libwesnoth-client.a(tls_root_store.cpp.o)
      desktop::battery_info::apple::get_iops_battery_info() in libwesnoth-client.a(apple_battery_info.mm.o)
  "_CFArrayGetValueAtIndex", referenced from:
      network_asio::load_tls_root_certs(boost::asio::ssl::context&) in libwesnoth-client.a(tls_root_store.cpp.o)
      desktop::battery_info::apple::get_iops_battery_info() in libwesnoth-client.a(apple_battery_info.mm.o)
  "_CFDataGetBytePtr", referenced from:
      network_asio::load_tls_root_certs(boost::asio::ssl::context&) in libwesnoth-client.a(tls_root_store.cpp.o)
  "_CFDataGetLength", referenced from:
      network_asio::load_tls_root_certs(boost::asio::ssl::context&) in libwesnoth-client.a(tls_root_store.cpp.o)
  "_CFDictionaryCreateCopy", referenced from:
      desktop::battery_info::apple::get_iops_battery_info() in libwesnoth-client.a(apple_battery_info.mm.o)
  "_CFRelease", referenced from:
      network_asio::load_tls_root_certs(boost::asio::ssl::context&) in libwesnoth-client.a(tls_root_store.cpp.o)
      desktop::battery_info::apple::get_iops_battery_info() in libwesnoth-client.a(apple_battery_info.mm.o)
  "_NSApp", referenced from:
      _main in SDLMain.mm.o
  "_NSClassFromString", referenced from:
      apple_notifications::available() in libwesnoth-client.a(apple_notification.mm.o)
      apple_notifications::send_notification(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, desktop::notifications::type) in libwesnoth-client.a(apple_notification.mm.o)
  "_OBJC_CLASS_$_NSApplication", referenced from:
      _OBJC_CLASS_$_WesnothSDLApplication in SDLMain.mm.o
  "_OBJC_CLASS_$_NSBundle", referenced from:
      objc-class-ref in SDLMain.mm.o
  "_OBJC_CLASS_$_NSDate", referenced from:
      objc-class-ref in libwesnoth-client.a(apple_notification.mm.o)
  "_OBJC_CLASS_$_NSObject", referenced from:
      _OBJC_CLASS_$_SDLMain in SDLMain.mm.o
  "_OBJC_CLASS_$_NSProcessInfo", referenced from:
      objc-class-ref in libwesnoth-client.a(apple_version.mm.o)
  "_OBJC_CLASS_$_NSScreen", referenced from:
      objc-class-ref in libwesnoth-client.a(apple_video.mm.o)
  "_OBJC_CLASS_$_NSString", referenced from:
      objc-class-ref in libwesnoth-client.a(apple_notification.mm.o)
  "_OBJC_CLASS_$_NSURL", referenced from:
      objc-class-ref in SDLMain.mm.o
  "_OBJC_CLASS_$_NSUserNotification", referenced from:
      objc-class-ref in libwesnoth-client.a(apple_notification.mm.o)
  "_OBJC_CLASS_$_NSUserNotificationCenter", referenced from:
      objc-class-ref in libwesnoth-client.a(apple_notification.mm.o)
  "_OBJC_CLASS_$_NSWorkspace", referenced from:
      objc-class-ref in SDLMain.mm.o
  "_OBJC_METACLASS_$_NSApplication", referenced from:
      _OBJC_METACLASS_$_WesnothSDLApplication in SDLMain.mm.o
  "_OBJC_METACLASS_$_NSObject", referenced from:
      _OBJC_METACLASS_$_WesnothSDLApplication in SDLMain.mm.o
      _OBJC_METACLASS_$_SDLMain in SDLMain.mm.o
  "___CFConstantStringClassReference", referenced from:
      CFString in SDLMain.mm.o
      CFString in SDLMain.mm.o
      CFString in SDLMain.mm.o
      CFString in libwesnoth-client.a(apple_version.mm.o)
      CFString in libwesnoth-client.a(apple_notification.mm.o)
      CFString in libwesnoth-client.a(apple_battery_info.mm.o)
      CFString in libwesnoth-client.a(apple_battery_info.mm.o)
      ...
  "__objc_empty_cache", referenced from:
      _OBJC_CLASS_$_WesnothSDLApplication in SDLMain.mm.o
      _OBJC_METACLASS_$_WesnothSDLApplication in SDLMain.mm.o
      _OBJC_METACLASS_$_SDLMain in SDLMain.mm.o
      _OBJC_CLASS_$_SDLMain in SDLMain.mm.o
  "_objc_alloc_init", referenced from:
      apple_notifications::send_cocoa_notification(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) in libwesnoth-client.a(apple_notification.mm.o)
  "_objc_autoreleasePoolPop", referenced from:
      apple_notifications::send_notification(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, desktop::notifications::type) in libwesnoth-client.a(apple_notification.mm.o)
  "_objc_autoreleasePoolPush", referenced from:
      apple_notifications::send_notification(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, desktop::notifications::type) in libwesnoth-client.a(apple_notification.mm.o)
  "_objc_msgSend", referenced from:
      -[WesnothSDLApplication _handleKeyEquivalent:] in SDLMain.mm.o
      -[WesnothSDLApplication sendEvent:] in SDLMain.mm.o
      -[SDLMain openHomepage:] in SDLMain.mm.o
      -[SDLMain openChangelog:] in SDLMain.mm.o
      -[SDLMain applicationDidFinishLaunching:] in SDLMain.mm.o
      _main in SDLMain.mm.o
      desktop::apple::get_scale_factor(int) in libwesnoth-client.a(apple_video.mm.o)
      ...
  "_objc_msgSendSuper2", referenced from:
      -[WesnothSDLApplication _handleKeyEquivalent:] in SDLMain.mm.o
      -[WesnothSDLApplication sendEvent:] in SDLMain.mm.o
  "_objc_opt_respondsToSelector", referenced from:
      _main in SDLMain.mm.o
      desktop::apple::get_scale_factor(int) in libwesnoth-client.a(apple_video.mm.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [wesnoth] Error 1
```

This PR fixes it by linking with the macOS AppKit and Foundation frameworks which define those symbols.