### PR TITLE
Address various minor highdpi TODOs

### DIFF
--- a/data/game_config.cfg
+++ b/data/game_config.cfg
@@ -36,9 +36,6 @@
     # zoom factors must be a sorted list of ascending multipliers
     zoom_levels = 0.25, 0.33333333333333333, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0
 
-    #temporary disable hex brightening
-    hex_brightening=1.25
-
     flag_rgb=flag_green
     unit_rgb=magenta
     red_green_scale="e60000,ff0000,ff4000,ff8000,ffc000,ffff00,c0ff00,80ff00,40ff00,00ff00,00e600"

--- a/data/schema/core/config.cfg
+++ b/data/schema/core/config.cfg
@@ -46,7 +46,6 @@
 	{SIMPLE_KEY hp_bar_scaling real}
 	{SIMPLE_KEY xp_bar_scaling real}
 	{SIMPLE_KEY zoom_levels real_list}
-	{SIMPLE_KEY hex_brightening real}
 	{SIMPLE_KEY flag_rgb string}
 	{SIMPLE_KEY unit_rgb string}
 	{SIMPLE_KEY red_green_scale hex_list}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1608,7 +1608,6 @@ void display::render_image(int x, int y, const display::drawing_layer drawing_la
 		tex = image::get_texture(i_locator);
 	}
 
-	// TODO: highdpi - flipping and alpha modification need to be propagated from hreverse, vreverse, alpha
 	const uint8_t alpha_mod = std::clamp(alpha, 0, 255);
 	drawing_buffer_add(drawing_layer, loc, dest, tex, sdl::empty_rect,
 		hreverse, vreverse, alpha_mod);
@@ -2878,7 +2877,6 @@ void display::refresh_report(const std::string& report_name, const config * new_
 		{
 			if (used_ellipsis) goto skip_element;
 
-			// TODO: highdpi - high dpi text
 			// Draw a text element.
 			font::pango_text& text = font::get_text_renderer();
 			bool eol = false;
@@ -2911,7 +2909,6 @@ void display::refresh_report(const std::string& report_name, const config * new_
 				//NOTE this space should be longer than minimal_text pixels
 				t = t + "    ";
 				text.set_text(t, true);
-				// TODO: highdpi - don't convert this here
 				s = text.render_texture();
 				// use the area of this element for next tooltips
 				used_ellipsis = true;

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -78,8 +78,6 @@ std::vector<unsigned int> zoom_levels {36, 72, 144};
 //
 double hp_bar_scaling  = 0.666;
 double xp_bar_scaling  = 0.5;
-// TODO: highdpi - remove hex_brightening? it is and was not actually used
-double hex_brightening = 1.25;
 
 //
 // Misc
@@ -366,7 +364,6 @@ void load_config(const config &v)
 
 	hp_bar_scaling  = v["hp_bar_scaling"].to_double(0.666);
 	xp_bar_scaling  = v["xp_bar_scaling"].to_double(0.5);
-	hex_brightening = v["hex_brightening"].to_double(1.25);
 
 	foot_speed_prefix   = utils::split(v["footprint_prefix"]);
 	foot_teleport_enter = v["footprint_teleport_enter"].str();

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -152,7 +152,6 @@ namespace game_config
 	extern std::string shroud_prefix, fog_prefix;
 
 	extern double hp_bar_scaling, xp_bar_scaling;
-	extern double hex_brightening; // UNUSED
 
 	extern std::string flag_rgb, unit_rgb;
 	extern std::vector<color_t> red_green_scale;

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -486,7 +486,6 @@ void game_display::draw_movement_info(const map_location& loc)
 	}
 }
 
-// TODO: highdpi - make sure the result of this gets scaled where it's used
 std::vector<texture> footsteps_images(const map_location& loc, const pathfind::marked_route & route_, const display_context * dc_)
 {
 	std::vector<texture> res;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -318,13 +318,12 @@ void image_shape::draw(wfl::map_formula_callable& variables)
 	local_variables.add("image_width", wfl::variant(w ? w : tex.w()));
 	local_variables.add("image_height", wfl::variant(h ? h : tex.h()));
 
-	// TODO: highdpi - why are these called "clip"?
-	const unsigned clip_x = x_(local_variables);
-	const unsigned clip_y = y_(local_variables);
+	const int x = x_(local_variables);
+	const int y = y_(local_variables);
 
-	// TODO: highdpi - what are these for? They are never used anywhere else.
-	local_variables.add("clip_x", wfl::variant(clip_x));
-	local_variables.add("clip_y", wfl::variant(clip_y));
+	// used in gui/dialogs/story_viewer.cpp
+	local_variables.add("clip_x", wfl::variant(x));
+	local_variables.add("clip_y", wfl::variant(y));
 
 	// Execute the provided actions for this context.
 	wfl::variant(variables.fake_ptr()).execute_variant(actions_formula_.evaluate(local_variables));
@@ -333,7 +332,7 @@ void image_shape::draw(wfl::map_formula_callable& variables)
 	if (!w) { w = tex.w(); }
 	if (!h) { h = tex.h(); }
 
-	const SDL_Rect dst_rect { static_cast<int>(clip_x), static_cast<int>(clip_y), w, h };
+	const SDL_Rect dst_rect { x, y, w, h };
 
 	// What to do with the image depends on whether we need to tile it or not.
 	switch(resize_mode_) {

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -558,12 +558,6 @@ void help_text_area::draw_contents()
 						it->rect.w - i * 2,
 						it->rect.h - i * 2
 					};
-
-					// SDL 2.0.10's render batching changes result in the
-					// surface's clipping rectangle being overridden even if
-					// no render clipping rectangle set operaton was queued,
-					// so let's not use the render API to draw the rectangle.
-					// TODO: highdpi - is the above still relevant?
 					draw::fill(draw_rect, 0, 0, 0, 0);
 					++dst.x;
 					++dst.y;

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -113,9 +113,8 @@ void help_text_area::set_items()
 	curr_loc_.second = 0;
 	curr_row_height_ = min_row_height_;
 	// Add the title item.
-	const std::string show_title =
-		font::pango_line_ellipsize(shown_topic_->title, title_size, inner_location().w);
-	// TODO: highdpi - pango textures
+	const std::string show_title = font::pango_line_ellipsize(
+		shown_topic_->title, title_size, inner_location().w);
 	texture tex(font::pango_render_text(show_title, title_size,
 		font::NORMAL_COLOR, font::pango_text::STYLE_BOLD));
 	if (tex) {
@@ -355,7 +354,6 @@ void help_text_area::add_text_item(const std::string& text, const std::string& r
 			down_one_line();
 		}
 		else {
-			// TODO: highdpi - pango textures
 			texture tex(font::pango_render_text(first_part,
 				scaled_font_size, color, font::pango_text::FONT_STYLE(state)));
 			if (tex) {

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -319,12 +319,10 @@ void dialog_frame::draw_background()
 	}
 
 	if (dialog_style_.blur_radius) {
-		SDL_Rect r = dim_.exterior;
-		surface surf = video_.read_pixels_low_res(&r);
-		surf = blur_surface(surf, dialog_style_.blur_radius);
-		// TODO: highdpi - converting this to texture every time is not ideal, but i also suspect this is not actually used anywhere, and all this is slated for removal anyway.
-		WRN_DP << "deprecated very slow blur" << std::endl;
-		draw::blit(texture(surf), r);
+		// This is no longer used by anything.
+		// The only thing that uses dialog_frame is help/help.cpp,
+		// and it uses the default style with no blur.
+		ERR_DP << "GUI1 dialog_frame blur has been removed" << std::endl;
 	}
 
 	if (!bg_) {

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -72,10 +72,6 @@ void trigger_full_redraw()
 	SDL_Event event;
 	event.type = SDL_WINDOWEVENT;
 	event.window.event = SDL_WINDOWEVENT_EXPOSED;
-	// TODO: highdpi - double check whether anything actually does need a resize event
-	//event.window.event = SDL_WINDOWEVENT_RESIZED;
-	//event.window.data1 = (*drawingSurface).h;
-	//event.window.data2 = (*drawingSurface).w;
 
 	for(const auto& layer : draw_layers) {
 		layer->handle_window_event(event);

--- a/src/whiteboard/attack.cpp
+++ b/src/whiteboard/attack.cpp
@@ -188,43 +188,44 @@ void attack::remove_temp_modifier(unit_map& unit_map)
 	move::remove_temp_modifier(unit_map);
 }
 
+// Draws the attack indicator.
 void attack::draw_hex(const map_location& hex)
 {
-	// TODO: highdpi - this indent is unnecessary
-	if (hex == get_dest_hex() || hex == target_hex_) //draw attack indicator
+	if (hex != get_dest_hex() && hex != target_hex_) {
+		return;
+	}
+
+	//@todo: replace this by either the use of transparency + LAYER_ATTACK_INDICATOR,
+	//or a dedicated layer
+	const display::drawing_layer layer = display::LAYER_FOOTSTEPS;
+
+	//calculate direction (valid for both hexes)
+	std::string direction_text = map_location::write_direction(
+			get_dest_hex().get_relative_dir(target_hex_));
+
+	if (hex == get_dest_hex()) //add symbol to attacker hex
 	{
-		//@todo: replace this by either the use of transparency + LAYER_ATTACK_INDICATOR,
-		//or a dedicated layer
-		const display::drawing_layer layer = display::LAYER_FOOTSTEPS;
+		auto disp = display::get_singleton();
+		int x = disp->get_location_x(get_dest_hex());
+		int y = disp->get_location_y(get_dest_hex());
+		const texture t = image::get_texture(
+			"whiteboard/attack-indicator-src-" + direction_text + ".png",
+			image::HEXED);
+		const SDL_Rect dest = disp->scaled_to_zoom({x, y, t.w(), t.h()});
 
-		//calculate direction (valid for both hexes)
-		std::string direction_text = map_location::write_direction(
-				get_dest_hex().get_relative_dir(target_hex_));
+		disp->drawing_buffer_add(layer, get_dest_hex(), dest, t);
+	}
+	else if (hex == target_hex_) //add symbol to defender hex
+	{
+		auto disp = display::get_singleton();
+		int x = disp->get_location_x(target_hex_);
+		int y = disp->get_location_y(target_hex_);
+		const texture t = image::get_texture(
+			"whiteboard/attack-indicator-dst-" + direction_text + ".png",
+			image::HEXED);
+		const SDL_Rect dest = disp->scaled_to_zoom({x, y, t.w(), t.h()});
 
-		if (hex == get_dest_hex()) //add symbol to attacker hex
-		{
-			auto disp = display::get_singleton();
-			int x = disp->get_location_x(get_dest_hex());
-			int y = disp->get_location_y(get_dest_hex());
-			const texture t = image::get_texture(
-				"whiteboard/attack-indicator-src-" + direction_text + ".png",
-				image::HEXED);
-			const SDL_Rect dest = disp->scaled_to_zoom({x, y, t.w(), t.h()});
-
-			disp->drawing_buffer_add(layer, get_dest_hex(), dest, t);
-		}
-		else if (hex == target_hex_) //add symbol to defender hex
-		{
-			auto disp = display::get_singleton();
-			int x = disp->get_location_x(target_hex_);
-			int y = disp->get_location_y(target_hex_);
-			const texture t = image::get_texture(
-				"whiteboard/attack-indicator-dst-" + direction_text + ".png",
-				image::HEXED);
-			const SDL_Rect dest = disp->scaled_to_zoom({x, y, t.w(), t.h()});
-
-			disp->drawing_buffer_add(layer, target_hex_, dest, t);
-		}
+		disp->drawing_buffer_add(layer, target_hex_, dest, t);
 	}
 }
 

--- a/src/whiteboard/suppose_dead.cpp
+++ b/src/whiteboard/suppose_dead.cpp
@@ -136,20 +136,20 @@ void suppose_dead::remove_temp_modifier(unit_map& unit_map)
 
 void suppose_dead::draw_hex(const map_location& hex)
 {
-	// TODO: highdpi - this indent is unnecessary
-	if(hex == loc_) //add symbol to hex
-	{
-		//@todo: Possibly use a different layer
-		const display::drawing_layer layer = display::LAYER_ARROWS;
-
-		auto disp = display::get_singleton();
-		int x = disp->get_location_x(loc_);
-		int y = disp->get_location_y(loc_);
-		const texture& tex = image::get_texture(
-			"whiteboard/suppose_dead.png", image::HEXED);
-		const SDL_Rect dest = disp->scaled_to_zoom({x, y, tex.w(), tex.h()});
-		disp->drawing_buffer_add(layer, loc_, dest, tex);
+	if (hex != loc_) {
+		return;
 	}
+
+	//@todo: Possibly use a different layer
+	const display::drawing_layer layer = display::LAYER_ARROWS;
+
+	auto disp = display::get_singleton();
+	int x = disp->get_location_x(loc_);
+	int y = disp->get_location_y(loc_);
+	const texture& tex = image::get_texture(
+		"whiteboard/suppose_dead.png", image::HEXED);
+	const SDL_Rect dest = disp->scaled_to_zoom({x, y, tex.w(), tex.h()});
+	disp->drawing_buffer_add(layer, loc_, dest, tex);
 }
 
 void suppose_dead::redraw()

--- a/src/widgets/menu_style.cpp
+++ b/src/widgets/menu_style.cpp
@@ -23,7 +23,6 @@
 #include "picture.hpp"
 #include "lexical_cast.hpp"
 #include "sdl/utils.hpp"
-#include "video.hpp"
 
 namespace gui {
 
@@ -154,7 +153,6 @@ void menu::imgsel_style::draw_row(menu& menu_ref, const std::size_t row_index, c
 			// draw border
 			texture image;
 			SDL_Rect area;
-			// TODO: highdpi - move clip API to draw.cpp, this is the last usage of video here
 			auto clipper = draw::set_clip(rect);
 			area.x = rect.x;
 			area.y = rect.y;

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -375,7 +375,6 @@ void textbox::update_text_cache(bool changed, const color_t& color)
 	cursor_pos_ = cursor_x - text_pos_;
 
 	if (text_image_) {
-		// TODO: highdpi - does this need pixel scale compensation?
 		set_full_size(text_image_.h());
 		set_shown_size(location().h);
 	}

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -206,6 +206,8 @@ void textbox::draw_contents()
 			const int endx = char_x_[end];
 			const int endy = char_y_[end];
 
+			auto clipper = draw::set_clip(loc);
+
 			while(starty <= endy) {
 				const std::size_t right = starty == endy ? endx : text_image_.w();
 				if(right <= std::size_t(startx)) {
@@ -216,9 +218,6 @@ void textbox::draw_contents()
 						, loc.y + starty - src.y
 						, right - startx
 						, line_height_);
-
-				// TODO: highdpi - this seems excessive
-				auto clipper = draw::set_clip(loc);
 
 				draw::fill(rect, 0, 0, 160, 140);
 


### PR DESCRIPTION
Mostly these just involved checking if something was okay.

A couple unused things were removed.
1. The `hex_brightening` config option. This was not used, and from the looks of it has not been for quite some time. It was added in 2010 for testing the mouseover effect. The current effect is hardcoded and ignores this value.
2. There was a function dealing with "report" images, which actively analyzed them for transparency and automatically clipped them. This is ridiculous and i removed it some time ago. No adverse effect has been reported.

I originally thought "reports" were maybe some automatically generated graphs or something. But no. It is just the name for the automatically updated UI sections of the game display, such as the amount of village gold etc.. The icon images do not need clipping, and even if they do, it should be done via IPF.