### PR TITLE
Submerge items on water, just like units

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/04_The_Bay_of_Pearls.cfg
@@ -180,20 +180,20 @@
         {OBJ_TRIDENT_STORM 5 4 bop_stormtrident}
 
         #when certain villages are entered, Merfolk are rescued
-        {PLACE_IMAGE "units/merfolk/fighter.png~RC(magenta>red)" 5 38}
-        {PLACE_IMAGE items/cage.png 5 38}
+        {PLACE_IMAGE_SUBMERGED "units/merfolk/fighter.png~RC(magenta>red)" 5 38}
+        {PLACE_IMAGE_SUBMERGED items/cage.png 5 38}
 
-        {PLACE_IMAGE "units/merfolk/fighter.png~RC(magenta>red)" 7 35}
-        {PLACE_IMAGE items/cage.png 7 35}
+        {PLACE_IMAGE_SUBMERGED "units/merfolk/fighter.png~RC(magenta>red)" 7 35}
+        {PLACE_IMAGE_SUBMERGED items/cage.png 7 35}
 
-        {PLACE_IMAGE "units/merfolk/fighter.png~RC(magenta>red)" 11 33}
-        {PLACE_IMAGE items/cage.png 11 33}
+        {PLACE_IMAGE_SUBMERGED "units/merfolk/fighter.png~RC(magenta>red)" 11 33}
+        {PLACE_IMAGE_SUBMERGED items/cage.png 11 33}
 
-        {PLACE_IMAGE "units/merfolk/fighter.png~RC(magenta>red)" 19 23}
-        {PLACE_IMAGE items/cage.png 19 23}
+        {PLACE_IMAGE_SUBMERGED "units/merfolk/fighter.png~RC(magenta>red)" 19 23}
+        {PLACE_IMAGE_SUBMERGED items/cage.png 19 23}
 
-        {PLACE_IMAGE "units/merfolk/fighter.png~RC(magenta>red)" 3 10}
-        {PLACE_IMAGE items/cage.png 3 10}
+        {PLACE_IMAGE_SUBMERGED "units/merfolk/fighter.png~RC(magenta>red)" 3 10}
+        {PLACE_IMAGE_SUBMERGED items/cage.png 3 10}
     [/event]
 
     [event]

--- a/data/core/editor/items.cfg
+++ b/data/core/editor/items.cfg
@@ -10,204 +10,238 @@
         id=altar_evil
         image=items/altar-evil.png
         name= _ "Evil Altar"
+        submerge=1
     [/item]
 
     [item]
         id=altar
         image=items/altar.png
         name= _ "Altar"
+        submerge=1
     [/item]
 
     [item]
         id=ankh-necklace
         image=items/ankh-necklace.png
         name= _ "Ankh Necklace"
+        submerge=1
     [/item]
 
     [item]
         id=ankh-necklace2
         image=items/ankh-necklace2.png
         name= _ "Ankh Necklace"
+        submerge=1
     [/item]
 
     [item]
         id=anvil
         image=items/anvil.png
         name= _ "Anvil"
+        submerge=1
     [/item]
 
     [item]
         id=archery-target
         image=items/archery-target-right.png
         name= _ "Archery Target"
+        submerge=1
     [/item]
 
     [item]
         id=armor-golden
         image=items/armor-golden.png
         name= _ "Golden Armor"
+        submerge=1
     [/item]
 
     [item]
         id=armor
         image=items/armor.png
         name= _ "Armor"
+        submerge=1
     [/item]
 
     [item]
         id=axe
         image=items/axe.png
         name= _ "Axe"
+        submerge=1
     [/item]
 
     [item]
         id=axe2
         image=items/axe-2.png
         name= _ "Axe"
+        submerge=1
     [/item]
 
     [item]
         id=axe-small
         image=items/axe-small.png
         name= _ "Small Axe"
+        submerge=1
     [/item]
 
     [item]
         id=axe-throwing
         image=items/axe-throwing.png
         name= _ "Throwing Axe"
+        submerge=1
     [/item]
 
     [item]
         id=ball-blue
         image=items/ball-blue.png
         name= _ "Blue Ball"
+        submerge=1
     [/item]
 
     [item]
         id=ball-green
         image=items/ball-green.png
         name= _ "Green Ball"
+        submerge=1
     [/item]
 
     [item]
         id=ball-magenta
         image=items/ball-magenta.png
         name= _ "Magenta Ball"
+        submerge=1
     [/item]
 
     [item]
         id=barrel
         image=items/barrel.png
         name= _ "Barrel"
+        submerge=1
     [/item]
 
     [item]
         id=bomb
         image=items/bomb.png
         name= _ "Bomb"
+        submerge=1
     [/item]
 
     [item]
         id=bones
         image=items/bones.png
         name= _ "Bones"
+        submerge=1
     [/item]
 
     [item]
         id=bonestack
         image=items/bonestack.png
         name= _ "Bonestack"
+        submerge=1
     [/item]
 
     [item]
         id=book1
         image=items/book1.png
         name= _ "Book"
+        submerge=1
     [/item]
 
     [item]
         id=book2
         image=items/book2.png
         name= _ "Book"
+        submerge=1
     [/item]
 
     [item]
         id=book3
         image=items/book3.png
         name= _ "Book"
+        submerge=1
     [/item]
 
     [item]
         id=book4
         image=items/book4.png
         name= _ "Book"
+        submerge=1
     [/item]
 
     [item]
         id=book5
         image=items/book5.png
         name= _ "Book"
+        submerge=1
     [/item]
 
     [item]
         id=bow
         image=items/bow.png
         name= _ "Bow"
+        submerge=1
     [/item]
 
     [item]
         id=bow2
         image=items/bow-2.png
         name= _ "Bow"
+        submerge=1
     [/item]
 
     [item]
         id=bow-crystal
         image=items/bow-crystal.png
         name= _ "Crystal Bow"
+        submerge=1
     [/item]
 
     [item]
         id=bow-crystal2
         image=items/bow-crystal-2.png
         name= _ "Crystal Bow"
+        submerge=1
     [/item]
 
     [item]
         id=bow-elven
         image=items/bow-elven.png
         name= _ "Elven Bow"
+        submerge=1
     [/item]
 
     [item]
         id=bow-elven2
         image=items/bow-elven-2.png
         name= _ "Elven Bow"
+        submerge=1
     [/item]
 
     [item]
         id=box
         image=items/box.png
         name= _ "Box"
+        submerge=1
     [/item]
 
     [item]
         id=branch
         image=items/branch.png
         name= _ "Branch"
+        submerge=1
     [/item]
 
     [item]
         id=branch-bare
         image=items/branch-bare.png
         name= _ "Bare Branch"
+        submerge=1
     [/item]
 
     [item]
         id=brazier
         image=items/brazier.png
         name= _ "Brazier"
+        submerge=1
     [/item]
 
     [item]
@@ -215,36 +249,42 @@
         halo=items/brazier-lit[1~8].png:100
         image=items/brazier-lit1.png
         name= _ "Lit Brazier"
+        submerge=1
     [/item]
 
     [item]
         id=buckler
         image=items/buckler.png
         name= _ "Buckler"
+        submerge=1
     [/item]
 
     [item]
         id=buckler2
         image=items/buckler-2.png
         name= _ "Buckler"
+        submerge=1
     [/item]
 
     [item]
         id=burial
         image=items/burial.png
         name= _ "Burial"
+        submerge=1
     [/item]
 
     [item]
         id=cage
         image=items/cage.png
         name= _ "Cage"
+        submerge=1
     [/item]
 
     [item]
         id=chest
         image=items/chest.png
         name= _ "Closed Chest"
+        submerge=1
     [/item]
 
     [item]
@@ -252,36 +292,42 @@
         image=items/chest-open.png
         #po: Open is an adjective here, not a verb. That is, a (treasure) chest that is open, not an action to open such a chest.
         name= _ "Open Chest"
+        submerge=1
     [/item]
 
     [item]
         id=chest-plain-closed
         image=items/chest-plain-closed.png
         name= _ "Closed Plain Chest"
+        submerge=1
     [/item]
 
     [item]
         id=chest-plain-open
         image=items/chest-plain-open.png
         name= _ "Open Plain Chest"
+        submerge=1
     [/item]
 
     [item]
         id=cloak-green
         image=items/cloak-green.png
         name= _ "Green Cloak"
+        submerge=1
     [/item]
 
     [item]
         id=club
         image=items/club.png
         name= _ "Club"
+        submerge=1
     [/item]
 
     [item]
         id=coffin-closed
         image=items/coffin-closed.png
         name= _ "Closed Coffin"
+        submerge=1
     [/item]
 
     [item]
@@ -289,72 +335,84 @@
         image=items/coffin-open.png
         #po: Open is an adjective here, not a verb. That is, a coffin that is open, not an action to open a coffin.
         name= _ "Open Coffin"
+        submerge=1
     [/item]
 
     [item]
         id=crossbow
         image=items/crossbow.png
         name= _ "Crossbow"
+        submerge=1
     [/item]
 
     [item]
         id=dagger
         image=items/dagger.png
         name= _ "Dagger"
+        submerge=1
     [/item]
 
     [item]
         id=dagger-poison
         image=items/dagger-poison.png
         name= _ "Poison Dagger"
+        submerge=1
     [/item]
 
     [item]
         id=dagger-poison-bare
         image=items/dagger-poison-bare.png
         name= _ "Poison Dagger (clean)"
+        submerge=1
     [/item]
 
     [item]
         id=dragonstatue
         image=items/dragonstatue.png
         name= _ "Dragon Statue"
+        submerge=1
     [/item]
 
     [item]
         id=flame-sword
         image=items/flame-sword.png
         name= _ "Flaming Sword"
+        submerge=1
     [/item]
 
     [item]
         id=flame-sword-bare
         image=items/flame-sword-bare.png
         name= _ "Unenchanted Flaming Sword"
+        submerge=1
     [/item]
 
     [item]
         id=flower1
         image=items/flower1.png
         name= _ "Flower"
+        submerge=1
     [/item]
 
     [item]
         id=flower2
         image=items/flower2.png
         name= _ "Flower"
+        submerge=1
     [/item]
 
     [item]
         id=flower3
         image=items/flower3.png
         name= _ "Flower"
+        submerge=1
     [/item]
 
     [item]
         id=flower4
         image=items/flower4.png
         name= _ "Flower"
+        submerge=1
     [/item]
 
     [item]
@@ -367,354 +425,413 @@
         id=gold-coins-large
         image=items/gold-coins-large.png
         name= _ "Large Pile of Gold Coins"
+        submerge=1
     [/item]
 
     [item]
         id=gold-coins-medium
         image=items/gold-coins-medium.png
         name= _ "Pile of Gold Coins"
+        submerge=1
     [/item]
 
     [item]
         id=gold-coins-small
         image=items/gold-coins-small.png
         name= _ "Small Pile of Gold Coins"
+        submerge=1
     [/item]
 
     [item]
         id=grain-sheaf
         image=items/grain-sheaf.png
         name= _ "Grain Sheaf"
+        submerge=1
     [/item]
 
     [item]
         id=hammer
         image=items/hammer.png
         name= _ "Hammer"
+        submerge=1
     [/item]
 
     [item]
         id=hammer-runic
         image=items/hammer-runic.png
         name= _ "Runic Hammer"
+        submerge=1
     [/item]
 
     [item]
         id=holy-water
         image=items/holy-water.png
         name= _ "Holy Water"
+        submerge=1
     [/item]
 
     [item]
         id=key
         image=items/key.png
         name= _ "Key"
+        submerge=1
     [/item]
 
     [item]
         id=key2
         image=items/key2.png
         name= _ "Key"
+        submerge=1
     [/item]
 
     [item]
         id=key-dark
         image=items/key-dark.png
         name= _ "Dark Key"
+        submerge=1
     [/item]
 
     [item]
         id=leather-pack
         image=items/leather-pack.png
         name= _ "Leather Pack"
+        submerge=1
     [/item]
 
     [item]
         id=mace
         image=items/mace.png
         name= _ "Mace"
+        submerge=1
     [/item]
 
     [item]
         id=necklace-bone
         image=items/necklace-bone.png
         name= _ "Bone Necklace"
+        submerge=1
     [/item]
 
     [item]
         id=necklace-stone
         image=items/necklace-stone.png
         name= _ "Stone Necklace"
+        submerge=1
     [/item]
 
     [item]
         id=orcish-flag
         image=items/orcish-flag.png
         name= _ "Orcish Flag"
+        submerge=1
     [/item]
 
     [item]
         id=ornate1
         image=items/ornate1.png
         name= _ "Ornate"
+        submerge=1
     [/item]
 
     [item]
         id=ornate2
         image=items/ornate2.png
         name= _ "Ornate"
+        submerge=1
     [/item]
 
     [item]
         id=potion-blue
         image=items/potion-blue.png
         name= _ "Blue Potion"
+        submerge=1
     [/item]
 
     [item]
         id=potion-green
         image=items/potion-green.png
         name= _ "Green Potion"
+        submerge=1
     [/item]
 
     [item]
         id=potion-gray
         image=items/potion-grey.png
         name= _ "Gray Potion"
+        submerge=1
     [/item]
 
     [item]
         id=potion-poison
         image=items/potion-poison.png
         name= _ "Poison"
+        submerge=1
     [/item]
 
     [item]
         id=potion-red
         image=items/potion-red.png
         name= _ "Red Potion"
+        submerge=1
     [/item]
 
     [item]
         id=potion-yellow
         image=items/potion-yellow.png
         name= _ "Yellow Potion"
+        submerge=1
     [/item]
 
     [item]
         id=ring-brown
         image=items/ring-brown.png
         name= _ "Brown Ring"
+        submerge=1
     [/item]
 
     [item]
         id=ring-gold
         image=items/ring-gold.png
         name= _ "Golden Ring"
+        submerge=1
     [/item]
 
     [item]
         id=ring-red
         image=items/ring-red.png
         name= _ "Red Ring"
+        submerge=1
     [/item]
 
     [item]
         id=ring-silver
         image=items/ring-silver.png
         name= _ "Silver Ring"
+        submerge=1
     [/item]
 
     [item]
         id=ring-white
         image=items/ring-white.png
         name= _ "White Ring"
+        submerge=1
     [/item]
 
     [item]
         id=rock
         image=items/rock.png
         name= _ "Rock"
+        submerge=1
     [/item]
 
     [item]
         id=scarecrow
         image=items/scarecrow.png
         name= _ "Scarecrow"
+        submerge=1
     [/item]
 
     [item]
         id=sceptre-of-fire
         image=items/sceptre-of-fire.png
         name= _ "Sceptre of Fire"
+        submerge=1
     [/item]
 
     [item]
         id=sling
         image=items/sling.png
         name= _ "Sling"
+        submerge=1
     [/item]
 
     [item]
         id=spear
         image=items/spear.png
         name= _ "Spear"
+        submerge=1
     [/item]
 
     [item]
         id=spear-fancy
         image=items/spear-fancy.png
         name= _ "Fancy Spear"
+        submerge=1
     [/item]
 
     [item]
         id=spear-fancy2
         image=items/spear-fancy-2.png
         name= _ "Fancy Spear"
+        submerge=1
     [/item]
 
     [item]
         id=spear-javelin
         image=items/spear-javelin.png
         name= _ "Javelin"
+        submerge=1
     [/item]
 
     [item]
         id=staff
         image=items/staff.png
         name= _ "Staff"
+        submerge=1
     [/item]
 
     [item]
         id=staff2
         image=items/staff-2.png
         name= _ "Staff"
+        submerge=1
     [/item]
 
     [item]
         id=staff-druid
         image=items/staff-druid.png
         name= _ "Druid Staff"
+        submerge=1
     [/item]
 
     [item]
         id=staff-magic
         image=items/staff-magic.png
         name= _ "Magic Staff"
+        submerge=1
     [/item]
 
     [item]
         id=staff-magic2
         image=items/staff-magic-2.png
         name= _ "Magic Staff"
+        submerge=1
     [/item]
 
     [item]
         id=staff-magic-wand
         image=items/staff-magic-wand.png
         name= _ "Magic Wand"
+        submerge=1
     [/item]
 
     [item]
         id=staff-plain
         image=items/staff-plain.png
         name= _ "Plain Staff"
+        submerge=1
     [/item]
 
     [item]
         id=stone-tablet
         image=items/stone-tablet.png
         name= _ "Stone Tablet"
+        submerge=1
     [/item]
 
     [item]
         id=storm-trident
         image=items/storm-trident.png
         name= _ "Storm Trident"
+        submerge=1
     [/item]
 
     [item]
         id=storm-trident2
         image=items/storm-trident-2.png
         name= _ "Storm Trident"
+        submerge=1
     [/item]
 
     [item]
         id=straw-bale1
         image=items/straw-bale1.png
         name= _ "Bale of Straw"
+        submerge=1
     [/item]
 
     [item]
         id=straw-bale2
         image=items/straw-bale2.png
         name= _ "Bale of Straw"
+        submerge=1
     [/item]
 
     [item]
         id=sword
         image=items/sword.png
         name= _ "Sword"
+        submerge=1
     [/item]
 
     [item]
         id=sword2
         image=items/sword-2.png
         name= _ "Sword"
+        submerge=1
     [/item]
 
     [item]
         id=sword-holy
         image=items/sword-holy.png
         name= _ "Holy Sword"
+        submerge=1
     [/item]
 
     [item]
         id=sword-short
         image=items/sword-short.png
         name= _ "Short Sword"
+        submerge=1
     [/item]
 
     [item]
         id=sword-wraith
         image=items/sword-wraith.png
         name= _ "Wraith Sword"
+        submerge=1
     [/item]
 
     [item]
         id=talisman-ankh
         image=items/talisman-ankh.png
         name= _ "Ankh Talisman"
+        submerge=1
     [/item]
 
     [item]
         id=talisman-bone
         image=items/talisman-bone.png
         name= _ "Bone Talisman"
+        submerge=1
     [/item]
 
     [item]
         id=talisman-stone
         image=items/talisman-stone.png
         name= _ "Stone Talisman"
+        submerge=1
     [/item]
 
     [item]
         id=thunderstick
         image=items/thunderstick.png
         name= _ "Thunderstick"
+        submerge=1
     [/item]
 
     [item]
         id=torch
         image=items/torch.png
         name= _ "Lit Torch"
+        submerge=1
     [/item]
 
     [item]
         id=torch-bare
         image=items/torch-bare.png
         name= _ "Unlit Torch"
+        submerge=1
     [/item]
 [/item_group]
 
@@ -758,6 +875,7 @@
         id=dwarven-doors-closed
         image=scenery/dwarven-doors-closed.png
         name= _ "Closed Dwarven Doors"
+        submerge=1
     [/item]
 
     [item]
@@ -778,12 +896,14 @@
         id=gate-rusty-se
         image=scenery/gate-rusty-se.png
         name= _ "Rusty Gate South East"
+        submerge=1
     [/item]
 
     [item]
         id=gate-rusty-sw
         image=scenery/gate-rusty-sw.png
         name= _ "Rusty Gate South West"
+        submerge=1
     [/item]
 
     [item]
@@ -796,6 +916,7 @@
         id=leanto
         image=scenery/leanto.png
         name= _ "Lean-to"
+        submerge=1
     [/item]
 
     [item]
@@ -809,36 +930,42 @@
         halo=scenery/mausoleum[01~22].png
         image=scenery/mausoleum01.png
         name= _ "Mausoleum"
+        submerge=1
     [/item]
 
     [item]
         id=mine-abandoned
         image=scenery/mine-abandoned.png
         name= _ "Abandoned Mine"
+        submerge=1
     [/item]
 
     [item]
         id=monolith1
         image=scenery/monolith1.png
         name= _ "Monolith"
+        submerge=1
     [/item]
 
     [item]
         id=monolith2
         image=scenery/monolith2.png
         name= _ "Monolith"
+        submerge=1
     [/item]
 
     [item]
         id=monolith3
         image=scenery/monolith3.png
         name= _ "Monolith"
+        submerge=1
     [/item]
 
     [item]
         id=monolith4
         image=scenery/monolith4.png
         name= _ "Monolith"
+        submerge=1
     [/item]
 
     [item]
@@ -857,54 +984,65 @@
         id=oak-leaning
         image=scenery/oak-leaning.png
         name= _ "Leaning Oak"
+        submerge=1
     [/item]
 
     [item]
         id=pine1
         image=scenery/pine1.png
         name= _ "Pine Tree"
+        submerge=1
     [/item]
 
     [item]
         id=pine2
         image=scenery/pine2.png
         name= _ "Pine Tree"
+        submerge=1
     [/item]
 
     [item]
         id=rock1
         image=scenery/rock1.png
         name= _ "Rock"
+        submerge=1
     [/item]
 
     [item]
         id=rock2
         image=scenery/rock2.png
         name= _ "Rock"
+        submerge=1
     [/item]
 
     [item]
         id=rock3
         image=scenery/rock3.png
         name= _ "Rock"
+        submerge=1
     [/item]
 
     [item]
         id=rock4
         image=scenery/rock4.png
         name= _ "Rock"
+        submerge=1
     [/item]
 
     [item]
         id=rock-cairn
         image=scenery/rock-cairn.png
         name= _ "Rock Cairn"
+        submerge=1
+        submerge=1
     [/item]
 
     [item]
         id=rock-cairn2
         image=scenery/rock-cairn2.png
         name= _ "Rock Cairn"
+        submerge=1
+        submerge=1
     [/item]
 
     [item]
@@ -995,6 +1133,7 @@
         id=signpost
         name= _ "Signpost"
         image=scenery/signpost.png
+        submerge=1
     [/item]
 
     [item]
@@ -1061,42 +1200,49 @@
         id=temple1
         image=scenery/temple1.png
         name= _ "Temple"
+        submerge=1
     [/item]
 
     [item]
         id=temple-cracked1
         image=scenery/temple-cracked1.png
         name= _ "Ruined Temple"
+        submerge=1
     [/item]
 
     [item]
         id=temple-cracked2
         image=scenery/temple-cracked2.png
         name= _ "Ruined Temple"
+        submerge=1
     [/item]
 
     [item]
         id=temple-cracked3
         image=scenery/temple-cracked3.png
         name= _ "Ruined Temple"
+        submerge=1
     [/item]
 
     [item]
         id=tent-fancy-red
         image=scenery/tent-fancy-red.png
         name= _ "Fancy Red Tent"
+        submerge=1
     [/item]
 
     [item]
         id=tent-ruin-1
         image=scenery/tent-ruin-1.png
         name= _ "Ruined Tent"
+        submerge=1
     [/item]
 
     [item]
         id=tent-shop-weapons
         name= _ "Weapons Shop Tent"
         image=scenery/tent-shop-weapons.png
+        submerge=1
     [/item]
 
     [item]
@@ -1115,30 +1261,35 @@
         id=trash
         image=scenery/trash.png
         name= _ "Trash Pile"
+        submerge=1
     [/item]
 
     [item]
         id=village-human-burned1
         image=scenery/village-human-burned1.png
         name= _ "Burned Human Village"
+        submerge=1
     [/item]
 
     [item]
         id=village-human-burned2
         image=scenery/village-human-burned2.png
         name= _ "Burned Human Village"
+        submerge=1
     [/item]
 
     [item]
         id=village-human-burned3
         image=scenery/village-human-burned3.png
         name= _ "Burned Human Village"
+        submerge=1
     [/item]
 
     [item]
         id=village-human-burned4
         image=scenery/village-human-burned4.png
         name= _ "Burned Human Village"
+        submerge=1
     [/item]
 
     [item]
@@ -1158,6 +1309,7 @@
         image=scenery/windmill-01.png
         halo=scenery/windmill-[01~14].png:150
         name= _ "Windmill"
+        submerge=1
     [/item]
 
     [item]

--- a/data/core/macros/image-utils.cfg
+++ b/data/core/macros/image-utils.cfg
@@ -172,6 +172,16 @@
     [/item]
 #enddef
 
+#define PLACE_IMAGE_SUBMERGED IMAGE X Y
+    # Place an image at a specified location on the map, submerging in water.
+    [item]
+        x={X}
+        y={Y}
+        image={IMAGE}
+        submerge=1
+    [/item]
+#enddef
+
 #define REMOVE_IMAGE X Y
     # Removes a previously set image from a tile.
     #

--- a/data/core/macros/items.cfg
+++ b/data/core/macros/items.cfg
@@ -97,6 +97,7 @@
     [item]
         x,y={X},{Y}
         image={IMAGE}
+        submerge=1
     [/item]
 
     [event]
@@ -193,6 +194,7 @@
         x={X}
         y={Y}
         image=items/potion-red.png
+        submerge=1
     [/item]
 
     [event]
@@ -232,6 +234,7 @@
         x={X}
         y={Y}
         image=items/potion-yellow.png
+        submerge=1
     [/item]
 
     [event]
@@ -302,6 +305,7 @@
         x={X}
         y={Y}
         image=items/potion-red.png
+        submerge=1
     [/item]
 
     [event]
@@ -346,6 +350,7 @@
         x={X}
         y={Y}
         image=items/potion-blue.png
+        submerge=1
     [/item]
 
     [event]
@@ -384,6 +389,7 @@
         x={X}
         y={Y}
         image=items/ring-red.png
+        submerge=1
     [/item]
 
     [event]
@@ -424,6 +430,7 @@
         x={X}
         y={Y}
         image=items/ring-brown.png
+        submerge=1
     [/item]
 
     [event]
@@ -462,6 +469,7 @@
         x={X}
         y={Y}
         image=items/staff.png
+        submerge=1
     [/item]
 
     [event]

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -24,6 +24,7 @@ local function add_overlay(x, y, cfg)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			submerge = cfg.submerge,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
@@ -60,6 +61,7 @@ end
 ---@field team_name string
 ---@field filter_team WML
 ---@field visible_in_fog boolean
+---@field submerge number
 ---@field redraw boolean
 ---@field name string
 ---@field z_order integer
@@ -82,6 +84,7 @@ function wesnoth.interface.get_items(x, y)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			submerge = cfg.submerge,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -2713,32 +2713,32 @@ For game purposes, the races group into factions; for example, orcs often cooper
         [/message]
     [/event]
 
-    {PLACE_IMAGE items/book1.png 2 2}
-    {PLACE_IMAGE items/book2.png 3 2}
-    {PLACE_IMAGE items/book3.png 4 2}
-    {PLACE_IMAGE items/book4.png 5 2}
-    {PLACE_IMAGE items/flower1.png 2 3}
-    {PLACE_IMAGE items/flower2.png 3 3}
-    {PLACE_IMAGE items/flower3.png 4 3}
-    {PLACE_IMAGE items/flower4.png 5 3}
-    {PLACE_IMAGE scenery/rock1.png 2 4}
-    {PLACE_IMAGE scenery/rock2.png 3 4}
-    {PLACE_IMAGE scenery/rock3.png 4 4}
-    {PLACE_IMAGE scenery/rock4.png 5 4}
-    {PLACE_IMAGE items/dragonstatue.png 2 5}
-    {PLACE_IMAGE items/ornate1.png 3 5}
-    {PLACE_IMAGE items/ornate2.png 4 5}
-    {PLACE_IMAGE items/barrel.png 5 5}
-    {PLACE_IMAGE scenery/monolith1.png 2 6}
-    {PLACE_IMAGE scenery/monolith2.png 3 6}
-    {PLACE_IMAGE scenery/monolith3.png 4 6}
-    {PLACE_IMAGE scenery/monolith4.png 5 6}
-    {PLACE_IMAGE scenery/well.png 2 7}
-    {PLACE_IMAGE scenery/leanto.png 3 7}
-    {PLACE_IMAGE items/ball-green.png 4 7}
-    {PLACE_IMAGE items/ball-blue.png 5 7}
-    {PLACE_IMAGE items/box.png 2 8}
-    {PLACE_IMAGE scenery/well.png 10 5}
+    {PLACE_IMAGE_SUBMERGED items/book1.png 2 2}
+    {PLACE_IMAGE_SUBMERGED items/book2.png 3 2}
+    {PLACE_IMAGE_SUBMERGED items/book3.png 4 2}
+    {PLACE_IMAGE_SUBMERGED items/book4.png 5 2}
+    {PLACE_IMAGE_SUBMERGED items/flower1.png 2 3}
+    {PLACE_IMAGE_SUBMERGED items/flower2.png 3 3}
+    {PLACE_IMAGE_SUBMERGED items/flower3.png 4 3}
+    {PLACE_IMAGE_SUBMERGED items/flower4.png 5 3}
+    {PLACE_IMAGE_SUBMERGED scenery/rock1.png 2 4}
+    {PLACE_IMAGE_SUBMERGED scenery/rock2.png 3 4}
+    {PLACE_IMAGE_SUBMERGED scenery/rock3.png 4 4}
+    {PLACE_IMAGE_SUBMERGED scenery/rock4.png 5 4}
+    {PLACE_IMAGE_SUBMERGED items/dragonstatue.png 2 5}
+    {PLACE_IMAGE_SUBMERGED items/ornate1.png 3 5}
+    {PLACE_IMAGE_SUBMERGED items/ornate2.png 4 5}
+    {PLACE_IMAGE_SUBMERGED items/barrel.png 5 5}
+    {PLACE_IMAGE_SUBMERGED scenery/monolith1.png 2 6}
+    {PLACE_IMAGE_SUBMERGED scenery/monolith2.png 3 6}
+    {PLACE_IMAGE_SUBMERGED scenery/monolith3.png 4 6}
+    {PLACE_IMAGE_SUBMERGED scenery/monolith4.png 5 6}
+    {PLACE_IMAGE_SUBMERGED scenery/well.png 2 7}
+    {PLACE_IMAGE_SUBMERGED scenery/leanto.png 3 7}
+    {PLACE_IMAGE_SUBMERGED items/ball-green.png 4 7}
+    {PLACE_IMAGE_SUBMERGED items/ball-blue.png 5 7}
+    {PLACE_IMAGE_SUBMERGED items/box.png 2 8}
+    {PLACE_IMAGE_SUBMERGED scenery/well.png 10 5}
 
     {OBJ_RING_REGENERATION 10 4 OBJ1}
     {OBJ_RING_REGENERATION 10 40 OBJ1}
@@ -2822,6 +2822,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
     [item]
         x,y=8,8
         image="items/orcish-flag.png"
+        submerge=1
     [/item]
     [label]
         x,y=8,8
@@ -2867,6 +2868,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
     [item]
         x,y=4,4
         image="items/orcish-flag.png"
+        submerge=1
     [/item]
     [label]
         x,y=10,9
@@ -3174,6 +3176,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
     [item]
         x,y=8,5
         image="items/orcish-flag.png"
+        submerge=1
     [/item]
     [label]
         x,y=8,5
@@ -3327,6 +3330,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
     [item]
         x,y=8,7
         image="items/chest-plain-closed.png"
+        submerge=1
     [/item]
     [label]
         x,y=8,7

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -749,6 +749,7 @@
 		{SIMPLE_KEY name string}
 		# Override some supertag keys to allow variable substitutions
 		{DEFAULT_KEY visible_in_fog s_bool yes}
+		{SIMPLE_KEY submerge s_real}
 		{FILTER_TAG "filter_side" side ()}
 	[/tag]
 	[tag]

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -462,6 +462,7 @@
 		{SIMPLE_KEY halo string}
 		{SIMPLE_KEY team_name string}
 		{DEFAULT_KEY visible_in_fog bool yes}
+		{SIMPLE_KEY submerge real}
 	[/tag]
 	[tag]
 		name="time"

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -139,7 +139,7 @@ void display::parse_team_overlays()
 }
 
 
-void display::add_overlay(const map_location& loc, const std::string& img, const std::string& halo, const std::string& team_name, const std::string& item_id, bool visible_under_fog, float z_order)
+void display::add_overlay(const map_location& loc, const std::string& img, const std::string& halo, const std::string& team_name, const std::string& item_id, bool visible_under_fog, float submerge, float z_order)
 {
 	halo::handle halo_handle;
 	if(halo != "") {
@@ -149,7 +149,7 @@ void display::add_overlay(const map_location& loc, const std::string& img, const
 
 	std::vector<overlay>& overlays = get_overlays()[loc];
 	auto it = std::find_if(overlays.begin(), overlays.end(), [z_order](const overlay& ov) { return ov.z_order > z_order; });
-	overlays.emplace(it, img, halo, halo_handle, team_name, item_id, visible_under_fog, z_order);
+	overlays.emplace(it, img, halo, halo_handle, team_name, item_id, visible_under_fog, submerge, z_order);
 }
 
 void display::remove_overlay(const map_location& loc)
@@ -1500,8 +1500,16 @@ void display::draw_text_in_hex(const map_location& loc,
 static void add_submerge_ipf_mod(
 	std::string& image_path,
 	int image_height,
-	double submersion_amount)
+	double submersion_amount,
+	int shift = 0)
 {
+	// We may also want to shift the position so that the waterline matches.
+	// Note: This currently has blending problems (see the note on sdl_blit),
+	// but if that blending problem is fixed it should work.
+	if (shift) {
+		image_path = "misc/blank-hex.png~BLIT(" + image_path;
+	}
+
 	// general formula for submerge alpha:
 	//   if (y > WATERLINE)
 	//   then min(max(alpha_mod, 0), 1) * alpha
@@ -1526,6 +1534,13 @@ static void add_submerge_ipf_mod(
 	// but that's not available below SDL 2.0.18.
 	// Alternately it could also be done fairly easily using shaders,
 	// if a graphics system supporting them (such as openGL) is moved to.
+
+	if (shift) {
+		// Finish the shifting blit. This assumes a hex-sized image.
+		image_path += ",0,";
+		image_path += std::to_string(shift);
+		image_path += ')';
+	}
 }
 
 void display::render_image(int x, int y, const display::drawing_layer drawing_layer,
@@ -2797,10 +2812,17 @@ void display::draw_hex(const map_location& loc)
 					{
 						point isize = image::get_size(ov.image, image::HEXED);
 						std::string ipf = ov.image;
-						add_submerge_ipf_mod(ipf, isize.y, submerge);
-						const texture tex = ov.image.find("~NO_TOD_SHIFT()") == std::string::npos ?
-							image::get_lighted_texture(ipf, lt) :
-							image::get_texture(ipf, image::HEXED);
+						if(ov.submerge) {
+							// Adjust submerge appropriately
+							double sub = submerge * ov.submerge;
+							// Shift the image so the waterline remains static.
+							// This is so that units swimming there look okay.
+							int shift = isize.y * (sub - submerge);
+							add_submerge_ipf_mod(ipf, isize.y, sub, shift);
+						}
+						const texture tex = ov.image.find("~NO_TOD_SHIFT()") == std::string::npos
+							? image::get_lighted_texture(ipf, lt)
+							: image::get_texture(ipf, image::HEXED);
 						drawing_buffer_add(LAYER_TERRAIN_BG, loc, dest, tex);
 					}
 				}

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -158,7 +158,7 @@ public:
 	 */
 	void add_overlay(const map_location& loc, const std::string& image,
 		const std::string& halo="", const std::string& team_name="",const std::string& item_id="",
-		bool visible_under_fog = true, float z_order = 0);
+		bool visible_under_fog = true, float submerge = 0.0f, float z_order = 0);
 
 	/** remove_overlay will remove all overlays on a tile. */
 	void remove_overlay(const map_location& loc);

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<editor_action> mouse_action_item::click_left(editor_display& dis
 	}
 
 	const overlay& item = item_palette_.selected_fg_item();
-	disp.add_overlay(start_hex_, item.image, item.halo, "", "", true);
+	disp.add_overlay(start_hex_, item.image, item.halo, "", "", item.visible_in_fog, item.submerge);
 
 	click_ = true;
 	return nullptr;

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -513,6 +513,9 @@ config map_context::to_config()
 			item["name"].write_if_not_empty(o.name);
 			item["team_name"].write_if_not_empty(o.team_name);
 			item["halo"].write_if_not_empty(o.halo);
+			if(o.submerge) {
+				item["submerge"] = o.submerge;
+			}
 		}
 	}
 

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -26,6 +26,7 @@ struct overlay
 			const std::string& overlay_team_name,
 			const std::string& item_id,
 			const bool fogged,
+			float submerge,
 			float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
@@ -33,6 +34,7 @@ struct overlay
 		, id(item_id)
 		, halo_handle(handle)
 		, visible_in_fog(fogged)
+		, submerge(submerge)
 		, z_order(item_z_order)
 	{}
 
@@ -45,6 +47,7 @@ struct overlay
 		, id(cfg["id"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
+		, submerge(cfg["submerge"].to_double(0))
 		, z_order(cfg["z_order"].to_double(0))
 	{
 	}
@@ -57,6 +60,7 @@ struct overlay
 
 	halo::handle halo_handle;
 	bool visible_in_fog;
+	float submerge;
 	float z_order;
 
 };

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3645,7 +3645,8 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 
 	if (game_display_) {
 		game_display_->add_overlay(loc, cfg["image"], cfg["halo"],
-			team_name, cfg["name"], cfg["visible_in_fog"].to_bool(true), cfg["z_order"].to_double(0));
+			team_name, cfg["name"], cfg["visible_in_fog"].to_bool(true),
+			cfg["submerge"].to_double(0), cfg["z_order"].to_double(0));
 	}
 	return 0;
 }


### PR DESCRIPTION
This is addressing #1146.

As per the comments in #1146 I made a change to simply use the same submerge code as units, for items. So when an item is placed on water it partially submerges. This fixes the visual appearance when a unit is swimming on top of the item, and also IMO makes items in water look a whole lot better.

There are one or two situations in which the item probably should not be submerged. It can be seen below, with the target circle. This could be fixed by using "halo" in stead of "image" in the item definition, so it draws over units in stead of under them.

It might make sense to have a separate "floating" item type, like say for debris that is actually floating on the water. There would need to be an implementation to split the item into two halves, one drawn in front of the unit and one drawn behind, as for unit ellipses. However unless there's an actual use case where this is required i don't want to speculatively implement it.

Here's the new look:
![submerge](https://user-images.githubusercontent.com/243646/178862538-86b81682-09b9-4f12-97db-ad4da4234a96.jpg)

And the old look for comparison:
![nosubmerge](https://user-images.githubusercontent.com/243646/178862555-a5f2bfb0-8cd2-4ef9-870e-339fce337ded.jpg)