### PR TITLE
Add options to skip adding images to the surface and texture caches

### DIFF
--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -357,6 +357,18 @@ locator& locator::operator=(const locator& a)
 	return *this;
 }
 
+std::ostream& operator<<(std::ostream& s, const locator& l)
+{
+	s << l.get_filename();
+	if(!l.get_modifications().empty()) {
+		if(l.get_modifications()[0] != '~') {
+			s << '~';
+		}
+		s << l.get_modifications();
+	}
+	return s;
+}
+
 locator::value::value()
 	: type_(NONE)
 	, is_data_uri_(false)
@@ -789,6 +801,7 @@ surface get_surface(const image::locator& i_locator, TYPE type)
 		imap = &hexed_images_;
 		break;
 	default:
+		WRN_IMG << "get_surface called with unknown image type" << std::endl;
 		return res;
 	}
 
@@ -797,13 +810,7 @@ surface get_surface(const image::locator& i_locator, TYPE type)
 		return i_locator.locate_in_cache(*imap);
 	}
 
-	if (i_locator.get_modifications().empty()) {
-		DBG_IMG << "surface cache miss: " << i_locator.get_filename()
-			<< std::endl;
-	} else {
-		DBG_IMG << "surface cache miss: " << i_locator.get_filename()
-			<< "+" << i_locator.get_modifications() << std::endl;
-	}
+	DBG_IMG << "surface cache [" << type << "] miss: " << i_locator << std::endl;
 
 	// not cached, generate it
 	switch(type) {
@@ -818,7 +825,7 @@ surface get_surface(const image::locator& i_locator, TYPE type)
 		res = get_hexed(i_locator);
 		break;
 	default:
-		return res;
+		throw game::error("get_surface somehow lost image type?");
 	}
 
 	i_locator.add_to_cache(*imap, res);
@@ -855,13 +862,7 @@ surface get_lighted_image(const image::locator& i_locator, const light_string& l
 		}
 	}
 
-	if (i_locator.get_modifications().empty()) {
-		DBG_IMG << "lit surface cache miss: " << i_locator.get_filename()
-			<< std::endl;
-	} else {
-		DBG_IMG << "lit surface cache miss: " << i_locator.get_filename()
-			<< "+" << i_locator.get_modifications() << std::endl;
-	}
+	DBG_IMG << "lit surface cache miss: " << i_locator << std::endl;
 
 	// not cached yet, generate it
 	res = get_surface(i_locator, HEXED);
@@ -898,13 +899,7 @@ texture get_lighted_texture(
 		}
 	}
 
-	if (i_locator.get_modifications().empty()) {
-		DBG_IMG << "lit texture cache miss: " << i_locator.get_filename()
-			<< std::endl;
-	} else {
-		DBG_IMG << "lit texture cache miss: " << i_locator.get_filename()
-			<< "+" << i_locator.get_modifications() << std::endl;
-	}
+	DBG_IMG << "lit texture cache miss: " << i_locator << std::endl;
 
 	// not cached yet, generate it
 	texture tex(get_lighted_image(i_locator, ls));
@@ -1122,13 +1117,7 @@ texture get_texture(const image::locator& i_locator, scale_quality quality, TYPE
 		return res;
 	}
 
-	if (i_locator.get_modifications().empty()) {
-		DBG_IMG << "texture cache miss: " << i_locator.get_filename()
-			<< std::endl;
-	} else {
-		DBG_IMG << "texture cache miss: " << i_locator.get_filename()
-			<< "+" << i_locator.get_modifications() << std::endl;
-	}
+	DBG_IMG << "texture cache [" << type << "] miss: " << i_locator << std::endl;
 
 	//
 	// No texture was cached. In that case, create a new one. The explicit cases require special

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -153,14 +153,13 @@ void locator::add_to_cache(cache_type<T>& cache, const T& data) const
 		cache.get_element(index_) = cache_item<T>(data);
 	}
 }
-}
 
 namespace
 {
 image::locator::locator_finder_t locator_finder;
 
 /** Definition of all image maps */
-std::array<image::surface_cache,image::TYPE::NUM_TYPES> surfaces_;
+std::array<surface_cache, NUM_TYPES> surfaces_;
 
 /**
  * Texture caches.
@@ -186,7 +185,7 @@ image::lit_surface_variants surface_lightmaps_;
 image::lit_texture_variants texture_lightmaps_;
 
 // diagnostics for tracking skipped cache impact
-std::array<image::bool_cache,image::TYPE::NUM_TYPES> skipped_cache_;
+std::array<bool_cache, NUM_TYPES> skipped_cache_;
 int duplicate_loads_ = 0;
 int total_loads_ = 0;
 
@@ -229,8 +228,6 @@ parsed_data_URI::parsed_data_URI(std::string_view data_URI)
 
 } // end anon namespace
 
-namespace image
-{
 mini_terrain_cache_map mini_terrain_cache;
 mini_terrain_cache_map mini_fogged_terrain_cache;
 mini_terrain_cache_map mini_highlighted_terrain_cache;

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -239,6 +239,7 @@ enum TYPE
 	HEXED,
 	/** Same as HEXED, but with Time of Day color tint applied. */
 	TOD_COLORED,
+	NUM_TYPES // Equal to the number of types specified above
 };
 
 enum class scale_quality { nearest, linear };
@@ -258,10 +259,14 @@ surface get_image(const locator& i_locator, TYPE type = UNSCALED);
  *
  * The equivalent get_texture() function should generally be preferred.
  *
+ * Surfaces will be cached for repeat access, unless skip_cache is set.
+ *
  * @param i_locator            Image path.
  * @param type                 Rendering format.
+ * @param skip_cache           Skip adding the result to the surface cache.
  */
-surface get_surface(const locator& i_locator, TYPE type = UNSCALED);
+surface get_surface(const locator& i_locator, TYPE type = UNSCALED,
+	bool skip_cache = false);
 
 /**
  * Returns an image texture suitable for hardware-accelerated rendering.
@@ -270,12 +275,19 @@ surface get_surface(const locator& i_locator, TYPE type = UNSCALED);
  * until no longer needed. Users of the returned texture do not have to
  * worry about texture management.
  *
+ * If caching is disabled via @a skip_cache, texture memory will be
+ * automatically freed once the returned object and all other linked
+ * textures (if any) are destroyed.
+ *
  * @param i_locator            Image path.
  * @param type                 Rendering format.
+ * @param skip_cache           Skip adding the result to the surface cache.
  */
-texture get_texture(const locator& i_locator, TYPE type = UNSCALED);
+texture get_texture(const locator& i_locator, TYPE type = UNSCALED,
+	bool skip_cache = false);
 
-texture get_texture(const image::locator& i_locator, scale_quality quality, TYPE type = UNSCALED);
+texture get_texture(const image::locator& i_locator, scale_quality quality,
+	TYPE type = UNSCALED, bool skip_cache = false);
 
 /**
  * Caches and returns an image with a lightmap applied to it.
@@ -296,10 +308,13 @@ surface get_hexmask();
 /**
  * Returns the width and height of an image.
  *
- * If the image is not yet in the surface cache, it will be loaded and cached.
+ * If the image is not yet in the surface cache, it will be loaded and cached
+ * unless skip_cache is explicitly set.
  *
+ * @param i_locator            Image path.
+ * @param skip_cache           If true, do not cache the image if loaded.
  */
-point get_size(const locator& i_locator);
+point get_size(const locator& i_locator, bool skip_cache = false);
 
 /**
  * Checks if an image fits into a single hex.

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -155,7 +155,7 @@ private:
 // write a readable representation of a locator, mostly for debugging
 std::ostream& operator<<(std::ostream&, const locator&);
 
-typedef cache_type<surface> image_cache;
+typedef cache_type<surface> surface_cache;
 typedef cache_type<texture> texture_cache;
 typedef cache_type<bool> bool_cache;
 

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -152,6 +152,9 @@ private:
 	value val_;
 };
 
+// write a readable representation of a locator, mostly for debugging
+std::ostream& operator<<(std::ostream&, const locator&);
+
 typedef cache_type<surface> image_cache;
 typedef cache_type<texture> texture_cache;
 typedef cache_type<bool> bool_cache;

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -180,11 +180,11 @@ extern mini_terrain_cache_map mini_highlighted_terrain_cache;
 typedef std::basic_string<signed char> light_string;
 
 /** Type used to pair light possibilities with the corresponding lit surface. */
-typedef std::map<light_string, surface> lit_variants;
+typedef std::map<light_string, surface> lit_surface_variants;
 typedef std::map<light_string, texture> lit_texture_variants;
 
 /** Lit variants for each locator. */
-typedef cache_type<lit_variants> lit_cache;
+typedef cache_type<lit_surface_variants> lit_surface_cache;
 typedef cache_type<lit_texture_variants> lit_texture_cache;
 
 /**


### PR DESCRIPTION
I also added some diagnostics, and did some minor cleanup.

After checking the diagnostics, i set it to skip the surface cache automatically when loading textures from image files unmodified. These get cached as textures only. Sometimes this causes images to be loaded twice when the surface is needed later, but not very frequently.

I left it caching surfaces when loading IPF modified textures, as these turned out to be often reused for other image loading operations. It could be revisited after hardware-acceleration conversion is more complete.

I'm considering exposing the cache skip to WML for edge-case use of animations (see #2915 ), but it would be kind of ugly to do for halos, so i'm a bit reluctant.

Currently the point of this is mostly to avoid keeping copies of images both in graphics memory and main memory unless both are required.