### PR TITLE
[Units] [Loyalists] Add missing resistance special notes to Javelineer

### DIFF
--- a/data/core/units/humans/Loyalist_Javelineer.cfg
+++ b/data/core/units/humans/Loyalist_Javelineer.cfg
@@ -16,6 +16,9 @@
     cost=25
     usage=fighter
     description= _ "Spearmen almost always equip themselves with a few javelins, to harry, if not kill, enemies at range. Some, however, take to them rather well, finding that they have a natural talent in their use. Javelineers are a valuable asset to an army, being able to supplement their skill in melee combat with an ability to handle distant foes. They can hurl javelins into enemy ranks from a distance, often without retribution, and still hold their ground in melee."
+    [special_note]
+        note= _ "Compared to other loyalists, Javelineers have a higher resistance to ‘pierce’ attacks."
+    [/special_note]
     die_sound={SOUND_LIST:HUMAN_DIE}
     {DEFENSE_ANIM_RANGE "units/human-loyalists/javelineer-defend.png" "units/human-loyalists/javelineer.png" {SOUND_LIST:HUMAN_HIT} melee}
     {DEFENSE_ANIM_RANGE "units/human-loyalists/javelineer-defend-ranged.png" "units/human-loyalists/javelineer-attack-ranged-1.png" {SOUND_LIST:HUMAN_HIT} ranged}


### PR DESCRIPTION
Pikeman and Swordsman have special notes denoting their resistance increases...but the Javelineer got ignored?

Javelineer has 40% pierce resistance (identical to the Pikeman)