### PR TITLE
preferences: Adjust show_deprecation default to coincide with usage

### DIFF
--- a/src/preferences/advanced.cpp
+++ b/src/preferences/advanced.cpp
@@ -15,6 +15,7 @@
 #include "preferences/advanced.hpp"
 
 #include "game_config_view.hpp"
+#include "game_version.hpp"
 #include "gettext.hpp"
 #include "log.hpp"
 
@@ -36,6 +37,15 @@ advanced_manager::advanced_manager(const game_config_view& gc)
 		} catch(const std::invalid_argument& e) {
 			ERR_ADV << e.what() << std::endl;
 			continue;
+		}
+	}
+
+	// show_deprecation has a different default on the dev branch
+	if(game_config::wesnoth_version.is_dev_version()) {
+		for(option& op : prefs) {
+			if(op.field == "show_deprecation") {
+				op.cfg["default"] = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
If unset it has different behaviour in dev branch when checked (defaulting to yes). However this was not reflected in the actual prefs dialog which clearly said that it was "no".

This is a bit ugly... but well the default is set statically in `data/advanced_preferences.cfg`, so...

Also usage of bool preferences and how the default values work is horribly wrong everywhere, as the default value must be given by the code that tries to access the value. But they don't know the default value. So they make something up. Which leads to situations such as this one where it does not match the actual default value and wrong shit happens.