### PR TITLE
SDL: Increase requirement to 2.0.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,7 +491,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 	find_package(VorbisFile REQUIRED)
 	find_package(PkgConfig REQUIRED)
 	find_package(Fontconfig REQUIRED)
-	find_package(SDL2 2.0.8 REQUIRED)
+	find_package(SDL2 2.0.10 REQUIRED)
 	if(NOT MSVC)
 		# for everything else, use pkgconfig
 		# SDL2_image and SDL2_mixer don't seem to have any cmake configuration available at all

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ order to build Wesnoth:
    * Program Options
    * System
  * SDL2 libraries:
-   * SDL2                      >= 2.0.8
+   * SDL2                      >= 2.0.10
    * SDL2_image                >= 2.0.2 (with PNG, JPEG, and WEBP support)
    * SDL2_mixer                >= 2.0.0 (with Ogg Vorbis support)
  * Fontconfig                  >= 2.4.1

--- a/SConstruct
+++ b/SConstruct
@@ -351,7 +351,7 @@ if env["prereqs"]:
 
     def have_sdl_other():
         return \
-            conf.CheckSDL2('2.0.8') & \
+            conf.CheckSDL2('2.0.10') & \
             conf.CheckSDL2Mixer() & \
             conf.CheckSDL2Image()
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
  ### Multiplayer
  ### Lua API
  ### Packaging
+   * Increased minimum required version of SDL to 2.0.10.
  ### Terrain
  ### Translations
  ### Units


### PR DESCRIPTION
@doofus-01 reported not being able to build master with SDL 2.0.8. [SDL_RenderCopyF](https://wiki.libsdl.org/SDL_RenderCopyF) and [SDL_RenderCopyExF](https://wiki.libsdl.org/SDL_RenderCopyExF) are only available from SDL 2.0.10 onwards.

These are the only instances of SDL 2.0.8 that I could find. I do not know if there are other places where references to SDL need to be updated.