### PR TITLE
Re-add an <fstream> include for GCC 11

### DIFF
--- a/src/gui/widgets/debug.cpp
+++ b/src/gui/widgets/debug.cpp
@@ -28,6 +28,7 @@
 #include "gui/widgets/window.hpp"
 #include "serialization/string_utils.hpp"
 
+#include <fstream>
 #include <iomanip>
 
 namespace gui2


### PR DESCRIPTION
3874fe5f0 compiled okay on the CI, but it seems it was relying
on an implicit include somewhere. GCC 11.3.0 requires this.