### PR TITLE
Colourful CI output

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -48,6 +48,7 @@ jobs:
           export CXX_STD=17
           export CFG=release
           export LTO=true
+          export CLICOLOR_FORCE=1
           ./.github/workflows/ci-scripts/ubuntu.sh
 
   ubuntu-2004-cmake-clang-debug:
@@ -69,6 +70,7 @@ jobs:
           export CXX_STD=17
           export CFG=debug
           export LTO=false
+          export CLICOLOR_FORCE=1
           ./.github/workflows/ci-scripts/ubuntu.sh
 
 
@@ -91,6 +93,7 @@ jobs:
           export CXX_STD=17
           export CFG=release
           export LTO=false
+          export CLICOLOR_FORCE=1
           ./.github/workflows/ci-scripts/ubuntu.sh
 
       - name: Upload
@@ -119,6 +122,7 @@ jobs:
           export CXX_STD=17
           export CFG=release
           export LTO=false
+          export CLICOLOR_FORCE=1
           ./.github/workflows/ci-scripts/ubuntu.sh
 
       - name: Upload 1
@@ -154,6 +158,7 @@ jobs:
           export CXX_STD=17
           export CFG=release
           export LTO=false
+          export CLICOLOR_FORCE=1
           ./.github/workflows/ci-scripts/ubuntu.sh
 
   translations:
@@ -175,6 +180,7 @@ jobs:
           export CXX_STD=17
           export CFG=release
           export LTO=false
+          export CLICOLOR_FORCE=1
           ./.github/workflows/ci-scripts/ubuntu.sh
 
   macos-intel-debug:

--- a/.github/workflows/ci-scripts/docker.sh
+++ b/.github/workflows/ci-scripts/docker.sh
@@ -92,7 +92,7 @@ else
     if [ "$TOOL" == "cmake" ]; then
         cmake -DCMAKE_BUILD_TYPE="$CFG" -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_NLS="$NLS" \
               -DEXTRA_FLAGS_CONFIG="-pipe" -DENABLE_STRICT_COMPILATION=true -DENABLE_LTO="$LTO" -DLTO_JOBS=2 -DENABLE_MYSQL=true \
-              -DCXX_STD="$CXX_STD" . || exit 1
+              -DFORCE_COLOR_OUTPUT=true -DCXX_STD="$CXX_STD" . || exit 1
         make conftests || exit 1
         make VERBOSE=1 -j2
         EXIT_VAL=$?
@@ -100,7 +100,7 @@ else
         scons wesnoth wesnothd campaignd boost_unit_tests build="$CFG" \
             ctool="$CC" cxxtool="$CXX" cxx_std="$CXX_STD" \
             extra_flags_config="-pipe" strict=true forum_user_handler=true \
-            nls="$NLS" enable_lto="$LTO" jobs=2 --debug=time
+            nls="$NLS" enable_lto="$LTO" force_color=true jobs=2 --debug=time
         EXIT_VAL=$?
     fi
 fi

--- a/.github/workflows/ci-scripts/docker.sh
+++ b/.github/workflows/ci-scripts/docker.sh
@@ -25,17 +25,23 @@ die() { error "$*"; exit 1; }
 # print given message ($1) and execute given command; sets EXIT_VAL on failure
 execute() {
     local message=$1; shift
-    printf 'Executing %s\n' "$message"
+    echo
+    echo -e "\e[1;34m -~=+=~-  ${message//?/-}\e[0m"
+    echo -e "\e[1;34mExecuting $message\e[0m"
+    echo -e "\e[1;34m -~=+=~-  ${message//?/-}\e[0m"
+    echo
     if "$@"; then
         : # success
     else
         EXIT_VAL=$?
-        echo "********** !FAILURE! **********"
-        echo "********** !FAILURE! **********"
-        echo "********** !FAILURE! **********"
-        echo "********** !FAILURE! **********"
-        echo "********** !FAILURE! **********"
+        echo -e "\e[1;31m********** !FAILURE! **********\e[0m"
+        echo -e "\e[1;31m********** !FAILURE! **********\e[0m"
+        echo -e "\e[1;31m********** !FAILURE! **********\e[0m"
+        echo -e "\e[1;31m********** !FAILURE! **********\e[0m"
+        echo -e "\e[1;31m********** !FAILURE! **********\e[0m"
+        echo
         error "$message failed! ($*)"
+        echo
     fi
 }
 

--- a/.github/workflows/ci-scripts/docker.sh
+++ b/.github/workflows/ci-scripts/docker.sh
@@ -123,7 +123,7 @@ execute "Whitespace and WML indentation check" checkindent
 execute "Doxygen check" ./utils/CI/doxygen-check.sh
 execute "WML tests" ./run_wml_tests -g -c -t 20
 execute "Play tests" ./utils/CI/play_test_executor.sh
-execute "MP tests" ./utils/CI/play_test_executor.sh
+execute "MP tests" ./utils/CI/mp_test_executor.sh
 execute "Boost unit tests" ./utils/CI/test_executor.sh
 
 if [ -f "errors.log" ]; then

--- a/.github/workflows/ci-scripts/ubuntu.sh
+++ b/.github/workflows/ci-scripts/ubuntu.sh
@@ -40,6 +40,6 @@ else
 
 		docker run ${tty+--tty} --cap-add=ALL --privileged \
 				--env BRANCH --env IMAGE --env NLS --env TOOL --env CC --env CXX \
-				--env CXX_STD --env CFG --env LTO \
+				--env CXX_STD --env CFG --env LTO --env CLICOLOR_FORCE \
 				wesnoth-repo:"$IMAGE"-"$BRANCH" ./.github/workflows/ci-scripts/docker.sh
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ option(ENABLE_DESIGN_DOCUMENTS "Enables the generation of design documents, and 
 option(ENABLE_LTO "Sets Link Time Optimization for Release builds" OFF)
 option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC" OFF)
 option(ENABLE_POT_UPDATE_TARGET "Enables the tools to update the pot files and manuals. This target has extra dependencies." OFF)
+option(FORCE_COLOR_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
 
 if(UNIX AND NOT APPLE AND NOT CYGWIN)
 	option(ENABLE_NOTIFICATIONS "Enable Window manager notification messages" ON)
@@ -212,6 +213,16 @@ if(NOT MSVC)
 		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=${SANITIZE}")
 		# manually disable some optimizations to get better stacktraces if sanitizers are used
 		set(COMPILER_FLAGS "${COMPILER_FLAGS} -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+	endif()
+
+### Force colour output (for example for Ninja, or piped CI)
+
+	if(FORCE_COLOR_OUTPUT)
+		if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+			set(COMPILER_FLAGS "${COMPILER_FLAGS} -fdiagnostics-color=always")
+		elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+			set(COMPILER_FLAGS "${COMPILER_FLAGS} -fcolor-diagnostics")
+		endif()
 	endif()
 
 ### Set the final compiler flags.

--- a/SConstruct
+++ b/SConstruct
@@ -114,7 +114,8 @@ opts.AddVariables(
     BoolVariable("autorevision", 'Use autorevision tool to fetch current git revision that will be embedded in version string', True),
     BoolVariable("lockfile", "Create a lockfile to prevent multiple instances of scons from being run at the same time on this working copy.", False),
     BoolVariable("OS_ENV", "Forward the entire OS environment to scons", False),
-    BoolVariable("history", "Clear to disable GNU history support in lua console", True)
+    BoolVariable("history", "Clear to disable GNU history support in lua console", True),
+    BoolVariable('force_color', 'Always produce ANSI-colored output (GNU/Clang only).', False),
     )
 
 #
@@ -488,6 +489,8 @@ for env in [test_env, client_env, env]:
 
         if env['pedantic']:
             env.AppendUnique(CXXFLAGS = Split("-Wdocumentation -Wno-documentation-deprecated-sync"))
+        if env['force_color']:
+            env.AppendUnique(CCFLAGS = ["-fcolor-diagnostics"])
 
     if "gcc" in env["TOOLS"]:
         env.AppendUnique(CCFLAGS = Split("-Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wtrampolines"))
@@ -501,6 +504,9 @@ for env in [test_env, client_env, env]:
         if env['sanitize']:
             env.AppendUnique(CCFLAGS = ["-fsanitize=" + env["sanitize"]], LINKFLAGS = ["-fsanitize=" + env["sanitize"]])
             env.AppendUnique(CCFLAGS = Split("-fno-omit-frame-pointer -fno-optimize-sibling-calls"))
+        if env['force_color']:
+            env.AppendUnique(CCFLAGS = ["-fdiagnostics-color=always"])
+
 
 # #
 # Determine optimization level

--- a/run_wml_tests
+++ b/run_wml_tests
@@ -237,7 +237,7 @@ class WesnothRunner:
             print("Wesnoth exited because of signal", -res.returncode)
             if options.backtrace:
                 print("Launching GDB for a backtrace...")
-                gdb_args = ["gdb", "-q", "-batch", "-ex", "start", "-ex", "continue", "-ex", "bt", "-ex", "quit", "--args"]
+                gdb_args = ["gdb", "-q", "-batch", "-ex", "set style enabled on", "-ex", "start", "-ex", "continue", "-ex", "bt", "-ex", "quit", "--args"]
                 gdb_args.extend(args)
                 subprocess.run(gdb_args, timeout=240)
             test_summary.crash_test(test_list)

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1142,8 +1142,8 @@ int main(int argc, char** argv)
 	} catch(const sdl::exception& e) {
 		std::cerr << e.what();
 		error_exit(1);
-	} catch(const game::error&) {
-		// A message has already been displayed.
+	} catch(const game::error& e) {
+		std::cerr << "Game error: " << e.what() << std::endl;
 		error_exit(1);
 	} catch(const std::bad_alloc&) {
 		std::cerr << "Ran out of memory. Aborted.\n";

--- a/utils/CI/play_test_executor.sh
+++ b/utils/CI/play_test_executor.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui 2> error.log
+gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui 2> error.log
 error_code="$?"
 while grep -q 'Could not initialize SDL_video' error.log; do
   echo "Could not initialize SDL_video error, retrying..."
-  gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui 2> error.log
+  gdb -q -batch -return-child-result -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./wesnoth -m --controller 1:ai --controller 2:ai --nogui 2> error.log
   error_code="$?"
 done
 cat error.log

--- a/utils/CI/schema_validation.sh
+++ b/utils/CI/schema_validation.sh
@@ -10,7 +10,7 @@ function validate_core()
     
     ./wesnoth --validate data/_main.cfg &> temp.log || SUCCESS="No"
     if [ "$SUCCESS" == "No" ]; then
-        echo "$NAME failed validation!"
+        echo -e "\e[1;31m$NAME failed validation!\e[0m"
         cat temp.log
         rm temp.log
     fi
@@ -32,7 +32,7 @@ function validate_misc()
     
     ./wesnoth --data-dir=. --validate=data/_main.cfg --preprocess-defines=$DEFINE &> temp.log || SUCCESS="No"
     if [ "$SUCCESS" == "No" ]; then
-        echo "$NAME failed validation!"
+        echo -e "\e[1;31m$NAME failed validation!\e[0m"
         cat temp.log
         rm temp.log
     fi
@@ -54,7 +54,7 @@ function validate_schema()
     
     ./wesnoth --data-dir=. --validate-schema=data/schema/$FILE.cfg &> temp.log || SUCCESS="No"
     if [ "$SUCCESS" == "No" ]; then
-        echo "$NAME failed validation!"
+        echo -e "\e[1;31m$NAME failed validation!\e[0m"
         cat temp.log
         rm temp.log
     fi
@@ -83,7 +83,7 @@ function validate_campaign()
             ./wesnoth --data-dir=. --validate=data/_main.cfg --preprocess-defines=$DEFINE,$DIFFICULTY &> temp.log || SUCCESS="No"
             
             if [ "$SUCCESS" == "No" ]; then
-                echo "$NAME failed $DIFFICULTY validation!"
+                echo -e "\e[1;31m$NAME failed $DIFFICULTY validation!\e[0m"
                 cat temp.log
             fi
             

--- a/utils/CI/test_executor.sh
+++ b/utils/CI/test_executor.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
+gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests --color_output --log_level=test_suite 2> error.log
 error_code="$?"
 while grep -q 'Could not initialize SDL_video' error.log; do
   echo "Could not initialize SDL_video error, retrying..."
-  gdb -q -batch -return-child-result -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
+  gdb -q -batch -return-child-result -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests --color_output --log_level=test_suite 2> error.log
   error_code="$?"
 done
 cat error.log

--- a/utils/CI/test_executor.sh
+++ b/utils/CI/test_executor.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
+gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
 error_code="$?"
 while grep -q 'Could not initialize SDL_video' error.log; do
   echo "Could not initialize SDL_video error, retrying..."
-  gdb -q -batch -return-child-result -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
+  gdb -q -batch -return-child-result -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests 2> error.log
   error_code="$?"
 done
 cat error.log

--- a/utils/CI/test_executor.sh
+++ b/utils/CI/test_executor.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests --color_output --log_level=test_suite 2> error.log
+gdb -q -batch -return-child-result -ex "set disable-randomization off" -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests --color_output --log_level=test_suite
 error_code="$?"
 while grep -q 'Could not initialize SDL_video' error.log; do
   echo "Could not initialize SDL_video error, retrying..."
-  gdb -q -batch -return-child-result -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests --color_output --log_level=test_suite 2> error.log
+  gdb -q -batch -return-child-result -ex "set style enabled on" -ex "run" -ex "thread apply all bt" -ex "quit" --args ./boost_unit_tests --color_output --log_level=test_suite
   error_code="$?"
 done
-cat error.log
 
 exit $error_code
 

--- a/utils/dockerbuilds/mingw/Dockerfile
+++ b/utils/dockerbuilds/mingw/Dockerfile
@@ -3,4 +3,4 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 COPY get_dlls.py /scripts/get_dlls.py
 
-ENTRYPOINT cd /output && scons -j `nproc` arch=x86-64 prefix=/msys64/mingw64 gtkdir=/msys64/mingw64 host=x86_64-w64-mingw32 -Y /wesnoth && python3 /scripts/get_dlls.py && rm -rf packaging && ln -sf /wesnoth/doc /wesnoth/packaging /wesnoth/data /wesnoth/fonts /wesnoth/images /wesnoth/sounds /wesnoth/README.md /wesnoth/copyright /wesnoth/COPYING /wesnoth/changelog.md /wesnoth/cwesnoth.cmd . && scons -Y /wesnoth windows-installer
+ENTRYPOINT cd /output && scons -j `nproc` arch=x86-64 prefix=/msys64/mingw64 gtkdir=/msys64/mingw64 host=x86_64-w64-mingw32 -Y /wesnoth force_color=true && python3 /scripts/get_dlls.py && rm -rf packaging && ln -sf /wesnoth/doc /wesnoth/packaging /wesnoth/data /wesnoth/fonts /wesnoth/images /wesnoth/sounds /wesnoth/README.md /wesnoth/copyright /wesnoth/COPYING /wesnoth/changelog.md /wesnoth/cwesnoth.cmd . && scons -Y /wesnoth windows-installer

--- a/utils/dockerbuilds/steamrt/Dockerfile
+++ b/utils/dockerbuilds/steamrt/Dockerfile
@@ -3,4 +3,4 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 COPY start.sh /staging/start.sh
 
-ENTRYPOINT mkdir -p /build && cd /build && scons -j `nproc` ctool=gcc-9 cxxtool=g++-9 boostdir=/usr/local/include boostlibdir=/usr/local/lib extra_flags_config=-lrt -Y /wesnoth && cp /build/wesnoth /output/ && cp /build/wesnothd /output/ && cp -r /staging/* /output/
+ENTRYPOINT mkdir -p /build && cd /build && scons -j `nproc` ctool=gcc-9 cxxtool=g++-9 boostdir=/usr/local/include boostlibdir=/usr/local/lib extra_flags_config=-lrt -Y /wesnoth force_color=true && cp /build/wesnoth /output/ && cp /build/wesnothd /output/ && cp -r /staging/* /output/


### PR DESCRIPTION
Adds colours to CI output in a variety of places. Most notably:

* compiler error messages (this was actually already working, but now it's explicit)
* cmake progress stages
* test section headers (these were also made more distinct with a border and spacing)
* test section failure messages
* WML validation failures
* gdb backtraces
* boost test suite stages are now displayed, in colour (they weren't previously displayed at all)

The coloured outputs only really work in the linux builds. I'm not sure what the equivalent commands are on mac and windows, if any.

I also ran into a couple other problems during this, so fixed them in some additional commits.

* game::error messages weren't always being displayed on exit
* the MP Test executor was not actually running MP Tests, but duplicating Play Tests, so i fixed that as well