### PR TITLE
Reduce the saturation of hex colour for movement points

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -179,8 +179,8 @@ static inline std::string get_mp_tooltip(int total_movement, std::function<int (
 		const bool cannot_move = tm.moves > total_movement;     // cannot move in this terrain
 		double movement_red_to_green = 100.0 - 25.0 * tm.moves;
 
-		// passing false to select the more saturated red-to-green scale
-		std::string color = game_config::red_to_green(movement_red_to_green, false).to_hex_string();
+		// passing true to select the less saturated red-to-green scale
+		std::string color = game_config::red_to_green(movement_red_to_green, true).to_hex_string();
 
 		tooltip << "<span color='" << color << "'>";
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -814,8 +814,8 @@ std::string unit_topic_generator::operator()() const {
 			const bool cannot_move = m.movement_cost > type_.movement();        // cannot move in this terrain
 			double movement_red_to_green = 100.0 - 25.0 * m.movement_cost;
 
-			// passing false to select the more saturated red-to-green scale
-			std::string movement_color = game_config::red_to_green(movement_red_to_green, false).to_hex_string();
+			// passing true to select the less saturated red-to-green scale
+			std::string movement_color = game_config::red_to_green(movement_red_to_green, true).to_hex_string();
 			str << "<format>color='" << movement_color << "' text='";
 			// A 5 MP margin; if the movement costs go above
 			// the unit's max moves + 5, we replace it with dashes.
@@ -858,8 +858,8 @@ std::string unit_topic_generator::operator()() const {
 				const bool cannot_view = m.vision_cost > type_.vision();        // cannot view in this terrain
 				double vision_red_to_green = 100.0 - 25.0 * m.vision_cost;
 
-				// passing false to select the more saturated red-to-green scale
-				std::string vision_color = game_config::red_to_green(vision_red_to_green, false).to_hex_string();
+				// passing true to select the less saturated red-to-green scale
+				std::string vision_color = game_config::red_to_green(vision_red_to_green, true).to_hex_string();
 				str << "<format>color='" << vision_color << "' text='";
 				// A 5 MP margin; if the vision costs go above
 				// the unit's vision + 5, we replace it with dashes.
@@ -889,8 +889,8 @@ std::string unit_topic_generator::operator()() const {
 				const bool cannot_jam = m.jamming_cost > type_.jamming();       // cannot jam in this terrain
 				double jamming_red_to_green = 100.0 - 25.0 * m.jamming_cost;
 
-				// passing false to select the more saturated red-to-green scale
-				std::string jamming_color = game_config::red_to_green(jamming_red_to_green, false).to_hex_string();
+				// passing true to select the less saturated red-to-green scale
+				std::string jamming_color = game_config::red_to_green(jamming_red_to_green, true).to_hex_string();
 				str << "<format>color='" << jamming_color << "' text='";
 				// A 5 MP margin; if the jamming costs go above
 				// the unit's jamming + 5, we replace it with dashes.

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -693,8 +693,8 @@ static config unit_moves(reports::context & rc, const unit* u, bool is_visible_u
 		const bool cannot_move = tm.moves > u->total_movement();		// cannot move in this terrain
 		double movement_red_to_green = 100.0 - 25.0 * tm.moves;
 
-		// passing false to select the more saturated red-to-green scale
-		std::string color = game_config::red_to_green(movement_red_to_green, false).to_hex_string();
+		// passing true to select the less saturated red-to-green scale
+		std::string color = game_config::red_to_green(movement_red_to_green, true).to_hex_string();
 		tooltip << "<span foreground=\"" << color << "\">";
 		// A 5 MP margin; if the movement costs go above
 		// the unit's max moves + 5, we replace it with dashes.


### PR DESCRIPTION
Attempting to mitigate #7017.

It's a subtle difference, but I think it may help ease the complaints of 'garishness' regarding the recent addition to the help page. (Also applied to the side bar reports, etc.)

Before:
![191890877-b944fe4f-0447-4323-9490-87b1624ed97d](https://user-images.githubusercontent.com/13679322/191895504-3fee2371-d832-44bb-81f1-cf214c51226f.png)

After:
![image](https://user-images.githubusercontent.com/13679322/191895520-3cc2a10f-b3f0-48b5-8883-e08714115bda.png)
