### PR TITLE
Timestamping server messages

### DIFF
--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -1955,6 +1955,9 @@ void game::send_server_message(const char* message, std::optional<player_iterato
 
 		msg.set_attr("id", "server");
 		msg.set_attr_dup("message", message);
+		std::stringstream ss;
+		ss << ::std::time(nullptr);
+		msg.set_attr_dup("time", ss.str().c_str());
 	} else {
 		simple_wml::node& msg = doc.root().add_child("message");
 


### PR DESCRIPTION
Implements #6641

Just add "time" in the "speak" command that the server sends, I guess it should be fine?

I push to master, but I wonder, can it be backported into 1.16? Would be nice if possible