### PR TITLE
Add PLAIN_LOG logging macro.

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -550,12 +550,10 @@ const std::string& get_version_path_suffix()
 
 		if(bfs::is_directory(new_saves_dir)) {
 			if(!bfs::exists(old_saves_dir)) {
-				std::cout << "Apple developer's userdata migration: ";
-				std::cout << "symlinking " << filesystem::sanitize_path(old_saves_dir.string()) << " to " << filesystem::sanitize_path(new_saves_dir.string()) << "\n";
+				LOG_FS << "Apple developer's userdata migration: symlinking " << old_saves_dir.string() << " to " << new_saves_dir.string() << "\n";
 				bfs::create_symlink(new_saves_dir, old_saves_dir);
 			} else if(!bfs::symbolic_link_exists(old_saves_dir)) {
-				std::cout << "Apple developer's userdata migration: ";
-				std::cout << "Problem! Old (non-containerized) directory " << filesystem::sanitize_path(old_saves_dir.string()) << " is not a symlink. Your savegames are scattered around 2 locations.\n";
+				ERR_FS << "Apple developer's userdata migration: Problem! Old (non-containerized) directory " << old_saves_dir.string() << " is not a symlink. Your savegames are scattered around 2 locations.\n";
 			}
 			return;
 		}
@@ -1459,8 +1457,8 @@ std::string get_binary_file_location(const std::string& type, const std::string&
 			if(result.empty()) {
 				result = bpath.string();
 			} else {
-				WRN_FS << "Conflicting files in binary_path: '" << sanitize_path(result)
-					   << "' and '" << sanitize_path(bpath.string()) << "'\n";
+				WRN_FS << "Conflicting files in binary_path: '" << result
+					   << "' and '" << bpath.string() << "'\n";
 			}
 		}
 	}

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -89,6 +89,8 @@ static lg::log_domain log_config("config");
 #define WRN_GENERAL LOG_STREAM(warn, lg::general())
 #define DBG_GENERAL LOG_STREAM(debug, lg::general())
 
+#define LOG_TEST FORCE_LOG_TO(lg::general(), log_config)
+
 static lg::log_domain log_mp_create("mp/create");
 #define DBG_MP LOG_STREAM(debug, log_mp_create)
 
@@ -263,13 +265,12 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts)
 		set_min_translation_percent(*cmdline_opts_.translation_percent);
 
 	if(!cmdline_opts.nobanner) {
-		std::cerr
-			<< "\nData directory:               " << filesystem::sanitize_path(game_config::path)
-			<< "\nUser configuration directory: " << filesystem::sanitize_path(filesystem::get_user_config_dir())
-			<< "\nUser data directory:          " << filesystem::sanitize_path(filesystem::get_user_data_dir())
-			<< "\nCache directory:              " << filesystem::sanitize_path(filesystem::get_cache_dir())
-			<< '\n';
-		std::cerr << '\n';
+		PLAIN_LOG
+			<< "\nData directory:               " << game_config::path
+			<< "\nUser configuration directory: " << filesystem::get_user_config_dir()
+			<< "\nUser data directory:          " << filesystem::get_user_data_dir()
+			<< "\nCache directory:              " << filesystem::get_cache_dir()
+			<< "\n\n";
 	}
 
 	// disable sound in nosound mode, or when sound engine failed to initialize
@@ -363,11 +364,11 @@ bool game_launcher::init_lua_script()
 
 			std::string full_script((std::istreambuf_iterator<char>(*sf)), std::istreambuf_iterator<char>());
 
-			std::cerr << "\nRunning lua script: " << filesystem::sanitize_path(*cmdline_opts_.script_file) << std::endl;
+			PLAIN_LOG << "\nRunning lua script: " << *cmdline_opts_.script_file << std::endl;
 
 			plugins_manager::get()->get_kernel_base()->run(full_script.c_str(), *cmdline_opts_.script_file);
 		} else {
-			std::cerr << "Encountered failure when opening script '" << filesystem::sanitize_path(*cmdline_opts_.script_file) << "'\n";
+			PLAIN_LOG << "Encountered failure when opening script '" << *cmdline_opts_.script_file << "'\n";
 			error = true;
 		}
 	}
@@ -375,7 +376,7 @@ bool game_launcher::init_lua_script()
 	if(cmdline_opts_.plugin_file) {
 		std::string filename = *cmdline_opts_.plugin_file;
 
-		std::cerr << "Loading a plugin file'" << filesystem::sanitize_path(filename) << "'...\n";
+		PLAIN_LOG << "Loading a plugin file'" << filename << "'...\n";
 
 		filesystem::scoped_istream sf = filesystem::istream_file(filename);
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -227,7 +227,7 @@ std::string sanitize_log(const std::string& logstr)
 	return str;
 }
 
-log_in_progress logger::operator()(const log_domain& domain, bool show_names, bool do_indent) const
+log_in_progress logger::operator()(const log_domain& domain, bool show_names, bool do_indent, bool show_timestamps) const
 {
 	if (severity_ > domain.domain_->second) {
 		return null_ostream;
@@ -242,7 +242,7 @@ log_in_progress logger::operator()(const log_domain& domain, bool show_names, bo
 		if(do_indent) {
 			stream.set_indent(indent);
 		}
-		if (timestamp) {
+		if (timestamp && show_timestamps) {
 			stream.enable_timestamp();
 		}
 		if (show_names) {

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -144,7 +144,7 @@ class logger {
 public:
 	logger(char const *name, int severity): name_(name), severity_(severity) {}
 	log_in_progress operator()(const log_domain& domain,
-		bool show_names = true, bool do_indent = false) const;
+		bool show_names = true, bool do_indent = false, bool show_timestamps = true) const;
 
 	bool dont_log(const log_domain& domain) const
 	{
@@ -230,3 +230,8 @@ std::stringstream& log_to_chat();
 // If you have an explicit logger object and want to ignore the logging level, use this.
 // Meant for cases where you explicitly call dont_log to avoid an expensive operation if the logging is disabled.
 #define FORCE_LOG_TO(logger, domain) logger(domain) | formatter()
+
+// always log (since it's at the error level) to the general log stream
+// outputting the log domain and timestamp is disabled
+// meant as a replacement to using cerr/cout, but that goes through the same logging infrastructure as everything else
+#define PLAIN_LOG lg::err()(lg::general(), false, false, false) | formatter()

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -158,7 +158,7 @@ static void encode(const std::string& input_file, const std::string& output_file
 		ifile.peek(); // We need to touch the stream to set the eof bit
 
 		if(!ifile.good()) {
-			std::cerr << "Input file " << filesystem::sanitize_path(input_file)
+			PLAIN_LOG << "Input file " << input_file
 					  << " is not good for reading. Exiting to prevent bzip2 from segfaulting\n";
 			safe_exit(1);
 		}
@@ -225,11 +225,11 @@ static void handle_preprocess_command(const commandline_options& cmdline_opts)
 	if(cmdline_opts.preprocess_input_macros) {
 		std::string file = *cmdline_opts.preprocess_input_macros;
 		if(filesystem::file_exists(file) == false) {
-			std::cerr << "please specify an existing file. File " << filesystem::sanitize_path(file) << " doesn't exist.\n";
+			PLAIN_LOG << "please specify an existing file. File " << file << " doesn't exist.\n";
 			return;
 		}
 
-		std::cerr << SDL_GetTicks() << " Reading cached defines from: " << filesystem::sanitize_path(file) << "\n";
+		PLAIN_LOG << SDL_GetTicks() << " Reading cached defines from: " << file << "\n";
 
 		config cfg;
 
@@ -237,7 +237,7 @@ static void handle_preprocess_command(const commandline_options& cmdline_opts)
 			filesystem::scoped_istream stream = filesystem::istream_file(file);
 			read(cfg, *stream);
 		} catch(const config::error& e) {
-			std::cerr << "Caught a config error while parsing file '" << filesystem::sanitize_path(file) << "':\n" << e.message << std::endl;
+			PLAIN_LOG << "Caught a config error while parsing file '" << file << "':\n" << e.message << std::endl;
 		}
 
 		int read = 0;
@@ -351,7 +351,7 @@ static int handle_validate_command(const std::string& file, abstract_validator& 
 		LOG_PREPROC << "adding define: " << define << '\n';
 		defines_map.emplace(define, preproc_define(define));
 	}
-	std::cout << "Validating " << filesystem::sanitize_path(file) << " against schema " << validator.name_ << std::endl;
+	PLAIN_LOG << "Validating " << file << " against schema " << validator.name_ << std::endl;
 	lg::set_strict_severity(0);
 	filesystem::scoped_istream stream = preprocess_file(file, &defines_map);
 	config result;
@@ -385,7 +385,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	}
 
 	if(cmdline_opts.userconfig_path) {
-		std::cout << filesystem::sanitize_path(filesystem::get_user_config_dir()) << '\n';
+		PLAIN_LOG << filesystem::get_user_config_dir() << '\n';
 		return 0;
 	}
 
@@ -394,7 +394,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	}
 
 	if(cmdline_opts.userdata_path) {
-		std::cout << filesystem::sanitize_path(filesystem::get_user_data_dir()) << '\n';
+		PLAIN_LOG << filesystem::get_user_data_dir() << '\n';
 		return 0;
 	}
 
@@ -412,10 +412,12 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		}
 
 		game_config::path = filesystem::normalize_path(game_config::path, true, true);
-		if(!cmdline_opts.nobanner) std::cerr << "Overriding data directory with " << filesystem::sanitize_path(game_config::path) << std::endl;
+		if(!cmdline_opts.nobanner) {
+			PLAIN_LOG << "Overriding data directory with " << game_config::path << std::endl;
+		}
 
 		if(!filesystem::is_directory(game_config::path)) {
-			std::cerr << "Could not find directory '" << filesystem::sanitize_path(game_config::path) << "'\n";
+			PLAIN_LOG << "Could not find directory '" << game_config::path << "'\n";
 			throw config::error("directory not found");
 		}
 
@@ -424,7 +426,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	}
 
 	if(cmdline_opts.data_path) {
-		std::cout << filesystem::sanitize_path(game_config::path) << '\n';
+		PLAIN_LOG << game_config::path << '\n';
 		return 0;
 	}
 
@@ -443,7 +445,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	if(cmdline_opts.gunzip) {
 		const std::string input_file(*cmdline_opts.gunzip);
 		if(!filesystem::is_gzip_file(input_file)) {
-			std::cerr << "file '" << filesystem::sanitize_path(input_file) << "'isn't a .gz file\n";
+			PLAIN_LOG << "file '" << input_file << "'isn't a .gz file\n";
 			return 2;
 		}
 
@@ -454,7 +456,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	if(cmdline_opts.bunzip2) {
 		const std::string input_file(*cmdline_opts.bunzip2);
 		if(!filesystem::is_bzip2_file(input_file)) {
-			std::cerr << "file '" << filesystem::sanitize_path(input_file) << "'isn't a .bz2 file\n";
+			PLAIN_LOG << "file '" << input_file << "'isn't a .bz2 file\n";
 			return 2;
 		}
 
@@ -644,8 +646,8 @@ static void handle_lua_script_args(game_launcher* game, commandline_options& /*c
 	first_time = false;
 
 	if(!game->init_lua_script()) {
-		// std::cerr << "error when loading lua scripts at startup\n";
-		// std::cerr << "could not load lua script: " << filesystem::sanitize_path(*cmdline_opts.script_file) << std::endl;
+		// PLAIN_LOG << "error when loading lua scripts at startup\n";
+		// PLAIN_LOG << "could not load lua script: " << *cmdline_opts.script_file << std::endl;
 	}
 }
 
@@ -1109,7 +1111,9 @@ int main(int argc, char** argv)
 			}
 
 			if(!auto_dir.empty()) {
-				if(!nobanner) std::cerr << "Automatically found a possible data directory at " << filesystem::sanitize_path(auto_dir) << '\n';
+				if(!nobanner) {
+					PLAIN_LOG << "Automatically found a possible data directory at " << auto_dir << '\n';
+				}
 				game_config::path = auto_dir;
 			}
 		}


### PR DESCRIPTION
This logs the provided text always, and without adding the log domain or timestamp. This is meant to be a replacement for std::cerr/std::cout, but that also goes through the normal logging logic as well.