### PR TITLE
Draw rectangles as lines for some SDL versions.

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -92,12 +92,7 @@ static bool sdl_bad_at_rects()
 {
 	// This could be done once at program start and cached,
 	// but it isn't all that heavy.
-	SDL_version ver;
-	SDL_GetVersion(&ver);
-	if (ver.major > 2 || ver.minor > 0) {
-		return false;
-	}
-	if (ver.patch >= 15 && ver.patch < 18) {
+	if (sdl::runtime_at_least(2,0,15) && !sdl::runtime_at_least(2,0,18)) {
 		return true;
 	}
 	return false;

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -31,11 +31,25 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/math/constants/constants.hpp>
 
-version_info sdl_get_version()
+version_info sdl::get_version()
 {
 	SDL_version sdl_version;
 	SDL_GetVersion(&sdl_version);
 	return version_info(sdl_version.major, sdl_version.minor, sdl_version.patch);
+}
+
+bool sdl::runtime_at_least(uint8_t major, uint8_t minor, uint8_t patch)
+{
+	SDL_version ver;
+	SDL_GetVersion(&ver);
+	if(ver.major < major) return false;
+	if(ver.major > major) return true;
+	// major version equal
+	if(ver.minor < minor) return false;
+	if(ver.minor > minor) return true;
+	// major and minor version equal
+	if(ver.patch < patch) return false;
+	return true;
 }
 
 surface stretch_surface_horizontal(

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -29,7 +29,20 @@
 
 class CVideo;
 
-version_info sdl_get_version();
+namespace sdl
+{
+
+/** Returns the runtime SDL version. */
+version_info get_version();
+
+/**
+ * Returns true if the runtime SDL version is at or greater than the
+ * specified version, false otherwise.
+ */
+bool runtime_at_least(uint8_t major, uint8_t minor = 0, uint8_t patch = 0);
+
+} // namespace sdl
+
 
 inline void sdl_blit(const surface& src, const SDL_Rect* src_rect, surface& dst, SDL_Rect* dst_rect){
 	SDL_BlitSurface(src, src_rect, dst, dst_rect);

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -13,11 +13,12 @@
 	See the COPYING file for more details.
 */
 
-#include "sdl/surface.hpp"
 #include "sdl/window.hpp"
-#include "sdl/input.hpp"
 
 #include "sdl/exception.hpp"
+#include "sdl/input.hpp"
+#include "sdl/surface.hpp"
+#include "sdl/utils.hpp"
 
 #include <SDL2/SDL_render.h>
 
@@ -38,11 +39,11 @@ window::window(const std::string& title,
 		throw exception("Failed to create a SDL_Window object.", true);
 	}
 
-#if SDL_VERSION_ATLEAST(2, 0, 10)
-	// Rendering in batches (for efficiency) is enabled by default from SDL 2.0.10
-	// The way Wesnoth uses SDL as of September 2019 does not work well with this rendering mode (eg story-only scenarios)
-	SDL_SetHint(SDL_HINT_RENDER_BATCHING, "0");
-#endif
+	if(sdl::runtime_at_least(2,0,10)) {
+		// Rendering in batches (for efficiency) is enabled by default from SDL 2.0.10
+		// The way Wesnoth uses SDL as of September 2019 does not work well with this rendering mode (eg story-only scenarios)
+		SDL_SetHint(SDL_HINT_RENDER_BATCHING, "0");
+	}
 
 	if(!SDL_CreateRenderer(window_, -1, render_flags)) {
 		throw exception("Failed to create a SDL_Renderer object.", true);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -785,7 +785,7 @@ bool CVideo::is_fullscreen() const
 
 bool CVideo::supports_software_vsync() const
 {
-	return sdl_get_version() >= version_info{2, 0, 17};
+	return sdl::runtime_at_least(2, 0, 17);
 }
 
 // TODO: highdpi - this should not be here.


### PR DESCRIPTION
Aimed at fixing #6799.

According to the SDL bug linked there this was reported in SDL 2.0.15 and should have been fixed in 2.0.18. So i've set it to draw rectangles as four individual lines when linked against the affected SDL versions.

If the problem crops up again for others, the version check could be extended.

I'm assuming the problem doesn't also occur for lines.