### PR TITLE
A thin wrapper for SDL_Rect

### DIFF
--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -83,7 +83,7 @@ void controller_base::long_touch_callback(int x, int y)
 
 		if(!yes_actually_dragging
 		   && (mouse_state & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0
-		   && sdl::point_in_rect(x_now, y_now, get_display().map_area()))
+		   && get_display().map_area().contains(x_now, y_now))
 		{
 			const theme::menu* const m = get_mouse_handler_base().gui().get_theme().context_menu();
 			if(m != nullptr) {
@@ -214,7 +214,7 @@ void controller_base::handle_event(const SDL_Event& event)
 			int y = static_cast<int>(reinterpret_cast<std::intptr_t>(event.user.data2));
 			if(event.user.code == static_cast<int>(SDL_TOUCH_MOUSEID)
 			   // TODO: Move to right_click_show_menu?
-			   && sdl::point_in_rect(x, y, get_display().map_area())
+			   && get_display().map_area().contains(x, y)
 			   // TODO: This chain repeats in several places, move to a method.
 			   && get_display().get_theme().context_menu() != nullptr) {
 				show_menu(get_display().get_theme().context_menu()->items(),
@@ -284,7 +284,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 		: 0;
 
 	for(const theme::menu& m : get_display().get_theme().menus()) {
-		if(sdl::point_in_rect(mousex, mousey, m.get_location())) {
+		if(m.get_location().contains(mousex, mousey)) {
 			scroll_threshold = 0;
 		}
 	}
@@ -334,9 +334,9 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 		const SDL_Point original_loc = mh_base.get_scroll_start();
 
 		if(mh_base.scroll_started()) {
-			const SDL_Rect& rect = get_display().map_outside_area();
-
-			if(sdl::point_in_rect(mousex, mousey, rect) && mh_base.scroll_started()) {
+			if(get_display().map_outside_area().contains(mousex, mousey)
+				&& mh_base.scroll_started())
+			{
 				// Scroll speed is proportional from the distance from the first
 				// middle click and scrolling speed preference.
 				const double speed = 0.01 * scroll_amount;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1933,10 +1933,10 @@ bool display::scroll(int xmove, int ymove, bool force)
 	//
 
 	if(!screen_.update_locked()) {
-		SDL_Rect dstrect = map_area();
+		rect dstrect = map_area();
 		dstrect.x += diff_x;
 		dstrect.y += diff_y;
-		dstrect = sdl::intersect_rects(dstrect, map_area());
+		dstrect.clip(map_area());
 
 		SDL_Rect srcrect = dstrect;
 		srcrect.x -= diff_x;
@@ -3000,7 +3000,7 @@ bool display::propagate_invalidation(const std::set<map_location>& locs)
 
 bool display::invalidate_visible_locations_in_rect(const SDL_Rect& rect)
 {
-	return invalidate_locations_in_rect(sdl::intersect_rects(map_area(), rect));
+	return invalidate_locations_in_rect(map_area().intersect(rect));
 }
 
 bool display::invalidate_locations_in_rect(const SDL_Rect& rect)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -534,9 +534,9 @@ bool display::is_blindfolded() const
 	return blindfold_ctr_ > 0;
 }
 
-const SDL_Rect& display::max_map_area() const
+rect display::max_map_area() const
 {
-	static SDL_Rect max_area{0, 0, 0, 0};
+	rect max_area{0, 0, 0, 0};
 
 	// hex_size() is always a multiple of 4
 	// and hex_width() a multiple of 3,
@@ -551,18 +551,16 @@ const SDL_Rect& display::max_map_area() const
 	return max_area;
 }
 
-const SDL_Rect& display::map_area() const
+rect display::map_area() const
 {
-	static SDL_Rect max_area;
-	max_area = max_map_area();
+	rect max_area = max_map_area();
 
 	// if it's for map_screenshot, maximize and don't recenter
 	if(map_screenshot_) {
 		return max_area;
 	}
 
-	static SDL_Rect res;
-	res = map_outside_area();
+	rect res = map_outside_area();
 
 	if(max_area.w < res.w) {
 		// map is smaller, center
@@ -589,13 +587,13 @@ bool display::outside_area(const SDL_Rect& area, const int x, const int y)
 // This function uses the screen as reference
 const map_location display::hex_clicked_on(int xclick, int yclick) const
 {
-	const SDL_Rect& rect = map_area();
-	if(sdl::point_in_rect(xclick,yclick,rect) == false) {
+	rect r = map_area();
+	if(!r.contains(xclick, yclick)) {
 		return map_location();
 	}
 
-	xclick -= rect.x;
-	yclick -= rect.y;
+	xclick -= r.x;
+	yclick -= r.y;
 
 	return pixel_position_to_hex(xpos_ + xclick, ypos_ + yclick);
 }
@@ -752,7 +750,7 @@ map_location display::minimap_location_on(int x, int y)
 	// TODO: don't return location for this,
 	//  instead directly scroll to the clicked pixel position
 
-	if(!sdl::point_in_rect(x, y, minimap_area())) {
+	if(!minimap_area().contains(x, y)) {
 		return map_location();
 	}
 
@@ -2497,7 +2495,7 @@ const map_labels& display::labels() const
 	return *map_labels_;
 }
 
-const SDL_Rect& display::get_clip_rect()
+rect display::get_clip_rect() const
 {
 	return map_area();
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1527,8 +1527,8 @@ void display::render_image(int x, int y, const display::drawing_layer drawing_la
 	}
 
 	// TODO: highdpi - are x,y correct here?
-	SDL_Rect dest = scaled_to_zoom({x, y, image_size.x, image_size.y});
-	if (!sdl::rects_overlap(dest, map_area())) {
+	rect dest = scaled_to_zoom({x, y, image_size.x, image_size.y});
+	if (!dest.overlaps(map_area())) {
 		return;
 	}
 
@@ -2509,8 +2509,8 @@ void display::draw_invalidated() {
 		int ypos = get_location_y(loc);
 
 		//const bool on_map = get_map().on_board(loc);
-		SDL_Rect hex_rect = sdl::create_rect(xpos, ypos, zoom_, zoom_);
-		if(!sdl::rects_overlap(hex_rect,clip_rect)) {
+		rect hex_rect(xpos, ypos, zoom_, zoom_);
+		if(!hex_rect.overlaps(clip_rect)) {
 			continue;
 		}
 		draw_hex(loc);

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -218,30 +218,30 @@ public:
 	 * Between mapx and x is the sidebar region.
 	 */
 
-	const SDL_Rect& minimap_area() const
+	const rect& minimap_area() const
 		{ return theme_.mini_map_location(screen_.draw_area()); }
-	const SDL_Rect& palette_area() const
+	const rect& palette_area() const
 		{ return theme_.palette_location(screen_.draw_area()); }
-	const SDL_Rect& unit_image_area() const
+	const rect& unit_image_area() const
 		{ return theme_.unit_image_location(screen_.draw_area()); }
 
 	/**
 	 * Returns the maximum area used for the map
 	 * regardless to resolution and view size
 	 */
-	const SDL_Rect& max_map_area() const;
+	rect max_map_area() const;
 
 	/**
 	 * Returns the area used for the map
 	 */
-	const SDL_Rect& map_area() const;
+	rect map_area() const;
 
 	/**
 	 * Returns the available area for a map, this may differ
 	 * from the above. This area will get the background area
 	 * applied to it.
 	 */
-	const SDL_Rect& map_outside_area() const { return map_screenshot_ ?
+	rect map_outside_area() const { return map_screenshot_ ?
 		max_map_area() : theme_.main_map_location(screen_.draw_area()); }
 
 	/** Check if the bbox of the hex at x,y has pixels outside the area rectangle. */
@@ -666,7 +666,7 @@ protected:
 	 * Get the clipping rectangle for drawing.
 	 * Virtual since the editor might use a slightly different approach.
 	 */
-	virtual const SDL_Rect& get_clip_rect();
+	virtual rect get_clip_rect() const;
 
 	/**
 	 * Only called when there's actual redrawing to do. Loops through

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -458,8 +458,7 @@ draw::clip_setter draw::reduce_clip(const SDL_Rect& clip)
 	if (!draw::clip_enabled()) {
 		return draw::clip_setter(clip);
 	}
-	SDL_Rect c = draw::get_clip();
-	return draw::clip_setter(sdl::intersect_rects(clip, c));
+	return draw::clip_setter(draw::get_clip().intersect(clip));
 }
 
 void draw::force_clip(const SDL_Rect& clip)
@@ -474,7 +473,7 @@ void draw::force_clip(const SDL_Rect& clip)
 	SDL_RenderSetClipRect(renderer(), &clip);
 }
 
-SDL_Rect draw::get_clip()
+rect draw::get_clip()
 {
 	// TODO: highdpi - fix whatever reason there is for this guard (CI fail)
 	if (!renderer()) {
@@ -487,7 +486,7 @@ SDL_Rect draw::get_clip()
 		return CVideo::get_singleton().draw_area();
 	}
 
-	SDL_Rect clip;
+	::rect clip;
 	SDL_RenderGetClipRect(renderer(), &clip);
 	return clip;
 }

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -29,7 +29,8 @@
  * resolution when possible, without any extra handling required.
  */
 
-#include <SDL2/SDL_rect.h>
+#include "sdl/rect.hpp"
+
 #include <vector>
 
 struct color_t;
@@ -329,7 +330,7 @@ void force_clip(const SDL_Rect& clip);
  *
  * If clipping is disabled, this will return the full drawing area.
  */
-SDL_Rect get_clip();
+::rect get_clip();
 
 /** Whether clipping is enabled. */
 bool clip_enabled();

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -93,7 +93,7 @@ void editor_display::draw_hex(const map_location& loc)
 	}
 }
 
-const SDL_Rect& editor_display::get_clip_rect()
+rect editor_display::get_clip_rect() const
 {
 	return map_outside_area();
 }

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -49,7 +49,7 @@ protected:
 	/** Inherited from display. */
 	virtual overlay_map& get_overlays() override;
 
-	const SDL_Rect& get_clip_rect() override;
+	rect get_clip_rect() const override;
 	void draw_sidebar() override;
 
 	std::set<map_location> brush_locations_;

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -70,7 +70,7 @@ public:
 	//TODO move to widget
 	bool hit(int x, int y) const
 	{
-		return sdl::point_in_rect(x, y, location());
+		return location().contains(x, y);
 	}
 
 	void mouse_up(const SDL_MouseButtonEvent& e)

--- a/src/editor/palette/palette_manager.cpp
+++ b/src/editor/palette/palette_manager.cpp
@@ -165,7 +165,7 @@ void palette_manager::handle_event(const SDL_Event& event) {
 
 	if (event.type == SDL_MOUSEMOTION) {
 		// If the mouse is inside the palette, give it focus.
-		if (sdl::point_in_rect(event.button.x, event.button.y, location())) {
+		if (location().contains(event.button.x, event.button.y)) {
 			if (!focus(&event)) set_focus(true);
 		}
 		// If the mouse is outside, remove focus.

--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -245,7 +245,7 @@ void tristate_button::draw_contents()
 
 //TODO move to widget
 bool tristate_button::hit(int x, int y) const {
-	return sdl::point_in_rect(x, y, location());
+	return location().contains(x, y);
 }
 
 void tristate_button::mouse_motion(const SDL_MouseMotionEvent& event) {

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -455,10 +455,10 @@ void text_shape::draw(wfl::map_formula_callable& variables)
 	const int y = y_(local_variables);
 	const int w = w_(local_variables);
 	const int h = h_(local_variables);
-	SDL_Rect dst_rect{x, y, w, h};
+	rect dst_rect{x, y, w, h};
 
 	// Get the visible portion of text.
-	SDL_Rect visible = sdl::intersect_rects(draw::get_clip(), dst_rect);
+	rect visible = dst_rect.intersect(draw::get_clip());
 
 	// Get the source region of text for clipping.
 	rect clip_in = visible;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -461,16 +461,12 @@ void text_shape::draw(wfl::map_formula_callable& variables)
 	SDL_Rect visible = sdl::intersect_rects(draw::get_clip(), dst_rect);
 
 	// Get the source region of text for clipping.
-	SDL_Rect clip_in = visible;
+	rect clip_in = visible;
 	clip_in.x -= x;
 	clip_in.y -= y;
 
 	// Source region for high-dpi text needs to have pixel scale applied.
-	const int pixel_scale = CVideo::get_singleton().get_pixel_scale();
-	clip_in.x *= pixel_scale;
-	clip_in.y *= pixel_scale;
-	clip_in.w *= pixel_scale;
-	clip_in.h *= pixel_scale;
+	clip_in *= CVideo::get_singleton().get_pixel_scale();
 
 	// Render the currently visible portion of text
 	// TODO: highdpi - it would be better to render this all, but some things currently have far too much text. Namely the credits screen.

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -144,8 +144,7 @@ void drop_down_menu::mouse_up_callback(bool&, bool&, const point& coordinate)
 		list.select_row(sel, false);
 	}
 
-	SDL_Rect rect = get_window()->get_rectangle();
-	if(!sdl::point_in_rect(coordinate, rect)) {
+	if(!get_window()->get_rectangle().contains(coordinate)) {
 		set_retval(retval::CANCEL);
 	} else if(!keep_open_) {
 		set_retval(retval::OK);

--- a/src/gui/dialogs/terrain_layers.cpp
+++ b/src/gui/dialogs/terrain_layers.cpp
@@ -107,8 +107,9 @@ void terrain_layers::pre_show(window& window)
 		// Cut and mask the image
 		// ~CROP and ~BLIT have limitations, we do some math to avoid them
 		// TODO: ^ eh? what limitations?
-		SDL_Rect r2 = sdl::intersect_rects(r, {0,0,img_size.x,img_size.y});
-		if(r2.w > 0 && r2.h > 0) {
+		rect r2{0, 0, img_size.x, img_size.y};
+		r2.clip(r);
+		if(!r2.empty()) {
 			image_steam
 				<< "~BLIT(" << name
 					<< "~CROP("

--- a/src/gui/widgets/horizontal_scrollbar.cpp
+++ b/src/gui/widgets/horizontal_scrollbar.cpp
@@ -73,11 +73,12 @@ unsigned horizontal_scrollbar::offset_after() const
 
 bool horizontal_scrollbar::on_positioner(const point& coordinate) const
 {
-	SDL_Rect positioner_rect =
-		sdl::create_rect(get_positioner_offset(), 0, get_positioner_length(), get_height());
+	rect positioner_rect(
+		get_positioner_offset(), 0, get_positioner_length(), get_height()
+	);
 
 	// Note we assume the positioner is over the entire height of the widget.
-	return sdl::point_in_rect(coordinate, positioner_rect);
+	return positioner_rect.contains(coordinate);
 }
 
 int horizontal_scrollbar::on_bar(const point& coordinate) const

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -309,14 +309,14 @@ void listbox::list_item_clicked(widget& caller)
 		return;
 	}
 
-	const SDL_Rect& visible = content_visible_area();
-	SDL_Rect rect = generator_->item(selected_item).get_rectangle();
+	const rect& visible = content_visible_area();
+	rect r = generator_->item(selected_item).get_rectangle();
 
-	if(sdl::rects_overlap(visible, rect)) {
-		rect.x = visible.x;
-		rect.w = visible.w;
+	if(visible.overlaps(r)) {
+		r.x = visible.x;
+		r.w = visible.w;
 
-		show_content_rect(rect);
+		show_content_rect(r);
 	}
 }
 

--- a/src/gui/widgets/pane.cpp
+++ b/src/gui/widgets/pane.cpp
@@ -74,7 +74,7 @@ struct pane_implementation
 			 * If the adjusted coordinate is in the item's grid let the grid
 			 * resolve the coordinate.
 			 */
-			if(sdl::point_in_rect(coordinate, item.item_grid->get_rectangle())) {
+			if(item.item_grid->get_rectangle().contains(coordinate)) {
 				return item.item_grid->find_at(coordinate, must_be_active);
 			}
 		}

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -466,7 +466,7 @@ void scrollbar_container::set_visible_rectangle(const SDL_Rect& rectangle)
 	container_base::set_visible_rectangle(rectangle);
 
 	// Now get the visible part of the content.
-	content_visible_area_ = sdl::intersect_rects(rectangle, content_->get_rectangle());
+	content_visible_area_ = content_->get_rectangle().intersect(rectangle);
 
 	content_grid_->set_visible_rectangle(content_visible_area_);
 }

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -145,11 +145,12 @@ unsigned slider::offset_after() const
 
 bool slider::on_positioner(const point& coordinate) const
 {
-	SDL_Rect positioner_rect =
-		sdl::create_rect(get_positioner_offset(), 0, get_positioner_length(), get_height());
+	rect positioner_rect(
+		get_positioner_offset(), 0, get_positioner_length(), get_height()
+	);
 
 	// Note we assume the positioner is over the entire height of the widget.
-	return sdl::point_in_rect(coordinate, positioner_rect);
+	return positioner_rect.contains(coordinate);
 }
 
 int slider::on_bar(const point& coordinate) const

--- a/src/gui/widgets/vertical_scrollbar.cpp
+++ b/src/gui/widgets/vertical_scrollbar.cpp
@@ -64,11 +64,12 @@ unsigned vertical_scrollbar::offset_after() const
 
 bool vertical_scrollbar::on_positioner(const point& coordinate) const
 {
-	SDL_Rect positioner_rect =
-		sdl::create_rect(0, get_positioner_offset(), get_width(), get_positioner_length());
+	rect positioner_rect(
+		0, get_positioner_offset(), get_width(), get_positioner_length()
+	);
 
 	// Note we assume the positioner is over the entire height of the widget.
-	return sdl::point_in_rect(coordinate, positioner_rect);
+	return positioner_rect.contains(coordinate);
 }
 
 int vertical_scrollbar::on_bar(const point& coordinate) const

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -459,7 +459,7 @@ SDL_Rect widget::get_dirty_rectangle() const
 
 void widget::set_visible_rectangle(const SDL_Rect& rectangle)
 {
-	clipping_rectangle_ = sdl::intersect_rects(rectangle, get_rectangle());
+	clipping_rectangle_ = get_rectangle().intersect(rectangle);
 
 	if(clipping_rectangle_ == get_rectangle()) {
 		redraw_action_ = redraw_action::full;

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -606,7 +606,7 @@ bool widget::is_at(const point& coordinate, const bool must_be_active) const
 		return false;
 	}
 
-	return sdl::point_in_rect(coordinate, get_rectangle());
+	return get_rectangle().contains(coordinate);
 }
 
 } // namespace gui2

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -309,9 +309,9 @@ point widget::get_size() const
 	return point(width_, height_);
 }
 
-SDL_Rect widget::get_rectangle() const
+rect widget::get_rectangle() const
 {
-	return sdl::create_rect(get_origin(), get_size());
+	return {get_origin(), get_size()};
 }
 
 int widget::get_x() const
@@ -463,7 +463,7 @@ void widget::set_visible_rectangle(const SDL_Rect& rectangle)
 
 	if(clipping_rectangle_ == get_rectangle()) {
 		redraw_action_ = redraw_action::full;
-	} else if(clipping_rectangle_ == sdl::empty_rect) {
+	} else if(clipping_rectangle_.empty()) {
 		redraw_action_ = redraw_action::none;
 	} else {
 		redraw_action_ = redraw_action::partly;

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -20,6 +20,7 @@
 #include "gui/widgets/event_executor.hpp"
 #include "scripting/lua_ptr.hpp"
 #include "sdl/point.hpp"
+#include "sdl/rect.hpp"
 
 #include <string>
 
@@ -437,7 +438,7 @@ public:
 	 *
 	 * @returns                   The bounding rectangle of the widget.
 	 */
-	SDL_Rect get_rectangle() const;
+	rect get_rectangle() const;
 
 	/*** *** *** *** *** *** Setters and getters. *** *** *** *** *** ***/
 
@@ -674,7 +675,7 @@ private:
 	redraw_action redraw_action_;
 
 	/** The clipping rectangle if a widget is partly visible. */
-	SDL_Rect clipping_rectangle_;
+	rect clipping_rectangle_;
 
 	/**
 	 * Mode for drawing the debug border.

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -67,7 +67,7 @@ private:
 
 	int x_, y_, w_, h_;
 	texture tex_, buffer_;
-	SDL_Rect rect_, buffer_pos_;
+	rect rect_, buffer_pos_;
 
 	/** The location of the center of the halo. */
 	map_location loc_;
@@ -210,21 +210,20 @@ bool halo_impl::effect::render()
 	const int xpos = x_ + screenx - w_/2;
 	const int ypos = y_ + screeny - h_/2;
 
-	SDL_Rect rect {xpos, ypos, w_, h_};
-	rect_ = rect;
-	SDL_Rect clip_rect = disp->map_outside_area();
+	rect_ = {xpos, ypos, w_, h_};
+	rect clip_rect = disp->map_outside_area();
 
 	// If rendered the first time, need to determine the area affected.
 	// If a halo changes size, it is not updated.
 	if(location_not_known()) {
-		display::rect_of_hexes hexes = disp->hexes_under_rect(rect);
+		display::rect_of_hexes hexes = disp->hexes_under_rect(rect_);
 		display::rect_of_hexes::iterator i = hexes.begin(), end = hexes.end();
 		for (;i != end; ++i) {
 			overlayed_hexes_.push_back(*i);
 		}
 	}
 
-	if(sdl::rects_overlap(rect,clip_rect) == false) {
+	if(!clip_rect.overlaps(rect_)) {
 		buffer_.reset();
 		return false;
 	}
@@ -235,9 +234,9 @@ bool halo_impl::effect::render()
 	buffer_ = disp->video().read_texture(&buffer_pos_);
 
 	if (orientation_ == NORMAL) {
-		draw::blit(tex_, rect);
+		draw::blit(tex_, rect_);
 	} else {
-		draw::flipped(tex_, rect,
+		draw::flipped(tex_, rect_,
 			orientation_ == HREVERSE || orientation_ == HVREVERSE,
 			orientation_ == VREVERSE || orientation_ == HVREVERSE);
 	}

--- a/src/help/help_browser.cpp
+++ b/src/help/help_browser.cpp
@@ -100,7 +100,7 @@ void help_browser::process_event()
 	sdl::get_mouse_state(&mousex,&mousey);
 
 	// Fake focus functionality for the menu, only process it if it has focus.
-	if (sdl::point_in_rect(mousex, mousey, menu_.location())) {
+	if (menu_.location().contains(mousex, mousey)) {
 		menu_.process();
 		const topic *chosen_topic = menu_.chosen_topic();
 		if (chosen_topic != nullptr && chosen_topic != shown_topic_) {

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -77,32 +77,32 @@ void help_text_area::show_topic(const topic &t)
 help_text_area::item::item(const texture& _tex, int x, int y, const std::string& _text,
 						   const std::string& reference_to, bool _floating,
 						   bool _box, ALIGNMENT alignment) :
-	rect(),
+	rect_(),
 	tex(_tex),
 	text(_text),
 	ref_to(reference_to),
 	floating(_floating), box(_box),
 	align(alignment)
 {
-	rect.x = x;
-	rect.y = y;
-	rect.w = box ? tex.w() + box_width * 2 : tex.w();
-	rect.h = box ? tex.h() + box_width * 2 : tex.h();
+	rect_.x = x;
+	rect_.y = y;
+	rect_.w = box ? tex.w() + box_width * 2 : tex.w();
+	rect_.h = box ? tex.h() + box_width * 2 : tex.h();
 }
 
 help_text_area::item::item(const texture& _tex, int x, int y, bool _floating,
 						   bool _box, ALIGNMENT alignment) :
-	rect(),
+	rect_(),
 	tex(_tex),
 	text(""),
 	ref_to(""),
 	floating(_floating),
 	box(_box), align(alignment)
 {
-	rect.x = x;
-	rect.y = y;
-	rect.w = box ? tex.w() + box_width * 2 : tex.w();
-	rect.h = box ? tex.h() + box_width * 2 : tex.h();
+	rect_.x = x;
+	rect_.y = y;
+	rect_.w = box ? tex.w() + box_width * 2 : tex.w();
+	rect_.h = box ? tex.h() + box_width * 2 : tex.h();
 }
 
 void help_text_area::set_items()
@@ -438,9 +438,9 @@ int help_text_area::get_y_for_floating_img(const int width, const int x, const i
 	for (std::list<item>::const_iterator it = items_.begin(); it != items_.end(); ++it) {
 		const item& itm = *it;
 		if (itm.floating) {
-			if ((itm.rect.x + itm.rect.w > x && itm.rect.x < x + width)
-				|| (itm.rect.x > x && itm.rect.x < x + width)) {
-				min_y = std::max<int>(min_y, itm.rect.y + itm.rect.h);
+			if ((itm.rect_.x + itm.rect_.w > x && itm.rect_.x < x + width)
+				|| (itm.rect_.x > x && itm.rect_.x < x + width)) {
+				min_y = std::max<int>(min_y, itm.rect_.y + itm.rect_.h);
 			}
 		}
 	}
@@ -453,8 +453,8 @@ int help_text_area::get_min_x(const int y, const int height)
 	for (std::list<item>::const_iterator it = items_.begin(); it != items_.end(); ++it) {
 		const item& itm = *it;
 		if (itm.floating) {
-			if (itm.rect.y < y + height && itm.rect.y + itm.rect.h > y && itm.align == LEFT) {
-				min_x = std::max<int>(min_x, itm.rect.w + 5);
+			if (itm.rect_.y < y + height && itm.rect_.y + itm.rect_.h > y && itm.align == LEFT) {
+				min_x = std::max<int>(min_x, itm.rect_.w + 5);
 			}
 		}
 	}
@@ -468,11 +468,11 @@ int help_text_area::get_max_x(const int y, const int height)
 	for (std::list<item>::const_iterator it = items_.begin(); it != items_.end(); ++it) {
 		const item& itm = *it;
 		if (itm.floating) {
-			if (itm.rect.y < y + height && itm.rect.y + itm.rect.h > y) {
+			if (itm.rect_.y < y + height && itm.rect_.y + itm.rect_.h > y) {
 				if (itm.align == RIGHT) {
-					max_x = std::min<int>(max_x, text_width - itm.rect.w - 5);
+					max_x = std::min<int>(max_x, text_width - itm.rect_.w - 5);
 				} else if (itm.align == MIDDLE) {
-					max_x = std::min<int>(max_x, text_width / 2 - itm.rect.w / 2 - 5);
+					max_x = std::min<int>(max_x, text_width / 2 - itm.rect_.w / 2 - 5);
 				}
 			}
 		}
@@ -484,16 +484,16 @@ void help_text_area::add_item(const item &itm)
 {
 	items_.push_back(itm);
 	if (!itm.floating) {
-		curr_loc_.first += itm.rect.w;
-		curr_row_height_ = std::max<int>(itm.rect.h, curr_row_height_);
+		curr_loc_.first += itm.rect_.w;
+		curr_row_height_ = std::max<int>(itm.rect_.h, curr_row_height_);
 		contents_height_ = std::max<int>(contents_height_, curr_loc_.second + curr_row_height_);
 		last_row_.push_back(&items_.back());
 	}
 	else {
 		if (itm.align == LEFT) {
-			curr_loc_.first = itm.rect.w + 5;
+			curr_loc_.first = itm.rect_.w + 5;
 		}
-		contents_height_ = std::max<int>(contents_height_, itm.rect.y + itm.rect.h);
+		contents_height_ = std::max<int>(contents_height_, itm.rect_.y + itm.rect_.h);
 	}
 }
 
@@ -528,8 +528,8 @@ void help_text_area::adjust_last_row()
 {
 	for (std::list<item *>::iterator it = last_row_.begin(); it != last_row_.end(); ++it) {
 		item &itm = *(*it);
-		const int gap = curr_row_height_ - itm.rect.h;
-		itm.rect.y += gap / 2;
+		const int gap = curr_row_height_ - itm.rect_.h;
+		itm.rect_.y += gap / 2;
 	}
 }
 
@@ -545,9 +545,9 @@ void help_text_area::draw_contents()
 	bg_restore();
 	auto clipper = draw::set_clip(loc);
 	for(std::list<item>::const_iterator it = items_.begin(), end = items_.end(); it != end; ++it) {
-		SDL_Rect dst = it->rect;
+		SDL_Rect dst = it->rect_;
 		dst.y -= get_position();
-		if (dst.y < static_cast<int>(loc.h) && dst.y + it->rect.h > 0) {
+		if (dst.y < static_cast<int>(loc.h) && dst.y + it->rect_.h > 0) {
 			dst.x += loc.x;
 			dst.y += loc.y;
 			if (it->box) {
@@ -555,8 +555,8 @@ void help_text_area::draw_contents()
 					SDL_Rect draw_rect {
 						dst.x,
 						dst.y,
-						it->rect.w - i * 2,
-						it->rect.h - i * 2
+						it->rect_.w - i * 2,
+						it->rect_.h - i * 2
 					};
 					draw::fill(draw_rect, 0, 0, 0, 0);
 					++dst.x;
@@ -577,7 +577,7 @@ void help_text_area::scroll(unsigned int)
 }
 
 bool help_text_area::item_at::operator()(const item& item) const {
-	return sdl::point_in_rect(x_, y_, item.rect);
+	return item.rect_.contains(x_, y_);
 }
 
 std::string help_text_area::ref_at(const int x, const int y)

--- a/src/help/help_text_area.hpp
+++ b/src/help/help_text_area.hpp
@@ -67,7 +67,7 @@ private:
 			 bool floating, bool box=false, ALIGNMENT=HERE);
 
 		/** Relative coordinates of this item. */
-		SDL_Rect rect;
+		rect rect_;
 
 		texture tex;
 

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -145,7 +145,7 @@ void mouse_handler::touch_motion(int x, int y, const bool browse, bool update, m
 	if((browse || !found_unit.valid()) && is_dragging() && dragging_started_) {
 		sdl::get_mouse_state(&mx, &my);
 
-		if(sdl::point_in_rect(x, y, gui().map_area())) {
+		if(gui().map_area().contains(x, y)) {
 			int dx = drag_from_x_ - mx;
 			int dy = drag_from_y_ - my;
 
@@ -771,7 +771,7 @@ bool mouse_handler::right_click_show_menu(int x, int y, const bool /*browse*/)
 		return false;
 	}
 
-	return sdl::point_in_rect(x, y, gui().map_area());
+	return gui().map_area().contains(x, y);
 }
 
 void mouse_handler::select_or_action(bool browse)

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -318,7 +318,7 @@ void mouse_handler_base::mouse_wheel(int scrollx, int scrolly, bool browse)
 	int movey = scrolly * preferences::scroll_speed();
 
 	// Don't scroll map if cursor is not in gamemap area
-	if(!sdl::point_in_rect(x, y, gui().map_area())) {
+	if(!gui().map_area().contains(x, y)) {
 		return;
 	}
 

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -577,7 +577,7 @@ static surface load_image_sub_file(const image::locator& loc)
 	}
 
 	if(loc.get_loc().valid()) {
-		SDL_Rect srcrect = sdl::create_rect(
+		rect srcrect(
 			((tile_size * 3) / 4)                           *  loc.get_loc().x,
 			  tile_size * loc.get_loc().y + (tile_size / 2) * (loc.get_loc().x % 2),
 			  tile_size,

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -20,20 +20,6 @@
 
 #include <iostream>
 
-namespace sdl
-{
-SDL_Rect intersect_rects(const SDL_Rect& rect1, const SDL_Rect& rect2)
-{
-	SDL_Rect res;
-	if(!SDL_IntersectRect(&rect1, &rect2, &res)) {
-		return empty_rect;
-	}
-
-	return res;
-}
-
-} // namespace sdl
-
 bool operator==(const SDL_Rect& a, const SDL_Rect& b)
 {
 	return SDL_RectEquals(&a, &b) != SDL_FALSE;
@@ -87,6 +73,20 @@ rect rect::minimal_cover(const SDL_Rect& other) const
 	rect result;
 	SDL_UnionRect(this, &other, &result);
 	return result;
+}
+
+rect rect::intersect(const SDL_Rect& other) const
+{
+	rect result;
+	if(!SDL_IntersectRect(this, &other, &result)) {
+		return rect();
+	}
+	return result;
+}
+
+void rect::clip(const SDL_Rect& other)
+{
+	*this = this->intersect(other);
 }
 
 std::ostream& operator<<(std::ostream& s, const rect& r)

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -22,12 +22,6 @@
 
 namespace sdl
 {
-bool rects_overlap(const SDL_Rect& rect1, const SDL_Rect& rect2)
-{
-	return (rect1.x < rect2.x+rect2.w && rect2.x < rect1.x+rect1.w &&
-			rect1.y < rect2.y+rect2.h && rect2.y < rect1.y+rect1.h);
-}
-
 SDL_Rect intersect_rects(const SDL_Rect& rect1, const SDL_Rect& rect2)
 {
 	SDL_Rect res;
@@ -88,6 +82,12 @@ bool rect::contains(int x, int y) const
 bool rect::contains(const point& point) const
 {
 	return SDL_PointInRect(&point, this) != SDL_FALSE;
+}
+
+bool rect::overlaps(const SDL_Rect& r) const
+{
+	return (r.x < x + w && x < r.x + r.w &&
+	        r.y < y + h && y < r.y + r.h);
 }
 
 std::ostream& operator<<(std::ostream& s, const rect& r)

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -32,14 +32,6 @@ SDL_Rect intersect_rects(const SDL_Rect& rect1, const SDL_Rect& rect2)
 	return res;
 }
 
-SDL_Rect union_rects(const SDL_Rect& rect1, const SDL_Rect& rect2)
-{
-	SDL_Rect res;
-	SDL_UnionRect(&rect1, &rect2, &res);
-
-	return res;
-}
-
 } // namespace sdl
 
 bool operator==(const SDL_Rect& a, const SDL_Rect& b)
@@ -88,6 +80,13 @@ bool rect::overlaps(const SDL_Rect& r) const
 {
 	return (r.x < x + w && x < r.x + r.w &&
 	        r.y < y + h && y < r.y + r.h);
+}
+
+rect rect::minimal_cover(const SDL_Rect& other) const
+{
+	rect result;
+	SDL_UnionRect(this, &other, &result);
+	return result;
 }
 
 std::ostream& operator<<(std::ostream& s, const rect& r)

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -22,17 +22,6 @@
 
 namespace sdl
 {
-bool point_in_rect(int x, int y, const SDL_Rect& rect)
-{
-	SDL_Point p {x, y};
-	return SDL_PointInRect(&p, &rect) != SDL_FALSE;
-}
-
-bool point_in_rect(const point& point, const SDL_Rect& rect)
-{
-	return point_in_rect(point.x, point.y, rect);
-}
-
 bool rects_overlap(const SDL_Rect& rect1, const SDL_Rect& rect2)
 {
 	return (rect1.x < rect2.x+rect2.w && rect2.x < rect1.x+rect1.w &&
@@ -88,6 +77,17 @@ bool rect::operator==(const SDL_Rect& r) const
 bool rect::empty() const
 {
 	return SDL_RectEmpty(this);
+}
+
+bool rect::contains(int x, int y) const
+{
+	SDL_Point p{x, y};
+	return SDL_PointInRect(&p, this) != SDL_FALSE;
+}
+
+bool rect::contains(const point& point) const
+{
+	return SDL_PointInRect(&point, this) != SDL_FALSE;
 }
 
 std::ostream& operator<<(std::ostream& s, const rect& r)

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -74,3 +74,24 @@ std::ostream& operator<<(std::ostream& s, const SDL_Rect& rect)
 	s << "x: " << rect.x << ", y: " << rect.y << ", w: " << rect.w << ", h: " << rect.h;
 	return s;
 }
+
+bool rect::operator==(const rect& r) const
+{
+	return SDL_RectEquals(this, &r) != SDL_FALSE;
+}
+
+bool rect::operator==(const SDL_Rect& r) const
+{
+	return SDL_RectEquals(this, &r) != SDL_FALSE;
+}
+
+bool rect::empty() const
+{
+	return SDL_RectEmpty(this);
+}
+
+std::ostream& operator<<(std::ostream& s, const rect& r)
+{
+	s << '[' << r.x << ',' << r.y << '|' << r.w << ',' << r.h << ']';
+	return s;
+}

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -41,19 +41,6 @@ inline SDL_Rect create_rect(const int x, const int y, const int w, const int h)
 }
 
 /**
- * Creates a rectangle.
- *
- * @param origin                  The top left corner.
- * @param size                    The width (x) and height (y).
- *
- * @returns                       SDL_Rect with the proper rectangle.
- */
-inline SDL_Rect create_rect(const point& origin, const point& size)
-{
-	return {origin.x, origin.y, size.x, size.y};
-}
-
-/**
  * Tests whether a point is inside a rectangle.
  *
  * @param x                       The x coordinate of the point.
@@ -106,3 +93,37 @@ bool operator==(const SDL_Rect& a, const SDL_Rect& b);
 bool operator!=(const SDL_Rect& a, const SDL_Rect& b);
 
 std::ostream& operator<<(std::ostream& s, const SDL_Rect& rect);
+
+/**
+ * An abstract description of a rectangle with integer coordinates.
+ *
+ * This is a thin wrapper over SDL_Rect, furnished with utility functions.
+ *
+ * As for SDL_Rect, member variables x, y, w and h are public.
+ */
+struct rect : SDL_Rect
+{
+public:
+	/** Explicitly initialize rects to 0. */
+	rect() : SDL_Rect{0, 0, 0, 0} {}
+
+	/** There's nothing extra when converting an SDL_Rect. */
+	rect(const SDL_Rect& r) : SDL_Rect{r} {}
+
+	/** Specify via (x, y, w, h). */
+	rect(int x, int y, int w, int h) : SDL_Rect{x, y, w, h} {}
+
+	/** Specify via top-left corner position and size. */
+	rect(const point& pos, const point& size)
+		: SDL_Rect{pos.x, pos.y, size.x, size.y}
+	{}
+
+	// Comparisons
+	bool operator==(const rect& r) const;
+	bool operator==(const SDL_Rect& r) const;
+
+	/** False if both w and h are > 0, true otherwise. */
+	bool empty() const;
+};
+
+std::ostream& operator<<(std::ostream&, const rect&);

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -50,18 +50,6 @@ inline SDL_Rect create_rect(const int x, const int y, const int w, const int h)
  */
 SDL_Rect intersect_rects(const SDL_Rect& rect1, const SDL_Rect& rect2);
 
-/**
- * Calculates the union of two rectangles. Note: "union" here doesn't mean the
- * union of the sets of points of the two polygons, but rather the minimal
- * rectangle that supersets both rectangles.
- *
- * @param rect1                   One rectangle.
- * @param rect2                   Another rectangle.
- *
- * @return                        The union of rect1 and rect2.
- */
-SDL_Rect union_rects(const SDL_Rect &rect1, const SDL_Rect &rect2);
-
 } // namespace sdl
 
 bool operator==(const SDL_Rect& a, const SDL_Rect& b);
@@ -113,6 +101,11 @@ public:
 	/** Whether the given rectangle and this rectangle overlap. */
 	bool overlaps(const SDL_Rect& r) const;
 
+	/**
+	 * Calculates the minimal rectangle that completely contains both
+	 * this rectangle and the given rectangle.
+	 */
+	rect minimal_cover(const SDL_Rect& r) const;
 };
 
 std::ostream& operator<<(std::ostream&, const rect&);

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -122,6 +122,12 @@ public:
 	bool operator==(const rect& r) const;
 	bool operator==(const SDL_Rect& r) const;
 
+	// Scalar multiplication and division
+	rect operator*(int s) const { return {x*s, y*s, w*s, h*s}; }
+	rect& operator*=(int s) { x*=s; y*=s; w*=s; h*=s; return *this; }
+	rect operator/(int s) const { return {x/s, y/s, w/s, h/s}; }
+	rect& operator/=(int s) { x/=s; y/=s; w/=s; h/=s; return *this; }
+
 	/** False if both w and h are > 0, true otherwise. */
 	bool empty() const;
 };

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -29,17 +29,6 @@ namespace sdl
 
 constexpr const SDL_Rect empty_rect { 0, 0, 0, 0 };
 
-/**
- * Creates an SDL_Rect with the given dimensions.
- *
- * This is a simple wrapper in order to avoid the narrowing conversion warnings
- * that occur when using aggregate initialization and non-int values.
- */
-inline SDL_Rect create_rect(const int x, const int y, const int w, const int h)
-{
-	return {x, y, w, h};
-}
-
 } // namespace sdl
 
 bool operator==(const SDL_Rect& a, const SDL_Rect& b);

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -41,17 +41,6 @@ inline SDL_Rect create_rect(const int x, const int y, const int w, const int h)
 }
 
 /**
- * Tests whether two rectangles overlap.
- *
- * @param rect1                   One rectangle.
- * @param rect2                   Another rectangle.
- *
- * @return                        True if rect1 and rect2 intersect, false if
- *                                not. Touching borders don't overlap.
- */
-bool rects_overlap(const SDL_Rect& rect1, const SDL_Rect& rect2);
-
-/**
  * Calculates the intersection of two rectangles.
  *
  * @param rect1                   One rectangle.
@@ -120,6 +109,10 @@ public:
 	/** Whether the given point lies within the rectangle. */
 	bool contains(int x, int y) const;
 	bool contains(const point& p) const;
+
+	/** Whether the given rectangle and this rectangle overlap. */
+	bool overlaps(const SDL_Rect& r) const;
+
 };
 
 std::ostream& operator<<(std::ostream&, const rect&);

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -40,16 +40,6 @@ inline SDL_Rect create_rect(const int x, const int y, const int w, const int h)
 	return {x, y, w, h};
 }
 
-/**
- * Calculates the intersection of two rectangles.
- *
- * @param rect1                   One rectangle.
- * @param rect2                   Another rectangle
- * @return                        The intersection of rect1 and rect2, or
- *                                empty_rect if they don't overlap.
- */
-SDL_Rect intersect_rects(const SDL_Rect& rect1, const SDL_Rect& rect2);
-
 } // namespace sdl
 
 bool operator==(const SDL_Rect& a, const SDL_Rect& b);
@@ -106,6 +96,19 @@ public:
 	 * this rectangle and the given rectangle.
 	 */
 	rect minimal_cover(const SDL_Rect& r) const;
+
+	/**
+	 * Calculates the intersection of this rectangle and another;
+	 * that is, the maximal rectangle that is contained by both.
+	 */
+	rect intersect(const SDL_Rect& r) const;
+
+	/**
+	 * Clip this rectangle by the given rectangle.
+	 *
+	 * This rectangle will be reduced to the intersection of both rectangles.
+	 */
+	void clip(const SDL_Rect& r);
 };
 
 std::ostream& operator<<(std::ostream&, const rect&);

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -41,20 +41,6 @@ inline SDL_Rect create_rect(const int x, const int y, const int w, const int h)
 }
 
 /**
- * Tests whether a point is inside a rectangle.
- *
- * @param x                       The x coordinate of the point.
- * @param y                       The y coordinate of the point.
- * @param rect                    The rectangle.
- *
- * @return                        True if point (x;y) is inside or on the border
- *                                of rect, false otherwise
- */
-bool point_in_rect(int x, int y, const SDL_Rect& rect);
-
-bool point_in_rect(const point& point, const SDL_Rect& rect);
-
-/**
  * Tests whether two rectangles overlap.
  *
  * @param rect1                   One rectangle.
@@ -130,6 +116,10 @@ public:
 
 	/** False if both w and h are > 0, true otherwise. */
 	bool empty() const;
+
+	/** Whether the given point lies within the rectangle. */
+	bool contains(int x, int y) const;
+	bool contains(const point& p) const;
 };
 
 std::ostream& operator<<(std::ostream&, const rect&);

--- a/src/sdl/surface.cpp
+++ b/src/sdl/surface.cpp
@@ -85,14 +85,14 @@ void surface::free_surface()
 
 surface_restorer::surface_restorer()
 	: target_(nullptr)
-	, rect_(sdl::empty_rect)
+	, rect_()
 	, surface_()
 {
 }
 
-surface_restorer::surface_restorer(CVideo* target, const SDL_Rect& rect)
+surface_restorer::surface_restorer(CVideo* target, const rect& location)
 	: target_(target)
-	, rect_(rect)
+	, rect_(location)
 	, surface_()
 {
 	update();
@@ -103,18 +103,18 @@ surface_restorer::~surface_restorer()
 	restore();
 }
 
-void surface_restorer::restore(const SDL_Rect& dst) const
+void surface_restorer::restore(const rect& dst) const
 {
 	if(!surface_) {
 		return;
 	}
 
-	SDL_Rect dst2 = sdl::intersect_rects(dst, rect_);
+	rect dst2 = rect_.intersect(dst);
 	if(dst2.w == 0 || dst2.h == 0) {
 		return;
 	}
 
-	SDL_Rect src = dst2;
+	rect src = dst2;
 	src.x -= rect_.x;
 	src.y -= rect_.y;
 	draw::blit(surface_, dst2, src);

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "sdl/rect.hpp"
 #include "sdl/texture.hpp" // for surface_restorer. Remove that, then remove this
 #include "utils/const_clone.hpp"
 
@@ -118,19 +119,19 @@ std::ostream& operator<<(std::ostream& stream, const surface& surf);
 struct surface_restorer
 {
 	surface_restorer();
-	surface_restorer(class CVideo* target, const SDL_Rect& rect);
+	surface_restorer(class CVideo* target, const rect& location);
 	~surface_restorer();
 
 	void restore() const;
-	void restore(const SDL_Rect& dst) const;
+	void restore(const rect& dst) const;
 	void update();
 	void cancel();
 
-	const SDL_Rect& area() const { return rect_; }
+	const rect& area() const { return rect_; }
 
 private:
 	class CVideo* target_;
-	SDL_Rect rect_;
+	rect rect_;
 	texture surface_;
 };
 

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -315,7 +315,7 @@ theme::border_t::border_t(const config& cfg)
 	VALIDATE(size >= 0.0 && size <= 0.5, _("border_size should be between 0.0 and 0.5."));
 }
 
-SDL_Rect& theme::object::location(const SDL_Rect& screen) const
+rect& theme::object::location(const SDL_Rect& screen) const
 {
 	if(last_screen_ == screen && !location_modified_)
 		return relative_loc_;

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -23,6 +23,7 @@
 #include "color.hpp"
 #include "config.hpp"
 #include "generic_event.hpp"
+#include "sdl/rect.hpp"
 
 #include <memory>
 #include <SDL2/SDL_rect.h>
@@ -48,8 +49,8 @@ class theme
 		object(std::size_t sw, std::size_t sh, const config& cfg);
 		virtual ~object() { }
 
-		virtual SDL_Rect& location(const SDL_Rect& screen) const;
-		const SDL_Rect& get_location() const { return loc_; }
+		virtual rect& location(const SDL_Rect& screen) const;
+		const rect& get_location() const { return loc_; }
 		const std::string& get_id() const { return id_; }
 
 		// This supports relocating of theme elements ingame.
@@ -70,9 +71,9 @@ class theme
 	private:
 		bool location_modified_;
 		std::string id_;
-		SDL_Rect loc_;
-		mutable SDL_Rect relative_loc_;
-		mutable SDL_Rect last_screen_;
+		rect loc_;
+		mutable rect relative_loc_;
+		mutable rect last_screen_;
 
 		ANCHORING xanchor_, yanchor_;
 		std::size_t spec_width_, spec_height_;
@@ -269,13 +270,13 @@ public:
 	const menu *get_menu_item(const std::string &key) const;
 	const action* get_action_item(const std::string &key) const;
 
-	const SDL_Rect& main_map_location(const SDL_Rect& screen) const
+	const rect& main_map_location(const SDL_Rect& screen) const
 		{ return main_map_.location(screen); }
-	const SDL_Rect& mini_map_location(const SDL_Rect& screen) const
+	const rect& mini_map_location(const SDL_Rect& screen) const
 		{ return mini_map_.location(screen); }
-	const SDL_Rect& unit_image_location(const SDL_Rect& screen) const
+	const rect& unit_image_location(const SDL_Rect& screen) const
 		{ return unit_image_.location(screen); }
-	const SDL_Rect& palette_location(const SDL_Rect& screen) const
+	const rect& palette_location(const SDL_Rect& screen) const
 		{ return palette_.location(screen); }
 
 	const border_t& border() const { return border_; }

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -125,10 +125,10 @@ void clear_tooltips()
 	current_tooltip = tips.end();
 }
 
-void clear_tooltips(const SDL_Rect& rect)
+void clear_tooltips(const SDL_Rect& r)
 {
 	for(std::map<int,tooltip>::iterator i = tips.begin(); i != tips.end(); ) {
-		if(sdl::rects_overlap(i->second.rect_,rect)) {
+		if(i->second.rect_.overlaps(r)) {
 			if (i==current_tooltip) {
 				clear_tooltip();
 			}

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -31,9 +31,9 @@ static const int text_width = 400;
 struct tooltip
 {
 	tooltip(const SDL_Rect& r, const std::string& msg, const std::string& act = "", bool use_markup = false, const surface& fg = surface())
-	: rect(r), message(msg), action(act), markup(use_markup), foreground(fg)
+	: rect_(r), message(msg), action(act), markup(use_markup), foreground(fg)
 	{}
-	SDL_Rect rect;
+	rect rect_;
 	std::string message;
 	std::string action;
 	bool markup;
@@ -88,13 +88,13 @@ static void show_tooltip(const tooltip& tip)
 	SDL_Rect rect = font::get_floating_label_rect(tooltip_handle);
 
 	//see if there is enough room to fit it above the tip area
-	if(tip.rect.y > rect.h) {
-		rect.y = tip.rect.y - rect.h;
+	if(tip.rect_.y > rect.h) {
+		rect.y = tip.rect_.y - rect.h;
 	} else {
-		rect.y = tip.rect.y + tip.rect.h;
+		rect.y = tip.rect_.y + tip.rect_.h;
 	}
 
-	rect.x = tip.rect.x;
+	rect.x = tip.rect_.x;
 	if(rect.x < 0) {
 		rect.x = 0;
 	} else if(rect.x + rect.w > area.w) {
@@ -128,7 +128,7 @@ void clear_tooltips()
 void clear_tooltips(const SDL_Rect& rect)
 {
 	for(std::map<int,tooltip>::iterator i = tips.begin(); i != tips.end(); ) {
-		if(sdl::rects_overlap(i->second.rect,rect)) {
+		if(sdl::rects_overlap(i->second.rect_,rect)) {
 			if (i==current_tooltip) {
 				clear_tooltip();
 			}
@@ -150,7 +150,7 @@ bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message,
 	it->second.action = action;
 	it->second.markup = use_markup;
 	it->second.message = message;
-	it->second.rect = rect;
+	it->second.rect_ = rect;
 	return true;
 }
 
@@ -163,7 +163,7 @@ bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message,
 	it->second.foreground = foreground;
 	it->second.markup = use_markup;
 	it->second.message = message;
-	it->second.rect = rect;
+	it->second.rect_ = rect;
 	return true;
 }
 
@@ -188,8 +188,8 @@ int add_tooltip(const SDL_Rect& rect, const std::string& message, const std::str
 void process(int mousex, int mousey)
 {
 	for(std::map<int, tooltip>::const_iterator i = tips.begin(); i != tips.end(); ++i) {
-		if(mousex > i->second.rect.x && mousey > i->second.rect.y &&
-		   mousex < i->second.rect.x + i->second.rect.w && mousey < i->second.rect.y + i->second.rect.h) {
+		if(mousex > i->second.rect_.x && mousey > i->second.rect_.y &&
+		   mousex < i->second.rect_.x + i->second.rect_.w && mousey < i->second.rect_.y + i->second.rect_.h) {
 			if(current_tooltip != i) {
 				show_tooltip(i->second);
 				current_tooltip = i;
@@ -206,7 +206,7 @@ void process(int mousex, int mousey)
 bool click(int mousex, int mousey)
 {
 	for(std::map<int, tooltip>::const_iterator i = tips.begin(); i != tips.end(); ++i) {
-		if(!i->second.action.empty() && sdl::point_in_rect(mousex, mousey, i->second.rect)) {
+		if(!i->second.action.empty() && i->second.rect_.contains(mousex, mousey)) {
 			help::show_help(i->second.action);
 			return true;
 		}

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -439,8 +439,8 @@ void unit_drawer::draw_bar(const std::string& image, int xpos, int ypos,
 
 	const std::size_t skip_rows = bar_loc.h - height;
 
-	SDL_Rect top {0, 0, surf->w, bar_loc.y};
-	SDL_Rect bot = sdl::create_rect(0, bar_loc.y + skip_rows, surf->w, 0);
+	rect top{0, 0, surf->w, bar_loc.y};
+	rect bot(0, bar_loc.y + skip_rows, surf->w, 0);
 	bot.h = surf->w - bot.y;
 
 	// TODO: highdpi - fix. see above
@@ -456,7 +456,7 @@ void unit_drawer::draw_bar(const std::string& image, int xpos, int ypos,
 	if(unfilled < height && alpha >= floating_to_fixed_point(0.3)) {
 		const uint8_t r_alpha = std::min<unsigned>(fixed_point_multiply(alpha,255),255);
 		surface filled_surf(bar_loc.w, height - unfilled);
-		SDL_Rect filled_area = sdl::create_rect(0, 0, bar_loc.w, height-unfilled);
+		rect filled_area(0, 0, bar_loc.w, height-unfilled);
 		sdl::fill_surface_rect(filled_surf,&filled_area,SDL_MapRGBA(bar_surf->format,col.r,col.g,col.b, r_alpha));
 		dest = {xpos + bar_loc.x, ypos + bar_loc.y + int(unfilled),
 			filled_surf->w, filled_surf->h};

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -225,8 +225,8 @@ void unit_drawer::redraw_unit (const unit & u) const
 	// We draw bars only if wanted, visible on the map view
 	bool draw_bars = ac.draw_bars_ ;
 	if (draw_bars) {
-		SDL_Rect unit_rect {xsrc, ysrc +adjusted_params.y, hex_size, hex_size};
-		draw_bars = sdl::rects_overlap(unit_rect, disp.map_outside_area());
+		rect unit_rect {xsrc, ysrc +adjusted_params.y, hex_size, hex_size};
+		draw_bars = unit_rect.overlaps(disp.map_outside_area());
 	}
 	texture ellipse_front;
 	texture ellipse_back;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -528,10 +528,9 @@ SDL_Rect CVideo::clip_to_draw_area(const SDL_Rect* r) const
 	}
 }
 
-SDL_Rect CVideo::to_output(const SDL_Rect& r) const
+rect CVideo::to_output(const rect& r) const
 {
-	int s = get_pixel_scale();
-	return {s * r.x, s * r.y, s * r.w, s * r.h};
+	return r * get_pixel_scale();
 }
 
 void CVideo::render_screen()

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -472,7 +472,7 @@ SDL_Point CVideo::window_size() const
 	return window->get_size();
 }
 
-SDL_Rect CVideo::draw_area() const
+rect CVideo::draw_area() const
 {
 	return {0, 0, logical_size_.x, logical_size_.y};
 }
@@ -522,7 +522,7 @@ SDL_Texture* CVideo::get_render_target()
 SDL_Rect CVideo::clip_to_draw_area(const SDL_Rect* r) const
 {
 	if(r) {
-		return sdl::intersect_rects(*r, draw_area());
+		return draw_area().intersect(*r);
 	} else {
 		return draw_area();
 	}
@@ -588,9 +588,9 @@ surface CVideo::read_pixels(SDL_Rect* r)
 	}
 
 	// Intersect with the given rect.
-	SDL_Rect r_clipped = d;
+	rect r_clipped = d;
 	if (r) {
-		r_clipped = sdl::intersect_rects(*r, d);
+		r_clipped.clip(*r);
 		if (r_clipped != *r) {
 			DBG_DP << "modifying pixel read area\n"
 			       << "  from " << *r << "\n"

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -166,7 +166,7 @@ public:
 	 * Returns the size and location of the current drawing area in pixels.
 	 * This will usually be an SDL_Rect indicating the full drawing surface.
 	 */
-	SDL_Rect draw_area() const;
+	rect draw_area() const;
 
 	/**
 	 * Returns the size and location of the window's input area in pixels.

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -19,6 +19,7 @@
 #include "exceptions.hpp"
 #include "lua_jailbreak_exception.hpp"
 #include "sdl/point.hpp"
+#include "sdl/rect.hpp"
 #include "sdl/texture.hpp"
 
 #include <SDL2/SDL_render.h>
@@ -198,7 +199,7 @@ public:
 	/**
 	 * Convert coordinates in draw space to coordinates in render space.
 	 */
-	SDL_Rect to_output(const SDL_Rect& draw_space_rect) const;
+	rect to_output(const rect& draw_space_rect) const;
 
 	/**
 	 * Tests whether the given flags are currently set on the SDL window.

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -400,7 +400,7 @@ void button::draw_contents()
 
 bool button::hit(int x, int y) const
 {
-	return sdl::point_in_rect(x,y,location());
+	return location().contains(x, y);
 }
 
 static bool is_valid_image(const std::string& str) { return !str.empty() && str[0] != IMAGE_PREFIX; }

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -1088,9 +1088,9 @@ SDL_Rect menu::get_item_rect_internal(std::size_t item) const
 		y = prev.y + prev.h;
 	}
 
-	SDL_Rect res = sdl::create_rect(loc.x, y, loc.w, get_item_height(item));
+	rect res(loc.x, y, loc.w, get_item_height(item));
 
-	const SDL_Rect& draw_area = video().draw_area();
+	const rect draw_area = video().draw_area();
 
 	if(res.x > draw_area.w) {
 		return sdl::empty_rect;

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -133,9 +133,9 @@ void scrollarea::process_event()
 	scroll(grip_position);
 }
 
-SDL_Rect scrollarea::inner_location() const
+rect scrollarea::inner_location() const
 {
-	SDL_Rect r = location();
+	rect r = location();
 	if (shown_scrollbar_)
 		r.w -= scrollbar_.width();
 	return r;
@@ -157,7 +157,7 @@ void scrollarea::handle_event(const SDL_Event& event)
 		const SDL_MouseWheelEvent &ev = event.wheel;
 		int x, y;
 		sdl::get_mouse_state(&x, &y);
-		if (sdl::point_in_rect(x, y, inner_location())) {
+		if (inner_location().contains(x, y)) {
 			if (ev.y > 0) {
 				scrollbar_.scroll_up();
 			} else if (ev.y < 0) {
@@ -194,7 +194,7 @@ void scrollarea::handle_event(const SDL_Event& event)
 				return;
 			}
 
-			if (sdl::point_in_rect(swipe_origin_.x, swipe_origin_.y, inner_location())
+			if (inner_location().contains(swipe_origin_.x, swipe_origin_.y)
 				&& abs(swipe_dy_) >= scrollbar_step)
 			{
 				unsigned int pos = std::max(

--- a/src/widgets/scrollarea.hpp
+++ b/src/widgets/scrollarea.hpp
@@ -40,7 +40,7 @@ protected:
 	virtual void scroll(unsigned int pos) = 0;
 	virtual void set_inner_location(const SDL_Rect& rect) = 0;
 
-	SDL_Rect inner_location() const;
+	rect inner_location() const;
 	unsigned scrollbar_width() const;
 
 	unsigned get_position() const;

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -226,23 +226,23 @@ void scrollbar::handle_event(const SDL_Event& event)
 		return;
 
 	STATE new_state = state_;
-	const SDL_Rect& grip = grip_area();
-	const SDL_Rect& groove = location();
+	const rect grip = grip_area();
+	const rect& groove = location();
 
 
 	switch (event.type) {
 	case SDL_MOUSEBUTTONUP:
 	{
 		const SDL_MouseButtonEvent& e = event.button;
-		bool on_grip = sdl::point_in_rect(e.x, e.y, grip);
+		bool on_grip = grip.contains(e.x, e.y);
 		new_state = on_grip ? ACTIVE : NORMAL;
 		break;
 	}
 	case SDL_MOUSEBUTTONDOWN:
 	{
 		const SDL_MouseButtonEvent& e = event.button;
-		bool on_grip = sdl::point_in_rect(e.x, e.y, grip);
-		bool on_groove = sdl::point_in_rect(e.x, e.y, groove);
+		bool on_grip = grip.contains(e.x, e.y);
+		bool on_groove = groove.contains(e.x, e.y);
 		if (on_grip && e.button == SDL_BUTTON_LEFT) {
 			mousey_on_grip_ = e.y - grip.y;
 			new_state = DRAGGED;
@@ -262,7 +262,7 @@ void scrollbar::handle_event(const SDL_Event& event)
 	{
 		const SDL_MouseMotionEvent& e = event.motion;
 		if (state_ == NORMAL || state_ == ACTIVE) {
-			bool on_grip = sdl::point_in_rect(e.x, e.y, grip);
+			bool on_grip = grip.contains(e.x, e.y);
 			new_state = on_grip ? ACTIVE : NORMAL;
 		} else if (state_ == DRAGGED && groove.h != grip.h) {
 			int y_dep = e.y - grip.y - mousey_on_grip_;
@@ -276,7 +276,7 @@ void scrollbar::handle_event(const SDL_Event& event)
 		const SDL_MouseWheelEvent& e = event.wheel;
 		int x, y;
 		sdl::get_mouse_state(&x, &y);
-		bool on_groove = sdl::point_in_rect(x, y, groove);
+		bool on_groove = groove.contains(x, y);
 		if (on_groove && e.y < 0) {
 			move_position(scroll_rate_);
 		} else if (on_groove && e.y > 0) {

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -640,9 +640,9 @@ void textbox::handle_event(const SDL_Event& event, bool was_forwarded)
 		grabmouse_ = false;
 	}
 
-	const SDL_Rect& loc = inner_location();
+	const rect loc = inner_location();
 
-	const bool mouse_inside = sdl::point_in_rect(mousex, mousey, loc);
+	const bool mouse_inside = loc.contains(mousex, mousey);
 
 	// Someone else may set the mouse cursor for us to something unusual (e.g.
 	// the WAIT cursor) so we ought to mess with that only if it's set to
@@ -699,7 +699,7 @@ void textbox::handle_event(const SDL_Event& event, bool was_forwarded)
 	//if we don't have the focus, then see if we gain the focus,
 	//otherwise return
 	if(!was_forwarded && focus(&event) == false) {
-		if (!mouse_locked() && event.type == SDL_MOUSEMOTION && sdl::point_in_rect(mousex, mousey, loc))
+		if (!mouse_locked() && event.type == SDL_MOUSEMOTION && loc.contains(mousex, mousey))
 			events::focus_handler(this);
 
 		return;

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -214,12 +214,12 @@ void textbox::draw_contents()
 					break;
 				}
 
-				SDL_Rect rect = sdl::create_rect(loc.x + startx
+				rect r(loc.x + startx
 						, loc.y + starty - src.y
 						, right - startx
 						, line_height_);
 
-				draw::fill(rect, 0, 0, 160, 140);
+				draw::fill(r, 0, 0, 160, 140);
 
 				starty += int(line_height_);
 				startx = 0;

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -184,7 +184,7 @@ void textbox::draw_contents()
 
 	draw::fill(loc, c);
 
-	SDL_Rect src;
+	rect src;
 
 	if(text_image_ == nullptr) {
 		update_text_cache(true);
@@ -227,8 +227,7 @@ void textbox::draw_contents()
 		}
 
 		// text may be rendered at high dpi, scale source clip accordingly
-		const int ps = video().get_pixel_scale();
-		src.x *= ps; src.y *= ps; src.w *= ps; src.h *= ps;
+		src *= video().get_pixel_scale();
 		// TODO: highdpi - consider sizing source clip in draw coordinates, now that textures have a draw-space w/h? That would work here.
 
 		if(enabled()) {

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -132,7 +132,7 @@ int widget::height() const
 	return rect_.h;
 }
 
-const SDL_Rect& widget::location() const
+const rect& widget::location() const
 {
 	return rect_;
 }
@@ -312,7 +312,7 @@ void widget::set_tooltip_string(const std::string& str)
 
 void widget::process_help_string(int mousex, int mousey)
 {
-	if (!hidden() && sdl::point_in_rect(mousex, mousey, rect_)) {
+	if (!hidden() && rect_.contains(mousex, mousey)) {
 		if(help_string_ == 0 && !help_text_.empty()) {
 			//std::cerr << "setting help string to '" << help_text_ << "'\n";
 			help_string_ = video().set_help_string(help_text_);
@@ -325,7 +325,7 @@ void widget::process_help_string(int mousex, int mousey)
 
 void widget::process_tooltip_string(int mousex, int mousey)
 {
-	if (!hidden() && sdl::point_in_rect(mousex, mousey, rect_)) {
+	if (!hidden() && rect_.contains(mousex, mousey)) {
 		if (!tooltip_text_.empty())
 			tooltips::add_tooltip(rect_, tooltip_text_ );
 	}

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -189,7 +189,7 @@ void widget::set_clip_rect(const SDL_Rect& rect)
 bool widget::hidden() const
 {
 	return (state_ == HIDDEN || hidden_override_ || state_ == UNINIT
-		|| (clip_ && !sdl::rects_overlap(clip_rect_, rect_)));
+		|| (clip_ && !rect_.overlaps(clip_rect_)));
 }
 
 void widget::enable(bool new_val)

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "events.hpp"
+#include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
 
 #include <string>
@@ -27,7 +28,7 @@ namespace gui {
 class widget : public events::sdl_handler
 {
 public:
-	const SDL_Rect& location() const;
+	const rect& location() const;
 	virtual void set_location(const SDL_Rect& rect);
 	void set_location(int x, int y);
 	void set_width(int w);
@@ -108,7 +109,7 @@ private:
 
 	CVideo* video_;
 	std::vector< surface_restorer > restorer_;
-	SDL_Rect rect_;
+	rect rect_;
 	mutable bool needs_restore_; // Have we drawn ourselves, so that if moved, we need to restore the background?
 
 	enum { UNINIT, HIDDEN, DIRTY, DRAWN } state_;


### PR DESCRIPTION
Similar to #6813 in creating a `rect` wrapper for `SDL_Rect`.

There are several things i wanted this for that are unwieldy when dealing with SDL_Rect directly. Things like pixel scale operations where i want to do things like multiply and divide rects by scalars, and intersections and clipping which rapidly become unwieldy when calling functions on pairs of rects.

The way this is done makes it interchangeable with SDL_Rect in all current situations. Things can either switch to using `rect`, or not, with no change.

Usage of rectangle manipulation functions generally becomes decently cleaner using this. I moved the standalone functions to rect member functions, so `sdl::point_in_rect(x, y, r)` became `r.contains(x, y)`, `sdl::intersect_rects(a, b)` became `a.intersect(b)` etc. Several usages were things like `a = sdl::intersect_rects(a, b)`, which became `a.clip(b)` which modifies `a` in place. It doesn't look like all that much, but existing usage became a lot cleaner when i converted things over.

The messiest part is dealing with things that are calling their internal variables "rect". I only converted things that were using the rectangle manipulation functions, most things are still using and can keep using SDL_Rect.

This is based on top of #6813 because i used the SDL_Point inheritance to simplify a couple things. So the parts of that that are in this can be ignored... i just want to put this up as a PR now because i have so much mess in my local at the moment. Trying to do one thing has led to four separate cleanups.