### PR TITLE
1.17 (test scenario) out-of-hex unit animation tests

### DIFF
--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -980,12 +980,9 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
             jamming=5
         [/unit]
         [unit]
-            # for testing out-of-hex graphical bugs
             x,y=10,7
             type="Orcish Archer"
-            # generate_name=yes
-            name="Animation Tester"
-            id=anim_tester_ooh
+            generate_name=yes
         [/unit]
         [unit]
             x,y=18,12
@@ -1160,6 +1157,16 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         fog=yes
         shroud=yes
         share_vision=none
+        [unit]
+            # for testing out-of-hex graphical bugs
+            x,y=11,9
+            type="Orcish Archer"
+            # generate_name=yes
+            name=_ "Animation Tester"
+            id=anim_tester_ooh
+            max_moves=0
+            random_traits=no
+        [/unit]
     [/side]
     [event]
         name=turn refresh
@@ -1471,23 +1478,38 @@ end
         [/lua]
     [/event]
 
+    # animation tester
     [label]
-        x,y=10,8
+        x,y=11,10
         text=_"Telekinesis"
-        color=70,135,135
         tooltip=_"This orc tests some ainmation features"
         visible_in_shroud=yes
     [/label]
     [event]
-        name=moveto
+        name=exit_hex
+        first_time_only=no
         [filter]
-            x,y=10,8
+            x,y=11,10
+            side=1
+        [/filter]
+        [remove_object]
+            id=anim_tester_ooh
+            object_id=flying_anvils
+        [/remove_object]
+    [/event]
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x,y=11,10
         [/filter]
         [modify_unit]
             [filter]
                 id=anim_tester_ooh
             [/filter]
             [object]
+                id=flying_anvils
+                take_only_once=no
                 [effect]
                     apply_to=new_animation
                     [standing_anim]

--- a/data/scenario-test.cfg
+++ b/data/scenario-test.cfg
@@ -980,9 +980,12 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
             jamming=5
         [/unit]
         [unit]
+            # for testing out-of-hex graphical bugs
             x,y=10,7
             type="Orcish Archer"
-            generate_name=yes
+            # generate_name=yes
+            name="Animation Tester"
+            id=anim_tester_ooh
         [/unit]
         [unit]
             x,y=18,12
@@ -1466,6 +1469,54 @@ end
                 end
             >>
         [/lua]
+    [/event]
+
+    [label]
+        x,y=10,8
+        text=_"Telekinesis"
+        color=70,135,135
+        tooltip=_"This orc tests some ainmation features"
+        visible_in_shroud=yes
+    [/label]
+    [event]
+        name=moveto
+        [filter]
+            x,y=10,8
+        [/filter]
+        [modify_unit]
+            [filter]
+                id=anim_tester_ooh
+            [/filter]
+            [object]
+                [effect]
+                    apply_to=new_animation
+                    [standing_anim]
+                        start_time=0
+                        y=0~-24:700,-24~24:1400,24~0:700
+                        anvil_start_time=0
+                        [frame]
+                            duration=2800
+                        [/frame]
+                        [anvil_frame]
+                            image=items/anvil.png:2800
+                            auto_vflip=no
+                            offset=-2.0~2.0:1400,2.0~-2.0:1400
+                            layer=200
+                            x=100
+                            y=-100
+                        [/anvil_frame]
+                        [circle_frame]
+                            image=scenery/circle-magic.png:2800
+                            auto_vflip=no
+                            offset=5.0~-5.0:1400,-5.0~5.0:1400
+                            layer=200
+                        [/circle_frame]
+                        base_score=3
+                    [/standing_anim]
+                [/effect]
+            [/object]
+            facing=se
+        [/modify_unit]
     [/event]
 
     [event]


### PR DESCRIPTION
This is for testing #6589, as well as looking at how ellipse and HP bar move with sprite in progressive y= key