### PR TITLE
Lua AI: speed up battle_calcs.battle_outcome in extreme cases

### DIFF
--- a/data/ai/lua/battle_calcs.lua
+++ b/data/ai/lua/battle_calcs.lua
@@ -670,6 +670,16 @@ function battle_calcs.battle_outcome(attacker, defender, cfg, cache)
         def_strikes = math.floor(def_strikes * defender.hitpoints / defender.max_hitpoints)
     end
 
+    -- At around 15 combined strikes, wesnoth.simulate_combat becomes faster
+    if (att_strikes + def_strikes > 14) then
+        if (def_weapon == 0) then def_weapon = nil end
+        if (att_weapon == 0) then
+            return wesnoth.simulate_combat(attacker, defender, def_weapon)
+        else
+            return wesnoth.simulate_combat(attacker, att_weapon, defender, def_weapon)
+        end
+    end
+
     -- Maximum number of hits that either unit can survive
     local att_max_hits = math.floor((attacker.hitpoints - 1) / def_damage)
     if (att_max_hits > def_strikes) then att_max_hits = def_strikes end


### PR DESCRIPTION
The method used in the battle_outcome() function is somewhat simplified compared to the default engine calculation and faster in the vast majority of cases, but it can become extremely slow when the combined number of strikes of the attacker and defender is very large.

This was reported as a complete stalling of the game in HttT The Princess of Wesnoth (which uses the Assassin Squad Micro AI) in combination with the Less Random modification.  Details are given in [this forum thread](https://forums.wesnoth.org/viewtopic.php?t=56116).