### PR TITLE
Don't include <iostream> in every single file

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <ctime>
 #include <mutex>
+#include <iostream>
 #include <iomanip>
 
 namespace {

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -51,7 +51,7 @@
  #endif
 #endif
 
-#include <iostream> // needed else all files including log.hpp need to do it.
+#include <iosfwd> // needed else all files including log.hpp need to do it.
 #include <sstream> // as above. iostream (actually, iosfwd) declares stringstream as an incomplete type, but does not define it
 #include <string>
 #include <utility>

--- a/src/log_windows.cpp
+++ b/src/log_windows.cpp
@@ -26,6 +26,7 @@
 
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 
 #include <boost/algorithm/string/predicate.hpp>
 

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -50,6 +50,7 @@
 #include <csignal>
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 
 // the fork execute is unix specific only tested on Linux quite sure it won't
 // work on Windows not sure which other platforms have a problem with it.

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -49,6 +49,7 @@
 #include <queue>
 #include <sstream>
 #include <string>
+#include <iostream>
 
 
 static lg::log_domain log_server("server");

--- a/src/server/common/simple_wml.cpp
+++ b/src/server/common/simple_wml.cpp
@@ -13,7 +13,6 @@
 	See the COPYING file for more details.
 */
 
-#include <iostream>
 #include <sstream>
 
 #include <boost/iostreams/copy.hpp>

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -54,6 +54,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <functional>
+#include <iostream>
 #include <iomanip>
 #include <map>
 #include <queue>

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -99,6 +99,7 @@
 #include <ctime>     // for time, ctime, std::time_t
 #include <exception> // for exception
 #include <vector>
+#include <iostream>
 
 //#define NO_CATCH_AT_GAME_END
 

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -32,7 +32,6 @@
 #include "wml_separators.hpp"
 
 #include <numeric>
-#include <iostream>
 
 namespace gui {
 

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -23,8 +23,6 @@
 #include "tooltips.hpp"
 
 #include <cassert>
-#include <iostream>
-
 namespace {
 	const SDL_Rect EmptyRect {-1234,-1234,0,0};
 }


### PR DESCRIPTION
We don't want std::cerr to be used at all, and std::cout is only for certain special
cases such as command-line responses.

Therefore, log.hpp should not include <iostream>.

This is open as a PR to make sure there are no CI failures.