### PR TITLE
Update mainline campaigns to use screen_fade

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/16_The_Chief_Must_Die.cfg
@@ -673,21 +673,7 @@
             name=potion.ogg
         [/sound]
 
-        [color_adjust]
-            red=100
-            green=100
-            blue=100
-        [/color_adjust]
-
-        [delay]
-            time=10
-        [/delay]
-
-        [color_adjust]
-            red=0
-            green=0
-            blue=0
-        [/color_adjust]
+        {FLASH_WHITE ()}
 
         [delay]
             time=2000

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -535,19 +535,7 @@
             [/variable]
 
             [then]
-                [color_adjust]
-                    red=255
-                    green=100
-                    blue=100
-                [/color_adjust]
-                [delay]
-                    time=10
-                [/delay]
-                [color_adjust]
-                    red=0
-                    green=0
-                    blue=0
-                [/color_adjust]
+                {FLASH 255 100 100 ()}
 
                 [terrain_mask]
                     x,y=16,33
@@ -661,19 +649,7 @@
             [/variable]
 
             [then]
-                [color_adjust]
-                    red=255
-                    green=255
-                    blue=100
-                [/color_adjust]
-                [delay]
-                    time=10
-                [/delay]
-                [color_adjust]
-                    red=0
-                    green=0
-                    blue=0
-                [/color_adjust]
+                {FLASH 255 255 100 ()}
 
                 [terrain_mask]
                     x,y=16,33

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/17_Mortality.cfg
@@ -322,11 +322,18 @@ Not far inside the cave was a ruined castle built in a style I did not recognize
             flag=sacrifice
         [/animate_unit]
 
-        [hide_unit]
-            # All units.
-        [/hide_unit]
+        # TODO: The skeleton should keep the final animation frame here,
+        # rather than flipping back to the standing animation for the fade.
 
-        {FADE_TO_BLACK_HOLD 1000}
+        [screen_fade]
+            red,green,blue=0,0,0
+            alpha=255
+            duration=1000
+        [/screen_fade]
+
+        [delay]
+            time=2000
+        [/delay]
 
         [fire_event]
             name=lichify  # See: sota-utils.cfg

--- a/data/campaigns/Secrets_of_the_Ancients/units/Skele_Sacrifice.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/units/Skele_Sacrifice.cfg
@@ -22,7 +22,7 @@
             layer=100
         [/frame]
         [frame]
-            image="units/undead/skeleton-se-sacrifice7.png:1000"
+            image="units/undead/skeleton-se-sacrifice7.png:500"
             x=33
             y=0
             layer=100

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
@@ -1489,27 +1489,11 @@
                     message= _ "Burn, burn and die!"
                 [/message]
 
-                [color_adjust]
-                    red,green,blue=255,0,0
-                [/color_adjust]
-
-                [redraw]
-                [/redraw]
-
-                [sound]
-                    name=fire.wav
-                [/sound]
-
-                [delay]
-                    time=100
-                [/delay]
-
-                [color_adjust]
-                    red,green,blue=0,0,0
-                [/color_adjust]
-
-                [redraw]
-                [/redraw]
+                {FLASH_RED (
+                    [sound]
+                        name=fire.wav
+                    [/sound]
+                )}
 
                 [message]
                     speaker=Dwarf Leader
@@ -1681,27 +1665,11 @@
                     message= _ "Let’s blast those monsters back to the pits they spawned from! Fire in the hole!"
                 [/message]
 
-                [color_adjust]
-                    red,green,blue=255,0,0
-                [/color_adjust]
-
-                [redraw]
-                [/redraw]
-
-                [sound]
-                    name=thunderstick.ogg
-                [/sound]
-
-                [delay]
-                    time=100
-                [/delay]
-
-                [color_adjust]
-                    red,green,blue=0,0,0
-                [/color_adjust]
-
-                [redraw]
-                [/redraw]
+                {FLASH_RED (
+                    [sound]
+                        name=thunderstick.ogg
+                    [/sound]
+                )}
 
                 [message]
                     speaker=Troll Leader

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
@@ -503,23 +503,12 @@
 
             # Have screen flash red
 
-            [color_adjust]
-                red,green,blue=255,0,0
-            [/color_adjust]
-
-            [redraw]
-            [/redraw]
-
-            [delay]
-                time=1000
-            [/delay]
-
-            [color_adjust]
-                red,green,blue=0,0,0
-            [/color_adjust]
-
-            [redraw]
-            [/redraw]
+            # TODO: should the explosion and shaking be inside the flash?
+            {FLASH_RED (
+                [delay]
+                    time=1000
+                [/delay]
+            )}
 
             [sound]
                 name=explosion.ogg
@@ -913,23 +902,8 @@
 
         # Have screen flash red
 
-        [color_adjust]
-            red,green,blue=255,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [delay]
-            time=200
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        # TODO: should the explosion and shaking be inside the flash?
+        {FLASH_RED ()}
 
         [sound]
             name=flame-big.ogg

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -522,27 +522,11 @@
 
             # Have screen flash red
 
-            [color_adjust]
-                red,green,blue=255,0,0
-            [/color_adjust]
-
-            [redraw]
-            [/redraw]
-
-            [sound]
-                name=explosion.ogg
-            [/sound]
-
-            [delay]
-                time=100
-            [/delay]
-
-            [color_adjust]
-                red,green,blue=0,0,0
-            [/color_adjust]
-
-            [redraw]
-            [/redraw]
+            {FLASH_RED (
+                [sound]
+                    name=explosion.ogg
+                [/sound]
+            )}
 
             # Have wall shake, then be replaced by dirt, then add rubble
 
@@ -1791,24 +1775,16 @@
                 message= _ "Hey, wait a minute, that amulet glows the same color as this rune. Maybe if I put the amulet on and step into the rune..."
             [/message]
 
-            [color_adjust]
-                red,green,blue=246,0,243
-            [/color_adjust]
+            {FLASH 246 0 243 (
+                {UTBS_SHAKE_SCREEN}
 
-            {UTBS_SHAKE_SCREEN}
+                [terrain]
+                    x,y=46,21
+                    terrain=Uu
+                [/terrain]
 
-            [terrain]
-                x,y=46,21
-                terrain=Uu
-            [/terrain]
-
-            {PLACE_IMAGE scenery/rubble.png 46 21}
-
-            [redraw][/redraw]
-
-            [color_adjust]
-                red,green,blue=0,0,0
-            [/color_adjust]
+                {PLACE_IMAGE scenery/rubble.png 46 21}
+            )}
 
             [remove_item]
                 x,y=45,21

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -1287,27 +1287,11 @@
             [/not]
         [/filter]
 
-        [color_adjust]
-            red,green,blue=255,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [sound]
-            name=magic-dark-big-miss.ogg
-        [/sound]
-
-        [delay]
-            time=100
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        {FLASH_RED (
+            [sound]
+                name=magic-dark-big-miss.ogg
+            [/sound]
+        )}
 
         [remove_item]
             x,y=20,45
@@ -1510,27 +1494,11 @@
             [/variable]
         [/filter_condition]
 
-        [color_adjust]
-            red,green,blue=31,122,255
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [sound]
-            name=heal.wav
-        [/sound]
-
-        [delay]
-            time=100
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        {FLASH 31 122 255 (
+            [sound]
+                name=heal.wav
+            [/sound]
+        )}
 
         [heal_unit]
         [/heal_unit]
@@ -1990,27 +1958,11 @@
         # upon entering chamber, remove entry rune and damage and
         # poison invading unit
 
-        [color_adjust]
-            red,green,blue=255,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [sound]
-            name=magic-dark-big-miss.ogg
-        [/sound]
-
-        [delay]
-            time=100
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        {FLASH_RED (
+            [sound]
+                name=magic-dark-big-miss.ogg
+            [/sound]
+        )}
 
         [remove_item]
             x,y=18,34
@@ -2222,27 +2174,11 @@
         [event]
             name=new turn
 
-            [color_adjust]
-                red,green,blue=255,0,0
-            [/color_adjust]
-
-            [redraw]
-            [/redraw]
-
-            [sound]
-                name=magic-dark-big-miss.ogg
-            [/sound]
-
-            [delay]
-                time=100
-            [/delay]
-
-            [color_adjust]
-                red,green,blue=0,0,0
-            [/color_adjust]
-
-            [redraw]
-            [/redraw]
+            {FLASH_RED (
+                [sound]
+                    name=magic-dark-big-miss.ogg
+                [/sound]
+            )}
 
             {NAMED_UNIT 3 (Ixthala Demon) 5 35 (Ancient Guardian 1) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}
             {NAMED_UNIT 3 (Ixthala Demon) 8 33 (Ancient Guardian 2) ( _ "Ancient Guardian") (upkeep=free)}{PASSABLE_HEX}

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -1346,21 +1346,7 @@
             message= _ "The time has come, my brethren. On this most holy day, let us sacrifice these infidels unto The Dark Lady. Their suffering shall be a testament to her power and glory!"
         [/message]
 
-        #have screen flash red
-
-        [color_adjust]
-            red,green,blue=255, 0, 0
-        [/color_adjust]
-        [redraw]
-        [/redraw]
-        [delay]
-            time=100
-        [/delay]
-        [color_adjust]
-            red,green,blue=0, 0, 0
-        [/color_adjust]
-        [redraw]
-        [/redraw]
+        {FLASH_RED ()}
 
         [if]
             [have_location]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/12_The_Final_Confrontation.cfg
@@ -735,23 +735,10 @@
             time=400
         [/delay]
 
-        [color_adjust]
-            red,green,blue=40,0,100
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [delay]
-            time=250
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        # TODO: check colour and timing for correctness with [screen_fade]
+        # there was previously a significant 250ms delay here, but that's
+        # still less time than the new flash animation takes to play.
+        {FLASH 40 0 100 ()}
 
         # main body appears
 
@@ -868,23 +855,10 @@
             message= _ "Eloh protect us!"
         [/message]
 
-        [color_adjust]
-            red,green,blue=33,181,140
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [delay]
-            time=250
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        # TODO: check colour and timing for correctness with [screen_fade]
+        # there was previously a significant 250ms delay here, but that's
+        # still less time than the new flash animation takes to play.
+        {FLASH 33 181 140 ()}
 
         # create 3/4/5 bugs
         [fire_event]
@@ -1165,23 +1139,12 @@
 
         #used to be 140,255,247
 
-        [color_adjust]
-            red,green,blue=40,0,100
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [delay]
-            time=250
-        [/delay]
-
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        # TODO: check colour and timing for correctness with [screen_fade]
+        # there was previously a significant 250ms delay here, but that's
+        # still less time than the new flash animation takes to play.
+        # Note that the above colour comment is unrelated and this was
+        # already 40 0 100 when converted to screen_fade.
+        {FLASH 40 0 100 ()}
 
         [delay]
             time=100
@@ -1393,55 +1356,39 @@
             x=-40
         [/scroll]
 
-        # flash dark blue, light blue, very light blue,
+        # progressive flash: dark blue, light blue, very light blue
+        # TODO: check colour and timing for correctness with [screen_fade]
 
         # dark blue
 
-        [color_adjust]
+        [screen_fade]
             red,green,blue=40,0,100
-        [/color_adjust]
+            alpha=200
+            duration=300
+        [/screen_fade]
 
-        [redraw]
-        [/redraw]
+        # light blue
 
-        [delay]
-            time=300
-        [/delay]
-
-        #light blue
-
-        [color_adjust]
+        [screen_fade]
             red,green,blue=33,181,140
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [delay]
-            time=300
-        [/delay]
+            alpha=200
+            duration=300
+        [/screen_fade]
 
         # very light blue
 
-        [color_adjust]
+        [screen_fade]
             red,green,blue=140,255,247
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
-
-        [delay]
-            time=300
-        [/delay]
+            alpha=200
+            duration=300
+        [/screen_fade]
 
         # back to normal
 
-        [color_adjust]
-            red,green,blue=0,0,0
-        [/color_adjust]
-
-        [redraw]
-        [/redraw]
+        [screen_fade]
+            alpha=0
+            duration=300
+        [/screen_fade]
     [/event]
 
     [event]


### PR DESCRIPTION
According to usage, i ended up adding the macros:

 * `SCREEN_FADE_OUT` - replaces `FADE_TO_BLACK` in most cases
 * `SCREEN_FADE_IN` - replaces `FADE_IN` in most cases
 * `SCREEN_FADE r g b duration` - convenience wrapper for `[screen_fade]` with 255 alpha. Mostly used internally.
 * `SCREEN_UNFADE duration` - convenience wrapper for `[screen_fade]` with 0 alpha. Mostly used internally.
 * `FLASH r g b actionWML` - like `FLASH_WHITE` etc but takes a colour
 * `FLASH_LIGHTNING actionWML` - flashes an appropriate colour and plays `lightning.ogg`

The `FLASH_WHITE`/`RED`/`GREEN`/`BLUE` macros were updated to use `screen_fade`.

All mainline campaigns were updated to use these or `[screen_fade]` over `[color_adjust]`, as appropriate. There are only a couple remaining uses of `color_adjust` that weren't obvious to switch, and nothing needed the old `FADE_TO_BLACK` behaviour.