### PR TITLE
Tweak debug representations of color_t, point and SDL_Rect

### DIFF
--- a/src/color.cpp
+++ b/src/color.cpp
@@ -105,6 +105,10 @@ std::string color_t::to_hex_string() const
 	  << std::setw(2) << static_cast<int>(g)
 	  << std::setw(2) << static_cast<int>(b);
 
+	if(a != ALPHA_OPAQUE) {
+		h << std::setw(2) << static_cast<int>(a);
+	}
+
 	return h.str();
 }
 

--- a/src/color.hpp
+++ b/src/color.hpp
@@ -221,11 +221,7 @@ struct color_t : SDL_Color
 
 inline std::ostream& operator<<(std::ostream& s, const color_t& c)
 {
-	s << static_cast<int>(c.r) << " "
-	  << static_cast<int>(c.g) << " "
-	  << static_cast<int>(c.b) << " "
-	  << static_cast<int>(c.a);
-
+	s << c.to_hex_string();
 	return s;
 }
 

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -44,7 +44,7 @@ void draw::fill(
 	const SDL_Rect& area,
 	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-	DBG_D << "fill " << area << " (" << color_t{r,g,b,a} << ")" << endl;
+	DBG_D << "fill " << area << ' ' << color_t{r,g,b,a} << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
 	SDL_RenderFillRect(renderer(), &area);
 }
@@ -69,15 +69,13 @@ void draw::fill(const SDL_Rect& area)
 
 void draw::set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-	DBG_D << "set color "
-	      << " [" << r << ',' << g << ',' << b << ',' << a << ']' << endl;
+	DBG_D << "set color " << color_t{r,g,b,a} << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
 }
 
 void draw::set_color(uint8_t r, uint8_t g, uint8_t b)
 {
-	DBG_D << "set color "
-	      << " [" << r << ',' << g << ',' << b << ']' << endl;
+	DBG_D << "set color " << color_t{r,g,b} << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, SDL_ALPHA_OPAQUE);
 }
 
@@ -126,8 +124,7 @@ void draw::rect(const SDL_Rect& rect)
 void draw::rect(const SDL_Rect& rect,
 	uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-	DBG_D << "rect " << rect
-	      << " [" << r << ',' << g << ',' << b << ',' << a << ']' << endl;
+	DBG_D << "rect " << rect << ' ' << color_t{r,g,b,a} << endl;
 	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
 	if (sdl_bad_at_rects()) {
 		return draw_rect_as_lines(rect);

--- a/src/sdl/point.cpp
+++ b/src/sdl/point.cpp
@@ -35,6 +35,6 @@ point& point::operator-=(const point& point)
 
 std::ostream& operator<<(std::ostream& stream, const point& point)
 {
-	stream << point.x << ',' << point.y;
+	stream << '(' << point.x << ',' << point.y << ')';
 	return stream;
 }

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -30,9 +30,9 @@ bool operator!=(const SDL_Rect& a, const SDL_Rect& b)
 	return !operator==(a,b);
 }
 
-std::ostream& operator<<(std::ostream& s, const SDL_Rect& rect)
+std::ostream& operator<<(std::ostream& s, const SDL_Rect& r)
 {
-	s << "x: " << rect.x << ", y: " << rect.y << ", w: " << rect.w << ", h: " << rect.h;
+	s << '[' << r.x << ',' << r.y << '|' << r.w << ',' << r.h << ']';
 	return s;
 }
 


### PR DESCRIPTION
These were somewhat inconsistent, and could be difficult to read. This only affects how these are written to an ostream.

It's basically as discussed in https://github.com/wesnoth/wesnoth/pull/6814#issuecomment-1171870532

The previous representations were:
```
color_t(255, 60, 140, 255) --> "255 60 140 255"
point(10,25) --> "10,25"
SDL_Rect(3, 15, 22, 89) --> "x: 3, y: 15, w: 22, h: 89"
```

The new representtions are:
```
color_t(255, 60, 140, 255) --> "#ff3c8c"
color_t(255, 60, 140, 128) --> "#ff3c8c80"
point(10,25) --> "(10,25)"
SDL_Rect(3, 15, 22, 89) --> "[3,15|22,89]"
```

The vertical bar in the rect representation is to differentiate the second pair as a size, not a position, and also (along with the square brackets) to make it clear that it's a rect, not some other 4-integer-element object.

The reasoning for this change is to make the representations both compact and clear for easy parsing in logs and debug output.