### PR TITLE
Canvas cleanup

### DIFF
--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -277,8 +277,10 @@ void tiled_highres(const texture& tex,
 
 /** A class to manage automatic restoration of the clipping region.
  *
- * While this can be constructed on its own, it is usually easier to
- * use the draw::set_clip() utility function.
+ * This can be constructed on its own, or one of the utility functions
+ * set_clip() and reduce_clip() can be used. Constructing a clip_setter
+ * or using set_clip() will completely override the current clipping area.
+ * To intersect with the current clipping area in stead, use reduce_clip().
  */
 class clip_setter
 {
@@ -287,6 +289,7 @@ public:
 	~clip_setter();
 private:
 	SDL_Rect c_;
+	bool clip_enabled_;
 };
 
 /**
@@ -319,14 +322,37 @@ clip_setter reduce_clip(const SDL_Rect& clip);
  */
 void force_clip(const SDL_Rect& clip);
 
-/** Get the current clipping area, in draw coordinates. */
+/**
+ * Get the current clipping area, in draw coordinates.
+ *
+ * The clipping area is interpreted relative to the current viewport.
+ *
+ * If clipping is disabled, this will return the full drawing area.
+ */
 SDL_Rect get_clip();
+
+/** Whether clipping is enabled. */
+bool clip_enabled();
+
+/** Disable clipping. To enable clipping, use set_clip() or force_clip(). */
+void disable_clip();
+
+/**
+ * Whether the current clipping region will disallow drawing.
+ *
+ * This returns true for any clipping region with negative or zero width
+ * or height.
+ */
+bool null_clip();
 
 
 /** A class to manage automatic restoration of the viewport region.
  *
- * While this can be constructed on its own, it is usually easier to
- * use the draw::set_viewport() utility function.
+ * This will also translate the current clipping region into the space
+ * of the viewport, if a clipping region is set.
+ *
+ * This can be constructed on its own, or the draw::set_viewport()
+ * utility function can be used.
  */
 class viewport_setter
 {
@@ -335,6 +361,8 @@ public:
 	~viewport_setter();
 private:
 	SDL_Rect v_;
+	SDL_Rect c_;
+	bool clip_enabled_;
 };
 
 /**

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -253,8 +253,6 @@ image_shape::image_shape(const config& cfg, wfl::action_function_symbol_table& f
 	, y_(cfg["y"])
 	, w_(cfg["w"])
 	, h_(cfg["h"])
-	, src_clip_()
-	, image_()
 	, image_name_(cfg["name"])
 	, resize_mode_(get_resize_mode(cfg["resize_mode"]))
 	, mirror_(cfg.get_old_attribute("mirror", "vertical_mirror", "image"))
@@ -305,9 +303,6 @@ void image_shape::draw(wfl::map_formula_callable& variables)
 		ERR_GUI_D << "Image: '" << name << "' not found and won't be drawn." << std::endl;
 		return;
 	}
-
-	// TODO: highdpi - this is never used, why is it set?
-	src_clip_ = {0, 0, tex.w(), tex.h()};
 
 	wfl::map_formula_callable local_variables(variables);
 	local_variables.add("image_original_width", wfl::variant(tex.w()));

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -63,15 +63,11 @@ public:
 		/**
 		 * Draws the canvas.
 		 *
-		 * @param portion_to_draw   The portion of the shape to draw, in canvas-local coordinates
-		 * @param draw_location     The location of the canvas on the screen, in draw coordinates.
 		 * @param variables       The canvas can have formulas in it's
 		 *                        definition, this parameter contains the values
 		 *                        for these formulas.
 		 */
-		virtual void draw(const SDL_Rect& portion_to_draw,
-		                  const SDL_Rect& draw_location,
-		                  wfl::map_formula_callable& variables) = 0;
+		virtual void draw(wfl::map_formula_callable& variables) = 0;
 
 		bool immutable() const
 		{
@@ -91,26 +87,13 @@ public:
 	canvas& operator=(const canvas&) = delete;
 	canvas(canvas&& c) noexcept;
 
-	private:
-	/**
-	 * Internal part of the blit() function - does the actual drawing.
-	 *
-	 * @param area_to_draw        Currently-visible part of the widget, in widget-local coordinates.
-	 *                            Any area outside here won't be blitted to the parent.
-	 * @param draw_location       Where to draw the widget on the screen, in draw coordinates.
-	 */
-	void draw(const SDL_Rect& area_to_draw, const SDL_Rect& draw_location);
-
-	public:
 	/**
 	 * Draw the canvas' shapes onto the screen.
 	 *
 	 * It makes sure the image on the canvas is up to date. Also executes the
 	 * pre-blitting functions.
-	 *
-	 * @param rect                Where to blit to, in drawing coordinates.
 	 */
-	void blit(SDL_Rect rect);
+	void draw();
 
 	/**
 	 * Sets the config.

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -332,14 +332,6 @@ private:
 	typed_formula<unsigned> w_; /**< The width of the image. */
 	typed_formula<unsigned> h_; /**< The height of the image. */
 
-	// TODO: highdpi - none of these cached items are ever used. Why is this here?
-
-	/** Contains the size of the image. */
-	SDL_Rect src_clip_;
-
-	/** The image is cached in this surface. */
-	texture image_;
-
 	/**
 	 * Name of the image.
 	 *

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -16,8 +16,8 @@
 #include "gui/core/canvas.hpp"
 #include "gui/auxiliary/typed_formula.hpp"
 
-namespace gui2 {
-
+namespace gui2
+{
 /**
  * @ingroup GUICanvasWML
  *
@@ -68,7 +68,8 @@ namespace gui2 {
  *
  * Drawing outside this area will result in unpredictable results including crashing. (That should be fixed, when encountered.)
  */
-class line_shape : public canvas::shape {
+class line_shape : public canvas::shape
+{
 public:
 	/**
 	 * Constructor.
@@ -77,15 +78,13 @@ public:
 	 */
 	explicit line_shape(const config& cfg);
 
-	void draw(const SDL_Rect& portion_to_draw,
-	          const SDL_Rect& draw_location,
-	          wfl::map_formula_callable& variables) override;
+	void draw(wfl::map_formula_callable& variables) override;
 
 private:
-	typed_formula<unsigned> x1_, /**< The start x coordinate of the line. */
-			y1_,			/**< The start y coordinate of the line. */
-			x2_,			/**< The end x coordinate of the line. */
-			y2_;			/**< The end y coordinate of the line. */
+	typed_formula<unsigned> x1_; /**< The start x coordinate of the line. */
+	typed_formula<unsigned> y1_; /**< The start y coordinate of the line. */
+	typed_formula<unsigned> x2_; /**< The end x coordinate of the line. */
+	typed_formula<unsigned> y2_; /**< The end y coordinate of the line. */
 
 	/** The color of the line. */
 	typed_formula<color_t> color_;
@@ -114,48 +113,23 @@ private:
  * w                  | @ref guivartype_f_unsigned "f_unsigned"|0      |The width of the rectangle.
  * h                  | @ref guivartype_f_unsigned "f_unsigned"|0      |The height of the rectangle.
  */
-class rect_bounded_shape : public canvas::shape {
+class rect_bounded_shape : public canvas::shape
+{
 protected:
 	/**
 	 * Constructor.
 	 *
 	 * @param cfg                 The config object to define the rectangle.
 	 */
-	explicit rect_bounded_shape(const config& cfg);
+	explicit rect_bounded_shape(const config& cfg)
+		: shape(cfg)
+		, x_(cfg["x"])
+		, y_(cfg["y"])
+		, w_(cfg["w"])
+		, h_(cfg["h"])
+	{
+	}
 
-	/**
-	 * Where to draw, calculated from the x,y,w,h formulas but with different reference points used
-	 * as the origin of the co-ordinate system.
-	 */
-	struct calculated_rects {
-		/**
-		 * True if there was no intersection between dst_on_widget and the viewport. If true, the
-		 * data in the SDL_Rects must be ignored.
-		 */
-		bool empty;
-		/** In the co-ordinate system that the WML uses, and unaffected by the view_bounds */
-		SDL_Rect dst_on_widget;
-		/** Intersection of dst_on_widget with view_bounds, in the co-ordinate system that the WML uses. */
-		SDL_Rect clip_on_widget;
-		/**
-		 * Intersection of view_bounds with the shape, in co-ordinates with the shape's top-left at
-		 * (0,0). For a text_shape, this co-ordinate system corresponds to the co-ordinates of the
-		 * Cairo surface that Pango draws on.
-		 */
-		SDL_Rect clip_in_shape;
-		/**
-		 * Translation of dst_on_widget to the viewport's co-ordinates. Here (0,0) corresponds to
-		 * view_bounds's top-left. Will often have negative values for x and y, and widths or
-		 * heights larger than the viewport's size.
-		 */
-		SDL_Rect unclipped_around_viewport;
-		/** Where to draw, in the co-ordinates of the viewport, and restricted to the view_bounds. */
-		SDL_Rect dst_in_viewport;
-	};
-
-	calculated_rects calculate_rects(const SDL_Rect& view_bounds, wfl::map_formula_callable& variables) const;
-
-private:
 	typed_formula<int> x_; /**< The x coordinate of the rectangle. */
 	typed_formula<int> y_; /**< The y coordinate of the rectangle. */
 	typed_formula<int> w_; /**< The width of the rectangle. */
@@ -179,7 +153,8 @@ private:
  *
  * Variables: see line_shape
  */
-class rectangle_shape : public rect_bounded_shape {
+class rectangle_shape : public rect_bounded_shape
+{
 public:
 	/**
 	 * Constructor.
@@ -188,9 +163,7 @@ public:
 	 */
 	explicit rectangle_shape(const config& cfg);
 
-	void draw(const SDL_Rect& portion_to_draw,
-	          const SDL_Rect& draw_location,
-	          wfl::map_formula_callable& variables) override;
+	void draw(wfl::map_formula_callable& variables) override;
 
 private:
 	/**
@@ -229,7 +202,8 @@ private:
  * fill_color      | @ref guivartype_color "color"          |""       |The color of the interior; if omitted it's not drawn.
  * debug           | @ref guivartype_string "string"        |""       |Debug message to show upon creation; this message is not stored.
  */
-class round_rectangle_shape : public rect_bounded_shape {
+class round_rectangle_shape : public rect_bounded_shape
+{
 public:
 	/**
 	 * Constructor.
@@ -238,9 +212,7 @@ public:
 	 */
 	explicit round_rectangle_shape(const config& cfg);
 
-	void draw(const SDL_Rect& portion_to_draw,
-	          const SDL_Rect& draw_location,
-	          wfl::map_formula_callable& variables) override;
+	void draw(wfl::map_formula_callable& variables) override;
 
 private:
 	typed_formula<int> r_; /**< The radius of the corners. */
@@ -287,7 +259,8 @@ private:
  *
  * Drawing outside the area will result in unpredictable results including crashing. (That should be fixed, when encountered.)
  */
-class circle_shape : public canvas::shape {
+class circle_shape : public canvas::shape
+{
 public:
 	/**
 	 * Constructor.
@@ -296,17 +269,20 @@ public:
 	 */
 	explicit circle_shape(const config& cfg);
 
-	void draw(const SDL_Rect& portion_to_draw,
-	          const SDL_Rect& draw_location,
-	          wfl::map_formula_callable& variables) override;
+	void draw( wfl::map_formula_callable& variables) override;
 
 private:
-	typed_formula<unsigned> x_, /**< The center x coordinate of the circle. */
-			y_,			   /**< The center y coordinate of the circle. */
-			radius_;	   /**< The radius of the circle. */
+	typed_formula<unsigned> x_; /**< The center x coordinate of the circle. */
+	typed_formula<unsigned> y_; /**< The center y coordinate of the circle. */
+
+	/** The radius of the circle. */
+	typed_formula<unsigned> radius_;
 
 	/** The border color of the circle. */
-	typed_formula<color_t> border_color_, fill_color_; /**< The fill color of the circle. */
+	typed_formula<color_t> border_color_;
+
+	/** The fill color of the circle. */
+	typed_formula<color_t> fill_color_;
 
 	/** The border thickness of the circle. */
 	unsigned int border_thickness_;
@@ -337,7 +313,8 @@ private:
  *
  * Also the general variables are available, see line_shape
  */
-class image_shape : public canvas::shape {
+class image_shape : public canvas::shape
+{
 public:
 	/**
 	 * Constructor.
@@ -347,15 +324,13 @@ public:
 	 */
 	image_shape(const config& cfg, wfl::action_function_symbol_table& functions);
 
-	void draw(const SDL_Rect& portion_to_draw,
-	          const SDL_Rect& draw_location,
-	          wfl::map_formula_callable& variables) override;
+	void draw(wfl::map_formula_callable& variables) override;
 
 private:
-	typed_formula<unsigned> x_, /**< The x coordinate of the image. */
-			y_,			   /**< The y coordinate of the image. */
-			w_,			   /**< The width of the image. */
-			h_;			   /**< The height of the image. */
+	typed_formula<unsigned> x_; /**< The x coordinate of the image. */
+	typed_formula<unsigned> y_; /**< The y coordinate of the image. */
+	typed_formula<unsigned> w_; /**< The width of the image. */
+	typed_formula<unsigned> h_; /**< The height of the image. */
 
 	// TODO: highdpi - none of these cached items are ever used. Why is this here?
 
@@ -432,7 +407,8 @@ private:
  * text_height        | @ref guivartype_unsigned "unsigned"      |The height of the rendered text.
  * Also the general variables are available, see line_shape
  */
-class text_shape : public rect_bounded_shape {
+class text_shape : public rect_bounded_shape
+{
 public:
 	/**
 	 * Constructor.
@@ -441,9 +417,7 @@ public:
 	 */
 	explicit text_shape(const config& cfg);
 
-	void draw(const SDL_Rect& portion_to_draw,
-	          const SDL_Rect& draw_location,
-	          wfl::map_formula_callable& variables) override;
+	void draw(wfl::map_formula_callable& variables) override;
 
 private:
 	/** The text font family. */

--- a/src/gui/widgets/container_base.cpp
+++ b/src/gui/widgets/container_base.cpp
@@ -196,12 +196,12 @@ void container_base::set_visible_rectangle(const SDL_Rect& rectangle)
 	grid_.set_visible_rectangle(rectangle);
 }
 
-void container_base::impl_draw_children(int x_offset, int y_offset)
+void container_base::impl_draw_children()
 {
 	assert(get_visible() == widget::visibility::visible
 	       && grid_.get_visible() == widget::visibility::visible);
 
-	grid_.draw_children(x_offset, y_offset);
+	grid_.draw_children();
 }
 
 void container_base::layout_children()

--- a/src/gui/widgets/container_base.hpp
+++ b/src/gui/widgets/container_base.hpp
@@ -108,7 +108,7 @@ public:
 	virtual void set_visible_rectangle(const SDL_Rect& rectangle) override;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 
 protected:
 	/** See @ref widget::layout_children. */

--- a/src/gui/widgets/generator.hpp
+++ b/src/gui/widgets/generator.hpp
@@ -280,7 +280,7 @@ public:
 	virtual void set_visible_rectangle(const SDL_Rect& rectangle) override = 0;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override = 0;
+	virtual void impl_draw_children() override = 0;
 
 protected:
 	/** See @ref widget::child_populate_dirty_list. */

--- a/src/gui/widgets/generator_private.hpp
+++ b/src/gui/widgets/generator_private.hpp
@@ -828,7 +828,7 @@ public:
 	}
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override
+	virtual void impl_draw_children() override
 	{
 		assert(this->get_visible() == widget::visibility::visible);
 
@@ -838,7 +838,7 @@ public:
 			child* item = items_[index].get();
 
 			if(item->child_grid.get_visible() == widget::visibility::visible && item->shown) {
-				item->child_grid.draw_children(x_offset, y_offset);
+				item->child_grid.draw_children();
 			}
 		}
 	}

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -995,7 +995,7 @@ void grid::layout(const point& origin)
 	}
 }
 
-void grid::impl_draw_children(int x_offset, int y_offset)
+void grid::impl_draw_children()
 {
 	/*
 	 * The call to SDL_PumpEvents seems a bit like black magic.
@@ -1024,9 +1024,9 @@ void grid::impl_draw_children(int x_offset, int y_offset)
 			continue;
 		}
 
-		widget->draw_background(x_offset, y_offset);
-		widget->draw_children(x_offset, y_offset);
-		widget->draw_foreground(x_offset, y_offset);
+		widget->draw_background();
+		widget->draw_children();
+		widget->draw_foreground();
 		widget->set_is_dirty(false);
 	}
 }

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -559,7 +559,7 @@ private:
 	void layout(const point& origin);
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 };
 
 /**

--- a/src/gui/widgets/matrix.cpp
+++ b/src/gui/widgets/matrix.cpp
@@ -108,9 +108,9 @@ void matrix::layout_initialize(const bool full_initialization)
 	content_.layout_initialize(full_initialization);
 }
 
-void matrix::impl_draw_children(int x_offset, int y_offset)
+void matrix::impl_draw_children()
 {
-	content_.draw_children(x_offset, y_offset);
+	content_.draw_children();
 }
 
 void matrix::layout_children()

--- a/src/gui/widgets/matrix.hpp
+++ b/src/gui/widgets/matrix.hpp
@@ -126,7 +126,7 @@ public:
 	virtual void layout_initialize(const bool full_initialization) override;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 
 	/** See @ref widget::layout_children. */
 	virtual void layout_children() override;

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -90,7 +90,7 @@ void minimap::set_map_data(const std::string& map_data)
 	}
 }
 
-void minimap::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
+void minimap::impl_draw_background()
 {
 	if(map_) {
 		image::render_minimap(get_width(), get_height(), *map_, nullptr, nullptr, nullptr, true);

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -69,158 +69,31 @@ unsigned minimap::get_state() const
 	return 0;
 }
 
-/** Key type for the cache. */
-struct key_type
-{
-	key_type(const int w, const int h, const std::string& map_data)
-		: w(w), h(h), map_data(map_data)
-	{
-	}
-
-	/** Width of the image. */
-	const int w;
-
-	/** Height of the image. */
-	const int h;
-
-	/** The data used to generate the image. */
-	const std::string map_data;
-};
-
-static bool operator<(const key_type& lhs, const key_type& rhs)
-{
-	return std::tie(lhs.w, lhs.h, lhs.map_data) < std::tie(rhs.w, rhs.h, rhs.map_data);
-}
-
-/** Value type for the cache. */
-struct value_type
-{
-	value_type(const texture& tex) : tex(tex), age(1)
-	{
-	}
-
-	/** The cached image. */
-	const texture tex;
-
-	/**
-	 * The age of the image.
-	 *
-	 * Every time an image is used its age is increased by one. Once the cache
-	 * is full 25% of the cache is emptied. This is done by halving the age of
-	 * the items in the cache and then erase the 25% with the lowest age. If
-	 * items have the same age their order is unspecified.
-	 */
-	unsigned age;
-};
-
-/**
- * Maximum number of items in the cache (multiple of 4).
- *
- * No testing on the optimal number is done, just seems a nice number.
- */
-static const size_t cache_max_size = 100;
-
-/** The cache. */
-typedef std::map<key_type, value_type> tcache;
-static tcache cache;
-
-static bool compare(const std::pair<unsigned, tcache::iterator>& lhs,
-					const std::pair<unsigned, tcache::iterator>& rhs)
-{
-	return lhs.first < rhs.first;
-}
-
-static void shrink_cache()
-{
-#ifdef DEBUG_MINIMAP_CACHE
-	std::cerr << "\nShrink cache from " << cache.size();
-#else
-	DBG_GUI_D << "Shrinking the minimap cache.\n";
-#endif
-
-	std::vector<std::pair<unsigned, tcache::iterator>> items;
-	for(tcache::iterator itor = cache.begin(); itor != cache.end(); ++itor) {
-
-		itor->second.age /= 2;
-		items.emplace_back(itor->second.age, itor);
-	}
-
-	std::partial_sort(items.begin(),
-					  items.begin() + cache_max_size / 4,
-					  items.end(),
-					  compare);
-
-	for(std::vector<std::pair<unsigned, tcache::iterator>>::iterator vitor
-		= items.begin();
-		vitor < items.begin() + cache_max_size / 4;
-		++vitor) {
-
-		cache.erase(vitor->second);
-	}
-
-#ifdef DEBUG_MINIMAP_CACHE
-	std::cerr << " to " << cache.size() << ".\n";
-#endif
-}
-
 bool minimap::disable_click_dismiss() const
 {
 	return false;
 }
 
-const texture minimap::get_image(const int w, const int h) const
+void minimap::set_map_data(const std::string& map_data)
 {
-	const key_type key(w, h, map_data_);
-	tcache::iterator itor = cache.find(key);
-
-	if(itor != cache.end()) {
-#ifdef DEBUG_MINIMAP_CACHE
-		std::cerr << '+';
-#endif
-		itor->second.age++;
-		return itor->second.tex;
-	}
-
-	if(cache.size() >= cache_max_size) {
-		shrink_cache();
-	}
-
-	try
-	{
-		const gamemap map(map_data_);
-		const texture tex = texture(image::getMinimap(w, h, map, nullptr, nullptr, true));
-		cache.emplace(key, value_type(tex));
-#ifdef DEBUG_MINIMAP_CACHE
-		std::cerr << '-';
-#endif
-		return tex;
-	}
-	catch(const incorrect_map_format_error& e)
-	{
-		ERR_CF << "Error while loading the map: " << e.message << '\n';
-#ifdef DEBUG_MINIMAP_CACHE
-		std::cerr << 'X';
-#endif
-	}
-	return texture();
-}
-
-void minimap::impl_draw_background(int x_offset, int y_offset)
-{
-	DBG_GUI_D << LOG_HEADER << " size "
-			  << calculate_blitting_rectangle(x_offset, y_offset) << ".\n";
-
-	if(map_data_.empty()) {
+	if(map_data == map_data_) {
 		return;
 	}
 
-	SDL_Rect rect = calculate_blitting_rectangle(x_offset, y_offset);
-	assert(rect.w > 0 && rect.h > 0);
+	map_data_ = map_data;
 
-	const texture tex = get_image(rect.w, rect.h);
-	if(tex) {
-		// get_image returns a pre-sized texture maintaining aspect ratio.
-		draw::blit(tex, {rect.x, rect.y, tex.w(), tex.h()});
+	try {
+		map_ = std::make_unique<gamemap>(map_data_);
+	} catch(const incorrect_map_format_error& e) {
+		map_.reset(nullptr);
+		ERR_CF << "Error while loading the map: " << e.message << '\n';
+	}
+}
+
+void minimap::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
+{
+	if(map_) {
+		image::render_minimap(get_width(), get_height(), *map_, nullptr, nullptr, nullptr, true);
 	}
 }
 

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -83,7 +83,7 @@ private:
 	std::unique_ptr<gamemap> map_;
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background(int x_offset, int y_offset) override;
+	virtual void impl_draw_background() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -21,6 +21,8 @@
 #include "gui/core/window_builder.hpp"
 
 class config;
+class gamemap;
+
 namespace gui2
 {
 namespace implementation
@@ -61,13 +63,7 @@ public:
 
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
-	void set_map_data(const std::string& map_data)
-	{
-		if(map_data != map_data_) {
-			map_data_ = map_data;
-			set_is_dirty(true);
-		}
-	}
+	void set_map_data(const std::string& map_data);
 
 	std::string get_map_data() const
 	{
@@ -83,15 +79,8 @@ private:
 	/** The map data to be used to generate the map. */
 	std::string map_data_;
 
-	/**
-	 * Gets the image for the minimap.
-	 *
-	 * @param w                   The wanted width of the image.
-	 * @param h                   The wanted height of the image.
-	 *
-	 * @returns                   The image, nullptr upon error.
-	 */
-	const texture get_image(const int w, const int h) const;
+	/** Game map generated from the provided data. */
+	std::unique_ptr<gamemap> map_;
 
 	/** See @ref widget::impl_draw_background. */
 	virtual void impl_draw_background(int x_offset, int y_offset) override;

--- a/src/gui/widgets/multi_page.cpp
+++ b/src/gui/widgets/multi_page.cpp
@@ -149,7 +149,7 @@ void multi_page::finalize(std::unique_ptr<generator_base> generator, const std::
 	swap_grid(nullptr, &get_grid(), std::move(generator), "_content_grid");
 }
 
-void multi_page::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
+void multi_page::impl_draw_background()
 {
 	/* DO NOTHING */
 }

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -217,7 +217,7 @@ private:
 	builder_grid_map page_builders_;
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background(int x_offset, int y_offset) override;
+	virtual void impl_draw_background() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/pane.cpp
+++ b/src/gui/widgets/pane.cpp
@@ -165,14 +165,14 @@ void pane::layout_initialize(const bool full_initialization)
 	}
 }
 
-void pane::impl_draw_children(int x_offset, int y_offset)
+void pane::impl_draw_children()
 {
 	DBG_GUI_D << LOG_HEADER << '\n';
 
 	for(auto & item : items_)
 	{
 		if(item.item_grid->get_visible() != widget::visibility::invisible) {
-			item.item_grid->draw_children(x_offset, y_offset);
+			item.item_grid->draw_children();
 		}
 	}
 }

--- a/src/gui/widgets/pane.hpp
+++ b/src/gui/widgets/pane.hpp
@@ -75,7 +75,7 @@ public:
 	virtual void layout_initialize(const bool full_initialization) override;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 
 	/** See @ref widget::child_populate_dirty_list. */
 	virtual void

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -65,13 +65,13 @@ unsigned panel::get_state() const
 	return 0;
 }
 
-void panel::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
+void panel::impl_draw_background()
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
 	get_canvas(0).draw();
 }
 
-void panel::impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)
+void panel::impl_draw_foreground()
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
 	get_canvas(1).draw();

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -65,18 +65,16 @@ unsigned panel::get_state() const
 	return 0;
 }
 
-void panel::impl_draw_background(int x_offset, int y_offset)
+void panel::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
-
-	get_canvas(0).blit(calculate_blitting_rectangle(x_offset, y_offset));
+	get_canvas(0).draw();
 }
 
-void panel::impl_draw_foreground(int x_offset, int y_offset)
+void panel::impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".\n";
-
-	get_canvas(1).blit(calculate_blitting_rectangle(x_offset, y_offset));
+	get_canvas(1).draw();
 }
 
 point panel::border_space() const

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -74,10 +74,10 @@ public:
 
 private:
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background(int x_offset, int y_offset) override;
+	virtual void impl_draw_background() override;
 
 	/** See @ref widget::impl_draw_foreground. */
-	virtual void impl_draw_foreground(int x_offset, int y_offset) override;
+	virtual void impl_draw_foreground() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -802,14 +802,14 @@ void scrollbar_container::set_horizontal_scrollbar_mode(const scrollbar_mode scr
 	}
 }
 
-void scrollbar_container::impl_draw_children(int x_offset, int y_offset)
+void scrollbar_container::impl_draw_children()
 {
 	assert(get_visible() == widget::visibility::visible && content_grid_->get_visible() == widget::visibility::visible);
 
 	// Inherited.
-	container_base::impl_draw_children(x_offset, y_offset);
+	container_base::impl_draw_children();
 
-	content_grid_->draw_children(x_offset, y_offset);
+	content_grid_->draw_children();
 }
 
 void scrollbar_container::layout_children()

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -510,7 +510,7 @@ private:
 	virtual void layout_children() override;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 
 	/** See @ref widget::child_populate_dirty_list. */
 	virtual void child_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack) override;

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -97,7 +97,7 @@ bool spacer::disable_click_dismiss() const
 	return false;
 }
 
-void spacer::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
+void spacer::impl_draw_background()
 {
 	/* DO NOTHING */
 }

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -87,7 +87,7 @@ private:
 	bool fills_available_space();
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background(int x_offset, int y_offset) override;
+	virtual void impl_draw_background() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -431,7 +431,7 @@ int styled_widget::get_text_maximum_height() const
 	return get_height() - config_->text_extra_height;
 }
 
-void styled_widget::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
+void styled_widget::impl_draw_background()
 {
 	DBG_GUI_D << LOG_HEADER << " label '" << debug_truncate(label_) << "' size "
 			  << get_rectangle() << ".\n";
@@ -439,7 +439,7 @@ void styled_widget::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
 	get_canvas(get_state()).draw();
 }
 
-void styled_widget::impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)
+void styled_widget::impl_draw_foreground()
 {
 	/* DO NOTHING */
 }

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -431,12 +431,12 @@ int styled_widget::get_text_maximum_height() const
 	return get_height() - config_->text_extra_height;
 }
 
-void styled_widget::impl_draw_background(int x_offset, int y_offset)
+void styled_widget::impl_draw_background(int /*x_offset*/, int /*y_offset*/)
 {
 	DBG_GUI_D << LOG_HEADER << " label '" << debug_truncate(label_) << "' size "
 			  << get_rectangle() << ".\n";
 
-	get_canvas(get_state()).blit(calculate_blitting_rectangle(x_offset, y_offset));
+	get_canvas(get_state()).draw();
 }
 
 void styled_widget::impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -459,10 +459,10 @@ public:
 
 protected:
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background(int x_offset, int y_offset) override;
+	virtual void impl_draw_background() override;
 
 	/** See @ref widget::impl_draw_foreground. */
-	virtual void impl_draw_foreground(int x_offset, int y_offset) override;
+	virtual void impl_draw_foreground() override;
 
 	/** Exposes font::pango_text::get_token, for the text label of this styled_widget */
 	std::string get_label_token(const point & position, const char * delimiters = " \n\r\t") const;

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -193,18 +193,18 @@ void toggle_panel::set_state(const state_t state)
 	assert(conf);
 }
 
-void toggle_panel::impl_draw_background(int x_offset, int y_offset)
+void toggle_panel::impl_draw_background()
 {
 	// We don't have a fore and background and need to draw depending on
 	// our state, like a styled_widget. So we use the styled_widget's drawing method.
-	styled_widget::impl_draw_background(x_offset, y_offset);
+	styled_widget::impl_draw_background();
 }
 
-void toggle_panel::impl_draw_foreground(int x_offset, int y_offset)
+void toggle_panel::impl_draw_foreground()
 {
 	// We don't have a fore and background and need to draw depending on
 	// our state, like a styled_widget. So we use the styled_widget's drawing method.
-	styled_widget::impl_draw_foreground(x_offset, y_offset);
+	styled_widget::impl_draw_foreground();
 }
 
 void toggle_panel::signal_handler_mouse_enter(const event::ui_event event,

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -175,10 +175,10 @@ private:
 	std::function<void(widget&)> callback_mouse_left_double_click_;
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background(int x_offset, int y_offset) override;
+	virtual void impl_draw_background() override;
 
 	/** See @ref widget::impl_draw_foreground. */
-	virtual void impl_draw_foreground(int x_offset, int y_offset) override;
+	virtual void impl_draw_foreground() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -631,16 +631,16 @@ void tree_view_node::set_visible_rectangle(const SDL_Rect& rectangle)
 	}
 }
 
-void tree_view_node::impl_draw_children(int x_offset, int y_offset)
+void tree_view_node::impl_draw_children()
 {
-	grid_.draw_children(x_offset, y_offset);
+	grid_.draw_children();
 
 	if(is_folded()) {
 		return;
 	}
 
 	for(auto& node : children_) {
-		node->impl_draw_children(x_offset, y_offset);
+		node->impl_draw_children();
 	}
 }
 

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -324,7 +324,7 @@ private:
 	virtual void set_visible_rectangle(const SDL_Rect& rectangle) override;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 
 	// FIXME rename to icon
 	void signal_handler_left_button_click(const event::ui_event event);

--- a/src/gui/widgets/viewport.cpp
+++ b/src/gui/widgets/viewport.cpp
@@ -107,15 +107,12 @@ void viewport::layout_initialize(const bool full_initialization)
 	}
 }
 
-void viewport::impl_draw_children(int x_offset, int y_offset)
+void viewport::impl_draw_children()
 {
-	x_offset += get_x();
-	y_offset += get_y();
-
 	if(widget_->get_visible() != widget::visibility::invisible) {
-		widget_->draw_background(x_offset, y_offset);
-		widget_->draw_children(x_offset, y_offset);
-		widget_->draw_foreground(x_offset, y_offset);
+		widget_->draw_background();
+		widget_->draw_children();
+		widget_->draw_foreground();
 		widget_->set_is_dirty(false);
 	}
 }

--- a/src/gui/widgets/viewport.hpp
+++ b/src/gui/widgets/viewport.hpp
@@ -59,7 +59,7 @@ public:
 	virtual void layout_initialize(const bool full_initialization) override;
 
 	/** See @ref widget::impl_draw_children. */
-	virtual void impl_draw_children(int x_offset, int y_offset) override;
+	virtual void impl_draw_children() override;
 
 	/** See @ref widget::child_populate_dirty_list. */
 	virtual void

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -351,33 +351,25 @@ void widget::set_linked_group(const std::string& linked_group)
 
 /***** ***** ***** ***** Drawing functions. ***** ***** ***** *****/
 
-SDL_Rect widget::calculate_blitting_rectangle(const int x_offset, const int y_offset) const
+SDL_Rect widget::calculate_blitting_rectangle() const
 {
-	SDL_Rect result = get_rectangle();
-	result.x += x_offset;
-	result.y += y_offset;
-	return result;
+	return get_rectangle();
 }
 
-SDL_Rect widget::calculate_clipping_rectangle(const int x_offset, const int y_offset) const
+SDL_Rect widget::calculate_clipping_rectangle() const
 {
-	SDL_Rect result;
 	switch(get_drawing_action()) {
 	case redraw_action::none:
 		return sdl::empty_rect;
 	case redraw_action::partly:
-		result = clipping_rectangle_;
-		break;
+		return clipping_rectangle_;
 	case redraw_action::full:
-		result = get_rectangle();
-		break;
+	default:
+		return get_rectangle();
 	}
-	result.x += x_offset;
-	result.y += y_offset;
-	return result;
 }
 
-void widget::draw_background(int x_offset, int y_offset)
+void widget::draw_background()
 {
 	assert(visible_ == visibility::visible);
 
@@ -385,17 +377,17 @@ void widget::draw_background(int x_offset, int y_offset)
 		return;
 	}
 
-	SDL_Rect dest = calculate_blitting_rectangle(x_offset, y_offset);
-	SDL_Rect clip = calculate_clipping_rectangle(x_offset, y_offset);
+	SDL_Rect dest = calculate_blitting_rectangle();
+	SDL_Rect clip = calculate_clipping_rectangle();
 	clip.x -= dest.x; clip.y -= dest.y;
 	auto view_setter = draw::set_viewport(dest);
 	auto clip_setter = draw::reduce_clip(clip);
 
-	draw_debug_border(x_offset, y_offset);
-	impl_draw_background(x_offset, y_offset);
+	draw_debug_border();
+	impl_draw_background();
 }
 
-void widget::draw_children(int x_offset, int y_offset)
+void widget::draw_children()
 {
 	assert(visible_ == visibility::visible);
 
@@ -403,16 +395,16 @@ void widget::draw_children(int x_offset, int y_offset)
 		return;
 	}
 
-	SDL_Rect dest = calculate_blitting_rectangle(x_offset, y_offset);
-	SDL_Rect clip = calculate_clipping_rectangle(x_offset, y_offset);
+	SDL_Rect dest = calculate_blitting_rectangle();
+	SDL_Rect clip = calculate_clipping_rectangle();
 	clip.x -= dest.x; clip.y -= dest.y;
 	auto view_setter = draw::set_viewport(dest);
 	auto clip_setter = draw::reduce_clip(clip);
 
-	impl_draw_children(x_offset, y_offset);
+	impl_draw_children();
 }
 
-void widget::draw_foreground(int x_offset, int y_offset)
+void widget::draw_foreground()
 {
 	assert(visible_ == visibility::visible);
 
@@ -420,13 +412,13 @@ void widget::draw_foreground(int x_offset, int y_offset)
 		return;
 	}
 
-	SDL_Rect dest = calculate_blitting_rectangle(x_offset, y_offset);
-	SDL_Rect clip = calculate_clipping_rectangle(x_offset, y_offset);
+	SDL_Rect dest = calculate_blitting_rectangle();
+	SDL_Rect clip = calculate_clipping_rectangle();
 	clip.x -= dest.x; clip.y -= dest.y;
 	auto view_setter = draw::set_viewport(dest);
 	auto clip_setter = draw::reduce_clip(clip);
 
-	impl_draw_foreground(x_offset, y_offset);
+	impl_draw_foreground();
 }
 
 void widget::populate_dirty_list(window& caller,
@@ -538,32 +530,9 @@ void widget::set_debug_border_color(const color_t debug_border_color)
 
 void widget::draw_debug_border()
 {
-	SDL_Rect r = redraw_action_ == redraw_action::partly ? clipping_rectangle_
-														  : get_rectangle();
-
-	switch(debug_border_mode_) {
-		case debug_border::none:
-			/* DO NOTHING */
-			break;
-		case debug_border::outline:
-			draw::rect(r, debug_border_color_);
-			break;
-
-		case debug_border::fill:
-			draw::fill(r, debug_border_color_);
-			break;
-
-		default:
-			assert(false);
-	}
-}
-
-void
-widget::draw_debug_border(int x_offset, int y_offset)
-{
 	SDL_Rect r = redraw_action_ == redraw_action::partly
-						 ? calculate_clipping_rectangle(x_offset, y_offset)
-						 : calculate_blitting_rectangle(x_offset, y_offset);
+		? calculate_clipping_rectangle()
+		: calculate_blitting_rectangle();
 
 	switch(debug_border_mode_) {
 		case debug_border::none:

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -523,42 +523,29 @@ public:
 	/**
 	 * Calculates the blitting rectangle of the widget.
 	 *
-	 * The blitting rectangle is the entire widget rectangle, but offsetted for
-	 * drawing position.
-	 *
-	 * @param x_offset            The offset in the x-direction when drawn.
-	 * @param y_offset            The offset in the y-direction when drawn.
+	 * The blitting rectangle is the entire widget rectangle.
 	 *
 	 * @returns                   The drawing rectangle.
 	 */
-	SDL_Rect calculate_blitting_rectangle(const int x_offset, const int y_offset) const;
+	SDL_Rect calculate_blitting_rectangle() const;
 
 	/**
 	 * Calculates the clipping rectangle of the widget.
 	 *
 	 * The clipping rectangle is used then the @ref redraw_action_ is
-	 * @ref redraw_action::partly. Since the drawing can be offsetted it also
-	 * needs offset parameters.
-	 *
-	 * @param x_offset            The offset in the x-direction when drawn.
-	 * @param y_offset            The offset in the y-direction when drawn.
+	 * @ref redraw_action::partly.
 	 *
 	 * @returns                   The clipping rectangle.
 	 */
-	SDL_Rect calculate_clipping_rectangle(const int x_offset, const int y_offset) const;
+	SDL_Rect calculate_clipping_rectangle() const;
 
 	/**
 	 * Draws the background of a widget.
 	 *
 	 * Derived should override @ref impl_draw_background instead of changing
 	 * this function.
-	 *
-	 * @param x_offset            The offset in the x-direction in the
-	 *                            @p frame_buffer to draw.
-	 * @param y_offset            The offset in the y-direction in the
-	 *                            @p frame_buffer to draw.
 	 */
-	void draw_background(int x_offset, int y_offset);
+	void draw_background();
 
 	/**
 	 * Draws the children of a widget.
@@ -567,13 +554,8 @@ public:
 	 *
 	 * Derived should override @ref impl_draw_children instead of changing
 	 * this function.
-	 *
-	 * @param x_offset            The offset in the x-direction in the
-	 *                            @p frame_buffer to draw.
-	 * @param y_offset            The offset in the y-direction in the
-	 *                            @p frame_buffer to draw.
 	 */
-	void draw_children(int x_offset, int y_offset);
+	void draw_children();
 
 	/**
 	 * Draws the foreground of the widget.
@@ -583,13 +565,8 @@ public:
 	 *
 	 * Derived should override @ref impl_draw_foreground instead of changing
 	 * this function.
-	 *
-	 * @param x_offset            The offset in the x-direction in the
-	 *                            @p frame_buffer to draw.
-	 * @param y_offset            The offset in the y-direction in the
-	 *                            @p frame_buffer to draw.
 	 */
-	void draw_foreground(int x_offset, int y_offset);
+	void draw_foreground();
 
 private:
 	/** See @ref draw_background. */
@@ -597,17 +574,13 @@ private:
 	{
 	}
 
-	virtual void impl_draw_background(int /*x_offset*/, int /*y_offset*/)
-	{
-	}
-
 	/** See @ref draw_children. */
-	virtual void impl_draw_children(int /*x_offset*/, int /*y_offset*/)
+	virtual void impl_draw_children()
 	{
 	}
 
 	/** See @ref draw_foreground. */
-	virtual void impl_draw_foreground(int /*x_offset*/, int /*y_offset*/)
+	virtual void impl_draw_foreground()
 	{
 	}
 
@@ -715,7 +688,6 @@ private:
 	color_t debug_border_color_;
 
 	void draw_debug_border();
-	void draw_debug_border(int x_offset, int y_offset);
 
 	/***** ***** ***** ***** Query functions ***** ***** ***** *****/
 

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -531,8 +531,7 @@ public:
 	 *
 	 * @returns                   The drawing rectangle.
 	 */
-	SDL_Rect calculate_blitting_rectangle(const int x_offset,
-										  const int y_offset);
+	SDL_Rect calculate_blitting_rectangle(const int x_offset, const int y_offset) const;
 
 	/**
 	 * Calculates the clipping rectangle of the widget.
@@ -546,8 +545,7 @@ public:
 	 *
 	 * @returns                   The clipping rectangle.
 	 */
-	SDL_Rect calculate_clipping_rectangle(const int x_offset,
-										  const int y_offset);
+	SDL_Rect calculate_clipping_rectangle(const int x_offset, const int y_offset) const;
 
 	/**
 	 * Draws the background of a widget.

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -738,12 +738,12 @@ void window::draw()
 			itor != item.end();
 			++itor) {
 
-			(**itor).draw_background(0, 0);
+			(**itor).draw_background();
 		}
 
 		// Children.
 		if(!item.empty()) {
-			item.back()->draw_children(0, 0);
+			item.back()->draw_children();
 		}
 
 		// Foreground.
@@ -751,7 +751,7 @@ void window::draw()
 			ritor != item.rend();
 			++ritor) {
 
-			(**ritor).draw_foreground(0, 0);
+			(**ritor).draw_foreground();
 			(**ritor).set_is_dirty(false);
 		}
 	}

--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -19,6 +19,7 @@
 
 #include "color.hpp"
 #include "display.hpp"
+#include "draw.hpp"
 #include "game_board.hpp"
 #include "gettext.hpp"
 #include "picture.hpp"
@@ -26,9 +27,11 @@
 #include "map/map.hpp"
 #include "preferences/general.hpp"
 #include "resources.hpp"
+#include "sdl/render_utils.hpp"
 #include "sdl/surface.hpp"
 #include "team.hpp"
 #include "terrain/type_data.hpp"
+#include "units/unit.hpp"
 
 static lg::log_domain log_display("display");
 #define DBG_DP LOG_STREAM(debug, log_display)
@@ -287,5 +290,301 @@ surface getMinimap(int w, int h, const gamemap &map, const team *vw, const std::
 	return minimap;
 }
 
+void render_minimap(unsigned dst_w,
+		unsigned dst_h,
+		const gamemap& map,
+		const team* vw,
+		const unit_map* units,
+		const std::map<map_location, unsigned int>* reach_map,
+		bool ignore_terrain_disabled)
+{
+	display* disp = display::get_singleton();
+
+	const bool is_blindfolded = disp && disp->is_blindfolded();
+
+	const terrain_type_data& tdata = *map.tdata();
+
+	// Drawing mode flags.
+	const bool preferences_minimap_draw_terrain   = preferences::minimap_draw_terrain() || ignore_terrain_disabled;
+	const bool preferences_minimap_terrain_coding = preferences::minimap_terrain_coding();
+	const bool preferences_minimap_draw_villages  = preferences::minimap_draw_villages();
+	const bool preferences_minimap_draw_units     = preferences::minimap_draw_units();
+	const bool preferences_minimap_unit_coding    = preferences::minimap_movement_coding();
+
+	const int scale = (preferences_minimap_draw_terrain && preferences_minimap_terrain_coding) ? 24 : 4;
+
+	DBG_DP << "Creating minimap: " << static_cast<int>(map.w() * scale * 0.75) << ", " << map.h() * scale << std::endl;
+
+	const std::size_t map_width  = map.w() * scale * 3 / 4;
+	const std::size_t map_height = map.h() * scale;
+
+	// Gets a destination rect for drawing at the given coordinates.
+	// We need a balanced shift up and down of the hexes.
+	// If not, only the bottom half-hexes are clipped and it looks asymmetrical.
+	auto get_dst_rect = [scale](int x, int y) ->SDL_Rect {
+		return {
+			x * scale             * 3 / 4                - (scale / 4),
+			y * scale + scale / 4 * (is_odd(x) ? 1 : -1) - (scale / 4),
+			scale,
+			scale
+		};
+	};
+
+	// No map!
+	if(map_width == 0 || map_height == 0) {
+		return;
+	}
+
+	// Nothing to draw!
+	if(!preferences_minimap_draw_villages && !preferences_minimap_draw_terrain) {
+		return;
+	}
+
+	// We want to draw the minimap with NN scaling.
+	set_texture_scale_quality("nearest");
+
+	// Create a temp texture a bit larger than we want. This allows us to compose the minimap and then
+	// scale the whole result down the desired destination texture size.
+	texture minimap(map_width, map_height, SDL_TEXTUREACCESS_TARGET);
+	if(!minimap) {
+		return;
+	}
+
+	{
+		// Point rendering to the temp minimap texture.
+		const draw::render_target_setter target_setter{minimap};
+
+		//
+		// Terrain
+		//
+		for(int y = 0; y <= map.total_height(); ++y) {
+			for(int x = 0; x <= map.total_width(); ++x) {
+				const map_location loc(x, y);
+
+				if(!map.on_board_with_border(loc)) {
+					continue;
+				}
+
+				const bool shrouded = is_blindfolded || (vw && vw->shrouded(loc));
+
+				// Shrouded hex are not considered fogged (no need to fog a black image)
+				const bool fogged = (vw != nullptr && !shrouded && vw->fogged(loc));
+
+				const bool highlighted = reach_map && reach_map->count(loc) != 0 && !shrouded;
+
+				const t_translation::terrain_code terrain = shrouded ? t_translation::VOID_TERRAIN : map[loc];
+				const terrain_type& terrain_info = tdata.get_terrain_info(terrain);
+
+				// Destination rect for drawing the current hex.
+				SDL_Rect map_dst_rect = get_dst_rect(x, y);
+
+				//
+				// Draw map terrain...
+				//
+				if(preferences_minimap_draw_terrain) {
+					if(preferences_minimap_terrain_coding) {
+						//
+						// ...either using terrain images...
+						//
+						if(!terrain_info.minimap_image().empty()) {
+							const std::string base_file = "terrain/" + terrain_info.minimap_image() + ".png";
+							const texture& tile = image::get_texture(base_file); // image::HEXED
+
+							// TODO: handle fog (was a -50, -50, -50 adjust) and highlight (was a 50, 50, 50 adjust).
+							draw::blit(tile, map_dst_rect);
+
+							// NOTE: we skip the overlay when base is missing (to avoid hiding the error)
+							if(tile && tdata.get_terrain_info(terrain).is_combined()
+								&& !terrain_info.minimap_image_overlay().empty())
+							{
+								const std::string overlay_file = "terrain/" + terrain_info.minimap_image_overlay() + ".png";
+
+								const texture& overlay = image::get_texture(overlay_file); // image::HEXED
+
+								// TODO: crop/center overlays?
+								draw::blit(overlay, map_dst_rect);
+							}
+						}
+					} else {
+						//
+						// ... or color coding.
+						//
+						color_t col(0, 0, 0, 0);
+
+						// Despite its name, game_config::team_rgb_range isn't just team colors,
+						// it has "red", "lightblue", "cave", "reef", "fungus", etc.
+						auto it = game_config::team_rgb_range.find(terrain_info.id());
+						if(it != game_config::team_rgb_range.end()) {
+							col = it->second.rep();
+						}
+
+						bool first = true;
+						const t_translation::ter_list& underlying_terrains = tdata.underlying_union_terrain(terrain);
+
+						for(const t_translation::terrain_code& underlying_terrain : underlying_terrains) {
+							const std::string& terrain_id = tdata.get_terrain_info(underlying_terrain).id();
+
+							it = game_config::team_rgb_range.find(terrain_id);
+							if(it == game_config::team_rgb_range.end()) {
+								continue;
+							}
+
+							color_t tmp = it->second.rep();
+
+							if(fogged) {
+								if(tmp.b < 50) {
+									tmp.b = 0;
+								} else {
+									tmp.b -= 50;
+								}
+
+								if(tmp.g < 50) {
+									tmp.g = 0;
+								} else {
+									tmp.g -= 50;
+								}
+
+								if(tmp.r < 50) {
+									tmp.r = 0;
+								} else {
+									tmp.r -= 50;
+								}
+							}
+
+							if(highlighted) {
+								if(tmp.b > 205) {
+									tmp.b = 255;
+								} else {
+									tmp.b += 50;
+								}
+
+								if(tmp.g > 205) {
+									tmp.g = 255;
+								} else {
+									tmp.g += 50;
+								}
+
+								if(tmp.r > 205) {
+									tmp.r = 255;
+								} else {
+									tmp.r += 50;
+								}
+							}
+
+							if(first) {
+								first = false;
+								col = tmp;
+							} else {
+								col.r = col.r - (col.r - tmp.r) / 2;
+								col.g = col.g - (col.g - tmp.g) / 2;
+								col.b = col.b - (col.b - tmp.b) / 2;
+							}
+						}
+
+						SDL_Rect fillrect {map_dst_rect.x, map_dst_rect.y, scale * 3 / 4, scale};
+						draw::fill(fillrect, col);
+					}
+				}
+
+				//
+				// Draw village markers independent of terrain.
+				//
+				if(terrain_info.is_village() && preferences_minimap_draw_villages) {
+					// Check needed for mp create dialog
+					const int side_num = resources::gameboard
+						? resources::gameboard->village_owner(loc)
+						: 0;
+
+					color_t col(255, 255, 255);
+
+					// TODO: Add a key to [game_config][colors] for this
+					auto iter = game_config::team_rgb_range.find("white");
+					if(iter != game_config::team_rgb_range.end()) {
+						col = iter->second.min();
+					}
+
+					if(!fogged && side_num > 0) {
+						if(preferences_minimap_unit_coding || !vw) {
+							col = team::get_minimap_color(side_num);
+						} else {
+							if(vw->owns_village(loc)) {
+								col = game_config::color_info(preferences::unmoved_color()).rep();
+							} else if(vw->is_enemy(side_num)) {
+								col = game_config::color_info(preferences::enemy_color()).rep();
+							} else {
+								col = game_config::color_info(preferences::allied_color()).rep();
+							}
+						}
+					}
+
+					SDL_Rect fillrect {map_dst_rect.x, map_dst_rect.y, scale * 3 / 4, scale};
+					draw::fill(fillrect, col);
+				}
+			}
+		}
+
+		//
+		// Units
+		//
+		if(units && preferences_minimap_draw_units && !is_blindfolded) {
+			for(const auto& u : *units) {
+				const map_location& u_loc = u.get_location();
+				const int side = u.side();
+				const bool is_enemy = vw && vw->is_enemy(side);
+
+				if((vw && vw->fogged(u_loc)) || (is_enemy && disp && u.invisible(u_loc)) || u.get_hidden()) {
+					continue;
+				}
+
+				color_t col = team::get_minimap_color(side);
+
+				if(!preferences_minimap_unit_coding) {
+					if(is_enemy) {
+						col = game_config::color_info(preferences::enemy_color()).rep();
+					} else {
+						if(vw && vw->side() == side) {
+							if(u.movement_left() == u.total_movement()) {
+								col = game_config::color_info(preferences::unmoved_color()).rep();
+							} else if (u.movement_left() == 0) {
+								col = game_config::color_info(preferences::moved_color()).rep();
+							} else {
+								col = game_config::color_info(preferences::partial_color()).rep();
+							}
+						} else {
+							col = game_config::color_info(preferences::allied_color()).rep();
+						}
+					}
+				}
+
+
+				SDL_Rect fillrect = get_dst_rect(u_loc.x, u_loc.y);
+				fillrect.w = scale * 3 / 4; // TODO: needed?
+
+				draw::fill(fillrect, col);
+			}
+		}
+	}
+
+	texture::info src_info = minimap.get_info();
+
+	const double wratio = dst_w * 1.0 / src_info.w;
+	const double hratio = dst_h * 1.0 / src_info.h;
+
+	const double ratio = std::min<double>(wratio, hratio);
+
+	// TODO: maybe add arguments so we can set render origin?
+	SDL_Rect final_dst_rect {
+		0,
+		0,
+		static_cast<int>(src_info.w * ratio),
+		static_cast<int>(src_info.h * ratio)
+	};
+
+	// Finally, render the composited minimap texture (scaled down) to the render target,
+	// which should be the passed texture.
+	draw::blit(minimap, final_dst_rect);
+
+	DBG_DP << "done generating minimap" << std::endl;
+}
 
 }

--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -315,8 +315,8 @@ void render_minimap(unsigned dst_w,
 
 	DBG_DP << "Creating minimap: " << static_cast<int>(map.w() * scale * 0.75) << ", " << map.h() * scale << std::endl;
 
-	const std::size_t map_width  = map.w() * scale * 3 / 4;
-	const std::size_t map_height = map.h() * scale;
+	const std::size_t map_width  = std::max(0, map.w()) * scale * 3 / 4;
+	const std::size_t map_height = std::max(0, map.h()) * scale;
 
 	// Gets a destination rect for drawing at the given coordinates.
 	// We need a balanced shift up and down of the hexes.

--- a/src/minimap.hpp
+++ b/src/minimap.hpp
@@ -21,6 +21,7 @@
 class gamemap;
 class surface;
 class team;
+class unit_map;
 struct map_location;
 
 namespace image {
@@ -29,4 +30,15 @@ namespace image {
 	 * the surface returned must be freed by the user
 	 */
 	surface getMinimap(int w, int h, const gamemap &map_, const team *vm = nullptr, const std::map<map_location,unsigned int> *reach_map = nullptr, bool ignore_terrain_disabled = false);
+
+/**
+ * Renders the minimap to the screen.
+ */
+void render_minimap(unsigned dst_w,
+	unsigned dst_h,
+	const gamemap& map,
+	const team* vw = nullptr,
+	const unit_map* units = nullptr,
+	const std::map<map_location, unsigned int>* reach_map = nullptr,
+	bool ignore_terrain_disabled = false);
 }


### PR DESCRIPTION
Pulling most of the canvas cleanup out of the `new_rendering` branch.

This fixes #6787 , or at least it puts it back to the state it was in before. The GUI is still using the wrong layout at those resolutions, but it won't go all black.

This also introduces bugs with the credits screen. I managed to get it at least not crashing, but it looks terrible. That can't be fixed without overhauling the credits screen to not try to draw 80000 pixels worth of text all at once. It's not trying to draw all that here, but the way the canvas overhaul was set up, it still can't handle the size even if it only draws a small amount.

I left out the massive removal of dirty widget handling code.

I also had to completely overhaul how viewport setting works to micromanage clipping regions. It was not pleasant. I am not a fan of viewports.