### PR TITLE
Inherit from SDL types for point and color_t

### DIFF
--- a/src/color.hpp
+++ b/src/color.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include <SDL2/SDL_pixels.h>
+
 #include <algorithm> // for max
 #include <cstdint>
 #include <ostream>
 #include <string>
 #include <utility>
-
-struct SDL_Color;
 
 //
 // TODO: constexpr
@@ -46,26 +46,25 @@ const uint32_t RGBA_RED_BITSHIFT   = 24;
 const uint32_t RGBA_GREEN_BITSHIFT = 16;
 const uint32_t RGBA_BLUE_BITSHIFT  = 8;
 
-const uint8_t ALPHA_OPAQUE = 255;
+const uint8_t ALPHA_OPAQUE = SDL_ALPHA_OPAQUE; // This is always 255 in SDL2
 
-struct color_t
+/**
+ * The basic class for representing 8-bit RGB or RGBA colour values.
+ *
+ * This is a thin wrapper over SDL_Color, and can be used interchangeably.
+ */
+struct color_t : SDL_Color
 {
-	color_t()
-		: r(255)
-		, g(255)
-		, b(255)
-		, a(ALPHA_OPAQUE)
-	{}
+	/** color_t initializes to fully opaque white by default. */
+	color_t() : SDL_Color{255, 255, 255, ALPHA_OPAQUE} {}
 
+	/** Basic RGB or RGBA constructor. */
 	color_t(uint8_t r_val, uint8_t g_val, uint8_t b_val, uint8_t a_val = ALPHA_OPAQUE)
-		: r(r_val)
-		, g(g_val)
-		, b(b_val)
-		, a(a_val)
+		: SDL_Color{r_val, g_val, b_val, a_val}
 	{}
 
-	// Implemented in sdl/utils.cpp to avoid dependency nightmares
-	explicit color_t(const SDL_Color& c);
+	/** This is a thin wrapper. There is nothing extra to do here. */
+	color_t(const SDL_Color& c) : SDL_Color{c} {}
 
 	/**
 	 * Creates a new color_t object from a string variable in "R,G,B,A" format.
@@ -165,26 +164,6 @@ struct color_t
 	 * @return      The new color string.
 	 */
 	std::string to_rgb_string() const;
-
-	/**
-	 * Returns the stored color as an color_t object.
-	 *
-	 * @return       The new color_t object.
-	 */
-	// Implemented in sdl/utils.cpp to avoid dependency nightmares
-	SDL_Color to_sdl() const;
-
-	/** Red value */
-	uint8_t r;
-
-	/** Green value */
-	uint8_t g;
-
-	/** Blue value */
-	uint8_t b;
-
-	/** Alpha value */
-	uint8_t a;
 
 	bool null() const
 	{

--- a/src/sdl/point.cpp
+++ b/src/sdl/point.cpp
@@ -19,11 +19,6 @@
 
 #include <iostream>
 
-point::operator SDL_Point() const
-{
-	return {x, y};
-}
-
 point& point::operator+=(const point& point)
 {
 	x += point.x;

--- a/src/sdl/point.hpp
+++ b/src/sdl/point.hpp
@@ -20,35 +20,15 @@
 #include <iosfwd>
 #include <tuple>
 
-/** Holds a 2D point. */
-struct point
+/** Holds a 2D point. This is a thin wrapper over SDL_Point. */
+struct point : SDL_Point
 {
-	point()
-		: x(0)
-		, y(0)
-	{
-	}
+	/** Initialize to 0 by default. */
+	point() : SDL_Point{0, 0} {}
 
-	point(const int x_, const int y_)
-		: x(x_)
-		, y(y_)
-	{
-	}
+	point(int x, int y) : SDL_Point{x, y} {}
 
-	point(const SDL_Point& p)
-		: x(p.x)
-		, y(p.y)
-	{
-	}
-
-	/** x coordinate. */
-	int x;
-
-	/** y coordinate. */
-	int y;
-
-	/** Allow implicit conversion to SDL_Point. */
-	operator SDL_Point() const;
+	point(const SDL_Point& p) : SDL_Point{p} {}
 
 	bool operator==(const point& point) const
 	{

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1952,14 +1952,3 @@ SDL_Rect get_non_transparent_portion(const surface &surf)
 
 	return res;
 }
-
-SDL_Color color_t::to_sdl() const {
-	return {r, g, b, a};
-}
-
-color_t::color_t(const SDL_Color& c)
-	: r(c.r)
-	, g(c.g)
-	, b(c.b)
-	, a(c.a)
-{}


### PR DESCRIPTION
This changes `color_t` and `point` to be thin wrappers over `SDL_Color` and `SDL_Point`.

They already had the same members, so usage is completely unchanged.

Aside from being a bit tidier to define, the practical differences are:
1. converting to and from the SDL versions no longer requires copying the data in most cases
2. color_t and point references can be passed directly to SDL functions requiring SDL_Color and SDL_Point pointers.

That second one was mostly why i wanted this.