### PR TITLE
Match lightning attacks to arcane damage icon

### DIFF
--- a/data/campaigns/Dead_Water/utils/items.cfg
+++ b/data/campaigns/Dead_Water/utils/items.cfg
@@ -28,7 +28,7 @@
             description= _ "storm trident"
             # need a better attack image, but this will do for now, replaced fireball with lightingbolt
             icon=attacks/lightning.png
-            type=fire
+            type=arcane
             range=ranged
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Delfadors_Memoirs/utils/items.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/items.cfg
@@ -73,7 +73,7 @@
                 description=_"lightning"
                 #textdomain wesnoth-dm
                 icon=attacks/lightning.png
-                type=fire
+                type=arcane
                 range=ranged
                 [specials]
                     {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -1403,12 +1403,12 @@
                             id=$unit.id
                         [/filter]
 
-                        # New 16-4 fire attack with cool lightning animation
+                        # New 16-4 arcane attack with cool lightning animation
                         [effect]
                             apply_to=new_attack
                             name=rod of justice
                             description= _ "rod of justice"
-                            type=fire
+                            type=arcane
                             range=ranged
                             damage=16
                             number=4

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
@@ -398,7 +398,7 @@
                         description= _ "storm trident"
                         #textdomain wesnoth-trow
                         icon=attacks/lightning.png
-                        type=fire
+                        type=arcane
                         range=ranged
                         [specials]
                             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/World_Conquest/resources/data/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/data/artifacts.cfg
@@ -698,7 +698,7 @@
             name=storm trident
             description=_ "storm trident"
             icon=attacks/lightning.png
-            type=fire
+            type=arcane
             range=ranged
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}

--- a/data/core/macros/items.cfg
+++ b/data/core/macros/items.cfg
@@ -543,7 +543,7 @@
                 name="storm trident"
                 description= _ "storm trident"
                 icon=attacks/lightning.png
-                type=fire
+                type=arcane
                 range=ranged
                 [specials]
                     {WEAPON_SPECIAL_MAGICAL}

--- a/data/core/units/humans/Mage_Elder.cfg
+++ b/data/core/units/humans/Mage_Elder.cfg
@@ -34,7 +34,7 @@
         name=lightning
         description= _"lightning"
         icon=attacks/lightning.png
-        type=fire
+        type=arcane
         range=ranged
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/core/units/monsters/Jinn.cfg
+++ b/data/core/units/monsters/Jinn.cfg
@@ -107,7 +107,7 @@ units/monsters/jinn#enddef
         name=desert lightning
         description= _ "desert lightning"
         icon=attacks/lightning.png
-        type=fire
+        type=arcane
         range=ranged
         damage=20
         number=1


### PR DESCRIPTION
[A lightning bolt](https://github.com/wesnoth/wesnoth/blob/master/images/icons/profiles/arcane.png) is prominently displayed throughout the UI as the icon for arcane attacks. So switch the rare instances of lightning attacks from fire to arcane to match this convention. Doing so also makes the core Jinn unit more versatile, by giving it better utility against drakes (which are resistant to all its existing attack types).