### PR TITLE
MP tooltips: allow line breaks between hexagons by using Unicode zero width space

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -196,7 +196,8 @@ static inline std::string get_mp_tooltip(int total_movement, std::function<int (
 			const int movement_hexes_per_turn = total_movement / tm.moves;
 			tooltip << " ";
 			for(int i = 0; i < movement_hexes_per_turn; ++i) {
-				tooltip << "\u2b23";	// Unicode horizontal black hexagon
+				// Unicode horizontal black hexagon and Unicode zero width space (to allow a line break)
+				tooltip << "\u2b23\u200b";
 			}
 		}
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -709,7 +709,8 @@ static config unit_moves(reports::context & rc, const unit* u, bool is_visible_u
 			const int movement_hexes_per_turn = u->total_movement() / tm.moves;
 			tooltip << " ";
 			for(int i = 0; i < movement_hexes_per_turn; ++i) {
-				tooltip << "\u2b23";	// Unicode horizontal black hexagon
+				// Unicode horizontal black hexagon and Unicode zero width space (to allow a line break)
+				tooltip << "\u2b23\u200b";
 			}
 		}
 		tooltip << naps << '\n';


### PR DESCRIPTION
To allow potential line breaks between the hexagons in MP tooltips, this pull request inserts (invisible) Unicode zero width space characters between them.

Previously, I have already used this little trick for the hexagons in the help browser.

With this pull request, the same thing is done for the MP tooltips in the sidebar and the recruitment dialog, which covers all places where MP hexagons appear.

This only makes a visible difference if a unit's movepoints are extremely large, quite beyond any mainline unit, but I see no drawbacks.