### PR TITLE
Fix inserting image=wesnoth-icon.png errors

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
@@ -337,6 +337,7 @@
         [message]
             speaker=narrator
             message= _ "Ignorance is the parent of fear."
+            image=wesnoth-icon.png
         [/message]
 
         {GIVE_MALIN_EXPERIENCE 4}
@@ -351,6 +352,7 @@
         [message]
             speaker=narrator
             message= _ "A monolith of pale stone, luminous and bright, but cold and brittle to the touch."
+            image=wesnoth-icon.png
         [/message]
 
         {GIVE_MALIN_EXPERIENCE 8}

--- a/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
@@ -1038,6 +1038,7 @@
                 [message]
                     speaker=narrator
                     message= _ "Nothing happens."
+                    image=wesnoth-icon.png
                 [/message]
             [/else]
         [/if]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
@@ -250,6 +250,7 @@ end
         [message]
             speaker=narrator
             message= _ "Revenge is a confession of pain."
+            image=wesnoth-icon.png
         [/message]
 
         {GIVE_MALIN_EXPERIENCE 6}

--- a/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/06_Return_to_Parthyn.cfg
@@ -483,6 +483,7 @@
         [message]
             speaker=narrator
             message= _ "A monolith of grey stone, appearing solid, but crumbling within."
+            image=wesnoth-icon.png
         [/message]
 
 #ifdef EASY
@@ -506,6 +507,7 @@
         [message]
             speaker=narrator
             message= _ "Darkness is not the enemy, but believing it is so makes it so."
+            image=wesnoth-icon.png
         [/message]
 
         {GIVE_MALIN_EXPERIENCE 6}
@@ -617,6 +619,7 @@
                 [message]
                     speaker=narrator
                     message= _ "The orc was carrying some gold."
+                    image=wesnoth-icon.png
                 [/message]
 
                 [gold]
@@ -828,6 +831,7 @@
             [message]
                 speaker=narrator
                 message= _ "A monolith of dark stone, shadowed panes reflecting distorted images."
+                image=wesnoth-icon.png
             [/message]
 
 #ifdef EASY

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
@@ -680,6 +680,7 @@
         [message]
             speaker=narrator
             message= _ "There is only one thing that makes a dream impossible to achieve."
+            image=wesnoth-icon.png
         [/message]
         [delay]
             time=350
@@ -693,6 +694,7 @@
         [message]
             speaker=narrator
             message= _ "... the fear of failure."
+            image=wesnoth-icon.png
         [/message]
     [/event]
     [event]
@@ -704,6 +706,7 @@
         [message]
             speaker=narrator
             message= _ "<i>There is nothing good or bad, but thinking makes it so.</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     [event]
@@ -717,6 +720,7 @@
             message= _ "<i>Mirrors of shallow blue, cold and opaque, they stare,
 Piercing, unblinking, a pitiless reflection,
 Shattering our brittle, fancied reality.</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     [event]
@@ -730,6 +734,7 @@ Shattering our brittle, fancied reality.</i>"
             message= _ "<i>Emerald, verdant green gives way,
 Touched by shadow, dark dye of black,
 An abhorrent stain of pestilence.</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     [event]
@@ -743,6 +748,7 @@ An abhorrent stain of pestilence.</i>"
             message= _ "<i>Crimson pool, essence of life,
 Flesh and blood flow away to rot,
 Leaving only bones to remain.</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
 
@@ -822,6 +828,7 @@ Leaving only bones to remain.</i>"
         [message]
             speaker=Malin Keshar
             message= _ "The mages have hidden their gold somewhere else."
+            image=wesnoth-icon.png
         [/message]
     [/event]
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
@@ -802,6 +802,7 @@
         [message]
             speaker=narrator
             message= _ "<i>Beware that, when fighting monsters, you yourself do not become a monster...</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     [event]
@@ -815,6 +816,7 @@
             message= _ "<i>Death is the twilight that follows the light of day.
 Life fades with the setting sun into darkness.
 Existence churns and the soul is reborn into endless night.</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     [event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -531,6 +531,7 @@
         [message]
             speaker=narrator
             message= _ "A monolith of dark stone, marred by cracks running throughout."
+            image=wesnoth-icon.png
         [/message]
 
 #ifdef EASY
@@ -913,6 +914,7 @@
             [message]
                 speaker=narrator
                 message= _ "A monolith of black stone, broken shards inexplicably held together by nothingness."
+                image=wesnoth-icon.png
             [/message]
 
 #ifdef EASY

--- a/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/09_Descent_into_Darkness.cfg
@@ -1592,6 +1592,7 @@
         [message]
             speaker=narrator
             message= _ "There is darkness..."
+            image=wesnoth-icon.png
         [/message]
 
         [delay]
@@ -1601,6 +1602,7 @@
         [message]
             speaker=narrator
             message= _ "and peace..."
+            image=wesnoth-icon.png
         [/message]
 
         [delay]
@@ -1610,6 +1612,7 @@
         [message]
             speaker=narrator
             message= _ "for a moment."
+            image=wesnoth-icon.png
         [/message]
 
         [delay]
@@ -1619,11 +1622,13 @@
         [message]
             speaker=narrator
             message= _ "Then, they are replaced by a pulling, a pain too strong to resist, and then..."
+            image=wesnoth-icon.png
         [/message]
 
         [message]
             speaker=narrator
             message= _ "... by emptiness."
+            image=wesnoth-icon.png
         [/message]
 
         [replace_map]
@@ -2001,6 +2006,7 @@
         [message]
             speaker=narrator
             message= _ "A monolith of black stone, a fractured surface shrouded by darkened shadow."
+            image=wesnoth-icon.png
         [/message]
     [/event]
 
@@ -2528,6 +2534,7 @@
                 [message]
                     speaker=narrator
                     message= _ "Mal Keshar drinks the potion and feels energy flow through his skeletal form. The power of death surges in his vacant body, threatening to overflow, to burst free, but at the last moment, he reins it in. The stream of magic trickles down to drops, diminished, tempered, but manageable."
+                    image=wesnoth-icon.png
                 [/message]
 
                 [remove_object]
@@ -2600,6 +2607,7 @@
 Unmasked by a lick of flame,
 Transmuted by the altar of darkness
 Into pitch black shadow.</i>"
+            image=wesnoth-icon.png
         [/message]
         [fire_event]
             name=potion text
@@ -2847,6 +2855,7 @@ Into pitch black shadow.</i>"
                     [message]
                         speaker=narrator
                         message= _ "Ash swirls upward, charred remnants of the once living. Charcoal from bone, embers from flesh, he consumes the pallid cinders, siphoning away the energy with a draining touch."
+                        image=wesnoth-icon.png
                     [/message]
 
                     [remove_object]
@@ -2909,6 +2918,7 @@ Reside outside their coffin, locked away,
 In eternal wakefulness.
 Then, the key is found and the lid opened,
 And the tongue of fire begets ashen repose.</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -1321,12 +1321,14 @@
                 [message]
                     speaker=narrator
                     message= _ "A monolith of black stone, a dark surface reflecting deep shadow infinitely into the night."
+                    image=wesnoth-icon.png
                 [/message]
             [/then]
             [else]
                 [message]
                     speaker=narrator
                     message= _ "A monolith of black stone, cold and brittle to the touch."
+                    image=wesnoth-icon.png
                 [/message]
             [/else]
         [/if]
@@ -1581,6 +1583,7 @@
                 [message]
                     speaker=narrator
                     message= _ "Mal Keshar stares into the abyss, oddly at ease alone amongst the darkness."
+                    image=wesnoth-icon.png
                 [/message]
             [/else]
         [/switch]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/22_Return_to_Wesnoth.cfg
@@ -66,6 +66,7 @@
                     [message]
                         speaker=narrator
                         message= _ "The battlefield falls silent as a loud shriek fills the air."
+                        image=wesnoth-icon.png
                     [/message]
                     [scroll_to]
                         x,y=1,1

--- a/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
+++ b/data/campaigns/Liberty/scenarios/04_Unlawful_Orders.cfg
@@ -424,6 +424,7 @@
         [message]
             speaker=narrator
             message= _ "<i>The sun sets...</i>"
+            image=wesnoth-icon.png
         [/message]
 
         [message]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -530,6 +530,7 @@
         [message]
             speaker=narrator
             message= _ "Alanin has gained new abilities!"
+            image=wesnoth-icon.png
         [/message]
 #endif
         [message]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/Epilogue.cfg
@@ -212,6 +212,7 @@
         [message]
             speaker=narrator
             message= _ "Krawg reached over his back with his beak and brought out a scorched parchment, which he dropped at the feet of the king."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=Alanin

--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -370,6 +370,7 @@
         [message]
             speaker=narrator
             message= _ "A lua error has occurred, and a corpse cannot be recruited."
+            image=wesnoth-icon.png
         [/message]
     [/event]
 

--- a/data/campaigns/Winds_of_Fate/scenarios/02_Reclamation.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/02_Reclamation.cfg
@@ -480,6 +480,7 @@ Jessene says her people are familiar with these dragons. Their tomes describe su
 <i>― Prince Leodren of Southbay,
 
 26th day of the Eastward Oceanic Expedition</i>"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     {BOOK_LEARNING 13 5 8}

--- a/data/campaigns/Winds_of_Fate/scenarios/05_Threshold.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/05_Threshold.cfg
@@ -397,6 +397,7 @@ And get to work feeding your petsss!" # no spellcheck
                         message= _ "Achievement Unlocked:
 
 <b>Leader of Mice</b>"
+                        image=wesnoth-icon.png
                     [/message]
                 [/command]
             [/option]
@@ -868,6 +869,7 @@ Indeed, þere must be an Aquadyne every twenty leagues around þe entire Great C
 ——Someþing is wrong. I am getting a signal of warning from þe norþwest watchtower and þere is smoke rising from þe souþern iland. Rhynnin’s expedition is under attack and I sense it is more þan just þe saurians. I must go to assist.
 
 I do not have time to cypher þis log, nor can I risk taking my logbook wiþ me to perhaps be captured by an unknown enemy. Yet I shall not destroy it, þe secrecy of þe Silver Order be damned. May þe sea carry þis book back to Fort Elense so someone will know what has been discovered here." # no spellcheck
+            image=wesnoth-icon.png
         [/message]
     [/event]
     {BOOK_LEARNING 18 2 16}
@@ -921,10 +923,12 @@ Carry on with your duty."
         [message]
             speaker=narrator
             message= _ "A powerful maelstrom, surrounded by paradoxically calm waters. The swirling current seems to come entirely from deep below the sandy seabed. It emanates a faint melodic humming."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
             message= _ "The humming grows slowly louder as a cold mist begins to billow out. The mist somehow moves against the wind."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=Reshan

--- a/data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/07_Harvest.cfg
@@ -447,6 +447,7 @@ My diary is very personal, Vonel!"
         [message]
             speaker=narrator
             message= _ "“The Diary of Lady Salennea”"
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
@@ -454,6 +455,7 @@ My diary is very personal, Vonel!"
             message= _ "7th day of Greenleaf
 
 ...the Sapphire of Ice has yet improved even my own talent for the art of scrying. I have discarded my Orb of Pondering in favor of it. Soon I shall peer into the far side of our Faerie Realm, which that pretender Lady Dionli claims she fears to descry. She simply has not the talent to do so, though she shall never admit it. How I despise that upstart Lady Dionli, that usurper of my rightful place in the Ka’lian, whose only real talent is the art of..."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
@@ -463,24 +465,28 @@ My diary is very personal, Vonel!"
 — A slab of cold black granite.
 — One of my fair young handmaidens.
 — A twisted metal dagger that menaces with spikes of..."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
             message= _ "29th day of Greenleaf
 
 ...how was I to know Vanar's ritual would involve blood sacrifice?! Oh, if only the wicked “Lady” Dionli had not put me in this unenviable position. Now I shall need another unsalaried novice handmaiden willing to work for “experience”..."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
             message= _ "1st day of Leaffall
 
 ...still more of these dreadful rituals must be completed before Vanar can place a curse upon my usurper. Yet if I stop now, everything I have sacrificed— <i>everyone</i> I have sacrificed —shall have been in vain! I owe it to them to continue..."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
             message= _ "13th day of Leaffall
 
 ...the Ka’lian is growing suspicious because more of my attendants have gone missing than usual. I must vastly intensify my persona. And for future rituals, I shall need new <i>“guests of honor”</i> which are not of elfkind..."
+            image=wesnoth-icon.png
         [/message]
         [message]
             speaker=narrator
@@ -488,6 +494,7 @@ My diary is very personal, Vonel!"
             message= _ "31st day of Leaffall
 
 ...those saurians may smell of the swamp they crawl from, but they shall make a worthy sacrifice to Vanar! I have extended a formal invitation to Arinexis, a saurian ambassador, or what passes for one amongst their primitive and malodorous kind. I shall show this saurian and its entourage every courtesy and tempt them with all the delights of elvish cuisine— seasoned with Shavings of the Yew..."
+            image=wesnoth-icon.png
         [/message]
     [/event]
     {BOOK_LEARNING 21 6 24}
@@ -501,6 +508,7 @@ My diary is very personal, Vonel!"
         [message]
             speaker=narrator
             message= _ "This tree has been debarked by repeated scratching from animals of somekind. It smells strongly of a fig tree yet it is clearly an oak."
+            image=wesnoth-icon.png
         [/message]
     [/event]
 

--- a/data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg
@@ -516,6 +516,7 @@ If thay dae come back with an airmie we cannae handle, we hae flashpowder kegs a
 Still, oor woodcutters cannae harvest ony mair mushroom fodder oot of the forest withoot elves chipping away at thaim and the lodestane mines ur nearly tae the end of thair veins.
 
 Mibbie ah shuid trade this cave tae that streenge “Nova” cratur efter all. Whit ever it be ah dae nae care; if the elves ever come back then thay kin deal with it."
+            image=wesnoth-icon.png
         [/message]
     [/event]
     {BOOK_LEARNING 9 20 24}

--- a/data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg
@@ -413,6 +413,7 @@ May it provide the safety for our weary flight that I have failed to."
             speaker=narrator
             #po: "Back next spring." As in the season after winter and before summer.
             message= _ "‘ BAK NEKST SPRING ’"
+            image=wesnoth-icon.png
         [/message]
     [/event]
 

--- a/data/campaigns/Winds_of_Fate/scenarios/10_Fire_Meets_Steel.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/10_Fire_Meets_Steel.cfg
@@ -596,6 +596,7 @@ A’richt lads, attack!"
             speaker=narrator
             #po: "Back next spring." As in the season after winter and before summer.
             message= _ "‘ BAK NEKST SPRING ’"
+            image=wesnoth-icon.png
         [/message]
     [/event]
 

--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -556,6 +556,7 @@ Yet there was a faint sound coming through the crystalline floor. It had the rhy
 On his glide down, he saw many wonders lost to our folk since the Time of Legend. This realm was alive with myriad creatures the <i>craftlings</i> fashioned from metal. Its watch places sat not upon towers; they instead hung from great bubbles in midair. Strangest of all, the many torches that gave light to this realm did so without flame. This was indeed the ally our folk needed to turn the war against the Faerie.
 
 ―  64th century of the Time of Turmoil  ―"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     {BOOK_LEARNING 44 3 32}
@@ -605,6 +606,7 @@ It seemed a fateful blow. Until the <i>craftling's</i> automoton rolled back, to
 A <i>craftling</i> runesmith strode onto the arena, laughing as he went. He told the bewildered clashers there was no one within his automaton, no one wielding its inner workings. By his glyph–making he had granted this thing a Will of its own. Turning again to the automaton, the clashers gave it a humble nod.
 
 ―  31st century of the Time of Legend  ―"
+            image=wesnoth-icon.png
         [/message]
     [/event]
     {BOOK_LEARNING 27 36 40}


### PR DESCRIPTION
Fixes all wmllint "inserting 'image=wesnoth-icon.png'" errors.
Wmllint will insert a image for the narrator when there isn't one, and print a warning (see comment starting on line 2765).
I added an image for the narrator when there wasn't one.
See #4494