### PR TITLE
Remove obsolete reference to gna.org

### DIFF
--- a/src/units/map.cpp
+++ b/src/units/map.cpp
@@ -179,15 +179,6 @@ unit_map::umap_retval_pair_t unit_map::insert(unit_ptr p)
 
 			int guard(0);
 			while(!uinsert.second && (++guard < 1e6)) {
-				if(guard % 10 == 9) {
-					ERR_NG << "\n\nPlease Report this error to https://gna.org/bugs/index.php?18591 "
-						"\nIn addition to the standard details of operating system and wesnoth version "
-						"and how it happened, please answer the following questions "
-						"\n 1. Were you playing multi-player?"
-						"\n 2. Did you start/restart/reload the game/scenario?"
-						"\nThank you for your help in fixing this bug.";
-				}
-
 				p->mark_clone(false);
 				uinsert = umap_.emplace(p->underlying_id(), upod);
 			}


### PR DESCRIPTION
Resolves #6933 - it was suggested there to just remove the error message altogether.