### PR TITLE
add GLIBCXX_USE_DEPRECATED=0 in codeblock projectfiles

### DIFF
--- a/projectfiles/CodeBlocks/campaignd.cbp
+++ b/projectfiles/CodeBlocks/campaignd.cbp
@@ -36,6 +36,7 @@
 			<Add option="-fopenmp" />
 			<Add option="-Wunused" />
 			<Add option="-Wunused-parameter" />
+			<Add option="-D_GLIBCXX_USE_DEPRECATED=0" />
 			<Add option="-DHAVE_PYTHON" />
 			<Add option="-DUSE_GZIP" />
 			<Add option="-D_WIN32_WINNT=0x0601" />

--- a/projectfiles/CodeBlocks/tests.cbp
+++ b/projectfiles/CodeBlocks/tests.cbp
@@ -40,6 +40,7 @@
 			<Add option="-Wunused" />
 			<Add option="-Wunused-parameter" />
 			<Add option="-DHAVE_LIBPNG" />
+			<Add option="-D_GLIBCXX_USE_DEPRECATED=0" />
 			<Add option="-D_WIN32_WINDOWS" />
 			<Add option="-D_WIN32_WINNT=0x0601" />
 			<Add option="-D_WIN32_IE=0x0601" />

--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -40,6 +40,7 @@
 			<Add option="-Wunused" />
 			<Add option="-Wunused-parameter" />
 			<Add option="-DHAVE_LIBPNG" />
+			<Add option="-D_GLIBCXX_USE_DEPRECATED=0" />
 			<Add option="-D_WIN32_WINDOWS" />
 			<Add option="-D_WIN32_WINNT=0x0601" />
 			<Add option="-D_WIN32_IE=0x0601" />

--- a/projectfiles/CodeBlocks/wesnothd.cbp
+++ b/projectfiles/CodeBlocks/wesnothd.cbp
@@ -36,6 +36,7 @@
 			<Add option="-fopenmp" />
 			<Add option="-Wunused" />
 			<Add option="-Wunused-parameter" />
+			<Add option="-D_GLIBCXX_USE_DEPRECATED=0" />
 			<Add option="-DHAVE_PYTHON" />
 			<Add option="-DUSE_GZIP" />
 			<Add option="-D_WIN32_WINNT=0x0601" />


### PR DESCRIPTION
This is for stop using of deprecated variable in boost