### PR TITLE
MP Create Game dialog: improve error handling

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -72,6 +72,8 @@ void scenario::set_metadata()
 	try {
 		map_.reset(new gamemap(map_data));
 	} catch(const incorrect_map_format_error& e) {
+		// Set map content to nullptr, so that it fails can_launch_game()
+		map_.reset(nullptr);
 		data_["description"] = _("Map could not be loaded: ") + e.message;
 
 		ERR_CF << "map could not be loaded: " << e.message << '\n';
@@ -662,6 +664,8 @@ void create_engine::init_all_levels()
 			try {
 				map.reset(new gamemap(user_map_data["map_data"]));
 			} catch (const incorrect_map_format_error& e) {
+				// Set map content to nullptr, so that it fails can_launch_game()
+				map.reset(nullptr);
 				user_map_data["description"] = _("Map could not be loaded: ") + e.message;
 
 				ERR_CF << "map could not be loaded: " << e.message << '\n';

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -660,7 +660,6 @@ void mp_create_game::update_details()
 	boost::replace_all(title, "\n", " " + font::unicode_em_dash + " ");
 	find_widget<styled_widget>(get_window(), "game_title", false).set_label(title);
 
-	show_description(create_engine_.current_level().description());
 
 	switch(create_engine_.current_level_type()) {
 		case level_type::type::scenario:
@@ -714,6 +713,9 @@ void mp_create_game::update_details()
 			break;
 		}
 	}
+
+	// This needs to be at the end, since errors found expanding the map data are put into the description
+	show_description(create_engine_.current_level().description());
 }
 
 void mp_create_game::update_map_settings()

--- a/src/terrain/translation.cpp
+++ b/src/terrain/translation.cpp
@@ -709,9 +709,10 @@ static ter_layer string_to_layer_(std::string_view str)
 		return NO_LAYER;
 	}
 
-	// Validate the string
-	VALIDATE(str.size() <= 4, _("A terrain with a string with more "
-		"than 4 characters has been found, the affected terrain is:") + std::string(str));
+	if(str.size() > 4) {
+		throw error("A terrain with a string with more "
+			"than 4 characters has been found, the affected terrain is: " + std::string(str));
+	}
 
 	ter_layer result = 0;
 	// The conversion to int puts the first char


### PR DESCRIPTION
This PR causes all map errors to be handled identically in the Create Game dialog.  The behavior is now the same for all errors, as well as for maps provided via both `map_file=` and `map_data=`; errors are always displayed in the description under the minimap; none of them causes the game to fall back to the main menu; and none of them allows advancing to the next dialog.

This addresses the additional issues discussed after #1346 was closed.