### PR TITLE
Units: Wyvern Rider XP set to 200

### DIFF
--- a/data/core/units/dunefolk/Wyvern_Rider.cfg
+++ b/data/core/units/dunefolk/Wyvern_Rider.cfg
@@ -7,7 +7,7 @@
     hitpoints=85
     movement_type=fly
     movement=7
-    experience=50
+    experience=200
     level=4
     alignment=liminal
     advances_to=null


### PR DESCRIPTION
This is a level 4 unit and so, by convention, `experience=` should be `200`.