### PR TITLE
wmllint: stop adding wesnoth-icon.png to messages

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2762,26 +2762,6 @@ def hack_syntax(filename, lines):
                             lines.insert(j+1, new_line)
                             j += 1
                     j += 1
-    # Ensure that every speaker=narrator block without an image uses
-    # wesnoth-icon.png as an image.
-    narrator = has_image = in_message = False
-    for i in range(len(lines)):
-        if "no-syntax-rewrite" in lines[i]:
-            break
-        precomment = lines[i].split("#")[0]
-        if '[message]' in precomment:
-            in_message = True
-        if "speaker=narrator" in precomment:
-            narrator = True
-        elif precomment.strip().startswith("image"):
-            has_image = True
-        elif '[/message]' in precomment:
-            if narrator and not has_image:
-                # This line presumes the code has been through wmlindent
-                if verbose:
-                    print('"%s", line %d: inserting "image=wesnoth-icon.png"'%(filename, i+1))
-                lines.insert(i, leader(precomment) + baseindent + "image=wesnoth-icon.png\n")
-            narrator = has_image = in_message = False
     # Hack tracking-map macros from 1.4 and earlier.  The idea is to lose
     # all assumptions about colors in the names
     for i in range(len(lines)):


### PR DESCRIPTION
We're had at least two people look at the "good first issue" list, pick up
the wmllint warnings, open a PR, and then get a response that these .pngs
shouldn't be added by default. That's not a welcoming introduction.

IIRC we didn't get full consensus that these should never be added, but I
think it's time to open a "just drop that code, no options" PR. If someone
wants it back in a subset of circumstances, they can always create a PR to
readd it along with adding an option to enable it.

Inspired by #6990, previously discussed in #5164.