### PR TITLE
Remove "Apply to all units" option from the pick_advance mod

### DIFF
--- a/data/modifications/pick_advance/dialog.lua
+++ b/data/modifications/pick_advance/dialog.lua
@@ -17,8 +17,6 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 
 	local unit_override_one = (advance_info.unit_override or {})[2] == nil
 		and (advance_info.unit_override or {})[1] or nil
-	local game_override_one = (advance_info.game_override or {})[2] == nil
-		and (advance_info.game_override or {})[1] or nil
 
 	local description_row = T.row {
 		T.column {
@@ -55,18 +53,6 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 					linked_group = "type"
 				}
 			},
-			T.column {
-				border = "all",
-				border_size = 5,
-				horizontal_alignment = "center",
-				vertical_alignment = "center",
-				T.image {
-					id = "global_icon",
-					linked_group = "global_icon",
-					label = "icons/action/editor-tool-unit_30-pressed.png",
-					tooltip = _ "This advancement is currently the default for all units of the same type"
-				}
-			}
 		}
 	}
 
@@ -103,10 +89,6 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 			id = "type",
 			fixed_width = true
 		},
-		T.linked_group {
-			id = "global_icon",
-			fixed_width = true
-		},
 		T.grid {
 			description_row,
 			T.row {
@@ -116,18 +98,6 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 					border_size = 5,
 					horizontal_grow = true,
 					listbox
-				}
-			},
-			T.row {
-				grow_factor = 0,
-				T.column {
-					border = "all",
-					border_size = 5,
-					horizontal_alignment = "left",
-					T.toggle_button {
-						id = "apply_to_all",
-						label = _ "Apply to all units of this type"
-					}
 				}
 			},
 			T.row {
@@ -163,7 +133,6 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 
 -- dialog preshow function
 	local function preshow(window)
-		window.apply_to_all.visible = not unit.canrecruit
 
 		local selection = 0
 
@@ -172,12 +141,11 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 		local null_row = window.the_list[1]
 		null_row.the_icon.label = empty_icon_unit
 		null_row.the_label.label = _ "No planned advancement"
-		null_row.global_icon.visible = false
 
 		for i, advance_type in ipairs(options) do
 			local n = i + 1
 			local text = advance_type.name
-			if advance_type.id == game_override_one or advance_type.id == unit_override_one then
+			if advance_type.id == unit_override_one then
 				selection = n
 			end
 			local this_row = window.the_list[n]
@@ -189,7 +157,6 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 				img = empty_icon_unit
 			end
 			this_row.the_icon.label = img
-			this_row.global_icon.visible = not not (advance_type.id == game_override_one) or "hidden"
 		end
 
 		window.the_list:focus()
@@ -200,10 +167,8 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 
 -- dialog postshow function
 	local item_result
-	local apply_to_all
 	local function postshow(window)
 		item_result = window.the_list.selected_index - 1
-		apply_to_all = window.apply_to_all.selected
 	end
 
 	local dialog_exit_code = gui.show_dialog(dialog, preshow, postshow)
@@ -216,11 +181,7 @@ function pickadvance.show_dialog_unsynchronized(advance_info, unit)
 	local is_reset = item_result == 0
 	return {
 		ignore = false,
-		is_unit_override = not apply_to_all,
 		unit_override = not is_reset and options[item_result].id or table.concat(unit_type_options, ","),
-
-		is_game_override = apply_to_all,
-		game_override = apply_to_all and (not is_reset and options[item_result].id) or nil,
 	}
 end
 

--- a/data/modifications/pick_advance/main.lua
+++ b/data/modifications/pick_advance/main.lua
@@ -78,8 +78,6 @@ end
 --         the unit's currently overridden advancement or nil if not set, but set by some other mechanism from the current game
 local function get_advance_info(unit)
 	local type_advances, orig_options_sanitized = original_advances(unit)
-	local game_override_key = "pickadvance_side" .. unit.side .. "_" .. orig_options_sanitized
-	local game_override = wml.variables[game_override_key]
 	local function correct(override)
 		return override and #override > 0 and #override < #type_advances and override or nil
 	end
@@ -87,7 +85,6 @@ local function get_advance_info(unit)
 	return {
 		type_advances = type_advances,
 		unit_override = correct(unit.advances_to),
-		game_override = correct(split_comma_units(game_override)),
 	}
 end
 
@@ -114,7 +111,7 @@ local function initialize_unit(unit)
 		}
 		unit.variables["pickadvance_orig_" .. clean_type] = table.concat(unit.advances_to, ",")
 		local advance_info = get_advance_info(unit)
-		local desired = advance_info.game_override or unit.advances_to
+		local desired = unit.advances_to
 		desired = filter_overrides(unit, desired)
 		set_advances(unit, desired)
 	end
@@ -133,16 +130,8 @@ function pickadvance.pick_advance(unit)
 		return
 	end
 	dialog_result.unit_override = split_comma_units(dialog_result.unit_override)
-	dialog_result.game_override = split_comma_units(dialog_result.game_override)
 	dialog_result.unit_override = filter_overrides(unit, dialog_result.unit_override)
-	dialog_result.game_override = filter_overrides(unit, dialog_result.game_override)
-	if dialog_result.is_unit_override then
-		set_advances(unit, dialog_result.unit_override)
-	end
-	if dialog_result.is_game_override then
-		local key = "pickadvance_side" .. unit.side .. "_" .. orig_options_sanitized
-		wml.variables[key] = table.concat(dialog_result.game_override, ",")
-	end
+	set_advances(unit, dialog_result.unit_override)
 end
 
 -- make unit advancement tree viewable in the ingame help


### PR DESCRIPTION
So, for starters I propose this change, completely remove "Apply to all units" option from the Plan Unit Advancements mod. It works in a buggy and confusing way: it enables the chosen advancement for all subsequent recruits and doesn't apply to the unit by clicking on which it was requested. There were no suggestions how to improve it and the more I thought about it, I came to a conclusion that it will be confusing either way. Some people think it sets for all units on the board, others that on all subsequent units on the board including the one you clicked on. So I propose for now just delete this option, people may set up advancements for each unit individually (although it may be tedious for very large scenario prob?) I'm not committed to this resolution and if any other good ideas on how to improve it appear, I will gladly double down on them.

As this mod is inlined in each game that uses it, afaik this change shouldn't cause any OOS and so could be merged right in 1.16