### PR TITLE
Several more invasive fixes arising from general tidyup

### DIFF
--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -148,11 +148,6 @@ protected:
 	 */
 	void handle_event(const SDL_Event& event) override;
 
-	void handle_window_event(const SDL_Event& /*event*/) override
-	{
-		// No action by default
-	}
-
 	/** Process keydown (only when the general map display does not have focus). */
 	virtual void process_focus_keydown_event(const SDL_Event& /*event*/)
 	{
@@ -211,7 +206,6 @@ private:
 		}
 
 		void handle_event(const SDL_Event& event) override;
-		void handle_window_event(const SDL_Event&) override {}
 
 	private:
 		controller_base& controller_;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -792,8 +792,7 @@ surface display::screenshot(bool map_screenshot)
 
 	map_screenshot_ = true;
 
-	invalidate_all();
-	draw_init();
+	invalidate_locations_in_rect(map_area());
 	draw();
 
 	map_screenshot_ = false;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -891,7 +891,7 @@ void display::create_buttons()
 			continue;
 		}
 
-		auto b = std::make_shared<gui::button>(screen_, menu.title(), gui::button::TYPE_PRESS, menu.image(),
+		auto b = std::make_shared<gui::button>(menu.title(), gui::button::TYPE_PRESS, menu.image(),
 			gui::button::DEFAULT_SPACE, true, menu.overlay(), font::SIZE_BUTTON_SMALL);
 
 		DBG_DP << "drawing button " << menu.get_id();
@@ -909,7 +909,7 @@ void display::create_buttons()
 
 	DBG_DP << "creating action buttons...";
 	for(const auto& action : theme_.actions()) {
-		auto b = std::make_shared<gui::button>(screen_, action.title(), string_to_button_type(action.type()),
+		auto b = std::make_shared<gui::button>(action.title(), string_to_button_type(action.type()),
 			action.image(), gui::button::DEFAULT_SPACE, true, action.overlay(), font::SIZE_BUTTON_SMALL);
 
 		DBG_DP << "drawing button " << action.get_id();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1479,9 +1479,7 @@ void display::draw_text_in_hex(const map_location& loc,
 	const int font_sz = int(font_size * zf);
 
 	// TODO: highdpi - use the same processing as floating_label::create_texture() and cache the effect result so it doesn't constantly rerender the same thing.
-	// TODO: highdpi - perhaps this could be a single texture with colour mod, in stead of rendering twice?
 	texture text_surf = font::pango_render_text(text, font_sz, color);
-	texture back_surf = font::pango_render_text(text, font_sz, font::BLACK_COLOR);
 	const int x = get_location_x(loc) - text_surf.w()/2
 	              + static_cast<int>(x_in_hex* hex_size());
 	const int y = get_location_y(loc) - text_surf.h()/2
@@ -1492,8 +1490,8 @@ void display::draw_text_in_hex(const map_location& loc,
 		for (int dx=-1; dx <= 1; ++dx) {
 			if (dx!=0 || dy!=0) {
 				const SDL_Rect dest{int(x + dx*zf), int(y + dy*zf), w, h};
-				auto& bh = drawing_buffer_add(layer, loc, dest, back_surf);
-				bh.alpha_mod = 128;
+				drawing_buffer_add(layer, loc, dest, text_surf)
+					.set_color_and_alpha({0, 0, 0, 128});
 			}
 		}
 	}

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -573,6 +573,9 @@ private:
 	bool prevent_draw_ = false;
 
 public:
+	/** ToD mask smooth fade */
+	void fade_tod_mask(const std::string& old, const std::string& new_);
+
 	/** Screen fade */
 	void fade_to(const color_t& color, int duration);
 	void set_fade(const color_t& color);
@@ -814,7 +817,10 @@ protected:
 	texture mouseover_hex_overlay_;
 	// If we're transitioning from one time of day to the next,
 	// then we will use these two masks on top of all hexes when we blit.
-	surface tod_hex_mask1, tod_hex_mask2; // TODO: highdpi - texture
+	texture tod_hex_mask1 = {};
+	texture tod_hex_mask2 = {};
+	uint8_t tod_hex_alpha1 = 0;
+	uint8_t tod_hex_alpha2 = 0;
 	std::vector<std::string> fog_images_;
 	std::vector<std::string> shroud_images_;
 

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -290,9 +290,10 @@ void raise_drawable(top_level_drawable* tld)
 static void tidy_drawables()
 {
 	// Remove all invalidated TLDs from the list.
-	DBG_DM << "tidying drawables";
+	DBG_DM << "tidying " << top_level_drawables_.size() << " drawables";
 	auto& vec = top_level_drawables_;
 	vec.erase(std::remove(vec.begin(), vec.end(), nullptr), vec.end());
+	DBG_DM << top_level_drawables_.size() << " after tidying";
 }
 
 } // namespace draw_manager

--- a/src/editor/palette/common_palette.hpp
+++ b/src/editor/palette/common_palette.hpp
@@ -20,7 +20,6 @@
 #include "widgets/widget.hpp"
 
 struct SDL_Rect;
-class CVideo;
 
 namespace editor {
 
@@ -47,7 +46,7 @@ class common_palette  : public gui::widget {
 
 public:
 
-	common_palette(CVideo& video) : gui::widget(video, true) {}
+	common_palette() : gui::widget(true) {}
 
 	virtual ~common_palette() {}
 
@@ -91,8 +90,8 @@ public:
 class tristate_palette : public common_palette
 {
 public:
-	tristate_palette(CVideo& video)
-		: common_palette(video)
+	tristate_palette()
+		: common_palette()
 	{
 	}
 	virtual void select_fg_item(const std::string& item_id) = 0;

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -173,7 +173,7 @@ void editor_palette<Item>::adjust_size(const SDL_Rect& target)
 	if(items_fitting > 0) {
 		const auto buttons_needed = static_cast<std::size_t>(items_fitting);
 		if(buttons_.size() != buttons_needed) {
-			buttons_.resize(buttons_needed, gui::tristate_button(gui_.video(), this));
+			buttons_.resize(buttons_needed, gui::tristate_button(this));
 		}
 	}
 

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -30,7 +30,7 @@ public:
 
 	editor_palette(editor_display &gui, const game_config_view& /*cfg*/
 	             , std::size_t item_size, std::size_t columns, editor_toolkit &toolkit)
-		: tristate_palette(gui.video())
+		: tristate_palette()
 		, groups_()
 		, gui_(gui)
 		, item_size_(item_size)

--- a/src/editor/palette/empty_palette.hpp
+++ b/src/editor/palette/empty_palette.hpp
@@ -29,7 +29,7 @@ class empty_palette : public common_palette {
 public:
 
 	empty_palette(display& gui) :
-		common_palette(gui.video()),
+		common_palette(),
 		gui_(gui) {}
 
 	//event handling

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -50,8 +50,8 @@ public:
 		}
 
 	};
-	location_palette_item(CVideo& video, editor::location_palette* parent)
-		: gui::widget(video, true)
+	location_palette_item(editor::location_palette* parent)
+		: gui::widget(true)
 		, parent_(parent)
 	{
 	}
@@ -137,8 +137,8 @@ private:
 class location_palette_button : public gui::button
 {
 public:
-	location_palette_button(CVideo& video, const SDL_Rect& location, const std::string& text, const std::function<void (void)>& callback)
-		: gui::button(video, text)
+	location_palette_button(const SDL_Rect& location, const std::string& text, const std::function<void (void)>& callback)
+		: gui::button(text)
 		, callback_(callback)
 	{
 		this->set_location(location.x, location.y);
@@ -160,7 +160,7 @@ protected:
 namespace editor {
 location_palette::location_palette(editor_display &gui, const game_config_view& /*cfg*/,
                                    editor_toolkit &toolkit)
-		: common_palette(gui.video())
+		: common_palette()
 		, item_size_(20)
 		//TODO avoid magic number
 		, item_space_(20 + 3)
@@ -247,14 +247,14 @@ void location_palette::adjust_size(const SDL_Rect& target)
 	const int button_y = 30;
 	int bottom = target.y + target.h;
 	if (!button_goto_) {
-		button_goto_.reset(new location_palette_button(video(), SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Go To"), [this]() {
+		button_goto_.reset(new location_palette_button(SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Go To"), [this]() {
 			//static_cast<mouse_action_starting_position&>(toolkit_.get_mouse_action()). ??
 			map_location pos = disp_.get_map().special_location(selected_item_);
 			if (pos.valid()) {
 				disp_.scroll_to_tile(pos, display::WARP);
 			}
 		}));
-		button_add_.reset(new location_palette_button(video(), SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Add"), [this]() {
+		button_add_.reset(new location_palette_button(SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Add"), [this]() {
 			std::string newid;
 			if (gui2::dialogs::edit_text::execute(_("New Location Identifier"), "", newid)) {
 				static const boost::regex valid_id("[a-zA-Z0-9_]+");
@@ -271,7 +271,7 @@ void location_palette::adjust_size(const SDL_Rect& target)
 				}
 			}
 		}));
-		button_delete_.reset(new location_palette_button(video(), SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Delete"), nullptr));
+		button_delete_.reset(new location_palette_button(SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height }, _("Delete"), nullptr));
 	}
 	else {
 		button_goto_->set_location(SDL_Rect{ target.x , bottom -= button_y, target.w - 10, button_height });
@@ -290,7 +290,7 @@ void location_palette::adjust_size(const SDL_Rect& target)
 		// This simplifies the scrolling code in add_item.
 		const std::size_t buttons_needed = items_fitting;
 		if(buttons_.size() != buttons_needed) {
-			location_palette_item lpi(disp_.video(), this);
+			location_palette_item lpi(this);
 			buttons_.resize(buttons_needed, lpi);
 		}
 	}

--- a/src/editor/palette/palette_manager.cpp
+++ b/src/editor/palette/palette_manager.cpp
@@ -25,7 +25,7 @@ namespace editor {
 
 palette_manager::palette_manager(editor_display& gui, const game_config_view& cfg
                                , editor_toolkit& toolkit)
-		: gui::widget(gui.video()),
+		: gui::widget(),
 		  gui_(gui),
 		  palette_start_(0),
 		  toolkit_(toolkit),

--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -23,18 +23,17 @@
 #include "log.hpp"
 #include "sdl/rect.hpp"
 #include "sound.hpp"
-#include "video.hpp" // TODO: highdpi - only needed for widget constructor
 
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
 
 namespace gui {
 
-tristate_button::tristate_button(CVideo& video,
+tristate_button::tristate_button(
 		editor::tristate_palette* palette,
 		std::string button_image_name,
 		const bool auto_join)
-	: widget(video, auto_join)
+	: widget(auto_join)
 	, baseImage_()
 	, touchedBaseImage_()
 	, activeBaseImage_()

--- a/src/editor/palette/tristate_button.hpp
+++ b/src/editor/palette/tristate_button.hpp
@@ -37,7 +37,7 @@ public:
 
 	enum PRESSED_STATE { LEFT, RIGHT, BOTH, NONE };
 
-	tristate_button(CVideo& video,
+	tristate_button(
 			editor::tristate_palette* palette,
 			std::string button_image="",
 			const bool auto_join=true);

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -76,7 +76,7 @@ class sdl_handler
 friend class context;
 public:
 	virtual void handle_event(const SDL_Event& event) = 0;
-	virtual void handle_window_event(const SDL_Event& event) = 0;
+	virtual void handle_window_event(const SDL_Event&) {};
 	virtual void process_event() {}
 	virtual void draw() {}
 

--- a/src/floating_textbox.cpp
+++ b/src/floating_textbox.cpp
@@ -112,12 +112,12 @@ namespace gui{
 		mode_ = mode;
 
 		if(!check_label.empty()) {
-			check_.reset(new gui::button(gui.video(),check_label,gui::button::TYPE_CHECK));
+			check_.reset(new gui::button(check_label,gui::button::TYPE_CHECK));
 			check_->set_check(checked);
 		}
 
 
-		box_.reset(new gui::textbox(gui.video(),100,"",true,256,font::SIZE_NORMAL,0.8,0.6));
+		box_.reset(new gui::textbox(100,"",true,256,font::SIZE_NORMAL,0.8,0.6));
 
 		update_location(gui);
 	}

--- a/src/font/sdl_ttf_compat.cpp
+++ b/src/font/sdl_ttf_compat.cpp
@@ -139,7 +139,6 @@ std::string pango_word_wrap(const std::string& unwrapped_text, int font_size, in
 	return res;
 }
 
-// TODO: highdpi - cache results, especially size checks
 SDL_Rect pango_draw_text(CVideo* video, const SDL_Rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips, pango_text::FONT_STYLE style)
 {
 	auto& ptext = private_renderer();

--- a/src/font/sdl_ttf_compat.cpp
+++ b/src/font/sdl_ttf_compat.cpp
@@ -139,7 +139,7 @@ std::string pango_word_wrap(const std::string& unwrapped_text, int font_size, in
 	return res;
 }
 
-SDL_Rect pango_draw_text(CVideo* video, const SDL_Rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips, pango_text::FONT_STYLE style)
+rect pango_draw_text(CVideo* video, const rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips, pango_text::FONT_STYLE style)
 {
 	auto& ptext = private_renderer();
 
@@ -148,14 +148,17 @@ SDL_Rect pango_draw_text(CVideo* video, const SDL_Rect& area, int size, const co
 		 .set_font_size(size)
 		 .set_font_style(style)
 		 .set_maximum_width(-1)
-		 .set_maximum_height(area.h, true)
 		 .set_foreground_color(color)
 		 .set_ellipse_mode(PANGO_ELLIPSIZE_END);
+
+	if(!area.empty()) {
+		ptext.set_maximum_height(area.h, true);
+	}
 
 	auto extents = ptext.get_size();
 	bool ellipsized = false;
 
-	if(extents.x > area.w) {
+	if(!area.empty() && extents.x > area.w) {
 		ptext.set_maximum_width(area.w);
 		ellipsized = true;
 	}

--- a/src/font/sdl_ttf_compat.hpp
+++ b/src/font/sdl_ttf_compat.hpp
@@ -30,6 +30,7 @@
 #include "font/text.hpp"
 
 class CVideo;
+struct rect;
 class texture;
 
 namespace font {
@@ -67,6 +68,7 @@ std::string pango_word_wrap(const std::string& unwrapped_text, int font_size, in
  *
  * The text will be clipped to area.  If the text runs outside of area
  * horizontally, an ellipsis will be displayed at the end of it.
+ * If area is empty, the text will not be clipped.
  *
  * If use_tooltips is true, then text with an ellipsis will have a tooltip
  * set for it equivalent to the entire contents of the text.
@@ -74,6 +76,6 @@ std::string pango_word_wrap(const std::string& unwrapped_text, int font_size, in
  * A bounding rectangle of the text is returned. If video is nullptr, then the
  * text will not be drawn, and a bounding rectangle only will be returned.
  */
-SDL_Rect pango_draw_text(CVideo* video, const SDL_Rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips = false, pango_text::FONT_STYLE style = pango_text::STYLE_NORMAL);
+rect pango_draw_text(CVideo* video, const rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips = false, pango_text::FONT_STYLE style = pango_text::STYLE_NORMAL);
 
 } // end namespace font

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -92,51 +92,15 @@ game_display::~game_display()
 void game_display::new_turn()
 {
 	static bool first_turn = true;
-	const time_of_day& tod = resources::tod_manager->get_time_of_day();
 
 	// We want to skip this on the first run of this function
 	if(!first_turn) {
+		const time_of_day& tod = resources::tod_manager->get_time_of_day();
 		const time_of_day& old_tod = resources::tod_manager->get_previous_time_of_day();
 
 		if(old_tod.image_mask != tod.image_mask) {
-			// TODO: highdpi - textures
-			// TODO: highdpi - make sure these are scaled correctly
-			surface old_mask(image::get_image(old_tod.image_mask,image::HEXED));
-			surface new_mask(image::get_image(tod.image_mask,image::HEXED));
-
-			const int niterations = static_cast<int>(10/turbo_speed());
-			const int frame_time = 30;
-			const int starting_ticks = SDL_GetTicks();
-			for(int i = 0; i != niterations; ++i) {
-
-				if(old_mask != nullptr) {
-					// TODO: highdpi - do this on the fly, rather than baking it
-					int32_t proportion = 256 - fixed_point_divide(i,niterations);
-					proportion = std::clamp(proportion, 0, 255);
-					adjust_surface_alpha(old_mask, proportion);
-					tod_hex_mask1 = old_mask;
-				}
-
-				if(new_mask != nullptr) {
-					// TODO: highdpi - do this on the fly, rather than baking it
-					int32_t proportion = fixed_point_divide(i,niterations);
-					proportion = std::clamp(proportion, 0, 255);
-					adjust_surface_alpha(new_mask, proportion);
-					tod_hex_mask2 = new_mask;
-				}
-
-				invalidate_all();
-
-				const int cur_ticks = SDL_GetTicks();
-				const int wanted_ticks = starting_ticks + i*frame_time;
-				if(cur_ticks < wanted_ticks) {
-					SDL_Delay(wanted_ticks - cur_ticks);
-				}
-			}
+			fade_tod_mask(old_tod.image_mask, tod.image_mask);
 		}
-
-		tod_hex_mask1 = nullptr;
-		tod_hex_mask2 = nullptr;
 	}
 
 	first_turn = false;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -500,7 +500,7 @@ void canvas::draw()
 		return;
 	}
 
-	// TODO: highdpi - it is assumed this will never move after blit
+	// Note: this doesn't update if whatever is underneath changes.
 	if(blur_depth_ && !blur_texture_) {
 		// Cache a blurred image of whatever is underneath.
 		SDL_Rect rect = draw::get_viewport();
@@ -510,7 +510,7 @@ void canvas::draw()
 	}
 
 	// Draw blurred background.
-	// TODO: highdpi - this should be able to be removed at some point with shaders
+	// TODO: hwaccel - this should be able to be removed at some point with shaders
 	if(blur_depth_ && blur_texture_) {
 		draw::blit(blur_texture_);
 	}

--- a/src/gui/core/top_level_drawable.cpp
+++ b/src/gui/core/top_level_drawable.cpp
@@ -29,4 +29,26 @@ top_level_drawable::~top_level_drawable()
 	draw_manager::deregister_drawable(this);
 }
 
+top_level_drawable::top_level_drawable(const top_level_drawable&)
+{
+	draw_manager::register_drawable(this);
+}
+
+top_level_drawable& top_level_drawable::operator=(const top_level_drawable&)
+{
+	draw_manager::register_drawable(this);
+	return *this;
+}
+
+top_level_drawable::top_level_drawable(top_level_drawable&&)
+{
+	draw_manager::register_drawable(this);
+}
+
+top_level_drawable& top_level_drawable::operator=(top_level_drawable&&)
+{
+	draw_manager::register_drawable(this);
+	return *this;
+}
+
 } // namespace gui2

--- a/src/gui/core/top_level_drawable.hpp
+++ b/src/gui/core/top_level_drawable.hpp
@@ -53,6 +53,13 @@ class top_level_drawable
 protected:
 	top_level_drawable();
 	virtual ~top_level_drawable();
+
+	// These make sure the TLD is registered.
+	top_level_drawable(const top_level_drawable&);
+	top_level_drawable& operator=(const top_level_drawable&);
+	top_level_drawable(top_level_drawable&&);
+	top_level_drawable& operator=(top_level_drawable&&);
+
 public:
 	/**
 	 * Update state and any parameters that may effect layout, or any of

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -49,7 +49,6 @@
 #include "gettext.hpp"
 #include "help/help.hpp"
 #include "preferences/lobby.hpp"
-#include "video.hpp"
 #include "wesnothd_connection.hpp"
 
 #include <functional>
@@ -911,25 +910,6 @@ void mp_lobby::show_help_callback()
 void mp_lobby::show_preferences_button_callback()
 {
 	gui2::dialogs::preferences_dialog::display();
-
-	/**
-	 * The screen size might have changed force an update of the size.
-	 *
-	 * @todo This might no longer be needed when gui2 is done.
-	 */
-	const SDL_Rect rect = CVideo::get_singleton().draw_area();
-
-	gui2::settings::gamemap_width  += rect.w - gui2::settings::screen_width;
-	gui2::settings::gamemap_height += rect.h - gui2::settings::screen_height;
-	gui2::settings::screen_width    = rect.w;
-	gui2::settings::screen_height   = rect.h;
-
-	/**
-	 * The screen size might have changed force an update of the size.
-	 *
-	 * @todo This might no longer be needed when gui2 is done.
-	 */
-	get_window()->invalidate_layout();
 
 	refresh_lobby();
 }

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -38,7 +38,7 @@
 #include "terrain/terrain.hpp"                  // for terrain_type
 #include "units/unit.hpp"                     // for unit
 #include "units/types.hpp"               // for unit_type, unit_type_data, etc
-#include "video.hpp"                    // for CVideo, resize_lock
+#include "video.hpp"               // TODO: draw_manager - only for draw_area
 #include "widgets/button.hpp"           // for button
 
 #include <cassert>                     // for assert
@@ -189,12 +189,10 @@ void show_with_toplevel(const section &toplevel_sec,
 			   const std::string& show_topic,
 			   int xloc, int yloc)
 {
-	CVideo& video = CVideo::get_singleton();
-
 	const events::event_context dialog_events_context;
 	const gui::dialog_manager manager;
 
-	SDL_Rect draw_area = video.draw_area();
+	SDL_Rect draw_area = CVideo::get_singleton().draw_area();
 
 	const int width  = std::min<int>(font::relative_size(1200), draw_area.w - font::relative_size(20));
 	const int height = std::min<int>(font::relative_size(850), draw_area.h - font::relative_size(150));
@@ -210,11 +208,11 @@ void show_with_toplevel(const section &toplevel_sec,
 		yloc = draw_area.h / 2 - height / 2;
 	}
 	std::vector<gui::button*> buttons_ptr;
-	gui::button close_button_(video, _("Close"));
+	gui::button close_button_(_("Close"));
 	buttons_ptr.push_back(&close_button_);
 
 	gui::dialog_frame f(
-		video, _("Help"), gui::dialog_frame::default_style, &buttons_ptr
+		_("Help"), gui::dialog_frame::default_style, &buttons_ptr
 	);
 	f.layout(xloc, yloc, width, height);
 
@@ -234,7 +232,7 @@ void show_with_toplevel(const section &toplevel_sec,
 		generate_contents();
 	}
 	try {
-		help_browser hb(video, toplevel_sec);
+		help_browser hb(toplevel_sec);
 		hb.set_location(xloc + left_padding, yloc + top_padding);
 		hb.set_width(width - left_padding - right_padding);
 		hb.set_height(height - top_padding - bot_padding);

--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -19,7 +19,6 @@ class config;
 class terrain_type;
 class unit;
 class unit_type;
-class CVideo;
 class game_config_view;
 
 #include <memory>

--- a/src/help/help_browser.cpp
+++ b/src/help/help_browser.cpp
@@ -25,21 +25,19 @@
 #include "sdl/rect.hpp"
 #include "sdl/input.hpp"                // for get_mouse_state
 
-class CVideo;
 struct SDL_Rect;
 
 namespace help {
 
-help_browser::help_browser(CVideo& video, const section &toplevel) :
-	gui::widget(video),
-	menu_(video,
-	toplevel),
-	text_area_(video, toplevel), toplevel_(toplevel),
+help_browser::help_browser(const section &toplevel) :
+	gui::widget(),
+	menu_(toplevel),
+	text_area_(toplevel), toplevel_(toplevel),
 	ref_cursor_(false),
 	back_topics_(),
 	forward_topics_(),
-	back_button_(video, "", gui::button::TYPE_PRESS, "button_normal/button_small_H22", gui::button::DEFAULT_SPACE, true, "icons/arrows/long_arrow_ornate_left"),
-	forward_button_(video, "", gui::button::TYPE_PRESS, "button_normal/button_small_H22", gui::button::DEFAULT_SPACE, true, "icons/arrows/long_arrow_ornate_right"),
+	back_button_("", gui::button::TYPE_PRESS, "button_normal/button_small_H22", gui::button::DEFAULT_SPACE, true, "icons/arrows/long_arrow_ornate_left"),
+	forward_button_("", gui::button::TYPE_PRESS, "button_normal/button_small_H22", gui::button::DEFAULT_SPACE, true, "icons/arrows/long_arrow_ornate_right"),
 	shown_topic_(nullptr)
 {
 	// Hide the buttons at first since we do not have any forward or

--- a/src/help/help_browser.hpp
+++ b/src/help/help_browser.hpp
@@ -22,7 +22,7 @@
 #include "help_text_area.hpp"           // for help_text_area
 #include "widgets/button.hpp"           // for button
 #include "widgets/widget.hpp"           // for widget
-class CVideo;  // lines 18-18
+
 struct SDL_Rect;
 
 namespace help {
@@ -31,7 +31,7 @@ namespace help {
 class help_browser : public gui::widget
 {
 public:
-	help_browser(CVideo& video, const section &toplevel);
+	help_browser(const section &toplevel);
 
 	void adjust_layout();
 

--- a/src/help/help_menu.cpp
+++ b/src/help/help_menu.cpp
@@ -26,12 +26,10 @@
 #include <utility>                      // for pair
 #include <SDL2/SDL.h>
 
-class CVideo;  // lines 56-56
-
 namespace help {
 
-help_menu::help_menu(CVideo &video, const section& toplevel, int max_height) :
-	gui::menu(video, empty_string_vector, true, max_height, -1, nullptr, &gui::menu::bluebg_style),
+help_menu::help_menu(const section& toplevel, int max_height) :
+	gui::menu(empty_string_vector, true, max_height, -1, nullptr, &gui::menu::bluebg_style),
 	visible_items_(),
 	toplevel_(toplevel),
 	expanded_(),

--- a/src/help/help_menu.hpp
+++ b/src/help/help_menu.hpp
@@ -20,8 +20,6 @@
 #include <vector>                       // for vector
 #include "widgets/menu.hpp"             // for menu
 
-class CVideo;
-
 namespace help { struct section; }
 namespace help { struct topic; }
 
@@ -34,7 +32,7 @@ namespace help {
 class help_menu : public gui::menu
 {
 public:
-	help_menu(CVideo &video, const section &toplevel, int max_height=-1);
+	help_menu(const section &toplevel, int max_height=-1);
 	int process();
 
 	/**

--- a/src/help/help_text_area.cpp
+++ b/src/help/help_text_area.cpp
@@ -27,7 +27,6 @@
 #include "sdl/rect.hpp"                 // for draw_rectangle, etc
 #include "sdl/texture.hpp"              // for texture
 #include "serialization/parser.hpp"     // for read, write
-#include "video.hpp"                    // for CVideo
 
 #include <algorithm>                    // for max, min, find_if
 #include <ostream>                      // for operator<<, stringstream, etc
@@ -43,8 +42,8 @@ static lg::log_domain log_help("help");
 
 namespace help {
 
-help_text_area::help_text_area(CVideo &video, const section &toplevel) :
-	gui::scrollarea(video),
+help_text_area::help_text_area(const section &toplevel) :
+	gui::scrollarea(),
 	items_(),
 	last_row_(),
 	toplevel_(toplevel),

--- a/src/help/help_text_area.hpp
+++ b/src/help/help_text_area.hpp
@@ -21,7 +21,7 @@
 #include "font/standard_colors.hpp"     // for NORMAL_COLOR
 #include "sdl/texture.hpp"              // for texture
 #include "widgets/scrollarea.hpp"       // for scrollarea
-class CVideo;
+
 class config;
 namespace help { struct section; }
 namespace help { struct topic; }
@@ -33,7 +33,7 @@ namespace help {
 class help_text_area : public gui::scrollarea
 {
 public:
-	help_text_area(CVideo &video, const section &toplevel);
+	help_text_area(const section &toplevel);
 	/** Display the topic. */
 	void show_topic(const topic &t);
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -32,7 +32,7 @@
 #include "tstring.hpp"                  // for t_string, operator<<
 #include "units/helper.hpp"             // for resistance_color
 #include "units/types.hpp"              // for unit_type, unit_type_data, etc
-#include "video.hpp"                    // fore current_resolution
+#include "video.hpp"                    // TODO: draw_manager - only draw_area
 
 #include <map>                          // for map, etc
 #include <optional>

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -31,6 +31,7 @@
 #include "sdl/rect.hpp"
 #include "sdl/input.hpp" // get_mouse_state
 #include "sdl/utils.hpp" // blur_surface
+#include "video.hpp"
 
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
@@ -81,11 +82,11 @@ dialog_manager::~dialog_manager()
 	SDL_PushEvent(&pb_event);
 }
 
-dialog_frame::dialog_frame(CVideo& video, const std::string& title,
+dialog_frame::dialog_frame(const std::string& title,
 		const style& style,
 		std::vector<button*>* buttons, button* help_button) :
 	title_(title),
-	video_(video),
+	video_(CVideo::get_singleton()),
 	dialog_style_(style),
 	buttons_(buttons),
 	help_button_(help_button),
@@ -316,7 +317,7 @@ void dialog_frame::draw_background()
 
 SDL_Rect dialog_frame::draw_title(CVideo* video)
 {
-	SDL_Rect rect = CVideo::get_singleton().draw_area();
+	SDL_Rect rect = video_.draw_area();
 	return font::pango_draw_text(video, rect, font::SIZE_TITLE, font::TITLE_COLOR,
 	                       title_, dim_.title.x, dim_.title.y, false, font::pango_text::STYLE_NORMAL);
 }

--- a/src/show_dialog.hpp
+++ b/src/show_dialog.hpp
@@ -21,8 +21,9 @@ class surface;
 #include "floating_label.hpp"
 #include "gui/core/top_level_drawable.hpp"
 #include "tooltips.hpp"
-#include "video.hpp"
 #include "widgets/button.hpp"
+
+class CVideo;
 
 namespace gui
 {
@@ -67,7 +68,7 @@ public:
 	static const int title_border_w, title_border_h;
 	static const style default_style;
 
-	dialog_frame(CVideo &video, const std::string& title="",
+	dialog_frame(const std::string& title="",
 		const style& dialog_style=default_style,
 		std::vector<button*>* buttons=nullptr,
 		button* help_button=nullptr);

--- a/src/units/drawer.hpp
+++ b/src/units/drawer.hpp
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "map/location.hpp"
+#include "sdl/rect.hpp"
 #include "utils/math.hpp"
 
 #include <map>
@@ -73,19 +74,21 @@ public:
 
 private:
 	/** draw a health/xp bar of a unit */
-	void draw_bar(const std::string& image, int xpos, int ypos,
-		const map_location& loc, std::size_t height, double filled,
-		const color_t& col, uint8_t alpha) const;
+	void draw_bar(int xpos, int ypos, const map_location& loc,
+		int height, double filled, const color_t& col, uint8_t alpha) const;
 
 	/**
-	 * Finds the start and end rows on the energy bar image.
+	 * Find where to draw the bar on an energy bar image.
 	 *
-	 * White pixels are substituted for the color of the energy.
+	 * Results are cached so this can be called frequently.
+	 *
+	 * This looks for a coloured region with significant (>0x10) alpha
+	 * and blackish colour (<0x10 in RGB channels).
 	 */
-	const SDL_Rect& calculate_energy_bar(surface surf) const;
+	rect calculate_energy_bar(const std::string& bar_image) const;
 
 	/** Scale a rect to the current zoom level. */
-	SDL_Rect scaled_to_zoom(const SDL_Rect& r) const;
+	rect scaled_to_zoom(const rect& r) const;
 	/** Scale a point to the current zoom level. */
 	point scaled_to_zoom(const point& p) const;
 };

--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -696,8 +696,10 @@ std::set<map_location> unit_frame::get_overlaped_hex(const int frame_time, const
 		}
 
 		if(w != 0 || h != 0) {
-			const int x = static_cast<int>(tmp_offset * xdst + (1.0 - tmp_offset) * xsrc);
-			const int y = static_cast<int>(tmp_offset * ydst + (1.0 - tmp_offset) * ysrc);
+			// TODO: unduplicate this code
+			const int x = static_cast<int>(tmp_offset * xdst + (1.0 - tmp_offset) * xsrc) + d2;
+			const int y = static_cast<int>(tmp_offset * ydst + (1.0 - tmp_offset) * ysrc) + d2;
+			const double disp_zoom = display::get_singleton()->get_zoom_factor();
 
 			bool facing_west = (
 				direction == map_location::NORTH_WEST ||
@@ -708,27 +710,27 @@ std::set<map_location> unit_frame::get_overlaped_hex(const int frame_time, const
 				direction == map_location::NORTH ||
 				direction == map_location::NORTH_EAST);
 
-			if(!current_data.auto_vflip) { facing_north = true; }
 			if(!current_data.auto_hflip) { facing_west = false; }
+			if(!current_data.auto_vflip) { facing_north = true; }
 
-			int my_x = x + current_data.x + d2 - w / 2;
-			int my_y = y + current_data.y + d2 - h / 2;
+			int my_x = x + disp_zoom * (current_data.x - w / 2);
+			int my_y = y + disp_zoom * (current_data.y - h / 2);
 
 			if(facing_west) {
-				my_x += current_data.directional_x;
+				my_x -= current_data.directional_x * disp_zoom;
 			} else {
-				my_x -= current_data.directional_x;
+				my_x += current_data.directional_x * disp_zoom;
 			}
 
 			if(facing_north) {
-				my_y += current_data.directional_y;
+				my_y += current_data.directional_y * disp_zoom;
 			} else {
-				my_y -= current_data.directional_y;
+				my_y -= current_data.directional_y * disp_zoom;
 			}
 
 			// Check if our underlying hexes are invalidated. If we need to update ourselves because we changed,
 			// invalidate our hexes and return whether or not was successful.
-			const SDL_Rect r {my_x, my_y, w, h};
+			const SDL_Rect r {my_x, my_y, int(w * disp_zoom), int(h * disp_zoom)};
 			display::rect_of_hexes underlying_hex = disp->hexes_under_rect(r);
 
 			result.insert(src);

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -28,7 +28,7 @@
 #include "sdl/rect.hpp"
 #include "serialization/string_utils.hpp"
 #include "sound.hpp"
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only needed for draw_area()
 #include "wml_separators.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -40,10 +40,10 @@ namespace gui {
 
 const int default_font_size = font::SIZE_BUTTON;
 
-button::button(CVideo& video, const std::string& label, button::TYPE type,
+button::button(const std::string& label, button::TYPE type,
                std::string button_image_name, SPACE_CONSUMPTION spacing,
                const bool auto_join, std::string overlay_image, int font_size)
-	: widget(video, auto_join), type_(type),
+	: widget(auto_join), type_(type),
 	  label_text_(label),
 	  image_(nullptr), pressedImage_(nullptr), activeImage_(nullptr), pressedActiveImage_(nullptr),
 	  disabledImage_(nullptr), pressedDisabledImage_(nullptr),

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -28,7 +28,6 @@
 #include "sdl/rect.hpp"
 #include "serialization/string_utils.hpp"
 #include "sound.hpp"
-#include "video.hpp" // TODO: draw_manager - only needed for draw_area()
 #include "wml_separators.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -211,7 +210,7 @@ void button::calculate_size()
 	}
 
 	if (type_ != TYPE_IMAGE){
-		textRect_ = font::pango_draw_text(nullptr, video().draw_area(), font_size_, font::BUTTON_COLOR, label_text_, 0, 0);
+		textRect_ = font::pango_draw_text(nullptr, sdl::empty_rect, font_size_, font::BUTTON_COLOR, label_text_, 0, 0);
 	}
 
 	// TODO: There's a weird text clipping bug, allowing the code below to run fixes it.

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -82,6 +82,7 @@ button::button(const std::string& label, button::TYPE type,
 	load_images();
 }
 
+// This function is a mess and i can only hope it someday dies a horrible death
 void button::load_images() {
 
 	std::string size_postfix;
@@ -106,12 +107,10 @@ void button::load_images() {
 		button_image_name_ + "-pressed.png" + button_image_path_suffix_);
 	activeImage_ = image::get_texture(
 		button_image_name_ + "-active.png" + button_image_path_suffix_);
-	// TODO: highdpi - why is this checking if the path exists? There should be no problem even if it doesn't.
 	if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + "-disabled.png")) {
 		disabledImage_ = image::get_texture(
 			button_image_name_ + "-disabled.png" + button_image_path_suffix_);
 	} else {
-		// TODO: highdpi - this was not previously reset. Is this function only ever run once, or can it be run multiple times?
 		disabledImage_.reset();
 	}
 
@@ -167,7 +166,6 @@ void button::load_images() {
 			pressedActiveImage_ = pressedImage_;
 		}
 
-		// TODO: highdpi - why is this check necessary? How does this work?
 		if (filesystem::file_exists(game_config::path + "/images/" + button_image_name_ + size_postfix + "-disabled-pressed.png")) {
 			pressedDisabledImage_ = image::get_texture(
 				button_image_name_ + "-disabled-pressed.png"+ button_image_path_suffix_);
@@ -178,7 +176,6 @@ void button::load_images() {
 		}
 	}
 
-	// TODO: highdpi - why is this check HERE? Why not back at the start? WTF is even going on in this function? And if checks like this work, WHY do we need all these filesystem::exists checks!?
 	if (!image_) {
 		std::string err_msg = "error initializing button images! file name: ";
 		err_msg += button_image_name_;
@@ -287,6 +284,7 @@ void button::enable(bool new_val)
 	}
 }
 
+// I can only assume this is working because nobody has complained it isn't.
 void button::draw_contents()
 {
 	texture image = image_;
@@ -334,32 +332,12 @@ void button::draw_contents()
 		button_color = font::GRAY_COLOR;
 	}
 
-	// TODO: highdpi - previous code was so much of a mess, i am not sure if this is doing anything like the correct thing.
 	SDL_Rect dest = loc;
 	if(type_ != TYPE_PRESS && type_ != TYPE_TURBO) {
 		// Scale other button types to match the base image?
 		dest.w = image_.w();
 		dest.h = image_.h();
 	}
-	// PREVIOUS HORRIBLE CODE FROM ELSEWHERE, FOR REFERENCE:
-	/*
-	if(type_ == TYPE_PRESS || type_ == TYPE_TURBO) {
-		image_ = scale_surface(button_image,location().w,location().h);
-		pressedImage_ = scale_surface(pressed_image,location().w,location().h);
-		activeImage_ = scale_surface(active_image,location().w,location().h);
-		disabledImage_ = scale_surface(disabled_image,location().w,location().h);
-	} else {
-		image_ = scale_surface(button_image,button_image->w,button_image->h);
-		activeImage_ = scale_surface(active_image,button_image->w,button_image->h);
-		disabledImage_ = scale_surface(disabled_image,button_image->w,button_image->h);
-		pressedImage_ = scale_surface(pressed_image,button_image->w,button_image->h);
-		if (type_ == TYPE_CHECK || type_ == TYPE_RADIO) {
-			pressedDisabledImage_ = scale_surface(pressed_disabled_image,button_image->w,button_image->h);
-			pressedActiveImage_ = scale_surface(pressed_active_image, button_image->w, button_image->h);
-			touchedImage_ = scale_surface(touched_image, button_image->w, button_image->h);
-		}
-	}
-	*/
 
 	draw::blit(image, dest);
 
@@ -383,7 +361,6 @@ void button::draw_contents()
 			}
 		}
 
-		// TODO: highdpi - should this be the whole button? Like... WTF? Previously these weren't scaled at all, so... maybe? Or maybe not? IT IS A MYSTERY
 		dest.w = overlay.w();
 		dest.h = overlay.h();
 		draw::blit(overlay, dest);

--- a/src/widgets/button.hpp
+++ b/src/widgets/button.hpp
@@ -62,7 +62,7 @@ public:
 
 	enum SPACE_CONSUMPTION { DEFAULT_SPACE, MINIMUM_SPACE };
 
-	button(CVideo& video, const std::string& label, TYPE type=TYPE_PRESS,
+	button(const std::string& label, TYPE type=TYPE_PRESS,
 	       std::string button_image="", SPACE_CONSUMPTION spacing=DEFAULT_SPACE,
 	       const bool auto_join=true, std::string overlay_image="", int font_size = -1);
 

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -147,10 +147,10 @@ bool menu::basic_sorter::less(int column, const item& row1, const item& row2) co
 	return false;
 }
 
-menu::menu(CVideo& video, const std::vector<std::string>& items,
+menu::menu(const std::vector<std::string>& items,
 		bool click_selects, int max_height, int max_width,
 		const sorter* sorter_obj, style *menu_style, const bool auto_join)
-: scrollarea(video, auto_join), silent_(false),
+: scrollarea(auto_join), silent_(false),
   max_height_(max_height), max_width_(max_width),
   max_items_(-1), item_height_(-1),
   heading_height_(-1),

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -137,7 +137,7 @@ public:
 		std::map<int,std::vector<int>> pos_sort_;
 	};
 
-	menu(CVideo& video, const std::vector<std::string>& items,
+	menu(const std::vector<std::string>& items,
 	     bool click_selects=false, int max_height=-1, int max_width=-1,
 		 const sorter* sorter_obj=nullptr, style *menu_style=nullptr, const bool auto_join=true);
 

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -17,13 +17,13 @@
 
 #include "widgets/scrollarea.hpp"
 #include "sdl/rect.hpp"
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only needed for draw_area()
 #include "sdl/input.hpp" // get_mouse_state
 
 namespace gui {
 
-scrollarea::scrollarea(CVideo &video, const bool auto_join)
-	: widget(video, auto_join), scrollbar_(video),
+scrollarea::scrollarea(const bool auto_join)
+	: widget(auto_join), scrollbar_(),
 	  old_position_(0), recursive_(false), shown_scrollbar_(false),
 	  shown_size_(0), full_size_(0), swipe_dy_(0)
 {

--- a/src/widgets/scrollarea.hpp
+++ b/src/widgets/scrollarea.hpp
@@ -28,7 +28,7 @@ public:
 	 */
 	//- \param d the display object
 	//- \param pane the widget where wheel events take place
-	scrollarea(CVideo &video, bool auto_join=true);
+	scrollarea(bool auto_join=true);
 
 	virtual void hide(bool value = true);
 

--- a/src/widgets/scrollbar.cpp
+++ b/src/widgets/scrollbar.cpp
@@ -24,7 +24,6 @@
 #include "sdl/rect.hpp"
 #include "sdl/texture.hpp"
 #include "sdl/utils.hpp"
-#include "video.hpp"
 
 namespace {
 
@@ -44,8 +43,8 @@ const std::string scrollbar_mid_pressed = "buttons/scrollbars/scrollmid-pressed.
 
 namespace gui {
 
-scrollbar::scrollbar(CVideo &video)
-	: widget(video)
+scrollbar::scrollbar()
+	: widget()
 	, state_(NORMAL)
 	, minimum_grip_height_(0)
 	, mousey_on_grip_(0)

--- a/src/widgets/scrollbar.hpp
+++ b/src/widgets/scrollbar.hpp
@@ -33,7 +33,7 @@ public:
 	//- @param d         the display object
 	//- @param pane      the widget where wheel events take place
 	//- @param callback  a callback interface for warning that the grip has been moved
-	scrollbar(CVideo &video);
+	scrollbar();
 
 	/**
 	 * Determine where the scrollbar is.

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -24,7 +24,7 @@
 #include "log.hpp"
 #include "sdl/rect.hpp"
 #include "serialization/string_utils.hpp"
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only needed for pixel scale
 #include "sdl/input.hpp" // get_mouse_state
 
 static lg::log_domain log_display("display");
@@ -33,8 +33,8 @@ static lg::log_domain log_display("display");
 
 namespace gui {
 
-textbox::textbox(CVideo &video, int width, const std::string& text, bool editable, std::size_t max_size, int font_size, double alpha, double alpha_focus, const bool auto_join)
-	   : scrollarea(video, auto_join), max_size_(max_size), font_size_(font_size), text_(unicode_cast<std::u32string>(text)),
+textbox::textbox(int width, const std::string& text, bool editable, std::size_t max_size, int font_size, double alpha, double alpha_focus, const bool auto_join)
+	   : scrollarea(auto_join), max_size_(max_size), font_size_(font_size), text_(unicode_cast<std::u32string>(text)),
 	     cursor_(text_.size()), selstart_(-1), selend_(-1),
 	     grabmouse_(false), text_pos_(0), editable_(editable),
 	     show_cursor_(true), show_cursor_at_(0), text_image_(nullptr),

--- a/src/widgets/textbox.hpp
+++ b/src/widgets/textbox.hpp
@@ -26,7 +26,7 @@ namespace gui {
 class textbox : public scrollarea
 {
 public:
-	textbox(CVideo &video, int width, const std::string& text="", bool editable=true, std::size_t max_size = 256, int font_size = font::SIZE_PLUS, double alpha = 0.4, double alpha_focus = 0.2, const bool auto_join = true);
+	textbox(int width, const std::string& text="", bool editable=true, std::size_t max_size = 256, int font_size = font::SIZE_PLUS, double alpha = 0.4, double alpha_focus = 0.2, const bool auto_join = true);
 	virtual ~textbox();
 
 	const std::string text() const;

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -31,8 +31,8 @@ namespace gui {
 
 bool widget::mouse_lock_ = false;
 
-widget::widget(CVideo& video, const bool auto_join)
-	: events::sdl_handler(auto_join), focus_(true), video_(&video), rect_(EmptyRect), needs_restore_(false),
+widget::widget(const bool auto_join)
+	: events::sdl_handler(auto_join), focus_(true), rect_(EmptyRect), needs_restore_(false),
 	  state_(UNINIT), hidden_override_(false), enabled_(true), clip_(false),
 	  clip_rect_(EmptyRect), help_string_(0), mouse_lock_local_(false)
 {
@@ -66,6 +66,12 @@ void widget::free_mouse_lock()
 bool widget::mouse_locked() const
 {
 	return mouse_lock_ && !mouse_lock_local_;
+}
+
+// TODO: draw_manager - overhaul CVideo interface
+CVideo& widget::video() const
+{
+	return CVideo::get_singleton();
 }
 
 // TODO: draw_manager - kill surface restorers

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -69,7 +69,7 @@ public:
 	virtual void process_tooltip_string(int mousex, int mousey) override;
 
 protected:
-	widget(CVideo& video, const bool auto_join=true);
+	widget(const bool auto_join=true);
 	virtual ~widget();
 
 	// During each relocation, this function should be called to register
@@ -80,7 +80,7 @@ protected:
 	void bg_update(); // TODO: draw_manager - remove
 	void bg_cancel(); // TODO: draw_manager - remove
 
-	CVideo& video() const { return *video_; }
+	CVideo& video() const;
 
 public:
 	/* draw_manager interface */
@@ -111,7 +111,6 @@ protected:
 private:
 	void hide_override(bool value = true);
 
-	CVideo* video_;
 	std::vector<rect> restorer_;
 	rect rect_;
 	mutable bool needs_restore_; // Have we drawn ourselves, so that if moved, we need to restore the background?

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -102,7 +102,6 @@ protected:
 
 	// TODO: draw_manager - only things that need events should be handlers
 	virtual void handle_event(const SDL_Event&) override {};
-	virtual void handle_window_event(const SDL_Event&) override {};
 	bool focus_;		// Should user input be ignored?
 
 	bool mouse_locked() const;


### PR DESCRIPTION
Notable items:
* tod_hex_mask is now hardware accelerated... whatever this is. There are no examples using it in mainline so i'm not sure it works correctly. But it should.
* HP/XP bars are now rendered in hardware, using the single-pixel image from my last PR.
* Unit animation invalidation code has been updated to properly account for zoom.

Re the HP/XP bars i ended up supporting the custom bar stuff, although it's confirmed to be unused by anything. Might still be better to do this by drawing rectangles, as it would give a better result when zoomed. I had an implementation for that too, but i discarded it as broken... turns out that was due to an unrelated bug.

Re the animation invalidation, this should address #6589 and maybe #6891... i confirmed it also fixed some leftovers from movement and attacking animations when zoomed in, so it might fix other bugs as well. This fix could probably be backported to 1.16

The rest of the stuff here is general cleanup.