### PR TITLE
Add "attack_alignment" weapon special/ability for specific attacks

### DIFF
--- a/changelog_entries/[attack_alignment]_changelog.md
+++ b/changelog_entries/[attack_alignment]_changelog.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Add a [attack_alignment] special to change the alignment of an attack under specific conditions (terrain, leadership, etc) with customise alignment possible

--- a/changelog_entries/[unit_alignment]_[attack_alignment]_changelog.md
+++ b/changelog_entries/[unit_alignment]_[attack_alignment]_changelog.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Add a attack_alignment in [attack] to change the alignment of an attack if name used matche with lawful|neutral|chaotic|liminal alignment, but [filter_weapon] and formula check the string write in wml code.

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -3,6 +3,7 @@
 	name="$filter_weapon"
 	max=0
 	{SIMPLE_KEY range string_list}
+	{SIMPLE_KEY attack_alignment alignment}
 	{SIMPLE_KEY name string_list}
 	{SIMPLE_KEY type string_list}
 	{SIMPLE_KEY special string_list}

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -139,6 +139,7 @@
 {BASED_ON_SPECIAL "poison"}
 {BASED_ON_SPECIAL "slow"}
 {BASED_ON_SPECIAL "petrifies"}
+{BASED_ON_SPECIAL "attack_alignment"}
 [tag]
 	name="*"
 	max=infinite

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -27,7 +27,8 @@
 				{SIMPLE_KEY set_type string}
 				{SIMPLE_KEY set_icon string}
 				{SIMPLE_KEY set_range string}
-				
+				{SIMPLE_KEY set_attack_alignment string}
+
 				{SIMPLE_KEY set_damage s_int}
 				{SIMPLE_KEY set_attacks s_int}
 				{SIMPLE_KEY set_parry s_int}

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -66,6 +66,12 @@
 	[/tag]
 [/tag]
 [tag]
+	name="attack_alignment"
+	max=infinite
+	super="units/unit_type/attack/specials/~value~"
+	{SIMPLE_KEY alignment alignment}
+[/tag]
+[tag]
 	name="attacks"
 	max=infinite
 	super="units/unit_type/attack/specials/~value~"

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -50,6 +50,7 @@
 		{SIMPLE_KEY icon string}
 		{SIMPLE_KEY type string}
 		{SIMPLE_KEY range string}
+		{SIMPLE_KEY attack_alignment alignment}
 		{SIMPLE_KEY damage int}
 		{SIMPLE_KEY number int}
 		{SIMPLE_KEY defense_weight real}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_alignment.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_alignment.cfg
@@ -1,0 +1,58 @@
+#textdomain wesnoth-test
+
+{COMMON_KEEP_A_B_UNIT_TEST "special_alignment_test" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {ABILITY_ILLUMINATES}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attack_alignment]
+                        alignment=lawful
+                    [/attack_alignment]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 125}
+        {SUCCEED}
+    [/event]
+)}
+
+{COMMON_KEEP_A_B_UNIT_TEST "special_custom_alignment_test" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {ABILITY_ILLUMINATES}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attack_alignment]
+                        alignment=lawful
+                        multiply=2
+                    [/attack_alignment]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 150}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/Attacks/attack_alignment.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/Attacks/attack_alignment.cfg
@@ -1,0 +1,24 @@
+#textdomain wesnoth-test
+
+{COMMON_KEEP_A_B_UNIT_TEST "attack_alignment_test" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {ABILITY_ILLUMINATES}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                set_attack_alignment=lawful
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 125}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -187,7 +187,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	// Time of day bonus.
 	damage_multiplier += combat_modifier(
-			resources::gameboard->units(), resources::gameboard->map(), u_loc, u.alignment(), u.is_fearless());
+			resources::gameboard->units(), resources::gameboard->map(), u_loc, weapon->alignment_in_attack(), u.is_fearless());
 
 	// Leadership bonus.
 	int leader_bonus = under_leadership(u, u_loc, weapon, opp_weapon);
@@ -316,7 +316,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	int base_damage = weapon->modified_damage();
 	int damage_multiplier = 100;
 	damage_multiplier
-			+= generic_combat_modifier(lawful_bonus, u_type->alignment(), u_type->musthave_status("fearless"), 0);
+			+= generic_combat_modifier(lawful_bonus, weapon->alignment_in_attack(), u_type->musthave_status("fearless"), 0);
 	damage_multiplier *= opp_type->resistance_against(weapon->type(), !attacking);
 
 	damage = round_damage(base_damage, damage_multiplier, 10000);

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -186,8 +186,9 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 	int damage_multiplier = 100;
 
 	// Time of day bonus.
+	std::pair<unit_alignments::type, int> alignment = weapon->specials_alignment();
 	damage_multiplier += combat_modifier(
-			resources::gameboard->units(), resources::gameboard->map(), u_loc, weapon->alignment_in_attack(), u.is_fearless());
+			resources::gameboard->units(), resources::gameboard->map(), u_loc, alignment.first, u.is_fearless(), alignment.second);
 
 	// Leadership bonus.
 	int leader_bonus = under_leadership(u, u_loc, weapon, opp_weapon);
@@ -1583,23 +1584,23 @@ int combat_modifier(const unit_map& units,
 		const gamemap& map,
 		const map_location& loc,
 		unit_alignments::type alignment,
-		bool is_fearless)
+		bool is_fearless, int special_bonus)
 {
 	const tod_manager& tod_m = *resources::tod_manager;
 	const time_of_day& effective_tod = tod_m.get_illuminated_time_of_day(units, map, loc);
-	return combat_modifier(effective_tod, alignment, is_fearless);
+	return combat_modifier(effective_tod, alignment, is_fearless, special_bonus);
 }
 
 int combat_modifier(const time_of_day& effective_tod,
 		unit_alignments::type alignment,
-		bool is_fearless)
+		bool is_fearless, int special_bonus)
 {
 	const tod_manager& tod_m = *resources::tod_manager;
 	const int lawful_bonus = effective_tod.lawful_bonus;
-	return generic_combat_modifier(lawful_bonus, alignment, is_fearless, tod_m.get_max_liminal_bonus());
+	return generic_combat_modifier(lawful_bonus, alignment, is_fearless, tod_m.get_max_liminal_bonus(), special_bonus);
 }
 
-int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, bool is_fearless, int max_liminal_bonus)
+int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, bool is_fearless, int max_liminal_bonus, int special_bonus)
 {
 	int bonus;
 
@@ -1620,6 +1621,7 @@ int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, b
 		bonus = 0;
 	}
 
+	bonus *= special_bonus;
 	if(is_fearless) {
 		bonus = std::max<int>(bonus, 0);
 	}

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -279,7 +279,7 @@ int combat_modifier(const unit_map& units,
 		const gamemap& map,
 		const map_location& loc,
 		unit_alignments::type alignment,
-		bool is_fearless);
+		bool is_fearless, int special_bonus = 1);
 
 /**
  * Returns the amount that a unit's damage should be multiplied by
@@ -287,13 +287,13 @@ int combat_modifier(const unit_map& units,
  */
 int combat_modifier(const time_of_day& effective_tod,
 		unit_alignments::type alignment,
-		bool is_fearless);
+		bool is_fearless, int special_bonus = 1);
 
 /**
  * Returns the amount that a unit's damage should be multiplied by
  * due to a given lawful_bonus.
  */
-int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, bool is_fearless, int max_liminal_bonus);
+int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, bool is_fearless, int max_liminal_bonus, int special_bonus = 1);
 /**
  * Function to check if an attack will satisfy the requirements for backstab.
  * Input:

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -93,6 +93,8 @@ variant attack_type_callable::get_value(const std::string& key) const
 		return variant(att_->icon());
 	} else if(key == "range") {
 		return variant(att_->range());
+	} else if(key == "attack_alignment") {
+		return variant(att_->attack_alignment());
 	} else if(key == "damage") {
 		return variant(att_->damage());
 	} else if(key == "number_of_attacks" || key == "number" || key == "num_attacks" || key == "attacks") {
@@ -130,6 +132,7 @@ void attack_type_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "description");
 	add_input(inputs, "icon");
 	add_input(inputs, "range");
+	add_input(inputs, "attack_alignment");
 	add_input(inputs, "damage");
 	add_input(inputs, "number");
 	add_input(inputs, "accuracy");
@@ -166,6 +169,10 @@ int attack_type_callable::do_compare(const formula_callable* callable) const
 
 	if(att_->range() != att_callable->att_->range()) {
 		return att_->range().compare(att_callable->att_->range());
+	}
+
+	if(att_->attack_alignment() != att_callable->att_->attack_alignment()) {
+		return att_->attack_alignment().compare(att_callable->att_->attack_alignment());
 	}
 
 	const auto self_specials = att_->specials().all_children_range();

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -225,7 +225,7 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	const unit& u = *attacker.unit_;
 
 	const int tod_modifier = combat_modifier(resources::gameboard->units(), resources::gameboard->map(),
-		u.get_location(), u.alignment(), u.is_fearless());
+		u.get_location(), weapon->alignment_in_attack(), u.is_fearless());
 
 	if(tod_modifier != 0) {
 		set_label_helper("tod_modifier", utils::signed_percent(tod_modifier));

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -224,8 +224,9 @@ void attack_predictions::set_data(window& window, const combatant_data& attacker
 	// Time of day modifier.
 	const unit& u = *attacker.unit_;
 
+	std::pair<unit_alignments::type, int> alignment = weapon->specials_alignment();
 	const int tod_modifier = combat_modifier(resources::gameboard->units(), resources::gameboard->map(),
-		u.get_location(), weapon->alignment_in_attack(), u.is_fearless());
+		u.get_location(), alignment.first, u.is_fearless(), alignment.second);
 
 	if(tod_modifier != 0) {
 		set_label_helper("tod_modifier", utils::signed_percent(tod_modifier));

--- a/src/gui/dialogs/unit_attack.cpp
+++ b/src/gui/dialogs/unit_attack.cpp
@@ -131,13 +131,13 @@ void unit_attack::pre_show(window& window)
 
 		const std::set<std::string> checking_tags_other = {"damage_type", "disable", "berserk", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 		std::string attw_specials = attacker_weapon.weapon_specials();
-		std::string attw_specials_dmg = attacker_weapon.weapon_specials_value({"leadership", "damage"});
+		std::string attw_specials_dmg = attacker_weapon.weapon_specials_value({"leadership", "damage", "attack_alignment"});
 		std::string attw_specials_atk = attacker_weapon.weapon_specials_value({"attacks", "swarm"});
 		std::string attw_specials_cth = attacker_weapon.weapon_specials_value({"chance_to_hit"});
 		std::string attw_specials_others = attacker_weapon.weapon_specials_value(checking_tags_other);
 		bool defender_attack = !(defender_weapon.name().empty() && defender_weapon.damage() == 0 && defender_weapon.num_attacks() == 0 && defender.chance_to_hit == 0);
 		std::string defw_specials = defender_attack ? defender_weapon.weapon_specials() : "";
-		std::string defw_specials_dmg = defender_attack ? defender_weapon.weapon_specials_value({"leadership", "damage"}) : "";
+		std::string defw_specials_dmg = defender_attack ? defender_weapon.weapon_specials_value({"leadership", "damage", "attack_alignment"}) : "";
 		std::string defw_specials_atk = defender_attack ? defender_weapon.weapon_specials_value({"attacks", "swarm"}) : "";
 		std::string defw_specials_cth = defender_attack ? defender_weapon.weapon_specials_value({"chance_to_hit"}) : "";
 		std::string defw_specials_others = defender_attack ? defender_weapon.weapon_specials_value(checking_tags_other) : "";

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -786,8 +786,8 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		int specials_damage = at.modified_damage();
 		int damage_multiplier = 100;
 		const_attack_ptr weapon  = at.shared_from_this();
-		unit_alignments::type alignment = weapon->alignment_in_attack();
-		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), alignment, u.is_fearless());
+		std::pair<unit_alignments::type, int> alignment = weapon->specials_alignment();
+		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), alignment.first, u.is_fearless(), alignment.second);
 		damage_multiplier += tod_bonus;
 		int leader_bonus = under_leadership(u, hex, weapon);
 		if (leader_bonus != 0)
@@ -957,9 +957,9 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		add_text(res, damage_and_num_attacks.str, damage_and_num_attacks.tooltip);
 		add_text(res, damage_versus.str, damage_versus.tooltip); // This string is usually empty
 
-		if(alignment != u.alignment()){
-			const std::string align = unit_type::alignment_description(alignment, u.gender());
-			const std::string align_id = unit_alignments::get_string(alignment);
+		if(alignment.first != u.alignment() || alignment.second != 1){
+			const std::string align = unit_type::alignment_description(alignment.first, u.gender());
+			const std::string align_id = unit_alignments::get_string(alignment.first);
 
 			color_t color = font::weapon_color;
 			if (tod_bonus != 0)

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -786,7 +786,8 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		int specials_damage = at.modified_damage();
 		int damage_multiplier = 100;
 		const_attack_ptr weapon  = at.shared_from_this();
-		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), u.alignment(), u.is_fearless());
+		unit_alignments::type alignment = weapon->alignment_in_attack();
+		int tod_bonus = combat_modifier(get_visible_time_of_day_at(rc, hex), alignment, u.is_fearless());
 		damage_multiplier += tod_bonus;
 		int leader_bonus = under_leadership(u, hex, weapon);
 		if (leader_bonus != 0)
@@ -955,6 +956,23 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		}
 		add_text(res, damage_and_num_attacks.str, damage_and_num_attacks.tooltip);
 		add_text(res, damage_versus.str, damage_versus.tooltip); // This string is usually empty
+
+		if(alignment != u.alignment()){
+			const std::string align = unit_type::alignment_description(alignment, u.gender());
+			const std::string align_id = unit_alignments::get_string(alignment);
+
+			color_t color = font::weapon_color;
+			if (tod_bonus != 0)
+				color = (tod_bonus > 0) ? font::good_dmg_color : font::bad_dmg_color;
+
+			str << align << " (" << span_color(color) << utils::signed_percent(tod_bonus)
+				<< naps << ")";
+
+			tooltip << _("Alignment: ") << "<b>" << align << "</b>\n"
+				<< string_table[align_id + "_description"];
+
+			add_text(res, flush(str), flush(tooltip));
+		}
 
 		const std::string &accuracy_parry = at.accuracy_parry_description();
 		if (!accuracy_parry.empty())

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -257,6 +257,7 @@ static int impl_unit_attack_get(lua_State *L)
 	return_string_attrib("type", attack.type());
 	return_string_attrib("icon", attack.icon());
 	return_string_attrib("range", attack.range());
+	return_string_attrib("attack_alignment", attack.attack_alignment());
 	return_int_attrib("damage", attack.damage());
 	return_int_attrib("number", attack.num_attacks());
 	return_float_attrib("attack_weight", attack.attack_weight());
@@ -290,6 +291,7 @@ static int impl_unit_attack_set(lua_State *L)
 	modify_string_attrib("type", attack.set_type(value));
 	modify_string_attrib("icon", attack.set_icon(value));
 	modify_string_attrib("range", attack.set_range(value));
+	modify_string_attrib("attack_alignment", attack.set_attack_alignment(value));
 	modify_int_attrib("damage", attack.set_damage(value));
 	modify_int_attrib("number", attack.set_num_attacks(value));
 	modify_int_attrib("attack_weight", attack.set_attack_weight(value));

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1284,6 +1284,19 @@ int attack_type::modified_damage() const
 	return damage_value;
 }
 
+unit_alignments::type attack_type::alignment_in_attack() const
+{
+	std::optional<unit_alignments::type> align = unit_alignments::get_enum(attack_alignment());
+	if(self_){
+		//here the value returned can't be null, if self_ exist like in attack.cpp and gui and report functions, unit alignment returned if attack_alignment empty or don't match regular alignment.
+		//if this function should be called without unit specified then "neutral" returned instead of empty or incorrect value(in case or function called in other file in future).
+		align = (!attack_alignment().empty() && (checking_alignment().count(attack_alignment()) != 0)) ? unit_alignments::get_enum(attack_alignment()) : (*self_).alignment();
+	} else {
+		align = (!attack_alignment().empty() && (checking_alignment().count(attack_alignment()) != 0)) ? unit_alignments::get_enum(attack_alignment()) : unit_alignments::type::neutral;
+	}
+	return *align;
+}
+
 
 namespace { // Helpers for attack_type::special_active()
 

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -145,8 +145,11 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if ( !filter_name.empty() && filter_name.count(attack.id()) == 0)
 		return false;
 
-	if(!filter_alignment.empty() && filter_alignment.count(attack.attack_alignment()) == 0){
-		return false;
+	if(!filter_alignment.empty()){
+		std::string attack_alignment = (tag_name == "attack_alignment") ? attack.attack_alignment() : unit_alignments::get_string((attack.specials_alignment()).first);
+		if (filter_alignment.count(attack_alignment) == 0 ){
+			return false;
+		}
 	}
 
 	if (!filter_type.empty()){

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -58,6 +58,7 @@ attack_type::attack_type(const config& cfg) :
 	range_(cfg["range"]),
 	min_range_(cfg["min_range"].to_int(1)),
 	max_range_(cfg["max_range"].to_int(1)),
+	attack_alignment_(cfg["attack_alignment"]),
 	damage_(cfg["damage"]),
 	num_attacks_(cfg["number"]),
 	attack_weight_(cfg["attack_weight"].to_double(1.0)),
@@ -109,6 +110,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	const std::string& filter_parry = filter["parry"];
 	const std::string& filter_movement = filter["movement_used"];
 	const std::string& filter_attacks_used = filter["attacks_used"];
+	const std::set<std::string> filter_alignment = utils::split_set(filter["attack_alignment"].str());
 	const std::set<std::string> filter_name = utils::split_set(filter["name"].str());
 	const std::set<std::string> filter_type = utils::split_set(filter["type"].str());
 	const std::vector<std::string> filter_special = utils::split(filter["special"]);
@@ -142,6 +144,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 
 	if ( !filter_name.empty() && filter_name.count(attack.id()) == 0)
 		return false;
+
+	if(!filter_alignment.empty() && filter_alignment.count(attack.attack_alignment()) == 0){
+		return false;
+	}
 
 	if (!filter_type.empty()){
 		//if special is type "damage_type" then check attack.type() only for don't have infinite recursion by calling damage_type() below.
@@ -296,6 +302,7 @@ bool attack_type::apply_modification(const config& cfg)
 	const t_string& set_desc = cfg["set_description"];
 	const std::string& set_type = cfg["set_type"];
 	const std::string& set_range = cfg["set_range"];
+	const std::string& set_attack_alignment = cfg["set_attack_alignment"];
 	const std::string& set_icon = cfg["set_icon"];
 	const std::string& del_specials = cfg["remove_specials"];
 	auto set_specials = cfg.optional_child("set_specials");
@@ -330,6 +337,10 @@ bool attack_type::apply_modification(const config& cfg)
 
 	if(set_range.empty() == false) {
 		range_ = set_range;
+	}
+
+	if(set_attack_alignment.empty() == false) {
+		attack_alignment_ = set_attack_alignment;
 	}
 
 	if(set_icon.empty() == false) {
@@ -581,6 +592,7 @@ void attack_type::write(config& cfg) const
 	cfg["range"] = range_;
 	cfg["min_range"] = min_range_;
 	cfg["max_range"] = max_range_;
+	cfg["attack_alignment"] = attack_alignment_;
 	cfg["damage"] = damage_;
 	cfg["number"] = num_attacks_;
 	cfg["attack_weight"] = attack_weight_;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -91,6 +91,9 @@ public:
 	/** Returns alignment specified by 'attack_alignment' If empty and have unit's alignment returns the unit's alignment.
 	 */
 	unit_alignments::type alignment_in_attack() const;
+	/** Returns alignment used in [attack_alignment] and percentage of alignment bonus. If no such specials are active, it returns the unit's alignment.
+	 */
+	std::pair<unit_alignments::type, int> specials_alignment() const;
 
 	/** Calculates the number of attacks this weapon has, considering specials. */
 	void modified_attacks(unsigned & min_attacks,

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -25,6 +25,7 @@
 #include <boost/dynamic_bitset_fwd.hpp>
 
 #include "units/ptr.hpp" // for attack_ptr
+#include "units/unit_alignments.hpp"
 
 class unit_ability_list;
 class unit_type;
@@ -59,6 +60,7 @@ public:
 	void set_type(const std::string& value) { type_ = value; set_changed(true); }
 	void set_icon(const std::string& value) { icon_ = value; set_changed(true); }
 	void set_range(const std::string& value) { range_ = value; set_changed(true); }
+	void set_attack_alignment(const std::string& value) { attack_alignment_ = value; set_changed(true); }
 	void set_accuracy(int value) { accuracy_ = value; set_changed(true); }
 	void set_parry(int value) { parry_ = value; set_changed(true); }
 	void set_damage(int value) { damage_ = value; set_changed(true); }
@@ -82,6 +84,13 @@ public:
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials() const;
 	std::string weapon_specials_value(const std::set<std::string> checking_tags) const;
+
+	const std::set<std::string>& checking_alignment() const { return checking_alignment_; }
+
+	const std::string& attack_alignment() const { return attack_alignment_; }
+	/** Returns alignment specified by 'attack_alignment' If empty and have unit's alignment returns the unit's alignment.
+	 */
+	unit_alignments::type alignment_in_attack() const;
 
 	/** Calculates the number of attacks this weapon has, considering specials. */
 	void modified_attacks(unsigned & min_attacks,
@@ -334,12 +343,15 @@ public:
 	}
 private:
 
+	const std::set<std::string> checking_alignment_{"neutral", "lawful", "chaotic", "liminal"};
+
 	t_string description_;
 	std::string id_;
 	std::string type_;
 	std::string icon_;
 	std::string range_;
 	int min_range_, max_range_;
+	std::string attack_alignment_;
 	int damage_;
 	int num_attacks_;
 	double attack_weight_;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1863,7 +1863,7 @@ public:
 
 private:
 
-	const std::set<std::string> checking_tags_{"attacks", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "damage_type"};
+	const std::set<std::string> checking_tags_{"attacks", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "damage_type", "attack_alignment"};
 	/**
 	 * Check if an ability is active.
 	 * @param ability The type (tag name) of the ability

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -359,6 +359,8 @@
 0 replace_special_with_filter_in_attack_event_inactive
 0 swarm_disables_upgrades
 0 attack_alignment_test
+0 special_alignment_test
+0 special_custom_alignment_test
 0 poison_opponent
 0 unslowable_status_test
 0 unpetrifiable_status_test

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -358,6 +358,7 @@
 0 replace_special_with_filter_in_attack_event_active
 0 replace_special_with_filter_in_attack_event_inactive
 0 swarm_disables_upgrades
+0 attack_alignment_test
 0 poison_opponent
 0 unslowable_status_test
 0 unpetrifiable_status_test


### PR DESCRIPTION
Although it is possible to mimic the operation of an alignment of the unit according to the time of day in standard conditions with [damage], the use of a fixed value limits the use of this substitutes for pre-determined conditions, but in the case of deep caves or large illuminations, the absolute value is no longer 25 and the special damage continues to mimic the standard values. That's why I propose a [attack_alignment] which actually replicates the alignment for a single attack.
The objective being that a unit can have attacks of alignment different from the standard alignment.

for [unit_alignment] the changes affect all attacks but appear in UI with name of alignment modified