### PR TITLE
Handle non-hex-sized images when cropping to hex

### DIFF
--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -1022,6 +1022,7 @@ surface adjust_surface_alpha_add(const surface &surf, int amount)
 surface mask_surface(const surface &surf, const surface &mask, bool* empty_result, const std::string& filename)
 {
 	if(surf == nullptr) {
+		*empty_result = true;
 		return nullptr;
 	}
 	if(mask == nullptr) {


### PR DESCRIPTION
Images that are not 72x72 are centered and cropped before masking.

This fixes the inconsistent masking in SoTA (#6118).