### PR TITLE
WoF/Units: Adjust XP value oversights in the campaign units.

### DIFF
--- a/data/campaigns/Winds_of_Fate/units/Outrigger.cfg
+++ b/data/campaigns/Winds_of_Fate/units/Outrigger.cfg
@@ -15,7 +15,7 @@ The shallow draft of the outrigger's hulls allows it to be landed at coastal vil
 
     # Leveling
     level=2
-    experience=50
+    experience=100
     advances_to=null
     {AMLA_DEFAULT}
 

--- a/data/campaigns/Winds_of_Fate/units/Stymphalian.cfg
+++ b/data/campaigns/Winds_of_Fate/units/Stymphalian.cfg
@@ -13,7 +13,7 @@
 
     # Leveling
     level=1
-    experience=100
+    experience=50
     advances_to=null
     {AMLA_DEFAULT}
     undead_variation=falcon

--- a/data/campaigns/Winds_of_Fate/units/Wyrm.cfg
+++ b/data/campaigns/Winds_of_Fate/units/Wyrm.cfg
@@ -14,7 +14,7 @@
 
     # Leveling
     level=1
-    experience=70
+    experience=50
     advances_to=null
     {AMLA_DEFAULT}
     undead_variation=drake


### PR DESCRIPTION
# Summary:

1. Outrigger max XP is now 100
2. Stymphalian XP set to 50
3. Wyrm XP set to 50

# Remark:

XP value conventions for units with no level ups

- Level 0: 25
- level 1: 50
- level 2: 100
- level 3: 150
- level 4: 200
- level 5: 250
- level 6: 300