### PR TITLE
Make modeless_dialog an actual window

### DIFF
--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -41,31 +41,7 @@ std::unique_ptr<window> build(const builder_window::window_resolution& definitio
 	// best size (if needed) after all widgets have been placed.
 	auto win = std::make_unique<window>(definition);
 	assert(win);
-
-	for(const auto& lg : definition.linked_groups) {
-		if(win->has_linked_size_group(lg.id)) {
-			t_string msg = VGETTEXT("Linked '$id' group has multiple definitions.", {{"id", lg.id}});
-
-			FAIL(msg);
-		}
-
-		win->init_linked_size_group(lg.id, lg.fixed_width, lg.fixed_height);
-	}
-
-	win->set_click_dismiss(definition.click_dismiss);
-
-	const auto conf = win->cast_config_to<window_definition>();
-	assert(conf);
-
-	if(conf->grid) {
-		win->init_grid(*conf->grid);
-		win->finalize(*definition.grid);
-	} else {
-		win->init_grid(*definition.grid);
-	}
-
-	win->add_to_keyboard_chain(win.get());
-
+	win->finish_build(definition);
 	return win;
 }
 

--- a/src/gui/dialogs/debug_clock.cpp
+++ b/src/gui/dialogs/debug_clock.cpp
@@ -17,7 +17,6 @@
 
 #include "gui/dialogs/debug_clock.hpp"
 
-#include "draw_manager.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/dialogs/modal_dialog.hpp"
 #include "gui/widgets/integer_selector.hpp"
@@ -35,57 +34,43 @@ namespace gui2::dialogs
 
 REGISTER_DIALOG(debug_clock)
 
-void debug_clock::pre_show(window& window)
+debug_clock::debug_clock()
+	: modeless_dialog(window_id())
+	, signal_()
+	, time_()
 {
 	hour_percentage_ = find_widget<progress_bar>(
-			&window, "hour_percentage", false, false);
+			this, "hour_percentage", false, false);
 	minute_percentage_ = find_widget<progress_bar>(
-			&window, "minute_percentage", false, false);
+			this, "minute_percentage", false, false);
 	second_percentage_ = find_widget<progress_bar>(
-			&window, "second_percentage", false, false);
+			this, "second_percentage", false, false);
 
-	hour_ = find_widget<integer_selector>(&window, "hour", false, false);
+	hour_ = find_widget<integer_selector>(this, "hour", false, false);
 	if(styled_widget *hour = dynamic_cast<styled_widget*>(hour_)) { //Note that the standard specifies that a dynamic cast of a null pointer is null
 		hour->set_active(false);
 	}
-	minute_ = find_widget<integer_selector>(&window, "minute", false, false);
+	minute_ = find_widget<integer_selector>(this, "minute", false, false);
 	if(styled_widget *minute = dynamic_cast<styled_widget*>(minute_)) {
 		minute->set_active(false);
 	}
-	second_ = find_widget<integer_selector>(&window, "second", false, false);
+	second_ = find_widget<integer_selector>(this, "second", false, false);
 	if(styled_widget *second = dynamic_cast<styled_widget*>(second_)) {
 		second->set_active(false);
 	}
 
-	pane_ = find_widget<pane>(&window, "pane", false, false);
+	pane_ = find_widget<pane>(this, "pane", false, false);
 
-	clock_ = find_widget<styled_widget>(&window, "clock", false, false);
-
-	draw_manager::register_drawable(this);
+	clock_ = find_widget<styled_widget>(this, "clock", false, false);
 
 	time_.set_current_time();
 	update_time(true);
 }
 
-void debug_clock::post_show()
-{
-	draw_manager::deregister_drawable(this);
-}
-
-void debug_clock::layout()
+void debug_clock::update()
 {
 	update_time(false);
-}
-
-rect debug_clock::screen_location()
-{
-	return get_window()->get_rectangle();
-}
-
-bool debug_clock::expose(const rect& /*region*/)
-{
-	// Drawing is handled by the window that this should be, but is not.
-	return false;
+	window::update();
 }
 
 void debug_clock::update_time(const bool force)

--- a/src/gui/dialogs/debug_clock.hpp
+++ b/src/gui/dialogs/debug_clock.hpp
@@ -47,23 +47,10 @@ namespace dialogs
  * second            | integer_selector |no       |This shows the seconds since the beginning of the current minute. The control should have a minimum_value of 0 and a maximum_value of 59.
  * clock             | control          |no       |A control which will have set three variables in its canvas:<ul><li>hour - the same value as the hour integer_selector.</li><li>minute - the same value as the minute integer_selector.</li><li>second - the same value as the second integer_selector.</li></ul>The control can then show the time in its own preferred format(s).
  */
-class debug_clock : public modeless_dialog, public top_level_drawable
+class debug_clock : public modeless_dialog
 {
 public:
-	debug_clock()
-		: modeless_dialog()
-		, hour_percentage_(nullptr)
-		, minute_percentage_(nullptr)
-		, second_percentage_(nullptr)
-		, hour_(nullptr)
-		, minute_(nullptr)
-		, second_(nullptr)
-		, pane_(nullptr)
-		, clock_(nullptr)
-		, signal_()
-		, time_()
-	{
-	}
+	debug_clock();
 
 private:
 	/** Progress bar for displaying the hours as a percentage. */
@@ -139,11 +126,8 @@ private:
 	 */
 	time time_;
 
+	/** The type of window this is. */
 	virtual const std::string& window_id() const override;
-
-	virtual void pre_show(window& window) override;
-
-	virtual void post_show();
 
 	/**
 	 * The callback for the drawing routine.
@@ -156,11 +140,8 @@ private:
 	 */
 	void update_time(const bool force);
 
-	// TODO: draw_manager - modeless dialog should be a window, fix
 	/* top_level_drawable interface */
-	virtual void layout() override;
-	virtual bool expose(const rect& region) override;
-	virtual rect screen_location() override;
+	virtual void update() override;
 };
 
 } // namespace dialogs

--- a/src/gui/dialogs/modeless_dialog.hpp
+++ b/src/gui/dialogs/modeless_dialog.hpp
@@ -15,14 +15,12 @@
 
 #pragma once
 
-#include <memory>
+#include "gui/widgets/window.hpp"
+
 #include <string>
 
 namespace gui2
 {
-
-class window;
-
 namespace dialogs
 {
 
@@ -32,7 +30,7 @@ namespace dialogs
  * At the moment these windows also don't capture the mouse and keyboard so can
  * only be used for things like tooltips. This behavior might change later.
  */
-class modeless_dialog
+class modeless_dialog : public window
 {
 	/**
 	 * Special helper function to get the id of the window.
@@ -51,7 +49,7 @@ class modeless_dialog
 	friend window* unit_test_window(const modeless_dialog& dialog);
 
 public:
-	modeless_dialog();
+	explicit modeless_dialog(const std::string& window_id);
 
 	virtual ~modeless_dialog();
 
@@ -70,52 +68,13 @@ public:
 	void show(const bool allow_interaction = false,
 			  const unsigned auto_close_time = 0);
 
-
-	/**
-	 * Hides the window.
-	 *
-	 * The hiding also destroys the window. It is save to call the function
-	 * when the window is not shown.
-	 */
-	void hide();
-
-	/** Returns a pointer to the dialog's window. Will be null if it hasn't been built yet. */
-	window* get_window() const
-	{
-		return window_.get();
-	}
-
-protected:
-	/** The window, used in show. */
-	std::unique_ptr<window> window_;
-
 private:
-	/** The id of the window to build. */
-	virtual const std::string& window_id() const = 0;
-
 	/**
-	 * Builds the window.
+	 * The ID of the window to build. Usually defined by REGISTER_DIALOG.
 	 *
-	 * Every dialog shows it's own kind of window, this function should return
-	 * the window to show.
-	 *
-	 * @returns                   The window to show.
+	 * Falls back to widget::id(), which is set during construction.
 	 */
-	std::unique_ptr<window> build_window() const;
-
-	/**
-	 * Actions to be taken directly after the window is build.
-	 *
-	 * @param window              The window just created.
-	 */
-	virtual void post_build(window& window);
-
-	/**
-	 * Actions to be taken before showing the window.
-	 *
-	 * @param window              The window to be shown.
-	 */
-	virtual void pre_show(window& window);
+	virtual const std::string& window_id() const { return widget::id(); }
 };
 
 } // namespace dialogs

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -74,7 +74,7 @@ class window : public panel, public top_level_drawable
 public:
 	explicit window(const builder_window::window_resolution& definition);
 
-	~window();
+	virtual ~window();
 
 	/**
 	 * Returns the instance of a window.
@@ -87,6 +87,8 @@ public:
 
 	/** Gets the retval for the default buttons. */
 	static retval get_retval_by_id(const std::string& id);
+
+	void finish_build(const builder_window::window_resolution&);
 
 	/**
 	 * Shows the window, running an event loop until it should close.

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -152,11 +152,6 @@ std::string unit_test_mark_popup_as_tested(const modeless_dialog& dialog)
 	return dialog.window_id();
 }
 
-window* unit_test_window(const modeless_dialog& dialog)
-{
-	return dialog.window_.get();
-}
-
 } // namespace dialogs
 } // namespace gui2
 
@@ -235,7 +230,7 @@ namespace {
 				std::string exception;
 				try {
 					dlg->show(interact);
-					gui2::window* window = unit_test_window((*dlg.get()));
+					gui2::window* window = dlg.get();
 					BOOST_REQUIRE_NE(window, static_cast<void*>(nullptr));
 					window->draw();
 				} catch(const gui2::layout_exception_width_modified&) {


### PR DESCRIPTION
Not only was it conceptually confusing that a modeless dialog was not a window, but it causes several inefficiencies and general incapabilities when converting to use the new draw system.

So here i made a modeless dialog a window. This was the easy one as there are basically no modeless dialogs right now. Basically just tooltips and the debug clock.

As a note this will slightly invalidate #5561 which also uses a modeless dialog. But any changes are minimal and can be tacked on to whichever gets merged second.

The window builder finalization stuff was moved to a method of `window` so it can be called in the modeless dialog constructor.

As far as practical usage changes go... most stuff that was previously in "post_build" and "pre_show" virtual callbacks can simply go into the subclass constructor.

Modeless dialogs now require the window id to be given as a constructor parameter. This is becaues the virtual function that is defined by `REGISTER_DIALOG` is not able to be called from the `modeless_dialog` cosntructor. It is simply called from the subclass constructor and passed on.