### PR TITLE
Fix wmlindent quote detection

### DIFF
--- a/data/ai/micro_ais/scenarios/animals.cfg
+++ b/data/ai/micro_ais/scenarios/animals.cfg
@@ -346,7 +346,6 @@
             message= _ "<span color='#A00000'>Important:</span> The animal Micro AIs in this scenario are written for a number of animal unit types that do not exist in Wesnoth mainline, such as sheep, sheep dogs, or deer. In this test scenario, these units have been replaced by mainline units."
         [/message]
 
-        # wmlindent: start ignoring
         [message]
             speaker=narrator
             image=wesnoth-icon.png
@@ -354,7 +353,6 @@
 
 "+{ANIMAL_AI_DESCRIPTIONS1}
         [/message]
-        # wmlindent: stop ignoring
         [message]
             speaker=narrator
             image=wesnoth-icon.png
@@ -366,13 +364,11 @@
             caption= _ "Question for the Player"
             image=wesnoth-icon.png
             # wmllint: unbalanced-on
-            # wmlindent: start ignoring
             message= _ "It is possible to include a human-controlled Side 1, so that the action stops once every turn for looking around (or to mess with things in debug mode).
 
 Note that there is no end to this scenario. For demonstration purposes, any unit that is killed is replaced by another unit of the same type at the beginning of the next turn. In order to end the scenario, there's a right-click option - but that only works in human-controlled mode. In AI-only mode, you have to press 'Esc' or reload a previous savefile.
 
 Also note: The Animal AIs are coded as Micro AIs. A Micro AI can be added and adapted to the need of a scenario easily using only WML and the [micro_ai] tag. Check out the <span color='#00A000'>Micro AI wiki page</span> at https://wiki.wesnoth.org/Micro_AIs for more information."  # wmllint: no spellcheck
-            # wmlindent: stop ignoring
             # wmllint: unbalanced-off
             [option]
                 label= _ "<span font='16'>I'll just watch the animals.</span>"
@@ -426,13 +422,11 @@ Also note: The Animal AIs are coded as Micro AIs. A Micro AI can be added and ad
             type=Wolf
         [/filter_second]
 
-        # wmlindent: start ignoring
         [message]
             speaker=$second_unit.id
             message= _ "Yowl!
 Translation: Those boars are mean!  We better stay away from them and their young."
         [/message]
-        # wmlindent: stop ignoring
 
         [micro_ai]
             side=6

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -197,7 +197,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:OVERLAY             *^Do                                               village/desert-oasis-3}
 
 # Swamp
-# To aid those updating terrain macros in 1.17/1.18, this next macro used to be 
+# To aid those updating terrain macros in 1.17/1.18, this next macro used to be
 # {OVERLAY_COMPLETE_LF     Ss        (!,Xv,Chs,!,C*,H*,M*,X*,Q*,A*,Ke,Kea,Kud*,I*) -85 base2      swamp/reed}
 {NEW:OVERLAY              Ss                                                swamp/reed LAYER=-85 FLAG=base2 ADJACENT="!,Xv,Chs,!,C*,H*,M*,X*,Q*,A*,Ke,Kea,Kud*,I*" }
 
@@ -207,7 +207,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:VOLCANO_2x2             Mv              Mm,Md                       mountains/volcano6 FLAG=base2}
 
 # Single-hex volcano
-{NEW:OVERLAY             Mv                                                mountains/volcano  BASE=140,140 FLAG=base2 ADJACENT="!,Xv,Mv,!,C*,K*,X*,Q*"}               
+{NEW:OVERLAY             Mv                                                mountains/volcano  BASE=140,140 FLAG=base2 ADJACENT="!,Xv,Mv,!,C*,K*,X*,Q*"}
 
 {NEW:OVERLAY             Mv                                       misc/smoke-A CENTER=90,108 ANIM=[01~12] TIME=100}
 
@@ -265,7 +265,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:BASE              Ms                                                        hills/snow}
 
 # Desert Mountains
-# To aid those updating terrain macros in 1.17/1.18, this next macro used to be 
+# To aid those updating terrain macros in 1.17/1.18, this next macro used to be
 # {OVERLAY_ROTATION_RESTRICTED2_F  Mdd        (!,Xv,!,C*,K*,X*,Ql,Qx*)      base2  desert_mountains/desert-castle}
 # {OVERLAY_ROTATION_RESTRICTED_F   Mdd        (!,Xv,!,C*,K*,X*,Ql,Qx*)      base2  desert_mountains/desert-castle@V}
 {NEW:OVERLAY             Mdd                                                   desert_mountains/desert BASE=72,72 FLAG=base2 ADJACENT="!,Xv,!,C*,K*,X*,Ql,Qx*" }
@@ -296,7 +296,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:OVERLAY             Mdd^Xm                                  desert_mountains/peak LAYER=2 FLAG=peaks}
 # {OVERLAY_RANDOM_LF       Mdd^Xm                                2         peaks   desert_mountains/peak}
 
-# To aid those updating terrain macros in 1.17/1.18, this next macro used to be 
+# To aid those updating terrain macros in 1.17/1.18, this next macro used to be
 # {OVERLAY_LF              *^Xm                                  1         clouds  mountains/cloud@V}
 {NEW:OVERLAY             *^Xm                                  mountains/cloud@V LAYER=1 FLAG=clouds}
 {NEW:PEAKS_1x2_SW_NE         *^Xm                                    mountains/peak_range1 FLAG=peaks PROB=15}
@@ -419,7 +419,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:OVERLAY             *^Gvs                                                     embellishments/farm-veg-spring LAYER=-81}
 
 # Water Lillies
-# To aid those updating terrain macros in 1.17/1.18, this next macro used to be 
+# To aid those updating terrain macros in 1.17/1.18, this next macro used to be
 # {OVERLAY_COMPLETE_L        *^Ewl         (C*,K*,X*,Ql*,Qx*,G*,M*,*^V*,R*,A*,D*,U*,H*)     -86      embellishments/water-lilies}
 {NEW:OVERLAY        *^Ewl                                                          embellishments/water-lilies LAYER=-86 ADJACENT="C*,K*,X*,Ql*,Qx*,G*,M*,*^V*,R*,A*,D*,U*,H*"}
 {NEW:OVERLAY        *^Ewf                                                          embellishments/water-lilies-flower LAYER=-86 ADJACENT="C*,K*,X*,Ql*,Qx*,G*,M*,*^V*,R*,A*,D*,U*,H*"}
@@ -525,7 +525,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:BASE                Rrd                                                       flat/sandy-path}
 {NEW:BASE                Rrc                                                       flat/road-clean}
 {NEW:BASE                Rp                                                        flat/stone-path}
-{NEW:BASE                Rra                                                       flat/road-icy} 
+{NEW:BASE                Rra                                                       flat/road-icy}
 
 # Hills base terrain
 {NEW:BASE                Hh                                                        hills/regular}
@@ -585,7 +585,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:BASE                Iwr,Icn                                                       interior/wood-regular LAYER=-284 FLAG=raised_base}
 {NEW:BASE                Ior                                                       interior/wood-ruined LAYER=-284 FLAG=raised_base}
 {NEW:BASE                Irs,Icr                                                       interior/stone-regular LAYER=-284 FLAG=raised_base}
-
 
 # Water base terrains
 {NEW:OVERLAY             Wwf                                                       water/ford FLAG=ford LAYER=-519}
@@ -721,7 +720,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:CASTLEWALL2            Koa           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/winter-orcish/keep-fort}
 {NEW:CASTLEWALL             Koa           (Ke,Kea,!,K*,Xu*,Xo*) K*                castle/winter-orcish/keep}
 
-
 # Desert castles
 
 {NEW:CASTLEWALL             Cd            (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/sand/castle}
@@ -743,7 +741,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:CASTLEWALL             Cha           (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/snowy/castle}
 {NEW:CASTLEWALL2            Kha           !,Ket,!,C*,Ke*        (!,C*,K*,Xu*,Xo*) castle/snowy/keep-castle}
 {NEW:CASTLEWALL             Kha           (Ke,Kea,!,K*,Xu*,Xo*) K*                castle/snowy/keep}
-
 
 # sunken/swamp ruins (submerged part)
 # Show sunken graphics for sunken castle only when next to water terrain
@@ -784,7 +781,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:CASTLEWALL             Cea,Kea       (!,C*,K*,Xu*,Xo*)     !,Ket,!,C*,Ke*    castle/encampment/snow}
 {NEW:CASTLEWALL2            Ket           (!,Ket,!,C*,Ke*)                  (!,C*,K*,Xu*,Xo*) castle/encampment/tall-keep-castle}
 {NEW:CASTLEWALL             Ket           (!,Ket,!,Ke*,!,K*,Xu*,Xo*)        K*                castle/encampment/tall-keep}
-
 
 # Castle & Encampment Base Transtions
 
@@ -907,7 +903,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:WALL                        Xo*           (!,Xu*,Xo*)      walls/stone/wall-stone}
 
 # New Generic Castle-to Chasm transition
-# To aid those updating terrain macros in 1.17/1.18, these next macros used to be 
+# To aid those updating terrain macros in 1.17/1.18, these next macros used to be
 # {TRANSITION_COMPLETE_LF (Cha,Kha,Coa,Koa,Cea,Kea,Cfa,Kfa)        Qx*                   -89    transition2   chasm/regular-snow-castle}
 # {TRANSITION_COMPLETE_LF (!,Cud*,Kud*,!,C*,K*)              Qxe                   -89    transition2   chasm/earthy-castle}
 # {TRANSITION_COMPLETE_LF (!,Cud*,Kud*,!,C*,K*)              Qx*                   -89    transition2   chasm/regular-castle}
@@ -935,7 +931,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 
 {NEW:TRANSITION_INTRA    (Xo*)                            -289   chasm/regular-castle FLAG=transition2 ADJACENT="Qx*"}
 
-
 # Stone wall transitions
 # the doubled comma is to improve transitions with the map edge
 # {WALL_ADJACENT_TRANSITION Xol (!,,Xo*,Xu*) ANIMATION_10 walls/wall-stone-lit}
@@ -949,7 +944,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 # layer numbers are used to make some special transitions to layer in more
 # complex ways.
 # Default layer is -500, so anything layering above should be higher.
-
 
 {NEW:TRANSITION_INTRA   (!,W*^Dr,!,*^Dr)           -158     misc/rubble FLAG=intra}
 {NEW:TRANSITION_INTRA   (*^Esd)           -158    embellishments/rocks  FLAG=intra}
@@ -998,11 +992,9 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION             Gg              Gs,Gd,Gll                          -256                 grass/green-long}
 {NEW:TRANSITION             Gs              Gg,Gd,Gll                          -257                 grass/semi-dry-long}
 
-
 {NEW:TRANSITION            Gs               (R*,D*,Aa,Ur,Urc,Ias)                    -260                   grass/semi-dry-medium}
 {NEW:TRANSITION            Gg               (R*,D*,Aa,Ur,Urc,Ias)                    -261                   grass/green-medium}
 {NEW:TRANSITION            Gd               (R*,D*,Aa,Ur,Urc,Ias)                    -262                   grass/dry-medium}
-
 
 {NEW:TRANSITION            Gll              (!,Gll,Q*,W*,Ai,C*,K*)            -270                  grass/leaf-litter}
 {NEW:TRANSITION            (Gg*,Qx*)        (!,Gg*,Q*,Mm,Ms,Hh,C*,K*)         -271                  grass/green-abrupt}
@@ -1038,7 +1030,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION            Ds               (!,Ds,W*,S*,Ai,Q*)                 -510                 sand/beach}
 {NEW:TRANSITION            Dd               (!,R*,Dd,W*,S*,Ai,Q*)              -510                 sand/desert}
 
-
 #  Dirt transitions are double sided
 {NEW:TRANSITION            (!,Rd,Rr*,Hh*,M*,Q*,D*,T*)           Rd                   -370                 flat/desert-road FLAG=inside}
 {NEW:TRANSITION            Rd                      (!,Rd,W*,Ai,Q*,D*,T*)             -371                 flat/desert-road}
@@ -1052,7 +1043,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION            Rb                              Ias                       -384                 flat/dirt-dark FLAG=inside}
 {NEW:TRANSITION            Ias                             Rb                        -388                 flat/dirt-dark}
 
-
 # This complicated part keeps the submerged part of ice or a bank from drawing over the above-water parts of banks or ice
 
 {NEW:TRANSITION            (!,Chw,Khw,Khs,!,C*,K*)       (Ai,W*)    -480        castle/castle-to-ice   FLAG=non_submerged}
@@ -1061,7 +1051,6 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 {NEW:TRANSITION            (Md,Hhd,Mv)          Ai,W*,S*            -482        hills/dry-to-water     FLAG=non_submerged}
 {NEW:TRANSITION            (!,Rra,Rrd,!,R*,G*,Uue,Ias)      Ai,W*               -483        flat/bank-to-ice       FLAG=non_submerged}
 {NEW:TRANSITION            (U*,Xu*,Ql*)         Ai,W*,S*            -486        cave/bank              FLAG=non_submerged}
-
 
 {NEW:TRANSITION            Aa,Ai                    (D*,Rrd)                -485        frozen/ice             FLAG=non_submerged}
 {NEW:TRANSITION            Aa,Ha,Ms,Ai,Rra          (W*,S*)             -485        frozen/ice             FLAG=non_submerged}
@@ -1073,10 +1062,8 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 # not needed for most core terrains, but can be useful for some UMC without transitions
 {NEW:TRANSITION            Ur                        (!,Ur*)              -506                      cave/path}
 
-
 # Beaches
 {NEW:GENERIC_CORNER_TRANSITION (!,D*,Hd,Chw,Khw,Khs,W*,S*,Xv,Qx*,A*,Rra,Rrd,_*)  W*  -500  water/bottom  masks/long ""}
-
 
 # Water Transitions below everything else
 

--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -1,5 +1,4 @@
 #textdomain wesnoth
-#wmlindent: start ignoring
 # This file needs to be processed *after* all others in this directory
 #
 # The following flags are defined to have a meaning
@@ -1125,5 +1124,3 @@ C*,K*,X*,Q*,W*,Ai,M*,*^V*,*^B*,_off^_usr#enddef
 #undef TG_RSTAR_NOT_RRD
 
 #############################################################
-
-#wmlindent: stop ignoring

--- a/data/core/units/orcs/Assassin.cfg
+++ b/data/core/units/orcs/Assassin.cfg
@@ -92,7 +92,7 @@
             [frame]
                 image=units/orcs/assassin-bob-lo.png:350,units/orcs/assassin.png:350
             [/frame]
-            [frame] 
+            [frame]
                 image="units/orcs/assassin-bob-[hi,hi2,hi].png:[350*3]"
             [/frame]
             [frame]
@@ -105,7 +105,7 @@
             [frame]
                 image=units/orcs/assassin-bob-lo.png:350,units/orcs/assassin.png:350
             [/frame]
-            [frame] 
+            [frame]
                 image="units/orcs/assassin-bob-[hi,hi2,hi].png:[350*3]"
             [/frame]
             [frame]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -2599,7 +2599,6 @@ Also, 0..9 = $below_ten, one,two,three = $ascii and the bonus answer is $mixed."
             x,y,side=17,9,1
         [/filter]
 
-#wmlindent: start ignoring
         [message]
             speaker=unit
             message=_"Battle for Wesnoth User’s Manual
@@ -2639,7 +2638,6 @@ In the world of Wesnoth there dwell humans, elves, dwarves, orcs, drakes, sauria
 
 For game purposes, the races group into factions; for example, orcs often cooperate with trolls, and elves or dwarves with humans. Some other factions reflect divisions within human society — loyalists vs. outlaws, for example. In most campaigns, you will control units drawn from a single faction. But sometimes factions make alliances with others, so you may face more than one faction in a scenario."
         [/message]
-#wmlindent: stop ignoring
     [/event]
 
     {PLACE_IMAGE items/book1.png 2 2}
@@ -2689,7 +2687,6 @@ For game purposes, the races group into factions; for example, orcs often cooper
 
         [modify_side]
             side=1
-#wmlindent: start ignoring
             shroud_data="|111111111111
 |1111111111111
 |1111111111111
@@ -2728,7 +2725,6 @@ For game purposes, the races group into factions; for example, orcs often cooper
 |000000000000000111111
 |00000000000000011111
 "
-#wmlindent: stop ignoring
         [/modify_side]
     [/event]
 
@@ -3420,7 +3416,6 @@ For game purposes, the races group into factions; for example, orcs often cooper
         [terrain_mask]
             x,y=20,1
             border=no
-#wmlindent: start ignoring
             mask="
 _s, _s, _s, _s, Aa, Aa, _s, _s, _s, _s
 _s, _s, _s, Aa, Aa, Aa, Aa, _s, _s, _s
@@ -3433,7 +3428,6 @@ _s, _s, Aa, Aa, Aa, Aa, Aa, Aa, _s, _s
 _s, _s, _s, Aa, Aa, Aa, Aa, _s, _s, _s
 _s, _s, _s, _s, Aa, Aa, _s, _s, _s, _s
 "
-#wmlindent: stop ignoring
             [rule]
                 old=Gg^Vh
                 new=Aa
@@ -3478,14 +3472,12 @@ _s, _s, _s, _s, Aa, Aa, _s, _s, _s, _s
         [terrain_mask]
             x,y=8,11
             border=no
-#wmlindent: start ignoring
             mask="
 ^Ft, ^Ft, ^Ft, ^Ft
 ^Ft, ^Ft, ^Ft, ^Ft
 ^Ft, ^Ft, ^Ft, ^Ft
 ^Ft, ^Ft, ^Ft, ^Ft
 "
-#wmlindent: stop ignoring
             [rule]
                 old=*^F*
                 layer=overlay
@@ -3519,14 +3511,12 @@ _s, _s, _s, _s, Aa, Aa, _s, _s, _s, _s
         [terrain_mask]
             x,y=8,11
             border=no
-#wmlindent: start ignoring
             mask="
 Ww, Ww, Ww, Ww
 Ww, Ww, Ww, Ww
 Ww, Ww, Ww, Ww
 Ww, Ww, Ww, Ww
 "
-#wmlindent: stop ignoring
             [rule]
                 old=*^Ve*
                 layer=base
@@ -3595,13 +3585,11 @@ Ww, Ww, Ww, Ww
                 [/message]
                 [message]
                     speaker=narrator
-#wmlindent: start ignoring
                     message="Formula:
 <span color='green'>    $formula</span>
 Result:
 <span color='red'>    $(debug_print( 'Result: ', ($formula) ))</span>
 "
-#wmlindent: stop ignoring
                 [/message]
             [/command]
         [/set_menu_item]

--- a/data/tools/wmlindent
+++ b/data/tools/wmlindent
@@ -103,6 +103,29 @@ class bailout(Exception):
         self.lineno = lineno
         self.msg = msg
 
+def strip_comment(line, in_string):
+    """
+    Strip a trailing comment from a line, if present.
+    Allows for unbalanced quotes, where comment characters are literal.
+    """
+    if not line:
+        return line
+    split = line.split('"')
+    result = split[0]
+    if not in_string and '#' in result:
+        return result.split('#')[0].rstrip();
+    split.pop(0)
+    for component in split:
+        in_string = not in_string
+        result += '"'
+        # If we end up outside a string and there's a comment, we're done
+        if not in_string and '#' in component:
+            result += component.split('#')[0]
+            break
+        else:
+            result += component
+    return result.rstrip()
+
 def reindent(name, infp, outfp):
     "Reindent WML."
     dostrip = True
@@ -208,10 +231,7 @@ def reindent(name, infp, outfp):
             instring = False
         # Compute the dostrip state likewise.
         # We look for unbalanced string quotes.
-        if dostrip:
-            eligible = re.split("\s#", transformed)[0]
-        else:
-            eligible = transformed
+        eligible = strip_comment(transformed, not dostrip)
         if dostrip and "<<" in eligible and not ">>" in eligible.split("<<", 1)[1]:
             dostrip = False
             in_lua = True
@@ -228,7 +248,7 @@ def reindent(name, infp, outfp):
             lasttag = ""
     # Pure macro files look like they have unbalanced indents.  That's OK
     if indent_level != 0 and seen_wml:
-        print('wmlindent: "%s". line %d: end of file with indent nonzero.' % (name, countlines), file=sys.stderr)
+        print('wmlindent: "%s". line %d: end of file with indent nonzero (%d).' % (name, countlines, indent_level), file=sys.stderr)
 
 def allwmlfiles(directory):
     "Get names of all WML files under dir, or dir itself if not a directory."


### PR DESCRIPTION
There's been a persistent wmlindent warning in the CI logs for awhile now, so I thought I'd fix it. This prevents wmlindent from treating commented-out quotes as opening or closing a string.

I also removed several ignore directives that were clear workarounds for the bug, as well as a clearly-pointless pair in terrain-graphics.cfg. As you can see, there are no actual changes in the wmlindent run as a result, other than the removal of trailing whitespace.