### PR TITLE
Give Shyde and Sylph unwalkable statistics

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -642,7 +642,7 @@ fire:  +10%"
     # everyone on lava dies
     [kill]
         [not]
-            type=Gryphon Rider,Gryphon Master
+            type=Elvish Shyde,Elvish Sylph,Gryphon Rider,Gryphon Master
         [/not]
         [filter_location]
             terrain=Ql

--- a/data/campaigns/The_South_Guard/maps/06a_Into_the_Depths.map
+++ b/data/campaigns/The_South_Guard/maps/06a_Into_the_Depths.map
@@ -14,12 +14,12 @@ Xu, Xu, Xu, Xu, Xu, Uu^Vud, Uu^Emf, Qxu, Ur^Es, Qxu, Xuc, Xuc, Xuc, Qxu, Xu, Xu,
 Xu, Xu, Xu, Xu, Xuc, Xom, Uu^Em, Uu^Br\, Ur^Br\, Ur^Ebn, Xuc, Xuc, Qxu, Qxu, Xu, Xu, Uu^Vu, Uu^Em, Rd^Es, Rd^Es, Wwg, Ss, Sm, Sm^Em, Sm^Emf, Sm^Em, Uue^Em, Rd^Es, Uue, Ss^Em, Sm^Tf, Ss^Emf, Xue, Xue, Xu, Xu
 Xu, Xu, Xuc, Xuc, Xuc, Xom, Xom, Ur^Es, Ur^Br/, Ur^Br/, Uu^Em, Xuc, Qxu, Qxu, Xu, Xu, Uu^Em, Uu^Es, Xu, Ds^Esd, Sm, Ww^Ewl, Ss^Em, Ss^Vhs, Ss^Tf, Uue^Em, Uue^Es, Rd^Es, Xu, Sm^Emf, Rb^Em, Ss^Em, Xue, Xu, Xu, Xu
 Xu, Xuc, Xuc, Uu^Vu, Xom, Xom, Uu^Em, Ur^Br\, Ur^Es, Ur^Br|, Xu, Uh^Vud, Uh^Emf, Qxu, Qxu, Qxu, Uu, Uu^Es, Xu, Xu, Xu, Sm^Em, Sm^Em, Wwg, Ss^Em, Xu, Uue^Es, Ur^Es, Uue^Em, Xu, Sm^Em, Xue, Xue, Xu, Xu, Xu
-Xu, Xom, Uh^Emf, Uu^Em, Uu^Es, Uu, Ur^Es, Ur^Es, Cud, Ur^Br|, Xu, Uh^Em, Cud, Qxu, Qxu^Bs/, Qxu^Bs/, Qxu, Qxu, Qxu, Xu, Qxu, Sm^Emf, Ss^Em, Ww^Ewl, Ww^Ewl, Sm^Em, Uue^Em, Ur, Uue^Em, Ss^Em, Sm^Em, Sm^Emf, Ss^Edb, Xue, Xu, Xu
-Xu, Xu, Uh^Tf, Uh, Uu^Ebn, Cud, Xuc, Cud, 5 Kud, Cud, Ur^Es, Ur, Uu, Ur^Es, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Ss^Em, Ww^Ewl, Wwg, Wwg, Wwg, Rd^Es, Rd^Es, Uh^Emf, Rb^Em, Xue, Xue, Ss^Edb, Xue, Xu, Xu
-Xu, Xu, Xu, Uh^Em, Uu^Em, Xuc, Xuc, Xuc, Xuc, Xuc, Xuc, Uh^Em, Xu, Xu, Xu, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Xu, Wo, Wo, Wwg, Xu, Rd^Es, Rd^Es, Uh^Tf, Xue, Ss^Em, Uue^Emf, Xue, Xu, Xu
-Xu, Xu, Xu, Uh^Em, Uh^Emf, Uu^Vu, Xuc, Xu, Xu, Xuc, Xu, Xom, Xu, Xu, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Xu, Xu, Wo, Wog^Edb, Wwg^Vm, Ww^Ewl, Xu, Uu^Emf, Ur, Uue, Uue^Vud, Uue^Em, Uu^Em, Xu, Xu
-Xu, Xu, Xu, Xu, Xu, Uh^Tf, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Qxu, Qxu, Qxu, Qxu, Qxu, Qxu, Xu, Xu, Wo, Wwg, Wwg, Ww^Ewl, Xu, Uu^Tf, Ur, Uue^Emf, Uue^Tf, Uu^Edb, Uu^Edb, Xu, Xu
-Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Qxu, Qxu, Qxu, Qxu, Qxu, Wwg, Wog^Edb, Wog^Edb, Wog^Edb, Wwg^Edb, Wwg, Wwg^Edb, Cud, Cud, Ur^Edb, Ur, Cud, Cud, Xu, Xu, Xu
+Xu, Xom, Uh^Emf, Uu^Em, Uu^Es, Uu, Ur^Es, Ur^Es, Cud, Ur^Br|, Xu, Uh^Em, Cud, Qxu, Qxu^Bs/, Qxu^Bs/, Qxu, Qxu, Qxu, Xu, Xu, Sm^Emf, Ss^Em, Ww^Ewl, Ww^Ewl, Sm^Em, Uue^Em, Ur, Uue^Em, Ss^Em, Sm^Em, Sm^Emf, Ss^Edb, Xue, Xu, Xu
+Xu, Xu, Uh^Tf, Uh, Uu^Ebn, Cud, Xuc, Cud, 5 Kud, Cud, Ur^Es, Ur, Uu, Ur^Es, Qxu, Qxu, Qxu, Qxu, Qxu, Xu, Xu, Ss^Em, Ww^Ewl, Wwg, Wwg, Wwg, Rd^Es, Rd^Es, Uh^Emf, Rb^Em, Xue, Xue, Ss^Edb, Xue, Xu, Xu
+Xu, Xu, Xu, Uh^Em, Uu^Em, Xuc, Xuc, Xuc, Xuc, Xuc, Xuc, Uh^Em, Xu, Xu, Xu, Qxu, Qxu, Qxu, Qxu, Xu, Xu, Xu, Xu, Wo, Wo, Wwg, Xu, Rd^Es, Rd^Es, Uh^Tf, Xue, Ss^Em, Uue^Emf, Xue, Xu, Xu
+Xu, Xu, Xu, Uh^Em, Uh^Emf, Uu^Vu, Xuc, Xu, Xu, Xuc, Xu, Xom, Xu, Xu, Xu, Qxu, Qxu, Qxu, Qxu, Qxu, Xu, Xu, Xu, Wo, Wog^Edb, Wwg^Vm, Ww^Ewl, Xu, Uu^Emf, Ur, Uue, Uue^Vud, Uue^Em, Uu^Em, Xu, Xu
+Xu, Xu, Xu, Xu, Xu, Uh^Tf, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Wo, Wwg, Wwg, Ww^Ewl, Xu, Uu^Tf, Ur, Uue^Emf, Uue^Tf, Uu^Edb, Uu^Edb, Xu, Xu
+Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Wwg, Wog^Edb, Wog^Edb, Wog^Edb, Wwg^Edb, Wwg, Wwg^Edb, Cud, Cud, Ur^Edb, Ur, Cud, Cud, Xu, Xu, Xu
 Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Sm^Em, Wwg^Edb, Wwg^Edb, Wwg, Sm^Edb, Wwg^Edb, Cud, 4 Kud, Cud, Ur^Edb, Ur^Edb, Cud, Xu, Xu, Xu, Xu
 Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xue, Xue, Sm^Em, Rb^Em, Ss, Sm, Wwg^Edb, Ww^Ewl, Cud, Cud, Uu^Es, Ur, Ur^Edb, Cud, Xu, Xu, Xu, Xu
 Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xue, Xue, Xue, Uh^Tf, Ss^Emf, Rb^Em, Uue^Vu, Ss, Sm^Em, Uue^Edb, Ww^Ewl, Uue^Es, Uu^Es, Ur^Edb, Ur^Edb, Uu, Xu, Xu, Xu, Xu, Xu

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -734,6 +734,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             cave=2
             frozen=1
             fungus=2
+            unwalkable=2
         [/movement_costs]
         [defense]
             deep_water=70
@@ -750,6 +751,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             cave=70
             frozen=60
             fungus=50
+            unwalkable=70
         [/defense]
         {WOODLAND_RESISTANCE}
     [/movetype]


### PR DESCRIPTION
With the same unwalkable terrain movement and defense as the Quenoth versions of these units. Makes them behave as true flying/floating units as their wings, movetype name and other statistics suggest, while opening up interesting game play possibilities.