### PR TITLE
Separate player-hosted games and bot-hosted games into tabs

### DIFF
--- a/data/gui/window/lobby_main.cfg
+++ b/data/gui/window/lobby_main.cfg
@@ -3,6 +3,117 @@
 ### Definition of the lobby screen
 ###
 
+#define _GUI_LOBBY_TABS
+[grid]
+
+	[row]
+
+		[column]
+			border = all
+			border_size = 5
+
+			[horizontal_listbox]
+				id = "games_list_tab_bar"
+				horizontal_scrollbar_mode = "never"
+				vertical_scrollbar_mode = "never"
+
+				[list_definition]
+					[row]
+						[column]
+                            [toggle_panel]
+                                linked_group = "tabs"
+
+                                [grid]
+
+                                    [row]
+
+                                        [column]
+                                            border = all
+                                            border_size = 5
+
+                                            [spacer][/spacer]
+
+                                        [/column]
+
+                                        [column]
+                                            grow_factor = 1
+                                            border = all
+                                            border_size = 5
+
+                                            [label]
+                                                id = "tab_label"
+                                                wrap = true
+                                            [/label]
+
+                                        [/column]
+
+                                        [column]
+                                            border = all
+                                            border_size = 5
+
+                                            [spacer][/spacer]
+
+                                        [/column]
+
+                                    [/row]
+
+                                [/grid]
+
+                            [/toggle_panel]
+						[/column]
+					[/row]
+				[/list_definition]
+
+				[list_data]
+
+					[row]
+
+						[column]
+
+							[widget]
+								id = "tab_label"
+								label = _ "Player Hosted"
+							[/widget]
+
+						[/column]
+					[/row]
+
+					[row]
+						[column]
+
+							[widget]
+								id = "tab_label"
+								label = _ "Bot Hosted"
+							[/widget]
+
+						[/column]
+
+					[/row]
+
+				[/list_data]
+			[/horizontal_listbox]
+
+		[/column]
+
+	[/row]
+
+	[row]
+		grow_factor = 1
+
+		[column]
+			grow_factor = 1
+			horizontal_grow = true
+			vertical_grow = true
+
+			{_GUI_GAME_LIST}
+
+		[/column]
+
+	[/row]
+
+[/grid]
+#enddef
+
 #define _GUI_GAME_LIST
 	[listbox]
 		id = "game_list"
@@ -593,6 +704,12 @@
 			id = "tooltip"
 		[/helptip]
 
+		[linked_group]
+			id = "tabs"
+			fixed_width = true
+			fixed_height = true
+		[/linked_group]
+
 		[grid]
 
 			[row]
@@ -741,7 +858,7 @@
 					border_size = 5
 
 					{GUI_FORCE_WIDGET_MINIMUM_SIZE 0 "((screen_height * 35) / 100)" (
-						{_GUI_GAME_LIST}
+						{_GUI_LOBBY_TABS}
 					)}
 				[/column]
 			[/row]
@@ -816,6 +933,12 @@
 			id = "tooltip"
 		[/helptip]
 
+		[linked_group]
+			id = "tabs"
+			fixed_width = true
+			fixed_height = true
+		[/linked_group]
+
 		[grid]
 
 			[row]
@@ -861,8 +984,6 @@
 										[/column]
 									[/row]
 
-									#{GUI_HORIZONTAL_SPACER_LINE}
-
 									[row]
 										grow_factor = 1
 										[column]
@@ -871,11 +992,9 @@
 											horizontal_grow = true
 											vertical_grow = true
 
-											{_GUI_GAME_LIST}
+											{_GUI_LOBBY_TABS}
 										[/column]
 									[/row]
-
-									#{GUI_HORIZONTAL_SPACER_LINE}
 
 									[row]
 										grow_factor = 0
@@ -914,3 +1033,4 @@
 #undef _GUI_FILTER_AREA
 #undef _GUI_GAME_LIST
 #undef _GUI_PLAYER_TREE_AREA
+#undef _GUI_LOBBY_TABS

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -749,6 +749,7 @@ void connect_engine::send_level_data() const
 				"name", params_.name,
 				"password", params_.password,
 				"ignored", preferences::get_ignored_delim(),
+				"auto_hosted", false,
 			},
 		});
 		mp::send_to_server(level_);

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -143,6 +143,7 @@ game_info::game_info(const config& game, const std::vector<std::string>& install
 	, have_all_mods(true)
 	, has_friends(false)
 	, has_ignored(false)
+	, auto_hosted(game["auto_hosted"].to_bool())
 	, display_status(disp_status::NEW)
 	, required_addons()
 	, addons_outcome(addon_req::SATISFIED)

--- a/src/game_initialization/lobby_data.hpp
+++ b/src/game_initialization/lobby_data.hpp
@@ -106,6 +106,7 @@ struct game_info
 
 	bool has_friends;
 	bool has_ignored;
+	bool auto_hosted;
 
 	enum class disp_status {
 		CLEAN,

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -115,6 +115,8 @@ private:
 
 	void open_profile_url();
 
+	void tab_switch_callback();
+
 	void refresh_lobby();
 
 	void game_filter_init();
@@ -145,6 +147,7 @@ private:
 	field_bool* filter_ignored_;
 	field_bool* filter_slots_;
 	field_bool* filter_invert_;
+	bool filter_auto_hosted_;
 
 	text_box* filter_text_;
 


### PR DESCRIPTION
Bot-hosted games are now shown in a separate tab from player-hosted games, based on the new `auto_hosted` attribute on the game creation WML. This is not something that's available to be selected during game creation since it's assumed it will instead be set by the bot implementation.

Resolves #6939