### PR TITLE
Rename display::current_frame_sample

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1345,10 +1345,10 @@ static unsigned calculate_fps(unsigned frametime)
 
 void display::update_fps_label()
 {
-	++current_frame_sample;
+	++current_frame_sample_;
 	const int sample_freq = 10;
 
-	if(current_frame_sample != sample_freq) {
+	if(current_frame_sample_ != sample_freq) {
 		return;
 	}
 
@@ -1358,7 +1358,7 @@ void display::update_fps_label()
 	const int max_fps = calculate_fps(*minmax_it.first);
 	const int min_fps = calculate_fps(*minmax_it.second);
 	fps_history_.emplace_back(min_fps, avg_fps, max_fps);
-	current_frame_sample = 0;
+	current_frame_sample_ = 0;
 
 	// flush out the stored fps values every so often
 	if(fps_history_.size() == 1000) {

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -767,7 +767,7 @@ protected:
 	mutable events::generic_event scroll_event_;
 
 	boost::circular_buffer<unsigned> frametimes_; // in milliseconds
-	int current_frame_sample = 0;
+	int current_frame_sample_ = 0;
 	unsigned int fps_counter_;
 	std::chrono::seconds fps_start_;
 	unsigned int fps_actual_;


### PR DESCRIPTION
Rename display::current_frame_sample to display::current_frame_sample_ for consistency.