### PR TITLE
Perform unit highlight and frame tint effects in hardware

### DIFF
--- a/src/color.hpp
+++ b/src/color.hpp
@@ -240,3 +240,29 @@ namespace std
 		}
 	};
 }
+
+/********************************************/
+/* Functions for manipulating colour values */
+/********************************************/
+
+/** Convert a double in the range [0.0,1.0] to an 8-bit colour value. */
+constexpr uint8_t float_to_color(double n)
+{
+	if(n <= 0.0) return 0;
+	else if(n >= 1.0) return 255;
+	else return uint8_t(n * 256.0);
+}
+
+/** Convert a float in the range [0.0,1.0] to an 8-bit colour value. */
+constexpr uint8_t float_to_color(float n)
+{
+	if(n <= 0.0f) return 0;
+	else if(n >= 1.0f) return 255;
+	else return uint8_t(n * 256.0f);
+}
+
+/** Multiply two 8-bit colour values as if in the range [0.0,1.0]. */
+constexpr uint8_t color_multiply(uint8_t n1, uint8_t n2)
+{
+	return uint8_t((uint16_t(n1) * uint16_t(n2))/255);
+}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1518,7 +1518,7 @@ void display::draw_text_in_hex(const map_location& loc,
 
 void display::render_image(int x, int y, const display::drawing_layer drawing_layer,
 		const map_location& loc, const image::locator& i_locator,
-		bool hreverse, bool greyscale, int32_t alpha,
+		bool hreverse, bool greyscale, uint8_t alpha, double highlight,
 		color_t blendto, double blend_ratio, double submerged, bool vreverse)
 {
 	const point image_size = image::get_size(i_locator);
@@ -1557,13 +1557,12 @@ void display::render_image(int x, int y, const display::drawing_layer drawing_la
 		new_modifications += ")";
 	}
 
-	// TODO: This is not what alpha means. Don't frivolously overload it.
 	// TODO: highdpi - perhaps this can be done by blitting twice, once in additive blend mode
 	// Note: this may not be identical to the original calculation,
 	// which was to multiply the RGB values by (alpha/255).
 	// But for now it looks close enough.
-	if(alpha > floating_to_fixed_point(1.0)) {
-		const std::string brighten_string = std::to_string((alpha - 255)/2);
+	if(highlight > 0.0) {
+		const std::string brighten_string = std::to_string(int(highlight*128.0));
 		new_modifications += "~CS(";
 		new_modifications += brighten_string;
 		new_modifications += ",";
@@ -1605,9 +1604,8 @@ void display::render_image(int x, int y, const display::drawing_layer drawing_la
 		tex = image::get_texture(i_locator);
 	}
 
-	const uint8_t alpha_mod = std::clamp(alpha, 0, 255);
 	drawing_buffer_add(drawing_layer, loc, dest, tex, sdl::empty_rect,
-		hreverse, vreverse, alpha_mod);
+		hreverse, vreverse, alpha);
 }
 
 void display::select_hex(map_location hex)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1583,29 +1583,31 @@ void display::render_image(int x, int y, const display::drawing_layer drawing_la
 	// Clamp blend ratio so nothing weird happens
 	blend_ratio = std::clamp(blend_ratio, 0.0, 1.0);
 
+	blit_helper& bh = drawing_buffer_add(drawing_layer, loc, dest, tex);
+	bh.hflip = hreverse;
+	bh.vflip = vreverse;
+	bh.alpha_mod = alpha;
+	bh.highlight = float_to_color(highlight);
+
 	// SDL hax to apply an active washout tint at the correct ratio
 	if (blend_ratio > 0.0) {
 		// Get a pure-white version of the texture
 		const image::locator whiteout_locator(
 			i_locator.get_filename(),
-			i_locator.get_modifications() + "~CHAN(255, 255, 255, alpha)"
+			i_locator.get_modifications()
+				+ new_modifications
+				+ "~CHAN(255, 255, 255, alpha)"
 		);
 		const texture& wt = image::get_texture(whiteout_locator);
 		// Blit the pure white version, tinted to the right colour
 		blit_helper &wh = drawing_buffer_add(drawing_layer, loc, dest, wt);
 		wh.hflip = hreverse;
 		wh.vflip = vreverse;
-		wh.alpha_mod = alpha;
+		wh.alpha_mod = uint8_t(alpha * blend_ratio);
 		wh.r_mod = blendto.r;
 		wh.g_mod = blendto.g;
 		wh.b_mod = blendto.b;
 	}
-
-	blit_helper& bh = drawing_buffer_add(drawing_layer, loc, dest, tex);
-	bh.hflip = hreverse;
-	bh.vflip = vreverse;
-	bh.alpha_mod = uint8_t(alpha * (1.0 - blend_ratio));
-	bh.highlight = float_to_color(highlight);
 }
 
 void display::select_hex(map_location hex)

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -849,8 +849,9 @@ public:
 	void render_image(int x, int y, const display::drawing_layer drawing_layer,
 			const map_location& loc, const image::locator& i_locator,
 			bool hreverse=false, bool greyscale=false,
-			int32_t alpha=SDL_ALPHA_OPAQUE, color_t blendto = {0,0,0},
-			double blend_ratio=0, double submerged=0.0,bool vreverse =false);
+			uint8_t alpha=SDL_ALPHA_OPAQUE, double highlight=0.0,
+			color_t blendto={0,0,0}, double blend_ratio=0,
+			double submerged=0.0, bool vreverse=false);
 
 	/**
 	 * Draw text on a hex. (0.5, 0.5) is the center.

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -978,7 +978,12 @@ protected:
 
 public:
 	/**
-	 * Add an item to the drawing buffer. You need to update screen on affected area
+	 * Add an item to the drawing buffer.
+	 *
+	 * This returns a blit_helper reference with several extra fields that can
+	 * be modified as necessary. In particular hflip, vflip and alpha_mod
+	 * have been moved to this helper. Fields that can be modified are
+	 * available as public members of blit_helper.
 	 *
 	 * @param layer              The layer to draw on.
 	 * @param loc                The hex the image belongs to, needed for the
@@ -987,10 +992,6 @@ public:
 	 *                           in drawing coordinates.
 	 * @param tex               The texture to use.
 	 * @param clip              The portion of the source texture to use.
-	 * @param hflip             If true, flip the image horizontally.
-	 * @param vflip             If true, flip the image vertically.
-	 * @param alpha_mod         An alpha modifier to apply - multiplies
-	 *                          texture alpha by this value when drawing.
 	 */
 	blit_helper& drawing_buffer_add(const drawing_layer layer,
 			const map_location& loc, const SDL_Rect& dest, const texture& tex,

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -926,30 +926,41 @@ protected:
 
 		blit_helper(const drawing_layer layer, const map_location& loc,
 				const SDL_Rect& dest, const texture& tex,
-				const SDL_Rect& clip, bool hflip=false, bool vflip=false,
-				uint8_t alpha_mod=SDL_ALPHA_OPAQUE)
-			: dest_(dest), tex_(1, tex), clip_(clip), hflip_(hflip),
-			vflip_(vflip), alpha_mod_(alpha_mod), key_(loc, layer)
+				const SDL_Rect& clip)
+			: dest_(dest), tex_(1, tex), clip_(clip), key_(loc, layer)
 		{}
 
 		blit_helper(const drawing_layer layer, const map_location& loc,
 				const SDL_Rect& dest, const std::vector<texture>& tex,
-				const SDL_Rect& clip, bool hflip=false, bool vflip=false,
-				uint8_t alpha_mod=SDL_ALPHA_OPAQUE)
-			: dest_(dest), tex_(tex), clip_(clip), hflip_(hflip),
-			vflip_(vflip), alpha_mod_(alpha_mod), key_(loc, layer)
+				const SDL_Rect& clip)
+			: dest_(dest), tex_(tex), clip_(clip), key_(loc, layer)
 		{}
 
 		const SDL_Rect& dest() const { return dest_; }
 		const std::vector<texture> &tex() const { return tex_; }
 		const SDL_Rect &clip() const { return clip_; }
-		uint8_t alpha_mod() const { return alpha_mod_; }
-		bool hflip() const { return hflip_; }
-		bool vflip() const { return vflip_; }
 
 		bool operator<(const blit_helper &rhs) const { return key_ < rhs.key_; }
 
+	public:
+		// Auxiliary parameters, can be modified directly as required.
+
+		/** Whether to mirror horizontally on draw */
+		bool hflip = false;
+		/** Whether to mirror vertically on draw */
+		bool vflip = false;
+		/** An alpha modifier to apply when drawing. 0-255. */
+		uint8_t alpha_mod = SDL_ALPHA_OPAQUE;
+		/** Colour modifiers. Multiply colour. 0 = 0.0, 255 = 1.0. */
+		uint8_t r_mod = 255;
+		uint8_t g_mod = 255;
+		uint8_t b_mod = 255;
+		/** Strength of highlight effect to apply, if any. */
+		uint8_t highlight = 0;
+
 	private:
+		// Core info is set on creation.
+
 		/** The location on screen to draw to, in drawing coordinates. */
 		SDL_Rect dest_;
 		/** One or more textures to render. */
@@ -957,13 +968,7 @@ protected:
 		/** The portion of the source texture to use.
 		  * If omitted, the entire source is used. */
 		SDL_Rect clip_;
-		/** Whether to mirror horizontally on draw */
-		bool hflip_;
-		/** Whether to mirror vertically on draw */
-		bool vflip_;
-		/** An alpha modifier to apply when drawing. 0-255. */
-		uint8_t alpha_mod_;
-		// TODO: highdpi - colour mod? blend mode? rotation?
+		// TODO: could also add blend mode and rotation if desirable
 		/** Allows ordering of draw calls by layer and location. */
 		drawing_buffer_key key_;
 	};
@@ -987,16 +992,14 @@ public:
 	 * @param alpha_mod         An alpha modifier to apply - multiplies
 	 *                          texture alpha by this value when drawing.
 	 */
-	void drawing_buffer_add(const drawing_layer layer,
+	blit_helper& drawing_buffer_add(const drawing_layer layer,
 			const map_location& loc, const SDL_Rect& dest, const texture& tex,
-			const SDL_Rect &clip = SDL_Rect(), bool hflip=false,
-			bool vflip=false, uint8_t alpha_mod=SDL_ALPHA_OPAQUE);
+			const SDL_Rect &clip = SDL_Rect());
 
-	void drawing_buffer_add(const drawing_layer layer,
+	blit_helper& drawing_buffer_add(const drawing_layer layer,
 			const map_location& loc, const SDL_Rect& dest,
 			const std::vector<texture> &tex,
-			const SDL_Rect &clip = SDL_Rect(), bool hflip=false,
-			bool vflip=false, uint8_t alpha_mod=SDL_ALPHA_OPAQUE);
+			const SDL_Rect &clip = SDL_Rect());
 
 protected:
 

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -145,12 +145,6 @@ bool floating_label::create_texture()
 			uint32_t color = SDL_MapRGBA(foreground->format, bgcolor_.r, bgcolor_.g, bgcolor_.b, bgalpha_);
 			sdl::fill_surface_rect(background, nullptr, color);
 
-			// we make the text less transparent, because the blitting on the
-			// dark background will darken the anti-aliased part.
-			// This 1.13 value seems to restore the brightness of version 1.4
-			// (where the text was blitted directly on screen)
-			adjust_surface_alpha(foreground, floating_to_fixed_point(1.13));
-
 			SDL_Rect r{border_ * sf, border_ * sf, 0, 0};
 			adjust_surface_alpha(foreground, SDL_ALPHA_OPAQUE);
 			sdl_blit(foreground, nullptr, background, &r);

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -111,14 +111,16 @@ void game_display::new_turn()
 
 				if(old_mask != nullptr) {
 					// TODO: highdpi - do this on the fly, rather than baking it
-					const int32_t proportion = floating_to_fixed_point(1.0) - fixed_point_divide(i,niterations);
+					int32_t proportion = 256 - fixed_point_divide(i,niterations);
+					proportion = std::clamp(proportion, 0, 255);
 					adjust_surface_alpha(old_mask, proportion);
 					tod_hex_mask1 = old_mask;
 				}
 
 				if(new_mask != nullptr) {
 					// TODO: highdpi - do this on the fly, rather than baking it
-					const int32_t proportion = fixed_point_divide(i,niterations);
+					int32_t proportion = fixed_point_divide(i,niterations);
+					proportion = std::clamp(proportion, 0, 255);
 					adjust_surface_alpha(new_mask, proportion);
 					tod_hex_mask2 = new_mask;
 				}

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -545,7 +545,7 @@ surface o_modification::operator()(const surface& src) const
 		return nullptr;
 	}
 
-	uint32_t amount = floating_to_fixed_point(opacity_);
+	uint8_t alpha_mod = float_to_color(opacity_);
 
 	{
 		surface_lock lock(nsurf);
@@ -561,7 +561,7 @@ surface o_modification::operator()(const surface& src) const
 				g = (*beg) >> 8;
 				b = (*beg);
 
-				alpha = std::min<unsigned>(fixed_point_multiply(alpha,amount), 255);
+				alpha = color_multiply(alpha, alpha_mod);
 				*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
 			}
 

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -972,13 +972,13 @@ surface brighten_image(const surface &surf, int32_t amount)
 	return nsurf;
 }
 
-void adjust_surface_alpha(surface& surf, int32_t amount)
+void adjust_surface_alpha(surface& surf, uint8_t alpha_mod)
 {
 	if(surf == nullptr) {
 		return;
 	}
 
-	SDL_SetSurfaceAlphaMod(surf, uint8_t(amount));
+	SDL_SetSurfaceAlphaMod(surf, alpha_mod);
 }
 
 surface adjust_surface_alpha_add(const surface &surf, int amount)

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -143,7 +143,7 @@ surface brighten_image(const surface &surf, int32_t amount);
  */
 surface get_surface_portion(const surface &surf, SDL_Rect &rect);
 
-void adjust_surface_alpha(surface& surf, int32_t amount);
+void adjust_surface_alpha(surface& surf, uint8_t alpha_mod);
 surface adjust_surface_alpha_add(const surface &surf, int amount);
 
 /** Applies a mask on a surface. */

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -334,7 +334,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 		const int bar_shift = static_cast<int>(-5*zoom_factor);
 		const int hp_bar_height = static_cast<int>(max_hitpoints * u.hp_bar_scaling());
 
-		const int32_t bar_alpha = (loc == mouse_hex || is_selected_hex) ? floating_to_fixed_point(1.0): floating_to_fixed_point(0.8);
+		const uint8_t bar_alpha = (loc == mouse_hex || is_selected_hex) ? 255 : float_to_color(0.8);
 
 		draw_bar(*energy_file, xsrc+xoff+bar_shift, ysrc+yoff+adjusted_params.y,
 			loc, hp_bar_height, unit_energy,hp_color, bar_alpha);
@@ -394,7 +394,7 @@ void unit_drawer::redraw_unit (const unit & u) const
 
 void unit_drawer::draw_bar(const std::string& image, int xpos, int ypos,
 		const map_location& loc, std::size_t height, double filled,
-		const color_t& col, int32_t alpha) const
+		const color_t& col, uint8_t alpha) const
 {
 
 	filled = std::min<double>(std::max<double>(filled,0.0),1.0);
@@ -453,11 +453,10 @@ void unit_drawer::draw_bar(const std::string& image, int xpos, int ypos,
 
 	std::size_t unfilled = static_cast<std::size_t>(height * (1.0 - filled));
 
-	if(unfilled < height && alpha >= floating_to_fixed_point(0.3)) {
-		const uint8_t r_alpha = std::min<unsigned>(fixed_point_multiply(alpha,255),255);
+	if(unfilled < height && alpha >= float_to_color(0.3)) {
 		surface filled_surf(bar_loc.w, height - unfilled);
 		rect filled_area(0, 0, bar_loc.w, height-unfilled);
-		sdl::fill_surface_rect(filled_surf,&filled_area,SDL_MapRGBA(bar_surf->format,col.r,col.g,col.b, r_alpha));
+		sdl::fill_surface_rect(filled_surf,&filled_area,SDL_MapRGBA(bar_surf->format,col.r,col.g,col.b, alpha));
 		dest = {xpos + bar_loc.x, ypos + bar_loc.y + int(unfilled),
 			filled_surf->w, filled_surf->h};
 		// TODO: highdpi - fix, see above

--- a/src/units/drawer.hpp
+++ b/src/units/drawer.hpp
@@ -75,7 +75,7 @@ private:
 	/** draw a health/xp bar of a unit */
 	void draw_bar(const std::string& image, int xpos, int ypos,
 		const map_location& loc, std::size_t height, double filled,
-		const color_t& col, int32_t alpha) const;
+		const color_t& col, uint8_t alpha) const;
 
 	/**
 	 * Finds the start and end rows on the energy bar image.

--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -18,7 +18,6 @@
 #include "color.hpp"
 #include "game_display.hpp"
 #include "log.hpp"
-#include "sdl/utils.hpp" // floating_to_fixed_point
 #include "sound.hpp"
 
 static lg::log_domain log_engine("engine");
@@ -554,10 +553,21 @@ void unit_frame::redraw(const int frame_time, bool on_start_time, bool in_scope_
 			my_y -= current_data.directional_y * disp_zoom;
 		}
 
+		// TODO: don't conflate highlights and alpha
+		double brighten;
+		uint8_t alpha;
+		if(current_data.highlight_ratio >= 1.0) {
+			brighten = current_data.highlight_ratio - 1.0;
+			alpha = 255;
+		} else {
+			brighten = 0.0;
+			alpha = float_to_color(current_data.highlight_ratio);
+		}
+
 		display::get_singleton()->render_image(my_x, my_y,
 			static_cast<display::drawing_layer>(display::LAYER_UNIT_FIRST + current_data.drawing_layer),
-			src, image_loc, facing_west, false,
-			floating_to_fixed_point(current_data.highlight_ratio), current_data.blend_with ? *current_data.blend_with : color_t(),
+			src, image_loc, facing_west, false, alpha, brighten,
+			current_data.blend_with ? *current_data.blend_with : color_t(),
 			current_data.blend_ratio, current_data.submerge, !facing_north);
 	}
 


### PR DESCRIPTION
I managed to get an effect that reproduces previous behaviour.

Some improvements could be made for things like the unit poisoning tint effect, but it would probably be better to revisit this when using GPU shaders is a possibility.

For now this does some semi-nasty hacks involving blitting one to four copies of the image depending on the effects used. This is still very cheap to do in hardware, so is fine for now. This should greatly improve performance for effects that animate colour tint, such as the flashing effect when clicking on an owned unit and some missile effects.

The tint effect is 1:1 identical to that in 1.16 for fully opaque pixels. It may differ slightly for translucent pixels. There's not much that can be done about that without shaders.