### PR TITLE
Fix crash in update_fps_label()

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1345,11 +1345,10 @@ static unsigned calculate_fps(unsigned frametime)
 
 void display::update_fps_label()
 {
-	static int frames = 0;
-	++frames;
+	++current_frame_sample;
 	const int sample_freq = 10;
 
-	if(frames != sample_freq) {
+	if(current_frame_sample != sample_freq) {
 		return;
 	}
 
@@ -1359,7 +1358,7 @@ void display::update_fps_label()
 	const int max_fps = calculate_fps(*minmax_it.first);
 	const int min_fps = calculate_fps(*minmax_it.second);
 	fps_history_.emplace_back(min_fps, avg_fps, max_fps);
-	frames = 0;
+	current_frame_sample = 0;
 
 	// flush out the stored fps values every so often
 	if(fps_history_.size() == 1000) {

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -767,6 +767,7 @@ protected:
 	mutable events::generic_event scroll_event_;
 
 	boost::circular_buffer<unsigned> frametimes_; // in milliseconds
+	int current_frame_sample = 0;
 	unsigned int fps_counter_;
 	std::chrono::seconds fps_start_;
 	unsigned int fps_actual_;


### PR DESCRIPTION
update_fps_label() uses a static variable to track current frame sample.
This causes division by zero while loading a save file if the
variable was previously equal to 9.

The commit changes the variable to private member to match its lifetime
with a lifetime of frametimes_ circular buffer.

Fixes: #5670