### PR TITLE
WoF S4: fix message not firing

### DIFF
--- a/data/campaigns/Winds_of_Fate/scenarios/04_Journey.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/04_Journey.cfg
@@ -435,7 +435,7 @@ I must advise against it."
         [switch]
             variable=turn_number
             [case]
-                value=4
+                value=6
                 {VARIABLE serpent_id "Sharpspikes"}
                 {VARIABLE serpent_name _"Sharpspikes"}
                 {VARIABLE serpent_msg _"Graarrrrrr!"}


### PR DESCRIPTION
The first of four sea serpent spawn messages was not firing, because it was set to fire before its speaker appeared. The bug was introduced last year in a balance update affecting the sea serpent spawn rate, and was minor enough that it was missed during several play tests.

This simple fix is fully tested.