### PR TITLE
CMake 2.24.0: Workaround for missing SDL2::SDL2main

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -58,6 +58,15 @@ if(SDL2_FOUND)
 
 	mark_as_advanced(SDL2_INCLUDE_DIRS SDL2_LIBRARIES)
 
+	if(NOT TARGET SDL2::SDL2main)
+		# In SDL 2.24.0, the CONFIG method doesn't add a target for libSDL2main. Seen on Debian
+		# Unstable, and seems to be https://github.com/libsdl-org/SDL/issues/6119 which is reported
+		# upstream on macOS. For consistency's sake, let's add a phony library we can link with,
+		# which is also the workaround that upstream suggests in the bug report.
+		message(STATUS "SDL2 found via CONFIG, but it didn't define SDL2::SDL2main, adding dummy target")
+		add_library(SDL2::SDL2main INTERFACE IMPORTED)
+	endif()
+
 	return()
 endif()
 


### PR DESCRIPTION
@bencsikandrei please would you review this? I can only add project members as reviewers, but you're probably the best reviewer.

In SDL 2.24.0, the CONFIG method doesn't add a target for libSDL2main. Seen on Debian Unstable, and seems to be https://github.com/libsdl-org/SDL/issues/6119 which is reported upstream on macOS. For consistency's sake, let's add a phony library we can link with, which is also the workaround that upstream suggests in the bug report.