### PR TITLE
Fix load_string() ignoring the passed chunk name

### DIFF
--- a/data/test/scenarios/test_lua_name.cfg
+++ b/data/test/scenarios/test_lua_name.cfg
@@ -1,0 +1,35 @@
+
+# Test that an error message in Lua includes the value of the tag's name key
+{GENERIC_UNIT_TEST test_lua_name (
+    [lua]
+        name=test
+        code=<<
+            -- Can't use assert_throws_with here because we want to test the preamble that's automatically prefixed to the error.
+            local ret, err = pcall(function()
+                local some_variable = bar
+            end)
+            unit_test.assert_contains(err, 'test', 'error contains name')
+        >>
+    [/lua]
+    [event]
+        name=start
+        {SUCCEED}
+    [/event]
+)}
+# Same as above but for Lua in events
+{GENERIC_UNIT_TEST test_lua_event_name (
+    [event]
+        name=start
+        [lua]
+            name=test
+            code=<<
+                -- Can't use assert_throws_with here because we want to test the preamble that's automatically prefixed to the error.
+                local ret, err = pcall(function()
+                    local some_variable = bar
+                end)
+                unit_test.assert_contains(err, 'test', 'error contains name')
+                unit_test.succeed()
+            >>
+        [/lua]
+    [/event]
+)}

--- a/data/test/scenarios/test_lua_name.cfg
+++ b/data/test/scenarios/test_lua_name.cfg
@@ -4,13 +4,13 @@
     [event]
         name=start
         [lua]
-            name=test
+            name=test_lua_name
             code=<<
                 -- Can't use assert_throws_with here because we want to test the preamble that's automatically prefixed to the error.
                 local ret, err = pcall(function()
                     local some_variable = bar
                 end)
-                unit_test.assert_contains(err, 'test', 'error contains name')
+                unit_test.assert_contains(err, 'test_lua_name', 'error contains name')
                 unit_test.succeed()
             >>
         [/lua]

--- a/data/test/scenarios/test_lua_name.cfg
+++ b/data/test/scenarios/test_lua_name.cfg
@@ -1,23 +1,6 @@
 
 # Test that an error message in Lua includes the value of the tag's name key
 {GENERIC_UNIT_TEST test_lua_name (
-    [lua]
-        name=test
-        code=<<
-            -- Can't use assert_throws_with here because we want to test the preamble that's automatically prefixed to the error.
-            local ret, err = pcall(function()
-                local some_variable = bar
-            end)
-            unit_test.assert_contains(err, 'test', 'error contains name')
-        >>
-    [/lua]
-    [event]
-        name=start
-        {SUCCEED}
-    [/event]
-)}
-# Same as above but for Lua in events
-{GENERIC_UNIT_TEST test_lua_event_name (
     [event]
         name=start
         [lua]

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -1021,7 +1021,7 @@ bool lua_kernel_base::protected_call(lua_State * L, int nArgs, int nRets, error_
 bool lua_kernel_base::load_string(char const * prog, const std::string& name, error_handler e_h)
 {
 	// pass 't' to prevent loading bytecode which is unsafe and can be used to escape the sandbox.
-	int errcode = luaL_loadbufferx(mState, prog, strlen(prog), name.empty() ? name.c_str() : prog, "t");
+	int errcode = luaL_loadbufferx(mState, prog, strlen(prog), name.empty() ? prog : name.c_str(), "t");
 	if (errcode != LUA_OK) {
 		char const * msg = lua_tostring(mState, -1);
 		std::string message = msg ? msg : "null string";

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -139,6 +139,8 @@
 0 test_ability_id_active
 0 test_ability_id_not_active
 0 event_test_filter_attack
+0 test_lua_name
+0 test_lua_event_name
 0 filter_vision
 0 test_shroud_init
 0 test_shroud_place_wml

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -140,7 +140,6 @@
 0 test_ability_id_not_active
 0 event_test_filter_attack
 0 test_lua_name
-0 test_lua_event_name
 0 filter_vision
 0 test_shroud_init
 0 test_shroud_place_wml


### PR DESCRIPTION
Complete with a unit test!
The test results in PASS_BY_VICTORY if it fails, which is a bit weird, but it does work.

There was a comment on this commit noting that it won't work without the events PR (#5663), but I suspect that comment is outdated, so I'm opening this to test the CI.