### PR TITLE
Add no-unit error message for unit debug command

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1981,6 +1981,11 @@ void console_handler::do_unit()
 
 	unit_map::iterator i = menu_handler_.current_unit();
 	if(i == menu_handler_.pc_.get_units().end()) {
+		utils::string_map symbols;
+		symbols["unit"] = get_arg(1);
+		command_failed(VGETTEXT(
+			"Debug command 'unit: $unit' failed: no unit selected or hovered over.",
+			symbols));
 		return;
 	}
 


### PR DESCRIPTION
This adds an error message when the `:unit` debug command fails because no unit is selected or hovered over, as suggested in #6116