### PR TITLE
[1.16] Show units' max move ranges, unless it's the owner's turn

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -361,19 +361,23 @@ void mouse_handler::show_reach_for_unit(const unit_ptr& un)
 				gui().set_route(&route);
 			}
 			over_route_ = true;
+		}
 
-			wb::future_map_if_active raii;
-			current_paths_ = pathfind::paths(*un, false, true,
-											 viewing_team(), path_turns_);
-		} else {
-			//unit under cursor is not on our team
-			//Note: planned unit map must be activated after this is done,
-			//since the future state includes changes to units' movement.
-			unit_movement_resetter move_reset(*un);
+		// Scope for the unit_movement_resetter and future_map_if_active.
+		{
+			// Making this non-null will show the unit's max moves instead of current moves.
+			// Because movement is reset to max in the side's refresh phase, use the max if
+			// that refresh will happen before the unit's side can move again.
+			std::unique_ptr<unit_movement_resetter> move_reset;
+			if(un->side() != side_num_) {
+				move_reset = std::make_unique<unit_movement_resetter>(*un);
+			}
 
+			// Handle whiteboard. Any move_reset must be done before this, since the future
+			// state includes changes to units' movement.
 			wb::future_map_if_active raii;
-			current_paths_ = pathfind::paths(*un, false, true,
-											 viewing_team(), path_turns_);
+
+			current_paths_ = pathfind::paths(*un, false, true, viewing_team(), path_turns_);
 		}
 
 		unselected_paths_ = true;

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -179,6 +179,10 @@ private:
 	map_location selected_hex_;
 	map_location next_unit_;
 	pathfind::marked_route current_route_;
+	/**
+	 * If non-empty, current_paths_.destinations contains a cache of highlighted
+	 * hexes, likely the movement range or attack range of a unit.
+	 */
 	pathfind::paths current_paths_;
 	bool unselected_paths_;
 	bool unselected_reach_;


### PR DESCRIPTION
Backport of #6998.

If it's another player's turn, then movement points will be reset in a refresh
phase and it's not useful to show current movement.

Partially reverts 978229c247 (af0968d9c3 on 1.16), using the old logic for
the movement range but the allies-based logic for goto_x,goto_y information.

Fixes #6716.

(cherry picked from commit ae4ecd17e4c617af72c8c2e00bca014dcfb1b993)