### PR TITLE
Fixed vcpkg build issue for port update to 2.6.1

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -267,7 +267,7 @@ jobs:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: win-cache-0005
+          key: win-cache-0006
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -322,4 +322,3 @@ jobs:
             pusher: ${{ github.actor }}
             commit: ${{ github.event.head_commit.message }}
             commit url: ${{ github.event.head_commit.url }}
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,7 +501,7 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 		# for MSVC, vcpkg builds and provides custom SDL2-related modules for cmake to use, so use those
 		# this also fixes the issue with our previous FindSDL2* scripts incorrectly using the Release version of these libs instead of the Debug version
 		find_package(sdl2-image CONFIG REQUIRED)
-		find_package(sdl2-mixer CONFIG REQUIRED)
+		find_package(SDL2_mixer CONFIG REQUIRED)
 	endif()
 	pkg_check_modules(CAIRO REQUIRED cairo>=1.10)
 	pkg_check_modules(PANGOCAIRO REQUIRED pangocairo>=1.22.0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,7 +251,7 @@ if(ENABLE_GAME)
 	)
 	if(MSVC)
 		target_link_libraries(wesnoth SDL2::SDL2_image)
-		target_link_libraries(wesnoth SDL2::SDL2_mixer)
+		target_link_libraries(wesnoth SDL2_mixer::SDL2_mixer)
 	endif()
 
 	if(ENABLE_DISPLAY_REVISION)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,7 +298,7 @@ if(ENABLE_TESTS)
 	)
 	if(MSVC)
 		target_link_libraries(boost_unit_tests SDL2::SDL2_image)
-		target_link_libraries(boost_unit_tests SDL2::SDL2_mixer)
+		target_link_libraries(boost_unit_tests SDL2_mixer::SDL2_mixer)
 	endif()
 
 	if(ENABLE_DISPLAY_REVISION)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,7 @@
     "libwebp",
     {
       "name": "sdl2-mixer",
-      "features": [ "libvorbis", "dynamic-load" ]
+      "features": [ "libvorbis" ]
     },
     "bzip2",
     "zlib",


### PR DESCRIPTION
Relevant vcpkg PR: https://github.com/microsoft/vcpkg/pull/25763