### PR TITLE
DiD S8: Handle situations where factions have not yet appeared

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -405,7 +405,6 @@
         {MODIFY_UNIT (id=Malin Keshar) facing ne}
 
         {VARIABLE dela_arrived no}
-        {VARIABLE cadaeus_arrived no}
     [/event]
 
     # This helps prevent Darken from getting himself killed easily by preventing
@@ -689,8 +688,6 @@
             speaker=Darken Volk
             message= _ "Pompous words from an arrogant fool. We shall see how well you fare once I have finished this upstart."
         [/message]
-
-        {VARIABLE cadaeus_arrived yes}
     [/event]
 
     # Dela joins the party
@@ -1083,53 +1080,10 @@
 
         {MOVE_UNIT (id=Malin Keshar) 1 8}
 
-        # GitHub Issue #7005: Handle presence/absence of the factions/leaders
-        [if]
-            # Phase one: Before Cadaeus or Dela have arrived
-            # Unlikely, but handle the case for completeness.
-            [variable]
-                name=cadaeus_arrived
-                boolean_equals=no
-            [/variable]
-            [and]
-                [variable]
-                    name=dela_arrived
-                    boolean_equals=no
-                [/variable]
-            [/and]
-            [then]
-                [message]
-                    speaker=Malin Keshar
-                    message= _ "The terrain is hazardous in these mountains. No one should be able to pursue me."
-                [/message]
-            [/then]
-
-            # Phase two: After Cadaeus arrives but before Dela arrives
-            # Even if Cadaeus' forces are wiped out at this point it seems reasonable to infer there could be more paladins 'off screen'.
-            [elseif]
-                [variable]
-                    name=dela_arrived
-                    boolean_equals=no
-                [/variable]
-                [then]
-                    [message]
-                        speaker=Malin Keshar
-                        message= _ "The terrain is hazardous in these mountains. The paladins will not be able to pursue me."
-                    [/message]
-                [/then]
-            [/elseif]
-
-            # Phase three: Cadaeus and Dela have arrived
-            # Generalise as 'Dela's men' in case Dela herself is killed.
-            # The scenario of both Cadaeus and Dela being killed is handled in the 'alternate victory' event.
-            [else]
-                [message]
-                    speaker=Malin Keshar
-					# po: Men refers to the soldiers under Dela's command, not necessarily all male. A gender-neutral term may be appropriate here.
-                    message= _ "The terrain is hazardous in these mountains. Neither the paladins nor Dela’s men will be able to pursue me."
-                [/message]
-            [/else]
-        [/if]
+        [message]
+            speaker=Malin Keshar
+            message= _ "The terrain is hazardous in these mountains. No one will be able to pursue me."
+        [/message]
 
         [message]
             speaker=Malin Keshar
@@ -1185,7 +1139,7 @@
             role=book_carrier
             object_id="book_icon"
         [/remove_object]
-        {CLEAR_VARIABLE bookX,bookY,dela_arrived,cadaeus_arrived}
+        {CLEAR_VARIABLE bookX,bookY,dela_arrived}
     [/event]
 
     {HERODEATH_MALIN}

--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -1125,6 +1125,7 @@
             [else]
                 [message]
                     speaker=Malin Keshar
+					# po: Men refers to the soldiers under Dela's command, not necessarily all male. A gender-neutral term may be appropriate here.
                     message= _ "The terrain is hazardous in these mountains. Neither the paladins nor Dela’s men will be able to pursue me."
                 [/message]
             [/else]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -405,6 +405,7 @@
         {MODIFY_UNIT (id=Malin Keshar) facing ne}
 
         {VARIABLE dela_arrived 0}
+        {VARIABLE cadaeus_arrived 0}
     [/event]
 
     # This helps prevent Darken from getting himself killed easily by preventing
@@ -688,6 +689,8 @@
             speaker=Darken Volk
             message= _ "Pompous words from an arrogant fool. We shall see how well you fare once I have finished this upstart."
         [/message]
+
+        {VARIABLE cadaeus_arrived 1}
     [/event]
 
     # Dela joins the party
@@ -1080,10 +1083,52 @@
 
         {MOVE_UNIT (id=Malin Keshar) 1 8}
 
-        [message]
-            speaker=Malin Keshar
-            message= _ "The terrain is hazardous in these mountains. Neither the paladins nor Dela will be able to pursue me."
-        [/message]
+        # GitHub Issue #7005: Handle presence/absence of the factions/leaders
+        [if]
+            # Phase one: Before Cadaeus or Dela have arrived
+            # Unlikely, but handle the case for completeness.
+            [variable]
+                name=cadaeus_arrived
+                numerical_not_equals=1
+            [/variable]
+            [and]
+                [variable]
+                    name=dela_arrived
+                    numerical_not_equals=1
+                [/variable]
+            [/and]
+            [then]
+                [message]
+                    speaker=Malin Keshar
+                    message= _ "The terrain is hazardous in these mountains. No one should be able to pursue me."
+                [/message]
+            [/then]
+
+            # Phase two: After Cadaeus arrives but before Dela arrives
+            # Even if Cadaeus' forces are wiped out at this point it seems reasonable to infer there could be more paladins 'off screen'.
+            [elseif]
+                [variable]
+                    name=dela_arrived
+                    numerical_not_equals=1
+                [/variable]
+                [then]
+                    [message]
+                        speaker=Malin Keshar
+                        message= _ "The terrain is hazardous in these mountains. The paladins will not be able to pursue me."
+                    [/message]
+                [/then]
+            [/elseif]
+
+            # Phase three: Cadaeus and Dela have arrived
+            # Generalise as 'Dela's men' in case Dela herself is killed.
+            # The scenario of both Cadaeus and Dela being killed is handled in the 'alternate victory' event.
+            [else]
+                [message]
+                    speaker=Malin Keshar
+                    message= _ "The terrain is hazardous in these mountains. Neither the paladins nor Dela’s men will be able to pursue me."
+                [/message]
+            [/else]
+        [/if]
 
         [message]
             speaker=Malin Keshar
@@ -1139,7 +1184,7 @@
             role=book_carrier
             object_id="book_icon"
         [/remove_object]
-        {CLEAR_VARIABLE bookX,bookY,dela_arrived}
+        {CLEAR_VARIABLE bookX,bookY,dela_arrived,cadaeus_arrived}
     [/event]
 
     {HERODEATH_MALIN}

--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -404,8 +404,8 @@
 
         {MODIFY_UNIT (id=Malin Keshar) facing ne}
 
-        {VARIABLE dela_arrived 0}
-        {VARIABLE cadaeus_arrived 0}
+        {VARIABLE dela_arrived no}
+        {VARIABLE cadaeus_arrived no}
     [/event]
 
     # This helps prevent Darken from getting himself killed easily by preventing
@@ -690,7 +690,7 @@
             message= _ "Pompous words from an arrogant fool. We shall see how well you fare once I have finished this upstart."
         [/message]
 
-        {VARIABLE cadaeus_arrived 1}
+        {VARIABLE cadaeus_arrived yes}
     [/event]
 
     # Dela joins the party
@@ -766,7 +766,7 @@
             message= _ "Nothing to say this time? No quip ’bout how we don’t understand ya? No comment about yer moral superiority? I can only hope you’ll be so quiet when I kill you."
         [/message]
 
-        {VARIABLE dela_arrived 1}
+        {VARIABLE dela_arrived yes}
     [/event]
 
     [event]
@@ -823,7 +823,7 @@
             [and]
                 [variable]
                     name=dela_arrived
-                    numerical_equals=1
+                    boolean_equals=yes
                 [/variable]
             [/and]
             [then]
@@ -1089,12 +1089,12 @@
             # Unlikely, but handle the case for completeness.
             [variable]
                 name=cadaeus_arrived
-                numerical_not_equals=1
+                boolean_equals=no
             [/variable]
             [and]
                 [variable]
                     name=dela_arrived
-                    numerical_not_equals=1
+                    boolean_equals=no
                 [/variable]
             [/and]
             [then]
@@ -1109,7 +1109,7 @@
             [elseif]
                 [variable]
                     name=dela_arrived
-                    numerical_not_equals=1
+                    boolean_equals=no
                 [/variable]
                 [then]
                     [message]


### PR DESCRIPTION
Resolves #7005.

I think this is perhaps overkill, but clearly at least some people notice the discrepancy in the dialogue if the scenario is completed before certain factions have appeared.

I consider 'paladins' as a generalisation for Cadaeus' forces, so there doesn't need to be yet another piece of dialogue differentiating whether or not Cadaeus is alive. Similarly, I generalise Dela's forces as 'Dela's men' so it shouldn't matter if Dela is alive or not. Regardless, the underlying bug report requires that there be work for the translators.

I think this scenario file is the same in 1.16 branch, so could be back-ported. I have tested the three phases as stated in the commentary: before Cadaeus appears, after Cadaeus appears but before Dela appears, and after Dela appears. It makes sense to me, given the context of the bug report.