### PR TITLE
Replace deprecated wesnoth.fire_event with wesnoth.game_events.fire

### DIFF
--- a/data/campaigns/Eastern_Invasion/lua/bandits.lua
+++ b/data/campaigns/Eastern_Invasion/lua/bandits.lua
@@ -62,7 +62,7 @@ local function bandits_found(x,y)
 		if rand3 <= boss_chance or #bandit_villages < 3 then
 			vars.boss_found = true
 			local loc = wesnoth.map.find({T["not"] { T.filter {} } , T["and"] { x = x, y = y, radius = 2 } })[1]
-			wesnoth.fire_event("boss_found", x, y, loc[1], loc[2])
+			wesnoth.game_events.fire("boss_found", x, y, loc[1], loc[2])
 		end
 	end
 end

--- a/data/campaigns/World_Conquest/lua/campaign/enemy.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/enemy.lua
@@ -215,7 +215,7 @@ end
 function enemy.init_data()
 	if wml.variables.wc2_enemy_army == nil then
 		-- give eras an option to overwrite the enemy data.
-		wesnoth.fire_event("wc2_init_enemy")
+		wesnoth.game_events.fire("wc2_init_enemy")
 	end
 	if wml.variables.wc2_enemy_army == nil then
 		-- give eras an option to overwrite the enemy data.

--- a/data/campaigns/World_Conquest/lua/campaign/scenario.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/scenario.lua
@@ -59,7 +59,7 @@ end
 -- carryover handling: we use a custom carryover machnics that
 -- splits the carryover gold evenly to all players
 on_event("prestart", function(cx)
-	wesnoth.fire_event("wc2_start")
+	wesnoth.game_events.fire("wc2_start")
 end)
 
 -- we need to do this also after difficulty selection.

--- a/data/campaigns/World_Conquest/lua/game_mechanics/dropping.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/dropping.lua
@@ -20,7 +20,7 @@ on_event("moveto", function(event_context)
 	for i, item in ipairs(items) do
 		dropping.current_item = item
 		dropping.item_taken = nil
-		wesnoth.fire_event("wc2_drop_pickup", x, y)
+		wesnoth.game_events.fire("wc2_drop_pickup", x, y)
 		if dropping.item_taken then
 			wesnoth.interface.remove_item(x,y, item.name)
 		end

--- a/data/lua/wml/move_unit.lua
+++ b/data/lua/wml/move_unit.lua
@@ -119,7 +119,7 @@ function wesnoth.wml_actions.move_unit(cfg)
 			end
 
 			if fire_event then
-				wesnoth.fire_event("moveto", x, y, x2, y2)
+				wesnoth.game_events.fire("moveto", x, y, x2, y2)
 			end
 		end
 	end


### PR DESCRIPTION
I tested and confirmed the deprecation warning and resolution for the bandits event in Eastern Invasion S5.

The only place I could find a `fire_event` within a `[move_unit]` block was the MP version of Legend of Wesmere S4 so I didn't test that one. I also didn't test World of Conquest.