### PR TITLE
Fix some SoTA zombie recruit dialog errors

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/gui/zombie_recruit_dialog.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/gui/zombie_recruit_dialog.cfg
@@ -78,7 +78,6 @@
                 border = "top,bottom"
                 border_size = 10
                 horizontal_alignment="left"
-                horizontal_grow=true
                 [image]
                     id = "large_unit_sprite"
                 [/image]
@@ -89,7 +88,6 @@
                 border = "bottom"
                 border_size = 5
                 horizontal_alignment="left"
-                horizontal_grow=true
                 [label]
                     use_markup = "true"
                     id = "large_unit_type"
@@ -154,7 +152,7 @@
             [column]
                 border = "bottom"
                 border_size = 12
-                horizontal_grow = true
+                horizontal_alignment = "left"
                 [label]
                     definition = "default_tiny"
                     use_markup = "true"
@@ -213,7 +211,6 @@
                 border = "bottom"
                 border_size = 2
                 horizontal_alignment = "left"
-                horizontal_grow = true
                 [label]
                     definition = "default_small"
                     use_markup = "true"
@@ -226,7 +223,6 @@
                 border = "bottom"
                 border_size = 2
                 horizontal_alignment = "left"
-                horizontal_grow = true
                 [label]
                     definition = "default_small"
                     use_markup = "true"

--- a/data/campaigns/Secrets_of_the_Ancients/gui/zombie_recruit_dialog.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/gui/zombie_recruit_dialog.cfg
@@ -168,7 +168,7 @@
                 [label]
                     definition ="default_small"
                     use_markup = "true"
-                    label = "<b>" .. _ "Traits" .. "</b>"
+                    label = "<b>" + _ "Traits" + "</b>"
                 [/label]
             [/column]
         [/row]
@@ -202,7 +202,7 @@
                 [label]
                     definition = "default_small"
                     use_markup = "true"
-                    label = "<b>" .. _ "Attacks" .. "</b>"
+                    label = "<b>" + _ "Attacks" + "</b>"
                 [/label]
             [/column]
         [/row]


### PR DESCRIPTION
There was an error `error gui/parse: horizontal_grow and horizontal_alignment can't be combined, alignment is ignored.` when opening the recruit dialog for corpses in SoTA.

I removed horizontal_grow in favour of horizontal_alignment here, as that matches what is used in other blocks. There seems to be no visible difference.

There were also some unnecessary `..` which seemed to be attempting to concatenate strings in WML. It looks like this is a lua thing? They were visible in-game like "..Traits.." and "..Attacks..". I removed them and it seems to work fine now?