### PR TITLE
[Units] Fix XP conventions oversight in some monster/horse Units

### DIFF
--- a/data/core/units/monsters/Caribe_Hunter.cfg
+++ b/data/core/units/monsters/Caribe_Hunter.cfg
@@ -18,7 +18,7 @@ units/monsters/caribe#enddef
         impact=80
     [/resistance]
     movement=8
-    experience=40
+    experience=100
     level=2
     alignment=neutral
     advances_to=null

--- a/data/core/units/monsters/Fire_Wraith.cfg
+++ b/data/core/units/monsters/Fire_Wraith.cfg
@@ -36,7 +36,7 @@ units/monsters/firewraith#enddef
         impact=90
     [/resistance]
     movement=6
-    experience=80
+    experience=100
     level=2
     alignment=neutral
     advances_to=null

--- a/data/core/units/monsters/Horse.cfg
+++ b/data/core/units/monsters/Horse.cfg
@@ -77,7 +77,7 @@
     [/base_unit]
     image="units/monsters/horse/horse.png{HORSE_WHITE_IPF}"
     profile="portraits/monsters/horse.webp{HORSE_WHITE_IPF_2}"
-    hitpoints=31
+    hitpoints=50
     advances_to=null
     {AMLA_DEFAULT}
     movement_type=woodland

--- a/data/core/units/monsters/Horse_Black.cfg
+++ b/data/core/units/monsters/Horse_Black.cfg
@@ -15,7 +15,7 @@
     {TRAIT_QUICK}
     movement_type=mounted
     movement=8
-    experience=80
+    experience=100
     {AMLA_DEFAULT}
     level=2
     alignment=chaotic

--- a/data/core/units/monsters/Horse_Great.cfg
+++ b/data/core/units/monsters/Horse_Great.cfg
@@ -10,7 +10,7 @@
     hitpoints=50
     movement_type=mounted
     movement=8
-    experience=80
+    experience=100
     {AMLA_DEFAULT}
     level=2
     alignment=neutral

--- a/data/core/units/monsters/Scarab.cfg
+++ b/data/core/units/monsters/Scarab.cfg
@@ -9,7 +9,7 @@
     hitpoints=36
     movement_type=gruefoot
     movement=4
-    experience=30
+    experience=50
     level=1
     alignment=neutral
     advances_to=null

--- a/data/core/units/monsters/Seahorse.cfg
+++ b/data/core/units/monsters/Seahorse.cfg
@@ -18,7 +18,7 @@
         pierce=120
     [/resistance]
     movement=3
-    experience=60
+    experience=50
     level=1
     alignment=neutral
     advances_to=null


### PR DESCRIPTION
## Summary:

Certain units with no level up/advancements were not adhering to the max XP conventions which had been set for core units. This rectifies such oversights.

## Reference Table:

| Level | Maximum XP |
| ----- |  -------------- |
| 0 | 25 |
| 1 | 50 |
| 2 | 100 |
| 3 | 150 |
| 4 | 200 |
| 5 | 250 |
| 6 | 300 |

Note: Only Applicable for Units with no further advancements being available apart from `{AMLA_DEFAULT}`

Note 2: Some commits here should/can be cherry-picked since these units exist in 1.16 as well (all except the Hunter Caribe)