### PR TITLE
Changed Fire_Dragon and Skeletal_Dragon to match issue 5703

### DIFF
--- a/data/core/units/monsters/Fire_Dragon.cfg
+++ b/data/core/units/monsters/Fire_Dragon.cfg
@@ -57,6 +57,17 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
         damage=14
         number=4
     [/attack]
+    #Commented out for lack of anim, but potential additional attack idea (on issue post)
+    #[attack]
+    #   name=tail_whip
+    #   description= _"tail_whip"
+    #   type=impact
+    #   range=melee
+    #   [specials]
+    #       {WEAPON_SPECIAL_STUN}
+    #   [/specials]
+    #   damage=28
+    #   number=1
 
     [attack_anim]
         [filter_attack]

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -5,21 +5,26 @@
     #not 'race=monster', because we need the not_living attribute
     race=undead
     image="units/monsters/skeletal-dragon/skeletal-dragon.png"
-    hitpoints=86
-    movement_type=undeadfly
-    movement=5
-    experience=200
+    hitpoints=75
+    movement_type=undeadfoot
+    movement=4
+    experience=220
     level=4
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
     cost=100
+    [abilities]
+    #Other undead beings have the submerge ability, maybe change to not have this
+	  {ABILITY_SUBMERGE}
+    [/abilities]
     usage=fighter
     [resistance]
         blade=60
         pierce=40
         impact=120
-        fire=100
+	  #completely resisted fire when alive, safe to give 50 resistance to match but also alter since dead.
+        fire=50
         #you have many arcane units by now, probably, and he shouldn't die all that easily.
         arcane=100
     [/resistance]
@@ -34,8 +39,8 @@
         [specials]
             {WEAPON_SPECIAL_DRAIN}
         [/specials]
-        damage=10
-        number=4
+        damage=15
+        number=3
     [/attack]
     [attack]
         name=claws
@@ -45,6 +50,17 @@
         damage=25
         number=2
     [/attack]
+    #Commented out for lack of anim, but potential additional attack idea (on issue post)
+    #[attack]
+    #   name=tail_whip
+    #   description= _"tail_whip"
+    #   type=impact
+    #   range=melee
+    #   [specials]
+    #       {WEAPON_SPECIAL_STUN}
+    #   [/specials]
+    #   damage=28
+    #   number=1
     {DEFENSE_ANIM "units/monsters/skeletal-dragon/skeletal-dragon.png" "units/monsters/skeletal-dragon/skeletal-dragon.png" {SOUND_LIST:SKELETON_BIG_HIT} }
     [attack_anim]
         [filter_attack]


### PR DESCRIPTION
Updated the Skeletal_Dragon and Fire_Dragon monsters to match the user request in 5703. Put a placeholder attack for Tail_Whip as it was matching an animation file. Resolves #5703 