### PR TITLE
Print vcpkg_abi_info.txt contents.

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -224,7 +224,7 @@ jobs:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: win-cache-0002
+          key: win-cache-0005
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -234,7 +234,6 @@ jobs:
         run: |
           if not exist "D:/a/wesnoth/vcpkg" git clone https://github.com/microsoft/vcpkg.git D:/a/wesnoth/vcpkg
           if not exist "D:/a/wesnoth/vcpkg" cd D:/a/wesnoth/vcpkg
-          if not exist "D:/a/wesnoth/vcpkg" git checkout b49b2bdf22559c89eddbf29a29621a1dc6929320
           if not exist "D:/a/wesnoth/vcpkg" D:/a/wesnoth/vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup cmake
@@ -277,7 +276,7 @@ jobs:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: win-cache-0002
+          key: win-cache-0005
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -287,7 +286,6 @@ jobs:
         run: |
           if not exist "D:/a/wesnoth/vcpkg" git clone https://github.com/microsoft/vcpkg.git D:/a/wesnoth/vcpkg
           if not exist "D:/a/wesnoth/vcpkg" cd D:/a/wesnoth/vcpkg
-          if not exist "D:/a/wesnoth/vcpkg" git checkout b49b2bdf22559c89eddbf29a29621a1dc6929320
           if not exist "D:/a/wesnoth/vcpkg" D:/a/wesnoth/vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup cmake
@@ -299,13 +297,14 @@ jobs:
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_MYSQL=false -DENABLE_NLS=false -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=D:/a/wesnoth/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64 -G "Visual Studio 16 2019" .
 
-# delete buildtrees directory to free up space after cmake invokes vcpkg to build the dependencies
-# otherwise the job was failing when trying to write a .obj file
-# building vcpkg on the more spacious C drive didn't work since for some reason vcpkg decides to not create the pango/cairo pkgconfig files there
+      - name: vcpkg_abi_info
+        shell: cmd
+        run: |
+          type "D:\a\wesnoth\vcpkg\buildtrees\bzip2\x64-windows.vcpkg_abi_info.txt"
+
       - name: Build wesnoth
         shell: cmd
         run: |
-          rmdir /s /q D:\a\wesnoth\vcpkg\buildtrees
           MSBuild.exe wesnoth.sln -p:Configuration=Release
 
       - name: Run WML unit tests


### PR DESCRIPTION
The only suggestion that came up was checking to see if something in this file changed between when the vcpkg cache is used vs isn't used, so... print out the contents of a random dependency and then check back later I guess.