### PR TITLE
Fixed Warden’s and Arbiter’s animations popping on water tiles.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
  ### Terrain
  ### Translations
  ### Units
+   * Fixed Warden’s and Arbiter’s animations popping on water tiles (issue #6508)
  ### User interface
  ### WML Engine
  ### Miscellaneous and Bug Fixes

--- a/data/core/units/drakes/Arbiter.cfg
+++ b/data/core/units/drakes/Arbiter.cfg
@@ -20,6 +20,12 @@
     [/special_note]
     die_sound=drake-die.ogg
     {DEFENSE_ANIM "units/drakes/arbiter-defend-2.png" "units/drakes/arbiter-defend-1.png" {SOUND_LIST:DRAKE_HIT} }
+    [+defend]
+        [if]
+            terrain_type=W*,S*
+            submerge=0.45
+        [/if]
+    [/defend]
     #   [death]
     #   [/death]
     [resistance]
@@ -53,6 +59,10 @@
         [/filter_attack]
         direction=s
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/arbiter.png:50"
@@ -72,6 +82,10 @@
         [/filter_attack]
         direction=se,sw
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/arbiter.png:50"
@@ -104,6 +118,10 @@
         [/filter_attack]
         direction=s
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/arbiter.png:50"
@@ -123,6 +141,10 @@
         [/filter_attack]
         direction=se,sw
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/arbiter.png:50"

--- a/data/core/units/drakes/Warden.cfg
+++ b/data/core/units/drakes/Warden.cfg
@@ -21,6 +21,12 @@
     [/special_note]
     die_sound=drake-die.ogg
     {DEFENSE_ANIM "units/drakes/warden-defend-2.png" "units/drakes/warden-defend-1.png" {SOUND_LIST:DRAKE_HIT} }
+    [+defend]
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4
+        [/if]
+    [/defend]
     [resistance]
         pierce=80
     [/resistance]
@@ -54,6 +60,10 @@
         [/filter_attack]
         direction=s
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4~0.425
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/warden.png:50"
@@ -73,6 +83,10 @@
         [/filter_attack]
         direction=se,sw
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4~0.425
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/warden.png:50"
@@ -105,6 +119,10 @@
         [/filter_attack]
         direction=s
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4~0.35
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/warden.png:50"
@@ -124,6 +142,10 @@
         [/filter_attack]
         direction=se,sw
         offset=0.0~0.1,0.1~0.0
+        [if]
+            terrain_type=W*,S*
+            submerge=0.4~0.35
+        [/if]
         start_time=-300
         [frame]
             image="units/drakes/warden.png:50"


### PR DESCRIPTION
Previously, part of these drakes were popping out of the water during attack and defense animations because their images were bigger than a hex. This adds hand-picked submerge values that makes the animation feel more connected on water.

Closes https://github.com/wesnoth/wesnoth/issues/6508