### PR TITLE
[UtBS] Add series of bat screeches in the Zochtanol Isle scenario

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
@@ -1436,6 +1436,10 @@
     # at first dusk, Kaleh comments strange noises in jungle
     [event]
         name=bat_noise_reaction
+        [sound]
+            name={SOUND_LIST:BAT_HIT}
+            repeat=6
+        [/sound]
         [message]
             speaker=Kaleh
             message= _ "What’s that strange screeching sound coming from the jungle?"


### PR DESCRIPTION
Resolves #6503. I tested this both with and without music enabled to the same level as the sound effects.

At worst, the player might not notice if music is on and louder than sound effects, but because the bat sound repeats 7 times it is more likely the player will notice. It also represents the fact that there are multiple bats that await.

At best, if the player falls under the demographic of players that like to play with music off, they will definitely hear the sound.

Requesting permission to merge.