### PR TITLE
Hardware unit submerge effect using SDL_RenderGeometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,7 +491,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 	find_package(VorbisFile REQUIRED)
 	find_package(PkgConfig REQUIRED)
 	find_package(Fontconfig REQUIRED)
-	find_package(SDL2 2.0.10 REQUIRED)
+	find_package(SDL2 2.0.18 REQUIRED)
 	if(NOT MSVC)
 		# for everything else, use pkgconfig
 		# SDL2_image and SDL2_mixer don't seem to have any cmake configuration available at all

--- a/SConstruct
+++ b/SConstruct
@@ -351,7 +351,7 @@ if env["prereqs"]:
 
     def have_sdl_other():
         return \
-            conf.CheckSDL2('2.0.10') & \
+            conf.CheckSDL2('2.0.18') & \
             conf.CheckSDL2Mixer() & \
             conf.CheckSDL2Image()
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -957,6 +957,8 @@ protected:
 		uint8_t b_mod = 255;
 		/** Strength of highlight effect to apply, if any. */
 		uint8_t highlight = 0;
+		std::array<SDL_Vertex,4> shader_verts;
+		bool smooth_shade = false;
 
 	private:
 		// Core info is set on creation.

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -427,6 +427,52 @@ void draw::tiled_highres(const texture& tex, const SDL_Rect& dst,
 	}
 }
 
+void draw::smooth_shaded(const texture& tex, const SDL_Rect& dst,
+	const SDL_Color& cTL, const SDL_Color& cTR,
+	const SDL_Color& cBL, const SDL_Color& cBR,
+	const SDL_FPoint& uvTL, const SDL_FPoint& uvTR,
+	const SDL_FPoint& uvBL, const SDL_FPoint& uvBR)
+{
+	const SDL_FPoint pTL{float(dst.x), float(dst.y)};
+	const SDL_FPoint pTR{float(dst.x + dst.w), float(dst.y)};
+	const SDL_FPoint pBL{float(dst.x), float(dst.y + dst.h)};
+	const SDL_FPoint pBR{float(dst.x + dst.w), float(dst.y + dst.h)};
+	std::array<SDL_Vertex,4> verts {
+		SDL_Vertex{pTL, cTL, uvTL},
+		SDL_Vertex{pTR, cTR, uvTR},
+		SDL_Vertex{pBL, cBL, uvBL},
+		SDL_Vertex{pBR, cBR, uvBR},
+	};
+	draw::smooth_shaded(tex, verts);
+}
+
+void draw::smooth_shaded(const texture& tex, const SDL_Rect& dst,
+	const SDL_Color& cTL, const SDL_Color& cTR,
+	const SDL_Color& cBL, const SDL_Color& cBR)
+{
+	SDL_FPoint uv[4] = {
+		{0.f, 0.f}, // top left
+		{1.f, 0.f}, // top right
+		{0.f, 1.f}, // bottom left
+		{1.f, 1.f}, // bottom right
+	};
+	draw::smooth_shaded(tex, dst, cTL, cTR, cBL, cBR,
+		uv[0], uv[1], uv[2], uv[3]);
+}
+
+void draw::smooth_shaded(const texture& tex,
+	const std::array<SDL_Vertex, 4>& verts)
+{
+	DBG_D << "smooth shade, verts:" << endl;
+	for (const SDL_Vertex& v : verts) {
+		DBG_D << "  {(" << v.position.x << ',' << v.position.y << ") "
+			<< v.color << " (" << v.tex_coord.x << ',' << v.tex_coord.y
+			<< ")}" << endl;
+	}
+	int indices[6] = {0, 1, 2, 2, 1, 3};
+	SDL_RenderGeometry(renderer(), tex, &verts[0], 4, indices, 6);
+}
+
 
 /***************************/
 /* RAII state manipulation */

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -33,6 +33,9 @@
 
 #include <vector>
 
+#include <SDL2/SDL_render.h>
+#include <array>
+
 struct color_t;
 class surface;
 class texture;
@@ -268,6 +271,41 @@ void tiled_highres(const texture& tex,
 	const SDL_Rect& dst,
 	bool centered = false,
 	bool mirrored = false
+);
+
+/**
+ * Draw a texture with smoothly varying colour and alpha modification,
+ * specified at the four corners of the drawing destination.
+ *
+ * The UV texture coordinates at each corner may also be specified.
+ * If unspecified, the full texture will be drawn.
+ *
+ * Colour modifiers multiply the output colour and alpha by their value
+ * after mapping to the range [0,1]. A value of 255 will have no effect.
+ *
+ * @param tex   The texture to draw
+ * @param dst   Where to draw the texture, in draw space
+ * @param cTL   The colour modifier at the top-left corner
+ * @param cTR   The colour modifier at the top-right corner
+ * @param cBL   The colour modifier at the bottom-left corner
+ * @param cBR   The colour modifier at the bottom-right corner
+ * @param uvTL  The UV texture coordinate at the top-left corner
+ * @param uvTR  The UV texture coordinate at the top-right corner
+ * @param uvBL  The UV texture coordinate at the bottom-left corner
+ * @param uvBR  The UV texture coordinate at the bottom-right corner
+ */
+void smooth_shaded(const texture& tex, const SDL_Rect& dst,
+	const SDL_Color& cTL, const SDL_Color& cTR,
+	const SDL_Color& cBL, const SDL_Color& cBR,
+	const SDL_FPoint& uvTL, const SDL_FPoint& uvTR,
+	const SDL_FPoint& uvBL, const SDL_FPoint& uvBR
+);
+void smooth_shaded(const texture& tex, const SDL_Rect& dst,
+	const SDL_Color& cTL, const SDL_Color& cTR,
+	const SDL_Color& cBL, const SDL_Color& cBR
+);
+void smooth_shaded(const texture& tex,
+	const std::array<SDL_Vertex, 4>& verts
 );
 
 


### PR DESCRIPTION
I'm putting this here without any intention of merging it, because it depends on SDL 2.0.18.

It does however pretty much complete moving the set of on-the-fly unit sprite effects to hardware manipulations.

This PR has three things:
1. An API function `draw::smooth_shaded` to draw a texture to a rectangle with specified colour modifier (including alpha) and UV texture coordinate at each corner. It linearly interpolates these values between the corners. It does this using `SDL_RenderGeometry`, which is only available in SDL version 2.0.18 and above.
2. An implementation of the unit submerge effect using the above API function.
3. A flag `ENABLE_RENDERGEOMETRY` added as an option in CMake and SCons, to optionally enable the use of the above.

Currently it works. It is, however, quite intrusive, and there are a lot of those ENABLE_RENDERGEOMETRY checks. Also the code it touches is quite likely to change, and might even get completely redone in the future. I don't want to have to maintain this while that happens.

This will however provide a good base if someone wants to implement this later. Either if the minimum SDL version progresses enough that it can be put in as is, or if this section of code becomes stable enough that it can be put in with the `#ifdef` checks, or if the game moves to a graphics framework supporting fragment shaders. The implementation here should port directly to pretty much any GPU framework.