### PR TITLE
A draw manager. To manage drawing to the screen.

### DIFF
--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -1061,6 +1061,10 @@
 		91FAC70A1C7FBC3400DAB2C3 /* lua_formula_bridge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FAC7091C7FBC2C00DAB2C3 /* lua_formula_bridge.cpp */; };
 		91FBBAD81CB6BC3F00470BFE /* filesystem_sdl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FBBAD71CB6BC3F00470BFE /* filesystem_sdl.cpp */; };
 		91FBBADB1CB6D1B700470BFE /* markov_generator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FBBAD91CB6D1B700470BFE /* markov_generator.cpp */; };
+		95EB8A52287A02B900B09F95 /* draw_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A50287A02B800B09F95 /* draw_manager.cpp */; };
+		95EB8A55287A02EC00B09F95 /* top_level_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */; };
+		95EB8A58287B138700B09F95 /* draw_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A50287A02B800B09F95 /* draw_manager.cpp */; };
+		95EB8A59287B139800B09F95 /* top_level_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */; };
 		B508D193100146E300B12852 /* engine_fai.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B508D191100146E300B12852 /* engine_fai.cpp */; };
 		B513B2290ED36BFB0006E551 /* libcairo.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B513B2270ED36BFB0006E551 /* libcairo.2.dylib */; };
 		B52EE8841213585300CFBDAB /* tod_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B52EE8821213585300CFBDAB /* tod_manager.cpp */; };
@@ -2284,6 +2288,10 @@
 		91FBBAD71CB6BC3F00470BFE /* filesystem_sdl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = filesystem_sdl.cpp; sourceTree = "<group>"; };
 		91FBBAD91CB6D1B700470BFE /* markov_generator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markov_generator.cpp; sourceTree = "<group>"; };
 		91FBBADA1CB6D1B700470BFE /* markov_generator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = markov_generator.hpp; sourceTree = "<group>"; };
+		95EB8A50287A02B800B09F95 /* draw_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = draw_manager.cpp; sourceTree = "<group>"; };
+		95EB8A51287A02B800B09F95 /* draw_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_manager.hpp; sourceTree = "<group>"; };
+		95EB8A53287A02EC00B09F95 /* top_level_drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = top_level_drawable.hpp; path = gui/core/top_level_drawable.hpp; sourceTree = "<group>"; };
+		95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = top_level_drawable.cpp; path = gui/core/top_level_drawable.cpp; sourceTree = "<group>"; };
 		B508D191100146E300B12852 /* engine_fai.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = engine_fai.cpp; sourceTree = "<group>"; };
 		B508D192100146E300B12852 /* engine_fai.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = engine_fai.hpp; sourceTree = "<group>"; };
 		B513B2270ED36BFB0006E551 /* libcairo.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libcairo.2.dylib; path = lib/libcairo.2.dylib; sourceTree = "<group>"; };
@@ -3122,6 +3130,10 @@
 				B5599A980EC62181008DD061 /* display.hpp */,
 				91AF55DE2848472F007A7652 /* draw.cpp */,
 				91AF55DD2848472E007A7652 /* draw.hpp */,
+				95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */,
+				95EB8A53287A02EC00B09F95 /* top_level_drawable.hpp */,
+				95EB8A50287A02B800B09F95 /* draw_manager.cpp */,
+				95EB8A51287A02B800B09F95 /* draw_manager.hpp */,
 				B5599FF60EC8FE2E008DD061 /* editor */,
 				B5599A970EC62181008DD061 /* events.cpp */,
 				B5599A960EC62181008DD061 /* events.hpp */,
@@ -5179,6 +5191,7 @@
 				620A386E15E9364E00A4F513 /* attack.cpp in Sources */,
 				46F92DB52174F6A300602C1C /* message.cpp in Sources */,
 				46E2D99125022BF6003D99F3 /* lua_widget_attributes.cpp in Sources */,
+				95EB8A52287A02B900B09F95 /* draw_manager.cpp in Sources */,
 				62D24F2D1519982500350848 /* brush.cpp in Sources */,
 				B552D92D108694BB002D8F86 /* ca_move_to_targets.cpp in Sources */,
 				46F92DED2174F6A400602C1C /* uninstall_list.cpp in Sources */,
@@ -5316,6 +5329,7 @@
 				46685C8F219D518B0009CFFE /* string_utils.cpp in Sources */,
 				46F92E812174F6A400602C1C /* styled_widget.cpp in Sources */,
 				ECDEAF79194FEA9D00DB2F47 /* game_classification.cpp in Sources */,
+				95EB8A55287A02EC00B09F95 /* top_level_drawable.cpp in Sources */,
 				46F92E972174F6A400602C1C /* stacked_widget.cpp in Sources */,
 				62CC8E4C1771E7E100C16B75 /* game_config_manager.cpp in Sources */,
 				B5599B6B0EC62181008DD061 /* game_config.cpp in Sources */,
@@ -5765,6 +5779,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95EB8A59287B139800B09F95 /* top_level_drawable.cpp in Sources */,
+				95EB8A58287B138700B09F95 /* draw_manager.cpp in Sources */,
 				46F92E802174F6A400602C1C /* pane.cpp in Sources */,
 				46F92DEA2174F6A400602C1C /* simple_item_selector.cpp in Sources */,
 				91E356341CACC47F00774252 /* main.cpp in Sources */,

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -73,6 +73,7 @@ desktop/paths.cpp
 desktop/version.cpp
 display_chat_manager.cpp
 draw.cpp
+draw_manager.cpp
 editor/action/action.cpp
 editor/action/action_item.cpp
 editor/action/action_label.cpp
@@ -160,6 +161,7 @@ gui/core/placer/horizontal_list.cpp
 gui/core/placer/vertical_list.cpp
 gui/core/static_registry.cpp
 gui/core/timer.cpp
+gui/core/top_level_drawable.cpp
 gui/core/widget_definition.cpp
 gui/core/window_builder.cpp
 gui/core/window_builder/helper.cpp

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -218,7 +218,8 @@ bool uninstall_local_addons()
 
 		gui2::show_transient_message(
 			dlg_title,
-			dlg_msg + list_lead + utils::bullet_list(succeeded_names), "", false, false, true);
+			dlg_msg + list_lead + utils::bullet_list(succeeded_names)
+		);
 
 		return true;
 	}

--- a/src/color.hpp
+++ b/src/color.hpp
@@ -48,6 +48,12 @@ const uint32_t RGBA_BLUE_BITSHIFT  = 8;
 
 const uint8_t ALPHA_OPAQUE = SDL_ALPHA_OPAQUE; // This is always 255 in SDL2
 
+// Functions for manipulating RGB values.
+constexpr uint8_t float_to_color(double n);
+constexpr uint8_t float_to_color(float n);
+constexpr uint8_t color_multiply(uint8_t n1, uint8_t n2);
+constexpr uint8_t color_blend(uint8_t n1, uint8_t n2, uint8_t p);
+
 /**
  * The basic class for representing 8-bit RGB or RGBA colour values.
  *
@@ -212,6 +218,23 @@ struct color_t : SDL_Color
 		};
 	}
 
+	/**
+	 * Blend smoothly with another color_t.
+	 *
+	 * @param c     The color to blend with.
+	 * @param p     The proportion of the other color to blend. 0 will
+	 *              return the original color, 255 the blending color.
+	 */
+	color_t smooth_blend(const color_t& c, uint8_t p) const
+	{
+		return {
+			color_blend(r, c.r, p),
+			color_blend(g, c.g, p),
+			color_blend(b, c.b, p),
+			color_blend(a, c.a, p)
+		};
+	}
+
 	/** Definition of a 'null' color - fully transparent black. */
 	static color_t null_color()
 	{
@@ -261,4 +284,14 @@ constexpr uint8_t float_to_color(float n)
 constexpr uint8_t color_multiply(uint8_t n1, uint8_t n2)
 {
 	return uint8_t((uint16_t(n1) * uint16_t(n2))/255);
+}
+
+/**
+ * Blend 8-bit colour value with another in the given proportion.
+ *
+ * A proportion of 0 returns the first value, 255 the second.
+ */
+constexpr uint8_t color_blend(uint8_t n1, uint8_t n2, uint8_t p)
+{
+	return color_multiply(n1, ~p) + color_multiply(n2, p);
 }

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -61,7 +61,7 @@ namespace soundsource
 class manager;
 }
 
-class controller_base : public video2::draw_layering, public events::pump_monitor
+class controller_base : public events::sdl_handler, public events::pump_monitor
 {
 public:
 	controller_base();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1738,6 +1738,9 @@ void display::announce(const std::string& message, const color_t& color, const a
 
 void display::recalculate_minimap()
 {
+	if(video().faked()) {
+		return;
+	}
 	const rect& area = minimap_area();
 	minimap_ = texture(image::getMinimap(
 		area.w, area.h, get_map(),

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2967,7 +2967,7 @@ void display::draw_report(const std::string& report_name, bool tooltip_test)
 				.set_ellipse_mode(PANGO_ELLIPSIZE_END)
 				.set_characters_per_line(0);
 
-			texture s = text.render_texture();
+			texture s = text.render_and_get_texture();
 
 			// check if next element is text with almost no space to show it
 			const int minimal_text = 12; // width in pixels
@@ -2980,7 +2980,7 @@ void display::draw_report(const std::string& report_name, bool tooltip_test)
 				//NOTE this space should be longer than minimal_text pixels
 				t = t + "    ";
 				text.set_text(t, true);
-				s = text.render_texture();
+				s = text.render_and_get_texture();
 				// use the area of this element for next tooltips
 				used_ellipsis = true;
 				ellipsis_area.x = x;

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -563,6 +563,14 @@ public:
 	/** Checks if location @a loc or one of the adjacent tiles is visible on screen. */
 	bool tile_nearly_on_screen(const map_location &loc) const;
 
+	/** Screen fade */
+	void fade_to(const color_t& color, int duration);
+	void set_fade(const color_t& color);
+
+private:
+	color_t fade_color_ = {0,0,0,0};
+
+public:
 	/**
 	 * Draws invalidated items.
 	 * If update is true, will also copy the display to the frame buffer.

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -118,6 +118,14 @@ void sparkle()
 	// Ensure layout and animations are up-to-date.
 	draw_manager::layout();
 
+	// Unit tests rely on not doing any rendering, or waiting at all...
+	// "behave differently when being tested" is really not good policy
+	// but whatever.
+	if(CVideo::get_singleton().any_fake()) {
+		invalidated_regions_.clear();
+		return;
+	}
+
 	// Ensure any off-screen render buffers are up-to-date.
 	draw_manager::render();
 
@@ -164,8 +172,6 @@ static void render()
 
 static bool draw()
 {
-	// TODO: draw_manager - some things were skipping draw when video is faked. Should this skip all in this case?
-
 	drawing_ = true;
 
 	// For now just send all regions to all TLDs in the correct order.

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -1,0 +1,233 @@
+/*
+	Copyright (C) 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#include "draw_manager.hpp"
+
+#include "draw.hpp"
+#include "exceptions.hpp"
+#include "log.hpp"
+#include "gui/core/top_level_drawable.hpp"
+#include "sdl/rect.hpp"
+#include "video.hpp"
+
+#include <SDL2/SDL_rect.h>
+#include <SDL2/SDL_timer.h>
+
+#include <vector>
+#include <map>
+
+static lg::log_domain log_draw_man("draw/manager");
+#define ERR_DM LOG_STREAM(err, log_draw_man)
+#define WRN_DM LOG_STREAM(warn, log_draw_man)
+#define LOG_DM LOG_STREAM(info, log_draw_man)
+#define DBG_DM LOG_STREAM(debug, log_draw_man)
+
+using std::endl;
+using gui2::top_level_drawable;
+
+namespace {
+std::vector<top_level_drawable*> top_level_drawables_;
+std::vector<rect> invalidated_regions_;
+bool drawing_ = false;
+uint32_t last_sparkle_ = 0;
+} // namespace
+
+namespace draw_manager {
+
+static void layout();
+static void render();
+static bool draw();
+static void wait_for_vsync();
+
+void invalidate_region(const rect& region)
+{
+	if (drawing_) {
+		ERR_DM << "Attempted to invalidate region " << region
+			<< " during draw" << endl;
+		throw game::error("invalidate during draw");
+	}
+
+	// On-add region optimization
+	rect progressive_cover = region;
+	int64_t cumulative_area = 0;
+	for (auto& r : invalidated_regions_) {
+		if (r.contains(region)) {
+			// An existing invalidated region already contains it,
+			// no need to do anything in this case.
+			//DBG_DM << "no need to invalidate " << region << endl;
+			//PLAIN_LOG << '.';
+			return;
+		}
+		if (region.contains(r)) {
+			// This region contains a previously invalidated region,
+			// might as well supercede it with this.
+			DBG_DM << "superceding previous invalidation " << r
+				<< " with " << region << endl;
+			//PLAIN_LOG << '\'';
+			r = region;
+			return;
+		}
+		// maybe merge with another rect
+		rect m = r.minimal_cover(region);
+		if (m.area() <= r.area() + region.area()) {
+			// This won't always be the best,
+			// but it also won't ever be the worst.
+			DBG_DM << "merging " << region << " with " << r
+				<< " to invalidate " << m << endl;
+			//PLAIN_LOG << ':';
+			r = m;
+			return;
+		}
+		// maybe merge *all* the rects
+		progressive_cover.expand_to_cover(r);
+		cumulative_area += r.area();
+		if (progressive_cover.area() <= cumulative_area) {
+			DBG_DM << "conglomerating invalidations to "
+				<< progressive_cover << endl;
+			//PLAIN_LOG << '%';
+			// replace the first one, so we can easily prune later
+			invalidated_regions_[0] = progressive_cover;
+			return;
+		}
+	}
+
+	// No optimization was found, so add a new invalidation
+	DBG_DM << "invalidating region " << region << endl;
+	//PLAIN_LOG << '.';
+	invalidated_regions_.push_back(region);
+}
+
+void sparkle()
+{
+	if (drawing_) {
+		ERR_DM << "Draw recursion detected" << endl;
+		throw game::error("recursive draw");
+	}
+
+	// Ensure layout and animations are up-to-date.
+	draw_manager::layout();
+
+	// Ensure any off-screen render buffers are up-to-date.
+	draw_manager::render();
+
+	// Draw to the screen.
+	if (draw_manager::draw()) {
+		// We only need to flip the screen if something was drawn.
+		CVideo::get_singleton().render_screen();
+	} else {
+		wait_for_vsync();
+	}
+
+	last_sparkle_ = SDL_GetTicks();
+}
+
+static void wait_for_vsync()
+{
+	int rr = CVideo::get_singleton().current_refresh_rate();
+	if (rr <= 0) {
+		// make something up
+		rr = 60;
+	}
+	// allow 1ms for general processing
+	int vsync_delay = (1000 / rr) - 1;
+	int time_to_wait = last_sparkle_ + vsync_delay - SDL_GetTicks();
+	if (time_to_wait > 0) {
+		// delay a maximum of 1 second in case something crazy happens
+		SDL_Delay(std::min(time_to_wait, 1000));
+	}
+}
+
+static void layout()
+{
+	for (auto tld : top_level_drawables_) {
+		tld->layout();
+	}
+}
+
+static void render()
+{
+	for (auto tld : top_level_drawables_) {
+		tld->render();
+	}
+}
+
+static bool draw()
+{
+	// TODO: draw_manager - some things were skipping draw when video is faked. Should this skip all in this case?
+
+	drawing_ = true;
+
+	// For now just send all regions to all TLDs in the correct order.
+	bool drawn = false;
+next:
+	while (!invalidated_regions_.empty()) {
+		rect r = invalidated_regions_.back();
+		invalidated_regions_.pop_back();
+		// check if this will be superceded by or should be merged with another
+		for (auto& other : invalidated_regions_) {
+			// r will never contain other, due to construction
+			if (other.contains(r)) {
+				DBG_DM << "skipping redundant draw " << r << endl;
+				//PLAIN_LOG << "-";
+				goto next;
+			}
+			rect m = other.minimal_cover(r);
+			if (m.area() <= r.area() + other.area()) {
+				DBG_DM << "merging inefficient draws " << r << endl;
+				//PLAIN_LOG << "=";
+				other = m;
+				goto next;
+			}
+		}
+		DBG_DM << "drawing " << r << endl;
+		//PLAIN_LOG << "+";
+		auto clipper = draw::set_clip(r);
+		for (auto tld : top_level_drawables_) {
+			rect i = r.intersect(tld->screen_location());
+			if (i.empty()) {
+				//DBG_DM << "  skip " << static_cast<void*>(tld) << endl;
+				//PLAIN_LOG << "x";
+				continue;
+			}
+			DBG_DM << "  to " << static_cast<void*>(tld) << endl;
+			//PLAIN_LOG << "*";
+			drawn |= tld->expose(i);
+		}
+	}
+	drawing_ = false;
+	return drawn;
+}
+
+void register_drawable(top_level_drawable* tld)
+{
+	DBG_DM << "registering TLD " << static_cast<void*>(tld) << endl;
+	top_level_drawables_.push_back(tld);
+}
+
+void deregister_drawable(top_level_drawable* tld)
+{
+	DBG_DM << "deregistering TLD " << static_cast<void*>(tld) << endl;
+	auto& vec = top_level_drawables_;
+	vec.erase(std::remove(vec.begin(), vec.end(), tld), vec.end());
+}
+
+void raise_drawable(top_level_drawable* tld)
+{
+	DBG_DM << "raising TLD " << static_cast<void*>(tld) << endl;
+	auto& vec = top_level_drawables_;
+	vec.erase(std::remove(vec.begin(), vec.end(), tld), vec.end());
+	vec.push_back(tld);
+}
+
+} // namespace draw_manager

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -40,6 +40,7 @@ namespace {
 std::vector<top_level_drawable*> top_level_drawables_;
 std::vector<rect> invalidated_regions_;
 bool drawing_ = false;
+bool tlds_invalidated_ = false;
 uint32_t last_sparkle_ = 0;
 } // namespace
 
@@ -115,6 +116,9 @@ void sparkle()
 		throw game::error("recursive draw");
 	}
 
+	// Keep track of whether the TLD vector has been invalidated.
+	tlds_invalidated_ = false;
+
 	// Ensure layout and animations are up-to-date.
 	draw_manager::layout();
 
@@ -159,6 +163,7 @@ static void wait_for_vsync()
 static void layout()
 {
 	for (auto tld : top_level_drawables_) {
+		if (tlds_invalidated_) { break; }
 		tld->layout();
 	}
 }
@@ -166,6 +171,7 @@ static void layout()
 static void render()
 {
 	for (auto tld : top_level_drawables_) {
+		if (tlds_invalidated_) { break; }
 		tld->render();
 	}
 }
@@ -226,6 +232,7 @@ void deregister_drawable(top_level_drawable* tld)
 	DBG_DM << "deregistering TLD " << static_cast<void*>(tld) << endl;
 	auto& vec = top_level_drawables_;
 	vec.erase(std::remove(vec.begin(), vec.end(), tld), vec.end());
+	tlds_invalidated_ = true;
 }
 
 void raise_drawable(top_level_drawable* tld)
@@ -234,6 +241,7 @@ void raise_drawable(top_level_drawable* tld)
 	auto& vec = top_level_drawables_;
 	vec.erase(std::remove(vec.begin(), vec.end(), tld), vec.end());
 	vec.push_back(tld);
+	tlds_invalidated_ = true;
 }
 
 } // namespace draw_manager

--- a/src/draw_manager.hpp
+++ b/src/draw_manager.hpp
@@ -1,0 +1,118 @@
+/*
+	Copyright (C) 2007 - 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "sdl/rect.hpp"
+
+namespace gui2 { class top_level_drawable; }
+
+/**
+ * A global draw management interface.
+ *
+ * This interface governs drawing things to the screen in the correct order.
+ * Drawable objects must inherit from gui2::top_level_drawable, and may be
+ * referred to as "TLD"s.
+ *
+ * There is an absolute requirement that events happen in a certain order.
+ * This is mostly managed by this interface, which calls the TLD methods in
+ * order at most once every vsync.
+ *
+ * The order of events is:
+ *   1. General event processing. This is governed by events::pump()
+ *      and is currently independent of this interface.
+ *   2. Layout and animation. TLDs should ensure their layout information
+ *      is up-to-date inside gui2::top_level_drawable::layout(). After
+ *      this call they should know where they are on the screen, and be
+ *      ready to report it via gui2::top_level_drawable::screen_location().
+ *      Animation can also be performed during this stage.
+ *   3. Offscreen rendering. TLDs should perform any offscreen rendering
+ *      during gui2::top_level_drawable::render(). After this call, all
+ *      internal drawing buffers should be in a state ready for display.
+ *   4. Drawing to the screen. Drawing to the screen should only ever happen
+ *      inside gui2::top_level_drawable::expose(). Drawing to the screen at
+ *      any other point is an error.
+ *
+ * The draw manager will call layout(), render() and expose() in the correct
+ * order to ensure all TLD objects are laid out correctly and drawn in the
+ * correct order.
+ *
+ * Drawing order of TLDs is initially set by creation time, but a TLD may
+ * be raised to the top of the drawing stack by calling
+ * draw_manager::raise_drawable() manually. register_drawable() and
+ * deregister_drawable() are called automatically by gui2::top_level_drawable
+ * in its constructor and destructor, and do not need to be manually managed.
+ *
+ * The drawing process happens inside draw_manager::sparkle(). In general,
+ * a game loop should perform two basic steps.
+ *   1. call events::pump() to process events. Anything other than drawing
+ *      to the screen may happen during this step.
+ *   2. call draw_manager::sparkle() to draw the screen, if necessary.
+ *
+ * The main sparkle() function will also rate-limit, so callers do not need
+ * to add their own delay to their loops. If vsync is disabled, drawing will
+ * happen as frequently as possible. If vsync is enabled, this function will
+ * wait for the next screen refresh before drawing. In both cases, if nothing
+ * needs to be drawn the function will block for an appropriate length of
+ * time before returning.
+ *
+ * To ensure they are presented for drawing, any drawable object must call
+ * draw_manager::invalidate_region() to indicate that an area of the screen
+ * needs to be redrawn. This may be called during any phase other than the
+ * draw phase. Invalidating regions during the draw phase is an error and
+ * will throw an exception.
+ */
+namespace draw_manager
+{
+
+/**
+ * Mark a region of the screen as requiring redraw.
+ *
+ * This should be called any time an item changes in such a way as to
+ * require redrawing.
+ *
+ * This may only be called outside the Draw phase.
+ *
+ * Regions are combined to result in a minimal number of draw calls,
+ * so this may be called for every invalidation without much concern.
+ */
+void invalidate_region(const rect& region);
+
+/**
+ * Ensure that everything which needs to be drawn is drawn.
+ *
+ * This includes making sure window sizes and locations are up to date,
+ * updating animation frames, and drawing whatever regions of the screen
+ * need drawing or redrawing.
+ *
+ * If vsync is enabled, this function will block until the next vblank.
+ * If nothing is drawn, it will still block for an appropriate amount of
+ * time to simulate vsync, even if vsync is disabled.
+ */
+void sparkle();
+
+/** Register a top-level drawable.
+ *
+ * Registered drawables will be drawn in the order of registration,
+ * so the most recently-registered drawable will be "on top".
+ */
+void register_drawable(gui2::top_level_drawable* tld);
+
+/** Remove a top-level drawable from the drawing stack. */
+void deregister_drawable(gui2::top_level_drawable* tld);
+
+/** Raise a TLD to the top of the drawing stack. */
+void raise_drawable(gui2::top_level_drawable* tld);
+
+} // namespace draw_manager

--- a/src/editor/action/mouse/mouse_action.cpp
+++ b/src/editor/action/mouse/mouse_action.cpp
@@ -32,10 +32,12 @@ bool mouse_action::has_context_menu() const
 
 void mouse_action::move(editor_display& disp, const map_location& hex)
 {
-	if (hex != previous_move_hex_) {
-		update_brush_highlights(disp, hex);
-		previous_move_hex_ = hex;
+	if (hex == previous_move_hex_) {
+		return;
 	}
+
+	update_brush_highlights(disp, hex);
+	previous_move_hex_ = hex;
 }
 
 void mouse_action::update_brush_highlights(editor_display& disp, const map_location& hex)

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -29,18 +29,19 @@ namespace editor {
 
 void mouse_action_item::move(editor_display& disp, const map_location& hex)
 {
-	if (hex != previous_move_hex_) {
-
-		update_brush_highlights(disp, hex);
-
-		std::set<map_location> adjacent_set;
-		for(const map_location& adj : get_adjacent_tiles(previous_move_hex_)) {
-			adjacent_set.insert(adj);
-		}
-
-		disp.invalidate(adjacent_set);
-		previous_move_hex_ = hex;
+	if (hex == previous_move_hex_) {
+		return;
 	}
+
+	update_brush_highlights(disp, hex);
+
+	std::set<map_location> adjacent_set;
+	for(const map_location& adj : get_adjacent_tiles(previous_move_hex_)) {
+		adjacent_set.insert(adj);
+	}
+
+	disp.invalidate(adjacent_set);
+	previous_move_hex_ = hex;
 }
 
 std::unique_ptr<editor_action> mouse_action_item::click_left(editor_display& disp, int x, int y)

--- a/src/editor/action/mouse/mouse_action_unit.cpp
+++ b/src/editor/action/mouse/mouse_action_unit.cpp
@@ -35,43 +35,44 @@ namespace editor {
 
 void mouse_action_unit::move(editor_display& disp, const map_location& hex)
 {
-	if (hex != previous_move_hex_) {
+	if (hex == previous_move_hex_) {
+		return;
+	}
 
-		update_brush_highlights(disp, hex);
+	update_brush_highlights(disp, hex);
 
-		std::set<map_location> adjacent_set;
-		for(const map_location& adj : get_adjacent_tiles(previous_move_hex_)) {
-			adjacent_set.insert(adj);
+	std::set<map_location> adjacent_set;
+	for(const map_location& adj : get_adjacent_tiles(previous_move_hex_)) {
+		adjacent_set.insert(adj);
+	}
+
+	disp.invalidate(adjacent_set);
+	previous_move_hex_ = hex;
+
+	const unit_map& units = disp.get_units();
+	const unit_map::const_unit_iterator unit_it = units.find(hex);
+	if (unit_it != units.end()) {
+
+		disp.clear_mouseover_hex_overlay();
+
+		SDL_Rect rect;
+		rect.x = disp.get_location_x(hex);
+		rect.y = disp.get_location_y(hex);
+		rect.h = disp.hex_size();
+		rect.w = disp.hex_size();
+		std::stringstream str;
+		str << _("Identifier: ") << unit_it->id()     << "\n";
+		if(unit_it->name() != "") {
+			str	<< _("Name: ")    << unit_it->name()      << "\n";
 		}
-
-		disp.invalidate(adjacent_set);
-		previous_move_hex_ = hex;
-
-		const unit_map& units = disp.get_units();
-		const unit_map::const_unit_iterator unit_it = units.find(hex);
-		if (unit_it != units.end()) {
-
-			disp.clear_mouseover_hex_overlay();
-
-			SDL_Rect rect;
-			rect.x = disp.get_location_x(hex);
-			rect.y = disp.get_location_y(hex);
-			rect.h = disp.hex_size();
-			rect.w = disp.hex_size();
-			std::stringstream str;
-			str << _("Identifier: ") << unit_it->id()     << "\n";
-			if(unit_it->name() != "") {
-				str	<< _("Name: ")    << unit_it->name()      << "\n";
-			}
-			str	<< _("Type: ")    << unit_it->type_name() << "\n"
-				<< _("Level: ")   << unit_it->level()     << "\n"
-				<< _("Cost: ")    << unit_it->cost()      << "\n";
-			tooltips::clear_tooltips();
-			tooltips::add_tooltip(rect, str.str());
-		}
-		else {
-			set_mouse_overlay(disp);
-		}
+		str	<< _("Type: ")    << unit_it->type_name() << "\n"
+			<< _("Level: ")   << unit_it->level()     << "\n"
+			<< _("Cost: ")    << unit_it->cost()      << "\n";
+		tooltips::clear_tooltips();
+		tooltips::add_tooltip(rect, str.str());
+	}
+	else {
+		set_mouse_overlay(disp);
 	}
 }
 

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -33,7 +33,7 @@
 class map_generator;
 
 namespace tooltips {
-struct manager;
+class manager;
 }
 
 namespace font {

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -98,7 +98,7 @@ rect editor_display::get_clip_rect() const
 	return map_outside_area();
 }
 
-void editor_display::draw_sidebar()
+void editor_display::refresh_reports()
 {
 	config element;
 	config::attribute_value &text = element.add_child("element")["text"];

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -50,7 +50,7 @@ protected:
 	virtual overlay_map& get_overlays() override;
 
 	rect get_clip_rect() const override;
-	void draw_sidebar() override;
+	void refresh_reports() override;
 
 	std::set<map_location> brush_locations_;
 

--- a/src/editor/palette/common_palette.hpp
+++ b/src/editor/palette/common_palette.hpp
@@ -66,7 +66,6 @@ public:
 
 	//drawing
 	virtual void adjust_size(const SDL_Rect& target) = 0;
-	virtual void draw() = 0;
 
 	//group
 	virtual void set_group(std::size_t index) = 0;

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -246,8 +246,12 @@ bool editor_palette<Item>::is_selected_bg_item(const std::string& id)
 }
 
 template<class Item>
-void editor_palette<Item>::draw_contents()
+void editor_palette<Item>::layout()
 {
+	if (!dirty()) {
+		return;
+	}
+
 	toolkit_.set_mouseover_overlay(gui_);
 
 	std::shared_ptr<gui::button> palette_menu_button = gui_.find_menu_button("menu-editor-terrain");
@@ -324,6 +328,16 @@ void editor_palette<Item>::draw_contents()
 
 		tile.set_dirty(true);
 		tile.hide(false);
+	}
+
+	set_dirty(false);
+}
+
+template<class Item>
+void editor_palette<Item>::draw_contents()
+{
+	for(std::size_t i = 0; i < buttons_.size(); ++i) {
+		gui::tristate_button& tile = buttons_[i];
 		tile.draw();
 	}
 }

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -66,9 +66,9 @@ public:
 
 	const std::vector<item_group>& get_groups() const override { return groups_; }
 
-	virtual void draw() override {
-		widget::draw();
-	}
+	/** Called by draw_manager to validate layout before drawing. */
+	virtual void layout() override;
+	/** Called by widget::draw() */
 	virtual void draw_contents() override;
 
 	void next_group() override {

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -336,8 +336,12 @@ bool location_palette::is_selected_item(const std::string& id)
 	return selected_item_ == id;
 }
 
-void location_palette::draw_contents()
+void location_palette::layout()
 {
+	if (!dirty()) {
+		return;
+	}
+
 	toolkit_.set_mouseover_overlay(disp_);
 
 	// The hotkey system will automatically enable and disable the buttons when it runs, but it doesn't
@@ -381,6 +385,15 @@ void location_palette::draw_contents()
 		tile.set_selected(is_selected_item(item_id));
 		tile.set_dirty(true);
 		tile.hide(false);
+	}
+
+	set_dirty(false);
+}
+
+void location_palette::draw_contents()
+{
+	for(std::size_t i = 0; i < num_visible_items(); ++i) {
+		location_palette_item& tile = buttons_[i];
 		tile.draw();
 	}
 }

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -55,9 +55,9 @@ public:
 	virtual void prev_group() override {}
 	virtual const std::vector<item_group>& get_groups() const override { static const std::vector<item_group> empty; return empty; }
 
-	virtual void draw() override {
-		widget::draw();
-	}
+	/** Called by draw_manager to validate layout before drawing. */
+	virtual void layout() override;
+	/** Called by widget::draw() */
 	virtual void draw_contents() override;
 
 	/**

--- a/src/editor/palette/palette_manager.cpp
+++ b/src/editor/palette/palette_manager.cpp
@@ -62,11 +62,7 @@ void palette_manager::scroll_down()
 	bool scrolled = active_palette().scroll_down();
 
 	if (scrolled) {
-
-//		const SDL_Rect& rect = gui_.palette_area();
-//		bg_restore(rect);
 		set_dirty();
-		draw();
 	}
 }
 
@@ -83,11 +79,9 @@ bool palette_manager::can_scroll_down()
 void palette_manager::scroll_up()
 {
 	bool scrolled_up = active_palette().scroll_up();
+
 	if(scrolled_up) {
-//		const SDL_Rect rect = gui_.palette_area();
-//		bg_restore(rect);
 		set_dirty();
-		draw();
 	}
 }
 
@@ -96,6 +90,7 @@ void palette_manager::scroll_top()
 	restore_palette_bg(true);
 }
 
+// TODO: draw_manager - can probably remove this...
 void palette_manager::restore_palette_bg(bool scroll_top)
 {
 	const SDL_Rect rect = gui_.palette_area();
@@ -121,15 +116,11 @@ void palette_manager::scroll_bottom()
 	}
 }
 
-void palette_manager::draw_contents()
+void palette_manager::layout()
 {
-	//if (!dirty() && !force) {
-	//	return;
-	//}
-
-	const SDL_Rect &loc = location();
-
-	tooltips::clear_tooltips(loc);
+	if (!dirty()) {
+		return;
+	}
 
 	std::shared_ptr<gui::button> upscroll_button = gui_.find_action_button("upscroll-button-editor");
 	if (upscroll_button)
@@ -141,12 +132,15 @@ void palette_manager::draw_contents()
 	if (palette_menu_button)
 		palette_menu_button->hide(false);
 
-//	bg_restore(loc);
 	active_palette().set_dirty(true);
 	active_palette().hide(false);
-	active_palette().draw();
 
-//	set_dirty(false);
+	set_dirty(false);
+}
+
+void palette_manager::draw_contents()
+{
+	active_palette().draw();
 }
 
 sdl_handler_vector palette_manager::handler_members()
@@ -166,10 +160,14 @@ void palette_manager::handle_event(const SDL_Event& event) {
 	if (event.type == SDL_MOUSEMOTION) {
 		// If the mouse is inside the palette, give it focus.
 		if (location().contains(event.button.x, event.button.y)) {
-			if (!focus(&event)) set_focus(true);
+			if (!focus(&event)) {
+				set_focus(true);
+			}
 		}
 		// If the mouse is outside, remove focus.
-		else if (focus(&event)) set_focus(false);
+		else if (focus(&event)) {
+			set_focus(false);
+		}
 	}
 	if (!focus(&event)) {
 		return;

--- a/src/editor/palette/palette_manager.hpp
+++ b/src/editor/palette/palette_manager.hpp
@@ -58,8 +58,11 @@ public:
 
 	void adjust_size();
 
-	sdl_handler_vector handler_members();
-	virtual void handle_event(const SDL_Event& event);
+	sdl_handler_vector handler_members() override;
+	virtual void handle_event(const SDL_Event& event) override;
+
+	/** Called by draw_manager to validate layout before drawing. */
+	virtual void layout() override;
 
 	/**
 	 * Draw the palette.
@@ -68,7 +71,7 @@ public:
 	 * even though it is not invalidated.
 	 */
 	//void draw(bool force=false);
-	void draw_contents(); // { draw(false); };
+	void draw_contents() override; // { draw(false); };
 
 public:
 

--- a/src/editor/palette/tristate_button.hpp
+++ b/src/editor/palette/tristate_button.hpp
@@ -66,10 +66,6 @@ public:
 		item_id_ = id;
 	}
 
-	void draw() override {
-		widget::draw();
-	}
-
 protected:
 
 	virtual void handle_event(const SDL_Event& event) override;

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -80,9 +80,6 @@ public:
 	virtual void process_event() {}
 	virtual void draw() {}
 
-	virtual void volatile_draw() {}
-	virtual void volatile_undraw() {}
-
 	virtual bool requires_event_focus(const SDL_Event * = nullptr) const { return false; }
 
 	virtual void process_help_string(int /*mousex*/, int /*mousey*/) {}
@@ -172,9 +169,6 @@ void raise_process_event();
 void raise_resize_event();
 void raise_draw_event();
 void raise_draw_all_event();
-void raise_volatile_draw_event();
-void raise_volatile_draw_all_event();
-void raise_volatile_undraw_event();
 void raise_help_string_event(int mousex, int mousey);
 
 

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -127,7 +127,7 @@ bool floating_label::create_texture()
 			text.set_text(text_, use_markup_);
 		}
 
-		surface foreground = text.render();
+		surface foreground = text.render_surface();
 
 		// Pixel scaling is necessary as we are manipulating the raw surface
 		const int ps = CVideo::get_singleton().get_pixel_scale();

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -16,6 +16,8 @@
 #pragma once
 
 #include "color.hpp"
+#include "sdl/point.hpp"
+#include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
 #include <string>
@@ -69,9 +71,14 @@ public:
 	void set_scroll_mode(LABEL_SCROLL_MODE scroll) {scroll_ = scroll;}
 	void use_markup(bool b) {use_markup_ = b;}
 
-	void move(double xmove, double ymove);
-	void draw(int time);
+	/** Mark the last drawn location as requiring redraw. */
 	void undraw();
+	/** Change the floating label's position. */
+	void move(double xmove, double ymove);
+	/** Finalize draw position and alpha, and queue redrawing if changed. */
+	void update(int time);
+	/** Draw the label to the screen. */
+	void draw();
 
 	/**
 	 * Ensure a texture for this floating label exists, creating one if needed.
@@ -96,10 +103,11 @@ private:
 
 	int get_time_alive(int current_time) const { return current_time - time_start_; }
 	int xpos(std::size_t width) const;
-	SDL_Point get_loc(int time);
+	point get_pos(int time);
 	uint8_t get_alpha(int time);
-	texture tex_, buf_;
-	SDL_Rect buf_pos_;
+	texture tex_;
+	rect screen_loc_;
+	uint8_t alpha_;
 	int fadeout_;
 	int time_start_;
 	std::string text_;
@@ -141,6 +149,6 @@ void show_floating_label(int handle, bool show);
 
 SDL_Rect get_floating_label_rect(int handle);
 void draw_floating_labels();
-void undraw_floating_labels();
+void update_floating_labels();
 
 } // end namespace font

--- a/src/floating_textbox.cpp
+++ b/src/floating_textbox.cpp
@@ -88,7 +88,6 @@ namespace gui{
 		}
 
 		if(box_ != nullptr) {
-			box_->set_volatile(true);
 			const SDL_Rect rect {
 				  area.x + label_area.w + border_size * 2
 				, ypos
@@ -100,7 +99,6 @@ namespace gui{
 		}
 
 		if(check_ != nullptr) {
-			check_->set_volatile(true);
 			check_->set_location(box_->location().x,box_->location().y + box_->location().h + border_size);
 		}
 	}

--- a/src/font/sdl_ttf_compat.cpp
+++ b/src/font/sdl_ttf_compat.cpp
@@ -57,7 +57,7 @@ texture pango_render_text(const std::string& text, int size, const color_t& colo
 		 .set_maximum_width(max_width)
 		 .set_ellipse_mode(max_width > 0 ? PANGO_ELLIPSIZE_END : PANGO_ELLIPSIZE_NONE);
 
-	return ptext.render_texture();
+	return ptext.render_and_get_texture();
 }
 
 std::pair<int, int> pango_line_size(const std::string& line, int font_size, font::pango_text::FONT_STYLE font_style)
@@ -161,7 +161,7 @@ SDL_Rect pango_draw_text(CVideo* video, const SDL_Rect& area, int size, const co
 		ellipsized = true;
 	}
 
-	texture t = ptext.render_texture();
+	auto t = ptext.render_and_get_texture();
 
 	SDL_Rect res = {x, y, t.w(), t.h()};
 

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -76,11 +76,13 @@ namespace font {
 class pango_text
 {
 public:
-
 	pango_text();
 
-	pango_text(const pango_text &) = delete;
-	pango_text & operator = (const pango_text &) = delete;
+	pango_text(const pango_text&) = delete;
+	pango_text& operator=(const pango_text&) = delete;
+
+	/** Returns the cached texture, or creates a new one otherwise. */
+	texture render_and_get_texture();
 
 	/**
 	 * Returns the rendered text as a texture.
@@ -95,7 +97,6 @@ public:
 	 * This function is otherwise identical to render().
 	 */
 	texture render_texture(const SDL_Rect& viewport);
-	texture render_texture();
 
 	/**
 	 * Returns the rendered text.
@@ -105,7 +106,7 @@ public:
 	 * width and height will be at least viewport.w and viewport.h (although
 	 * they may be larger).
 	 */
-	surface& render(const SDL_Rect& viewport);
+	surface render_surface(const SDL_Rect& viewport);
 
 	/**
 	 * Equivalent to render(viewport), where the viewport's top-left is at
@@ -115,13 +116,7 @@ public:
 	 * of x and y.  If the x or y co-ordinates are non-zero, then x columns and
 	 * y rows of blank space are included in the amount of memory allocated.
 	 */
-	surface& render();
-
-	/** Returns the width needed for the text. */
-	int get_width();
-
-	/** Returns the height needed for the text. */
-	int get_height();
+	surface render_surface();
 
 	/** Returns the size of the text, in drawing coordinates. */
 	point get_size();
@@ -286,10 +281,6 @@ private:
 	std::unique_ptr<PangoLayout, std::function<void(void*)>> layout_;
 	mutable PangoRectangle rect_;
 
-	/** The SDL surface to render upon used as a cache. */
-	mutable surface surface_;
-
-
 	/** The text to draw (stored as UTF-8). */
 	std::string text_;
 
@@ -389,18 +380,12 @@ private:
 	/** Calculates surface size. */
 	PangoRectangle calculate_size(PangoLayout& layout) const;
 
-	/** The dirty state of the surface. */
-	mutable bool surface_dirty_;
+	/** Allow specialization of std::hash for pango_text. */
+	friend struct std::hash<pango_text>;
 
-	/** The area that's cached in surface_, which is the area that was rendered when surface_dirty_ was last set to false. */
-	SDL_Rect rendered_viewport_;
-
-	/**
-	 * Renders the text.
-	 *
-	 * It will do a recalculation first so no need to call both.
-	 */
-	void rerender(const SDL_Rect& viewport);
+	/** Renders the text to a surface. */
+	surface create_surface();
+	surface create_surface(const SDL_Rect& viewport);
 
 	void render(PangoLayout& layout, const SDL_Rect& viewport, const unsigned stride);
 
@@ -476,3 +461,14 @@ pango_text& get_text_renderer();
 int get_max_height(unsigned size, font::family_class fclass = font::FONT_SANS_SERIF, pango_text::FONT_STYLE style = pango_text::STYLE_NORMAL);
 
 } // namespace font
+
+// Specialize std::hash for pango_text
+namespace std
+{
+template<>
+struct hash<font::pango_text>
+{
+	std::size_t operator()(const font::pango_text&) const;
+};
+
+} // namespace std

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -18,6 +18,7 @@
 #include "font/font_options.hpp"
 #include "color.hpp"
 #include "sdl/surface.hpp"
+#include "sdl/texture.hpp"
 #include "serialization/string_utils.hpp"
 
 #include <pango/pango.h>

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -68,7 +68,7 @@ game_display::game_display(game_board& board,
 		reports& reports_object,
 		const std::string& theme_id,
 		const config& level)
-	: display(&board, wb, reports_object, theme_id, level, false)
+	: display(&board, wb, reports_object, theme_id, level)
 	, overlay_map_()
 	, attack_indicator_src_()
 	, attack_indicator_dst_()
@@ -247,11 +247,6 @@ void game_display::draw_invalidated()
 	}
 }
 
-void game_display::post_commit()
-{
-	halo_man_->render();
-}
-
 void game_display::draw_hex(const map_location& loc)
 {
 	const bool on_map = get_map().on_board(loc);
@@ -369,7 +364,7 @@ bool game_display::has_time_area() const
 	return resources::tod_manager->has_time_area();
 }
 
-void game_display::draw_sidebar()
+void game_display::refresh_reports()
 {
 	if ( !team_valid() )
 		return;

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -148,7 +148,8 @@ protected:
 
 	virtual void draw_invalidated() override;
 
-	virtual void post_commit() override;
+	// TODO: draw_manager - maybe delete
+	//virtual void post_commit() override;
 
 	virtual void draw_hex(const map_location& loc) override;
 
@@ -219,7 +220,7 @@ private:
 	game_display(const game_display&);
 	void operator=(const game_display&);
 
-	virtual void draw_sidebar() override;
+	virtual void refresh_reports() override;
 
 	overlay_map overlay_map_;
 

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -457,27 +457,16 @@ void text_shape::draw(wfl::map_formula_callable& variables)
 	const int h = h_(local_variables);
 	rect dst_rect{x, y, w, h};
 
-	// Get the visible portion of text.
-	rect visible = dst_rect.intersect(draw::get_clip());
-
-	// Get the source region of text for clipping.
-	rect clip_in = visible;
-	clip_in.x -= x;
-	clip_in.y -= y;
-
-	// Source region for high-dpi text needs to have pixel scale applied.
-	clip_in *= CVideo::get_singleton().get_pixel_scale();
-
-	// Render the currently visible portion of text
-	// TODO: highdpi - it would be better to render this all, but some things currently have far too much text. Namely the credits screen.
-	texture tex = text_renderer.render_texture(clip_in);
+	texture tex = text_renderer.render_and_get_texture();
 	if(!tex) {
 		DBG_GUI_D << "Text: Rendering '" << text << "' resulted in an empty canvas, leave.\n";
 		return;
 	}
 
-	// TODO: highdpi - this /should/ be fine. But, in some cases (Credits) the maximum viewport height is exceeded. This is bad, but at least it shows something and doesn't crash.
-	draw::blit(tex, visible);
+	dst_rect.w = std::min(dst_rect.w, tex.w());
+	dst_rect.h = std::min(dst_rect.h, tex.h());
+
+	draw::blit(tex, dst_rect);
 }
 
 /***** ***** ***** ***** ***** CANVAS ***** ***** ***** ***** *****/

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -139,12 +139,6 @@ public:
 		variables_.add(key, std::move(value));
 	}
 
-	// TODO: highdpi - find everywhere that is calling this, and determine why.
-	void set_is_dirty(bool)
-	{
-		update_size_variables();
-	}
-
 private:
 	/** Vector with the shapes to draw. */
 	std::vector<std::unique_ptr<shape>> shapes_;

--- a/src/gui/core/event/distributor.hpp
+++ b/src/gui/core/event/distributor.hpp
@@ -249,17 +249,6 @@ public:
 	widget* keyboard_focus() const;
 
 private:
-	class layer : public video2::draw_layering
-	{
-	public:
-		virtual void handle_event(const SDL_Event& ) {}
-		virtual void handle_window_event(const SDL_Event& ) {}
-		layer() : video2::draw_layering(false) { }
-	};
-
-	// make sure the appropriate things happens when we close.
-	layer layer_;
-
 	/** The widget that holds the keyboard focus_. */
 	widget* keyboard_focus_;
 

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -17,6 +17,7 @@
 
 #include "gui/core/event/handler.hpp"
 
+#include "draw_manager.hpp"
 #include "gui/core/event/dispatcher.hpp"
 #include "gui/core/timer.hpp"
 #include "gui/core/log.hpp"
@@ -563,13 +564,8 @@ void sdl_event_handler::disconnect(dispatcher* disp)
 		keyboard_focus_ = nullptr;
 	}
 
-	/***** Set proper state for the other dispatchers. *****/
-	for(auto d : dispatchers_)
-	{
-		dynamic_cast<widget&>(*d).set_is_dirty(true);
-	}
-
-	activate();
+	// TODO: draw_manager - Why TF was this "activate"ing on "disconnect"? Seriously WTF?
+	//activate();
 
 	/***** Validate post conditions. *****/
 	assert(std::find(dispatchers_.begin(), dispatchers_.end(), disp)
@@ -592,6 +588,7 @@ void sdl_event_handler::activate()
 
 void sdl_event_handler::draw()
 {
+	/*
 	for(auto dispatcher : dispatchers_)
 	{
 		dispatcher->fire(DRAW, dynamic_cast<widget&>(*dispatcher));
@@ -600,14 +597,16 @@ void sdl_event_handler::draw()
 	if(!dispatchers_.empty()) {
 		CVideo::get_singleton().render_screen();
 	}
+	*/
+
+	draw_manager::sparkle();
 }
 
 void sdl_event_handler::draw_everything()
 {
-	for(auto dispatcher : dispatchers_) {
-		dynamic_cast<widget&>(*dispatcher).set_is_dirty(true);
-	}
-
+	// TODO: draw_manager - look into usage of this
+	//std::cerr << "sdl_event_handler::draw_everything" << std::endl;
+	draw_manager::invalidate_region(CVideo::get_singleton().draw_area());
 	draw();
 }
 

--- a/src/gui/core/top_level_drawable.cpp
+++ b/src/gui/core/top_level_drawable.cpp
@@ -1,0 +1,32 @@
+/*
+	Copyright (C) 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#include "gui/core/top_level_drawable.hpp"
+
+#include "draw_manager.hpp"
+
+namespace gui2
+{
+
+top_level_drawable::top_level_drawable()
+{
+	draw_manager::register_drawable(this);
+}
+
+top_level_drawable::~top_level_drawable()
+{
+	draw_manager::deregister_drawable(this);
+}
+
+} // namespace gui2

--- a/src/gui/core/top_level_drawable.hpp
+++ b/src/gui/core/top_level_drawable.hpp
@@ -1,0 +1,90 @@
+/*
+	Copyright (C) 2007 - 2022
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "sdl/rect.hpp"
+
+namespace gui2
+{
+
+/**
+ * A top-level drawable item (TLD), such as a window.
+ *
+ * For now, TLDs keep track of where they are on the screen on their own.
+ * They must draw themselves when requested via expose().
+ *
+ * The TLD interface will be called in the following order:
+ *   - layout()
+ *   - render()
+ *   - screen_location()
+ *   - zero or more expose() calls
+ */
+class top_level_drawable
+{
+protected:
+	top_level_drawable();
+	virtual ~top_level_drawable();
+public:
+	/**
+	 * Size and position the drawable and its children.
+	 *
+	 * If this results in a change, it should invalidate both the previous
+	 * and new drawable regions via draw_manager::invalidate_region().
+	 * If the drawable was not previously laid out, it should invalidate
+	 * the newly determined region.
+	 *
+	 * TLDs must not perform any actual drawing during layout.
+	 *
+	 * Implementation of this interface is mandatory.
+	 */
+	virtual void layout() = 0;
+
+	/**
+	 * Perform any internal rendering necessary to prepare the drawable.
+	 *
+	 * For example if the drawable has an offscreen buffer it manages,
+	 * it should ensure this buffer is up to date.
+	 *
+	 * TLDs should also invalidate any regions visibly changed by this call.
+	 *
+	 * This interface is optional.
+	 */
+	virtual void render() {}
+
+	/**
+	 * Draw the portion of the drawable intersecting @p region to the screen.
+	 *
+	 * TLDs must not invalidate regions during expose. Only drawing must
+	 * occur, with no modification of layout.
+	 *
+	 * Implementation of this interface is mandatory.
+	 *
+	 * @param region    The region to expose, in absolute draw-space
+	 *                  coordinates.
+	 * @returns         True if anything was drawn, false otherwise.
+	 */
+	virtual bool expose(const SDL_Rect& region) = 0;
+
+	/**
+	 * The location of the TLD on the screen, in drawing coordinates.
+	 *
+	 * This will be used to determine the region (if any) to expose.
+	 *
+	 * Implementation of this interface is mandatory.
+	 */
+	virtual rect screen_location() = 0;
+};
+
+} // namespace gui2

--- a/src/gui/dialogs/addon/connect.cpp
+++ b/src/gui/dialogs/addon/connect.cpp
@@ -35,7 +35,6 @@ addon_connect::addon_connect(std::string& host_name,
 							   const bool allow_remove)
 	: allow_remove_(allow_remove)
 {
-	set_restore(true);
 	register_text("host_name", false, host_name, true);
 }
 

--- a/src/gui/dialogs/addon/uninstall_list.cpp
+++ b/src/gui/dialogs/addon/uninstall_list.cpp
@@ -31,8 +31,6 @@ REGISTER_DIALOG(addon_uninstall_list)
 
 void addon_uninstall_list::pre_show(window& window)
 {
-	set_restore(true);
-
 	listbox& list = find_widget<listbox>(&window, "addons_list", false);
 	window.keyboard_capture(&list);
 

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -60,7 +60,6 @@ campaign_difficulty::campaign_difficulty(const config& campaign)
 	, campaign_id_(campaign["id"])
 	, selected_difficulty_("CANCEL")
 {
-	set_restore(true);
 }
 
 void campaign_difficulty::pre_show(window& window)

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -67,7 +67,6 @@ public:
 		, current_sorting_(RANK)
 		, currently_sorted_asc_(true)
 	{
-		set_restore(true);
 	}
 
 	/***** ***** ***** setters / getters for members ***** ****** *****/

--- a/src/gui/dialogs/debug_clock.cpp
+++ b/src/gui/dialogs/debug_clock.cpp
@@ -109,7 +109,7 @@ void debug_clock::update_time(const bool force)
 			canvas.set_variable("minute", wfl::variant(minute_stamp));
 			canvas.set_variable("second", wfl::variant(second_stamp));
 		}
-		clock_->set_is_dirty(true);
+		clock_->queue_redraw();
 	}
 
 	const std::map<std::string, std::string> tags;

--- a/src/gui/dialogs/debug_clock.hpp
+++ b/src/gui/dialogs/debug_clock.hpp
@@ -19,6 +19,8 @@
 
 #include "gui/core/event/dispatcher.hpp"
 
+class CVideo;
+
 namespace gui2
 {
 

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -91,7 +91,6 @@ drop_down_menu::drop_down_menu(styled_widget* parent, const std::vector<config>&
 	, keep_open_(keep_open)
 	, mouse_down_happened_(false)
 {
-	set_restore(true);
 }
 
 drop_down_menu::drop_down_menu(SDL_Rect button_pos, const std::vector<config>& items, int selected_item, bool use_markup, bool keep_open)
@@ -103,7 +102,6 @@ drop_down_menu::drop_down_menu(SDL_Rect button_pos, const std::vector<config>& i
 	, keep_open_(keep_open)
 	, mouse_down_happened_(false)
 {
-	set_restore(true);
 }
 
 void drop_down_menu::mouse_up_callback(bool&, bool&, const point& coordinate)

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -238,6 +238,7 @@ void custom_tod::update_tod_display()
 	// theme UI sidebar after redrawing tiles and before we have a
 	// chance to redraw the rest of this window.
 	get_window()->undraw();
+	// TODO: draw_manager - do this properly, probably by removing this undraw
 
 	// NOTE: We only really want to re-render the gamemap tiles here.
 	// Redrawing everything is a significantly more expensive task.
@@ -253,11 +254,8 @@ void custom_tod::update_tod_display()
 	// invalidate all tiles so they are redrawn with the new ToD tint next
 	disp->invalidate_all();
 
-	// redraw tiles
-	disp->draw(false);
-
 	// NOTE: revert to invalidate_layout if necessary to display the ToD mask image.
-	get_window()->set_is_dirty(true);
+	get_window()->queue_redraw();
 }
 
 void custom_tod::update_lawful_bonus()

--- a/src/gui/dialogs/end_credits.cpp
+++ b/src/gui/dialogs/end_credits.cpp
@@ -48,11 +48,8 @@ end_credits::end_credits(const std::string& campaign)
 
 void end_credits::pre_show(window& window)
 {
-	window.set_callback_next_draw([this]()
-	{
-		// Delay a little before beginning the scrolling
-		last_scroll_ = SDL_GetTicks() + 3000;
-	});
+	// Delay a little before beginning the scrolling
+	last_scroll_ = SDL_GetTicks() + 3000;
 
 	connect_signal_on_draw(window, std::bind(&end_credits::timer_callback, this));
 

--- a/src/gui/dialogs/file_dialog.cpp
+++ b/src/gui/dialogs/file_dialog.cpp
@@ -117,7 +117,6 @@ file_dialog::file_dialog()
 	, current_bookmark_()
 	, user_bookmarks_begin_()
 {
-	set_restore(true);
 }
 
 std::string file_dialog::path() const

--- a/src/gui/dialogs/game_delete.cpp
+++ b/src/gui/dialogs/game_delete.cpp
@@ -45,8 +45,6 @@ static void set_dont_ask_again(const bool ask_again)
 
 game_delete::game_delete()
 {
-	set_restore(true);
-
 	register_bool(
 			"dont_ask_again", true, &get_dont_ask_again, &set_dont_ask_again);
 }

--- a/src/gui/dialogs/game_save.cpp
+++ b/src/gui/dialogs/game_save.cpp
@@ -30,8 +30,6 @@ REGISTER_DIALOG(game_save)
 
 game_save::game_save(std::string& filename, const std::string& title)
 {
-	set_restore(true);
-
 	register_text("txtFilename", false, filename, true);
 	register_label("lblTitle", true, title);
 }
@@ -42,8 +40,6 @@ game_save_message::game_save_message(std::string& filename,
 									   const std::string& title,
 									   const std::string& message)
 {
-	set_restore(true);
-
 	register_label("lblTitle", true, title);
 	register_text("txtFilename", false, filename, true);
 	register_label("lblMessage", true, message);

--- a/src/gui/dialogs/hotkey_bind.cpp
+++ b/src/gui/dialogs/hotkey_bind.cpp
@@ -30,7 +30,6 @@ hotkey_bind::hotkey_bind(const std::string& hotkey_id)
 	: hotkey_id_(hotkey_id)
 	, new_binding_()
 {
-	set_restore(true);
 }
 
 void hotkey_bind::pre_show(window& window)

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -148,6 +148,13 @@ void loading_screen::spin()
 	}
 }
 
+void loading_screen::raise()
+{
+	if (singleton_) {
+		draw_manager::raise_drawable(singleton_);
+	}
+}
+
 // This will be run inside the window::show() loop.
 void loading_screen::process(events::pump_info&)
 {

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "gui/core/top_level_drawable.hpp"
 #include "gui/dialogs/modal_dialog.hpp"
 
 #include "events.hpp"
@@ -72,7 +73,7 @@ class window;
 
 namespace dialogs
 {
-class loading_screen : public modal_dialog, public events::pump_monitor
+class loading_screen : public modal_dialog, public events::pump_monitor, public gui2::top_level_drawable
 {
 public:
 	loading_screen(std::function<void()> f);
@@ -118,8 +119,18 @@ private:
 	/** Inherited from events::pump_monitor. */
 	virtual void process(events::pump_info&) override;
 
-	/** Callback to handle drawing the progress animation. */
-	void draw_callback();
+	/** Called by draw_manager to assign concrete layout. */
+	virtual void layout() override;
+
+	/**
+	 * Called by draw_manager when it believes a redraw is necessary.
+	 *
+	 * Currently this is every frame, as pre_show() registers as an animator.
+	 */
+	virtual bool expose(const SDL_Rect& region) override;
+
+	/** The current draw location of the window, on the screen. */
+	virtual rect screen_location() override;
 
 	static loading_screen* singleton_;
 

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -109,6 +109,14 @@ public:
 	 */
 	static void spin();
 
+	/**
+	 * Raise the loading screen to the top of the draw stack.
+	 *
+	 * This can be called if another TLD has been created during loading,
+	 * such as happens with the game display.
+	 */
+	static void raise();
+
 private:
 	virtual const std::string& window_id() const override;
 

--- a/src/gui/dialogs/log_settings.cpp
+++ b/src/gui/dialogs/log_settings.cpp
@@ -57,8 +57,6 @@ log_settings::log_settings()
 
 void log_settings::pre_show(window& window)
 {
-	set_restore(true); //why is this done manually?
-
 	listbox& logger_box = find_widget<listbox>(&window, "logger_listbox", false);
 
 	for(unsigned int i = 0; i < domain_list_.size(); i++){

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -85,12 +85,8 @@ public:
 	void update_contents(const std::string & str)
 	{
 		assert(msg_label);
-
 		msg_label->set_label(str);
-		window_->set_callback_next_draw([this]()
-		{
-			msg_label->scroll_vertical_scrollbar(scrollbar_base::END);
-		});
+		msg_label->scroll_vertical_scrollbar(scrollbar_base::END);
 	}
 
 	void pg_up()
@@ -516,7 +512,7 @@ void lua_interpreter::controller::input_keypress_callback(bool& handled,
 
 		// Commands such as `wesnoth.interface.zoom` might cause the display to redraw and leave the window half-drawn.
 		// This preempts that.
-		window.set_is_dirty(true);
+		window.queue_redraw();
 
 		LOG_LUA << "finished executing\n";
 	} else if(key == SDLK_TAB) {	// handle tab completion

--- a/src/gui/dialogs/message.cpp
+++ b/src/gui/dialogs/message.cpp
@@ -67,8 +67,6 @@ struct message_implementation
 
 void message::pre_show(window& window)
 {
-	set_restore(true);
-
 	// ***** Validate the required buttons ***** ***** ***** *****
 	message_implementation::init_button(window, buttons_[left_1], "left_side");
 	message_implementation::init_button(window, buttons_[cancel], "cancel");

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -24,6 +24,10 @@
 #include "scripting/plugins/manager.hpp"
 #include "video.hpp"
 
+static lg::log_domain log_display("display");
+#define DBG_DP LOG_STREAM(debug, log_display)
+#define WRN_DP LOG_STREAM(warn, log_display)
+
 namespace gui2::dialogs
 {
 modal_dialog::modal_dialog()
@@ -32,7 +36,6 @@ modal_dialog::modal_dialog()
 	, always_save_fields_(false)
 	, fields_()
 	, focus_()
-	, restore_(false)
 	, allow_plugin_skip_(true)
 	, show_even_without_video_(false)
 {
@@ -57,6 +60,7 @@ namespace {
 bool modal_dialog::show(const unsigned auto_close_time)
 {
 	if(CVideo::get_singleton().faked() && !show_even_without_video_) {
+		DBG_DP << "modal_dialog::show denied" << std::endl;
 		if(!allow_plugin_skip_) {
 			return false;
 		}
@@ -87,7 +91,7 @@ bool modal_dialog::show(const unsigned auto_close_time)
 	{ // Scope the window stack
 		cursor::setter cur{cursor::NORMAL};
 		window_stack_handler push_window_stack(window_);
-		retval_ = window_->show(restore_, auto_close_time);
+		retval_ = window_->show(auto_close_time);
 	}
 
 	/*

--- a/src/gui/dialogs/modal_dialog.hpp
+++ b/src/gui/dialogs/modal_dialog.hpp
@@ -190,11 +190,6 @@ public:
 		always_save_fields_ = always_save_fields;
 	}
 
-	void set_restore(const bool restore)
-	{
-		restore_ = restore;
-	}
-
 	void set_allow_plugin_skip(const bool allow_plugin_skip)
 	{
 		allow_plugin_skip_ = allow_plugin_skip;
@@ -379,15 +374,6 @@ private:
 	 * Contains the widget that should get the focus when the window is shown.
 	 */
 	std::string focus_;
-
-	/**
-	 * Restore the screen after showing?
-	 *
-	 * Most windows should restore the display after showing so this value
-	 * defaults to true. Toplevel windows (like the titlescreen don't want this
-	 * behavior so they can change it in pre_show().
-	 */
-	bool restore_;
 
 	/**
 	 * Allow plugins to skip through the dialog?

--- a/src/gui/dialogs/multiplayer/mp_connect.cpp
+++ b/src/gui/dialogs/multiplayer/mp_connect.cpp
@@ -71,7 +71,6 @@ mp_connect::mp_connect()
 	, builtin_servers_(preferences::builtin_servers_list())
 	, user_servers_(preferences::user_servers_list())
 {
-	set_restore(true);
 }
 
 std::array<mp_connect::server_list*, 2> mp_connect::server_lists()

--- a/src/gui/dialogs/multiplayer/mp_host_game_prompt.cpp
+++ b/src/gui/dialogs/multiplayer/mp_host_game_prompt.cpp
@@ -42,8 +42,6 @@ static void set_do_not_show_again(const bool do_not_show_again)
 
 mp_host_game_prompt::mp_host_game_prompt()
 {
-	set_restore(true);
-
 	register_bool("do_not_show_again",
 				  true,
 				  &get_do_not_show_again,

--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -68,7 +68,6 @@ network_transmission::network_transmission(
 	, subtitle_(subtitle)
 {
 	register_label("title", true, title, false);
-	set_restore(true);
 }
 
 void network_transmission::pre_show(window& window)

--- a/src/gui/dialogs/outro.cpp
+++ b/src/gui/dialogs/outro.cpp
@@ -138,9 +138,8 @@ void outro::draw_callback()
 	}
 
 	window_canvas.set_variable("fade_step", wfl::variant(fade_step_));
-	window_canvas.set_is_dirty(true);
-
-	get_window()->set_is_dirty(true);
+	window_canvas.update_size_variables();
+	get_window()->queue_redraw();
 
 	if(fading_in_) {
 		fade_step_++;

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -211,7 +211,7 @@ void preferences_dialog::add_friend_list_entry(const bool is_friend, text_box& t
 {
 	std::string username = textbox.text();
 	if(username.empty()) {
-		gui2::show_transient_message("", _("No username specified"), "", false, false, true);
+		gui2::show_transient_message("", _("No username specified"));
 		return;
 	}
 
@@ -226,7 +226,7 @@ void preferences_dialog::add_friend_list_entry(const bool is_friend, text_box& t
 	auto [entry, added_new] = add_acquaintance(username, (is_friend ? "friend": "ignore"), reason);
 
 	if(!entry) {
-		gui2::show_transient_message(_("Error"), _("Invalid username"), "", false, false, true);
+		gui2::show_transient_message(_("Error"), _("Invalid username"));
 		return;
 	}
 
@@ -268,7 +268,7 @@ void preferences_dialog::remove_friend_list_entry(listbox& friends_list, text_bo
 	const std::string to_remove = !textbox.text().empty() ? textbox.text() : who->second.get_nick();
 
 	if(to_remove.empty()) {
-		gui2::show_transient_message("", _("No username specified"), "", false, false, true);
+		gui2::show_transient_message("", _("No username specified"));
 		return;
 	}
 
@@ -887,8 +887,7 @@ void preferences_dialog::add_hotkey_callback(listbox& hotkeys)
 
 void preferences_dialog::default_hotkey_callback()
 {
-	gui2::show_transient_message(_("Hotkeys Reset"), _("All hotkeys have been reset to their default values."),
-			std::string(), false, false, true);
+	gui2::show_transient_message(_("Hotkeys Reset"), _("All hotkeys have been reset to their default values."));
 
 	clear_hotkeys();
 

--- a/src/gui/dialogs/sp_options_configure.cpp
+++ b/src/gui/dialogs/sp_options_configure.cpp
@@ -28,7 +28,6 @@ sp_options_configure::sp_options_configure(ng::create_engine& create_engine, ng:
 	, config_engine_(config_engine)
 	, options_manager_()
 {
-	set_restore(true);
 }
 
 void sp_options_configure::pre_show(window& window)

--- a/src/gui/dialogs/statistics_dialog.cpp
+++ b/src/gui/dialogs/statistics_dialog.cpp
@@ -60,7 +60,6 @@ statistics_dialog::statistics_dialog(const team& current_team)
 	, selection_index_(scenarios_.size()) // The extra All Scenarios menu entry makes size() a valid initial index.
 	, main_stat_table_()
 {
-	set_restore(true);
 }
 
 void statistics_dialog::pre_show(window& window)

--- a/src/gui/dialogs/story_viewer.cpp
+++ b/src/gui/dialogs/story_viewer.cpp
@@ -91,9 +91,6 @@ void story_viewer::pre_show(window& window)
 	connect_signal_mouse_left_click(find_widget<button>(&window, "back", false),
 		std::bind(&story_viewer::nav_button_callback, this, DIR_BACKWARDS));
 
-	connect_signal_on_draw(window,
-		std::bind(&story_viewer::draw_callback, this));
-
 	display_part();
 }
 
@@ -223,8 +220,8 @@ void story_viewer::display_part()
 	window_canvas.set_cfg(cfg);
 
 	// Needed to make the background redraw correctly.
-	window_canvas.set_is_dirty(true);
-	get_window()->set_is_dirty(true);
+	window_canvas.update_size_variables();
+	get_window()->queue_redraw();
 
 	//
 	// Title
@@ -358,8 +355,8 @@ void story_viewer::draw_floating_image(floating_image_list::const_iterator image
 		window_canvas.append_cfg(std::move(cfg));
 
 		// Needed to make the background redraw correctly.
-		window_canvas.set_is_dirty(true);
-		get_window()->set_is_dirty(true);
+		window_canvas.update_size_variables();
+		get_window()->queue_redraw();
 
 		// If a delay is specified, schedule the next image draw and break out of the loop.
 		const unsigned int draw_delay = floating_image.display_delay();
@@ -451,7 +448,7 @@ void story_viewer::halt_fade_draw()
 	fade_state_ = NOT_FADING;
 }
 
-void story_viewer::draw_callback()
+void story_viewer::layout()
 {
 	if(next_draw_ && SDL_GetTicks() < next_draw_) {
 		return;
@@ -492,7 +489,7 @@ void story_viewer::draw_callback()
 
 void story_viewer::flag_stack_as_dirty()
 {
-	find_widget<stacked_widget>(get_window(), "text_and_control_stack", false).set_is_dirty(true);
+	find_widget<stacked_widget>(get_window(), "text_and_control_stack", false).queue_redraw();
 }
 
 } // namespace dialogs

--- a/src/gui/dialogs/story_viewer.hpp
+++ b/src/gui/dialogs/story_viewer.hpp
@@ -25,7 +25,7 @@ namespace gui2::dialogs
 {
 
 /** Dialog to view the storyscreen. */
-class story_viewer : public modal_dialog
+class story_viewer : public modal_dialog, public top_level_drawable
 {
 public:
 	story_viewer(const std::string& scenario_name, const config& cfg_parsed);
@@ -41,6 +41,14 @@ public:
 			}
 		} catch(const std::out_of_range&) {}
 	}
+
+	// top_level_drawable overrides
+	// used to animate the view
+	// TODO: draw_manager - better animation step / hook
+	// TODO: draw_manager - i still am horrified that a modal_dialog is not a window
+	virtual void layout() override;
+	virtual bool expose(const SDL_Rect&) override { return false; }
+	virtual rect screen_location() override { return {0,0,0,0}; }
 
 private:
 	virtual const std::string& window_id() const override;
@@ -68,8 +76,6 @@ private:
 	void set_next_draw();
 	void begin_fade_draw(bool fade_in);
 	void halt_fade_draw();
-
-	void draw_callback();
 
 	void flag_stack_as_dirty();
 

--- a/src/gui/dialogs/surrender_quit.cpp
+++ b/src/gui/dialogs/surrender_quit.cpp
@@ -25,7 +25,6 @@ REGISTER_DIALOG(surrender_quit)
 
 surrender_quit::surrender_quit()
 {
-	set_restore(true);
 }
 
 } // namespace dialogs

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -76,8 +76,6 @@ title_screen::title_screen(game_launcher& game)
 	: debug_clock_()
 	, game_(game)
 {
-	set_restore(false);
-
 	// Need to set this in the constructor, pre_show() / post_build() is too late
 	set_allow_plugin_skip(false);
 }
@@ -404,15 +402,6 @@ void title_screen::update_tip(const bool previous)
 	}
 
 	tip_pages->select_page(page);
-
-	/**
-	 * @todo Look for a proper fix.
-	 *
-	 * This dirtying is required to avoid the blurring to be rendered wrong.
-	 * Not entirely sure why, but since we plan to move to SDL2 that change
-	 * will probably fix this issue automatically.
-	 */
-	get_window()->set_is_dirty(true);
 }
 
 void title_screen::show_debug_clock_window()

--- a/src/gui/dialogs/transient_message.cpp
+++ b/src/gui/dialogs/transient_message.cpp
@@ -61,13 +61,11 @@ void show_transient_message(const std::string& title,
 							const std::string& message,
 							const std::string& image,
 							const bool message_use_markup,
-							const bool title_use_markup,
-							const bool restore_background)
+							const bool title_use_markup)
 {
 	dialogs::transient_message dlg(
 			title, title_use_markup, message, message_use_markup, image);
 
-	dlg.set_restore(restore_background);
 	dlg.show();
 }
 

--- a/src/gui/dialogs/transient_message.hpp
+++ b/src/gui/dialogs/transient_message.hpp
@@ -58,15 +58,12 @@ private:
  * @param image               An image to show in the dialog.
  * @param message_use_markup  Use markup for the message?
  * @param title_use_markup    Use markup for the title?
- * @param restore_background  Restore the background to the state it was before
- * 							  the message appeared
  */
 void show_transient_message(const std::string& title,
 							const std::string& message,
 							const std::string& image = std::string(),
 							const bool message_use_markup = false,
-							const bool title_use_markup = false,
-							const bool restore_background = false);
+							const bool title_use_markup = false);
 
 /**
  * Shows a transient error message to the user.

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -53,7 +53,6 @@ unit_create::unit_create()
 	, variation_(last_variation)
 	, last_words_()
 {
-	set_restore(true);
 }
 
 void unit_create::pre_show(window& window)

--- a/src/gui/dialogs/wml_error.cpp
+++ b/src/gui/dialogs/wml_error.cpp
@@ -143,8 +143,6 @@ wml_error::wml_error(const std::string& summary,
 	, have_post_summary_(!post_summary.empty())
 	, report_()
 {
-	set_restore(true);
-
 	const std::string& file_list_text = format_file_list(files);
 
 	report_ = summary;

--- a/src/gui/dialogs/wml_message.cpp
+++ b/src/gui/dialogs/wml_message.cpp
@@ -58,8 +58,6 @@ void wml_message_base::set_option_list(const std::vector<wml_message_option>& op
  */
 void wml_message_base::pre_show(window& window)
 {
-	set_restore(true);
-
 	window.get_canvas(1).set_variable("portrait_image", wfl::variant(portrait_));
 	window.get_canvas(1).set_variable("portrait_mirror", wfl::variant(mirror_));
 

--- a/src/gui/widgets/button.cpp
+++ b/src/gui/widgets/button.cpp
@@ -81,7 +81,7 @@ void button::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/container_base.cpp
+++ b/src/gui/widgets/container_base.cpp
@@ -209,14 +209,6 @@ void container_base::layout_children()
 	grid_.layout_children();
 }
 
-void
-container_base::child_populate_dirty_list(window& caller,
-									   const std::vector<widget*>& call_stack)
-{
-	std::vector<widget*> child_call_stack = call_stack;
-	grid_.populate_dirty_list(caller, child_call_stack);
-}
-
 widget* container_base::find_at(const point& coordinate,
 							  const bool must_be_active)
 {
@@ -252,7 +244,7 @@ void container_base::set_active(const bool active)
 		return;
 	}
 
-	set_is_dirty(true);
+	queue_redraw();
 
 	set_self_active(active);
 }

--- a/src/gui/widgets/container_base.hpp
+++ b/src/gui/widgets/container_base.hpp
@@ -114,11 +114,6 @@ protected:
 	/** See @ref widget::layout_children. */
 	virtual void layout_children() override;
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override;
-
 public:
 	/** See @ref widget::find_at. */
 	virtual widget* find_at(const point& coordinate,

--- a/src/gui/widgets/generator.hpp
+++ b/src/gui/widgets/generator.hpp
@@ -282,13 +282,6 @@ public:
 	/** See @ref widget::impl_draw_children. */
 	virtual void impl_draw_children() override = 0;
 
-protected:
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override
-			= 0;
-
 public:
 	/** See @ref widget::find_at. */
 	virtual widget* find_at(const point& coordinate,

--- a/src/gui/widgets/generator_private.hpp
+++ b/src/gui/widgets/generator_private.hpp
@@ -843,15 +843,6 @@ public:
 		}
 	}
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void child_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack) override
-	{
-		for(auto& item : items_) {
-			std::vector<widget*> child_call_stack = call_stack;
-			item->child_grid.populate_dirty_list(caller, child_call_stack);
-		}
-	}
-
 	/** See @ref widget::find_at. */
 	virtual widget* find_at(const point& coordinate, const bool must_be_active) override
 	{
@@ -985,7 +976,7 @@ private:
 	{
 		order_func_ = order;
 		order_dirty_ = true;
-		this->set_is_dirty(true);
+		this->queue_redraw();
 	}
 
 	virtual unsigned get_ordered_index(unsigned index) const override

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -629,21 +629,6 @@ void grid::layout_children()
 	}
 }
 
-void grid::child_populate_dirty_list(window& caller,
-									  const std::vector<widget*>& call_stack)
-{
-	assert(!call_stack.empty() && call_stack.back() == this);
-
-	for(auto & child : children_)
-	{
-
-		assert(child.get_widget());
-
-		std::vector<widget*> child_call_stack = call_stack;
-		child.get_widget()->populate_dirty_list(caller, child_call_stack);
-	}
-}
-
 widget* grid::find_at(const point& coordinate, const bool must_be_active)
 {
 	return grid_implementation::find_at<widget>(
@@ -997,6 +982,7 @@ void grid::layout(const point& origin)
 
 void grid::impl_draw_children()
 {
+	// TODO: draw_manager - what is this comment talking about here? something that was removed?
 	/*
 	 * The call to SDL_PumpEvents seems a bit like black magic.
 	 * With the call the resizing doesn't seem to lose resize events.
@@ -1008,11 +994,10 @@ void grid::impl_draw_children()
 	 */
 
 	assert(get_visible() == widget::visibility::visible);
-	set_is_dirty(false);
 
+	// TODO: draw_manager - don't draw children outside clip area. This is problematic because either clip area is not correct here or widget positions are not absolute
 	for(auto & child : children_)
 	{
-
 		widget* widget = child.get_widget();
 		assert(widget);
 
@@ -1027,7 +1012,6 @@ void grid::impl_draw_children()
 		widget->draw_background();
 		widget->draw_children();
 		widget->draw_foreground();
-		widget->set_is_dirty(false);
 	}
 }
 

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -88,7 +88,7 @@ public:
 	{
 		assert(row < row_grow_factor_.size());
 		row_grow_factor_[row] = factor;
-		set_is_dirty(true);
+		queue_redraw(); // TODO: draw_manager - relayout?
 	}
 
 	/**
@@ -103,7 +103,7 @@ public:
 	{
 		assert(column < col_grow_factor_.size());
 		col_grow_factor_[column] = factor;
-		set_is_dirty(true);
+		queue_redraw(); // TODO: draw_manager - relayout?
 	}
 
 	/***** ***** ***** ***** CHILD MANIPULATION ***** ***** ***** *****/
@@ -272,11 +272,6 @@ public:
 
 	/** See @ref widget::layout_children. */
 	virtual void layout_children() override;
-
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override;
 
 	/** See @ref widget::find_at. */
 	virtual widget* find_at(const point& coordinate,

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -77,7 +77,7 @@ void label::set_text_alpha(unsigned short alpha)
 	if(alpha != text_alpha_) {
 		text_alpha_ = alpha;
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -93,7 +93,7 @@ void label::set_link_aware(bool link_aware)
 	if(link_aware != link_aware_) {
 		link_aware_ = link_aware;
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -102,7 +102,7 @@ void label::set_link_color(const color_t& color)
 	if(color != link_color_) {
 		link_color_ = color;
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -110,7 +110,7 @@ void label::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -163,7 +163,7 @@ void listbox::set_row_shown(const unsigned row, const bool shown)
 		window->invalidate_layout();
 	} else {
 		content_grid_->set_visible_rectangle(content_visible_area());
-		set_is_dirty(true);
+		queue_redraw(); // TODO: draw_manager - does this get the right area?
 	}
 
 	if(selected_row != get_selected_row()) {
@@ -206,7 +206,7 @@ void listbox::set_row_shown(const boost::dynamic_bitset<>& shown)
 		window->invalidate_layout();
 	} else {
 		content_grid_->set_visible_rectangle(content_visible_area());
-		set_is_dirty(true);
+		queue_redraw(); // TODO: draw_manager - does this get the right area?
 	}
 
 	if(selected_row != get_selected_row()) {
@@ -337,7 +337,7 @@ bool listbox::update_content_size()
 
 	if(content_resize_request(true)) {
 		content_grid_->set_visible_rectangle(content_visible_area());
-		set_is_dirty(true);
+		queue_redraw(); // TODO: draw_manager - does this get the right area?
 		return true;
 	}
 
@@ -400,7 +400,7 @@ void listbox::resize_content(const int width_modification,
 
 		// If the content grows assume it "overwrites" the old content.
 		if(width_modification < 0 || height_modification < 0) {
-			set_is_dirty(true);
+			queue_redraw();
 		}
 
 		DBG_GUI_L << LOG_HEADER << " succeeded.\n";
@@ -433,16 +433,6 @@ void listbox::resize_content(const widget& row)
 void listbox::layout_children()
 {
 	layout_children(false);
-}
-
-void listbox::child_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack)
-{
-	// Inherited.
-	scrollbar_container::child_populate_dirty_list(caller, call_stack);
-
-	assert(generator_);
-	std::vector<widget*> child_call_stack = call_stack;
-	generator_->populate_dirty_list(caller, child_call_stack);
 }
 
 point listbox::calculate_best_size() const
@@ -618,7 +608,7 @@ void listbox::order_by(const generator_base::order_func& func)
 {
 	generator_->set_order(func);
 
-	set_is_dirty(true);
+	queue_redraw();
 	need_layout_ = true;
 }
 
@@ -704,7 +694,7 @@ void listbox::layout_children(const bool force)
 		content_grid()->set_visible_rectangle(visible);
 
 		need_layout_ = false;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -256,9 +256,6 @@ public:
 	/** See @ref widget::layout_children. */
 	virtual void layout_children() override;
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void child_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack) override;
-
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
 	void order_by(const generator_base::order_func& func);

--- a/src/gui/widgets/matrix.cpp
+++ b/src/gui/widgets/matrix.cpp
@@ -118,13 +118,6 @@ void matrix::layout_children()
 	content_.layout_children();
 }
 
-void matrix::child_populate_dirty_list(window& caller,
-										const std::vector<widget*>& call_stack)
-{
-	std::vector<widget*> child_call_stack = call_stack;
-	content_.populate_dirty_list(caller, child_call_stack);
-}
-
 void matrix::request_reduce_width(const unsigned /*maximum_width*/)
 {
 }

--- a/src/gui/widgets/matrix.hpp
+++ b/src/gui/widgets/matrix.hpp
@@ -131,11 +131,6 @@ public:
 	/** See @ref widget::layout_children. */
 	virtual void layout_children() override;
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override;
-
 	/** See @ref widget::request_reduce_width. */
 	virtual void request_reduce_width(const unsigned maximum_width) override;
 

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -93,7 +93,7 @@ void menu_button::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -189,7 +189,7 @@ void menu_button::set_values(const std::vector<::config>& values, unsigned selec
 	assert(selected_ < values_.size());
 
 	if(values[selected]["label"] != values_[selected_]["label"]) {
-		set_is_dirty(true);
+		queue_redraw();
 	}
 
 	values_ = values;
@@ -204,7 +204,7 @@ void menu_button::set_selected(unsigned selected, bool fire_event)
 	assert(selected_ < values_.size());
 
 	if(selected != selected_) {
-		set_is_dirty(true);
+		queue_redraw();
 	}
 
 	selected_ = selected;

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -81,7 +81,7 @@ void minimap::set_map_data(const std::string& map_data)
 	}
 
 	map_data_ = map_data;
-	set_is_dirty(true);
+	queue_redraw();
 
 	try {
 		map_ = std::make_unique<gamemap>(map_data_);

--- a/src/gui/widgets/multimenu_button.cpp
+++ b/src/gui/widgets/multimenu_button.cpp
@@ -89,7 +89,7 @@ void multimenu_button::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -229,7 +229,7 @@ void multimenu_button::select_options(boost::dynamic_bitset<> states)
 
 void multimenu_button::set_values(const std::vector<::config>& values)
 {
-	set_is_dirty(true);
+	queue_redraw(); // TODO: draw_manager - does this need a relayout first?
 
 	values_ = values;
 	toggle_states_.resize(values_.size(), false);

--- a/src/gui/widgets/pane.cpp
+++ b/src/gui/widgets/pane.cpp
@@ -177,16 +177,6 @@ void pane::impl_draw_children()
 	}
 }
 
-void pane::child_populate_dirty_list(window& caller,
-									  const std::vector<widget*>& call_stack)
-{
-	for(auto & item : items_)
-	{
-		std::vector<widget*> child_call_stack = call_stack;
-		item.item_grid->populate_dirty_list(caller, child_call_stack);
-	}
-}
-
 void pane::sort(const compare_functor_t& compare_functor)
 {
 	items_.sort(compare_functor);

--- a/src/gui/widgets/pane.hpp
+++ b/src/gui/widgets/pane.hpp
@@ -77,11 +77,6 @@ public:
 	/** See @ref widget::impl_draw_children. */
 	virtual void impl_draw_children() override;
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override;
-
 	/** See @ref widget::request_reduce_width. */
 	virtual void request_reduce_width(const unsigned maximum_width) override;
 

--- a/src/gui/widgets/progress_bar.cpp
+++ b/src/gui/widgets/progress_bar.cpp
@@ -68,7 +68,7 @@ void progress_bar::set_percentage(unsigned percentage)
 			c.set_variable("percentage", wfl::variant(percentage));
 		}
 
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/repeating_button.cpp
+++ b/src/gui/widgets/repeating_button.cpp
@@ -93,7 +93,7 @@ void repeating_button::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 
 		if(state_ == DISABLED && repeat_timer_) {
 			remove_timer(repeat_timer_);

--- a/src/gui/widgets/scrollbar.cpp
+++ b/src/gui/widgets/scrollbar.cpp
@@ -183,14 +183,14 @@ void scrollbar_base::update_canvas()
 		tmp.set_variable("positioner_offset", wfl::variant(positioner_offset_));
 		tmp.set_variable("positioner_length", wfl::variant(positioner_length_));
 	}
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void scrollbar_base::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/scrollbar_container.cpp
+++ b/src/gui/widgets/scrollbar_container.cpp
@@ -821,16 +821,6 @@ void scrollbar_container::layout_children()
 	content_grid_->layout_children();
 }
 
-void scrollbar_container::child_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack)
-{
-	// Inherited.
-	container_base::child_populate_dirty_list(caller, call_stack);
-
-	assert(content_grid_);
-	std::vector<widget*> child_call_stack(call_stack);
-	content_grid_->populate_dirty_list(caller, child_call_stack);
-}
-
 void scrollbar_container::set_content_size(const point& origin, const point& size)
 {
 	content_grid_->place(origin, size);
@@ -1083,7 +1073,7 @@ void scrollbar_container::scrollbar_moved()
 
 	content_grid_->set_origin(content_origin);
 	content_grid_->set_visible_rectangle(content_visible_area_);
-	content_grid_->set_is_dirty(true);
+	queue_redraw(content_visible_area_);
 
 	// Update scrollbar.
 	set_scrollbar_button_status();

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -512,9 +512,6 @@ private:
 	/** See @ref widget::impl_draw_children. */
 	virtual void impl_draw_children() override;
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void child_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack) override;
-
 	/**
 	 * Sets the size of the content grid.
 	 *

--- a/src/gui/widgets/slider.hpp
+++ b/src/gui/widgets/slider.hpp
@@ -111,7 +111,7 @@ public:
 	void set_best_slider_length(const unsigned length)
 	{
 		best_slider_length_ = length;
-		set_is_dirty(true);
+		queue_redraw(); // TODO: draw_manager - does the above change the size?
 	}
 
 	void set_value_range(int min_value, int max_value);

--- a/src/gui/widgets/slider_base.cpp
+++ b/src/gui/widgets/slider_base.cpp
@@ -148,14 +148,14 @@ void slider_base::update_canvas()
 		tmp.set_variable("positioner_length", wfl::variant(positioner_length_));
 	}
 
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void slider_base::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -329,7 +329,7 @@ void styled_widget::set_label(const t_string& label)
 	label_ = label;
 	set_layout_size(point());
 	update_canvas();
-	set_is_dirty(true);
+	queue_redraw();
 
 	// FIXME: This isn't the most elegant solution. Typically, we don't rely on the text rendering
 	// cache for anything except size calculations, but since we have link awareness now we need to
@@ -349,7 +349,7 @@ void styled_widget::set_use_markup(bool use_markup)
 
 	use_markup_ = use_markup;
 	update_canvas();
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void styled_widget::set_text_alignment(const PangoAlignment text_alignment)
@@ -360,7 +360,7 @@ void styled_widget::set_text_alignment(const PangoAlignment text_alignment)
 
 	text_alignment_ = text_alignment;
 	update_canvas();
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void styled_widget::set_text_ellipse_mode(const PangoEllipsizeMode ellipse_mode)
@@ -371,7 +371,7 @@ void styled_widget::set_text_ellipse_mode(const PangoEllipsizeMode ellipse_mode)
 
 	text_ellipse_mode_ = ellipse_mode;
 	update_canvas();
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void styled_widget::update_canvas()

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -267,7 +267,7 @@ void text_box::handle_mouse_selection(point mouse, const bool start_selection)
 
 	set_cursor(offset, !start_selection);
 	update_canvas();
-	set_is_dirty(true);
+	queue_redraw();
 	dragging_ |= start_selection;
 }
 

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -116,7 +116,7 @@ void text_box_base::set_maximum_length(const std::size_t maximum_length)
 			selection_length_ = maximum_length - selection_start_;
 		}
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -129,7 +129,7 @@ void text_box_base::set_value(const std::string& text)
 		selection_start_ = text_.get_length();
 		selection_length_ = 0;
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -150,7 +150,7 @@ void text_box_base::set_cursor(const std::size_t offset, const bool select)
 		copy_selection(true);
 #endif
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 
 	} else {
 		assert(offset <= text_.get_length());
@@ -158,7 +158,7 @@ void text_box_base::set_cursor(const std::size_t offset, const bool select)
 		selection_length_ = 0;
 
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -171,7 +171,7 @@ void text_box_base::insert_char(const std::string& unicode)
 		// Update status
 		set_cursor(selection_start_ + utf8::size(unicode), false);
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -230,7 +230,7 @@ void text_box_base::paste_selection(const bool mouse)
 	selection_start_ += text_.insert_text(selection_start_, text);
 
 	update_canvas();
-	set_is_dirty(true);
+	queue_redraw();
 	fire(event::NOTIFY_MODIFIED, *this, nullptr);
 }
 
@@ -238,7 +238,7 @@ void text_box_base::set_selection_start(const std::size_t selection_start)
 {
 	if(selection_start != selection_start_) {
 		selection_start_ = selection_start;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -246,7 +246,7 @@ void text_box_base::set_selection_length(const int selection_length)
 {
 	if(selection_length != selection_length_) {
 		selection_length_ = selection_length;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -286,7 +286,7 @@ void text_box_base::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 
@@ -331,7 +331,7 @@ void text_box_base::cursor_timer_callback()
 		tmp.set_variable("cursor_alpha", wfl::variant(cursor_alpha_));
 	}
 
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void text_box_base::reset_cursor_state()
@@ -501,7 +501,7 @@ void text_box_base::handle_editing(bool& handled, const std::string& unicode, in
 			set_cursor(std::min(maximum_length, ime_start_point_ + start + len), true);
 		}
 		update_canvas();
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -107,7 +107,7 @@ void toggle_button::update_canvas()
 		canvas.set_variable("icon", wfl::variant(icon_name_));
 	}
 
-	set_is_dirty(true);
+	queue_redraw();
 }
 
 void toggle_button::set_value(unsigned selected, bool fire_event)
@@ -117,7 +117,7 @@ void toggle_button::set_value(unsigned selected, bool fire_event)
 		return;
 	}
 	state_num_ = selected;
-	set_is_dirty(true);
+	queue_redraw();
 
 	// Check for get_window() is here to prevent the callback from
 	// being called when the initial value is set.
@@ -143,7 +143,7 @@ void toggle_button::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-		set_is_dirty(true);
+		queue_redraw();
 	}
 }
 

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -166,7 +166,7 @@ void toggle_panel::set_value(unsigned selected, bool fire_event)
 		return;
 	}
 	state_num_ = selected;
-	set_is_dirty(true);
+	queue_redraw();
 
 	// Check for get_window() is here to prevent the callback from
 	// being called when the initial value is set.
@@ -187,7 +187,7 @@ void toggle_panel::set_state(const state_t state)
 	}
 
 	state_ = state;
-	set_is_dirty(true);
+	queue_redraw();
 
 	const auto conf = cast_config_to<toggle_panel_definition>();
 	assert(conf);

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -92,17 +92,6 @@ void tree_view::clear()
 	resize_content(0, -content_grid()->get_size().y);
 }
 
-void
-tree_view::child_populate_dirty_list(window& caller,
-									  const std::vector<widget*>& call_stack)
-{
-	// Inherited.
-	scrollbar_container::child_populate_dirty_list(caller, call_stack);
-
-	assert(root_node_);
-	root_node_->impl_populate_dirty_list(caller, call_stack);
-}
-
 void tree_view::set_self_active(const bool /*active*/)
 {
 	/* DO NOTHING */
@@ -144,7 +133,7 @@ void tree_view::resize_content(const int width_modification,
 		need_layout_ = true;
 		// If the content grows assume it "overwrites" the old content.
 		if(width_modification < 0 || height_modification < 0) {
-			set_is_dirty(true);
+			queue_redraw();
 		}
 		horizontal_scrollbar_moved();
 		DBG_GUI_L << LOG_HEADER << " succeeded.\n";

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -92,11 +92,6 @@ public:
 
 	void clear();
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override;
-
 	/** See @ref container_base::set_self_active. */
 	virtual void set_self_active(const bool active) override;
 

--- a/src/gui/widgets/tree_view_node.cpp
+++ b/src/gui/widgets/tree_view_node.cpp
@@ -452,21 +452,6 @@ const widget* tree_view_node::find(const std::string& id, const bool must_be_act
 	return nullptr;
 }
 
-void tree_view_node::impl_populate_dirty_list(window& caller, const std::vector<widget*>& call_stack)
-{
-	std::vector<widget*> my_call_stack = call_stack;
-	grid_.populate_dirty_list(caller, my_call_stack);
-
-	if(is_folded()) {
-		return;
-	}
-
-	for(auto& node : children_) {
-		std::vector<widget*> child_call_stack = call_stack;
-		node->impl_populate_dirty_list(caller, child_call_stack);
-	}
-}
-
 point tree_view_node::calculate_best_size() const
 {
 	return calculate_best_size(-1, get_tree_view().indentation_step_size_);

--- a/src/gui/widgets/tree_view_node.hpp
+++ b/src/gui/widgets/tree_view_node.hpp
@@ -290,14 +290,6 @@ private:
 	void fold_internal();
 	void unfold_internal();
 
-	/**
-	 * "Inherited" from widget.
-	 *
-	 * This version needs to call its children, which are it's child nodes.
-	 */
-	void impl_populate_dirty_list(window& caller,
-								  const std::vector<widget*>& call_stack);
-
 	/** See @ref widget::calculate_best_size. */
 	virtual point calculate_best_size() const override;
 

--- a/src/gui/widgets/viewport.cpp
+++ b/src/gui/widgets/viewport.cpp
@@ -113,16 +113,7 @@ void viewport::impl_draw_children()
 		widget_->draw_background();
 		widget_->draw_children();
 		widget_->draw_foreground();
-		widget_->set_is_dirty(false);
 	}
-}
-
-void
-viewport::child_populate_dirty_list(window& caller,
-									 const std::vector<widget*>& call_stack)
-{
-	std::vector<widget*> child_call_stack = call_stack;
-	widget_->populate_dirty_list(caller, child_call_stack);
 }
 
 void viewport::request_reduce_width(const unsigned /*maximum_width*/)

--- a/src/gui/widgets/viewport.hpp
+++ b/src/gui/widgets/viewport.hpp
@@ -61,11 +61,6 @@ public:
 	/** See @ref widget::impl_draw_children. */
 	virtual void impl_draw_children() override;
 
-	/** See @ref widget::child_populate_dirty_list. */
-	virtual void
-	child_populate_dirty_list(window& caller,
-							  const std::vector<widget*>& call_stack) override;
-
 	/** See @ref widget::request_reduce_width. */
 	virtual void request_reduce_width(const unsigned maximum_width) override;
 

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -84,6 +84,10 @@ static lg::log_domain log_gui("gui/layout");
 	window.get_control_type() + " [" + window.id() + "] " + __func__
 #define LOG_IMPL_HEADER LOG_IMPL_SCOPE_HEADER + ':'
 
+static lg::log_domain log_display("display");
+#define DBG_DP LOG_STREAM(debug, log_display)
+#define WRN_DP LOG_STREAM(warn, log_display)
+
 namespace gui2
 {
 
@@ -286,9 +290,6 @@ window::window(const builder_window::window_resolution& definition)
 	, variables_()
 	, invalidate_layout_blocked_(false)
 	, suspend_drawing_(true)
-	, restore_(true)
-	, is_toplevel_(!is_in_dialog())
-	, restorer_()
 	, automatic_placement_(definition.automatic_placement)
 	, horizontal_placement_(definition.horizontal_placement)
 	, vertical_placement_(definition.vertical_placement)
@@ -307,22 +308,15 @@ window::window(const builder_window::window_resolution& definition)
 	, escape_disabled_(false)
 	, linked_size_()
 	, mouse_button_state_(0) /**< Needs to be initialized in @ref show. */
-	, dirty_list_()
 #ifdef DEBUG_WINDOW_LAYOUT_GRAPHS
 	, debug_layout_(new debug_layout_graph(this))
 #endif
 	, event_distributor_(new event::distributor(*this, event::dispatcher::front_child))
 	, exit_hook_([](window&)->bool { return true; })
-	, callback_next_draw_(nullptr)
 {
 	manager::instance().add(*this);
 
 	connect();
-
-	if (!video_.faked())
-	{
-		connect_signal<event::DRAW>(std::bind(&window::draw, this));
-	}
 
 	connect_signal<event::SDL_VIDEO_RESIZE>(std::bind(
 			&window::signal_handler_sdl_video_resize, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_5));
@@ -465,6 +459,8 @@ void window::show_tooltip(/*const unsigned auto_close_timeout*/)
 	 */
 	invalidate_layout();
 	suspend_drawing_ = false;
+	queue_redraw();
+	DBG_DP << "show tooltip queued to " << get_rectangle() << std::endl;
 }
 
 void window::show_non_modal(/*const unsigned auto_close_timeout*/)
@@ -486,13 +482,16 @@ void window::show_non_modal(/*const unsigned auto_close_timeout*/)
 	 */
 	invalidate_layout();
 	suspend_drawing_ = false;
+	queue_redraw();
+
+	DBG_DP << "show non-modal queued to " << get_rectangle() << std::endl;
 
 	push_draw_event();
 
 	events::pump();
 }
 
-int window::show(const bool restore, const unsigned auto_close_timeout)
+int window::show(const unsigned auto_close_timeout)
 {
 	/*
 	 * Removes the old tip if one shown. The show_tip doesn't remove
@@ -501,7 +500,6 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 	dialogs::tip::remove();
 
 	show_mode_ = show_mode::modal;
-	restore_ = restore;
 
 	log_scope2(log_gui_draw, LOG_SCOPE_HEADER);
 
@@ -516,12 +514,13 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 	 */
 	invalidate_layout();
 	suspend_drawing_ = false;
+	queue_redraw();
+
+	// Make sure we display at least once in all cases.
+	// TODO: draw_manager - rename this so it's clear what's going on
+	events::raise_draw_event();
 
 	if(auto_close_timeout) {
-		// Make sure we're drawn before we try to close ourselves, which can
-		// happen if the timeout is small.
-		draw();
-
 		SDL_Event event;
 		sdl::UserEvent data(CLOSE_WINDOW_EVENT, manager::instance().get_id(*this));
 
@@ -531,14 +530,11 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 		delay_event(event, auto_close_timeout);
 	}
 
-
 	try
 	{
 		// Start our loop drawing will happen here as well.
 		bool mouse_button_state_initialized = false;
 		for(status_ = status::SHOWING; status_ != status::CLOSED;) {
-			push_draw_event();
-
 			// process installed callback if valid, to allow e.g. network
 			// polling
 			events::pump();
@@ -562,37 +558,18 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 				status_ = exit_hook_(*this) ? status::CLOSED : status::SHOWING;
 			}
 
-			// Add a delay so we don't keep spinning if there's no event.
-			if(status_ != status::CLOSED) {
-				SDL_Delay(10);
-			}
+			// This will rate limit to vsync
+			events::raise_draw_event();
 		}
 	}
 	catch(...)
 	{
-		/**
-		 * @todo Clean up the code duplication.
-		 *
-		 * In the future the restoring shouldn't be needed so the duplication
-		 * doesn't hurt too much but keep this todo as a reminder.
-		 */
-		suspend_drawing_ = true;
-
-		// restore area
-		if(restore_) {
-			draw::blit(restorer_, get_rectangle());
-			font::undraw_floating_labels();
-		}
+		// TODO: is this even necessary? What are we catching?
+		undraw();
 		throw;
 	}
 
-	suspend_drawing_ = true;
-
-	// restore area
-	if(restore_) {
-		draw::blit(restorer_, get_rectangle());
-		font::undraw_floating_labels();
-	}
+	undraw();
 
 	if(text_box_base* tb = dynamic_cast<text_box_base*>(event_distributor_->keyboard_focus())) {
 		tb->interrupt_composition();
@@ -603,178 +580,47 @@ int window::show(const bool restore, const unsigned auto_close_timeout)
 
 void window::draw()
 {
-	/***** ***** ***** ***** Init ***** ***** ***** *****/
-	// Prohibited from drawing?
+	// TODO: draw_manager - is there a better way of handling window close?
 	if(suspend_drawing_) {
+		WRN_DP << "window::draw called with drawing suspended" << std::endl;
 		return;
 	}
 
-	/***** ***** Layout and get dirty list ***** *****/
-	if(need_layout_) {
-		// Restore old surface. In the future this phase will not be needed
-		// since all will be redrawn when needed with dirty rects. Since that
-		// doesn't work yet we need to undraw the window.
-		if(restore_ && restorer_) {
-			draw::blit(restorer_, get_rectangle());
-		}
+	// Draw background.
+	this->draw_background();
 
-		layout();
+	// Draw children.
+	this->draw_children();
 
-		// Get new surface for restoring
-		SDL_Rect rect = get_rectangle();
+	// Draw foreground.
+	this->draw_foreground();
 
-		// We want the labels underneath the window so draw them and use them
-		// as restore point.
-		if(is_toplevel_) {
-			font::draw_floating_labels();
-		}
-
-		if(restore_) {
-			restorer_ = video_.read_texture(&rect);
-		}
-
-		// Need full redraw so only set ourselves dirty.
-		dirty_list_.emplace_back(1, this);
-	} else {
-
-		// Let widgets update themselves, which might dirty some things.
-		layout_children();
-
-		// Now find the widgets that are dirty.
-		std::vector<widget*> call_stack;
-		if(!new_widgets) {
-			populate_dirty_list(*this, call_stack);
-		} else {
-			/* Force to update and redraw the entire screen */
-			dirty_list_.clear();
-			dirty_list_.emplace_back(1, this);
-		}
-	}
-
-	if (dirty_list_.empty()) {
-		consecutive_changed_frames_ = 0u;
-		return;
-	}
-
-	++consecutive_changed_frames_;
-	if(consecutive_changed_frames_ >= 100u && id_ == "title_screen") {
-		/* The title screen has changed in 100 consecutive frames, i.e. every
-		frame for two seconds. It looks like the screen is constantly changing
-		or at least marking widgets as dirty.
-
-		That's a severe problem. Every time the title screen changes, all
-		other GUI windows need to be fully redrawn, with huge CPU usage cost.
-		For that reason, this situation is a hard error. */
-		throw std::logic_error("The title screen is constantly changing, "
-			"which has a huge CPU usage cost. See the code comment.");
-	}
-
-	for(auto & item : dirty_list_)
-	{
-
-		assert(!item.empty());
-
-		const SDL_Rect dirty_rect
-				= new_widgets ? video_.draw_area()
-							  : item.back()->get_dirty_rectangle();
-
-// For testing we disable the clipping rect and force the entire screen to
-// update. This way an item rendered at the wrong place is directly visible.
-#if 0
-		dirty_list_.clear();
-		dirty_list_.emplace_back(1, this);
-#else
-		auto clipper = draw::set_clip(dirty_rect);
-#endif
-
-		/*
-		 * The actual update routine does the following:
-		 * - Restore the background.
-		 *
-		 * - draw [begin, end) the back ground of all widgets.
-		 *
-		 * - draw the children of the last item in the list, if this item is
-		 *   a container it's children get a full redraw. If it's not a
-		 *   container nothing happens.
-		 *
-		 * - draw [rbegin, rend) the fore ground of all widgets. For items
-		 *   which have two layers eg window or panel it draws the foreground
-		 *   layer. For other widgets it's a nop.
-		 *
-		 * Before drawing there needs to be determined whether a dirty widget
-		 * really needs to be redrawn. If the widget doesn't need to be
-		 * redrawing either being not visibility::visible or has status
-		 * widget::redraw_action::none. If it's not drawn it's still set not
-		 * dirty to avoid it keep getting on the dirty list.
-		 */
-
-		for(std::vector<widget*>::iterator itor = item.begin();
-			itor != item.end();
-			++itor) {
-
-			if((**itor).get_visible() != widget::visibility::visible
-			   || (**itor).get_drawing_action()
-				  == widget::redraw_action::none) {
-
-				for(std::vector<widget*>::iterator citor = itor;
-					citor != item.end();
-					++citor) {
-
-					(**citor).set_is_dirty(false);
-				}
-
-				item.erase(itor, item.end());
-				break;
-			}
-		}
-
-		// Restore.
-		if(restore_) {
-			draw::blit(restorer_, get_rectangle());
-		}
-
-		// Background.
-		for(std::vector<widget*>::iterator itor = item.begin();
-			itor != item.end();
-			++itor) {
-
-			(**itor).draw_background();
-		}
-
-		// Children.
-		if(!item.empty()) {
-			item.back()->draw_children();
-		}
-
-		// Foreground.
-		for(std::vector<widget*>::reverse_iterator ritor = item.rbegin();
-			ritor != item.rend();
-			++ritor) {
-
-			(**ritor).draw_foreground();
-			(**ritor).set_is_dirty(false);
-		}
-	}
-
-	dirty_list_.clear();
-
-	redraw_windows_on_top();
-
-	std::vector<widget*> call_stack;
-	populate_dirty_list(*this, call_stack);
-	assert(dirty_list_.empty());
-
-	if(callback_next_draw_ != nullptr) {
-		callback_next_draw_();
-		callback_next_draw_ = nullptr;
-	}
+	return;
 }
 
+// TODO: draw_manager - can probably remove "undraw", or at least rename
 void window::undraw()
 {
-	if(restore_ && restorer_) {
-		draw::blit(restorer_, get_rectangle());
+	// TODO: draw_manager - is suspend_drawing_ necessary?
+	suspend_drawing_ = true;
+	queue_redraw();
+}
+
+bool window::expose(const SDL_Rect& region)
+{
+	DBG_DP << "window::expose " << region << std::endl;
+	rect i = get_rectangle().intersect(region);
+	i.clip(draw::get_clip());
+	if (i.empty()) {
+		return false;
 	}
+	draw();
+	return true;
+}
+
+rect window::screen_location()
+{
+	return get_rectangle();
 }
 
 window::invalidate_layout_blocker::invalidate_layout_blocker(window& window)
@@ -869,6 +715,11 @@ void window::remove_linked_widget(const std::string& id, const widget* wgt)
 
 void window::layout()
 {
+	if(!need_layout_) {
+		return;
+	}
+	DBG_DP << "window::layout" << std::endl;
+
 	/***** Initialize. *****/
 
 	const auto conf = cast_config_to<window_definition>();
@@ -1121,17 +972,6 @@ bool window::click_dismiss(const int mouse_button_mask)
 		return true;
 	}
 	return false;
-}
-
-void window::redraw_windows_on_top() const
-{
-	std::vector<dispatcher*>& dispatchers = event::get_all_dispatchers();
-	auto me = std::find(dispatchers.begin(), dispatchers.end(), this);
-
-	for(auto it = std::next(me); it != dispatchers.end(); ++it) {
-		// Note that setting an entire window dirty like this is expensive.
-		dynamic_cast<widget&>(**it).set_is_dirty(true);
-	}
 }
 
 void window::finalize(const builder_grid& content_grid)

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -38,7 +38,7 @@ const int NO_HALO = 0;
 class manager
 {
 public:
-	manager(display& screen);
+	manager();
 
 	/**
 	 * Add a haloing effect using 'image centered on (x,y).
@@ -58,13 +58,11 @@ public:
 	/** Remove the halo with the given handle. */
 	void remove(const handle & h);
 
-	/**
-	 * Render and unrender haloes.
-	 *
-	 * Which haloes are rendered is determined by invalidated_locations and the
-	 * internal state in the control sets (in halo.cpp).
-	 */
-	void unrender(std::set<map_location> invalidated_locations);
+	/** Process animations, remove deleted halos, and invalidate screen
+	  * regions now requiring redraw. */
+	void update();
+
+	/** Render halos. */
 	void render();
 
 private:

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -213,10 +213,10 @@ void show_with_toplevel(const section &toplevel_sec,
 	gui::button close_button_(video, _("Close"));
 	buttons_ptr.push_back(&close_button_);
 
-	gui::dialog_frame f(video, _("Help"), gui::dialog_frame::default_style,
-					 true, &buttons_ptr);
+	gui::dialog_frame f(
+		video, _("Help"), gui::dialog_frame::default_style, &buttons_ptr
+	);
 	f.layout(xloc, yloc, width, height);
-	f.draw();
 
 	// Find all unit_types that have not been constructed yet and fill in the information
 	// needed to create the help topics
@@ -250,8 +250,6 @@ void show_with_toplevel(const section &toplevel_sec,
 		for (;;) {
 			events::pump();
 			events::raise_process_event();
-			f.draw();
-			events::raise_draw_event();
 			if (key[SDLK_ESCAPE]) {
 				// Escape quits from the dialog.
 				return;
@@ -263,8 +261,8 @@ void show_with_toplevel(const section &toplevel_sec,
 					return;
 				}
 			}
-			video.render_screen();
-			CVideo::delay(10);
+			// This also rate limits to vsync
+			events::raise_draw_event();
 		}
 	}
 	catch (const parse_error& e) {

--- a/src/help/help_menu.cpp
+++ b/src/help/help_menu.cpp
@@ -35,7 +35,6 @@ help_menu::help_menu(CVideo &video, const section& toplevel, int max_height) :
 	visible_items_(),
 	toplevel_(toplevel),
 	expanded_(),
-	restorer_(),
 	chosen_topic_(nullptr),
 	selected_item_(&toplevel, "", 0)
 {

--- a/src/help/help_menu.hpp
+++ b/src/help/help_menu.hpp
@@ -21,7 +21,6 @@
 #include "widgets/menu.hpp"             // for menu
 
 class CVideo;
-struct surface_restorer;
 
 namespace help { struct section; }
 namespace help { struct topic; }
@@ -104,7 +103,6 @@ private:
 	std::vector<visible_item> visible_items_;
 	const section &toplevel_;
 	std::set<const section*> expanded_;
-	surface_restorer restorer_;
 	topic const *chosen_topic_;
 	visible_item selected_item_;
 };

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -542,7 +542,7 @@ int help_text_area::get_remaining_width()
 void help_text_area::draw_contents()
 {
 	const SDL_Rect& loc = inner_location();
-	bg_restore();
+	//bg_restore();
 	auto clipper = draw::set_clip(loc);
 	for(std::list<item>::const_iterator it = items_.begin(), end = items_.end(); it != end; ++it) {
 		SDL_Rect dst = it->rect_;

--- a/src/hotkey/command_executor.hpp
+++ b/src/hotkey/command_executor.hpp
@@ -18,6 +18,8 @@
 #include "hotkey_command.hpp"
 #include "game_end_exceptions.hpp"
 
+#include <SDL2/SDL_events.h>
+
 class display;
 class CVideo;
 

--- a/src/map/label.cpp
+++ b/src/map/label.cpp
@@ -496,8 +496,9 @@ void terrain_label::calculate_shroud()
 
 	// tooltips::update_tooltip(tooltip_handle, get_rect(), tooltip_.str(), "", true);
 
+	// TODO: draw_manager - why the fuck is this happening in "calculate_shroud"?
 	if(tooltip_handle_) {
-		tooltips::update_tooltip(tooltip_handle_, get_rect(), tooltip_.str(), "", true);
+		tooltips::update_tooltip(tooltip_handle_, get_rect(), tooltip_.str());
 	} else {
 		tooltip_handle_ = tooltips::add_tooltip(get_rect(), tooltip_.str());
 	}

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -394,6 +394,11 @@ void mouse_handler::mouse_motion(int x, int y, const bool browse, bool update, m
 		return;
 	}
 
+	// Don't process other motion events while scrolling
+	if(scroll_started_) {
+		return;
+	}
+
 	if(new_hex == map_location::null_location()) {
 		new_hex = gui().hex_clicked_on(x, y);
 	}

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -229,6 +229,9 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 					last_hex_ = loc;
 					gui().scroll_to_tile(loc, display::WARP, false);
 				}
+			} else {
+				// Deselect the current tile as we're scrolling
+				gui().highlight_hex({-1,-1});
 			}
 		} else if(event.state == SDL_RELEASED) {
 			minimap_scrolling_ = false;

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -138,7 +138,7 @@ static void clear_resources()
 	resources::classification = nullptr;
 }
 
-play_controller::play_controller(const config& level, saved_game& state_of_game, bool skip_replay)
+play_controller::play_controller(const config& level, saved_game& state_of_game, bool skip_replay, bool start_faded)
 	: controller_base()
 	, observer()
 	, quit_confirmation()
@@ -165,6 +165,7 @@ play_controller::play_controller(const config& level, saved_game& state_of_game,
 	, linger_(false)
 	, init_side_done_now_(false)
 	, map_start_()
+	, start_faded_(start_faded)
 	, victory_when_enemies_defeated_(level["victory_when_enemies_defeated"].to_bool(true))
 	, remove_from_carryover_on_defeat_(level["remove_from_carryover_on_defeat"].to_bool(true))
 	, victory_music_()
@@ -239,6 +240,9 @@ void play_controller::init(const config& level)
 
 		gui_.reset(new game_display(gamestate().board_, whiteboard_manager_, *gamestate().reports_, theme(), level));
 		map_start_ = map_location(level.child_or_empty("display").child_or_empty("location"));
+		if(start_faded_) {
+			gui_->set_fade({0,0,0,255});
+		}
 
 		// Ensure the loading screen doesn't end up underneath the game display
 		gui2::dialogs::loading_screen::raise();

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -236,8 +236,12 @@ void play_controller::init(const config& level)
 
 		LOG_NG << "building terrain rules... " << (SDL_GetTicks() - ticks()) << std::endl;
 		gui2::dialogs::loading_screen::progress(loading_stage::build_terrain);
+
 		gui_.reset(new game_display(gamestate().board_, whiteboard_manager_, *gamestate().reports_, theme(), level));
 		map_start_ = map_location(level.child_or_empty("display").child_or_empty("location"));
+
+		// Ensure the loading screen doesn't end up underneath the game display
+		gui2::dialogs::loading_screen::raise();
 
 		if(!gui_->video().faked()) {
 			if(saved_game_.mp_settings().mp_countdown) {

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -285,9 +285,6 @@ void play_controller::init(const config& level)
 		plugins_context_->set_callback("quit", [](const config&) { throw_quit_game_exception(); }, false);
 		plugins_context_->set_accessor_string("scenario_name", [this](config) { return get_scenario_name(); });
 	});
-
-	// Do this after the loadingscreen, so that ita happens in the main thread.
-	gui_->join();
 }
 
 void play_controller::reset_gamestate(const config& level, int replay_pos)
@@ -332,7 +329,6 @@ void play_controller::reset_gamestate(const config& level, int replay_pos)
 void play_controller::init_managers()
 {
 	LOG_NG << "initializing managers... " << (SDL_GetTicks() - ticks()) << std::endl;
-	tooltips_manager_.reset(new tooltips::manager());
 	soundsources_manager_.reset(new soundsource::manager(*gui_));
 
 	resources::soundsources = soundsources_manager_.get();

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -80,7 +80,10 @@ class game_state;
 class play_controller : public controller_base, public events::observer, public quit_confirmation
 {
 public:
-	play_controller(const config& level, saved_game& state_of_game, bool skip_replay);
+	play_controller(const config& level,
+			saved_game& state_of_game,
+			bool skip_replay,
+			bool start_faded = false);
 	virtual ~play_controller();
 
 	//event handler, overridden from observer
@@ -399,6 +402,9 @@ protected:
 	bool init_side_done_now_;
 	//the displayed location when we load a game.
 	map_location map_start_;
+	// Whether to start with the display faded to black
+	bool start_faded_;
+
 	const std::string& select_music(bool victory) const;
 
 	void reset_gamestate(const config& level, int replay_pos);

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -67,7 +67,7 @@ namespace pathfind {
 }
 
 namespace tooltips {
-	struct manager;
+	class manager;
 } // namespace tooltips
 
 namespace wb {
@@ -364,7 +364,7 @@ protected:
 	saved_game& saved_game_;
 
 	//managers
-	std::unique_ptr<tooltips::manager> tooltips_manager_;
+	tooltips::manager tooltips_manager_;
 
 	//whiteboard manager
 	std::shared_ptr<wb::manager> whiteboard_manager_;

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -217,16 +217,14 @@ void playmp_controller::set_end_scenario_button()
 	}
 
 	gui_->get_theme().refresh_title2("button-endturn", "title2");
-	gui_->invalidate_theme();
-	gui_->redraw_everything();
+	gui_->redraw_everything(); // TODO: draw_manager - verify this is right
 }
 
 void playmp_controller::reset_end_scenario_button()
 {
 	// revert the end-turn button text to its normal label
 	gui_->get_theme().refresh_title2("button-endturn", "title");
-	gui_->invalidate_theme();
-	gui_->redraw_everything();
+	gui_->redraw_everything();// TODO: draw_manager - verify this is right
 	gui_->set_game_mode(game_display::RUNNING);
 }
 
@@ -416,7 +414,6 @@ void playmp_controller::handle_generic_event(const std::string& name)
 		mp_info_->is_host = true;
 		if(linger_) {
 			end_turn_enable(true);
-			gui_->invalidate_theme();
 		}
 	}
 }

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -66,7 +66,7 @@ static lg::log_domain log_enginerefac("enginerefac");
 #define LOG_RG LOG_STREAM(info, log_enginerefac)
 
 playsingle_controller::playsingle_controller(const config& level, saved_game& state_of_game, bool skip_replay)
-	: play_controller(level, state_of_game, skip_replay)
+	: play_controller(level, state_of_game, skip_replay, true) // start faded
 	, cursor_setter_(cursor::NORMAL)
 	, textbox_info_()
 	, replay_sender_(*resources::recorder)
@@ -127,6 +127,13 @@ void playsingle_controller::init_gui()
 		} else {
 			LOG_NG << "Found bad stored ui location\n";
 		}
+	}
+
+	// Fade in
+	if(!gui_->video().any_fake()) {
+		gui_->fade_to({0,0,0,0}, 500);
+	} else {
+		gui_->set_fade({0,0,0,0});
 	}
 
 	update_locker lock_display(gui_->video(), is_skipping_replay());

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -518,7 +518,6 @@ void playsingle_controller::linger()
 
 	// change the end-turn button text to its alternate label
 	gui_->get_theme().refresh_title2("button-endturn", "title2");
-	gui_->invalidate_theme();
 	gui_->redraw_everything();
 
 	try {
@@ -537,7 +536,6 @@ void playsingle_controller::linger()
 
 	// revert the end-turn button text to its normal label
 	gui_->get_theme().refresh_title2("button-endturn", "title");
-	gui_->invalidate_theme();
 	gui_->redraw_everything();
 	gui_->set_game_mode(game_display::RUNNING);
 

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -201,7 +201,8 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			if(side_changed) {
 				display::get_singleton()->redraw_everything();
 				display::get_singleton()->recalculate_minimap();
-				video2::trigger_full_redraw();
+				// TODO: decide what should replace this
+				//video2::trigger_full_redraw();
 			}
 		};
 

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -97,9 +97,6 @@ void replay_controller::add_replay_theme()
 		if (const auto replay_theme_cfg = res->optional_child("replay")) {
 			controller_.get_display().get_theme().modify(replay_theme_cfg.value());
 		}
-		//Make sure we get notified if the theme is redrawn completely. That way we have
-		//a chance to restore the replay controls of the theme as well.
-		controller_.get_display().invalidate_theme();
 	}
 }
 
@@ -144,7 +141,7 @@ void replay_controller::update_gui()
 
 void replay_controller::update_enabled_buttons()
 {
-	controller_.get_display().invalidate_theme();
+	// TODO: draw_manager - is this the right call?
 	controller_.get_display().redraw_everything();
 }
 

--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -76,7 +76,7 @@ int intf_show_dialog(lua_State* L)
 	}
 
 	gui2::open_window_stack.push_back(wp.get());
-	int v = wp->show(true, 0);
+	int v = wp->show();
 	gui2::remove_from_window_stack(wp.get());
 
 	if (!lua_isnoneornil(L, 3)) {
@@ -330,7 +330,7 @@ static int intf_set_dialog_canvas(lua_State* L)
 
 	config cfg = luaW_checkconfig(L, 3);
 	cv[i - 1].set_cfg(cfg);
-	c->set_is_dirty(true);
+	c->queue_redraw();
 	return 0;
 }
 

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -83,6 +83,12 @@ rect rect::minimal_cover(const SDL_Rect& other) const
 	return result;
 }
 
+rect& rect::expand_to_cover(const SDL_Rect& other)
+{
+	SDL_UnionRect(this, &other, this);
+	return *this;
+}
+
 rect rect::intersect(const SDL_Rect& other) const
 {
 	rect result;

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -70,6 +70,9 @@ public:
 	rect operator/(int s) const { return {x/s, y/s, w/s, h/s}; }
 	rect& operator/=(int s) { x/=s; y/=s; w/=s; h/=s; return *this; }
 
+	/** The area of this rectangle, in square pixels. */
+	int area() const { return w * h; }
+
 	/** False if both w and h are > 0, true otherwise. */
 	bool empty() const;
 
@@ -88,6 +91,9 @@ public:
 	 * this rectangle and the given rectangle.
 	 */
 	rect minimal_cover(const SDL_Rect& r) const;
+
+	/** Minimally expand this rect to fully contain another. */
+	rect& expand_to_cover(const SDL_Rect& r);
 
 	/**
 	 * Calculates the intersection of this rectangle and another;

--- a/src/sdl/surface.cpp
+++ b/src/sdl/surface.cpp
@@ -15,9 +15,7 @@
 #include "sdl/surface.hpp"
 
 #include "color.hpp"
-#include "draw.hpp" // for surface_restorer. Remove that then remove this.
 #include "sdl/rect.hpp"
-#include "video.hpp" // for surface_restorer. Remove that then remove this.
 
 const SDL_PixelFormat surface::neutral_pixel_format = []() {
 	return *SDL_CreateRGBSurfaceWithFormat(0, 1, 1, 32, SDL_PIXELFORMAT_ARGB8888)->format;
@@ -81,67 +79,6 @@ void surface::free_surface()
 	if(surface_) {
 		SDL_FreeSurface(surface_);
 	}
-}
-
-surface_restorer::surface_restorer()
-	: target_(nullptr)
-	, rect_()
-	, surface_()
-{
-}
-
-surface_restorer::surface_restorer(CVideo* target, const rect& location)
-	: target_(target)
-	, rect_(location)
-	, surface_()
-{
-	update();
-}
-
-surface_restorer::~surface_restorer()
-{
-	restore();
-}
-
-void surface_restorer::restore(const rect& dst) const
-{
-	if(!surface_) {
-		return;
-	}
-
-	rect dst2 = rect_.intersect(dst);
-	if(dst2.w == 0 || dst2.h == 0) {
-		return;
-	}
-
-	rect src = dst2;
-	src.x -= rect_.x;
-	src.y -= rect_.y;
-	draw::blit(surface_, dst2, src);
-	//target_->blit_surface(dst2.x, dst2.y, surface_, &src, nullptr);
-}
-
-void surface_restorer::restore() const
-{
-	if(!surface_) {
-		return;
-	}
-
-	draw::blit(surface_, rect_);
-}
-
-void surface_restorer::update()
-{
-	if(rect_.w <= 0 || rect_.h <= 0) {
-		surface_.reset();
-	} else {
-		surface_ = texture(target_->read_pixels_low_res(&rect_));
-	}
-}
-
-void surface_restorer::cancel()
-{
-	surface_.reset();
 }
 
 bool operator<(const surface& a, const surface& b)

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "sdl/rect.hpp"
-#include "sdl/texture.hpp" // for surface_restorer. Remove that, then remove this
 #include "utils/const_clone.hpp"
 
 #include <SDL2/SDL.h>
@@ -115,25 +114,6 @@ private:
 bool operator<(const surface& a, const surface& b);
 
 std::ostream& operator<<(std::ostream& stream, const surface& surf);
-
-struct surface_restorer
-{
-	surface_restorer();
-	surface_restorer(class CVideo* target, const rect& location);
-	~surface_restorer();
-
-	void restore() const;
-	void restore(const rect& dst) const;
-	void update();
-	void cancel();
-
-	const rect& area() const { return rect_; }
-
-private:
-	class CVideo* target_;
-	rect rect_;
-	texture surface_;
-};
 
 /**
  * Helper class for pinning SDL surfaces into memory.

--- a/src/show_dialog.hpp
+++ b/src/show_dialog.hpp
@@ -19,6 +19,7 @@ class surface;
 
 #include "cursor.hpp"
 #include "floating_label.hpp"
+#include "gui/core/top_level_drawable.hpp"
 #include "tooltips.hpp"
 #include "video.hpp"
 #include "widgets/button.hpp"
@@ -49,7 +50,7 @@ private:
 	bool reset_to;
 };
 
-class dialog_frame :public video2::draw_layering {
+class dialog_frame : public gui2::top_level_drawable {
 public:
 	struct dimension_measurements {
 		dimension_measurements();
@@ -68,7 +69,7 @@ public:
 
 	dialog_frame(CVideo &video, const std::string& title="",
 		const style& dialog_style=default_style,
-		bool auto_restore=true, std::vector<button*>* buttons=nullptr,
+		std::vector<button*>* buttons=nullptr,
 		button* help_button=nullptr);
 	~dialog_frame();
 
@@ -82,6 +83,15 @@ public:
 
 	void draw();
 
+	/** Called by draw_manager to validate layout. */
+	virtual void layout() override;
+
+	/** Called by draw_manager when it believes a redraw is necessary. */
+	virtual bool expose(const SDL_Rect &region) override;
+
+	/** The current draw location of the window, on the screen. */
+	virtual rect screen_location() override;
+
 	//called by draw
 	void draw_border();
 	void draw_background();
@@ -91,9 +101,6 @@ public:
 
 	void set_dirty(bool dirty = true);
 
-	virtual void handle_event(const SDL_Event&);
-	void handle_window_event(const SDL_Event& event);
-
 private:
 	void clear_background();
 
@@ -102,7 +109,6 @@ private:
 	const style& dialog_style_;
 	std::vector<button*>* buttons_;
 	button* help_button_;
-	surface_restorer* restorer_;
 	bool auto_restore_;
 	dimension_measurements dim_;
 	texture top_, bot_, left_, right_, top_left_, bot_left_, top_right_, bot_right_, bg_;

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -15,13 +15,20 @@
 
 #include "tooltips.hpp"
 
+#include "draw_manager.hpp"
 #include "floating_label.hpp"
 #include "font/standard_colors.hpp"
 #include "game_display.hpp"
 #include "help/help.hpp"
+#include "log.hpp"
 #include "video.hpp"
 
-#include <SDL2/SDL_rect.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL2/SDL_sound.h>
+#include <SDL2/SDL_rect.h>
+
+static lg::log_domain log_font("font");
+#define DBG_FT LOG_STREAM(debug, log_font)
+
+using std::endl;
 
 namespace {
 
@@ -30,85 +37,87 @@ static const int text_width = 400;
 
 struct tooltip
 {
-	tooltip(const SDL_Rect& r, const std::string& msg, const std::string& act = "", bool use_markup = false, const surface& fg = surface())
-	: rect_(r), message(msg), action(act), markup(use_markup), foreground(fg)
-	{}
-	rect rect_;
+	tooltip(const SDL_Rect& r, const std::string& msg, const std::string& act = "");
+	rect origin;
+	rect loc = {};
 	std::string message;
 	std::string action;
-	bool markup;
-	surface foreground;
+	font::floating_label label;
 };
 
-std::map<int, tooltip> tips;
-std::map<int, tooltip>::const_iterator current_tooltip = tips.end();
+tooltip::tooltip(const SDL_Rect& r, const std::string& msg, const std::string& act)
+	: origin(r), message(msg), action(act), label(msg)
+{
+	const color_t bgcolor {0,0,0,192};
+	rect area = CVideo::get_singleton().draw_area();
+	unsigned int border = 10;
 
-int tooltip_handle = 0;
-int tooltip_id = 0;
+	label.set_font_size(font_size);
+	label.set_color(font::NORMAL_COLOR);
+	label.set_clip_rect(area);
+	label.set_width(text_width);
+	label.set_alignment(font::LEFT_ALIGN);
+	label.set_bg_color(bgcolor);
+	label.set_border_size(border);
+
+	label.create_texture();
+	point lsize = label.get_draw_size();
+	loc = {0, 0, lsize.x, lsize.y};
+
+	// See if there is enough room to fit it above the tip area
+	if(origin.y > loc.h) {
+		loc.y = origin.y - loc.h;
+	} else {
+		loc.y = origin.y + origin.h;
+	}
+
+	// Try to keep it within the screen
+	loc.x = origin.x;
+	if(loc.x < 0) {
+		loc.x = 0;
+	} else if(loc.x + loc.w > area.w) {
+		loc.x = area.w - loc.w;
+	}
+
+	label.move(loc.x, loc.y);
+
+	DBG_FT << "created tooltip for " << origin << " at " << loc << endl;
+}
+
+
+std::map<int, tooltip> tips;
+int active_tooltip = 0;
+
+int tooltip_id = 1;
 
 surface current_background = nullptr;
 
-}
+// Is this a freaking singleton or is it not?
+// This is horrible, but that's how the usage elsewhere is.
+// If you want to fix this, either make it an actual singleton,
+// or ensure that tooltips:: functions are called on an instance.
+tooltips::manager* current_manager = nullptr;
 
-static void clear_tooltip()
+} // anon namespace
+
+/** Clear/hide the active tooltip. */
+static void clear_active()
 {
-	if(tooltip_handle != 0) {
-		font::remove_floating_label(tooltip_handle);
-		tooltip_handle = 0;
-	}
-}
-
-static void show_tooltip(const tooltip& tip)
-{
-	CVideo& video = CVideo::get_singleton();
-
-	if(video.faked()) {
+	if(!active_tooltip) {
 		return;
 	}
-
-	clear_tooltip();
-
-	const color_t bgcolor {0,0,0,192};
-	SDL_Rect area = video.draw_area();
-
-	unsigned int border = 10;
-
-	font::floating_label flabel(tip.message, tip.foreground);
-	flabel.use_markup(tip.markup);
-	flabel.set_font_size(font_size);
-	flabel.set_color(font::NORMAL_COLOR);
-	flabel.set_clip_rect(area);
-	flabel.set_width(text_width);
-	flabel.set_alignment(font::LEFT_ALIGN);
-	flabel.set_bg_color(bgcolor);
-	flabel.set_border_size(border);
-
-	tooltip_handle = font::add_floating_label(flabel);
-
-	SDL_Rect rect = font::get_floating_label_rect(tooltip_handle);
-
-	//see if there is enough room to fit it above the tip area
-	if(tip.rect_.y > rect.h) {
-		rect.y = tip.rect_.y - rect.h;
-	} else {
-		rect.y = tip.rect_.y + tip.rect_.h;
-	}
-
-	rect.x = tip.rect_.x;
-	if(rect.x < 0) {
-		rect.x = 0;
-	} else if(rect.x + rect.w > area.w) {
-		rect.x = area.w - rect.w;
-	}
-
-	font::move_floating_label(tooltip_handle,rect.x,rect.y);
+	DBG_FT << "clearing active tooltip " << active_tooltip << endl;
+	tips.at(active_tooltip).label.undraw();
+	active_tooltip = 0;
 }
 
-namespace tooltips {
+namespace tooltips
+{
 
 manager::manager()
 {
 	clear_tooltips();
+	current_manager = this;
 }
 
 manager::~manager()
@@ -116,102 +125,154 @@ manager::~manager()
 	try {
 	clear_tooltips();
 	} catch (...) {}
+	current_manager = nullptr;
+}
+
+void manager::layout()
+{
+	if(!active_tooltip) {
+		return;
+	}
+	// Update the active tooltip's draw state.
+	// This will trigger redraws if necessary.
+	tips.at(active_tooltip).label.update(SDL_GetTicks());
+}
+
+bool manager::expose(const SDL_Rect& region)
+{
+	// Only the active tip is shown.
+	if(!active_tooltip) {
+		return false;
+	}
+	tooltip& tip = tips.at(active_tooltip);
+	if(!tip.loc.overlaps(region)) {
+		return false;
+	}
+	tip.label.draw();
+	return true;
+}
+
+rect manager::screen_location()
+{
+	// Only the active tip, if any, should be visible.
+	if(!active_tooltip) {
+		return {};
+	} else {
+		return tips.at(active_tooltip).loc;
+	}
 }
 
 void clear_tooltips()
 {
-	clear_tooltip();
+	DBG_FT << "clearing all tooltips" << endl;
+	clear_active();
 	tips.clear();
-	current_tooltip = tips.end();
 }
 
 void clear_tooltips(const SDL_Rect& r)
 {
-	for(std::map<int,tooltip>::iterator i = tips.begin(); i != tips.end(); ) {
-		if(i->second.rect_.overlaps(r)) {
-			if (i==current_tooltip) {
-				clear_tooltip();
+	for(auto i = tips.begin(); i != tips.end(); ) {
+		if(i->second.origin.overlaps(r)) {
+			DBG_FT << "clearing tip " << i->first << " at "
+				<< i->second.origin << " overlapping " << r << endl;
+
+			if (i->first == active_tooltip) {
+				i->second.label.undraw();
+				active_tooltip = 0;
 			}
+
 			i = tips.erase(i);
-			current_tooltip = tips.end();
 		} else {
 			++i;
 		}
 	}
 }
 
-
-
-bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message,
-		const std::string& action, bool use_markup)
+bool update_tooltip(int id, const SDL_Rect& origin, const std::string& message)
 {
+	// TODO: draw_manager - update floating label
 	std::map<int, tooltip>::iterator it = tips.find(id);
 	if (it == tips.end() ) return false;
-	it->second.action = action;
-	it->second.markup = use_markup;
 	it->second.message = message;
-	it->second.rect_ = rect;
-	return true;
-}
-
-bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message,
-		const std::string& action, bool use_markup, const surface& foreground)
-{
-	std::map<int, tooltip>::iterator it = tips.find(id);
-	if (it == tips.end() ) return false;
-	it->second.action = action;
-	it->second.foreground = foreground;
-	it->second.markup = use_markup;
-	it->second.message = message;
-	it->second.rect_ = rect;
+	it->second.origin = origin;
 	return true;
 }
 
 void remove_tooltip(int id)
 {
+	DBG_FT << "removing tooltip " << id << endl;
+	if(id == active_tooltip) {
+		clear_active();
+	}
 	tips.erase(id);
-	clear_tooltip();
 }
 
-int add_tooltip(const SDL_Rect& rect, const std::string& message, const std::string& action, bool use_markup, const surface& foreground)
+int add_tooltip(const SDL_Rect& origin, const std::string& message, const std::string& action)
 {
-	clear_tooltips(rect);
+	// Because some other things are braindead, we have to check we're not
+	// just adding the same tooltip over and over every time the mouse moves.
+	for(auto& [id, tip] : tips) {
+		if(tip.origin == origin && tip.message == message && tip.action == action) {
+			return id;
+		}
+	}
+	DBG_FT << "adding tooltip for " << origin << endl;
 
+	// Clear any existing tooltips for this origin
+	clear_tooltips(origin);
+	// Create and add a new tooltip
 	int id = tooltip_id++;
-
-	tips.emplace(id, tooltip(rect, message, action, use_markup, foreground));
-
-	current_tooltip = tips.end();
+	tips.emplace(id, tooltip(origin, message, action));
 	return id;
+}
+
+static void raise_to_top()
+{
+	// Raise the current manager so it will display on top of everything.
+	if(!current_manager) {
+		throw game::error("trying to show tooltip with no tooltip manager");
+	}
+	draw_manager::raise_drawable(current_manager);
+}
+
+static void select_active(int id)
+{
+	if(active_tooltip == id) {
+		return;
+	}
+	tooltip& tip = tips.at(id);
+	DBG_FT << "showing tip " << id << " for " << tip.origin << endl;
+	clear_active();
+	active_tooltip = id;
+	tip.label.update(SDL_GetTicks());
+	raise_to_top();
 }
 
 void process(int mousex, int mousey)
 {
-	for(std::map<int, tooltip>::const_iterator i = tips.begin(); i != tips.end(); ++i) {
-		if(mousex > i->second.rect_.x && mousey > i->second.rect_.y &&
-		   mousex < i->second.rect_.x + i->second.rect_.w && mousey < i->second.rect_.y + i->second.rect_.h) {
-			if(current_tooltip != i) {
-				show_tooltip(i->second);
-				current_tooltip = i;
-			}
-
+	point mouseloc{mousex, mousey};
+	for(auto& [id, tip] : tips) {
+		if(tip.origin.contains(mouseloc)) {
+			select_active(id);
 			return;
 		}
 	}
 
-	clear_tooltip();
-	current_tooltip = tips.end();
+	if(active_tooltip) {
+		DBG_FT << "clearing tooltip because none hovered" << endl;
+		clear_active();
+	}
 }
 
 bool click(int mousex, int mousey)
 {
-	for(std::map<int, tooltip>::const_iterator i = tips.begin(); i != tips.end(); ++i) {
-		if(!i->second.action.empty() && i->second.rect_.contains(mousex, mousey)) {
-			help::show_help(i->second.action);
+	for(auto& [id, tip] : tips) { (void)id;
+		if(!tip.action.empty() && tip.origin.contains(mousex, mousey)) {
+			help::show_help(tip.action);
 			return true;
 		}
 	}
 	return false;
 }
 
-}
+} // namespace tooltips

--- a/src/tooltips.hpp
+++ b/src/tooltips.hpp
@@ -15,26 +15,30 @@
 
 #pragma once
 
+#include "gui/core/top_level_drawable.hpp"
+#include "sdl/rect.hpp"
+
 #include <string>
-#include "sdl/surface.hpp"
 
 struct SDL_Rect;
 
 namespace tooltips {
 
-struct manager
+class manager : public gui2::top_level_drawable
 {
+public:
 	manager();
 	~manager();
+	// TLD interface
+	virtual void layout() override;
+	virtual bool expose(const SDL_Rect& region) override;
+	virtual rect screen_location() override;
 };
 
 void clear_tooltips();
 void clear_tooltips(const SDL_Rect& rect);
-int  add_tooltip(const SDL_Rect& rect, const std::string& message, const std::string& action ="", bool use_markup = true, const surface& foreground = surface(nullptr));
-bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message,
-		const std::string& action, bool use_markup, const surface& foreground);
-bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message,
-		const std::string& action, bool use_markup);
+int  add_tooltip(const SDL_Rect& rect, const std::string& message, const std::string& action ="");
+bool update_tooltip(int id, const SDL_Rect& rect, const std::string& message);
 void remove_tooltip(int id);
 void process(int mousex, int mousey);
 

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -208,20 +208,6 @@ void unit_drawer::redraw_unit (const unit & u) const
 	const int xdst = disp.get_location_x(dst);
 	const int ydst = disp.get_location_y(dst);
 
-	const int x = static_cast<int>(adjusted_params.offset * xdst + (1.0-adjusted_params.offset) * xsrc) + hex_size_by_2;
-	const int y = static_cast<int>(adjusted_params.offset * ydst + (1.0-adjusted_params.offset) * ysrc) + hex_size_by_2;
-
-	bool has_halo = ac.unit_halo_ && ac.unit_halo_->valid();
-	if(!has_halo && !u.image_halo().empty()) {
-		ac.unit_halo_ = halo_man.add(x, y - height_adjust, u.image_halo()+u.TC_image_mods(), map_location(-1, -1));
-	}
-	if(has_halo && u.image_halo().empty()) {
-		halo_man.remove(ac.unit_halo_);
-		ac.unit_halo_.reset();
-	} else if(has_halo) {
-		halo_man.set_location(ac.unit_halo_, x, y - height_adjust);
-	}
-
 	// We draw bars only if wanted, visible on the map view
 	bool draw_bars = ac.draw_bars_ ;
 	if (draw_bars) {
@@ -387,6 +373,35 @@ void unit_drawer::redraw_unit (const unit & u) const
 	}
 	params.y -= height_adjust_unit - height_adjust;
 	params.halo_y -= height_adjust_unit - height_adjust;
+	// TODO: params.halo_y is not used. Why is it set?
+
+	const int halo_x =
+		static_cast<int>(
+			adjusted_params.offset * xdst
+			+ (1.0 - adjusted_params.offset) * xsrc
+		)
+		+ hex_size_by_2;
+	const int halo_y =
+		static_cast<int>(
+			adjusted_params.offset * ydst
+			+ (1.0 - adjusted_params.offset) * ysrc
+		)
+		+ hex_size_by_2 - height_adjust_unit * zoom_factor;
+
+	bool has_halo = ac.unit_halo_ && ac.unit_halo_->valid();
+	if(!has_halo && !u.image_halo().empty()) {
+		ac.unit_halo_ = halo_man.add(
+			halo_x, halo_y,
+			u.image_halo() + u.TC_image_mods(),
+			map_location(-1, -1)
+		);
+	}
+	if(has_halo && u.image_halo().empty()) {
+		halo_man.remove(ac.unit_halo_);
+		ac.unit_halo_.reset();
+	} else if(has_halo) {
+		halo_man.set_location(ac.unit_halo_, halo_x, halo_y);
+	}
 
 	ac.anim_->redraw(params, halo_man);
 	ac.refreshing_ = false;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2639,6 +2639,7 @@ void unit::set_hidden(bool state) const
 		return;
 	}
 
+	// TODO: this should really hide the halo, not destroy it
 	// We need to get rid of haloes immediately to avoid display glitches
 	anim_comp_->clear_haloes();
 }

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -76,6 +76,8 @@ public:
 		return fake_screen_;
 	}
 
+	bool any_fake() const;
+
 	bool non_interactive() const;
 
 	bool surface_initialized() const;
@@ -463,15 +465,3 @@ public:
 private:
 	CVideo& video_;
 };
-
-namespace video2
-{
-class draw_layering : public events::sdl_handler
-{
-protected:
-	draw_layering(const bool auto_join = true);
-	virtual ~draw_layering();
-};
-
-void trigger_full_redraw();
-}

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -32,6 +32,7 @@
 #include "wml_separators.hpp"
 
 #include <numeric>
+#include <iostream>
 
 namespace gui {
 
@@ -664,8 +665,8 @@ void menu::handle_event(const SDL_Event& event)
 			const int item = hit(event.motion.x,event.motion.y);
 			const bool out = (item == -1);
 			if (out_ != out) {
-					out_ = out;
-					invalidate_row_pos(selected_);
+				out_ = out;
+				invalidate_row_pos(selected_);
 			}
 			if (item != -1) {
 				move_selection_to(item);
@@ -777,9 +778,9 @@ SDL_Rect menu::style::item_size(const std::string& item) const {
 	return res;
 }
 
-void menu::style::draw_row_bg(menu& menu_ref, const std::size_t /*row_index*/, const SDL_Rect& rect, ROW_TYPE type)
+void menu::style::draw_row_bg(menu& /*menu_ref*/, const std::size_t /*row_index*/, const SDL_Rect& rect, ROW_TYPE type)
 {
-	menu_ref.bg_restore(rect);
+	//menu_ref.bg_restore(rect);
 
 	int rgb = 0;
 	double alpha = 0.0;
@@ -969,11 +970,10 @@ void menu::draw_contents()
 	}
 }
 
-void menu::draw()
+
+void menu::layout()
 {
-	if(hidden()) {
-		return;
-	}
+	widget::layout();
 
 	if(!dirty()) {
 
@@ -986,7 +986,7 @@ void menu::draw()
 			} else if(*i >= 0 && *i < int(item_pos_.size())) {
 				const unsigned int pos = item_pos_[*i];
 				const SDL_Rect& rect = get_item_rect(*i);
-				bg_restore(rect);
+				queue_redraw(rect);
 				style_->draw_row(*this,pos,rect,
 					(!out_ && pos == selected_) ? SELECTED_ROW : NORMAL_ROW);
 			}
@@ -998,17 +998,7 @@ void menu::draw()
 
 	invalid_.clear();
 
-	bg_restore();
-
-	const SDL_Rect* clip = clip_rect();
-	if (clip) {
-		auto clipper = draw::set_clip(*clip);
-		draw_contents();
-	} else {
-		draw_contents();
-	}
-
-	set_dirty(false);
+	queue_redraw();
 }
 
 int menu::hit(int x, int y) const

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -166,6 +166,9 @@ public:
 	virtual void set_items(const std::vector<std::string>& items, bool strip_spaces=true,
 				   bool keep_viewport=false);
 
+	/** top_level_drawable */
+	virtual void layout() override;
+
 	/**
 	 * Set a new max height for this menu. Note that this does not take
 	 * effect immediately, only after certain operations that clear
@@ -186,7 +189,8 @@ public:
 	void set_click_selects(bool value);
 	void set_numeric_keypress_selection(bool value);
 
-	void scroll(unsigned int pos);
+	// scrollarea override
+	void scroll(unsigned int pos) override;
 
 	//currently, menus do not manage the memory of their sorter
 	//this should be changed to a more object-oriented approach
@@ -197,10 +201,10 @@ public:
 
 protected:
 	bool item_ends_with_image(const std::string& item) const;
-	virtual void handle_event(const SDL_Event& event);
-	void set_inner_location(const SDL_Rect& rect);
+	virtual void handle_event(const SDL_Event& event) override;
+	void set_inner_location(const SDL_Rect& rect) override;
 
-	bool requires_event_focus(const SDL_Event *event=nullptr) const;
+	bool requires_event_focus(const SDL_Event *event=nullptr) const override;
 	const std::vector<int>& column_widths() const;
 	virtual void draw_row(const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE type);
 
@@ -236,7 +240,7 @@ private:
 	mutable int heading_height_;
 
 	void create_help_strings();
-	void process_help_string(int mousex, int mousey);
+	void process_help_string(int mousex, int mousey) override;
 
 	std::pair<int,int> cur_help_;
 	int help_string_;
@@ -256,8 +260,7 @@ private:
 	void column_widths_item(const std::vector<std::string>& row, std::vector<int>& widths) const;
 
 	void clear_item(int item);
-	void draw_contents();
-	void draw();
+	void draw_contents() override;
 
 	mutable std::map<int,SDL_Rect> itemRects_;
 

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -173,6 +173,13 @@ void textbox::draw_cursor(int pos) const
 	}
 }
 
+void textbox::layout()
+{
+	if(text_image_ == nullptr) {
+		update_text_cache(true);
+	}
+}
+
 void textbox::draw_contents()
 {
 	const SDL_Rect& loc = inner_location();
@@ -185,10 +192,6 @@ void textbox::draw_contents()
 	draw::fill(loc, c);
 
 	rect src;
-
-	if(text_image_ == nullptr) {
-		update_text_cache(true);
-	}
 
 	if(text_image_ != nullptr) {
 		src.y = yscroll_;
@@ -709,17 +712,9 @@ void textbox::handle_event(const SDL_Event& event, bool was_forwarded)
 
 	if (event.type == SDL_TEXTINPUT && listening_) {
 		changed = handle_text_input(event);
-	} else
-		if (event.type == SDL_KEYDOWN) {
-			changed = handle_key_down(event);
+	} else if (event.type == SDL_KEYDOWN) {
+		changed = handle_key_down(event);
 	}
-	else {
-		if(event.type != SDL_KEYDOWN || (!was_forwarded && focus(&event) != true)) {
-			draw();
-			return;
-		}
-	}
-
 
 	if(is_selection() && (selend_ != cursor_))
 		selstart_ = selend_ = -1;

--- a/src/widgets/textbox.hpp
+++ b/src/widgets/textbox.hpp
@@ -49,11 +49,15 @@ public:
 
 	void set_edit_target(textbox* target);
 
+	/** Called by draw_manager to validate layout. */
+	virtual void layout() override;
+
 protected:
-	virtual void draw_contents();
-	virtual void update_location(const SDL_Rect& rect);
-	virtual void set_inner_location(const SDL_Rect& );
-	virtual void scroll(unsigned int pos);
+	// scrollarea overrides
+	virtual void draw_contents() override;
+	virtual void update_location(const SDL_Rect& rect) override;
+	virtual void set_inner_location(const SDL_Rect& ) override;
+	virtual void scroll(unsigned int pos) override;
 
 private:
 	virtual void handle_text_changed(const std::u32string&) {}
@@ -101,7 +105,7 @@ private:
 
 	void handle_event(const SDL_Event& event, bool was_forwarded);
 
-	void handle_event(const SDL_Event& event);
+	void handle_event(const SDL_Event& event) override;
 
 	void pass_event_to_target(const SDL_Event& event);
 
@@ -113,7 +117,7 @@ private:
 
 	//make it so that only one textbox object can be receiving
 	//events at a time.
-	bool requires_event_focus(const SDL_Event *event=nullptr) const;
+	bool requires_event_focus(const SDL_Event *event=nullptr) const override;
 
 	bool show_scrollbar() const;
 	bool handle_text_input(const SDL_Event& event);

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "events.hpp"
+#include "gui/core/top_level_drawable.hpp"
 #include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
 
@@ -25,7 +26,8 @@ class CVideo;
 
 namespace gui {
 
-class widget : public events::sdl_handler
+// TODO: making widgets TLDs is horrible. Please move everything to GUI2.
+class widget : public events::sdl_handler, public gui2::top_level_drawable
 {
 public:
 	const rect& location() const;
@@ -49,26 +51,22 @@ public:
 
 	void set_clip_rect(const SDL_Rect& rect);
 
-	//Function to set the widget to draw in 'volatile' mode.
-	//When in 'volatile' mode, instead of using the normal
-	//save-background-redraw-when-dirty procedure, redrawing is done
-	//every frame, and then after every frame the area under the widget
-	//is restored to the state it was in before the frame. This is useful
-	//for drawing widgets with alpha components in volatile settings where
-	//the background may change at any time.
-	//(e.g. for putting widgets on top of the game map)
-	void set_volatile(bool val=true);
+	/** Indicate that the widget should be redrawn. */
+	void queue_redraw();
+	/** Indicate that a specific region of the screen should be redrawn.
+	  * This is in absolute drawing coordinates, and is not clipped. */
+	void queue_redraw(const rect&);
 
-	void set_dirty(bool dirty=true);
-	bool dirty() const;
+	void set_dirty(bool dirty=true); // TODO: draw_manager - remove
+	bool dirty() const; // TODO: draw_manager - remove
 	const std::string& id() const;
 	void set_id(const std::string& id);
 
 	void set_help_string(const std::string& str);
 	void set_tooltip_string(const std::string& str);
 
-	virtual void process_help_string(int mousex, int mousey);
-	virtual void process_tooltip_string(int mousex, int mousey);
+	virtual void process_help_string(int mousex, int mousey) override;
+	virtual void process_tooltip_string(int mousex, int mousey) override;
 
 protected:
 	widget(CVideo& video, const bool auto_join=true);
@@ -76,25 +74,35 @@ protected:
 
 	// During each relocation, this function should be called to register
 	// the rectangles the widget needs to refresh automatically
-	void bg_register(const SDL_Rect& rect);
-	void bg_restore() const;
-	void bg_restore(const SDL_Rect& rect) const;
-	void bg_update();
-	void bg_cancel();
+	void bg_register(const SDL_Rect& rect); // TODO: draw_manager - remove
+	void bg_restore() const; // TODO: draw_manager - remove
+	void bg_restore(const SDL_Rect& rect) const; // TODO: draw_manager - remove
+	void bg_update(); // TODO: draw_manager - remove
+	void bg_cancel(); // TODO: draw_manager - remove
 
 	CVideo& video() const { return *video_; }
 
 public:
-	virtual void draw();
+	/* draw_manager interface */
+
+	/** Called by draw_manager to validate layout. */
+	virtual void layout() override;
+	/** Called by draw_manager when it believes a redraw is necessary. */
+	virtual bool expose(const SDL_Rect &region) override;
+	/** The current draw location of the display, on the screen. */
+	virtual rect screen_location() override { return location(); }
+
+public:
+	virtual void draw() override; // TODO: draw_manager - private nonvirtual
 protected:
 	virtual void draw_contents() {}
 	virtual void update_location(const SDL_Rect& rect);
 
 	const SDL_Rect* clip_rect() const;
-	virtual sdl_handler_vector member_handlers() { return sdl_handler::handler_members(); }
 
-	virtual void handle_event(const SDL_Event&);
-	virtual void handle_window_event(const SDL_Event& event);
+	// TODO: draw_manager - only things that need events should be handlers
+	virtual void handle_event(const SDL_Event&) override {};
+	virtual void handle_window_event(const SDL_Event&) override {};
 	bool focus_;		// Should user input be ignored?
 
 	bool mouse_locked() const;
@@ -102,13 +110,10 @@ protected:
 	void aquire_mouse_lock();
 	void free_mouse_lock();
 private:
-	void volatile_draw();
-	void volatile_undraw();
-
 	void hide_override(bool value = true);
 
 	CVideo* video_;
-	std::vector< surface_restorer > restorer_;
+	std::vector<rect> restorer_;
 	rect rect_;
 	mutable bool needs_restore_; // Have we drawn ourselves, so that if moved, we need to restore the background?
 
@@ -117,8 +122,6 @@ private:
 	bool enabled_;
 	bool clip_;
 	SDL_Rect clip_rect_;
-
-	bool volatile_;
 
 	std::string help_text_;
 	std::string tooltip_text_;


### PR DESCRIPTION
This is now basically feature-complete and fully functional.

It is a complete overhaul of the way things are drawn to the screen.

In summary:

 * objects no-longer draw by hooking a draw event. In stead they inherit from a new (mostly-)abstract base class `gui2::top_level_drawable`, and implement its interface.
 * the gamemap now renders to an offscreen buffer. This is used to implement hardware scrolling, and to redraw after halos, floating labels etc. move.
 * halos, floating labels, tooltips, and a few more things are now drawn on top of the gamemap, rather than as part of it. This allows them to be updated independently without reading pixels from the screen.
 * surface restorers have been removed. Reading pixels from the screen should now be unnecessary excepting two cases: (a) screenshots, (b) background blur. Blur is cached, and screenshots are occasional.
 * GUI2 widgets no longer keep track of dirty state. They are redrawn as necessary. Most places which previously set dirty state now queue a redraw in their part of the screen in stead.
 * A consequence is that active translucency is enabled across all UI elements, and the game display can (and does) continue to animate while menus and dialogs are showing.
 * performance is drastically increased for basically everything, most notably map scrolling, floating text, and halos.
 * CPU usage is drastically decreased. With animations disabled it is essentially zero while nothing is moving.
 * GPU usage is also minimal. The display is only flipped if something is drawn.

I haven't merged with new_rendering yet, but that shouldn't be too much trouble. For now i'm putting this up in a state that can be tested. There will be bugs. But there shouldn't be anything too major or insoluble.

Apologies for the megacommit, but it really was a mess. Easier just to commit the final cleaned version than try to preserve any separable changes.