### PR TITLE
Add --log-to-file command line option.

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -190,6 +190,9 @@ lists defined log domains (only the ones containing
 .I filter
 if used) and exits
 .TP
+.B --log-to-file
+redirects logged output to a file. Log files are created in the logs directory under the userdata folder.
+.TP
 .BI --max-fps \ fps
 the number of frames per second the game can show, the value should be between
 .B 1

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -257,6 +257,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("log-debug", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'debug'. Similar to --log-error.")
 		("log-none", po::value<std::string>(), "sets the severity level of the specified log domain(s) to 'none'. Similar to --log-error.")
 		("log-precise", "shows the timestamps in log output with more precision.")
+		("log-to-file", "log output is written to a file rather than to standard error.")
 		;
 
 	po::options_description multiplayer_opts("Multiplayer options");
@@ -268,7 +269,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("era", po::value<std::string>(), "selects the era to be played in by its id.")
 		("exit-at-end", "exit Wesnoth at the end of the scenario.")
 		("ignore-map-settings", "do not use map settings.")
-		("label", po::value<std::string>(), "sets the label for AIs.") //TODO is the description precise? this option was undocumented before.
+		("label", po::value<std::string>(), "sets the label for AIs.") // TODO: is the description precise? this option was undocumented before.
 		("multiplayer-repeat",  po::value<unsigned int>(), "repeats a multiplayer game after it is finished <arg> times.")
 		("nogui", "runs the game without the GUI.")
 		("parm", po::value<std::vector<std::string>>()->composing(), "sets additional parameters for this side. <arg> should have format side:name:value.")

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -583,9 +583,12 @@ static void setup_user_data_dir()
 	create_directory_if_missing(user_data_dir / "data" / "add-ons");
 	create_directory_if_missing(user_data_dir / "saves");
 	create_directory_if_missing(user_data_dir / "persist");
+	create_directory_if_missing(filesystem::get_logs_dir());
 
 #ifdef _WIN32
 	lg::finish_log_file_setup();
+#else
+	lg::rotate_logs(filesystem::get_logs_dir());
 #endif
 }
 
@@ -790,6 +793,11 @@ std::string get_user_config_dir()
 std::string get_user_data_dir()
 {
 	return get_user_data_path().string();
+}
+
+std::string get_logs_dir()
+{
+	return filesystem::get_user_data_dir() + "/logs";
 }
 
 std::string get_cache_dir()
@@ -1042,7 +1050,6 @@ filesystem::scoped_istream istream_file(const std::string& fname, bool treat_fai
 filesystem::scoped_ostream ostream_file(const std::string& fname, std::ios_base::openmode mode, bool create_directory)
 {
 	LOG_FS << "streaming " << fname << " for writing.";
-#if 1
 	try {
 		boost::iostreams::file_descriptor_sink fd(bfs::path(fname), mode);
 		return std::make_unique<boost::iostreams::stream<boost::iostreams::file_descriptor_sink>>(fd, 4096, 0);
@@ -1056,9 +1063,6 @@ filesystem::scoped_ostream ostream_file(const std::string& fname, std::ios_base:
 
 		throw filesystem::io_exception(e.what());
 	}
-#else
-	return new bfs::ofstream(bfs::path(fname), mode);
-#endif
 }
 
 // Throws io_exception if an error occurs

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -165,6 +165,7 @@ void set_user_data_dir(std::string path);
 
 std::string get_user_config_dir();
 std::string get_user_data_dir();
+std::string get_logs_dir();
 std::string get_cache_dir();
 
 struct other_version_dir

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -61,6 +61,15 @@
 
 namespace lg {
 
+// Prefix and extension for log files. This is used both to generate the unique
+// log file name during startup and to find old files to delete.
+const std::string log_file_prefix = "wesnoth-";
+const std::string log_file_suffix = ".log";
+
+// Maximum number of older log files to keep intact. Other files are deleted.
+// Note that this count does not include the current log file!
+const unsigned max_logs = 8;
+
 enum severity
 {
 	LG_ERROR=0,
@@ -117,6 +126,11 @@ std::string list_logdomains(const std::string& filter);
 void set_strict_severity(int severity);
 void set_strict_severity(const logger &lg);
 bool broke_strict();
+void set_log_to_file();
+
+bool is_not_log_file(const std::string& filename);
+void rotate_logs(const std::string& log_dir);
+std::string unique_log_filename();
 
 // A little "magic" to surround the logging operation in a mutex.
 // This works by capturing the output first to a stringstream formatter, then

--- a/src/log_windows.hpp
+++ b/src/log_windows.hpp
@@ -39,16 +39,6 @@
  * and later versions, requiring UAC virtualization to be enabled).
  */
 
-namespace filesystem
-{
-
-/**
- * Returns the path to the permanent log storage directory.
- */
-std::string get_logs_dir();
-
-}
-
 namespace lg
 {
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -986,12 +986,18 @@ int main(int argc, char** argv)
 	assert(!args.empty());
 
 	// --nobanner needs to be detected before the main command-line parsing happens
+	// --log-to needs to be detected so the logging output location is set before any actual logging happens
 	bool nobanner = false;
 	for(const auto& arg : args) {
 		if(arg == "--nobanner") {
 			nobanner = true;
 			break;
 		}
+#ifndef _WIN32
+		else if(arg == "--log-to-file") {
+			lg::set_log_to_file();
+		}
+#endif
 	}
 
 #ifdef _WIN32


### PR DESCRIPTION
This option sets up writing both the cerr and cout streams to a log file, as well as pulls the log rotation logic out of log_windows.*pp into the general logger.

Note that this is meant for usage on macOS and Linux, not Windows. log_windows.*pp has additional functionality in it, as well as a fair bit related to the --wconsole option.

---

Testing locally this seems to work fine, though the fact that this wasn't done years ago makes me wonder if there's something obvious that I'm missing.