### PR TITLE
Utbs s6 add scroll to detonation event

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1240,6 +1240,23 @@
             message= _ "I couldn’t do it. Blow the backup charges! If we can’t stop them then maybe the black lake will."
         [/message]
 
+        {SCROLL_TO 12 20}
+
+        [remove_shroud]
+            side=1
+            x=11-15
+            y=19-23
+        [/remove_shroud]
+
+        [delay]
+            time=1200
+        [/delay]
+
+        [place_shroud]
+            side=1
+            x,y=11,19
+        [/place_shroud]
+
         {BACKUP_CHARGES}
 
         [remove_event]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -1031,6 +1031,14 @@
                     time=1000
                 [/delay]
 
+                [sound]
+                    name=thunderstick-miss.ogg
+                [/sound]
+
+                [delay]
+                    time=1800
+                [/delay]
+
                 [message]
                     speaker="East Scout"
                     message= _ "What?! Nothing happened! Who rigged the darn charges anyway? I’m going to have to hold them off by myself."
@@ -1121,6 +1129,14 @@
 
                 [delay]
                     time=1000
+                [/delay]
+
+                [sound]
+                    name=thunderstick-miss.ogg
+                [/sound]
+
+                [delay]
+                    time=1800
                 [/delay]
 
                 [message]


### PR DESCRIPTION
One of the subitems of #6197. When Jorgin dies, the map scrolls to the place where the detonation will occur. Some shroud is removed so that the player can see the event unfold.