### PR TITLE
High-res tiled textures

### DIFF
--- a/data/gui/widget/panel_box_display.cfg
+++ b/data/gui/widget/panel_box_display.cfg
@@ -29,6 +29,8 @@
 
 					border_thickness = 3
 					border_color = "16, 22, 35, 255"
+
+					fill_color = "0, 0, 0, 137"
 				[/rectangle]
 
 				[rectangle]
@@ -40,14 +42,6 @@
 					border_thickness = 1
 					border_color = {GUI__BORDER_COLOR_DARK}
 				[/rectangle]
-
-				[image]
-					x = 3
-					y = 3
-					w = "(width - 6)"
-					h = "(height - 6)"
-					name = "dialogs/translucent54-background.png"
-				[/image]
 
 			[/draw]
 

--- a/data/gui/widget/window_borderless.cfg
+++ b/data/gui/widget/window_borderless.cfg
@@ -23,7 +23,7 @@
 					w = "(width)"
 					h = "(height)"
 					name = "dialogs/opaque-background.png"
-					resize_mode = "tile"
+					resize_mode = "tile_highres"
 				[/image]
 
 				{_BACKGROUND_DRAW}

--- a/data/gui/widget/window_default.cfg
+++ b/data/gui/widget/window_default.cfg
@@ -48,7 +48,7 @@
 					w = "(width - 4)"
 					h = "(height - 4)"
 					name = "dialogs/{BASE_NAME}-background.png"
-					resize_mode = "tile"
+					resize_mode = "tile_highres"
 				[/image]
 
 			[/draw]
@@ -152,7 +152,7 @@
 					w = "(width)"
 					h = "(height)"
 					name = "dialogs/menu-background.png"
-					resize_mode = "tile"
+					resize_mode = "tile_highres"
 				[/image]
 
 				[rectangle]

--- a/data/schema/gui.cfg
+++ b/data/schema/gui.cfg
@@ -31,7 +31,7 @@
     [/type]
     [type]
         name=resize_mode
-        value="scale|scale_sharp|stretch|tile|tile_center"
+        value="scale|scale_sharp|stretch|tile|tile_center|tile_highres"
     [/type]
     [type]
         name=scrollbar_mode

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -572,7 +572,7 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 	fmt.insert("Window size", geometry_to_string(
 		video.current_resolution().x, video.current_resolution().y));
 	fmt.insert("Game canvas size", geometry_to_string(
-		video.get_width(), video.get_height()));
+		video.draw_area().w, video.draw_area().h));
 	fmt.insert("Final render target size", geometry_to_string(
 		video.output_size().x, video.output_size().y));
 	fmt.insert("Screen refresh rate", std::to_string(video.current_refresh_rate()));

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -314,7 +314,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 			dy -= scroll_amount;
 		}
 
-		if(mousey > get_display().video().get_height() - scroll_threshold) {
+		if(mousey > get_display().video().draw_area().h - scroll_threshold) {
 			dy += scroll_amount;
 		}
 
@@ -322,7 +322,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 			dx -= scroll_amount;
 		}
 
-		if(mousex > get_display().video().get_width() - scroll_threshold) {
+		if(mousex > get_display().video().draw_area().w - scroll_threshold) {
 			dx += scroll_amount;
 		}
 	}

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -15,6 +15,7 @@
 #include "draw.hpp"
 
 #include "color.hpp"
+#include "log.hpp"
 #include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
@@ -22,6 +23,12 @@
 
 #include <SDL2/SDL_rect.h>
 #include <SDL2/SDL_render.h>
+
+static lg::log_domain log_draw("draw");
+#define DBG_D LOG_STREAM(debug, log_draw)
+#define WRN_D LOG_STREAM(warn, log_draw)
+
+using std::endl;
 
 static SDL_Renderer* renderer()
 {
@@ -36,6 +43,8 @@ void draw::fill(
 	const SDL_Rect& area,
 	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+	DBG_D << "fill " << area
+	      << " [" << r << ',' << g << ',' << b << ',' << a << ']' << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
 	SDL_RenderFillRect(renderer(), &area);
 }
@@ -54,32 +63,41 @@ void draw::fill(const SDL_Rect& area, const color_t& c)
 
 void draw::fill(const SDL_Rect& area)
 {
+	DBG_D << "fill " << area << endl;
 	SDL_RenderFillRect(renderer(), &area);
 }
 
 void draw::set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+	DBG_D << "set color "
+	      << " [" << r << ',' << g << ',' << b << ',' << a << ']' << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
 }
 
 void draw::set_color(uint8_t r, uint8_t g, uint8_t b)
 {
+	DBG_D << "set color "
+	      << " [" << r << ',' << g << ',' << b << ']' << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, SDL_ALPHA_OPAQUE);
 }
 
 void draw::set_color(const color_t& c)
 {
+	DBG_D << "set color " << c << endl;
 	SDL_SetRenderDrawColor(renderer(), c.r, c.g, c.b, c.a);
 }
 
 void draw::rect(const SDL_Rect& rect)
 {
+	DBG_D << "rect " << rect << endl;
 	SDL_RenderDrawRect(renderer(), &rect);
 }
 
 void draw::rect(const SDL_Rect& rect,
 	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
+	DBG_D << "rect " << rect
+	      << " [" << r << ',' << g << ',' << b << ',' << a << ']' << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
 	SDL_RenderDrawRect(renderer(), &rect);
 }
@@ -96,22 +114,29 @@ void draw::rect(const SDL_Rect& rect, const color_t& c)
 
 void draw::line(int from_x, int from_y, int to_x, int to_y)
 {
+	DBG_D << "line from (" << from_x << ',' << from_y
+	      << ") to (" << to_x << ',' << to_y << ')' << endl;
 	SDL_RenderDrawLine(renderer(), from_x, from_y, to_x, to_y);
 }
 
 void draw::line(int from_x, int from_y, int to_x, int to_y, const color_t& c)
 {
+	DBG_D << "line from (" << from_x << ',' << from_y
+	      << ") to (" << to_x << ',' << to_y
+	      << ") with colour " << c << endl;
 	SDL_SetRenderDrawColor(renderer(), c.r, c.g, c.b, c.a);
 	SDL_RenderDrawLine(renderer(), from_x, from_y, to_x, to_y);
 }
 
 void draw::points(const std::vector<SDL_Point>& points)
 {
+	DBG_D << points.size() << " points" << endl;
 	SDL_RenderDrawPoints(renderer(), points.data(), points.size());
 }
 
 void draw::point(int x, int y)
 {
+	DBG_D << "point (" << x << ',' << y << ')' << endl;
 	SDL_RenderDrawPoint(renderer(), x, y);
 }
 
@@ -123,6 +148,9 @@ void draw::circle(int cx, int cy, int r, const color_t& c, uint8_t octants)
 
 void draw::circle(int cx, int cy, int r, uint8_t octants)
 {
+	DBG_D << "circle (" << cx << ',' << cy
+	      << ") -> " << r << ", oct " << int(octants) << endl;
+
 	// Algorithm based on
 	// http://de.wikipedia.org/wiki/Rasterung_von_Kreisen#Methode_von_Horn
 	// version of 2011.02.07.
@@ -162,6 +190,9 @@ void draw::disc(int cx, int cy, int r, const color_t& c, uint8_t octants)
 
 void draw::disc(int cx, int cy, int r, uint8_t octants)
 {
+	DBG_D << "disc (" << cx << ',' << cy
+	      << ") -> " << r << ", oct " << int(octants) << endl;
+
 	int d = -r;
 	int x = r;
 	int y = 0;
@@ -213,19 +244,25 @@ void draw::disc(int cx, int cy, int r, uint8_t octants)
 
 void draw::blit(const texture& tex, const SDL_Rect& dst, const SDL_Rect& src)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null blit" << endl; return; }
+	DBG_D << "blit " << dst << " from " << src << endl;
+
 	SDL_RenderCopy(renderer(), tex, &src, &dst);
 }
 
 void draw::blit(const texture& tex, const SDL_Rect& dst)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null blit" << endl; return; }
+	DBG_D << "blit " << dst << endl;
+
 	SDL_RenderCopy(renderer(), tex, nullptr, &dst);
 }
 
 void draw::blit(const texture& tex)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null blit" << endl; return; }
+	DBG_D << "blit" << endl;
+
 	SDL_RenderCopy(renderer(), tex, nullptr, nullptr);
 }
 
@@ -246,7 +283,10 @@ void draw::flipped(
 	bool flip_h,
 	bool flip_v)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null flipped" << endl; return; }
+	DBG_D << "flipped (" << flip_h << '|' << flip_v
+	      << ") to " << dst << " from " << src << endl;
+
 	SDL_RendererFlip flip = get_flip(flip_h, flip_v);
 	SDL_RenderCopyEx(renderer(), tex, &src, &dst, 0.0, nullptr, flip);
 }
@@ -257,14 +297,19 @@ void draw::flipped(
 	bool flip_h,
 	bool flip_v)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null flipped" << endl; return; }
+	DBG_D << "flipped (" << flip_h << '|' << flip_v
+	      << ") to " << dst << endl;
+
 	SDL_RendererFlip flip = get_flip(flip_h, flip_v);
 	SDL_RenderCopyEx(renderer(), tex, nullptr, &dst, 0.0, nullptr, flip);
 }
 
 void draw::flipped(const texture& tex, bool flip_h, bool flip_v)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null flipped" << endl; return; }
+	DBG_D << "flipped (" << flip_h << '|' << flip_v << ')' << endl;
+
 	SDL_RendererFlip flip = get_flip(flip_h, flip_v);
 	SDL_RenderCopyEx(renderer(), tex, nullptr, nullptr, 0.0, nullptr, flip);
 }
@@ -274,7 +319,9 @@ void draw::flipped(const texture& tex, bool flip_h, bool flip_v)
 void draw::tiled(const texture& tex, const SDL_Rect& dst, bool centered,
 	bool mirrored)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null tiled" << endl; return; }
+	DBG_D << "tiled (" << centered << '|' << mirrored
+	      << ") " << dst << endl;
 
 	// Reduce clip to dst.
 	auto clipper = draw::reduce_clip(dst);
@@ -300,7 +347,9 @@ void draw::tiled(const texture& tex, const SDL_Rect& dst, bool centered,
 void draw::tiled_highres(const texture& tex, const SDL_Rect& dst,
 	bool centered, bool mirrored)
 {
-	if (!tex) { return; }
+	if (!tex) { DBG_D << "null tiled_highres" << endl; return; }
+	DBG_D << "tiled_highres (" << centered << '|' << mirrored
+	      << ") " << dst << endl;
 
 	const int pixel_scale = CVideo::get_singleton().get_pixel_scale();
 
@@ -365,7 +414,12 @@ draw::clip_setter draw::reduce_clip(const SDL_Rect& clip)
 void draw::force_clip(const SDL_Rect& clip)
 {
 	// TODO: highdpi - fix whatever reason there is for this guard (CI fail)
-	if (!renderer()) { return; }
+	if (!renderer()) {
+		WRN_D << "trying to force clip will null renderer" << endl;
+		return;
+	}
+	DBG_D << "forcing clip to " << clip << endl;
+
 	SDL_RenderSetClipRect(renderer(), &clip);
 }
 
@@ -406,12 +460,19 @@ draw::viewport_setter draw::set_viewport(const SDL_Rect& viewport)
 
 void draw::force_viewport(const SDL_Rect& viewport)
 {
+	if (!renderer()) {
+		WRN_D << "trying to force viewport will null renderer" << endl;
+		return;
+	}
+	DBG_D << "forcing viewport to " << viewport << endl;
+
 	SDL_RenderSetViewport(renderer(), &viewport);
 }
 
 SDL_Rect draw::get_viewport()
 {
 	if (!renderer()) {
+		WRN_D << "no renderer available to get viewport" << endl;
 		return sdl::empty_rect;
 	}
 
@@ -433,6 +494,11 @@ draw::render_target_setter::render_target_setter(const texture& t)
 	// Validate we can render to this texture.
 	assert(t.get_info().access == SDL_TEXTUREACCESS_TARGET);
 
+	if (!renderer()) {
+		WRN_D << "can't set render target with null renderer" << endl;
+		return;
+	}
+
 	target_ = CVideo::get_singleton().get_render_target();
 	SDL_RenderGetViewport(renderer(), &viewport_);
 
@@ -441,11 +507,17 @@ draw::render_target_setter::render_target_setter(const texture& t)
 
 draw::render_target_setter::~render_target_setter()
 {
+	if (!renderer()) {
+		WRN_D << "can't reset render target with null renderer" << endl;
+		return;
+	}
 	CVideo::get_singleton().force_render_target(target_);
 	SDL_RenderSetViewport(renderer(), &viewport_);
 }
 
 draw::render_target_setter draw::set_render_target(const texture& t)
 {
+	DBG_D << "setting render target to "
+	      << t.w() << 'x' << t.h() << " texture" << endl;
 	return draw::render_target_setter(t);
 }

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -238,6 +238,8 @@ void flipped(const texture& tex, bool flip_h = true, bool flip_v = false);
 /**
  * Tile a texture to fill a region.
  *
+ * This function tiles the texture in draw-space.
+ *
  * The texture may be aligned either with its center at the center
  * of the region, or with its top-left corner at the top-left corner
  * of the region.
@@ -251,6 +253,17 @@ void flipped(const texture& tex, bool flip_h = true, bool flip_v = false);
  *                  better for images that are not perfect tiles.
  */
 void tiled(const texture& tex,
+	const SDL_Rect& dst,
+	bool centered = false,
+	bool mirrored = false
+);
+
+/** Tile a texture to fill a region.
+ *
+ * This function tiles the texture in output space. It is otherwise
+ * identical to draw::tiled().
+ */
+void tiled_highres(const texture& tex,
 	const SDL_Rect& dst,
 	bool centered = false,
 	bool mirrored = false

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -431,6 +431,9 @@ void image_shape::draw(
 	case (resize_mode::tile_center):
 		draw::tiled(tex, adjusted_draw_loc, true, mirror_(variables));
 		break;
+	case resize_mode::tile_highres:
+		draw::tiled_highres(tex, adjusted_draw_loc, false, mirror_(variables));
+		break;
 	case resize_mode::stretch:
 		// Stretching is identical to scaling in terms of handling.
 		// Is this intended? That's what previous code was doing.
@@ -456,6 +459,8 @@ image_shape::resize_mode image_shape::get_resize_mode(const std::string& resize_
 		return resize_mode::tile;
 	} else if(resize_mode == "tile_center") {
 		return resize_mode::tile_center;
+	} else if(resize_mode == "tile_highres") {
+		return resize_mode::tile_highres;
 	} else if(resize_mode == "stretch") {
 		return resize_mode::stretch;
 	} else if(resize_mode == "scale_sharp") {

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -644,7 +644,7 @@ void canvas::blit(SDL_Rect rect)
 	// From those, as the first column is off-screen:
 	// rect_clipped_to_parent={0, 2, 329, 440}
 	// area_to_draw={1, 0, 329, 440}
-	SDL_Rect parent {0, 0, video.get_width(), video.get_height()};
+	SDL_Rect parent {0, 0, video.draw_area().w, video.draw_area().h};
 	SDL_Rect rect_clipped_to_parent;
 	if(!SDL_IntersectRect(&rect, &parent, &rect_clipped_to_parent)) {
 		DBG_GUI_D << "Area to draw is completely outside parent.\n";

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -386,6 +386,7 @@ private:
 		stretch,
 		tile,
 		tile_center,
+		tile_highres,
 	};
 
 	/** Converts a string to a resize mode. */

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -458,7 +458,7 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 					break;
 
 				case SDL_WINDOWEVENT_RESIZED:
-					video_resize(point(video.get_width(), video.get_height()));
+					video_resize(point(video.draw_area().w, video.draw_area().h));
 					break;
 
 				case SDL_WINDOWEVENT_ENTER:

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -293,7 +293,7 @@ std::string unit_topic_generator::operator()() const {
 	const unit_type& female_type = type_.get_gender_unit_type(unit_race::FEMALE);
 	const unit_type& male_type = type_.get_gender_unit_type(unit_race::MALE);
 
-	const int screen_width = CVideo::get_singleton().get_width();
+	const int screen_width = CVideo::get_singleton().draw_area().w;
 
 	ss << _("Level") << " " << type_.level();
 	ss << "\n\n";

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -18,15 +18,15 @@
 #include "display.hpp"
 #include "floating_label.hpp"
 #include "font/sdl_ttf_compat.hpp"
-#include "picture.hpp"
 #include "log.hpp"
+#include "picture.hpp"
 #include "preferences/general.hpp"
+#include "sdl/input.hpp"
 #include "sdl/point.hpp"
+#include "sdl/texture.hpp"
 #include "sdl/userevent.hpp"
 #include "sdl/utils.hpp"
 #include "sdl/window.hpp"
-#include "sdl/input.hpp"
-#include "sdl/texture.hpp"
 
 #ifdef TARGET_OS_OSX
 #include "desktop/apple_video.hpp"
@@ -43,8 +43,6 @@ static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
 #define WRN_DP LOG_STREAM(warn, log_display)
 #define DBG_DP LOG_STREAM(debug, log_display)
-
-CVideo* CVideo::singleton_ = nullptr;
 
 namespace
 {
@@ -96,7 +94,6 @@ void trigger_full_redraw()
 
 CVideo::CVideo(FAKE_TYPES type)
 	: window()
-	, drawing_texture_(nullptr)
 	, render_texture_(nullptr)
 	, fake_screen_(false)
 	, help_string_(0)
@@ -127,9 +124,7 @@ CVideo::CVideo(FAKE_TYPES type)
 
 void CVideo::initSDL()
 {
-	const int res = SDL_InitSubSystem(SDL_INIT_VIDEO);
-
-	if(res < 0) {
+	if(SDL_InitSubSystem(SDL_INIT_VIDEO) < 0) {
 		ERR_DP << "Could not initialize SDL_video: " << SDL_GetError() << std::endl;
 		throw error("Video initialization failed");
 	}
@@ -189,7 +184,7 @@ void CVideo::make_test_fake(const unsigned width, const unsigned height)
 	refresh_rate_ = 1;
 
 	if (window) {
-		set_resolution(width, height);
+		set_resolution({int(width), int(height)});
 	} else {
 		fake_size = {int(width), int(height)};
 		init_fake_window();
@@ -408,7 +403,7 @@ void CVideo::init_window()
 
 	// It is assumed that this function is only ever called once.
 	// If that is no longer true, then you should clean things up.
-	assert(!render_texture_ && !drawing_texture_);
+	assert(!render_texture_);
 
 	std::cerr << "Setting mode to " << w << "x" << h << std::endl;
 
@@ -500,16 +495,6 @@ SDL_Rect CVideo::input_area() const
 	return {0, 0, p.x, p.y};
 }
 
-int CVideo::get_width() const
-{
-	return logical_size_.x;
-}
-
-int CVideo::get_height() const
-{
-	return logical_size_.y;
-}
-
 void CVideo::delay(unsigned int milliseconds)
 {
 	if(!game_config::no_delay) {
@@ -529,7 +514,7 @@ void CVideo::force_render_target(SDL_Texture* t)
 	// so make sure it gets set back appropriately.
 	if (t == nullptr || t == render_texture_) {
 		// TODO: highdpi - sort out who owns this
-		window->set_logical_size(get_width(), get_height());
+		window->set_logical_size(draw_area().w, draw_area().h);
 	}
 }
 
@@ -540,7 +525,7 @@ SDL_Texture* CVideo::get_render_target()
 
 SDL_Rect CVideo::clip_to_draw_area(const SDL_Rect* r) const
 {
-	if (r) {
+	if(r) {
 		return sdl::intersect_rects(*r, draw_area());
 	} else {
 		return draw_area();
@@ -550,7 +535,7 @@ SDL_Rect CVideo::clip_to_draw_area(const SDL_Rect* r) const
 SDL_Rect CVideo::to_output(const SDL_Rect& r) const
 {
 	int s = get_pixel_scale();
-	return {s*r.x, s*r.y, s*r.w, s*r.h};
+	return {s * r.x, s * r.y, s * r.w, s * r.h};
 }
 
 void CVideo::render_screen()
@@ -583,7 +568,7 @@ void CVideo::render_screen()
 
 		// SDL resets the logical size when setting a render texture target,
 		// so we also have to reset that every time.
-		window->set_logical_size(get_width(), get_height());
+		window->set_logical_size(draw_area().w, draw_area().h);
 	}
 }
 
@@ -642,15 +627,15 @@ surface CVideo::read_pixels(SDL_Rect* r)
 
 surface CVideo::read_pixels_low_res(SDL_Rect* r)
 {
-	if (!window) {
+	if(!window) {
 		WRN_DP << "trying to read pixels with no window" << std::endl;
 		return surface();
 	}
 	surface s = read_pixels(r);
-	if (r) {
+	if(r) {
 		return scale_surface(s, r->w, r->h);
 	} else {
-		return scale_surface(s, get_width(), get_height());
+		return scale_surface(s, draw_area().w, draw_area().h);
 	}
 }
 
@@ -687,11 +672,9 @@ void CVideo::set_window_icon(surface& icon)
 
 void CVideo::clear_screen()
 {
-	if(!window) {
-		return;
+	if(window) {
+		window->fill(0, 0, 0, 255);;
 	}
-
-	window->fill(0, 0, 0, 255);
 }
 
 sdl::window* CVideo::get_window()
@@ -729,11 +712,7 @@ std::vector<std::string> CVideo::enumerate_drivers()
 
 bool CVideo::window_has_flags(uint32_t flags) const
 {
-	if(!window) {
-		return false;
-	}
-
-	return (window->get_flags() & flags) != 0;
+	return window && (window->get_flags() & flags) != 0;
 }
 
 std::vector<point> CVideo::get_available_resolutions(const bool include_current)
@@ -753,11 +732,6 @@ std::vector<point> CVideo::get_available_resolutions(const bool include_current)
 	}
 
 	const point min_res(preferences::min_window_width, preferences::min_window_height);
-
-#if 0
-	// DPI scale factor.
-	auto [scale_h, scale_v] = get_dpi_scale_factor();
-#endif
 
 	// The maximum size to which this window can be set. For some reason this won't
 	// pop up as a display mode of its own.
@@ -824,7 +798,7 @@ int CVideo::set_help_string(const std::string& str)
 	int size = font::SIZE_LARGE;
 
 	while(size > 0) {
-		if(font::pango_line_width(str, size) > get_width()) {
+		if(font::pango_line_width(str, size) > draw_area().w) {
 			size--;
 		} else {
 			break;
@@ -835,7 +809,7 @@ int CVideo::set_help_string(const std::string& str)
 
 	font::floating_label flabel(str);
 	flabel.set_font_size(size);
-	flabel.set_position(get_width() / 2, get_height());
+	flabel.set_position(draw_area().w / 2, draw_area().h);
 	flabel.set_bg_color(color);
 	flabel.set_border_size(border);
 
@@ -891,11 +865,6 @@ void CVideo::set_fullscreen(bool ison)
 void CVideo::toggle_fullscreen()
 {
 	set_fullscreen(!preferences::fullscreen());
-}
-
-bool CVideo::set_resolution(const unsigned width, const unsigned height)
-{
-	return set_resolution(point(width, height));
 }
 
 bool CVideo::set_resolution(const point& resolution)

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -122,8 +122,6 @@ public:
 
 	bool supports_vsync() const;
 
-	bool set_resolution(const unsigned width, const unsigned height);
-
 	/**
 	 * Set the window resolution.
 	 *
@@ -169,20 +167,6 @@ public:
 	 * draw_area(), but for clarity there are two separate functions.
 	 */
 	SDL_Rect input_area() const;
-
-	/**
-	 * Returns the width of the drawing surface in pixels.
-	 * Input coordinates are automatically scaled to correspond,
-	 * so this also indicates the width of the input surface.
-	 */
-	int get_width() const;
-
-	/**
-	 * Returns the height of the drawing surface in pixels.
-	 * Input coordinates are automatically scaled to correspond,
-	 * so this also indicates the height of the input surface.
-	 */
-	int get_height() const;
 
 	/**
 	 * Get the current active pixel scale multiplier.
@@ -375,13 +359,10 @@ public:
 	};
 
 private:
-	static CVideo* singleton_;
+	static inline CVideo* singleton_ = nullptr;
 
 	/** The SDL window object. */
 	std::unique_ptr<sdl::window> window;
-
-	/** The drawing texture. */
-	SDL_Texture* drawing_texture_;
 
 	/** The current offscreen render target. */
 	SDL_Texture* render_texture_;

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -441,7 +441,7 @@ std::size_t menu::max_items_onscreen() const
 		return std::size_t(max_items_);
 	}
 
-	const std::size_t max_height = (max_height_ == -1 ? (video().get_height()*66)/100 : max_height_) - heading_height();
+	const std::size_t max_height = (max_height_ == -1 ? (video().draw_area().h*66)/100 : max_height_) - heading_height();
 
 	std::vector<int> heights;
 	std::size_t n;


### PR DESCRIPTION
This adds back the smooth scaling image mode, and also adds a new tiling mode "tile_highres" which can be used to tile images in full high-dpi output resolution rather than game resolution.

This is useful for texturing effects, such as the image that is used to texture window backgrounds which has been updated to use this tiling mode.

I didn't make it the default, because it would break anything relying on the previous sizing. The other modes "tile" and "tile_center" both tile images in draw-space - so their drawn sizes will match with sprite scales and with other sizing in WML.

Mostly just putting this up for the CI check.