### PR TITLE
Units: add sand_scorpion variation to Walking Corpse and Soulless

### DIFF
--- a/data/core/units/monsters/Giant_Scorpion.cfg
+++ b/data/core/units/monsters/Giant_Scorpion.cfg
@@ -114,6 +114,7 @@
         small_profile="portraits/monsters/scuttler.webp~FL()"
         profile="portraits/monsters/scuttler.webp~RIGHT()"
         image="units/monsters/scorpion/sand-scuttler.png"
+        undead_variation=sand_scorpion
         description= _ "Making their homes in sandy dunes, these critters are an odd mix of mundane creature and elemental beast. Though usually timid, Sand Scuttlers sometimes attack unwary travelers, especially when startled."
         [standing_anim]
             start_time=0

--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -265,6 +265,24 @@
         variation_id=scorpion
         variation_name= _ "wc_variation^Scorpion"
         inherit=yes
+        [resistance]
+            blade=90
+            pierce=80
+            impact=110
+            fire=90
+            cold=110
+            arcane=80
+        [/resistance]
+        profile=portraits/undead/zombie-scorpion.webp
+        {UNIT_BODY_SOULLESS_STATS    scuttlefoot 4 33}
+        {UNIT_BODY_SOULLESS_GRAPHICS soulless-scorpion}
+    [/variation]
+
+    # account for sand scuttler
+    [variation]
+        variation_id=sand_scorpion
+        variation_name= _ "wc_variation^Scuttler"
+        inherit=yes
         profile=portraits/undead/zombie-scorpion.webp
         {UNIT_BODY_SOULLESS_STATS    scuttlefoot 4 33}
         {UNIT_BODY_SOULLESS_GRAPHICS soulless-scorpion}

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -264,6 +264,24 @@
         variation_id=scorpion
         variation_name= _ "wc_variation^Scorpion"
         inherit=yes
+        [resistance]
+            blade=90
+            pierce=80
+            impact=110
+            fire=90
+            cold=110
+            arcane=80
+        [/resistance]
+        profile=portraits/undead/zombie-scorpion.webp
+        {UNIT_BODY_WALKING_CORPSE_STATS    scuttlefoot 4 21}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-scorpion}
+    [/variation]
+
+    # account for sand scuttler
+    [variation]
+        variation_id=sand_scorpion
+        variation_name= _ "wc_variation^Scuttler"
+        inherit=yes
         profile=portraits/undead/zombie-scorpion.webp
         {UNIT_BODY_WALKING_CORPSE_STATS    scuttlefoot 4 21}
         {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-scorpion}


### PR DESCRIPTION
This accommodates the variation of the Giant Scorpion, the Sand Scuttler.

## Why has this been done?

Well, compare the resistances of the Giant Scorpion base variation and the Walking Corpse scorpion variation...do they match? No, They don't.

The WC/SL variation of the scorpion coincidences perfectly with the sand scuttler variation of the Giant Scorpion, not the base.
Oversight developed from b9e67f459840a01a3d453570cd6ceec31ef10ac6

Closes #7015 