### PR TITLE
addon/client: Add file operation progress dialog for installing add-ons

### DIFF
--- a/data/gui/window/file_progress.cfg
+++ b/data/gui/window/file_progress.cfg
@@ -1,14 +1,14 @@
 #textdomain wesnoth-lib
 ###
-### Dialog that tracks progress of a network transmission
+### Modeless dialog that tracks progress of a file operation
 ###
-### NOTE: The dialog layout is intended to match file_progress' since they are
-### both used during the add-on download/install flow.
+### NOTE: The dialog layout is intended to match network_transmission's since
+### they are both used during the add-on download/install flow.
 ###
 
 [window]
-	id = "network_transmission"
-	description = "Dialog that tracks progress of a network transmission"
+	id = "file_progress"
+	description = "Modeless dialog that tracks progress of a file operation"
 
 	[resolution]
 		definition = "default"
@@ -51,7 +51,7 @@
 					horizontal_alignment = "left"
 
 					[label]
-						id = "subtitle"
+						id = "message"
 						definition = "default"
 					[/label]
 
@@ -81,40 +81,18 @@
 
 				[column]
 
-					horizontal_grow = true
+					horizontal_alignment = "right"
+					grow_factor = 0
+					border = "all"
+					border_size = 5
 
-					[grid]
-
-						[row]
-
-							[column]
-								grow_factor = 1
-								border = "all"
-								border_size = 5
-								horizontal_grow = true
-
-								[label]
-									id = "numeric_progress"
-									definition = "gold_small"
-								[/label]
-
-							[/column]
-
-							[column]
-								grow_factor = 0
-								border = "all"
-								border_size = 5
-
-								[button]
-									id = "cancel"
-									definition = "default"
-									label = _ "Cancel"
-								[/button]
-
-							[/column]
-
-						[/row]
-					[/grid]
+					[button]
+						# This button is only used for decoration and doesn't
+						# actually do anything, hence the nonstandard id.
+						id = "placeholder"
+						definition = "default"
+						label = _ "Cancel"
+					[/button]
 
 				[/column]
 

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -323,6 +323,8 @@
 		46F92DBA2174F6A300602C1C /* help_browser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F92C692174F6A300602C1C /* help_browser.cpp */; };
 		46F92DBB2174F6A300602C1C /* file_dialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F92C6B2174F6A300602C1C /* file_dialog.cpp */; };
 		46F92DBC2174F6A300602C1C /* file_dialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F92C6B2174F6A300602C1C /* file_dialog.cpp */; };
+		1234567890ABCDEF12345678 /* file_progress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1234567890ABCDEF12345680 /* file_progress.cpp */; };
+		1234567890ABCDEF12345679 /* file_progress.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1234567890ABCDEF12345680 /* file_progress.cpp */; };
 		46F92DBD2174F6A300602C1C /* folder_create.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F92C6E2174F6A300602C1C /* folder_create.cpp */; };
 		46F92DBE2174F6A300602C1C /* folder_create.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F92C6E2174F6A300602C1C /* folder_create.cpp */; };
 		46F92DBF2174F6A300602C1C /* language_selection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46F92C6F2174F6A300602C1C /* language_selection.cpp */; };
@@ -1731,6 +1733,7 @@
 		46F92C692174F6A300602C1C /* help_browser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = help_browser.cpp; sourceTree = "<group>"; };
 		46F92C6A2174F6A300602C1C /* title_screen.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = title_screen.hpp; sourceTree = "<group>"; };
 		46F92C6B2174F6A300602C1C /* file_dialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_dialog.cpp; sourceTree = "<group>"; };
+		1234567890ABCDEF12345680 /* file_progress.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = file_progress.cpp; sourceTree = "<group>"; };
 		46F92C6C2174F6A300602C1C /* attack_predictions.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = attack_predictions.hpp; sourceTree = "<group>"; };
 		46F92C6D2174F6A300602C1C /* tooltip.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tooltip.hpp; sourceTree = "<group>"; };
 		46F92C6E2174F6A300602C1C /* folder_create.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = folder_create.cpp; sourceTree = "<group>"; };
@@ -1756,6 +1759,7 @@
 		46F92C822174F6A300602C1C /* unit_recruit.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unit_recruit.cpp; sourceTree = "<group>"; };
 		46F92C832174F6A300602C1C /* edit_text.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = edit_text.cpp; sourceTree = "<group>"; };
 		46F92C842174F6A300602C1C /* file_dialog.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file_dialog.hpp; sourceTree = "<group>"; };
+		1234567890ABCDEF12345681 /* file_progress.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file_progress.hpp; sourceTree = "<group>"; };
 		46F92C852174F6A300602C1C /* attack_predictions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = attack_predictions.cpp; sourceTree = "<group>"; };
 		46F92C862174F6A300602C1C /* tooltip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tooltip.cpp; sourceTree = "<group>"; };
 		46F92C872174F6A300602C1C /* title_screen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = title_screen.cpp; sourceTree = "<group>"; };
@@ -3623,6 +3627,8 @@
 				46F92C8D2174F6A300602C1C /* end_credits.hpp */,
 				46F92C6B2174F6A300602C1C /* file_dialog.cpp */,
 				46F92C842174F6A300602C1C /* file_dialog.hpp */,
+				1234567890ABCDEF12345680 /* file_progress.cpp */,
+				1234567890ABCDEF12345681 /* file_progress.hpp */,
 				46F92C6E2174F6A300602C1C /* folder_create.cpp */,
 				46F92C8A2174F6A300602C1C /* folder_create.hpp */,
 				46F92CBB2174F6A300602C1C /* formula_debugger.cpp */,
@@ -5497,6 +5503,7 @@
 				B52EE8D6121359A600CFBDAB /* persist_context.cpp in Sources */,
 				B52EE8D7121359A600CFBDAB /* persist_manager.cpp in Sources */,
 				46F92DBB2174F6A300602C1C /* file_dialog.cpp in Sources */,
+				1234567890ABCDEF12345678 /* file_progress.cpp in Sources */,
 				46F92F0F2174FEC000602C1C /* standard_colors.cpp in Sources */,
 				46F92E852174F6A400602C1C /* debug.cpp in Sources */,
 				B52EE8D8121359A600CFBDAB /* persist_var.cpp in Sources */,
@@ -6116,6 +6123,7 @@
 				46F92E142174F6A400602C1C /* player_list_helper.cpp in Sources */,
 				91E3570A1CACC9B200774252 /* playcampaign.cpp in Sources */,
 				46F92DBC2174F6A300602C1C /* file_dialog.cpp in Sources */,
+				1234567890ABCDEF12345679 /* file_progress.cpp in Sources */,
 				91E3570B1CACC9B200774252 /* singleplayer.cpp in Sources */,
 				4649B88B20288EEF00827CFB /* surface.cpp in Sources */,
 				46F92DB02174F6A300602C1C /* campaign_selection.cpp in Sources */,

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -193,6 +193,7 @@ gui/dialogs/editor/new_map.cpp
 gui/dialogs/editor/resize_map.cpp
 gui/dialogs/end_credits.cpp
 gui/dialogs/file_dialog.cpp
+gui/dialogs/file_progress.cpp
 gui/dialogs/folder_create.cpp
 gui/dialogs/formula_debugger.cpp
 gui/dialogs/game_cache_options.cpp

--- a/src/addon/manager.hpp
+++ b/src/addon/manager.hpp
@@ -33,6 +33,7 @@ class version_info;
 
 #include "addon/validation.hpp"
 
+#include <functional>
 #include <string>
 #include <vector>
 #include <utility>
@@ -153,7 +154,7 @@ bool is_addon_installed(const std::string& addon_name);
 void archive_addon(const std::string& addon_name, class config& cfg);
 
 /** Unarchives an add-on from campaignd's retrieved config object. */
-void unarchive_addon(const class config& cfg);
+void unarchive_addon(const class config& cfg, std::function<void(unsigned)> progress_callback = {});
 
 /** Removes the listed files from the addon. */
 void purge_addon(const config& removelist);

--- a/src/gui/dialogs/file_progress.cpp
+++ b/src/gui/dialogs/file_progress.cpp
@@ -1,0 +1,80 @@
+/*
+   Copyright (C) 2021 by Iris Morelle <shadowm@wesnoth.org>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "gui/dialogs/file_progress.hpp"
+
+#include "gui/auxiliary/find_widget.hpp"
+#include "gui/widgets/button.hpp"
+#include "gui/dialogs/modal_dialog.hpp"
+#include "gui/widgets/label.hpp"
+#include "gui/widgets/progress_bar.hpp"
+#include "gui/widgets/settings.hpp"
+#include "gui/widgets/window.hpp"
+
+namespace gui2::dialogs {
+
+REGISTER_WINDOW(file_progress)
+
+const std::string& file_progress::window_id() const
+{
+	static std::string wid = "file_progress";
+	return wid;
+}
+
+file_progress::file_progress(const std::string& title, const std::string& message)
+	: title_(title)
+	, message_(message)
+	, update_time_()
+{
+}
+
+void file_progress::pre_show(window& window)
+{
+	find_widget<label>(&window, "title", false).set_label(title_);
+	auto& message = find_widget<label>(&window, "message", false);
+
+	message.set_use_markup(true);
+	message.set_label(message_);
+
+	find_widget<button>(&window, "placeholder", false).set_active(false);
+
+	update_time_ = clock::now();
+}
+
+void file_progress::update_progress(unsigned value)
+{
+	auto* window = get_window();
+
+	if(!window) {
+		return;
+	}
+
+	using std::chrono::duration_cast;
+	using std::chrono::milliseconds;
+	using namespace std::chrono_literals;
+
+	auto now = clock::now();
+
+	if(duration_cast<milliseconds>(now - update_time_) < 120ms) {
+		return;
+	}
+
+	find_widget<progress_bar>(window, "progress", false).set_percentage(value);
+	force_redraw();
+	update_time_ = now;
+}
+
+}

--- a/src/gui/dialogs/file_progress.cpp
+++ b/src/gui/dialogs/file_progress.cpp
@@ -39,21 +39,18 @@ const std::string& file_progress::window_id() const
 }
 
 file_progress::file_progress(const std::string& title, const std::string& message)
-	: title_(title)
+	: modeless_dialog(file_progress::window_id())
+	, title_(title)
 	, message_(message)
 	, update_time_()
 {
-}
+	find_widget<label>(this, "title", false).set_label(title_);
+	auto& label_widget = find_widget<label>(this, "message", false);
 
-void file_progress::pre_show(window& window)
-{
-	find_widget<label>(&window, "title", false).set_label(title_);
-	auto& message = find_widget<label>(&window, "message", false);
+	label_widget.set_use_markup(true);
+	label_widget.set_label(message_);
 
-	message.set_use_markup(true);
-	message.set_label(message_);
-
-	find_widget<button>(&window, "placeholder", false).set_active(false);
+	find_widget<button>(this, "placeholder", false).set_active(false);
 
 	update_time_ = clock::now();
 }

--- a/src/gui/dialogs/file_progress.hpp
+++ b/src/gui/dialogs/file_progress.hpp
@@ -1,0 +1,53 @@
+/*
+   Copyright (C) 2021 by Iris Morelle <shadowm@wesnoth.org>
+   Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "gui/dialogs/modeless_dialog.hpp"
+
+#include <chrono>
+
+namespace gui2::dialogs {
+
+class file_progress : public modeless_dialog
+{
+public:
+	file_progress(const std::string& title, const std::string& message);
+
+	template<typename... T>
+	static auto display(T&&... args)
+	{
+		auto instance = std::make_unique<file_progress>(std::forward<T>(args)...);
+		instance->show(true);
+		return instance;
+	}
+
+	void update_progress(unsigned value);
+
+private:
+	/** Inherited from modeless_dialog. */
+	virtual const std::string& window_id() const override;
+
+	/** Inherited from modeless_dialog. */
+	virtual void pre_show(window& window) override;
+
+	std::string title_;
+	std::string message_;
+
+	using clock = std::chrono::steady_clock;
+
+	std::chrono::time_point<clock> update_time_;
+};
+
+}

--- a/src/gui/dialogs/file_progress.hpp
+++ b/src/gui/dialogs/file_progress.hpp
@@ -39,9 +39,6 @@ private:
 	/** Inherited from modeless_dialog. */
 	virtual const std::string& window_id() const override;
 
-	/** Inherited from modeless_dialog. */
-	virtual void pre_show(window& window) override;
-
 	std::string title_;
 	std::string message_;
 

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -646,6 +646,7 @@ BOOST_AUTO_TEST_CASE(test_last)
 		"sp_options_configure",// segfault with LTO
 		"campaign_selection",// segfault with LTO
 		"game_load",// segfault after disabling the above tests
+		"file_progress",
 	};
 	filesystem::delete_file(test_gui2_fixture::widgets_file);
 


### PR DESCRIPTION
This implements an add-on extraction progress dialog that does not actually run its own event loop, allowing the caller to take ownership of it (`display()` static method) and update its state using a callback function object.

The dialog is roughly identical to the network progress dialog, except for the greyed out Cancel button. This is intentional so that the dialogs can be transitioned more or less seamlessly into each other by the add-ons client code.

![image](https://user-images.githubusercontent.com/489895/108446452-e6c1d900-723c-11eb-8b1c-cb18894a7057.png)

In order to avoid stalling the extraction process in UI code, the callback is invoked for every single file, but the dialog's progress update method places a time restriction on GUI2 API calls of 120 milliseconds -- this is a good throttle interval that allows add-ons to be extracted in about the same amount of time as before while still updating the progress bar smoothly enough for add-ons that take longer than that.

(This is not the most trivial code to test, so it is suggested to add a sleep/delay API call in `unarchive_file()` in src/addon/manager.cpp to introduce artificial delays.)

One issue with this code, however, is that because `modeless_dialog` doesn't execute its own event loop, the only way to get the dialog to be updated is to force a draw event in ourselves via the new `gui2::dialogs::modeless_dialog::force_redraw()` method. This is really a side-effect of my design choice here to run the dialog in the middle of a blocking operation instead of somewhere where events are being processed normally. I'm not entirely sure if the draw events would be pushed even in that case, however.

---

This is a re-PR of #5561