### PR TITLE
Video interface refactor and clean

### DIFF
--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -123,7 +123,7 @@ namespace
 		// When the unit advances, it fades to white, and then switches
 		// to the new unit, then fades back to the normal color
 
-		if (animate && !CVideo::get_singleton().update_locked()) {
+		if (animate && !CVideo::get_singleton().faked()) {
 			unit_animator animator;
 			bool with_bars = true;
 			animator.add_animation(u.get_shared_ptr(), "levelout", u->get_location(), map_location(), 0, with_bars);
@@ -144,7 +144,7 @@ namespace
 		u = resources::gameboard->units().find(loc);
 		game_display::get_singleton()->invalidate_unit();
 
-		if (animate && u != resources::gameboard->units().end() && !CVideo::get_singleton().update_locked()) {
+		if (animate && u != resources::gameboard->units().end() && !CVideo::get_singleton().faked()) {
 			unit_animator animator;
 			animator.add_animation(u.get_shared_ptr(), "levelin", u->get_location(), map_location(), 0, true);
 			animator.start_animations();

--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -41,7 +41,7 @@
 #include "units/udisplay.hpp"
 #include "units/helper.hpp" //number_of_possible_advances
 #include "utils/general.hpp"
-#include "video.hpp" // for faked, non_interactive
+#include "video.hpp"
 #include "whiteboard/manager.hpp"
 
 static lg::log_domain log_engine("engine");
@@ -124,7 +124,7 @@ namespace
 		// When the unit advances, it fades to white, and then switches
 		// to the new unit, then fades back to the normal color
 
-		if (animate && !video::faked()) {
+		if (animate && !video::headless()) {
 			unit_animator animator;
 			bool with_bars = true;
 			animator.add_animation(u.get_shared_ptr(), "levelout", u->get_location(), map_location(), 0, with_bars);
@@ -145,7 +145,7 @@ namespace
 		u = resources::gameboard->units().find(loc);
 		game_display::get_singleton()->invalidate_unit();
 
-		if (animate && u != resources::gameboard->units().end() && !video::faked()) {
+		if (animate && u != resources::gameboard->units().end() && !video::headless()) {
 			unit_animator animator;
 			animator.add_animation(u.get_shared_ptr(), "levelin", u->get_location(), map_location(), 0, true);
 			animator.start_animations();
@@ -205,7 +205,7 @@ namespace
 
 			//to make mp games equal we only allow selecting advancements to the current side.
 			//otherwise we'd give an unfair advantage to the side that hosts ai sides if units advance during ai turns.
-			if(!video::non_interactive() && (force_dialog_ || (t.is_local_human() && !t.is_droid() && !t.is_idle() && (is_current_side || !is_mp))))
+			if(!video::headless() && (force_dialog_ || (t.is_local_human() && !t.is_droid() && !t.is_idle() && (is_current_side || !is_mp))))
 			{
 				res = advance_unit_dialog(loc_);
 			}

--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -41,6 +41,7 @@
 #include "units/udisplay.hpp"
 #include "units/helper.hpp" //number_of_possible_advances
 #include "utils/general.hpp"
+#include "video.hpp" // for faked, non_interactive
 #include "whiteboard/manager.hpp"
 
 static lg::log_domain log_engine("engine");
@@ -123,7 +124,7 @@ namespace
 		// When the unit advances, it fades to white, and then switches
 		// to the new unit, then fades back to the normal color
 
-		if (animate && !CVideo::get_singleton().faked()) {
+		if (animate && !video::faked()) {
 			unit_animator animator;
 			bool with_bars = true;
 			animator.add_animation(u.get_shared_ptr(), "levelout", u->get_location(), map_location(), 0, with_bars);
@@ -144,7 +145,7 @@ namespace
 		u = resources::gameboard->units().find(loc);
 		game_display::get_singleton()->invalidate_unit();
 
-		if (animate && u != resources::gameboard->units().end() && !CVideo::get_singleton().faked()) {
+		if (animate && u != resources::gameboard->units().end() && !video::faked()) {
 			unit_animator animator;
 			animator.add_animation(u.get_shared_ptr(), "levelin", u->get_location(), map_location(), 0, true);
 			animator.start_animations();
@@ -204,7 +205,7 @@ namespace
 
 			//to make mp games equal we only allow selecting advancements to the current side.
 			//otherwise we'd give an unfair advantage to the side that hosts ai sides if units advance during ai turns.
-			if(!CVideo::get_singleton().non_interactive() && (force_dialog_ || (t.is_local_human() && !t.is_droid() && !t.is_idle() && (is_current_side || !is_mp))))
+			if(!video::non_interactive() && (force_dialog_ || (t.is_local_human() && !t.is_droid() && !t.is_idle() && (is_current_side || !is_mp))))
 			{
 				res = advance_unit_dialog(loc_);
 			}

--- a/src/actions/vision.cpp
+++ b/src/actions/vision.cpp
@@ -335,12 +335,8 @@ bool shroud_clearer::clear_unit(const map_location &view_loc, team &view_team,
                                 const map_location & real_loc,
                                 const std::set<map_location>* known_units,
                                 std::size_t * enemy_count, std::size_t * friend_count,
-                                move_unit_spectator * spectator, bool instant)
+                                move_unit_spectator * spectator, bool /*instant*/)
 {
-	// Give animations a chance to progress; see bug #20324.
-	if ( !instant  && display::get_singleton() )
-		display::get_singleton()->draw(true);
-
 	bool cleared_something = false;
 	// Dummy variables to make some logic simpler.
 	std::size_t enemies=0, friends=0;
@@ -352,16 +348,10 @@ bool shroud_clearer::clear_unit(const map_location &view_loc, team &view_team,
 	// Make sure the jamming map is up-to-date.
 	if ( view_team_ != &view_team ) {
 		calculate_jamming(&view_team);
-		// Give animations a chance to progress; see bug #20324.
-		if ( !instant  && display::get_singleton() )
-			display::get_singleton()->draw(true);
 	}
 
 	// Determine the hexes to clear.
 	pathfind::vision_path sight(costs, slowed, sight_range, view_loc, jamming_);
-	// Give animations a chance to progress; see bug #20324.
-	if ( !instant  && display::get_singleton() )
-		display::get_singleton()->draw(true);
 
 	// Clear the fog.
 	for (const pathfind::paths::step &dest : sight.destinations) {

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -545,18 +545,16 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 {
 	list_formatter fmt{heading};
 
-	if(!CVideo::setup_completed()) {
+	if(!video::setup_completed()) {
 		fmt.set_placeholder("Graphics not initialized.");
 		return fmt;
 	}
 
-	CVideo& video = CVideo::get_singleton();
-
 	std::string placeholder;
 
-	if(video.non_interactive()) {
+	if(video::non_interactive()) {
 		placeholder = "Running in non-interactive mode.";
-	} else if(!video.has_window()) {
+	} else if(!video::has_window()) {
 		placeholder = "Running without a game window.";
 	}
 
@@ -565,17 +563,17 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 		return fmt;
 	}
 
-	const auto& current_driver = CVideo::current_driver();
-	auto drivers = CVideo::enumerate_drivers();
+	const auto& current_driver = video::current_driver();
+	auto drivers = video::enumerate_drivers();
 
 	fmt.insert("SDL video drivers", format_sdl_driver_list(drivers, current_driver));
 	fmt.insert("Window size", geometry_to_string(
-		video.current_resolution().x, video.current_resolution().y));
+		video::current_resolution().x, video::current_resolution().y));
 	fmt.insert("Game canvas size", geometry_to_string(
-		video.draw_area().w, video.draw_area().h));
+		video::draw_area().w, video::draw_area().h));
 	fmt.insert("Final render target size", geometry_to_string(
-		video.output_size().x, video.output_size().y));
-	fmt.insert("Screen refresh rate", std::to_string(video.current_refresh_rate()));
+		video::output_size().x, video::output_size().y));
+	fmt.insert("Screen refresh rate", std::to_string(video::current_refresh_rate()));
 
 	return fmt;
 }

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -545,17 +545,10 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 {
 	list_formatter fmt{heading};
 
-	if(!video::setup_completed()) {
-		fmt.set_placeholder("Graphics not initialized.");
-		return fmt;
-	}
-
 	std::string placeholder;
 
 	if(video::non_interactive()) {
 		placeholder = "Running in non-interactive mode.";
-	} else if(!video::has_window()) {
-		placeholder = "Running without a game window.";
 	}
 
 	if(!placeholder.empty()) {

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -547,7 +547,7 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 
 	std::string placeholder;
 
-	if(video::non_interactive()) {
+	if(video::headless()) {
 		placeholder = "Running in non-interactive mode.";
 	}
 

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -516,10 +516,9 @@ list_formatter optional_features_report_internal(const std::string& heading = ""
 	return fmt;
 }
 
-template<typename T>
-inline std::string geometry_to_string(T horizontal, T vertical)
+inline std::string geometry_to_string(point p)
 {
-	return std::to_string(horizontal) + 'x' + std::to_string(vertical);
+	return std::to_string(p.x) + 'x' + std::to_string(p.y);
 }
 
 std::string format_sdl_driver_list(std::vector<std::string> drivers, const std::string& current_driver)
@@ -560,12 +559,9 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 	auto drivers = video::enumerate_drivers();
 
 	fmt.insert("SDL video drivers", format_sdl_driver_list(drivers, current_driver));
-	fmt.insert("Window size", geometry_to_string(
-		video::current_resolution().x, video::current_resolution().y));
-	fmt.insert("Game canvas size", geometry_to_string(
-		video::draw_area().w, video::draw_area().h));
-	fmt.insert("Final render target size", geometry_to_string(
-		video::output_size().x, video::output_size().y));
+	fmt.insert("Window size", geometry_to_string(video::current_resolution()));
+	fmt.insert("Game canvas size", geometry_to_string(video::game_canvas_size()));
+	fmt.insert("Final render target size", geometry_to_string(video::output_size()));
 	fmt.insert("Screen refresh rate", std::to_string(video::current_refresh_rate()));
 
 	return fmt;

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -315,7 +315,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 			dy -= scroll_amount;
 		}
 
-		if(mousey > video::draw_area().h - scroll_threshold) {
+		if(mousey > video::game_canvas_size().y - scroll_threshold) {
 			dy += scroll_amount;
 		}
 
@@ -323,7 +323,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 			dx -= scroll_amount;
 		}
 
-		if(mousex > video::draw_area().w - scroll_threshold) {
+		if(mousex > video::game_canvas_size().x - scroll_threshold) {
 			dx += scroll_amount;
 		}
 	}
@@ -400,7 +400,7 @@ void controller_base::play_slice(bool is_delay_enabled)
 
 	const theme::menu* const m = get_display().menu_pressed();
 	if(m != nullptr) {
-		const rect& menu_loc = m->location(video::draw_area());
+		const rect& menu_loc = m->location(video::game_canvas());
 		show_menu(m->items(), menu_loc.x + 1, menu_loc.y + menu_loc.h + 1, false, get_display());
 
 		return;
@@ -408,7 +408,7 @@ void controller_base::play_slice(bool is_delay_enabled)
 
 	const theme::action* const a = get_display().action_pressed();
 	if(a != nullptr) {
-		const rect& action_loc = a->location(video::draw_area());
+		const rect& action_loc = a->location(video::game_canvas());
 		execute_action(a->items(), action_loc.x + 1, action_loc.y + action_loc.h + 1, false);
 
 		return;

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -30,6 +30,7 @@
 #include "soundsource.hpp"
 #include "gui/core/timer.hpp"
 #include "sdl/input.hpp" // get_mouse_state
+#include "video.hpp"
 
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
@@ -273,7 +274,7 @@ bool controller_base::have_keyboard_focus()
 bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 {
 	const bool mouse_in_window =
-		CVideo::get_singleton().window_has_flags(SDL_WINDOW_MOUSE_FOCUS)
+		video::window_has_flags(SDL_WINDOW_MOUSE_FOCUS)
 		|| preferences::get("scroll_when_mouse_outside", true);
 
 	int scroll_speed = preferences::scroll_speed();
@@ -314,7 +315,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 			dy -= scroll_amount;
 		}
 
-		if(mousey > get_display().video().draw_area().h - scroll_threshold) {
+		if(mousey > video::draw_area().h - scroll_threshold) {
 			dy += scroll_amount;
 		}
 
@@ -322,7 +323,7 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 			dx -= scroll_amount;
 		}
 
-		if(mousex > get_display().video().draw_area().w - scroll_threshold) {
+		if(mousex > video::draw_area().w - scroll_threshold) {
 			dx += scroll_amount;
 		}
 	}
@@ -399,7 +400,7 @@ void controller_base::play_slice(bool is_delay_enabled)
 
 	const theme::menu* const m = get_display().menu_pressed();
 	if(m != nullptr) {
-		const SDL_Rect& menu_loc = m->location(get_display().video().draw_area());
+		const rect& menu_loc = m->location(video::draw_area());
 		show_menu(m->items(), menu_loc.x + 1, menu_loc.y + menu_loc.h + 1, false, get_display());
 
 		return;
@@ -407,7 +408,7 @@ void controller_base::play_slice(bool is_delay_enabled)
 
 	const theme::action* const a = get_display().action_pressed();
 	if(a != nullptr) {
-		const SDL_Rect& action_loc = a->location(get_display().video().draw_area());
+		const rect& action_loc = a->location(video::draw_area());
 		execute_action(a->items(), action_loc.x + 1, action_loc.y + action_loc.h + 1, false);
 
 		return;
@@ -429,8 +430,8 @@ void controller_base::play_slice(bool is_delay_enabled)
 	map_location highlighted_hex = get_display().mouseover_hex();
 
 	// be nice when window is not visible	// NOTE should be handled by display instead, to only disable drawing
-	if(is_delay_enabled && !CVideo::get_singleton().window_has_flags(SDL_WINDOW_SHOWN)) {
-		CVideo::delay(200);
+	if(is_delay_enabled && !video::window_has_flags(SDL_WINDOW_SHOWN)) {
+		video::delay(200);
 	}
 
 	// Scrolling ended, update the cursor and the brightened hex

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -274,7 +274,7 @@ bool controller_base::have_keyboard_focus()
 bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 {
 	const bool mouse_in_window =
-		video::window_has_flags(SDL_WINDOW_MOUSE_FOCUS)
+		video::window_has_mouse_focus()
 		|| preferences::get("scroll_when_mouse_outside", true);
 
 	int scroll_speed = preferences::scroll_speed();
@@ -430,8 +430,8 @@ void controller_base::play_slice(bool is_delay_enabled)
 	map_location highlighted_hex = get_display().mouseover_hex();
 
 	// be nice when window is not visible	// NOTE should be handled by display instead, to only disable drawing
-	if(is_delay_enabled && !video::window_has_flags(SDL_WINDOW_SHOWN)) {
-		video::delay(200);
+	if(is_delay_enabled && !video::window_is_visible()) {
+		SDL_Delay(200);
 	}
 
 	// Scrolling ended, update the cursor and the brightened hex

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -40,7 +40,6 @@
 #include "hotkey/hotkey_command.hpp"
 #include "key.hpp"
 #include "quit_confirmation.hpp"
-#include "video.hpp"
 
 class game_config_view;
 class display;

--- a/src/desktop/notifications.cpp
+++ b/src/desktop/notifications.cpp
@@ -18,7 +18,7 @@
 #include "preferences/game.hpp"
 #include "gettext.hpp"
 
-#include "video.hpp" //CVideo::get_singleton().window_state()
+#include "video.hpp" // window_has_flags()
 
 #ifdef HAVE_LIBDBUS
 #include "desktop/dbus_features.hpp"
@@ -56,12 +56,10 @@ bool available()
 
 void send(const std::string& owner, const std::string& message, type t)
 {
-	CVideo& video = CVideo::get_singleton();
-
 	// Do not show notifications when the window is visible...
-	if(video.window_has_flags(SDL_WINDOW_SHOWN)) {
+	if(video::window_has_flags(SDL_WINDOW_SHOWN)) {
 		// ... and it has a focus.
-		if(video.window_has_flags(SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_INPUT_FOCUS)) {
+		if(video::window_has_flags(SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_INPUT_FOCUS)) {
 			return;
 		}
 	}

--- a/src/desktop/notifications.cpp
+++ b/src/desktop/notifications.cpp
@@ -56,12 +56,9 @@ bool available()
 
 void send(const std::string& owner, const std::string& message, type t)
 {
-	// Do not show notifications when the window is visible...
-	if(video::window_has_flags(SDL_WINDOW_SHOWN)) {
-		// ... and it has a focus.
-		if(video::window_has_flags(SDL_WINDOW_MOUSE_FOCUS | SDL_WINDOW_INPUT_FOCUS)) {
-			return;
-		}
+	// Do not show notifications when the window is visible and has focus
+	if(video::window_is_visible() && video::window_has_focus()) {
+		return;
 	}
 
 #ifdef HAVE_LIBDBUS

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -21,7 +21,7 @@
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
 #include "sdl/window.hpp"
-#include "video.hpp"		// CVideo class holds the window -> SDL_Window object which contains the handle of the main window
+#include "video.hpp" // for get_window
 
 NOTIFYICONDATA* windows_tray_notification::nid = nullptr;
 bool windows_tray_notification::message_reset = false;
@@ -173,7 +173,6 @@ HWND windows_tray_notification::get_window_handle()
 {
 	SDL_SysWMinfo wmInfo;
 	SDL_VERSION(&wmInfo.version);
-	// TODO: draw_manager - refactor?
 	sdl::window* window = video::get_window();
 	// SDL 1.2 keeps track of window handles internally whereas SDL 2.0 allows the caller control over which window to use
 	if (!window || SDL_GetWindowWMInfo (static_cast<SDL_Window *> (*window), &wmInfo) != SDL_TRUE) {

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -173,9 +173,9 @@ HWND windows_tray_notification::get_window_handle()
 {
 	SDL_SysWMinfo wmInfo;
 	SDL_VERSION(&wmInfo.version);
-	sdl::window* window = video::get_window();
+	SDL_Window* window = video::get_window();
 	// SDL 1.2 keeps track of window handles internally whereas SDL 2.0 allows the caller control over which window to use
-	if (!window || SDL_GetWindowWMInfo (static_cast<SDL_Window *> (*window), &wmInfo) != SDL_TRUE) {
+	if (!window || SDL_GetWindowWMInfo (window, &wmInfo) != SDL_TRUE) {
 		return nullptr;
 	}
 

--- a/src/desktop/windows_tray_notification.cpp
+++ b/src/desktop/windows_tray_notification.cpp
@@ -173,7 +173,8 @@ HWND windows_tray_notification::get_window_handle()
 {
 	SDL_SysWMinfo wmInfo;
 	SDL_VERSION(&wmInfo.version);
-	sdl::window* window = CVideo::get_singleton().get_window();
+	// TODO: draw_manager - refactor?
+	sdl::window* window = video::get_window();
 	// SDL 1.2 keeps track of window handles internally whereas SDL 2.0 allows the caller control over which window to use
 	if (!window || SDL_GetWindowWMInfo (static_cast<SDL_Window *> (*window), &wmInfo) != SDL_TRUE) {
 		return nullptr;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1886,7 +1886,7 @@ bool display::scroll(int xmove, int ymove, bool force)
 		src.x -= diff_x;
 		src.y -= diff_y;
 
-		src = video::to_output(src);
+		src *= video::get_pixel_scale();
 
 		// swap buffers
 		std::swap(front_, back_);
@@ -2624,7 +2624,8 @@ void display::update_render_textures()
 		return;
 	}
 
-	// TODO: highdpi - is this correct when there is a logical offset?
+	// We ignore any logical offset on the underlying window buffer.
+	// Render buffer size is always a simple multiple of the draw area.
 	rect darea = video::game_canvas();
 	rect oarea = darea * video::get_pixel_scale();
 
@@ -2639,7 +2640,6 @@ void display::update_render_textures()
 		return;
 	}
 
-	// TODO: draw_manager - these need to account for the logical offset
 	if(raw_size_changed) {
 		LOG_DP << "regenerating render buffers as " << oarea;
 		front_ = texture(oarea.w, oarea.h, SDL_TEXTUREACCESS_TARGET);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2484,6 +2484,7 @@ void display::draw()
 
 void display::update()
 {
+	//DBG_DP << "display::update";
 	// Ensure render textures are correctly sized and up-to-date.
 	update_render_textures();
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -183,7 +183,7 @@ display::display(const display_context* dc,
 	, xpos_(0)
 	, ypos_(0)
 	, view_locked_(false)
-	, theme_(theme::get_theme_config(theme_id.empty() ? preferences::theme() : theme_id), video::draw_area())
+	, theme_(theme::get_theme_config(theme_id.empty() ? preferences::theme() : theme_id), video::game_canvas())
 	, zoom_index_(0)
 	, fake_unit_man_(new fake_unit_manager(*this))
 	, builder_(new terrain_builder(level, (dc_ ? &dc_->map() : nullptr), theme_.border().tile_image, theme_.border().show_border))
@@ -280,7 +280,7 @@ display::~display()
 
 void display::set_theme(const std::string& new_theme)
 {
-	theme_ = theme{theme::get_theme_config(new_theme), video::draw_area()};
+	theme_ = theme{theme::get_theme_config(new_theme), video::game_canvas()};
 	builder_->set_draw_border(theme_.border().show_border);
 	menu_buttons_.clear();
 	action_buttons_.clear();
@@ -512,17 +512,17 @@ bool display::is_blindfolded() const
 
 const rect& display::minimap_area() const
 {
-	return theme_.mini_map_location(video::draw_area());
+	return theme_.mini_map_location(video::game_canvas());
 }
 
 const rect& display::palette_area() const
 {
-	return theme_.palette_location(video::draw_area());
+	return theme_.palette_location(video::game_canvas());
 }
 
 const rect& display::unit_image_area() const
 {
-	return theme_.unit_image_location(video::draw_area());
+	return theme_.unit_image_location(video::game_canvas());
 }
 
 rect display::max_map_area() const
@@ -573,7 +573,7 @@ rect display::map_outside_area() const
 	if(map_screenshot_) {
 		return max_map_area();
 	} else {
-		return theme_.main_map_location(video::draw_area());
+		return theme_.main_map_location(video::game_canvas());
 	}
 }
 
@@ -846,7 +846,7 @@ void display::layout_buttons()
 	DBG_DP << "positioning menu buttons...";
 	for(const auto& menu : theme_.menus()) {
 		if(auto b = find_menu_button(menu.get_id())) {
-			const SDL_Rect& loc = menu.location(video::draw_area());
+			const SDL_Rect& loc = menu.location(video::game_canvas());
 			b->set_location(loc);
 			b->set_measurements(0,0);
 			b->set_label(menu.title());
@@ -857,7 +857,7 @@ void display::layout_buttons()
 	DBG_DP << "positioning action buttons...";
 	for(const auto& action : theme_.actions()) {
 		if(auto b = find_action_button(action.get_id())) {
-			const SDL_Rect& loc = action.location(video::draw_area());
+			const SDL_Rect& loc = action.location(video::game_canvas());
 			b->set_location(loc);
 			b->set_measurements(0,0);
 			b->set_label(action.title());
@@ -1412,7 +1412,7 @@ void display::draw_panel(const theme::panel& panel)
 	}
 
 	// TODO: highdpi - draw area should probably be moved to new drawing API
-	const rect& loc = panel.location(video::draw_area());
+	const rect& loc = panel.location(video::game_canvas());
 
 	if (!loc.overlaps(draw::get_clip())) {
 		return;
@@ -1432,7 +1432,7 @@ void display::draw_panel(const theme::panel& panel)
 
 void display::draw_label(const theme::label& label)
 {
-	const rect& loc = label.location(video::draw_area());
+	const rect& loc = label.location(video::game_canvas());
 
 	if (!loc.overlaps(draw::get_clip())) {
 		return;
@@ -2395,7 +2395,7 @@ void display::queue_rerender()
 
 	tooltips::clear_tooltips();
 
-	theme_.set_resolution(video::draw_area());
+	theme_.set_resolution(video::game_canvas());
 
 	if(!menu_buttons_.empty() || !action_buttons_.empty()) {
 		create_buttons();
@@ -2614,7 +2614,7 @@ rect display::screen_location()
 	assert(!map_screenshot_);
 	//return map_outside_area();
 	// well actually it also has to draw the panels, so
-	return video::draw_area();
+	return video::game_canvas();
 	// TODO: draw_manager - get this from theme perhaps?
 }
 
@@ -2624,8 +2624,8 @@ void display::update_render_textures()
 		return;
 	}
 
-	// TODO: draw_manager - tidy these video accessors
-	rect darea = video::draw_area();
+	// TODO: highdpi - is this correct when there is a logical offset?
+	rect darea = video::game_canvas();
 	rect oarea = darea * video::get_pixel_scale();
 
 	// Check that the front buffer size is correct.
@@ -2943,7 +2943,7 @@ void display::refresh_report(const std::string& report_name, const config * new_
 
 	rect& loc = reportLocations_[report_name];
 	// TODO: draw_manager - rect
-	const SDL_Rect& new_loc = item->location(video::draw_area());
+	const SDL_Rect& new_loc = item->location(video::game_canvas());
 	config &report = reports_[report_name];
 
 	// Report and its location is unchanged since last time. Do nothing.

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2475,7 +2475,7 @@ void display::redraw_everything()
 
 	invalidate_all();
 
-	draw_manager::invalidate_region(video::draw_area());
+	draw_manager::invalidate_all();
 }
 
 void display::add_redraw_observer(std::function<void(display&)> f)

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1411,7 +1411,6 @@ void display::draw_panel(const theme::panel& panel)
 		return;
 	}
 
-	// TODO: highdpi - draw area should probably be moved to new drawing API
 	const rect& loc = panel.location(video::game_canvas());
 
 	if (!loc.overlaps(draw::get_clip())) {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -893,7 +893,7 @@ const std::string& get_direction(std::size_t n)
 
 void display::create_buttons()
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return;
 	}
 
@@ -1701,7 +1701,7 @@ void display::announce(const std::string& message, const color_t& color, const a
 
 void display::recalculate_minimap()
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return;
 	}
 
@@ -1876,7 +1876,7 @@ bool display::scroll(int xmove, int ymove, bool force)
 	// NOTE: the next three blocks can be removed once we switch to accelerated rendering.
 	//
 
-	if(!video::faked()) {
+	if(!video::headless()) {
 		rect dst = map_area();
 		dst.x += diff_x;
 		dst.y += diff_y;
@@ -2034,7 +2034,7 @@ bool display::tile_nearly_on_screen(const map_location& loc) const
 void display::scroll_to_xy(int screenxpos, int screenypos, SCROLL_TYPE scroll_type, bool force)
 {
 	if(!force && (view_locked_ || !preferences::scroll_to_action())) return;
-	if(video::faked()) {
+	if(video::headless()) {
 		return;
 	}
 	const SDL_Rect area = map_area();
@@ -2317,7 +2317,7 @@ double display::turbo_speed() const
 		res = !res;
 	}
 
-	res |= video::faked();
+	res |= video::headless();
 	if(res)
 		return preferences::turbo_speed();
 	else
@@ -2379,7 +2379,7 @@ void display::set_fade(const color_t& c)
 
 void display::queue_rerender()
 {
-	if(video::faked())
+	if(video::headless())
 		return;
 
 	DBG_DP << "redrawing everything";
@@ -2447,7 +2447,7 @@ void display::draw()
 {
 	//	log_scope("display::draw");
 
-	if(video::faked()) {
+	if(video::headless()) {
 		DBG_DP << "display::draw denied";
 		// TODO: draw_manager - deny drawing in draw_manager if appropriate
 		return;
@@ -2620,7 +2620,7 @@ rect display::screen_location()
 
 void display::update_render_textures()
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return;
 	}
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -244,13 +244,6 @@ display::display(const display_context* dc,
 
 	read(level.child_or_empty("display"));
 
-	if (screen_.non_interactive()
-		&& screen_.surface_initialized()
-		&& screen_.faked())
-	{
-		screen_.lock_updates(true);
-	}
-
 	fill_images_list(game_config::fog_prefix, fog_images_);
 	fill_images_list(game_config::shroud_prefix, shroud_images_);
 
@@ -1338,7 +1331,7 @@ static unsigned calculate_fps(unsigned frametime)
 
 void display::update_display()
 {
-	if (screen_.update_locked()) {
+	if (screen_.faked()) {
 		return;
 	}
 
@@ -1913,7 +1906,7 @@ bool display::scroll(int xmove, int ymove, bool force)
 	// NOTE: the next three blocks can be removed once we switch to accelerated rendering.
 	//
 
-	if(!screen_.update_locked()) {
+	if(!screen_.faked()) {
 		rect dst = map_area();
 		dst.x += diff_x;
 		dst.y += diff_y;
@@ -2071,7 +2064,7 @@ bool display::tile_nearly_on_screen(const map_location& loc) const
 void display::scroll_to_xy(int screenxpos, int screenypos, SCROLL_TYPE scroll_type, bool force)
 {
 	if(!force && (view_locked_ || !preferences::scroll_to_action())) return;
-	if(screen_.update_locked() || screen_.faked()) {
+	if(screen_.faked()) {
 		return;
 	}
 	const SDL_Rect area = map_area();
@@ -2416,7 +2409,7 @@ void display::set_fade(const color_t& c)
 
 void display::redraw_everything()
 {
-	if(screen_.update_locked())
+	if(screen_.faked())
 		return;
 
 	DBG_DP << "redrawing everything";
@@ -2485,7 +2478,7 @@ void display::draw(bool update, bool force)
 {
 	//	log_scope("display::draw");
 
-	if(screen_.update_locked() || screen_.faked()) {
+	if(screen_.faked()) {
 		DBG_DP << "display::draw denied";
 		// TODO: draw_manager - deny drawing in draw_manager if appropriate
 		return;

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -466,10 +466,15 @@ public:
 
 	terrain_builder& get_builder() {return *builder_;}
 
-	void flip();
+	// TODO: draw_manager - remove
+	void flip() {}
 
+	// TODO: draw_manager - remove
 	/** Copy the backbuffer to the framebuffer. */
-	void update_display();
+	void update_display() {}
+	void update_fps_label();
+	void clear_fps_label();
+	void update_fps_count();
 
 	/** Rebuild all dynamic terrain. */
 	void rebuild_all();
@@ -583,21 +588,30 @@ public:
 	 * virtuals (further below) to allow specialized behavior in derived classes.
 	 */
 	virtual void draw();
+	// TODO: nonvirtual, WTF goddamn fuck shit
 
-	void draw(bool update);
+	// TODO: draw_manager - remove
+	void draw(bool /*update*/) { draw(); }
+	// TODO: draw_manager - remove
+	void draw(bool /*update*/, bool /*force*/) { draw(); }
 
-	void draw(bool update, bool force);
+	/*-------------------------------------------------------*/
+	/* top_level_drawable interface (called by draw_manager) */
+	/*-------------------------------------------------------*/
 
-	/** Called by draw_manager to finalize screen layout. */
+	/** Update animations and internal state */
+	virtual void update() override;
+
+	/** Finalize screen layout. */
 	virtual void layout() override;
 
-	/** Called by draw_manager to update offscreen render buffers. */
+	/** Update offscreen render buffers. */
 	virtual void render() override;
 
-	/** Called by draw_manager when it believes a redraw is necessary. */
+	/** Paint the indicated region to the screen. */
 	virtual bool expose(const SDL_Rect& region) override;
 
-	/** The current draw location of the display, on the screen. */
+	/** Return the current draw location of the display, on the screen. */
 	virtual rect screen_location() override;
 
 private:

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -982,20 +982,17 @@ protected:
 		blit_helper(const blit_helper&) = delete;
 
 		blit_helper(const drawing_layer layer, const map_location& loc,
-				const SDL_Rect& dest, const texture& tex,
-				const SDL_Rect& clip)
-			: dest_(dest), tex_(1, tex), clip_(clip), key_(loc, layer)
+				const SDL_Rect& dest, const texture& tex)
+			: dest_(dest), tex_(1, tex), key_(loc, layer)
 		{}
 
 		blit_helper(const drawing_layer layer, const map_location& loc,
-				const SDL_Rect& dest, const std::vector<texture>& tex,
-				const SDL_Rect& clip)
-			: dest_(dest), tex_(tex), clip_(clip), key_(loc, layer)
+				const SDL_Rect& dest, const std::vector<texture>& tex)
+			: dest_(dest), tex_(tex), key_(loc, layer)
 		{}
 
 		const SDL_Rect& dest() const { return dest_; }
 		const std::vector<texture> &tex() const { return tex_; }
-		const SDL_Rect &clip() const { return clip_; }
 
 		bool operator<(const blit_helper &rhs) const { return key_ < rhs.key_; }
 
@@ -1063,9 +1060,6 @@ protected:
 		SDL_Rect dest_;
 		/** One or more textures to render. */
 		std::vector<texture> tex_;
-		/** The portion of the source texture to use.
-		  * If omitted, the entire source is used. */
-		SDL_Rect clip_;
 		// TODO: could also add blend mode and rotation if desirable
 		/** Allows ordering of draw calls by layer and location. */
 		drawing_buffer_key key_;
@@ -1088,17 +1082,14 @@ public:
 	 *                           drawing order.
 	 * @param dest               The target destination on screen,
 	 *                           in drawing coordinates.
-	 * @param tex               The texture to use.
-	 * @param clip              The portion of the source texture to use.
+	 * @param tex                The texture to use.
 	 */
 	blit_helper& drawing_buffer_add(const drawing_layer layer,
-			const map_location& loc, const SDL_Rect& dest, const texture& tex,
-			const SDL_Rect &clip = SDL_Rect());
+			const map_location& loc, const SDL_Rect& dest, const texture& tex);
 
 	blit_helper& drawing_buffer_add(const drawing_layer layer,
 			const map_location& loc, const SDL_Rect& dest,
-			const std::vector<texture> &tex,
-			const SDL_Rect &clip = SDL_Rect());
+			const std::vector<texture> &tex);
 
 protected:
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -365,10 +365,15 @@ public:
 	/** Capture a (map-)screenshot into a surface. */
 	surface screenshot(bool map_screenshot = false);
 
-	/** Invalidates entire screen, including all tiles and sidebar. Calls redraw observers. */
-	void redraw_everything();
+	/** Marks everything for rendering including all tiles and sidebar.
+	  * Also calls redraw observers. */
+	void queue_rerender();
 
-	/** Adds a redraw observer, a function object to be called when redraw_everything is used */
+	/** Queues repainting to the screen, but doesn't rerender. */
+	void queue_repaint();
+
+	/** Adds a redraw observer, a function object to be called when a
+	  * full rerender is queued. */
 	void add_redraw_observer(std::function<void(display&)> f);
 
 	/** Clear the redraw observers */
@@ -579,26 +584,11 @@ public:
 private:
 	color_t fade_color_ = {0,0,0,0};
 
-public:
-	/**
-	 * Draws invalidated items.
-	 * If update is true, will also copy the display to the frame buffer.
-	 * If force is true, will not skip frames, even if running behind.
-	 * Not virtual, since it gathers common actions. Calls various protected
-	 * virtuals (further below) to allow specialized behavior in derived classes.
-	 */
-	virtual void draw();
-	// TODO: nonvirtual, WTF goddamn fuck shit
-
-	// TODO: draw_manager - remove
-	void draw(bool /*update*/) { draw(); }
-	// TODO: draw_manager - remove
-	void draw(bool /*update*/, bool /*force*/) { draw(); }
-
 	/*-------------------------------------------------------*/
 	/* top_level_drawable interface (called by draw_manager) */
 	/*-------------------------------------------------------*/
 
+public:
 	/** Update animations and internal state */
 	virtual void update() override;
 
@@ -625,6 +615,9 @@ private:
 	/** Draw/redraw the off-map background area.
 	  * This updates both render textures. */
 	void render_map_outside_area();
+
+	/** Perform rendering of invalidated items. */
+	void draw();
 
 public:
 	map_labels& labels();
@@ -1179,8 +1172,6 @@ private:
 	arrows_map_t arrows_map_;
 
 	tod_color color_adjust_;
-
-	bool dirty_;
 
 	std::vector<std::tuple<int, int, int>> fps_history_;
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -64,7 +64,6 @@ namespace wb {
 #include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
 #include "theme.hpp"
-#include "video.hpp"
 #include "widgets/button.hpp"
 
 #include <boost/circular_buffer.hpp>
@@ -200,10 +199,6 @@ public:
 	void adjust_color_overlay(int r, int g, int b);
 	tod_color get_color_overlay() const { return color_adjust_; }
 
-
-	/** Gets the underlying screen object. */
-	CVideo& video() { return screen_; }
-
 	virtual bool in_game() const { return false; }
 	virtual bool in_editor() const { return false; }
 
@@ -217,12 +212,9 @@ public:
 	 * Between mapx and x is the sidebar region.
 	 */
 
-	const rect& minimap_area() const
-		{ return theme_.mini_map_location(screen_.draw_area()); }
-	const rect& palette_area() const
-		{ return theme_.palette_location(screen_.draw_area()); }
-	const rect& unit_image_area() const
-		{ return theme_.unit_image_location(screen_.draw_area()); }
+	const rect& minimap_area() const;
+	const rect& palette_area() const;
+	const rect& unit_image_area() const;
 
 	/**
 	 * Returns the maximum area used for the map
@@ -240,8 +232,7 @@ public:
 	 * from the above. This area will get the background area
 	 * applied to it.
 	 */
-	rect map_outside_area() const { return map_screenshot_ ?
-		max_map_area() : theme_.main_map_location(screen_.draw_area()); }
+	rect map_outside_area() const;
 
 	/** Check if the bbox of the hex at x,y has pixels outside the area rectangle. */
 	static bool outside_area(const SDL_Rect& area, const int x,const int y);
@@ -768,7 +759,6 @@ protected:
 
 	static const std::string& get_variant(const std::vector<std::string>& variants, const map_location &loc);
 
-	CVideo& screen_;
 	std::size_t currentTeam_;
 	bool dont_show_all_; //const team *viewpoint_;
 	/**

--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -27,6 +27,7 @@
 #include "color.hpp"
 #include "preferences/credentials.hpp"
 #include "serialization/utf8_exception.hpp"
+#include "video.hpp" // only for faked
 
 #include <SDL2/SDL_timer.h>
 
@@ -105,7 +106,7 @@ void display_chat_manager::add_chat_message(const std::time_t& time, const std::
 	try {
 		// We've had a joker who send an invalid utf-8 message to crash clients
 		// so now catch the exception and ignore the message.
-		msg = my_disp_.video().faked() ? "" : font::pango_word_wrap(msg,font::SIZE_15,my_disp_.map_outside_area().w*3/4);
+		msg = video::faked() ? "" : font::pango_word_wrap(msg,font::SIZE_15,my_disp_.map_outside_area().w*3/4);
 	} catch (utf8::invalid_utf8_exception&) {
 		ERR_NG << "Invalid utf-8 found, chat message is ignored.";
 		return;

--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -106,7 +106,7 @@ void display_chat_manager::add_chat_message(const std::time_t& time, const std::
 	try {
 		// We've had a joker who send an invalid utf-8 message to crash clients
 		// so now catch the exception and ignore the message.
-		msg = video::faked() ? "" : font::pango_word_wrap(msg,font::SIZE_15,my_disp_.map_outside_area().w*3/4);
+		msg = video::headless() ? "" : font::pango_word_wrap(msg,font::SIZE_15,my_disp_.map_outside_area().w*3/4);
 	} catch (utf8::invalid_utf8_exception&) {
 		ERR_NG << "Invalid utf-8 found, chat message is ignored.";
 		return;

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -504,9 +504,7 @@ rect draw::get_clip()
 	}
 
 	if (!SDL_RenderIsClipEnabled(renderer())) {
-		// TODO: highdpi - fix this in the case of render to texture
-		// TODO: highdpi - fix this for viewports
-		return video::draw_area();
+		return draw::get_viewport();
 	}
 
 	::rect clip;
@@ -599,7 +597,6 @@ SDL_Rect draw::get_viewport()
 	SDL_RenderGetViewport(renderer(), &viewport);
 
 	if (viewport == sdl::empty_rect) {
-		// TODO: highdpi - fix this in the case of render to texture
 		return video::draw_area();
 	}
 	return viewport;

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -298,18 +298,6 @@ void draw::disc(int cx, int cy, int r, uint8_t octants)
 /*******************/
 
 
-void draw::blit(const texture& tex, const SDL_Rect& dst, const SDL_Rect& src)
-{
-	if (src == sdl::empty_rect) {
-		return draw::blit(tex, dst);
-	}
-
-	if (!tex) { DBG_D << "null blit"; return; }
-	DBG_D << "blit " << dst << " from " << src;
-
-	SDL_RenderCopy(renderer(), tex, &src, &dst);
-}
-
 void draw::blit(const texture& tex, const SDL_Rect& dst)
 {
 	if (dst == sdl::empty_rect) {
@@ -319,7 +307,7 @@ void draw::blit(const texture& tex, const SDL_Rect& dst)
 	if (!tex) { DBG_D << "null blit"; return; }
 	DBG_D << "blit " << dst;
 
-	SDL_RenderCopy(renderer(), tex, nullptr, &dst);
+	SDL_RenderCopy(renderer(), tex, tex.src(), &dst);
 }
 
 void draw::blit(const texture& tex)
@@ -327,7 +315,7 @@ void draw::blit(const texture& tex)
 	if (!tex) { DBG_D << "null blit"; return; }
 	DBG_D << "blit";
 
-	SDL_RenderCopy(renderer(), tex, nullptr, nullptr);
+	SDL_RenderCopy(renderer(), tex, tex.src(), nullptr);
 }
 
 
@@ -338,25 +326,6 @@ static SDL_RendererFlip get_flip(bool flip_h, bool flip_v)
 		static_cast<int>(flip_h ? SDL_FLIP_HORIZONTAL : SDL_FLIP_NONE)
 		| static_cast<int>(flip_v ? SDL_FLIP_VERTICAL : SDL_FLIP_NONE)
 	);
-}
-
-void draw::flipped(
-	const texture& tex,
-	const SDL_Rect& dst,
-	const SDL_Rect& src,
-	bool flip_h,
-	bool flip_v)
-{
-	if (src == sdl::empty_rect) {
-		return draw::flipped(tex, dst, flip_h, flip_v);
-	}
-
-	if (!tex) { DBG_D << "null flipped"; return; }
-	DBG_D << "flipped (" << flip_h << '|' << flip_v
-	      << ") to " << dst << " from " << src;
-
-	SDL_RendererFlip flip = get_flip(flip_h, flip_v);
-	SDL_RenderCopyEx(renderer(), tex, &src, &dst, 0.0, nullptr, flip);
 }
 
 void draw::flipped(
@@ -374,7 +343,7 @@ void draw::flipped(
 	      << ") to " << dst;
 
 	SDL_RendererFlip flip = get_flip(flip_h, flip_v);
-	SDL_RenderCopyEx(renderer(), tex, nullptr, &dst, 0.0, nullptr, flip);
+	SDL_RenderCopyEx(renderer(), tex, tex.src(), &dst, 0.0, nullptr, flip);
 }
 
 void draw::flipped(const texture& tex, bool flip_h, bool flip_v)
@@ -383,7 +352,7 @@ void draw::flipped(const texture& tex, bool flip_h, bool flip_v)
 	DBG_D << "flipped (" << flip_h << '|' << flip_v << ')';
 
 	SDL_RendererFlip flip = get_flip(flip_h, flip_v);
-	SDL_RenderCopyEx(renderer(), tex, nullptr, nullptr, 0.0, nullptr, flip);
+	SDL_RenderCopyEx(renderer(), tex, tex.src(), nullptr, 0.0, nullptr, flip);
 }
 
 

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -31,7 +31,7 @@ static lg::log_domain log_draw("draw");
 
 static SDL_Renderer* renderer()
 {
-	return CVideo::get_singleton().get_renderer();
+	return video::get_renderer();
 }
 
 /**************************************/
@@ -423,7 +423,7 @@ void draw::tiled_highres(const texture& tex, const SDL_Rect& dst,
 	DBG_D << "tiled_highres (" << centered << '|' << mirrored
 	      << ") " << dst;
 
-	const int pixel_scale = CVideo::get_singleton().get_pixel_scale();
+	const int pixel_scale = video::get_pixel_scale();
 
 	// Reduce clip to dst.
 	auto clipper = draw::reduce_clip(dst);
@@ -506,7 +506,7 @@ rect draw::get_clip()
 	if (!SDL_RenderIsClipEnabled(renderer())) {
 		// TODO: highdpi - fix this in the case of render to texture
 		// TODO: highdpi - fix this for viewports
-		return CVideo::get_singleton().draw_area();
+		return video::draw_area();
 	}
 
 	::rect clip;
@@ -600,7 +600,7 @@ SDL_Rect draw::get_viewport()
 
 	if (viewport == sdl::empty_rect) {
 		// TODO: highdpi - fix this in the case of render to texture
-		return CVideo::get_singleton().draw_area();
+		return video::draw_area();
 	}
 	return viewport;
 }
@@ -618,10 +618,10 @@ draw::render_target_setter::render_target_setter(const texture& t)
 		return;
 	}
 
-	target_ = CVideo::get_singleton().get_render_target();
+	target_ = video::get_render_target();
 	SDL_RenderGetViewport(renderer(), &viewport_);
 
-	CVideo::get_singleton().force_render_target(t);
+	video::force_render_target(t);
 }
 
 draw::render_target_setter::~render_target_setter()
@@ -630,7 +630,7 @@ draw::render_target_setter::~render_target_setter()
 		WRN_D << "can't reset render target with null renderer";
 		return;
 	}
-	CVideo::get_singleton().force_render_target(target_);
+	video::force_render_target(target_);
 	SDL_RenderSetViewport(renderer(), &viewport_);
 }
 

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -218,10 +218,7 @@ void disc(int x, int y, int r, uint8_t octants = 0xff);
  * @param dst       The target location to copy the texture to,
  *                  in low-resolution game-native drawing coordinates.
  *                  If null, this fills the entire render target.
- * @param src       The portion of the texture to copy.
- *                  If null, this copies the entire texture.
  */
-void blit(const texture& tex, const SDL_Rect& dst, const SDL_Rect& src);
 void blit(const texture& tex, const SDL_Rect& dst);
 void blit(const texture& tex);
 
@@ -235,17 +232,9 @@ void blit(const texture& tex);
  * @param dst       The target location to copy the texture to,
  *                  in low-resolution game-native drawing coordinates.
  *                  If not given, the entire render target will be filled.
- * @param src       The portion of the texture to copy.
- *                  If null or not given, the entire texture will be copied.
  * @param flip_h    Whether to flip/mirror the texture horizontally.
  * @param flip_v    Whether to flip/mirror the texture vertically.
  */
-void flipped(const texture& tex,
-	const SDL_Rect& dst,
-	const SDL_Rect& src,
-	bool flip_h = true,
-	bool flip_v = false
-);
 void flipped(const texture& tex,
 	const SDL_Rect& dst,
 	bool flip_h = true,

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -132,7 +132,7 @@ void sparkle()
 	// Unit tests rely on not doing any rendering, or waiting at all...
 	// "behave differently when being tested" is really not good policy
 	// but whatever.
-	if(CVideo::get_singleton().any_fake()) {
+	if(video::any_fake()) {
 		invalidated_regions_.clear();
 		return;
 	}
@@ -143,7 +143,7 @@ void sparkle()
 	// Draw to the screen.
 	if (draw_manager::expose()) {
 		// We only need to flip the screen if something was drawn.
-		CVideo::get_singleton().render_screen();
+		video::render_screen();
 	} else {
 		wait_for_vsync();
 	}
@@ -153,7 +153,7 @@ void sparkle()
 
 static void wait_for_vsync()
 {
-	int rr = CVideo::get_singleton().current_refresh_rate();
+	int rr = video::current_refresh_rate();
 	if (rr <= 0) {
 		// make something up
 		rr = 60;

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -117,7 +117,8 @@ void invalidate_region(const rect& region)
 
 void invalidate_all()
 {
-	invalidate_region(video::draw_area());
+	// Note: this does not support render targets other than the screen.
+	invalidate_region(video::game_canvas());
 }
 
 void sparkle()

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -139,10 +139,9 @@ void sparkle()
 	// Ensure layout is up-to-date.
 	draw_manager::layout();
 
-	// Unit tests rely on not doing any rendering, or waiting at all...
-	// "behave differently when being tested" is really not good policy
-	// but whatever.
-	if(video::any_fake()) {
+	// If we are running headless or executing unit tests, do not render.
+	// There are not currently any tests for actual rendering output.
+	if(video::headless() || video::testing()) {
 		invalidated_regions_.clear();
 		return;
 	}

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -24,6 +24,7 @@
 #include <SDL2/SDL_rect.h>
 #include <SDL2/SDL_timer.h>
 
+#include <algorithm>
 #include <vector>
 #include <map>
 
@@ -34,6 +35,10 @@ static lg::log_domain log_draw_man("draw/manager");
 #define DBG_DM LOG_STREAM(debug, log_draw_man)
 
 using gui2::top_level_drawable;
+
+// This is not publically exposed, because nobody else should be using it.
+// Implementation is in video.cpp.
+namespace video { void render_screen(); }
 
 namespace {
 std::vector<top_level_drawable*> top_level_drawables_;

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -115,6 +115,11 @@ void invalidate_region(const rect& region)
 	invalidated_regions_.push_back(region);
 }
 
+void invalidate_all()
+{
+	invalidate_region(video::draw_area());
+}
+
 void sparkle()
 {
 	if (drawing_) {

--- a/src/draw_manager.hpp
+++ b/src/draw_manager.hpp
@@ -89,6 +89,9 @@ namespace draw_manager
  */
 void invalidate_region(const rect& region);
 
+/** Mark the entire screen as requiring redraw. */
+void invalidate_all();
+
 /**
  * Ensure that everything which needs to be drawn is drawn.
  *

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -1099,7 +1099,7 @@ void editor_controller::show_menu(const std::vector<config>& items_arg, int xloc
 
 void editor_controller::preferences()
 {
-	gui_->video().clear_all_help_strings();
+	font::clear_help_string();
 	gui2::dialogs::preferences_dialog::display();
 
 	gui_->redraw_everything();

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -705,7 +705,7 @@ bool editor_controller::do_execute_command(const hotkey::hotkey_command& cmd, in
 //			std::vector< std::pair< std::string, std::string >> blah_items;
 //			toolkit_->get_palette_manager()->active_palette().expand_palette_groups_menu(blah_items);
 //			int selected = 1; //toolkit_->get_palette_manager()->active_palette().get_selected;
-//			gui2::teditor_select_palette_group::execute(selected, blah_items, gui_->video());
+//			gui2::teditor_select_palette_group::execute(selected, blah_items);
 		}
 			return true;
 		case HOTKEY_EDITOR_PALETTE_UPSCROLL:

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -91,8 +91,7 @@ editor_controller::editor_controller()
 	get_current_map_context().set_starting_position_labels(gui());
 	cursor::set(cursor::NORMAL);
 
-	gui().create_buttons();
-	gui().redraw_everything();
+	gui().queue_rerender();
 }
 
 void editor_controller::init_gui()
@@ -1102,7 +1101,7 @@ void editor_controller::preferences()
 	font::clear_help_string();
 	gui2::dialogs::preferences_dialog::display();
 
-	gui_->redraw_everything();
+	gui_->queue_rerender();
 }
 
 void editor_controller::toggle_grid()
@@ -1230,7 +1229,6 @@ void editor_controller::refresh_image_cache()
 
 void editor_controller::display_redraw_callback(display&)
 {
-	// TODO: draw_manager - this is the only use of this redraw_callback system, refactor it away
 	set_button_state();
 	toolkit_->adjust_size();
 	get_current_map_context().get_labels().recalculate_labels();

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -218,7 +218,7 @@ class editor_controller : public controller_base,
 		void refresh_image_cache();
 
 		/**
-		 * Callback function passed to display to be called on each redraw_everything run.
+		 * Callback function passed to display to be called on queue_rerender.
 		 * Redraws toolbar, brush bar and related items.
 		 */
 		void display_redraw_callback(display&);

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -23,7 +23,6 @@
 #include "team.hpp"
 #include "terrain/builder.hpp"
 #include "units/map.hpp"
-#include "video.hpp" // TODO: draw_manager - for clear_screen, remove
 
 namespace wb {
 	class manager;
@@ -36,8 +35,6 @@ editor_display::editor_display(editor_controller& controller, reports& reports_o
 	, brush_locations_()
 	, controller_(controller)
 {
-	// TODO: draw_manager - don't use video for this, use draw, if anything.
-	video::clear_screen();
 }
 
 void editor_display::add_brush_loc(const map_location& hex)

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -23,6 +23,7 @@
 #include "team.hpp"
 #include "terrain/builder.hpp"
 #include "units/map.hpp"
+#include "video.hpp" // TODO: draw_manager - for clear_screen, remove
 
 namespace wb {
 	class manager;
@@ -35,7 +36,8 @@ editor_display::editor_display(editor_controller& controller, reports& reports_o
 	, brush_locations_()
 	, controller_(controller)
 {
-	video().clear_screen();
+	// TODO: draw_manager - don't use video for this, use draw, if anything.
+	video::clear_screen();
 }
 
 void editor_display::add_brush_loc(const map_location& hex)

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -27,6 +27,7 @@
 #include "generators/map_create.hpp"
 #include "generators/map_generator.hpp"
 #include "gettext.hpp"
+#include "video.hpp"
 
 #include "editor/action/action.hpp"
 #include "editor/controller/editor_controller.hpp"
@@ -91,7 +92,7 @@ context_manager::context_manager(editor_display& gui, const game_config_view& ga
 context_manager::~context_manager()
 {
 	// Restore default window title
-	CVideo::get_singleton().set_window_title(game_config::get_default_title_string());
+	video::set_window_title(game_config::get_default_title_string());
 
 	resources::filter_con = nullptr;
 }
@@ -1079,7 +1080,7 @@ void context_manager::set_window_title()
 	}
 
 	const std::string& wm_title_string = name + " - " + game_config::get_default_title_string();
-	CVideo::get_singleton().set_window_title(wm_title_string);
+	video::set_window_title(wm_title_string);
 }
 
 } //Namespace editor

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -19,6 +19,7 @@
 
 #include "gettext.hpp"
 #include "font/text_formatting.hpp"
+#include "floating_label.hpp"
 #include "tooltips.hpp"
 #include "overlay.hpp"
 #include "filesystem.hpp"
@@ -190,8 +191,8 @@ void editor_palette<Item>::adjust_size(const SDL_Rect& target)
 
 	set_location(target);
 	set_dirty(true);
-	gui_.video().clear_help_string(help_handle_);
-	help_handle_ = gui_.video().set_help_string(get_help_string());
+	font::clear_help_string();
+	font::set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -201,8 +202,8 @@ void editor_palette<Item>::select_fg_item(const std::string& item_id)
 		selected_fg_item_ = item_id;
 		set_dirty();
 	}
-	gui_.video().clear_help_string(help_handle_);
-	help_handle_ = gui_.video().set_help_string(get_help_string());
+	font::clear_help_string();
+	font::set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -212,8 +213,8 @@ void editor_palette<Item>::select_bg_item(const std::string& item_id)
 		selected_bg_item_ = item_id;
 		set_dirty();
 	}
-	gui_.video().clear_help_string(help_handle_);
-	help_handle_ = gui_.video().set_help_string(get_help_string());
+	font::clear_help_string();
+	font::set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -230,6 +231,24 @@ std::size_t editor_palette<Item>::num_items()
 {
 	return group_map_[active_group_].size();
 }
+
+
+template<class Item>
+void editor_palette<Item>::hide(bool hidden)
+{
+	widget::hide(hidden);
+
+	if (!hidden) {
+		font::set_help_string(get_help_string());
+	} else {
+		font::clear_help_string();
+	}
+
+	for (gui::widget& w : buttons_) {
+		w.hide(hidden);
+	}
+}
+
 
 template<class Item>
 bool editor_palette<Item>::is_selected_fg_item(const std::string& id)

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -46,7 +46,6 @@ public:
 		, selected_bg_item_()
 		, toolkit_(toolkit)
 		, buttons_()
-		, help_handle_(-1)
 	{
 	}
 
@@ -123,15 +122,7 @@ private:
 	/** Return the number of items in the currently-active group. */
 	std::size_t num_items() override;
 
-	void hide(bool hidden) override {
-		widget::hide(hidden);
-		if (!hidden)
-			help_handle_ = gui_.video().set_help_string(get_help_string());
-		else gui_.video().clear_help_string(help_handle_);
-		for (gui::widget& w : buttons_) {
-			w.hide(hidden);
-		}
-	}
+	void hide(bool hidden) override;
 
 protected:
 	/**
@@ -189,8 +180,6 @@ private:
 
 	editor_toolkit& toolkit_;
 	std::vector<gui::tristate_button> buttons_;
-
-	int help_handle_;
 };
 
 

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -20,6 +20,7 @@
 #include "draw.hpp"
 #include "editor/editor_common.hpp"
 #include "editor/toolkit/editor_toolkit.hpp"
+#include "floating_label.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "font/standard_colors.hpp"
 #include "formula/string_utils.hpp"
@@ -172,7 +173,6 @@ location_palette::location_palette(editor_display &gui, const game_config_view& 
 		, button_add_()
 		, button_delete_()
 		, button_goto_()
-		, help_handle_(-1)
 		, disp_(gui)
 	{
 		for (int i = 1; i < 10; ++i) {
@@ -197,7 +197,7 @@ void location_palette::hide(bool hidden)
 {
 	widget::hide(hidden);
 
-	disp_.video().clear_help_string(help_handle_);
+	font::clear_help_string();
 
 	std::shared_ptr<gui::button> palette_menu_button = disp_.find_menu_button("menu-editor-terrain");
 	palette_menu_button->set_overlay("");
@@ -308,8 +308,8 @@ void location_palette::adjust_size(const SDL_Rect& target)
 
 	set_location(target);
 	set_dirty(true);
-	disp_.video().clear_help_string(help_handle_);
-	help_handle_ = disp_.video().set_help_string(get_help_string());
+	font::clear_help_string();
+	font::set_help_string(get_help_string());
 }
 
 void location_palette::select_item(const std::string& item_id)
@@ -318,8 +318,8 @@ void location_palette::select_item(const std::string& item_id)
 		selected_item_ = item_id;
 		set_dirty();
 	}
-	disp_.video().clear_help_string(help_handle_);
-	help_handle_ = disp_.video().set_help_string(get_help_string());
+	font::clear_help_string();
+	font::set_help_string(get_help_string());
 }
 
 std::size_t location_palette::num_items()

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -65,7 +65,7 @@ public:
 		if (state_.selected) {
 			draw::rect(location(), 255, 255, 255, 255);
 		}
-		font::pango_draw_text(&video(), location(), 16, font::NORMAL_COLOR, desc_.empty() ? id_ : desc_, location().x + 2, location().y, 0);
+		font::pango_draw_text(true, location(), 16, font::NORMAL_COLOR, desc_.empty() ? id_ : desc_, location().x + 2, location().y, 0);
 	}
 
 	//TODO move to widget

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -120,7 +120,6 @@ private:
 	std::unique_ptr<location_palette_button> button_add_;
 	std::unique_ptr<location_palette_button> button_delete_;
 	std::unique_ptr<location_palette_button> button_goto_;
-	int help_handle_;
 	editor_display& disp_;
 };
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -533,6 +533,7 @@ void pump()
 
 				if(event.motion.state & SDL_BUTTON(SDL_BUTTON_RIGHT))
 				{
+					// TODO: highdpi - this will be slightly off if there is a logical offset
 					rect r = video::input_area();
 
 					// TODO: Check if SDL_FINGERMOTION is actually signaled for COMPLETE motions (I doubt, but tbs)
@@ -560,6 +561,7 @@ void pump()
 					event.button.button = SDL_BUTTON_LEFT;
 					event.button.which = SDL_TOUCH_MOUSEID;
 
+					// TODO: highdpi - this will be slightly off if there is a logical offset
 					rect r = video::input_area();
 					SDL_Event touch_event;
 					touch_event.type = (event.type == SDL_MOUSEBUTTONDOWN) ? SDL_FINGERDOWN : SDL_FINGERUP;
@@ -604,7 +606,7 @@ void pump()
 
 			// Resized comes after size_changed.
 			// Here we can trigger any watchers for resize events.
-			// Video settings such as draw_area() will be correct.
+			// Video settings such as game_canvas_size() will be correct.
 			case SDL_WINDOWEVENT_RESIZED:
 				LOG_DP << "events/RESIZED "
 					<< event.window.data1 << 'x' << event.window.data2;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -644,7 +644,6 @@ void pump()
 
 			// make sure this runs in it's own scope.
 			{
-				flip_locker flip_lock(CVideo::get_singleton());
 				for(auto& context : event_contexts) {
 					for(auto handler : context.handlers) {
 						handler->handle_window_event(event);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -586,7 +586,7 @@ void pump()
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
 				LOG_DP << "events/SIZE_CHANGED "
 					<< event.window.data1 << 'x' << event.window.data2;
-				CVideo::get_singleton().update_buffers();
+				CVideo::get_singleton().update_framebuffer();
 				break;
 
 			// Resized comes after size_changed.
@@ -662,12 +662,6 @@ void pump()
 				last_click_y = event.button.y;
 			}
 			break;
-		}
-
-		case DRAW_ALL_EVENT: {
-			draw_manager::invalidate_region(CVideo::get_singleton().draw_area());
-			// Nothing else needs to or should ever react to this.
-			continue;
 		}
 
 #ifndef __APPLE__
@@ -746,13 +740,6 @@ void raise_resize_event()
 
 void raise_draw_event()
 {
-	draw_manager::sparkle();
-}
-
-void raise_draw_all_event()
-{
-	// TODO: draw_manager - look into usage of this
-	//std::cerr << "draw all event raised" << std::endl;
 	draw_manager::sparkle();
 }
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -533,8 +533,8 @@ void pump()
 
 				if(event.motion.state & SDL_BUTTON(SDL_BUTTON_RIGHT))
 				{
-					// TODO: highdpi - this will be slightly off if there is a logical offset
-					rect r = video::input_area();
+					// Events are given by SDL in draw space
+					point c = video::game_canvas_size();
 
 					// TODO: Check if SDL_FINGERMOTION is actually signaled for COMPLETE motions (I doubt, but tbs)
 					SDL_Event touch_event;
@@ -543,10 +543,10 @@ void pump()
 					touch_event.tfinger.timestamp = event.motion.timestamp;
 					touch_event.tfinger.touchId = 1;
 					touch_event.tfinger.fingerId = 1;
-					touch_event.tfinger.dx = static_cast<float>(event.motion.xrel) / r.w;
-					touch_event.tfinger.dy = static_cast<float>(event.motion.yrel) / r.h;
-					touch_event.tfinger.x = static_cast<float>(event.motion.x) / r.w;
-					touch_event.tfinger.y = static_cast<float>(event.motion.y) / r.h;
+					touch_event.tfinger.dx = static_cast<float>(event.motion.xrel) / c.x;
+					touch_event.tfinger.dy = static_cast<float>(event.motion.yrel) / c.y;
+					touch_event.tfinger.x = static_cast<float>(event.motion.x) / c.x;
+					touch_event.tfinger.y = static_cast<float>(event.motion.y) / c.y;
 					touch_event.tfinger.pressure = 1;
 					::SDL_PushEvent(&touch_event);
 
@@ -561,8 +561,9 @@ void pump()
 					event.button.button = SDL_BUTTON_LEFT;
 					event.button.which = SDL_TOUCH_MOUSEID;
 
-					// TODO: highdpi - this will be slightly off if there is a logical offset
-					rect r = video::input_area();
+					// Events are given by SDL in draw space
+					point c = video::game_canvas_size();
+
 					SDL_Event touch_event;
 					touch_event.type = (event.type == SDL_MOUSEBUTTONDOWN) ? SDL_FINGERDOWN : SDL_FINGERUP;
 					touch_event.tfinger.type = touch_event.type;
@@ -571,8 +572,8 @@ void pump()
 					touch_event.tfinger.fingerId = 1;
 					touch_event.tfinger.dx = 0;
 					touch_event.tfinger.dy = 0;
-					touch_event.tfinger.x = static_cast<float>(event.button.x) / r.w;
-					touch_event.tfinger.y = static_cast<float>(event.button.y) / r.h;
+					touch_event.tfinger.x = static_cast<float>(event.button.x) / c.x;
+					touch_event.tfinger.y = static_cast<float>(event.button.y) / c.y;
 					touch_event.tfinger.pressure = 1;
 					::SDL_PushEvent(&touch_event);
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -64,7 +64,7 @@ struct invoked_function_data
 	{
 		try {
 			f();
-		} catch(const CVideo::quit&) {
+		} catch(const video::quit&) {
 			// Handle this exception in the main thread.
 			throw;
 		} catch(...) {
@@ -520,7 +520,7 @@ void pump()
 
 				if(event.motion.state & SDL_BUTTON(SDL_BUTTON_RIGHT))
 				{
-					SDL_Rect r = CVideo::get_singleton().input_area();
+					rect r = video::input_area();
 
 					// TODO: Check if SDL_FINGERMOTION is actually signaled for COMPLETE motions (I doubt, but tbs)
 					SDL_Event touch_event;
@@ -547,7 +547,7 @@ void pump()
 					event.button.button = SDL_BUTTON_LEFT;
 					event.button.which = SDL_TOUCH_MOUSEID;
 
-					SDL_Rect r = CVideo::get_singleton().input_area();
+					rect r = video::input_area();
 					SDL_Event touch_event;
 					touch_event.type = (event.type == SDL_MOUSEBUTTONDOWN) ? SDL_FINGERDOWN : SDL_FINGERUP;
 					touch_event.tfinger.type = touch_event.type;
@@ -586,7 +586,7 @@ void pump()
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
 				LOG_DP << "events/SIZE_CHANGED "
 					<< event.window.data1 << 'x' << event.window.data2;
-				CVideo::get_singleton().update_framebuffer();
+				video::update_framebuffer();
 				break;
 
 			// Resized comes after size_changed.
@@ -604,7 +604,7 @@ void pump()
 			case SDL_WINDOWEVENT_EXPOSED:
 				LOG_DP << "events/EXPOSED";
 				draw_manager::invalidate_region(
-					CVideo::get_singleton().draw_area());
+					video::draw_area());
 				break;
 
 			case SDL_WINDOWEVENT_MAXIMIZED:
@@ -727,7 +727,7 @@ void raise_process_event()
 
 void raise_resize_event()
 {
-	SDL_Point size = CVideo::get_singleton().window_size();
+	point size = video::window_size();
 	SDL_Event event;
 	event.window.type = SDL_WINDOWEVENT;
 	event.window.event = SDL_WINDOWEVENT_RESIZED;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -586,7 +586,7 @@ void pump()
 			case SDL_WINDOWEVENT_SIZE_CHANGED:
 				LOG_DP << "events/SIZE_CHANGED "
 					<< event.window.data1 << 'x' << event.window.data2;
-				video::update_framebuffer();
+				video::update_buffers(false);
 				break;
 
 			// Resized comes after size_changed.

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -616,8 +616,7 @@ void pump()
 			// an expose is triggered to display the changed content.
 			case SDL_WINDOWEVENT_EXPOSED:
 				LOG_DP << "events/EXPOSED";
-				draw_manager::invalidate_region(
-					video::draw_area());
+				draw_manager::invalidate_all();
 				break;
 
 			case SDL_WINDOWEVENT_MAXIMIZED:

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -27,8 +27,7 @@
 #define DRAW_EVENT (SDL_USEREVENT + 3)
 #define CLOSE_WINDOW_EVENT (SDL_USEREVENT + 4)
 #define SHOW_HELPTIP_EVENT (SDL_USEREVENT + 5)
-#define DRAW_ALL_EVENT (SDL_USEREVENT + 6)
-#define INVOKE_FUNCTION_EVENT (SDL_USEREVENT + 7)
+#define INVOKE_FUNCTION_EVENT (SDL_USEREVENT + 6)
 
 namespace events
 {
@@ -168,7 +167,6 @@ public:
 void raise_process_event();
 void raise_resize_event();
 void raise_draw_event();
-void raise_draw_all_event();
 void raise_help_string_event(int mousex, int mousey);
 
 

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -18,6 +18,7 @@
 #include "display.hpp"
 #include "draw.hpp"
 #include "draw_manager.hpp"
+#include "font/sdl_ttf_compat.hpp" // pango_line_width
 #include "font/text.hpp"
 #include "log.hpp"
 #include "sdl/utils.hpp"
@@ -43,6 +44,9 @@ label_map labels;
 int label_id = 1;
 
 std::stack<std::set<int>> label_contexts;
+
+/** Curent ID of the help string. */
+int help_string_ = 0;
 }
 
 // TODO: draw_manager - why tf is this in namespace font?
@@ -421,4 +425,42 @@ void update_floating_labels()
 		}
 	}
 }
+
+void set_help_string(const std::string& str)
+{
+	remove_floating_label(help_string_);
+
+	const color_t color{0, 0, 0, 0xbb};
+
+	int size = font::SIZE_LARGE;
+	rect draw_area = CVideo::get_singleton().draw_area();
+
+	while(size > 0) {
+		if(pango_line_width(str, size) > draw_area.w) {
+			size--;
+		} else {
+			break;
+		}
+	}
+
+	const int border = 5;
+
+	floating_label flabel(str);
+	flabel.set_font_size(size);
+	flabel.set_position(draw_area.w / 2, draw_area.h);
+	flabel.set_bg_color(color);
+	flabel.set_border_size(border);
+
+	help_string_ = add_floating_label(flabel);
+
+	const rect& r = get_floating_label_rect(help_string_);
+	move_floating_label(help_string_, 0.0, -double(r.h));
+}
+
+void clear_help_string()
+{
+	remove_floating_label(help_string_);
+	help_string_ = 0;
+}
+
 }

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -102,7 +102,7 @@ int floating_label::xpos(std::size_t width) const
 
 bool floating_label::create_texture()
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return false;
 	}
 
@@ -197,7 +197,7 @@ void floating_label::undraw()
 
 void floating_label::update(int time)
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return;
 	}
 

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -70,7 +70,7 @@ floating_label::floating_label(const std::string& text, const surface& surf)
 	, lifetime_(-1)
 	, width_(-1)
 	, height_(-1)
-	, clip_rect_(CVideo::get_singleton().draw_area())
+	, clip_rect_(video::draw_area())
 	, visible_(true)
 	, align_(CENTER_ALIGN)
 	, border_(0)
@@ -102,7 +102,7 @@ int floating_label::xpos(std::size_t width) const
 
 bool floating_label::create_texture()
 {
-	if(CVideo::get_singleton().faked()) {
+	if(video::faked()) {
 		return false;
 	}
 
@@ -135,7 +135,7 @@ bool floating_label::create_texture()
 	surface foreground = text.render_surface();
 
 	// Pixel scaling is necessary as we are manipulating the raw surface
-	const int ps = CVideo::get_singleton().get_pixel_scale();
+	const int ps = video::get_pixel_scale();
 	// For consistent results we must also enlarge according to zoom
 	const int sf = ps * display::get_singleton()->get_zoom_factor();
 
@@ -197,7 +197,7 @@ void floating_label::undraw()
 
 void floating_label::update(int time)
 {
-	if(CVideo::get_singleton().faked()) {
+	if(video::faked()) {
 		return;
 	}
 
@@ -433,7 +433,7 @@ void set_help_string(const std::string& str)
 	const color_t color{0, 0, 0, 0xbb};
 
 	int size = font::SIZE_LARGE;
-	rect draw_area = CVideo::get_singleton().draw_area();
+	rect draw_area = video::draw_area();
 
 	while(size > 0) {
 		if(pango_line_width(str, size) > draw_area.w) {

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -70,7 +70,7 @@ floating_label::floating_label(const std::string& text, const surface& surf)
 	, lifetime_(-1)
 	, width_(-1)
 	, height_(-1)
-	, clip_rect_(video::draw_area())
+	, clip_rect_(video::game_canvas())
 	, visible_(true)
 	, align_(CENTER_ALIGN)
 	, border_(0)
@@ -433,10 +433,10 @@ void set_help_string(const std::string& str)
 	const color_t color{0, 0, 0, 0xbb};
 
 	int size = font::SIZE_LARGE;
-	rect draw_area = video::draw_area();
+	point canvas_size = video::game_canvas_size();
 
 	while(size > 0) {
-		if(pango_line_width(str, size) > draw_area.w) {
+		if(pango_line_width(str, size) > canvas_size.x) {
 			size--;
 		} else {
 			break;
@@ -447,7 +447,7 @@ void set_help_string(const std::string& str)
 
 	floating_label flabel(str);
 	flabel.set_font_size(size);
-	flabel.set_position(draw_area.w / 2, draw_area.h);
+	flabel.set_position(canvas_size.x / 2, canvas_size.y);
 	flabel.set_bg_color(color);
 	flabel.set_border_size(border);
 

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -151,4 +151,15 @@ SDL_Rect get_floating_label_rect(int handle);
 void draw_floating_labels();
 void update_floating_labels();
 
+/**
+ * Displays a help string with the given text. A 'help string' is like a tooltip,
+ * but appears at the bottom of the screen so as to not be intrusive.
+ *
+ * @param str                 The text to display.
+ */
+void set_help_string(const std::string& str);
+
+/** Removes the help string. */
+void clear_help_string();
+
 } // end namespace font

--- a/src/font/sdl_ttf_compat.cpp
+++ b/src/font/sdl_ttf_compat.cpp
@@ -23,7 +23,6 @@
 #include "sdl/utils.hpp"
 #include "serialization/unicode.hpp"
 #include "tooltips.hpp"
-#include "video.hpp"
 
 static lg::log_domain log_font("font");
 #define DBG_FT LOG_STREAM(debug, log_font)
@@ -139,7 +138,7 @@ std::string pango_word_wrap(const std::string& unwrapped_text, int font_size, in
 	return res;
 }
 
-rect pango_draw_text(CVideo* video, const rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips, pango_text::FONT_STYLE style)
+rect pango_draw_text(bool actually_draw, const rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips, pango_text::FONT_STYLE style)
 {
 	auto& ptext = private_renderer();
 
@@ -167,7 +166,7 @@ rect pango_draw_text(CVideo* video, const rect& area, int size, const color_t& c
 
 	SDL_Rect res = {x, y, t.w(), t.h()};
 
-	if(video) {
+	if(actually_draw) {
 		draw::blit(t, res);
 	}
 

--- a/src/font/sdl_ttf_compat.hpp
+++ b/src/font/sdl_ttf_compat.hpp
@@ -29,7 +29,6 @@
 
 #include "font/text.hpp"
 
-class CVideo;
 struct rect;
 class texture;
 
@@ -73,9 +72,10 @@ std::string pango_word_wrap(const std::string& unwrapped_text, int font_size, in
  * If use_tooltips is true, then text with an ellipsis will have a tooltip
  * set for it equivalent to the entire contents of the text.
  *
- * A bounding rectangle of the text is returned. If video is nullptr, then the
- * text will not be drawn, and a bounding rectangle only will be returned.
+ * A bounding rectangle of the text is returned. If actually_draw is true
+ * the text will also be drawn to the screen. Otherwise only the bounding
+ * rectangle is returned.
  */
-rect pango_draw_text(CVideo* video, const rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips = false, pango_text::FONT_STYLE style = pango_text::STYLE_NORMAL);
+rect pango_draw_text(bool actually_draw, const rect& area, int size, const color_t& color, const std::string& text, int x, int y, bool use_tooltips = false, pango_text::FONT_STYLE style = pango_text::STYLE_NORMAL);
 
 } // end namespace font

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -552,7 +552,7 @@ int pango_text::get_max_glyph_height() const
 
 void pango_text::update_pixel_scale()
 {
-	const int ps = CVideo::get_singleton().get_pixel_scale();
+	const int ps = video::get_pixel_scale();
 	if (ps == pixel_scale_) {
 		return;
 	}

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -33,6 +33,7 @@
 #include "units/map.hpp"
 #include "units/unit.hpp"
 #include "variable.hpp"
+#include "video.hpp" // only for faked
 #include "whiteboard/manager.hpp"
 
 #include <iomanip>
@@ -523,7 +524,7 @@ pump_result_t wml_event_pump::operator()()
 void wml_event_pump::flush_messages()
 {
 	// Dialogs can only be shown if the display is not fake
-	if(game_display::get_singleton() && !CVideo::get_singleton().faked()) {
+	if(game_display::get_singleton() && !video::faked()) {
 		show_wml_errors();
 		show_wml_messages();
 	}

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -524,7 +524,7 @@ pump_result_t wml_event_pump::operator()()
 void wml_event_pump::flush_messages()
 {
 	// Dialogs can only be shown if the display is not fake
-	if(game_display::get_singleton() && !video::faked()) {
+	if(game_display::get_singleton() && !video::headless()) {
 		show_wml_errors();
 		show_wml_messages();
 	}

--- a/src/game_events/pump.cpp
+++ b/src/game_events/pump.cpp
@@ -522,8 +522,8 @@ pump_result_t wml_event_pump::operator()()
 
 void wml_event_pump::flush_messages()
 {
-	// Dialogs can only be shown if the display is not locked
-	if(game_display::get_singleton() && !CVideo::get_singleton().update_locked()) {
+	// Dialogs can only be shown if the display is not fake
+	if(game_display::get_singleton() && !CVideo::get_singleton().faked()) {
 		show_wml_errors();
 		show_wml_messages();
 	}

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -44,6 +44,7 @@
 #include "saved_game.hpp"
 #include "savegame.hpp"
 #include "sound.hpp"
+#include "video.hpp" // TODO: draw_manager - only for faked, refactor?
 #include "wesnothd_connection.hpp"
 #include "wml_exception.hpp"
 
@@ -208,7 +209,7 @@ level_result::type campaign_controller::playsingle_scenario(end_level_data &end_
 	end_level = playcontroller.get_end_level_data();
 	show_carryover_message(playcontroller, end_level, res);
 
-	if(!CVideo::get_singleton().faked()) {
+	if(!video::faked()) {
 		playcontroller.maybe_linger();
 	}
 

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -44,7 +44,7 @@
 #include "saved_game.hpp"
 #include "savegame.hpp"
 #include "sound.hpp"
-#include "video.hpp" // TODO: draw_manager - only for faked, refactor?
+#include "video.hpp"
 #include "wesnothd_connection.hpp"
 #include "wml_exception.hpp"
 

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -209,7 +209,7 @@ level_result::type campaign_controller::playsingle_scenario(end_level_data &end_
 	end_level = playcontroller.get_end_level_data();
 	show_carryover_message(playcontroller, end_level, res);
 
-	if(!video::faked()) {
+	if(!video::headless()) {
 		playcontroller.maybe_linger();
 	}
 

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -333,11 +333,8 @@ bool game_launcher::init_video()
 		return true;
 	}
 
+	// Initialize video subsystem, and create a new window.
 	video::init();
-
-	// Initialize a new window
-	// TODO: draw_manager - surely this should happen automatically?
-	video::init_window();
 
 	// Set window title and icon
 	video::set_window_title(game_config::get_default_title_string());

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -32,7 +32,6 @@
 
 class commandline_options;
 class config;
-class CVideo;
 
 struct jump_to_campaign_info
 {
@@ -131,8 +130,7 @@ private:
 	unit_test_result single_unit_test();
 
 	const commandline_options& cmdline_opts_;
-	//Never null.
-	const std::unique_ptr<CVideo> video_;
+	bool start_in_fullscreen_ = false;
 
 	font::manager font_manager_;
 	const preferences::manager prefs_manager_;

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -35,7 +35,7 @@
 #include "sdl/rect.hpp"
 #include "sdl/texture.hpp"
 #include "sdl/utils.hpp" // blur_surface
-#include "video.hpp"
+#include "video.hpp" // read_pixels_low_res, only used for blurring
 #include "wml_exception.hpp"
 
 namespace gui2
@@ -504,7 +504,7 @@ void canvas::draw()
 	if(blur_depth_ && !blur_texture_) {
 		// Cache a blurred image of whatever is underneath.
 		SDL_Rect rect = draw::get_viewport();
-		surface s = CVideo::get_singleton().read_pixels_low_res(&rect);
+		surface s = video::read_pixels_low_res(&rect);
 		s = blur_surface(s, blur_depth_);
 		blur_texture_ = texture(s);
 	}

--- a/src/gui/core/event/distributor.hpp
+++ b/src/gui/core/event/distributor.hpp
@@ -41,7 +41,6 @@
 #include "gui/core/event/dispatcher.hpp"
 #include "gui/core/event/handler.hpp"
 #include "sdl/point.hpp"
-#include "video.hpp"
 
 #include <string>
 #include <vector>

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -419,11 +419,11 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 			break;
 
 		case DRAW_EVENT:
-			draw();
+			//draw();
 			break;
 
 		case DRAW_ALL_EVENT:
-			draw_everything();
+			//draw_everything();
 			break;
 
 		case TIMER_EVENT:
@@ -455,7 +455,7 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 		case SDL_WINDOWEVENT:
 			switch(event.window.event) {
 				case SDL_WINDOWEVENT_EXPOSED:
-					draw();
+					//draw();
 					break;
 
 				case SDL_WINDOWEVENT_RESIZED:
@@ -607,7 +607,7 @@ void sdl_event_handler::draw_everything()
 	// TODO: draw_manager - look into usage of this
 	//std::cerr << "sdl_event_handler::draw_everything" << std::endl;
 	draw_manager::invalidate_region(CVideo::get_singleton().draw_area());
-	draw();
+	//draw();
 }
 
 void sdl_event_handler::video_resize(const point& new_size)

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -18,6 +18,7 @@
 #include "gui/core/event/handler.hpp"
 
 #include "draw_manager.hpp"
+#include "events.hpp"
 #include "gui/core/event/dispatcher.hpp"
 #include "gui/core/timer.hpp"
 #include "gui/core/log.hpp"

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -446,8 +446,7 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 		case SDL_WINDOWEVENT:
 			switch(event.window.event) {
 				case SDL_WINDOWEVENT_RESIZED:
-					// TODO: draw_manager - rect accessor for {w,h}
-					video_resize(point(video::draw_area().w, video::draw_area().h));
+					video_resize(video::game_canvas_size());
 					break;
 
 				case SDL_WINDOWEVENT_ENTER:
@@ -468,31 +467,40 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_FINGERMOTION:
 			{
-				rect r = video::draw_area();
-				touch_motion(point(event.tfinger.x * r.w, event.tfinger.y * r.h),
-							 point(event.tfinger.dx * r.w, event.tfinger.dy * r.h));
+				// TODO: highdpi - this may be wrong if there is a logical offset
+				point c = video::game_canvas_size();
+				touch_motion(
+					point(event.tfinger.x * c.x, event.tfinger.y * c.y),
+					point(event.tfinger.dx * c.x, event.tfinger.dy * c.y)
+				);
 			}
 			break;
 
 		case SDL_FINGERUP:
 			{
-				rect r = video::draw_area();
-				touch_up(point(event.tfinger.x * r.w, event.tfinger.y * r.h));
+				// TODO: highdpi - this may be wrong if there is a logical offset
+				point c = video::game_canvas_size();
+				touch_up(point(event.tfinger.x * c.x, event.tfinger.y * c.y));
 			}
 			break;
 
 		case SDL_FINGERDOWN:
 			{
-				rect r = video::draw_area();
-				touch_down(point(event.tfinger.x * r.w, event.tfinger.y * r.h));
+				// TODO: highdpi - this may be wrong if there is a logical offset
+				point c = video::game_canvas_size();
+				touch_down(point(event.tfinger.x * c.x, event.tfinger.y * c.y));
 			}
 			break;
 
 		case SDL_MULTIGESTURE:
 			{
-				rect r = video::draw_area();
-				touch_multi_gesture(point(event.mgesture.x * r.w, event.mgesture.y * r.h),
-									event.mgesture.dTheta, event.mgesture.dDist, event.mgesture.numFingers);
+				// TODO: highdpi - this may be wrong if there is a logical offset
+				point c = video::game_canvas_size();
+				touch_multi_gesture(
+					point(event.mgesture.x * c.x, event.mgesture.y * c.y),
+					event.mgesture.dTheta, event.mgesture.dDist,
+					event.mgesture.numFingers
+				);
 			}
 			break;
 

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -103,7 +103,7 @@ static uint32_t timer_sdl_poll_events(uint32_t, void*)
 	{
 		events::pump();
 	}
-	catch(CVideo::quit&)
+	catch(video::quit&)
 	{
 		return 0;
 	}
@@ -380,7 +380,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 	}
 
 	uint8_t button = event.button.button;
-	CVideo& video = CVideo::get_singleton();
 
 	switch(event.type) {
 		case SDL_MOUSEMOTION:
@@ -446,7 +445,8 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 		case SDL_WINDOWEVENT:
 			switch(event.window.event) {
 				case SDL_WINDOWEVENT_RESIZED:
-					video_resize(point(video.draw_area().w, video.draw_area().h));
+					// TODO: draw_manager - rect accessor for {w,h}
+					video_resize(point(video::draw_area().w, video::draw_area().h));
 					break;
 
 				case SDL_WINDOWEVENT_ENTER:
@@ -467,7 +467,7 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_FINGERMOTION:
 			{
-				SDL_Rect r = video.draw_area();
+				rect r = video::draw_area();
 				touch_motion(point(event.tfinger.x * r.w, event.tfinger.y * r.h),
 							 point(event.tfinger.dx * r.w, event.tfinger.dy * r.h));
 			}
@@ -475,21 +475,21 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_FINGERUP:
 			{
-				SDL_Rect r = video.draw_area();
+				rect r = video::draw_area();
 				touch_up(point(event.tfinger.x * r.w, event.tfinger.y * r.h));
 			}
 			break;
 
 		case SDL_FINGERDOWN:
 			{
-				SDL_Rect r = video.draw_area();
+				rect r = video::draw_area();
 				touch_down(point(event.tfinger.x * r.w, event.tfinger.y * r.h));
 			}
 			break;
 
 		case SDL_MULTIGESTURE:
 			{
-				SDL_Rect r = video.draw_area();
+				rect r = video::draw_area();
 				touch_multi_gesture(point(event.mgesture.x * r.w, event.mgesture.y * r.h),
 									event.mgesture.dTheta, event.mgesture.dDist, event.mgesture.numFingers);
 			}

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -467,7 +467,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_FINGERMOTION:
 			{
-				// TODO: highdpi - this may be wrong if there is a logical offset
 				point c = video::game_canvas_size();
 				touch_motion(
 					point(event.tfinger.x * c.x, event.tfinger.y * c.y),
@@ -478,7 +477,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_FINGERUP:
 			{
-				// TODO: highdpi - this may be wrong if there is a logical offset
 				point c = video::game_canvas_size();
 				touch_up(point(event.tfinger.x * c.x, event.tfinger.y * c.y));
 			}
@@ -486,7 +484,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_FINGERDOWN:
 			{
-				// TODO: highdpi - this may be wrong if there is a logical offset
 				point c = video::game_canvas_size();
 				touch_down(point(event.tfinger.x * c.x, event.tfinger.y * c.y));
 			}
@@ -494,7 +491,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_MULTIGESTURE:
 			{
-				// TODO: highdpi - this may be wrong if there is a logical offset
 				point c = video::game_canvas_size();
 				touch_multi_gesture(
 					point(event.mgesture.x * c.x, event.mgesture.y * c.y),

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -172,7 +172,6 @@ private:
 	/** Fires a draw event. */
 	using events::sdl_handler::draw;
 	void draw() override;
-	void draw_everything();
 
 	/**
 	 * Fires a video resize event.
@@ -418,14 +417,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 			// remove_popup();
 			break;
 
-		case DRAW_EVENT:
-			//draw();
-			break;
-
-		case DRAW_ALL_EVENT:
-			//draw_everything();
-			break;
-
 		case TIMER_EVENT:
 			execute_timer(reinterpret_cast<std::size_t>(event.user.data1));
 			break;
@@ -454,10 +445,6 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_WINDOWEVENT:
 			switch(event.window.event) {
-				case SDL_WINDOWEVENT_EXPOSED:
-					//draw();
-					break;
-
 				case SDL_WINDOWEVENT_RESIZED:
 					video_resize(point(video.draw_area().w, video.draw_area().h));
 					break;
@@ -588,26 +575,10 @@ void sdl_event_handler::activate()
 
 void sdl_event_handler::draw()
 {
-	/*
 	for(auto dispatcher : dispatchers_)
 	{
 		dispatcher->fire(DRAW, dynamic_cast<widget&>(*dispatcher));
 	}
-
-	if(!dispatchers_.empty()) {
-		CVideo::get_singleton().render_screen();
-	}
-	*/
-
-	draw_manager::sparkle();
-}
-
-void sdl_event_handler::draw_everything()
-{
-	// TODO: draw_manager - look into usage of this
-	//std::cerr << "sdl_event_handler::draw_everything" << std::endl;
-	draw_manager::invalidate_region(CVideo::get_singleton().draw_area());
-	//draw();
 }
 
 void sdl_event_handler::video_resize(const point& new_size)

--- a/src/gui/dialogs/debug_clock.cpp
+++ b/src/gui/dialogs/debug_clock.cpp
@@ -67,7 +67,7 @@ void debug_clock::pre_show(window& window)
 	update_time(true);
 }
 
-void debug_clock::post_show(CVideo& /*video*/)
+void debug_clock::post_show()
 {
 	draw_manager::deregister_drawable(this);
 }

--- a/src/gui/dialogs/debug_clock.cpp
+++ b/src/gui/dialogs/debug_clock.cpp
@@ -17,6 +17,7 @@
 
 #include "gui/dialogs/debug_clock.hpp"
 
+#include "draw_manager.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/dialogs/modal_dialog.hpp"
 #include "gui/widgets/integer_selector.hpp"
@@ -60,8 +61,7 @@ void debug_clock::pre_show(window& window)
 
 	clock_ = find_widget<styled_widget>(&window, "clock", false, false);
 
-	signal_ = std::bind(&debug_clock::update_time, this, false);
-	connect_signal_on_draw(window, signal_);
+	draw_manager::register_drawable(this);
 
 	time_.set_current_time();
 	update_time(true);
@@ -69,7 +69,23 @@ void debug_clock::pre_show(window& window)
 
 void debug_clock::post_show(CVideo& /*video*/)
 {
-	get_window()->disconnect_signal<event::DRAW>(signal_);
+	draw_manager::deregister_drawable(this);
+}
+
+void debug_clock::layout()
+{
+	update_time(false);
+}
+
+rect debug_clock::screen_location()
+{
+	return get_window()->get_rectangle();
+}
+
+bool debug_clock::expose(const SDL_Rect& /*region*/)
+{
+	// Drawing is handled by the window that this should be, but is not.
+	return false;
 }
 
 void debug_clock::update_time(const bool force)

--- a/src/gui/dialogs/debug_clock.hpp
+++ b/src/gui/dialogs/debug_clock.hpp
@@ -20,8 +20,6 @@
 #include "gui/core/event/dispatcher.hpp"
 #include "gui/core/top_level_drawable.hpp"
 
-class CVideo;
-
 namespace gui2
 {
 
@@ -145,7 +143,7 @@ private:
 
 	virtual void pre_show(window& window) override;
 
-	virtual void post_show(CVideo& video);
+	virtual void post_show();
 
 	/**
 	 * The callback for the drawing routine.

--- a/src/gui/dialogs/debug_clock.hpp
+++ b/src/gui/dialogs/debug_clock.hpp
@@ -18,6 +18,7 @@
 #include "gui/dialogs/modeless_dialog.hpp"
 
 #include "gui/core/event/dispatcher.hpp"
+#include "gui/core/top_level_drawable.hpp"
 
 class CVideo;
 
@@ -48,7 +49,7 @@ namespace dialogs
  * second            | integer_selector |no       |This shows the seconds since the beginning of the current minute. The control should have a minimum_value of 0 and a maximum_value of 59.
  * clock             | control          |no       |A control which will have set three variables in its canvas:<ul><li>hour - the same value as the hour integer_selector.</li><li>minute - the same value as the minute integer_selector.</li><li>second - the same value as the second integer_selector.</li></ul>The control can then show the time in its own preferred format(s).
  */
-class debug_clock : public modeless_dialog
+class debug_clock : public modeless_dialog, public top_level_drawable
 {
 public:
 	debug_clock()
@@ -156,6 +157,12 @@ private:
 	 *                            initially.)
 	 */
 	void update_time(const bool force);
+
+	// TODO: draw_manager - modeless dialog should be a window, fix
+	/* top_level_drawable interface */
+	virtual void layout() override;
+	virtual bool expose(const SDL_Rect& region) override;
+	virtual rect screen_location() override;
 };
 
 } // namespace dialogs

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -247,7 +247,7 @@ void custom_tod::update_tod_display()
 	// the image caching mechanism.
 	//
 	// If this ceases to be the case in the future, you'll need to call
-	// redraw_everything() instead.
+	// queue_rerender() instead.
 
 	disp->update_tod(&get_selected_tod());
 

--- a/src/gui/dialogs/end_credits.cpp
+++ b/src/gui/dialogs/end_credits.cpp
@@ -51,7 +51,8 @@ void end_credits::pre_show(window& window)
 	// Delay a little before beginning the scrolling
 	last_scroll_ = SDL_GetTicks() + 3000;
 
-	connect_signal_on_draw(window, std::bind(&end_credits::timer_callback, this));
+	//connect_signal_on_draw(window, std::bind(&end_credits::timer_callback, this));
+	// TODO: draw_manager - modal_dialog should be a window, i'm not hacking any more of these
 
 	connect_signal_pre_key_press(window, std::bind(&end_credits::key_press_callback, this, std::placeholders::_5));
 

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -229,7 +229,7 @@ loading_screen::~loading_screen()
 
 void loading_screen::display(std::function<void()> f)
 {
-	if(singleton_ || video::faked()) {
+	if(singleton_ || video::headless()) {
 		LOG_LS << "Directly executing loading function.";
 		f();
 	} else {

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -229,7 +229,7 @@ loading_screen::~loading_screen()
 
 void loading_screen::display(std::function<void()> f)
 {
-	if(singleton_ || CVideo::get_singleton().faked()) {
+	if(singleton_ || video::faked()) {
 		LOG_LS << "Directly executing loading function.";
 		f();
 	} else {

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -18,6 +18,7 @@
 #include "gui/dialogs/modal_dialog.hpp"
 
 #include "cursor.hpp"
+#include "events.hpp"
 #include "gui/auxiliary/field.hpp"
 #include "gui/widgets/integer_selector.hpp"
 #include "scripting/plugins/context.hpp"

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -60,7 +60,7 @@ namespace {
 
 bool modal_dialog::show(const unsigned auto_close_time)
 {
-	if(video::faked() && !show_even_without_video_) {
+	if(video::headless() && !show_even_without_video_) {
 		DBG_DP << "modal_dialog::show denied";
 		if(!allow_plugin_skip_) {
 			return false;

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -59,7 +59,7 @@ namespace {
 
 bool modal_dialog::show(const unsigned auto_close_time)
 {
-	if(CVideo::get_singleton().faked() && !show_even_without_video_) {
+	if(video::faked() && !show_even_without_video_) {
 		DBG_DP << "modal_dialog::show denied";
 		if(!allow_plugin_skip_) {
 			return false;

--- a/src/gui/dialogs/modeless_dialog.cpp
+++ b/src/gui/dialogs/modeless_dialog.cpp
@@ -34,7 +34,7 @@ modeless_dialog::~modeless_dialog()
 
 void modeless_dialog::show(const bool allow_interaction, const unsigned /*auto_close_time*/)
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return;
 	}
 

--- a/src/gui/dialogs/modeless_dialog.cpp
+++ b/src/gui/dialogs/modeless_dialog.cpp
@@ -18,7 +18,7 @@
 #include "gui/dialogs/modeless_dialog.hpp"
 
 #include "gui/widgets/window.hpp"
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only for faked(), is it needed?
 
 namespace gui2::dialogs
 {
@@ -34,7 +34,7 @@ modeless_dialog::~modeless_dialog()
 
 void modeless_dialog::show(const bool allow_interaction, const unsigned /*auto_close_time*/)
 {
-	if(CVideo::get_singleton().faked()) {
+	if(video::faked()) {
 		return;
 	}
 

--- a/src/gui/dialogs/outro.cpp
+++ b/src/gui/dialogs/outro.cpp
@@ -95,7 +95,8 @@ void outro::pre_show(window& window)
 	window.set_enter_disabled(true);
 	window.get_canvas(0).set_variable("outro_text", wfl::variant(*current_text_));
 
-	connect_signal_on_draw(window, std::bind(&outro::draw_callback, this));
+	//connect_signal_on_draw(window, std::bind(&outro::draw_callback, this));
+	// TODO: draw_manager - modal_dialog should be a window, i'm not hacking any more of these
 }
 
 void outro::draw_callback()

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -18,6 +18,7 @@
 
 #include "gui/dialogs/preferences_dialog.hpp"
 
+#include "display.hpp"
 #include "events.hpp"
 #include "filesystem.hpp"
 #include "formatter.hpp"
@@ -325,6 +326,11 @@ void preferences_dialog::apply_pixel_scale()
 
 	// Update draw buffers, taking these into account.
 	video::update_buffers();
+
+	// Update game display, if active
+	if(::display* disp = display::get_singleton()) {
+		disp->queue_rerender();
+	}
 
 	// Raise a window resize event so we can react to the change
 	events::raise_resize_event();

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -122,7 +122,7 @@ preferences_dialog::preferences_dialog(const PREFERENCE_VIEW initial_view)
 // Helper function to refresh resolution list
 void preferences_dialog::set_resolution_list(menu_button& res_list)
 {
-	resolutions_ = CVideo::get_singleton().get_available_resolutions(true);
+	resolutions_ = video::get_available_resolutions(true);
 
 	std::vector<config> options;
 	for(const point& res : resolutions_) {
@@ -140,8 +140,8 @@ void preferences_dialog::set_resolution_list(menu_button& res_list)
 		options.push_back(std::move(option));
 	}
 
-	const unsigned current_res = std::distance(resolutions_.begin(), std::find(resolutions_.begin(), resolutions_.end(),
-		CVideo::get_singleton().current_resolution()));
+	const unsigned current_res = std::distance(resolutions_.begin(), std::find(
+		resolutions_.begin(), resolutions_.end(), video::current_resolution()));
 
 	res_list.set_values(options, current_res);
 }
@@ -323,7 +323,7 @@ void preferences_dialog::apply_pixel_scale()
 	set_auto_pixel_scale(auto_ps_toggle.get_value_bool());
 
 	// Update draw buffers, taking these into account.
-	CVideo::get_singleton().update_buffers();
+	video::update_buffers();
 }
 
 
@@ -1075,7 +1075,7 @@ void preferences_dialog::set_visible_page(unsigned int page, const std::string& 
 void preferences_dialog::fullscreen_toggle_callback()
 {
 	const bool ison = find_widget<toggle_button>(get_window(), "fullscreen", false).get_value_bool();
-	CVideo::get_singleton().set_fullscreen(ison);
+	video::set_fullscreen(ison);
 
 	menu_button& res_list = find_widget<menu_button>(get_window(), "resolution_set", false);
 
@@ -1087,7 +1087,7 @@ void preferences_dialog::handle_res_select()
 {
 	menu_button& res_list = find_widget<menu_button>(get_window(), "resolution_set", false);
 
-	if(CVideo::get_singleton().set_resolution(resolutions_[res_list.get_value()])) {
+	if(video::set_resolution(resolutions_[res_list.get_value()])) {
 		set_resolution_list(res_list);
 	}
 }

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -18,6 +18,7 @@
 
 #include "gui/dialogs/preferences_dialog.hpp"
 
+#include "events.hpp"
 #include "filesystem.hpp"
 #include "formatter.hpp"
 #include "formula/string_utils.hpp"
@@ -324,6 +325,9 @@ void preferences_dialog::apply_pixel_scale()
 
 	// Update draw buffers, taking these into account.
 	video::update_buffers();
+
+	// Raise a window resize event so we can react to the change
+	events::raise_resize_event();
 }
 
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -106,7 +106,7 @@ static void launch_lua_console()
 
 static void make_screenshot()
 {
-	surface screenshot = CVideo::get_singleton().read_pixels();
+	surface screenshot = video::read_pixels();
 	if(screenshot) {
 		std::string filename = filesystem::get_screenshot_dir() + "/" + _("Screenshot") + "_";
 		filename = filesystem::get_next_filename(filename, ".jpg");

--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -16,6 +16,7 @@
 #include "gui/widgets/settings.hpp"
 
 #include "display.hpp"
+#include "video.hpp" // TODO: draw_manager - only for draw_area
 
 namespace gui2
 {
@@ -55,11 +56,10 @@ std::vector<game_tip> tips;
 
 void update_screen_size_variables()
 {
-	CVideo& video = CVideo::get_singleton();
-	const SDL_Rect rect = video.draw_area();
+	rect r = video::draw_area();
 
-	screen_width = rect.w;
-	screen_height = rect.h;
+	screen_width = r.w;
+	screen_height = r.h;
 
 	gamemap_width = screen_width;
 	gamemap_height = screen_height;

--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -16,7 +16,7 @@
 #include "gui/widgets/settings.hpp"
 
 #include "display.hpp"
-#include "video.hpp" // TODO: draw_manager - only for draw_area
+#include "video.hpp"
 
 namespace gui2
 {
@@ -56,10 +56,10 @@ std::vector<game_tip> tips;
 
 void update_screen_size_variables()
 {
-	rect r = video::draw_area();
+	point canvas_size = video::game_canvas_size();
 
-	screen_width = r.w;
-	screen_height = r.h;
+	screen_width = canvas_size.x;
+	screen_height = canvas_size.y;
 
 	gamemap_width = screen_width;
 	gamemap_height = screen_height;

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -60,7 +60,7 @@
 #include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
 #include "formula/variant.hpp"
-#include "video.hpp"
+#include "video.hpp" // only for toggle_fullscreen
 #include "wml_exception.hpp"
 #include "sdl/userevent.hpp"
 #include "sdl/input.hpp" // get_mouse_button_mask
@@ -260,7 +260,6 @@ window* manager::get_window(const unsigned id)
 
 window::window(const builder_window::window_resolution& definition)
 	: panel(implementation::builder_window(::config {"definition", definition.definition}), type())
-	, video_(CVideo::get_singleton())
 	, status_(status::NEW)
 	, show_mode_(show_mode::none)
 	, retval_(retval::NONE)
@@ -362,7 +361,7 @@ window::window(const builder_window::window_resolution& definition)
 
 	/** @todo: should eventally become part of global hotkey handling. */
 	register_hotkey(hotkey::HOTKEY_FULLSCREEN,
-		std::bind(&CVideo::toggle_fullscreen, std::ref(video_)));
+		std::bind(&video::toggle_fullscreen));
 }
 
 window::~window()

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -127,27 +127,6 @@ const unsigned LAYOUT = 0;
 #endif
 
 /**
- * Pushes a single draw event to the queue. To be used before calling
- * events::pump when drawing windows.
- *
- * @todo: in the future we should simply call draw functions directly
- * from events::pump and do away with the custom drawing events, but
- * that's a 1.15 target. For now, this will have to do.
- */
-static void push_draw_event()
-{
-	//	DBG_GUI_E << "Pushing draw event in queue.";
-
-	SDL_Event event;
-	sdl::UserEvent data(DRAW_EVENT);
-
-	event.type = DRAW_EVENT;
-	event.user = data;
-
-	SDL_PushEvent(&event);
-}
-
-/**
  * SDL_AddTimer() callback for delay_event.
  *
  * @param event                   The event to push in the event queue.
@@ -486,9 +465,8 @@ void window::show_non_modal(/*const unsigned auto_close_timeout*/)
 
 	DBG_DP << "show non-modal queued to " << get_rectangle();
 
-	push_draw_event();
-
 	events::pump();
+	events::raise_draw_event();
 }
 
 int window::show(const unsigned auto_close_timeout)

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -38,7 +38,6 @@
 #include <string>
 #include <vector>
 
-class CVideo;
 struct point;
 
 namespace gui2
@@ -428,9 +427,6 @@ public:
 	};
 
 private:
-	/** Needed so we can change what's drawn on the screen. */
-	CVideo& video_;
-
 	/** The status of the window. */
 	status status_;
 

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -192,7 +192,7 @@ void show_with_toplevel(const section &toplevel_sec,
 	const events::event_context dialog_events_context;
 	const gui::dialog_manager manager;
 
-	SDL_Rect draw_area = CVideo::get_singleton().draw_area();
+	rect draw_area = video::draw_area();
 
 	const int width  = std::min<int>(font::relative_size(1200), draw_area.w - font::relative_size(20));
 	const int height = std::min<int>(font::relative_size(850), draw_area.h - font::relative_size(150));

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -29,19 +29,19 @@
 #include "game_config_manager.hpp"
 #include "gettext.hpp"                  // for _
 #include "gui/dialogs/transient_message.hpp"
-#include "help/help_browser.hpp"             // for help_browser
-#include "help/help_impl.hpp"                // for hidden_symbol, toplevel, etc
+#include "help/help_browser.hpp"        // for help_browser
+#include "help/help_impl.hpp"           // for hidden_symbol, toplevel, etc
 #include "key.hpp"                      // for CKey
 #include "log.hpp"                      // for LOG_STREAM, log_domain
-#include "sdl/surface.hpp"                // for surface
+#include "sdl/surface.hpp"              // for surface
 #include "show_dialog.hpp"              // for dialog_frame, etc
-#include "terrain/terrain.hpp"                  // for terrain_type
-#include "units/unit.hpp"                     // for unit
-#include "units/types.hpp"               // for unit_type, unit_type_data, etc
-#include "video.hpp"               // TODO: draw_manager - only for draw_area
+#include "terrain/terrain.hpp"          // for terrain_type
+#include "units/unit.hpp"               // for unit
+#include "units/types.hpp"              // for unit_type, unit_type_data, etc
+#include "video.hpp"                    // for game_canvas_size
 #include "widgets/button.hpp"           // for button
 
-#include <cassert>                     // for assert
+#include <cassert>                      // for assert
 #include <algorithm>                    // for min
 #include <ostream>                      // for basic_ostream, operator<<, etc
 #include <vector>                       // for vector, vector<>::iterator
@@ -192,10 +192,10 @@ void show_with_toplevel(const section &toplevel_sec,
 	const events::event_context dialog_events_context;
 	const gui::dialog_manager manager;
 
-	rect draw_area = video::draw_area();
+	point canvas_size = video::game_canvas_size();
 
-	const int width  = std::min<int>(font::relative_size(1200), draw_area.w - font::relative_size(20));
-	const int height = std::min<int>(font::relative_size(850), draw_area.h - font::relative_size(150));
+	const int width  = std::min<int>(font::relative_size(1200), canvas_size.x - font::relative_size(20));
+	const int height = std::min<int>(font::relative_size(850), canvas_size.y - font::relative_size(150));
 	const int left_padding = font::relative_size(10);
 	const int right_padding = font::relative_size(10);
 	const int top_padding = font::relative_size(10);
@@ -204,8 +204,8 @@ void show_with_toplevel(const section &toplevel_sec,
 	// If not both locations were supplied, put the dialog in the middle
 	// of the screen.
 	if (yloc <= -1 || xloc <= -1) {
-		xloc = draw_area.w / 2 - width / 2;
-		yloc = draw_area.h / 2 - height / 2;
+		xloc = canvas_size.x / 2 - width / 2;
+		yloc = canvas_size.y / 2 - height / 2;
 	}
 	std::vector<gui::button*> buttons_ptr;
 	gui::button close_button_(_("Close"));

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -292,7 +292,7 @@ std::string unit_topic_generator::operator()() const {
 	const unit_type& female_type = type_.get_gender_unit_type(unit_race::FEMALE);
 	const unit_type& male_type = type_.get_gender_unit_type(unit_race::MALE);
 
-	const int screen_width = CVideo::get_singleton().draw_area().w;
+	const int screen_width = video::draw_area().w;
 
 	ss << _("Level") << " " << type_.level();
 	ss << "\n\n";

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -32,7 +32,7 @@
 #include "tstring.hpp"                  // for t_string, operator<<
 #include "units/helper.hpp"             // for resistance_color
 #include "units/types.hpp"              // for unit_type, unit_type_data, etc
-#include "video.hpp"                    // TODO: draw_manager - only draw_area
+#include "video.hpp"                    // for game_canvas_size
 
 #include <map>                          // for map, etc
 #include <optional>
@@ -292,7 +292,7 @@ std::string unit_topic_generator::operator()() const {
 	const unit_type& female_type = type_.get_gender_unit_type(unit_race::FEMALE);
 	const unit_type& male_type = type_.get_gender_unit_type(unit_race::MALE);
 
-	const int screen_width = video::draw_area().w;
+	const int screen_width = video::game_canvas_size().x;
 
 	ss << _("Level") << " " << type_.level();
 	ss << "\n\n";

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -34,6 +34,7 @@
 #include "../resources.hpp"
 #include "../playmp_controller.hpp"
 #include "sdl/input.hpp" // get_mouse_state
+#include "video.hpp" // toggle_fullscreen
 
 #include <functional>
 
@@ -628,7 +629,7 @@ void command_executor::execute_command_wrap(const command_executor::queued_comma
 
 	switch(command.command->command) {
 		case HOTKEY_FULLSCREEN:
-			CVideo::get_singleton().toggle_fullscreen();
+			video::toggle_fullscreen();
 			break;
 		case HOTKEY_SCREENSHOT:
 			make_screenshot(_("Screenshot"), false);

--- a/src/hotkey/command_executor.hpp
+++ b/src/hotkey/command_executor.hpp
@@ -21,7 +21,6 @@
 #include <SDL2/SDL_events.h>
 
 class display;
-class CVideo;
 
 namespace hotkey {
 

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -186,7 +186,7 @@ void menu_handler::preferences()
 {
 	gui2::dialogs::preferences_dialog::display();
 	// Needed after changing fullscreen/windowed mode or display resolution
-	gui_->redraw_everything();
+	gui_->queue_rerender();
 }
 
 void menu_handler::show_chat_log()
@@ -1462,7 +1462,7 @@ void console_handler::do_refresh()
 	sound::flush_cache();
 
 	menu_handler_.gui_->create_buttons();
-	menu_handler_.gui_->redraw_everything();
+	menu_handler_.gui_->queue_rerender();
 }
 
 void console_handler::do_droid()

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -67,6 +67,7 @@
 #include "units/types.hpp"
 #include "units/unit.hpp"
 #include "utils/general.hpp"
+#include "video.hpp"
 #include "whiteboard/manager.hpp"
 
 #include <functional>
@@ -248,7 +249,7 @@ void play_controller::init(const config& level)
 		// Ensure the loading screen doesn't end up underneath the game display
 		gui2::dialogs::loading_screen::raise();
 
-		if(!gui_->video().faked()) {
+		if(!video::faked()) {
 			if(saved_game_.mp_settings().mp_countdown) {
 				gui_->get_theme().modify_label("time-icon", _("time left for current turn"));
 			} else {
@@ -1041,7 +1042,7 @@ void play_controller::check_victory()
 		return;
 	}
 
-	if(gui_->video().non_interactive()) {
+	if(video::non_interactive()) {
 		LOG_AIT << "winner: ";
 		for(unsigned l : not_defeated) {
 			std::string ai = ai::manager::get_singleton().get_active_ai_identifier_for_side(l);
@@ -1064,7 +1065,7 @@ void play_controller::check_victory()
 
 void play_controller::process_oos(const std::string& msg) const
 {
-	if(gui_->video().non_interactive()) {
+	if(video::non_interactive()) {
 		throw game::game_error(msg);
 	}
 
@@ -1343,7 +1344,7 @@ void play_controller::play_turn()
 
 	LOG_NG << "turn: " << turn();
 
-	if(gui_->video().non_interactive()) {
+	if(video::non_interactive()) {
 		LOG_AIT << "Turn " << turn() << ":";
 	}
 
@@ -1385,7 +1386,7 @@ void play_controller::play_turn()
 				return;
 			}
 
-			if(gui_->video().non_interactive()) {
+			if(video::non_interactive()) {
 				LOG_AIT << " Player " << current_side() << ": " << current_team().villages().size() << " Villages";
 				ai_testing::log_turn_end(current_side());
 			}
@@ -1422,7 +1423,7 @@ void play_controller::check_time_over()
 			return;
 		}
 
-		if(gui_->video().non_interactive()) {
+		if(video::non_interactive()) {
 			LOG_AIT << "time over (draw)";
 			ai_testing::log_draw();
 		}

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -249,7 +249,7 @@ void play_controller::init(const config& level)
 		// Ensure the loading screen doesn't end up underneath the game display
 		gui2::dialogs::loading_screen::raise();
 
-		if(!video::faked()) {
+		if(!video::headless()) {
 			if(saved_game_.mp_settings().mp_countdown) {
 				gui_->get_theme().modify_label("time-icon", _("time left for current turn"));
 			} else {
@@ -1042,7 +1042,7 @@ void play_controller::check_victory()
 		return;
 	}
 
-	if(video::non_interactive()) {
+	if(video::headless()) {
 		LOG_AIT << "winner: ";
 		for(unsigned l : not_defeated) {
 			std::string ai = ai::manager::get_singleton().get_active_ai_identifier_for_side(l);
@@ -1065,7 +1065,7 @@ void play_controller::check_victory()
 
 void play_controller::process_oos(const std::string& msg) const
 {
-	if(video::non_interactive()) {
+	if(video::headless()) {
 		throw game::game_error(msg);
 	}
 
@@ -1344,7 +1344,7 @@ void play_controller::play_turn()
 
 	LOG_NG << "turn: " << turn();
 
-	if(video::non_interactive()) {
+	if(video::headless()) {
 		LOG_AIT << "Turn " << turn() << ":";
 	}
 
@@ -1386,7 +1386,7 @@ void play_controller::play_turn()
 				return;
 			}
 
-			if(video::non_interactive()) {
+			if(video::headless()) {
 				LOG_AIT << " Player " << current_side() << ": " << current_team().villages().size() << " Villages";
 				ai_testing::log_turn_end(current_side());
 			}
@@ -1423,7 +1423,7 @@ void play_controller::check_time_over()
 			return;
 		}
 
-		if(video::non_interactive()) {
+		if(video::headless()) {
 			LOG_AIT << "time over (draw)";
 			ai_testing::log_draw();
 		}

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -356,7 +356,6 @@ void play_controller::fire_prestart()
 {
 	// pre-start events must be executed before any GUI operation,
 	// as those may cause the display to be refreshed.
-	update_locker lock_display(gui_->video());
 	gamestate().gamedata_.set_phase(game_data::PRESTART);
 
 	// Fire these right before prestart events, to catch only the units sides

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -435,7 +435,7 @@ void playmp_controller::maybe_linger()
 {
 	// mouse_handler expects at least one team for linger mode to work.
 	assert(is_regular_game_end());
-	if(!get_end_level_data().transient.linger_mode || get_teams().empty() || video::faked()) {
+	if(!get_end_level_data().transient.linger_mode || get_teams().empty() || video::headless()) {
 		const bool has_next_scenario
 			= !gamestate().gamedata_.next_scenario().empty() && gamestate().gamedata_.next_scenario() != "null";
 		if(!is_host() && has_next_scenario) {

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -35,6 +35,7 @@
 #include "savegame.hpp"
 #include "serialization/string_utils.hpp"
 #include "synced_context.hpp"
+#include "video.hpp" // only for faked
 #include "wesnothd_connection.hpp"
 #include "whiteboard/manager.hpp"
 
@@ -434,7 +435,7 @@ void playmp_controller::maybe_linger()
 {
 	// mouse_handler expects at least one team for linger mode to work.
 	assert(is_regular_game_end());
-	if(!get_end_level_data().transient.linger_mode || get_teams().empty() || gui_->video().faked()) {
+	if(!get_end_level_data().transient.linger_mode || get_teams().empty() || video::faked()) {
 		const bool has_next_scenario
 			= !gamestate().gamedata_.next_scenario().empty() && gamestate().gamedata_.next_scenario() != "null";
 		if(!is_host() && has_next_scenario) {

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -92,8 +92,8 @@ void playmp_controller::remove_blindfold()
 {
 	if(gui_->is_blindfolded()) {
 		blindfold_.unblind();
-		LOG_NG << "Taking off the blindfold now ";
-		gui_->redraw_everything();
+		LOG_NG << "Taking off the blindfold now";
+		gui_->queue_rerender();
 	}
 }
 
@@ -218,14 +218,14 @@ void playmp_controller::set_end_scenario_button()
 	}
 
 	gui_->get_theme().refresh_title2("button-endturn", "title2");
-	gui_->redraw_everything(); // TODO: draw_manager - verify this is right
+	gui_->queue_rerender();
 }
 
 void playmp_controller::reset_end_scenario_button()
 {
 	// revert the end-turn button text to its normal label
 	gui_->get_theme().refresh_title2("button-endturn", "title");
-	gui_->redraw_everything();// TODO: draw_manager - verify this is right
+	gui_->queue_rerender();
 	gui_->set_game_mode(game_display::RUNNING);
 }
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -137,7 +137,6 @@ void playsingle_controller::init_gui()
 		gui_->set_fade({0,0,0,0});
 	}
 
-	update_locker lock_display(gui_->video(), is_skipping_replay());
 	get_hotkey_command_executor()->set_button_state();
 }
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -287,9 +287,9 @@ level_result::type playsingle_controller::play_scenario(const config& level)
 		}
 		const bool is_victory = get_end_level_data().is_victory;
 
-		if(gamestate().gamedata_.phase() <= game_data::PRESTART) {
-			video::clear_screen();
-		}
+		//if(gamestate().gamedata_.phase() <= game_data::PRESTART) {
+		//	video::clear_screen();
+		//}
 
 		ai_testing::log_game_end();
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -132,6 +132,7 @@ void playsingle_controller::init_gui()
 
 	// Fade in
 	gui_->set_prevent_draw(false);
+	gui_->queue_repaint();
 	if(!video::any_fake()) {
 		gui_->fade_to({0,0,0,0}, 500);
 	} else {
@@ -474,8 +475,7 @@ void playsingle_controller::show_turn_dialog()
 {
 	if(preferences::turn_dialog() && !is_regular_game_end()) {
 		blindfold b(*gui_, true); // apply a blindfold for the duration of this dialog
-		gui_->redraw_everything();
-		gui_->recalculate_minimap();
+		gui_->queue_rerender();
 		std::string message = _("It is now $name|’s turn");
 		utils::string_map symbols;
 		symbols["name"] = gamestate().board_.get_team(current_side()).side_name();
@@ -526,7 +526,7 @@ void playsingle_controller::linger()
 
 	// change the end-turn button text to its alternate label
 	gui_->get_theme().refresh_title2("button-endturn", "title2");
-	gui_->redraw_everything();
+	gui_->queue_rerender();
 
 	try {
 		// Same logic as single-player human turn, but
@@ -544,7 +544,7 @@ void playsingle_controller::linger()
 
 	// revert the end-turn button text to its normal label
 	gui_->get_theme().refresh_title2("button-endturn", "title");
-	gui_->redraw_everything();
+	gui_->queue_rerender();
 	gui_->set_game_mode(game_display::RUNNING);
 
 	LOG_NG << "ending end-of-scenario linger";

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -133,7 +133,7 @@ void playsingle_controller::init_gui()
 	// Fade in
 	gui_->set_prevent_draw(false);
 	gui_->queue_repaint();
-	if(!video::any_fake()) {
+	if(!video::headless() && !video::testing()) {
 		gui_->fade_to({0,0,0,0}, 500);
 	} else {
 		gui_->set_fade({0,0,0,0});

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -49,6 +49,7 @@
 #include "statistics.hpp"
 #include "synced_context.hpp"
 #include "units/unit.hpp"
+#include "video.hpp"
 #include "wesnothd_connection_error.hpp"
 #include "whiteboard/manager.hpp"
 
@@ -131,7 +132,7 @@ void playsingle_controller::init_gui()
 
 	// Fade in
 	gui_->set_prevent_draw(false);
-	if(!gui_->video().any_fake()) {
+	if(!video::any_fake()) {
 		gui_->fade_to({0,0,0,0}, 500);
 	} else {
 		gui_->set_fade({0,0,0,0});
@@ -287,7 +288,7 @@ level_result::type playsingle_controller::play_scenario(const config& level)
 		const bool is_victory = get_end_level_data().is_victory;
 
 		if(gamestate().gamedata_.phase() <= game_data::PRESTART) {
-			gui_->video().clear_screen();
+			video::clear_screen();
 		}
 
 		ai_testing::log_game_end();

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -199,10 +199,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			display::get_singleton()->set_team(side_index);
 
 			if(side_changed) {
-				display::get_singleton()->redraw_everything();
-				display::get_singleton()->recalculate_minimap();
-				// TODO: decide what should replace this
-				//video2::trigger_full_redraw();
+				display::get_singleton()->queue_rerender();
 			}
 		};
 

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -801,8 +801,7 @@ void set_autosavemax(int value)
 
 std::string theme()
 {
-	// TODO: draw_manager - is this correct?
-	if(video::non_interactive()) {
+	if(video::headless()) {
 		static const std::string null_theme = "null";
 		return null_theme;
 	}

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -27,6 +27,7 @@
 #include "serialization/unicode_cast.hpp"
 #include "units/map.hpp"
 #include "units/unit.hpp"
+#include "video.hpp"
 #include "wml_exception.hpp"
 
 #include <cassert>
@@ -800,7 +801,8 @@ void set_autosavemax(int value)
 
 std::string theme()
 {
-	if(CVideo::get_singleton().non_interactive()) {
+	// TODO: draw_manager - is this correct?
+	if(video::non_interactive()) {
 		static const std::string null_theme = "null";
 		return null_theme;
 	}

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -32,7 +32,7 @@
 #include "sdl/point.hpp"
 #include "serialization/parser.hpp"
 #include "sound.hpp"
-#include "video.hpp" // non_interactive()
+#include "video.hpp"
 #include "game_config_view.hpp"
 
 #include <sys/stat.h> // for setting the permissions of the preferences file
@@ -468,7 +468,7 @@ void set_vsync(bool ison)
 
 bool turbo()
 {
-	if(video::non_interactive()) {
+	if(video::headless()) {
 		return true;
 	}
 

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -122,7 +122,6 @@ void prefs_event_handler::handle_window_event(const SDL_Event& event)
 
 	switch(event.window.event) {
 	case SDL_WINDOWEVENT_RESIZED:
-		// TODO: draw_manager - is this actually okay?
 		_set_resolution(video::window_size());
 
 		break;

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -112,7 +112,7 @@ base_manager::~base_manager()
 /*
  * Hook for setting window state variables on window resize and maximize
  * events. Since there is no fullscreen window event, that setter is called
- * from the CVideo function instead.
+ * from the video function instead.
  */
 void prefs_event_handler::handle_window_event(const SDL_Event& event)
 {
@@ -122,7 +122,8 @@ void prefs_event_handler::handle_window_event(const SDL_Event& event)
 
 	switch(event.window.event) {
 	case SDL_WINDOWEVENT_RESIZED:
-		_set_resolution(CVideo::get_singleton().window_size());
+		// TODO: draw_manager - is this actually okay?
+		_set_resolution(video::window_size());
 
 		break;
 
@@ -467,7 +468,7 @@ void set_vsync(bool ison)
 
 bool turbo()
 {
-	if(CVideo::get_singleton().non_interactive()) {
+	if(video::non_interactive()) {
 		return true;
 	}
 

--- a/src/quit_confirmation.cpp
+++ b/src/quit_confirmation.cpp
@@ -15,7 +15,7 @@
 #include "quit_confirmation.hpp"
 #include "game_end_exceptions.hpp"
 #include "gettext.hpp"
-#include "video.hpp"
+#include "video.hpp" // only for video::quit
 #include "resources.hpp"
 #include "playmp_controller.hpp"
 #include "gui/dialogs/surrender_quit.hpp"
@@ -47,7 +47,7 @@ void quit_confirmation::quit_to_title()
 
 void quit_confirmation::quit_to_desktop()
 {
-	if(quit()) { throw CVideo::quit(); }
+	if(quit()) { throw video::quit(); }
 }
 
 bool quit_confirmation::show_prompt(const std::string& message)

--- a/src/quit_confirmation.hpp
+++ b/src/quit_confirmation.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-class CVideo;
-
 #include <cassert>
 #include <vector>
 #include <string>
@@ -39,7 +37,7 @@ public:
 	/**
 	 * Shows the quit confirmation if needed.
 	 *
-	 * @throws CVideo::quit If the user chooses to quit or no prompt was
+	 * @throws video::quit If the user chooses to quit or no prompt was
 	 *                      displayed.
 	 */
 	static bool quit();

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -692,7 +692,6 @@ REPLAY_RETURN do_replay(bool one_move)
 		display::get_singleton()->recalculate_minimap();
 	}
 
-	update_locker lock_update(CVideo::get_singleton(), resources::controller->is_skipping_replay());
 	return do_replay_handle(one_move);
 }
 /**

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -76,8 +76,7 @@ replay_controller::replay_controller(play_controller& controller, bool control_v
 		vision_ = HUMAN_TEAM;
 	}
 	controller_.get_display().get_theme().theme_reset_event().attach_handler(this);
-	controller_.get_display().create_buttons();
-	controller_.get_display().redraw_everything();
+	controller_.get_display().queue_rerender();
 }
 replay_controller::~replay_controller()
 {
@@ -85,9 +84,7 @@ replay_controller::~replay_controller()
 		controller_.toggle_skipping_replay();
 	}
 	controller_.get_display().get_theme().theme_reset_event().detach_handler(this);
-	controller_.get_display().create_buttons();
-	controller_.get_display().redraw_everything();
-	controller_.get_display().create_buttons();
+	controller_.get_display().queue_rerender();
 }
 void replay_controller::add_replay_theme()
 {
@@ -133,16 +130,12 @@ void replay_controller::play_replay()
 
 void replay_controller::update_gui()
 {
-	controller_.get_display().recalculate_minimap();
-	controller_.get_display().redraw_minimap();
-	controller_.get_display().invalidate_all();
-	controller_.get_display().redraw_everything();
+	controller_.get_display().queue_rerender();
 }
 
 void replay_controller::update_enabled_buttons()
 {
-	// TODO: draw_manager - is this the right call?
-	controller_.get_display().redraw_everything();
+	controller_.get_display().queue_rerender();
 }
 
 void replay_controller::handle_generic_event(const std::string& name)

--- a/src/replay_controller.hpp
+++ b/src/replay_controller.hpp
@@ -20,8 +20,6 @@
 
 #include <vector>
 
-class video;
-
 class replay_controller : public events::observer
 {
 public:

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -45,7 +45,7 @@
 #include "serialization/parser.hpp"
 #include "serialization/utf8_exception.hpp"
 #include "statistics.hpp"
-#include "video.hpp"
+#include "video.hpp" // only for faked
 
 #include <algorithm>
 #include <iomanip>
@@ -121,7 +121,7 @@ bool loadgame::show_difficulty_dialog()
 // throws a "load_game_exception" to signal a resulting load game request.
 bool loadgame::load_game_ingame()
 {
-	if(CVideo::get_singleton().faked()) {
+	if(video::faked()) {
 		return false;
 	}
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -121,7 +121,7 @@ bool loadgame::show_difficulty_dialog()
 // throws a "load_game_exception" to signal a resulting load game request.
 bool loadgame::load_game_ingame()
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return false;
 	}
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -108,6 +108,7 @@
 #include "utils/scope_exit.hpp"
 #include "variable.hpp"                 // for vconfig, etc
 #include "variable_info.hpp"
+#include "video.hpp"                    // for faked and delay, consider refactor
 #include "whiteboard/manager.hpp"       // for whiteboard
 #include "wml_exception.hpp"
 #include "deprecation.hpp"
@@ -126,8 +127,6 @@
 #include <vector>                       // for vector, etc
 #include <SDL2/SDL_timer.h>                  // for SDL_GetTicks
 #include "lua/lauxlib.h"                // for luaL_checkinteger, lua_setfield, etc
-
-class CVideo;
 
 #ifdef DEBUG_LUA
 #include "scripting/debug_lua.hpp"
@@ -372,8 +371,7 @@ static int impl_add_animation(lua_State* L)
 
 int game_lua_kernel::impl_run_animation(lua_State* L)
 {
-	CVideo& v = CVideo::get_singleton();
-	if(v.faked()) {
+	if(video::faked()) {
 		return 0;
 	}
 	events::command_disabler command_disabler;
@@ -3918,7 +3916,7 @@ int game_lua_kernel::intf_delay(lua_State *L)
 	const unsigned final = SDL_GetTicks() + delay;
 	do {
 		play_controller_.play_slice(false);
-		CVideo::delay(10);
+		video::delay(10);
 	} while (static_cast<int>(final - SDL_GetTicks()) > 0);
 	return 0;
 }

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -108,7 +108,7 @@
 #include "utils/scope_exit.hpp"
 #include "variable.hpp"                 // for vconfig, etc
 #include "variable_info.hpp"
-#include "video.hpp"                    // for faked and delay, consider refactor
+#include "video.hpp"                    // only for faked
 #include "whiteboard/manager.hpp"       // for whiteboard
 #include "wml_exception.hpp"
 #include "deprecation.hpp"
@@ -3916,7 +3916,7 @@ int game_lua_kernel::intf_delay(lua_State *L)
 	const unsigned final = SDL_GetTicks() + delay;
 	do {
 		play_controller_.play_slice(false);
-		video::delay(10);
+		SDL_Delay(10);
 	} while (static_cast<int>(final - SDL_GetTicks()) > 0);
 	return 0;
 }

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -373,7 +373,7 @@ static int impl_add_animation(lua_State* L)
 int game_lua_kernel::impl_run_animation(lua_State* L)
 {
 	CVideo& v = CVideo::get_singleton();
-	if(v.update_locked() || v.faked()) {
+	if(v.faked()) {
 		return 0;
 	}
 	events::command_disabler command_disabler;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3863,7 +3863,6 @@ int game_lua_kernel::intf_color_adjust(lua_State *L)
 	if (game_display_) {
 		game_display_->adjust_color_overlay(luaL_checkinteger(L, 1), luaL_checkinteger(L, 2), luaL_checkinteger(L, 3));
 		game_display_->invalidate_all();
-		game_display_->draw(true,true);
 	}
 	return 0;
 }
@@ -4019,8 +4018,6 @@ int game_lua_kernel::intf_redraw(lua_State *L)
 		if (!result) {
 			screen.invalidate_all();
 		}
-
-		screen.draw(true,true);
 	}
 	return 0;
 }
@@ -4341,7 +4338,6 @@ int game_lua_kernel::intf_scroll(lua_State * L)
 
 	if (game_display_) {
 		game_display_->scroll(x, y, true);
-		game_display_->draw(true, true);
 	}
 
 	return 0;
@@ -4469,7 +4465,6 @@ int game_lua_kernel::intf_teleport(lua_State *L)
 	}
 
 	game_display_->invalidate_unit_after_move(src_loc, vacant_dst);
-	game_display_->draw();
 
 	// Sighted events.
 	clearer.fire_events();

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -371,7 +371,7 @@ static int impl_add_animation(lua_State* L)
 
 int game_lua_kernel::impl_run_animation(lua_State* L)
 {
-	if(video::faked()) {
+	if(video::headless()) {
 		return 0;
 	}
 	events::command_disabler command_disabler;

--- a/src/sdl/input.cpp
+++ b/src/sdl/input.cpp
@@ -28,6 +28,10 @@ uint32_t get_mouse_state(int *x, int *y)
 {
 	uint32_t buttons = SDL_GetMouseState(x, y);
 
+	if (video::headless()) {
+		return buttons;
+	}
+
 	// The game canvas may be offset inside the window,
 	// as well as potentially having a different size.
 	rect input_area = video::input_area();

--- a/src/sdl/input.hpp
+++ b/src/sdl/input.hpp
@@ -22,7 +22,7 @@
  * Contains functions for cleanly handling SDL input.
  */
 
-struct SDL_Point;
+struct point;
 
 namespace sdl
 {
@@ -36,7 +36,7 @@ uint32_t get_mouse_state(int *x, int *y);
 uint32_t get_mouse_button_mask();
 
 /** Returns the current mouse location in draw space. */
-SDL_Point get_mouse_location();
+point get_mouse_location();
 
 /**
  * Returns a bitmask of active modifier keys (ctrl, shift, alt, gui).
@@ -51,25 +51,5 @@ SDL_Point get_mouse_location();
  * @returns  A bitmask of SDL_Keymod values representing the active state.
  */
 unsigned get_mods();
-
-/**
- * Update the cached drawing area and input area sizes. These correspond to
- * the size of the drawing surface in pixels, and the size of the window in
- * display coordinates.
- *
- * This should be called every time the window is resized, or the pixel scale
- * multiplier changes.
- *
- * @param draw_width         The width of the drawing surface, in pixels
- * @param draw_height        The height of the drawing surface, in pixels
- * @param input_width        The width of the input surface, in display coordinates
- * @param input_height       The height of the input surface, in display coordinates
- */
-void update_input_dimensions(
-	int draw_width, int draw_height,
-	int input_width, int input_height
-);
-void update_input_dimensions(SDL_Point draw_size, SDL_Point input_size);
-
 
 } // namespace sdl

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -21,8 +21,6 @@
 
 #include <ostream>
 
-class CVideo;
-
 class surface
 {
 public:

--- a/src/sdl/texture.cpp
+++ b/src/sdl/texture.cpp
@@ -65,7 +65,7 @@ texture::texture(const surface& surf, bool linear_interpolation)
 		return;
 	}
 
-	SDL_Renderer* renderer = CVideo::get_singleton().get_renderer();
+	SDL_Renderer* renderer = video::get_renderer();
 	if(!renderer) {
 		return;
 	}
@@ -204,7 +204,7 @@ void texture::reset(int width, int height, SDL_TextureAccess access)
 	// No-op if texture is null.
 	reset();
 
-	SDL_Renderer* renderer = CVideo::get_singleton().get_renderer();
+	SDL_Renderer* renderer = video::get_renderer();
 	if(!renderer) {
 		return;
 	}

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -76,9 +76,6 @@ window::window(const std::string& title,
 
 	fill(0,0,0);
 
-	// Now that we have a window and renderer we can scale input correctly.
-	update_input_dimensions(get_logical_size(), get_size());
-
 	render();
 
 	// If we didn't explicitly ask for the window to be hidden, show it
@@ -97,7 +94,6 @@ window::~window()
 void window::set_size(const int w, const int h)
 {
 	SDL_SetWindowSize(window_, w, h);
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 SDL_Point window::get_size()
@@ -124,25 +120,21 @@ void window::center()
 void window::maximize()
 {
 	SDL_MaximizeWindow(window_);
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 void window::to_window()
 {
 	SDL_SetWindowFullscreen(window_, 0);
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 void window::restore()
 {
 	SDL_RestoreWindow(window_);
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 void window::full_screen()
 {
 	SDL_SetWindowFullscreen(window_, SDL_WINDOW_FULLSCREEN_DESKTOP);
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 void window::fill(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
@@ -177,8 +169,6 @@ uint32_t window::get_flags()
 void window::set_minimum_size(int min_w, int min_h)
 {
 	SDL_SetWindowMinimumSize(window_, min_w, min_h);
-	// Can this change the size of the window?
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 int window::get_display_index()
@@ -190,7 +180,6 @@ void window::set_logical_size(int w, int h)
 {
 	SDL_Renderer* r = SDL_GetRenderer(window_);
 	SDL_RenderSetLogicalSize(r, w, h);
-	update_input_dimensions(get_logical_size(), get_size());
 }
 
 void window::set_logical_size(const point& p)

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -31,7 +31,7 @@
 #include "sdl/rect.hpp"
 #include "sdl/input.hpp" // get_mouse_state
 #include "sdl/utils.hpp" // blur_surface
-#include "video.hpp" // TODO: draw_manager - only for draw_area
+#include "video.hpp"
 
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
@@ -186,7 +186,7 @@ dialog_frame::dimension_measurements dialog_frame::layout(int x, int y, int w, i
 	h += dim_.title.h + dim_.button_row.h;
 	dim_.button_row.x += x + w;
 
-	rect bounds = video::draw_area();
+	rect bounds = video::game_canvas();
 	if(have_border_) {
 		bounds.x += left_.w();
 		bounds.y += top_.h();
@@ -316,7 +316,7 @@ void dialog_frame::draw_background()
 
 rect dialog_frame::draw_title(bool actually_draw)
 {
-	rect r = video::draw_area();
+	rect r = video::game_canvas();
 	return font::pango_draw_text(
 		actually_draw, r, font::SIZE_TITLE, font::TITLE_COLOR, title_,
 		dim_.title.x, dim_.title.y, false, font::pango_text::STYLE_NORMAL

--- a/src/show_dialog.cpp
+++ b/src/show_dialog.cpp
@@ -31,7 +31,7 @@
 #include "sdl/rect.hpp"
 #include "sdl/input.hpp" // get_mouse_state
 #include "sdl/utils.hpp" // blur_surface
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only for draw_area
 
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
@@ -86,7 +86,6 @@ dialog_frame::dialog_frame(const std::string& title,
 		const style& style,
 		std::vector<button*>* buttons, button* help_button) :
 	title_(title),
-	video_(CVideo::get_singleton()),
 	dialog_style_(style),
 	buttons_(buttons),
 	help_button_(help_button),
@@ -160,7 +159,7 @@ int dialog_frame::bottom_padding() const {
 dialog_frame::dimension_measurements dialog_frame::layout(int x, int y, int w, int h) {
 	dim_ = dimension_measurements();
 	if(!title_.empty()) {
-		dim_.title = draw_title(nullptr);
+		dim_.title = draw_title(false);
 		dim_.title.w += title_border_w;
 	}
 	if(buttons_ != nullptr) {
@@ -187,7 +186,7 @@ dialog_frame::dimension_measurements dialog_frame::layout(int x, int y, int w, i
 	h += dim_.title.h + dim_.button_row.h;
 	dim_.button_row.x += x + w;
 
-	SDL_Rect bounds = video_.draw_area();
+	rect bounds = video::draw_area();
 	if(have_border_) {
 		bounds.x += left_.w();
 		bounds.y += top_.h();
@@ -315,11 +314,13 @@ void dialog_frame::draw_background()
 	}
 }
 
-SDL_Rect dialog_frame::draw_title(CVideo* video)
+rect dialog_frame::draw_title(bool actually_draw)
 {
-	SDL_Rect rect = video_.draw_area();
-	return font::pango_draw_text(video, rect, font::SIZE_TITLE, font::TITLE_COLOR,
-	                       title_, dim_.title.x, dim_.title.y, false, font::pango_text::STYLE_NORMAL);
+	rect r = video::draw_area();
+	return font::pango_draw_text(
+		actually_draw, r, font::SIZE_TITLE, font::TITLE_COLOR, title_,
+		dim_.title.x, dim_.title.y, false, font::pango_text::STYLE_NORMAL
+	);
 }
 
 void dialog_frame::draw()
@@ -332,7 +333,7 @@ void dialog_frame::draw()
 
 	//draw title
 	if (!title_.empty()) {
-		draw_title(&video_);
+		draw_title(true);
 	}
 }
 

--- a/src/show_dialog.hpp
+++ b/src/show_dialog.hpp
@@ -23,8 +23,6 @@ class surface;
 #include "tooltips.hpp"
 #include "widgets/button.hpp"
 
-class CVideo;
-
 namespace gui
 {
 
@@ -98,7 +96,7 @@ public:
 	void draw_background();
 
 	//also called by layout with null param
-	SDL_Rect draw_title(CVideo *video);
+	rect draw_title(bool actually_draw);
 
 	void set_dirty(bool dirty = true);
 
@@ -106,7 +104,6 @@ private:
 	void clear_background();
 
 	std::string title_;
-	CVideo &video_;
 	const style& dialog_style_;
 	std::vector<button*>* buttons_;
 	button* help_button_;

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -650,7 +650,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_turn_limit, child, use_undo, /*show*/, /*e
 	debug_cmd_notification("turn_limit");
 
 	resources::tod_manager->set_number_of_turns(child["turn_limit"].to_int(-1));
-	display::get_singleton()->redraw_everything();
+	display::get_singleton()->queue_rerender();
 	return true;
 }
 
@@ -665,7 +665,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_turn, child, use_undo, /*show*/, /*error_h
 	resources::tod_manager->set_turn(child["turn"].to_int(1), resources::gamedata);
 
 	game_display::get_singleton()->new_turn();
-	display::get_singleton()->redraw_everything();
+	display::get_singleton()->queue_rerender();
 
 	return true;
 }
@@ -697,7 +697,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_gold, child, use_undo, /*show*/, /*error_h
 	debug_cmd_notification("gold");
 
 	resources::controller->current_team().spend_gold(-child["gold"].to_int(0));
-	display::get_singleton()->redraw_everything();
+	display::get_singleton()->queue_rerender();
 	return true;
 }
 
@@ -711,7 +711,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_event, child, use_undo, /*show*/, /*error_
 	debug_cmd_notification("throw");
 
 	resources::controller->pump().fire(child["eventname"]);
-	display::get_singleton()->redraw_everything();
+	display::get_singleton()->queue_rerender();
 
 	return true;
 }
@@ -730,7 +730,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_fog, /*child*/, use_undo, /*show*/, /*erro
 	actions::recalculate_fog(current_team.side());
 
 	display::get_singleton()->recalculate_minimap();
-	display::get_singleton()->redraw_everything();
+	display::get_singleton()->queue_rerender();
 
 	return true;
 }
@@ -749,7 +749,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_shroud, /*child*/, use_undo, /*show*/, /*e
 	actions::clear_shroud(current_team.side());
 
 	display::get_singleton()->recalculate_minimap();
-	display::get_singleton()->redraw_everything();
+	display::get_singleton()->queue_rerender();
 
 	return true;
 }

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -118,7 +118,6 @@
 #include "tests/utils/fake_display.hpp"
 //#include "scripting/lua_kernel_base.hpp"
 #include <functional>
-#include "video.hpp"
 #include "wesnothd_connection.hpp"
 #include "wml_exception.hpp"
 
@@ -607,9 +606,9 @@ Sed faucibus nibh sit amet ligula porta, non malesuada nibh tristique. Maecenas 
 template<>
 struct dialog_tester<addon_manager>
 {
-	CVideo& video = test_utils::get_fake_display(10, 10).video();
 	dialog_tester()
 	{
+		test_utils::get_fake_display(10, 10);
 	}
 	addon_manager* create()
 	{

--- a/src/tests/utils/fake_display.cpp
+++ b/src/tests/utils/fake_display.cpp
@@ -21,6 +21,7 @@
 #include "game_config_view.hpp"
 #include "game_display.hpp"
 #include "reports.hpp"
+#include "video.hpp"
 
 namespace wb
 {
@@ -33,7 +34,6 @@ class fake_display_manager
 {
 	static fake_display_manager* manager_;
 
-	CVideo video_;
 	config dummy_cfg_;
 	config dummy_cfg2_;
 	game_board dummy_board_;
@@ -62,13 +62,13 @@ fake_display_manager* fake_display_manager::get_manager()
 }
 
 fake_display_manager::fake_display_manager()
-	: video_(CVideo::FAKE_TEST)
-	, dummy_cfg_()
+	: dummy_cfg_()
 	, dummy_cfg2_()
 	, dummy_board_(dummy_cfg2_)
 	, main_event_context_()
 	, disp_(dummy_board_, std::shared_ptr<wb::manager>(), dummy_reports, "", dummy_cfg_)
 {
+	video::init(video::fake::draw);
 }
 
 game_display& fake_display_manager::get_display()
@@ -81,7 +81,7 @@ game_display& get_fake_display(const int width, const int height)
 	game_display& display = fake_display_manager::get_manager()->get_display();
 
 	if(width >= 0 && height >= 0) {
-		display.video().make_test_fake(width, height);
+		video::make_test_fake(width, height);
 	}
 
 	return display;

--- a/src/tests/utils/fake_display.cpp
+++ b/src/tests/utils/fake_display.cpp
@@ -81,7 +81,7 @@ game_display& get_fake_display(const int width, const int height)
 	game_display& display = fake_display_manager::get_manager()->get_display();
 
 	if(width >= 0 && height >= 0) {
-		video::make_test_fake(width, height);
+		video::set_resolution({width, height});
 	}
 
 	return display;

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -21,7 +21,7 @@
 #include "game_display.hpp"
 #include "help/help.hpp"
 #include "log.hpp"
-#include "video.hpp" // TODO: draw_manager - only for draw_area
+#include "video.hpp"
 
 #include <SDL2/SDL_rect.h>
 
@@ -47,12 +47,12 @@ tooltip::tooltip(const SDL_Rect& r, const std::string& msg, const std::string& a
 	: origin(r), message(msg), action(act), label(msg)
 {
 	const color_t bgcolor {0,0,0,192};
-	rect area = video::draw_area();
+	rect game_canvas = video::game_canvas();
 	unsigned int border = 10;
 
 	label.set_font_size(font_size);
 	label.set_color(font::NORMAL_COLOR);
-	label.set_clip_rect(area);
+	label.set_clip_rect(game_canvas);
 	label.set_width(text_width);
 	label.set_alignment(font::LEFT_ALIGN);
 	label.set_bg_color(bgcolor);
@@ -73,8 +73,8 @@ tooltip::tooltip(const SDL_Rect& r, const std::string& msg, const std::string& a
 	loc.x = origin.x;
 	if(loc.x < 0) {
 		loc.x = 0;
-	} else if(loc.x + loc.w > area.w) {
-		loc.x = area.w - loc.w;
+	} else if(loc.x + loc.w > game_canvas.w) {
+		loc.x = game_canvas.w - loc.w;
 	}
 
 	label.move(loc.x, loc.y);

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -21,7 +21,7 @@
 #include "game_display.hpp"
 #include "help/help.hpp"
 #include "log.hpp"
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only for draw_area
 
 #include <SDL2/SDL_rect.h>
 
@@ -47,7 +47,7 @@ tooltip::tooltip(const SDL_Rect& r, const std::string& msg, const std::string& a
 	: origin(r), message(msg), action(act), label(msg)
 {
 	const color_t bgcolor {0,0,0,192};
-	rect area = CVideo::get_singleton().draw_area();
+	rect area = video::draw_area();
 	unsigned int border = 10;
 
 	label.set_font_size(font_size);

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -25,7 +25,6 @@
 #include "units/animation_component.hpp"
 #include "units/filter.hpp"
 #include "variable.hpp"
-#include "video.hpp" // TODO: draw_manager - only for delay
 #include "random.hpp"
 
 #include <algorithm>

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -1440,14 +1440,17 @@ void unit_animator::wait_until(int animation_time) const
 	resources::controller->play_slice(false);
 
 	int end_tick = animated_units_[0].my_unit->anim_comp().get_animation()->time_to_tick(animation_time);
-	while(SDL_GetTicks() < static_cast<unsigned int>(end_tick) - std::min<int>(static_cast<unsigned int>(20 / speed), 20)) {
-		video::delay(std::max<int>(0, std::min<int>(10, static_cast<int>((animation_time - get_animation_time()) * speed))));
-
+	while(SDL_GetTicks() < unsigned(end_tick - std::min(int(20 / speed), 20))) {
+		if(!game_config::no_delay) {
+			SDL_Delay(std::clamp(int((animation_time - get_animation_time()) * speed), 0, 10));
+		}
 		resources::controller->play_slice(false);
 		end_tick = animated_units_[0].my_unit->anim_comp().get_animation()->time_to_tick(animation_time);
 	}
 
-	video::delay(std::max<int>(0, end_tick - SDL_GetTicks() + 5));
+	if(!game_config::no_delay) {
+		SDL_Delay(std::max<int>(0, end_tick - SDL_GetTicks() + 5));
+	}
 
 	new_animation_frame();
 	animated_units_[0].my_unit->anim_comp().get_animation()->set_max_animation_time(0);
@@ -1461,7 +1464,7 @@ void unit_animator::wait_for_end() const
 	while(!finished) {
 		resources::controller->play_slice(false);
 
-		video::delay(10);
+		SDL_Delay(10);
 
 		finished = true;
 		for(const auto& anim : animated_units_) {

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -25,6 +25,7 @@
 #include "units/animation_component.hpp"
 #include "units/filter.hpp"
 #include "variable.hpp"
+#include "video.hpp" // TODO: draw_manager - only for delay
 #include "random.hpp"
 
 #include <algorithm>
@@ -1440,13 +1441,13 @@ void unit_animator::wait_until(int animation_time) const
 
 	int end_tick = animated_units_[0].my_unit->anim_comp().get_animation()->time_to_tick(animation_time);
 	while(SDL_GetTicks() < static_cast<unsigned int>(end_tick) - std::min<int>(static_cast<unsigned int>(20 / speed), 20)) {
-		CVideo::delay(std::max<int>(0, std::min<int>(10, static_cast<int>((animation_time - get_animation_time()) * speed))));
+		video::delay(std::max<int>(0, std::min<int>(10, static_cast<int>((animation_time - get_animation_time()) * speed))));
 
 		resources::controller->play_slice(false);
 		end_tick = animated_units_[0].my_unit->anim_comp().get_animation()->time_to_tick(animation_time);
 	}
 
-	CVideo::delay(std::max<int>(0, end_tick - SDL_GetTicks() + 5));
+	video::delay(std::max<int>(0, end_tick - SDL_GetTicks() + 5));
 
 	new_animation_frame();
 	animated_units_[0].my_unit->anim_comp().get_animation()->set_max_animation_time(0);
@@ -1460,7 +1461,7 @@ void unit_animator::wait_for_end() const
 	while(!finished) {
 		resources::controller->play_slice(false);
 
-		CVideo::delay(10);
+		video::delay(10);
 
 		finished = true;
 		for(const auto& anim : animated_units_) {

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -415,16 +415,17 @@ void unit_drawer::draw_bar(int xpos, int ypos, const map_location& loc,
 	filled = std::clamp(filled, 0.0, 1.0);
 	height = std::clamp(height, 0, bar_loc.h);
 
-	// TODO: highdpi - src clip region in texture?
-	// this only works because raw and draw sizes are the same here...
 	rect top{0, 0, tex.w(), bar_loc.y};
 	rect bot(0, bar_loc.y + bar_loc.h - height, tex.w(), 0);
 	bot.h = tex.h() - bot.y;
 
 	rect dest = scaled_to_zoom({xpos, ypos, top.w, top.h});
-	disp.drawing_buffer_add(display::LAYER_UNIT_BAR, loc, dest, tex, top);
+	tex.set_src(top);
+	disp.drawing_buffer_add(display::LAYER_UNIT_BAR, loc, dest, tex);
 	dest = scaled_to_zoom({xpos, ypos + int(top.h * zoom_factor), bot.w, bot.h});
-	disp.drawing_buffer_add(display::LAYER_UNIT_BAR, loc, dest, tex, bot);
+	tex.set_src(bot);
+	disp.drawing_buffer_add(display::LAYER_UNIT_BAR, loc, dest, tex);
+	tex.clear_src();
 
 	int unfilled = height * (1.0 - filled);
 

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -841,8 +841,6 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 				animator.add_animation(leader.get_shared_ptr(), "recruiting", leader_loc, loc, 0, true);
 			}
 		}
-
-		disp->draw();
 	}
 	animator.add_animation(u.get_shared_ptr(), "recruited", loc, leader_loc);
 	animator.start_animations();

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -169,7 +169,7 @@ int move_unit_between(const map_location& a,
 bool do_not_show_anims(display* disp)
 {
 
-	return !disp || video::faked();
+	return !disp || video::headless();
 }
 
 } // end anon namespace
@@ -179,7 +179,7 @@ bool do_not_show_anims(display* disp)
  */
 unit_mover::unit_mover(const std::vector<map_location>& path, bool animate, bool force_scroll) :
 	disp_(game_display::get_singleton()),
-	can_draw_(disp_ && !video::faked() && path.size() > 1),
+	can_draw_(disp_ && !video::headless() && path.size() > 1),
 	animate_(animate),
 	force_scroll_(force_scroll),
 	animator_(),

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -167,7 +167,7 @@ int move_unit_between(const map_location& a,
 bool do_not_show_anims(display* disp)
 {
 
-	return !disp || disp->video().update_locked() || disp->video().faked();
+	return !disp || disp->video().faked();
 }
 
 } // end anon namespace
@@ -177,8 +177,7 @@ bool do_not_show_anims(display* disp)
  */
 unit_mover::unit_mover(const std::vector<map_location>& path, bool animate, bool force_scroll) :
 	disp_(game_display::get_singleton()),
-	can_draw_(disp_  &&  !disp_->video().update_locked()  &&
-	          !disp_->video().faked()  &&  path.size() > 1),
+	can_draw_(disp_ && !disp_->video().faked() && path.size() > 1),
 	animate_(animate),
 	force_scroll_(force_scroll),
 	animator_(),

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -31,6 +31,7 @@
 #include "units/filter.hpp"
 #include "units/map.hpp"
 #include "utils/scope_exit.hpp"
+#include "video.hpp"
 
 #define LOG_DP LOG_STREAM(info, display)
 
@@ -167,7 +168,7 @@ int move_unit_between(const map_location& a,
 bool do_not_show_anims(display* disp)
 {
 
-	return !disp || disp->video().faked();
+	return !disp || video::faked();
 }
 
 } // end anon namespace
@@ -177,7 +178,7 @@ bool do_not_show_anims(display* disp)
  */
 unit_mover::unit_mover(const std::vector<map_location>& path, bool animate, bool force_scroll) :
 	disp_(game_display::get_singleton()),
-	can_draw_(disp_ && !disp_->video().faked() && path.size() > 1),
+	can_draw_(disp_ && !video::faked() && path.size() > 1),
 	animate_(animate),
 	force_scroll_(force_scroll),
 	animator_(),

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -110,6 +110,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 	}
 
 	temp_unit.anim_comp().set_standing();
+	// TODO: draw_manager - ugh, don't. WTF do you even think you're doing here
 	disp.update_display();
 	events::pump();
 }

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -97,10 +97,6 @@ void init(fake type)
 	}
 }
 
-// TODO: draw_manager - the CVideo class was previously calling SDL_Quit() in its destructor. Fix so that it calls correctly.
-// It would have (usually?) been called in game_launcher destructor,
-// as that's what (usually?) owns the instance.
-
 bool faked()
 {
 	return fake_screen_;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -69,14 +69,17 @@ rect input_area_ = {};
 namespace video
 {
 
-// Forward declarations
-void init_window();
-void init_test_window();
-void init_fake();
-void init_test();
-bool update_framebuffer();
-bool update_test_framebuffer();
-point draw_offset();
+// Non-public interface
+void render_screen(); // exposed and used only in draw_manager.cpp
+
+// Internal functions
+static void init_window();
+static void init_test_window();
+static void init_fake();
+static void init_test();
+static bool update_framebuffer();
+static bool update_test_framebuffer();
+static point draw_offset();
 
 
 void init(fake type)
@@ -414,14 +417,6 @@ rect output_area()
 	return {0, 0, p.x, p.y};
 }
 
-point to_output(const point& p)
-{
-	// Multiply p by the integer scale, then add the draw offset if any.
-	point dsize = current_render_target_.draw_size();
-	point osize = current_render_target_.get_raw_size();
-	return (p * (osize / dsize)) + draw_offset();
-}
-
 rect to_output(const rect& r)
 {
 	// Multiply r by integer scale, adding draw_offset to the position.
@@ -602,6 +597,11 @@ SDL_Renderer* get_renderer()
 	} else {
 		return nullptr;
 	}
+}
+
+SDL_Window* get_window()
+{
+	return *window;
 }
 
 std::string current_driver()

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -775,7 +775,7 @@ bool set_resolution(const point& resolution)
 
 void update_buffers(bool autoupdate)
 {
-	LOG_DP << "updating buffers";
+	LOG_DP << "updating video buffers";
 	if(update_framebuffer() && autoupdate) {
 		draw_manager::invalidate_all();
 	}

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -777,7 +777,7 @@ void update_buffers(bool autoupdate)
 {
 	LOG_DP << "updating buffers";
 	if(update_framebuffer() && autoupdate) {
-		draw_manager::invalidate_region(draw_area());
+		draw_manager::invalidate_all();
 	}
 }
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -73,6 +73,8 @@ namespace video
 {
 
 // Forward declarations
+void init_window();
+void init_fake_window();
 void make_fake();
 bool update_framebuffer();
 bool update_framebuffer_fake();
@@ -87,6 +89,7 @@ void init(fake type)
 
 	switch(type) {
 	case fake::none:
+		init_window();
 		break;
 	case fake::window:
 		make_fake();

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -345,24 +345,6 @@ private:
 	// if there is no display at all, but we 'fake' it for clients
 	bool fake_screen_;
 
-	/** Helper class to manage SDL events. */
-	class video_event_handler : public events::sdl_handler
-	{
-	public:
-		virtual void handle_event(const SDL_Event&)
-		{
-		}
-
-		virtual void handle_window_event(const SDL_Event& event);
-
-		video_event_handler()
-			: sdl_handler(false)
-		{
-		}
-	};
-
-	video_event_handler event_handler_;
-
 	int refresh_rate_;
 	int offset_x_, offset_y_;
 	point logical_size_;

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -149,7 +149,7 @@ void set_window_icon(surface& icon);
 // TODO: revisit these for correctness and usefulness
 /**
  * Returns the size of the final render target. This is irrelevant
- * for most purposes. Use draw_area() in stead.
+ * for most purposes. Use game_canvas_size() in stead.
  */
 point output_size();
 
@@ -167,15 +167,32 @@ point window_size();
 rect draw_area();
 
 /**
+ * The game canvas area, in drawing coordinates.
+ *
+ * This is the "screen area", as seen by game systems, and as used for
+ * specifying where to draw things on-screen. It may differ, in high-dpi
+ * contexts, from input area, window area, and output area.
+ *
+ * Usually this is the only area game components should use or care about.
+ *
+ * The units it uses can be considered "pixels". Final output will be
+ * rendered in higher resolution automatically if and when appropriate.
+ */
+rect game_canvas();
+
+/** The size of the game canvas, in drawing coordinates / game pixels. */
+point game_canvas_size();
+
+/**
  * Returns the size and location of the window's input area in pixels.
  * We use SDL_RendererSetLogicalSize to ensure this always matches
- * draw_area(), but for clarity there are two separate functions.
+ * game_canvas(), but for clarity there are two separate functions.
  */
 rect input_area();
 
 /**
  * Get the current active pixel scale multiplier.
- * This is equal to output_size() / draw_area().
+ * This is equal to output_size() / game_canvas_size().
  * Currently it is always integer, and the same in both dimensions.
  *
  * This may differ from preferences::pixel_scale() in some cases,

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -72,37 +72,30 @@ bool any_fake();
 bool non_interactive();
 
 
-/****************************/
-/* Window-related functions */
-/****************************/
-// TODO: other things probably should never be calling these. remove/refactor
+/***********************/
+/* Windowing functions */
+/***********************/
 
-/** Initializes a new SDL window instance, taking into account any preiously saved states. */
-void init_window();
-
-// private:
-void init_fake_window();
-
-// TODO: refactor? only draw.cpp and texture.cpp should need to access the renderer
-
-/** Returns a pointer to the underlying window's renderer. */
-SDL_Renderer* get_renderer();
-
-/** The current video driver in use, or else "<not initialized>". */
-std::string current_driver();
-
-/** A list of available video drivers. */
-std::vector<std::string> enumerate_drivers();
-
-
-/************/
-/* Resizing */
-/************/
-
-// TODO: check these are okay and don't do bad things
-void set_fullscreen(bool);
-void toggle_fullscreen();
+/** Whether we are currently in fullscreen mode */
 bool is_fullscreen();
+
+/**
+ * Set the fullscreen state.
+ *
+ * If the setting matches the current fullscreen state, the window state
+ * will not be changed.
+ *
+ * If false and the window is fullscreen, the window will be restored to
+ * its last saved non-fullscreen configuration.
+ */
+void set_fullscreen(bool);
+
+/**
+ * Toggle fullscreen mode.
+ *
+ * Equivalent to set_fullscreen(!is_fullscreen()).
+ */
+void toggle_fullscreen();
 
 /**
  * Set the window resolution.
@@ -113,10 +106,38 @@ bool is_fullscreen();
  */
 bool set_resolution(const point& resolution);
 
+/** The current window size in desktop coordinates. */
 point current_resolution();
 
 /** Returns the list of available screen resolutions. */
 std::vector<point> get_available_resolutions(bool include_current = false);
+
+/** The current video driver in use, or else "<not initialized>". */
+std::string current_driver();
+
+/** A list of available video drivers. */
+std::vector<std::string> enumerate_drivers();
+
+/**
+ * The refresh rate of the screen.
+ *
+ * If a refresh cannot be detected, this may return 0, or it may return a
+ * substitute value.
+ */
+int current_refresh_rate();
+
+/** True iff the window is not hidden. */
+bool window_is_visible();
+/** True iff the window has mouse or input focus */
+bool window_has_focus();
+/** True iff the window has mouse focus */
+bool window_has_mouse_focus();
+
+/** Sets the title of the main window. */
+void set_window_title(const std::string& title);
+
+/** Sets the icon of the main window. */
+void set_window_icon(surface& icon);
 
 
 /*******/
@@ -180,23 +201,6 @@ int get_pixel_scale();
  * Convert coordinates in draw space to coordinates in render space.
  */
 rect to_output(const rect& draw_space_rect);
-
-// TODO: move these:
-
-/** True iff the window is not hidden. */
-bool window_is_visible();
-/** True iff the window has mouse or input focus */
-bool window_has_focus();
-/** True iff the window has mouse focus */
-bool window_has_mouse_focus();
-
-/** Sets the title of the main window. */
-void set_window_title(const std::string& title);
-
-/** Sets the icon of the main window. */
-void set_window_icon(surface& icon);
-
-int current_refresh_rate();
 
 
 /******************/
@@ -283,5 +287,9 @@ public:
 private:
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(quit)
 };
+
+/* This should only be used by draw.cpp for drawing, and texture.cpp for
+ * texture creation. Try not to use it for anything else. */
+SDL_Renderer* get_renderer();
 
 } // namespace video

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -37,316 +37,328 @@ namespace sdl
 class window;
 }
 
-class CVideo
+namespace video
+{
+
+/******************/
+/* Initialization */
+/******************/
+
+// TODO: this whole faking system is a mess
+/**
+ * For describing the type of faked display, if any.
+ *
+ * fake::window never tries to create a window, or draw anything.
+ * fake::draw does create an offscreen window, but does not draw to it.
+ */
+enum class fake { none, window, draw };
+
+/**
+ * Initialize the video subsystem.
+ *
+ * This must be called before attempting to use any video functions.
+ */
+void init(fake fake_type = fake::none);
+
+// TODO: refactor? only used by build_info.cpp.
+inline bool setup_completed() { return true; } // previously checked singleton_ ptr
+
+// TODO: refactor? this probably shouldn't be public
+/**
+ * Updates and ensures the framebuffer surface is valid.
+ * This needs to be invoked immediately after a resize event or the game will crash.
+ */
+void update_framebuffer();
+// private:
+void update_framebuffer_fake();
+
+
+/********************************/
+/* Unit-test and No-GUI support */
+/********************************/
+
+// TODO: refactor, this should be internal
+void make_fake();
+
+// TODO: tests are calling this constantly, refactor the tests to not do that
+/**
+ * Creates a fake frame buffer for the unit tests.
+ *
+ * @param width               The width of the buffer.
+ * @param height              The height of the buffer.
+ */
+void make_test_fake(const unsigned width = 1024, const unsigned height = 768);
+
+// TODO: rename and refactor - these don't clearly express what they mean
+bool faked();
+bool any_fake();
+bool non_interactive();
+
+
+/****************************/
+/* Window-related functions */
+/****************************/
+// TODO: other things probably should never be calling these. remove/refactor
+
+/** Initializes a new SDL window instance, taking into account any preiously saved states. */
+void init_window();
+
+// private:
+void init_fake_window();
+
+// TODO: refactor? only draw.cpp and texture.cpp should need to access the renderer
+
+/** Returns a pointer to the underlying window's renderer. */
+SDL_Renderer* get_renderer();
+
+// TODO: refactor? only used by build_info.cpp
+inline bool has_window() { return !faked(); }; // previously checked window ptr
+
+/** The current video driver in use, or else "<not initialized>". */
+std::string current_driver();
+
+/** A list of available video drivers. */
+std::vector<std::string> enumerate_drivers();
+
+
+/************/
+/* Resizing */
+/************/
+
+// private:
+
+// TODO: refactor
+enum MODE_EVENT { TO_RES, TO_FULLSCREEN, TO_WINDOWED, TO_MAXIMIZED_WINDOW };
+
+/**
+ * Sets the window's mode - ie, changing it to fullscreen, maximizing, etc.
+ *
+ * @param mode                The action to perform.
+ * @param size                The new window size. Utilized if @a mode is TO_RES.
+ */
+void set_window_mode(const MODE_EVENT mode, const point& size);
+
+// public:
+
+// TODO: check these are okay and don't do bad things
+void set_fullscreen(bool ison);
+void toggle_fullscreen();
+bool is_fullscreen();
+
+/**
+ * Set the window resolution.
+ *
+ * @param resolution          The new width and height.
+ *
+ * @returns                   Whether the resolution was successfully changed.
+ */
+bool set_resolution(const point& resolution);
+
+point current_resolution();
+
+/** Returns the list of available screen resolutions. */
+std::vector<point> get_available_resolutions(bool include_current = false);
+
+
+/*******/
+/* IDK */
+/*******/
+
+// TODO: refactor? only used by preferences_dialog.cpp
+/**
+ * Update buffers to match current resolution and pixel scale settings.
+ * Also triggers a full redraw.
+ */
+void update_buffers();
+
+
+/***********/
+/* Queries */
+/***********/
+
+// TODO: revisit these for correctness and usefulness
+/**
+ * Returns the size of the final render target. This is irrelevant
+ * for most purposes. Use draw_area() in stead.
+ */
+point output_size();
+
+/**
+ * Returns the size of the window in display units / screen coordinates.
+ * This should match the value sent by window resize events, and also
+ * those used for setting resolution.
+ */
+point window_size();
+
+/**
+ * Returns the size and location of the current drawing area in pixels.
+ * This will usually be an SDL_Rect indicating the full drawing surface.
+ */
+rect draw_area();
+
+/**
+ * Returns the size and location of the window's input area in pixels.
+ * We use SDL_RendererSetLogicalSize to ensure this always matches
+ * draw_area(), but for clarity there are two separate functions.
+ */
+rect input_area();
+
+/**
+ * Get the current active pixel scale multiplier.
+ * This is equal to output_size() / draw_area().
+ * Currently it is always integer, and the same in both dimensions.
+ *
+ * This may differ from preferences::pixel_scale() in some cases,
+ * For example if the window is too small to fit the desired scale.
+ *
+ * @returns     The currently active pixel scale multiplier.
+ */
+int get_pixel_scale();
+
+// TODO: move
+/**
+ * Convert coordinates in draw space to coordinates in render space.
+ */
+rect to_output(const rect& draw_space_rect);
+
+// TODO: move these:
+
+// TODO: split use into individual functions to avoid use of SDL enums
+/**
+ * Tests whether the given flags are currently set on the SDL window.
+ *
+ * @param flags               The flags to test, OR'd together.
+ */
+bool window_has_flags(uint32_t flags);
+
+/**
+ * Sets the title of the main window.
+ *
+ * @param title               The new title for the window.
+ */
+void set_window_title(const std::string& title);
+
+/**
+ * Sets the icon of the main window.
+ *
+ * @param icon                The new icon for the window.
+ */
+void set_window_icon(surface& icon);
+
+int current_refresh_rate();
+
+
+/***********************/
+/* Rendering functions */
+/***********************/
+
+// TODO: hide this so it's not tempting to use
+/** Renders the screen. Should normally not be called directly! */
+void render_screen();
+
+// TODO: this should probably be in draw
+/** Clear the screen contents */
+void clear_screen();
+
+// TODO: different header? idk
+/**
+ * Copy back a portion of the render target that is already drawn.
+ *
+ * This area is specified in draw coordinates, not render coordinates.
+ * Thus the size of the retrieved surface may not match the size of r.
+ *
+ * If not null, r will be automatically clipped to the drawing area.
+ *
+ * Note: This is a very slow function! Its use should be phased out
+ * for everything except maybe screenshots.
+ *
+ * @param r       The portion of the render target to retrieve, in
+ *                draw coordinates.
+ *                If not null, this will be modified to reflect the
+ *                portion of the draw area that has been returned.
+ */
+surface read_pixels(SDL_Rect* r = nullptr);
+
+/**
+ * The same as read_pixels, but returns a low-resolution surface
+ * suitable for use with the old drawing system.
+ *
+ * This should be considered deprecated, and phased out ASAP.
+ */
+surface read_pixels_low_res(SDL_Rect* r = nullptr);
+
+/**
+ * Copy a portion of the render target to another texture.
+ *
+ * This area is specified in draw coordinates, not render coordinates.
+ * Thus the size of the retrieved texture may not match the size of r.
+ *
+ * If not null, r will be automatically clipped to the drawing area.
+ *
+ * Note: This is a very slow function! Its use should be phased out
+ * for everything except maybe screenshots.
+ *
+ * @param r       The portion of the render target to retrieve, in
+ *                draw coordinates.
+ *                If not null, this will be modified to reflect the
+ *                portion of the draw area that has been returned.
+ */
+texture read_texture(SDL_Rect* r = nullptr);
+
+
+/****************************/
+/* Render target management */
+/****************************/
+
+// TODO: revisit who owns this
+/**
+ * Set the render target, without any provided way of setting it back.
+ *
+ * End-users should not use this function directly. In stead use
+ * draw::set_render_target(), which returns a setter object which
+ * will automatically restore the render target upon leaving scope.
+ *
+ * @param t     The new render target. This must be a texture created
+ *              with SDL_TEXTUREACCESS_TARGET, or an empty texture to
+ *              indicate the underlying window.
+ */
+void force_render_target(const texture& t);
+
+/** Reset the render target to the main window / screen. */
+void clear_render_target();
+
+/** Get the current render target.
+ *
+ * Will return an empty texture if the render target is the underlying
+ * window.
+ */
+texture get_render_target();
+
+/********/
+/* Misc */
+/********/
+
+// TODO: this should not be here
+/** Waits a given number of milliseconds before returning. */
+void delay(unsigned int milliseconds);
+
+struct error : public game::error
+{
+	error() : game::error("unspecified video subsystem error") {}
+	error(const std::string& msg) : game::error(msg) {}
+};
+
+/** Type that can be thrown as an exception to quit to desktop. */
+class quit : public lua_jailbreak_exception
 {
 public:
-	CVideo(const CVideo&) = delete;
-	CVideo& operator=(const CVideo&) = delete;
-
-	enum FAKE_TYPES { NO_FAKE, FAKE, FAKE_TEST };
-
-	CVideo(FAKE_TYPES type = NO_FAKE);
-
-	~CVideo();
-
-	// TODO: refactor? only used by build_info.cpp
-	static bool setup_completed()
+	quit()
+		: lua_jailbreak_exception()
 	{
-		return singleton_ != nullptr;
 	}
-
-	// TODO: remove / replace
-	static CVideo& get_singleton()
-	{
-		return *singleton_;
-	}
-
-	/***** ***** ***** ***** Unit test-related functions ***** ***** ****** *****/
-
-	void make_fake();
-
-	/**
-	 * Creates a fake frame buffer for the unit tests.
-	 *
-	 * @param width               The width of the buffer.
-	 * @param height              The height of the buffer.
-	 */
-	void make_test_fake(const unsigned width = 1024, const unsigned height = 768);
-
-	bool faked() const
-	{
-		return fake_screen_;
-	}
-
-	bool any_fake() const;
-
-	bool non_interactive() const;
-
-	/***** ***** ***** ***** Window-related functions ***** ***** ****** *****/
-
-	/** Initializes a new SDL window instance, taking into account any preiously saved states. */
-	void init_window();
-private:
-	void init_fake_window();
-
-public:
-	/** Returns a pointer to the underlying window's renderer. */
-	SDL_Renderer* get_renderer();
-
-	// TODO: refactor? only used by build_info.cpp
-	bool has_window()
-	{
-		return window != nullptr;
-	}
-
-	static std::string current_driver();
-
-	static std::vector<std::string> enumerate_drivers();
 
 private:
-	enum MODE_EVENT { TO_RES, TO_FULLSCREEN, TO_WINDOWED, TO_MAXIMIZED_WINDOW };
-
-	/**
-	 * Sets the window's mode - ie, changing it to fullscreen, maximizing, etc.
-	 *
-	 * @param mode                The action to perform.
-	 * @param size                The new window size. Utilized if @a mode is TO_RES.
-	 */
-	void set_window_mode(const MODE_EVENT mode, const point& size);
-
-public:
-	void set_fullscreen(bool ison);
-
-	void toggle_fullscreen();
-
-	bool is_fullscreen() const;
-
-	/**
-	 * Set the window resolution.
-	 *
-	 * @param resolution          The new width and height.
-	 *
-	 * @returns                   Whether the resolution was successfully changed.
-	 */
-	bool set_resolution(const point& resolution);
-
-	point current_resolution();
-
-	// TODO: refactor? only used by preferences_dialog.cpp
-	/**
-	 * Update buffers to match current resolution and pixel scale settings.
-	 * Also triggers a full redraw.
-	 */
-	void update_buffers();
-
-	/** Returns the list of available screen resolutions. */
-	std::vector<point> get_available_resolutions(const bool include_current = false);
-
-	/**
-	 * Returns the size of the final render target. This is irrelevant
-	 * for most purposes. Use draw_area() in stead.
-	 */
-	SDL_Point output_size() const;
-
-	/**
-	 * Returns the size of the window in display units / screen coordinates.
-	 * This should match the value sent by window resize events, and also
-	 * those used for setting resolution.
-	 */
-	SDL_Point window_size() const;
-
-	/**
-	 * Returns the size and location of the current drawing area in pixels.
-	 * This will usually be an SDL_Rect indicating the full drawing surface.
-	 */
-	rect draw_area() const;
-
-	/**
-	 * Returns the size and location of the window's input area in pixels.
-	 * We use SDL_RendererSetLogicalSize to ensure this always matches
-	 * draw_area(), but for clarity there are two separate functions.
-	 */
-	SDL_Rect input_area() const;
-
-	/**
-	 * Get the current active pixel scale multiplier.
-	 * This is equal to output_size() / draw_area().
-	 * Currently it is always integer, and the same in both dimensions.
-	 *
-	 * This may differ from preferences::pixel_scale() in some cases,
-	 * For example if the window is too small to fit the desired scale.
-	 *
-	 * @returns     The currently active pixel scale multiplier.
-	 */
-	int get_pixel_scale() const { return pixel_scale_; }
-
-	/**
-	 * Convert coordinates in draw space to coordinates in render space.
-	 */
-	rect to_output(const rect& draw_space_rect) const;
-
-	// TODO: split use into individual functions to avoid use of SDL enums
-	/**
-	 * Tests whether the given flags are currently set on the SDL window.
-	 *
-	 * @param flags               The flags to test, OR'd together.
-	 */
-	bool window_has_flags(uint32_t flags) const;
-
-	/**
-	 * Sets the title of the main window.
-	 *
-	 * @param title               The new title for the window.
-	 */
-	void set_window_title(const std::string& title);
-
-	/**
-	 * Sets the icon of the main window.
-	 *
-	 * @param icon                The new icon for the window.
-	 */
-	void set_window_icon(surface& icon);
-
-	// TODO: this should be more clever, depending on usage
-	int current_refresh_rate() const
-	{
-		return refresh_rate_;
-	}
-
-	/***** ***** ***** ***** Drawing functions ***** ***** ****** *****/
-
-	// TODO: hide this so it's not tempting to use
-	/** Renders the screen. Should normally not be called directly! */
-	void render_screen();
-
-	// TODO: refactor? this shouldn't be public. why does events.cpp use it?
-	/**
-	 * Updates and ensures the framebuffer surface is valid.
-	 * This needs to be invoked immediately after a resize event or the game will crash.
-	 */
-	void update_framebuffer();
-private:
-	void update_framebuffer_fake();
-
-public:
-	// TODO: this should probably be in draw
-	/** Clear the screen contents */
-	void clear_screen();
-
-	/**
-	 * Copy back a portion of the render target that is already drawn.
-	 *
-	 * This area is specified in draw coordinates, not render coordinates.
-	 * Thus the size of the retrieved surface may not match the size of r.
-	 *
-	 * If not null, r will be automatically clipped to the drawing area.
-	 *
-	 * Note: This is a very slow function! Its use should be phased out
-	 * for everything except maybe screenshots.
-	 *
-	 * @param r       The portion of the render target to retrieve, in
-	 *                draw coordinates.
-	 *                If not null, this will be modified to reflect the
-	 *                portion of the draw area that has been returned.
-	 */
-	surface read_pixels(SDL_Rect* r = nullptr);
-
-	/**
-	 * The same as read_pixels, but returns a low-resolution surface
-	 * suitable for use with the old drawing system.
-	 *
-	 * This should be considered deprecated, and phased out ASAP.
-	 */
-	surface read_pixels_low_res(SDL_Rect* r = nullptr);
-
-	/**
-	 * Copy a portion of the render target to another texture.
-	 *
-	 * This area is specified in draw coordinates, not render coordinates.
-	 * Thus the size of the retrieved texture may not match the size of r.
-	 *
-	 * If not null, r will be automatically clipped to the drawing area.
-	 *
-	 * Note: This is a very slow function! Its use should be phased out
-	 * for everything except maybe screenshots.
-	 *
-	 * @param r       The portion of the render target to retrieve, in
-	 *                draw coordinates.
-	 *                If not null, this will be modified to reflect the
-	 *                portion of the draw area that has been returned.
-	 */
-	texture read_texture(SDL_Rect* r = nullptr);
-
-	/***** ***** ***** ***** State management ***** ***** ****** *****/
-
-	/**
-	 * Set the render target, without any provided way of setting it back.
-	 *
-	 * End-users should not use this function directly. In stead use
-	 * draw::set_render_target(), which returns a setter object which
-	 * will automatically restore the render target upon leaving scope.
-	 *
-	 * @param t     The new render target. This must be a texture created
-	 *              with SDL_TEXTUREACCESS_TARGET, or an empty texture to
-	 *              indicate the underlying window.
-	 */
-	void force_render_target(const texture& t);
-
-	/** Reset the render target to the main window / screen. */
-	void clear_render_target();
-
-	/** Get the current render target.
-	 *
-	 * Will return an empty texture if the render target is the underlying
-	 * window.
-	 */
-	texture get_render_target();
-
-	/***** ***** ***** ***** General utils ***** ***** ****** *****/
-
-	// TODO: this should not be here
-	/** Waits a given number of milliseconds before returning. */
-	static void delay(unsigned int milliseconds);
-
-	struct error : public game::error
-	{
-		error() : game::error("unspecified video subsystem error") {}
-		error(const std::string& msg) : game::error(msg) {}
-	};
-
-	/** Type that can be thrown as an exception to quit to desktop. */
-	class quit : public lua_jailbreak_exception
-	{
-	public:
-		quit()
-			: lua_jailbreak_exception()
-		{
-		}
-
-	private:
-		IMPLEMENT_LUA_JAILBREAK_EXCEPTION(quit)
-	};
-
-private:
-	static inline CVideo* singleton_ = nullptr;
-
-	/** The SDL window object. */
-	std::unique_ptr<sdl::window> window;
-
-	/** The main offscreen render target. */
-	texture render_texture_ = {};
-
-	/** The current offscreen render target. */
-	texture current_render_target_ = {};
-
-	/** Initializes the SDL video subsystem. */
-	void initSDL();
-
-	// if there is no display at all, but we 'fake' it for clients
-	bool fake_screen_;
-
-	int refresh_rate_;
-	int offset_x_, offset_y_;
-	point logical_size_;
-	int pixel_scale_;
+	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(quit)
 };
+
+} // namespace video

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -102,6 +102,8 @@ void toggle_fullscreen();
 /**
  * Set the window resolution.
  *
+ * @todo this is no longer useful as fullscreen is always native resolution.
+ *
  * @param resolution          The new width and height.
  *
  * @returns                   Whether the resolution was successfully changed.
@@ -142,9 +144,9 @@ void set_window_title(const std::string& title);
 void set_window_icon(surface& icon);
 
 
-/***********/
-/* Queries */
-/***********/
+/**********************/
+/* Coordinate Systems */
+/**********************/
 
 /**
  * The game canvas area, in drawing coordinates.
@@ -178,8 +180,6 @@ point draw_size();
  */
 rect draw_area();
 
-
-// TODO: revisit these for correctness and usefulness
 /**
  * Returns the size of the final render target. This is irrelevant
  * for most purposes. Use game_canvas_size() in stead.
@@ -197,9 +197,16 @@ rect output_area();
 point window_size();
 
 /**
- * Returns the size and location of the window's input area in pixels.
- * We use SDL_RendererSetLogicalSize to ensure this always matches
- * game_canvas(), but for clarity there are two separate functions.
+ * Returns the input area of the window, in display coordinates.
+ *
+ * This can be slightly offset within the window, if the drawable area
+ * is not the same as the full window area. This will happen if output
+ * size is not a perfect multiple of the draw size.
+ *
+ * In general this will be almost, but not quite, equal to window_size().
+ *
+ * input_area() represents the portion of the window corresponding to
+ * game_canvas().
  */
 rect input_area();
 

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -146,26 +146,6 @@ void set_window_icon(surface& icon);
 /* Queries */
 /***********/
 
-// TODO: revisit these for correctness and usefulness
-/**
- * Returns the size of the final render target. This is irrelevant
- * for most purposes. Use game_canvas_size() in stead.
- */
-point output_size();
-
-/**
- * Returns the size of the window in display units / screen coordinates.
- * This should match the value sent by window resize events, and also
- * those used for setting resolution.
- */
-point window_size();
-
-/**
- * Returns the size and location of the current drawing area in pixels.
- * This will usually be an SDL_Rect indicating the full drawing surface.
- */
-rect draw_area();
-
 /**
  * The game canvas area, in drawing coordinates.
  *
@@ -182,6 +162,39 @@ rect game_canvas();
 
 /** The size of the game canvas, in drawing coordinates / game pixels. */
 point game_canvas_size();
+
+/**
+ * The size of the current render target in drawing coordinates.
+ *
+ * This will be the same as game_canvas_size() unless the render target
+ * has been manually changed.
+ */
+point draw_size();
+
+/**
+ * The current drawable area.
+ *
+ * Equivalent to {0, 0, draw_size().x, draw_size().y}.
+ */
+rect draw_area();
+
+
+// TODO: revisit these for correctness and usefulness
+/**
+ * Returns the size of the final render target. This is irrelevant
+ * for most purposes. Use game_canvas_size() in stead.
+ */
+point output_size();
+
+/** {0, 0, output_size().x, output_size().y} */
+rect output_area();
+
+/**
+ * Returns the size of the window in display units / screen coordinates.
+ * This should match the value sent by window resize events, and also
+ * those used for setting resolution.
+ */
+point window_size();
 
 /**
  * Returns the size and location of the window's input area in pixels.

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -35,7 +35,6 @@ namespace video
 /* Initialization */
 /******************/
 
-// TODO: this whole faking system is a mess
 /**
  * For describing the type of faked display, if any.
  *
@@ -51,25 +50,28 @@ enum class fake { none, window, draw };
  */
 void init(fake fake_type = fake::none);
 
-
-/********************************/
-/* Unit-test and No-GUI support */
-/********************************/
-
-
-// TODO: tests are calling this constantly, refactor the tests to not do that
 /**
- * Creates a fake frame buffer for the unit tests.
+ * Update buffers to match current resolution and pixel scale settings.
  *
- * @param width               The width of the buffer.
- * @param height              The height of the buffer.
+ * If @p autoupdate is true and buffers are changed by this call,
+ * a full redraw is also triggered.
+ *
+ * If nothing has changed, it will not generate any new buffers or queue
+ * the redraw.
  */
-void make_test_fake(const unsigned width = 1024, const unsigned height = 768);
+void update_buffers(bool autoupdate = true);
 
-// TODO: rename and refactor - these don't clearly express what they mean
-bool faked();
-bool any_fake();
-bool non_interactive();
+
+/**********************************/
+/* Unit-test and headless support */
+/**********************************/
+
+/** The game is running headless. There is no window or renderer. */
+bool headless();
+
+/** The game is running unit tests. There is a window and offscreen
+  * render buffer, but performing actual rendering is unnecessary. */
+bool testing();
 
 
 /***********************/
@@ -140,19 +142,6 @@ void set_window_title(const std::string& title);
 void set_window_icon(surface& icon);
 
 
-/*******/
-/* IDK */
-/*******/
-
-/**
- * Update buffers to match current resolution and pixel scale settings.
- *
- * If @p autoupdate is true and buffers are changed by this call,
- * a full redraw is also triggered.
- */
-void update_buffers(bool autoupdate = true);
-
-
 /***********/
 /* Queries */
 /***********/
@@ -196,7 +185,6 @@ rect input_area();
  */
 int get_pixel_scale();
 
-// TODO: move
 /**
  * Convert coordinates in draw space to coordinates in render space.
  */
@@ -239,7 +227,6 @@ surface read_pixels_low_res(SDL_Rect* r = nullptr);
 /* Render target management */
 /****************************/
 
-// TODO: revisit who owns this
 /**
  * Set the render target, without any provided way of setting it back.
  *

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -316,4 +316,9 @@ private:
  * texture creation. Try not to use it for anything else. */
 SDL_Renderer* get_renderer();
 
+/* This should not be used unless absolutely necessary. It's currently used
+ * for Windows tray notification and that's it. If it can be refactored out
+ * somehow then that would be best. */
+SDL_Window* get_window();
+
 } // namespace video

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1051,10 +1051,12 @@ int main(int argc, char** argv)
 	lg::early_log_file_setup(!log_redirect);
 #endif
 
+	// Is there a reason not to just use SDL_INIT_EVERYTHING?
 	if(SDL_Init(SDL_INIT_TIMER) < 0) {
 		PLAIN_LOG << "Couldn't initialize SDL: " << SDL_GetError();
 		return (1);
 	}
+	atexit(SDL_Quit);
 
 #ifndef _WIN32
 	struct sigaction terminate_handler;

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -54,7 +54,7 @@
 #include "statistics.hpp"              // for fresh_stats
 #include <functional>
 #include "game_version.hpp"        // for version_info
-#include "video.hpp"          // for CVideo
+#include "video.hpp"          // for video::error and video::quit
 #include "wesconfig.h"        // for PACKAGE
 #include "widgets/button.hpp" // for button
 #include "wml_exception.hpp"  // for wml_exception
@@ -1122,7 +1122,7 @@ int main(int argc, char** argv)
 	} catch(const boost::program_options::error& e) {
 		PLAIN_LOG << "Error in command line: " << e.what();
 		error_exit(1);
-	} catch(const CVideo::error& e) {
+	} catch(const video::error& e) {
 		PLAIN_LOG << "Video system error: " << e.what();
 		error_exit(1);
 	} catch(const font::error& e) {
@@ -1134,7 +1134,7 @@ int main(int argc, char** argv)
 	} catch(const gui::button::error&) {
 		PLAIN_LOG << "Could not create button: Image could not be found";
 		error_exit(1);
-	} catch(const CVideo::quit&) {
+	} catch(const video::quit&) {
 		// just means the game should quit
 	} catch(const return_to_play_side_exception&) {
 		PLAIN_LOG << "caught return_to_play_side_exception, please report this bug (quitting)";

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -210,7 +210,7 @@ void button::calculate_size()
 	}
 
 	if (type_ != TYPE_IMAGE){
-		textRect_ = font::pango_draw_text(nullptr, sdl::empty_rect, font_size_, font::BUTTON_COLOR, label_text_, 0, 0);
+		textRect_ = font::pango_draw_text(false, sdl::empty_rect, font_size_, font::BUTTON_COLOR, label_text_, 0, 0);
 	}
 
 	// TODO: There's a weird text clipping bug, allowing the code below to run fixes it.
@@ -370,7 +370,7 @@ void button::draw_contents()
 		clipArea.y += offset;
 		clipArea.w -= 2*offset;
 		clipArea.h -= 2*offset;
-		font::pango_draw_text(&video(), clipArea, font_size_, button_color, label_text_, textx, texty);
+		font::pango_draw_text(true, clipArea, font_size_, button_color, label_text_, textx, texty);
 	}
 }
 

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -29,7 +29,7 @@
 #include "sdl/texture.hpp"
 #include "sound.hpp"
 #include "utils/general.hpp"
-#include "video.hpp" // TODO: draw_manager - only for draw_area
+#include "video.hpp"
 #include "wml_separators.hpp"
 
 #include <numeric>
@@ -442,7 +442,11 @@ std::size_t menu::max_items_onscreen() const
 		return std::size_t(max_items_);
 	}
 
-	const std::size_t max_height = (max_height_ == -1 ? (video::draw_area().h*66)/100 : max_height_) - heading_height();
+	const std::size_t max_height = (
+			max_height_ == -1
+				? (video::game_canvas_size().y * 66) / 100
+				: max_height_
+		) - heading_height();
 
 	std::vector<int> heights;
 	std::size_t n;
@@ -872,7 +876,7 @@ void menu::draw_row(const std::size_t row_index, const SDL_Rect& loc, ROW_TYPE t
 {
 	//called from style, draws one row's contents in a generic and adaptable way
 	const std::vector<std::string>& row = (type == HEADING_ROW) ? heading_ : items_[row_index].fields;
-	rect area = video::draw_area();
+	rect area = video::game_canvas();
 	rect column = inner_location();
 	const std::vector<int>& widths = column_widths();
 	bool lang_rtl = current_language_rtl();
@@ -1075,18 +1079,18 @@ SDL_Rect menu::get_item_rect_internal(std::size_t item) const
 
 	rect res(loc.x, y, loc.w, get_item_height(item));
 
-	const rect draw_area = video::draw_area();
+	const point canvas_size = video::game_canvas_size();
 
-	if(res.x > draw_area.w) {
+	if(res.x > canvas_size.x) {
 		return sdl::empty_rect;
-	} else if(res.x + res.w > draw_area.w) {
-		res.w = draw_area.w - res.x;
+	} else if(res.x + res.w > canvas_size.x) {
+		res.w = canvas_size.x - res.x;
 	}
 
-	if(res.y > draw_area.h) {
+	if(res.y > canvas_size.y) {
 		return sdl::empty_rect;
-	} else if(res.y + res.h > draw_area.h) {
-		res.h = draw_area.h - res.y;
+	} else if(res.y + res.h > canvas_size.y) {
+		res.h = canvas_size.y - res.y;
 	}
 
 	//only insert into the cache if the menu's co-ordinates have

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -18,12 +18,13 @@
 #include "widgets/menu.hpp"
 
 #include "draw.hpp"
-#include "game_config.hpp"
+#include "font/sdl_ttf_compat.hpp"
 #include "font/standard_colors.hpp"
+#include "floating_label.hpp"
+#include "game_config.hpp"
 #include "language.hpp"
 #include "lexical_cast.hpp"
 #include "picture.hpp"
-#include "font/sdl_ttf_compat.hpp"
 #include "sdl/rect.hpp"
 #include "sdl/texture.hpp"
 #include "sound.hpp"
@@ -154,7 +155,7 @@ menu::menu(const std::vector<std::string>& items,
   max_height_(max_height), max_width_(max_width),
   max_items_(-1), item_height_(-1),
   heading_height_(-1),
-  cur_help_(-1,-1), help_string_(-1),
+  cur_help_(-1,-1),
   selected_(0), click_selects_(click_selects), out_(false),
   previous_button_(true), show_result_(false),
   double_clicked_(false),
@@ -1139,20 +1140,16 @@ void menu::process_help_string(int mousex, int mousey)
 	if(loc == cur_help_) {
 		return;
 	} else if(loc.first == -1) {
-		video().clear_help_string(help_string_);
-		help_string_ = -1;
+		font::clear_help_string();
 	} else {
-		if(help_string_ != -1) {
-			video().clear_help_string(help_string_);
-			help_string_ = -1;
-		}
+		font::clear_help_string();
 		if(std::size_t(loc.first) < items_.size()) {
 			const std::vector<std::string>& row = items_[item_pos_[loc.first]].help;
 			if(std::size_t(loc.second) < row.size()) {
 				const std::string& help = row[loc.second];
 				if(help.empty() == false) {
 					//PLAIN_LOG << "setting help string from menu to '" << help << "'";
-					help_string_ = video().set_help_string(help);
+					font::set_help_string(help);
 				}
 			}
 		}

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -243,7 +243,6 @@ private:
 	void process_help_string(int mousex, int mousey) override;
 
 	std::pair<int,int> cur_help_;
-	int help_string_;
 
 	mutable std::vector<int> column_widths_;
 

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -16,9 +16,9 @@
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
 #include "widgets/scrollarea.hpp"
+#include "sdl/input.hpp" // for get_mouse_state
 #include "sdl/rect.hpp"
-#include "video.hpp" // TODO: draw_manager - only needed for draw_area()
-#include "sdl/input.hpp" // get_mouse_state
+#include "video.hpp" // for converting input events to game coordinates
 
 namespace gui {
 
@@ -171,10 +171,13 @@ void scrollarea::handle_event(const SDL_Event& event)
 	}
 
 	if (event.type == SDL_FINGERDOWN || event.type == SDL_FINGERMOTION) {
-		rect r = video::draw_area();
-		auto tx = static_cast<int>(event.tfinger.x * r.w);
-		auto ty = static_cast<int>(event.tfinger.y * r.h);
-		auto dy = static_cast<int>(event.tfinger.dy * r.h);
+		// These events are given as a proportion of the full game canvas.
+		// 0.0 is top/left edge, 1.0 is bottom/right edge.
+		// Thus first convert them to game pixels.
+		point canvas_size = video::game_canvas_size();
+		auto tx = static_cast<int>(event.tfinger.x * canvas_size.x);
+		auto ty = static_cast<int>(event.tfinger.y * canvas_size.y);
+		auto dy = static_cast<int>(event.tfinger.dy * canvas_size.y);
 
 		if (event.type == SDL_FINGERDOWN) {
 			swipe_dy_ = 0;

--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -171,7 +171,7 @@ void scrollarea::handle_event(const SDL_Event& event)
 	}
 
 	if (event.type == SDL_FINGERDOWN || event.type == SDL_FINGERMOTION) {
-		SDL_Rect r = video().draw_area();
+		rect r = video::draw_area();
 		auto tx = static_cast<int>(event.tfinger.x * r.w);
 		auto ty = static_cast<int>(event.tfinger.y * r.h);
 		auto dy = static_cast<int>(event.tfinger.dy * r.h);

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -43,8 +43,7 @@ textbox::textbox(int width, const std::string& text, bool editable, std::size_t 
 	     edit_target_(nullptr)
 		,listening_(false)
 {
-	// static const SDL_Rect area = video.draw_area();
-	// const int height = font::pango_draw_text(nullptr,area,font_size,font::NORMAL_COLOR,"ABCD",0,0).h;
+	// const int height = font::pango_draw_text(nullptr,sdl::empty_rect,font_size,font::NORMAL_COLOR,"ABCD",0,0).h;
 	set_measurements(width, font::get_max_height(font_size_));
 	set_scroll_rate(font::get_max_height(font_size_) / 2);
 	update_text_cache(true);

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -230,7 +230,7 @@ void textbox::draw_contents()
 		}
 
 		// text may be rendered at high dpi, scale source clip accordingly
-		src *= video().get_pixel_scale();
+		src *= video::get_pixel_scale();
 		// TODO: highdpi - consider sizing source clip in draw coordinates, now that textures have a draw-space w/h? That would work here.
 
 		if(enabled()) {

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -228,21 +228,23 @@ void textbox::draw_contents()
 			}
 		}
 
-		// text may be rendered at high dpi, scale source clip accordingly
-		src *= video::get_pixel_scale();
-		// TODO: highdpi - consider sizing source clip in draw coordinates, now that textures have a draw-space w/h? That would work here.
+		// Set the source region on the texture.
+		text_image_.set_src(src);
 
 		if(enabled()) {
-			draw::blit(text_image_, dest, src);
+			draw::blit(text_image_, dest);
 		} else {
 			// HACK: using 30% opacity allows white text to look as though it is grayed out,
 			// while not changing any applicable non-grayscale AA. Actual colored text will
 			// not look as good, but this is not currently a concern since GUI1 textboxes
 			// are not used much nowadays, and they will eventually all go away.
 			text_image_.set_alpha_mod(76);
-			draw::blit(text_image_, dest, src);
+			draw::blit(text_image_, dest);
 			text_image_.set_alpha_mod(255);
 		}
+
+		// This doesn't really need to be cleared, but why not.
+		text_image_.clear_src();
 	}
 
 	draw_cursor(cursor_pos_ == 0 ? 0 : cursor_pos_ - 1);

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -17,6 +17,7 @@
 
 #include "draw.hpp"
 #include "draw_manager.hpp"
+#include "floating_label.hpp"
 #include "widgets/widget.hpp"
 #include "video.hpp"
 #include "sdl/rect.hpp"
@@ -34,7 +35,7 @@ bool widget::mouse_lock_ = false;
 widget::widget(const bool auto_join)
 	: events::sdl_handler(auto_join), focus_(true), rect_(EmptyRect), needs_restore_(false),
 	  state_(UNINIT), hidden_override_(false), enabled_(true), clip_(false),
-	  clip_rect_(EmptyRect), help_string_(0), mouse_lock_local_(false)
+	  clip_rect_(EmptyRect), has_help_(false), mouse_lock_local_(false)
 {
 }
 
@@ -340,13 +341,14 @@ void widget::set_tooltip_string(const std::string& str)
 void widget::process_help_string(int mousex, int mousey)
 {
 	if (!hidden() && rect_.contains(mousex, mousey)) {
-		if(help_string_ == 0 && !help_text_.empty()) {
+		if(!has_help_ && !help_text_.empty()) {
 			//PLAIN_LOG << "setting help string to '" << help_text_ << "'";
-			help_string_ = video().set_help_string(help_text_);
+			font::set_help_string(help_text_);
+			has_help_ = true;
 		}
-	} else if(help_string_ > 0) {
-		video().clear_help_string(help_string_);
-		help_string_ = 0;
+	} else if(has_help_) {
+		font::clear_help_string();
+		has_help_ = false;
 	}
 }
 

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -19,7 +19,7 @@
 #include "draw_manager.hpp"
 #include "floating_label.hpp"
 #include "widgets/widget.hpp"
-#include "video.hpp"
+#include "video.hpp" // TODO: draw_manager - only for draw_area
 #include "sdl/rect.hpp"
 #include "tooltips.hpp"
 
@@ -67,12 +67,6 @@ void widget::free_mouse_lock()
 bool widget::mouse_locked() const
 {
 	return mouse_lock_ && !mouse_lock_local_;
-}
-
-// TODO: draw_manager - overhaul CVideo interface
-CVideo& widget::video() const
-{
-	return CVideo::get_singleton();
 }
 
 // TODO: draw_manager - kill surface restorers
@@ -262,8 +256,8 @@ void widget::bg_update()
 
 void widget::bg_restore() const
 {
-	rect c = clip_ ? clip_rect_ : video().draw_area();
-	//auto clipper = draw::set_clip(clip_ ? clip_rect_ : video().draw_area());
+	rect c = clip_ ? clip_rect_ : video::draw_area();
+	//auto clipper = draw::set_clip(clip_ ? clip_rect_ : video::draw_area());
 
 	if (needs_restore_) {
 		for(const rect& r : restorer_) {
@@ -278,9 +272,9 @@ void widget::bg_restore() const
 
 void widget::bg_restore(const SDL_Rect& where) const
 {
-	rect c = clip_ ? clip_rect_ : video().draw_area();
+	rect c = clip_ ? clip_rect_ : video::draw_area();
 	c.clip(where);
-	//auto clipper = draw::set_clip(clip_ ? clip_rect_ : video().draw_area());
+	//auto clipper = draw::set_clip(clip_ ? clip_rect_ : video::draw_area());
 
 	for(const rect& r : restorer_) {
 		draw_manager::invalidate_region(r.intersect(c));

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -19,7 +19,6 @@
 #include "draw_manager.hpp"
 #include "floating_label.hpp"
 #include "widgets/widget.hpp"
-#include "video.hpp" // TODO: draw_manager - only for draw_area
 #include "sdl/rect.hpp"
 #include "tooltips.hpp"
 
@@ -256,12 +255,13 @@ void widget::bg_update()
 
 void widget::bg_restore() const
 {
-	rect c = clip_ ? clip_rect_ : video::draw_area();
-	//auto clipper = draw::set_clip(clip_ ? clip_rect_ : video::draw_area());
-
 	if (needs_restore_) {
 		for(const rect& r : restorer_) {
-			draw_manager::invalidate_region(r.intersect(c));
+			if(clip_) {
+				draw_manager::invalidate_region(r.intersect(clip_rect_));
+			} else {
+				draw_manager::invalidate_region(r);
+			}
 		}
 		/*for(std::vector< surface_restorer >::const_iterator i = restorer_.begin(),
 		    i_end = restorer_.end(); i != i_end; ++i)
@@ -272,9 +272,8 @@ void widget::bg_restore() const
 
 void widget::bg_restore(const SDL_Rect& where) const
 {
-	rect c = clip_ ? clip_rect_ : video::draw_area();
+	rect c = clip_ ? clip_rect_ : where;
 	c.clip(where);
-	//auto clipper = draw::set_clip(clip_ ? clip_rect_ : video::draw_area());
 
 	for(const rect& r : restorer_) {
 		draw_manager::invalidate_region(r.intersect(c));

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -123,7 +123,7 @@ private:
 
 	std::string help_text_;
 	std::string tooltip_text_;
-	int help_string_;
+	bool has_help_;
 	std::string id_;
 
 	bool mouse_lock_local_;

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -22,8 +22,6 @@
 
 #include <string>
 
-class CVideo;
-
 namespace gui {
 
 // TODO: making widgets TLDs is horrible. Please move everything to GUI2.
@@ -79,8 +77,6 @@ protected:
 	void bg_restore(const SDL_Rect& rect) const; // TODO: draw_manager - remove
 	void bg_update(); // TODO: draw_manager - remove
 	void bg_cancel(); // TODO: draw_manager - remove
-
-	CVideo& video() const;
 
 public:
 	/* draw_manager interface */


### PR DESCRIPTION
This is addressing the remaining TODOs for the high-dpi work (not including the ongoing hardware acceleration work). Particularly it focuses on cleaning up and making sure the video interface is correct, and on cleaning up the systems to do with drawing in response to events, in particular window resize events and the now-obsolete "draw" type events.

1. I overhauled the video interface, previously known as the `CVideo` class. In stead of acting on a singleton class, this interface is now a `video` namespace. So functions such as `CVideo::get_singleton().draw_area()` are now accessed via `video::draw_area()`.

2. There was a large internal rearrangement and overhaul of the video interface. Many functions were removed or renamed. Many were checked for correctness and fixed. Most notably the whole "fake" video system was reworked to clearly differentiate normal operation from "headless" operation from "testing" operation.

3. Video resizing was overhauled. It should now work much better in all cases. The display will auto-resize as the user resizes the window in real-time, and it should do so without glitches, missing areas, flashing black rectangles, and glitching UI in the wrong resolution.

4. The interface for drawing was clarified. "DRAW" events are now no longer used, as drawing is handled via the draw manager. "DRAW_ALL" events are also no longer used, as screen invalidation is handled by the draw manager.

5. The `display` class was cleaned to make use of the improved video interface, and to remove various bugs relating to flickering and resizing.

6. Size calculations and coordinate spaces were clarified and verified (and in some cases fixed). Such calculations should now also work correctly for custom render targets.

7. Input space calculations were also clarified and fixed - notably there was a single-render-pixel offset in some situations that was not previously accounted for.

8. `texture` objects now store their source region for blits internally. This cleans up and clarifies usage, particularly whether the source region is specified in draw space or texture space.

These changes were mostly related and intertwined. I squashed a lot of the individual fixes and changes together into single commits where reasonable, so it should generally make sense. But on the whole it's easiest just to apply this all as one big chunk.