### PR TITLE
[UtBS] In S6b, add an "explosive charge failed" sound to event

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1031,6 +1031,14 @@
                     time=1000
                 [/delay]
 
+                [sound]
+                    name=thunderstick-miss.ogg
+                [/sound]
+
+                [delay]
+                    time=1800
+                [/delay]
+
                 [message]
                     speaker="East Scout"
                     message= _ "What?! Nothing happened! Who rigged the darn charges anyway? I’m going to have to hold them off by myself."
@@ -1121,6 +1129,14 @@
 
                 [delay]
                     time=1000
+                [/delay]
+
+                [sound]
+                    name=thunderstick-miss.ogg
+                [/sound]
+
+                [delay]
+                    time=1800
                 [/delay]
 
                 [message]


### PR DESCRIPTION
Used the dwarvish thunderer miss sound as a sound effect that plays in an event where a dwarf lights an explosive charge but if fails to detonate.
One of the subitems of #6197.