### PR TITLE
Fix seg fault when weapon is removed during attack

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1221,6 +1221,16 @@ bool attack::perform_hit(bool attacker_turn, statistics::attack_context& stats)
 	}
 
 	--attacker.n_attacks_;
+
+	// If an event removed a unit's weapon, set number of remaining attacks to zero
+	// for that unit, but let the other unit continue
+	if (attacker_stats->weapon == nullptr){
+        attacker.n_attacks_ = 0;
+	}
+	if (defender_stats->weapon == nullptr){
+        defender.n_attacks_ = 0;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Events during attacks may modify either of the units involved. If, as a result, one of the units does not have a weapon of the type used any more, this previously caused a segmentation fault in unit_attack() in udisplay.cpp. The solution is to set the remaining number of strikes for the unit to zero. This prevents that unit from striking again, but lets the opponent continue its attack.

I have confirmed that this fixes both #4927 and #5914. That's also the reason why this is based on 1.16, because the save provided in one of the issues is for 1.16.  Obviously, if this is merged, it should be forward ported as well.