### PR TITLE
Add [filter_weapon][not]special_id_active=forced_cth in chance_to_hit abilities using overwrite_specials attribute

### DIFF
--- a/data/test/scenarios/test_force_chance_to_hit_macro.cfg
+++ b/data/test/scenarios/test_force_chance_to_hit_macro.cfg
@@ -37,6 +37,15 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
             [filter]
                 id=bob
             [/filter]
@@ -57,6 +66,15 @@
                         value=100
                     [/chance_to_hit]
                 [/set_specials]
+            [/effect]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
             [/effect]
             [filter]
                 id=alice

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1658,15 +1658,32 @@ bool attack_type::special_active_impl(
 			return false;
 	}
 
+	//filter forced_cth for macro work if wml devellopper forget to add when using overwrite_specials attribute in [chance_to_hit] ability
+	config cfg = special;
+	bool bool_force_cth = (tag_name == "chance_to_hit") && (special["id"] != "forced_cth")  && (filter_self == "filter_student") && overwrite_special_affects(special);
+	if(bool_force_cth){
+		config filter;
+		filter["special_id_active"] = "forced_cth";
+		if(whom_is_self){
+			config& filter_child = cfg.child_or_add(filter_self);
+			config& filter_weapon = filter_child.child_or_add("filter_weapon");
+			filter_weapon.add_child("not", filter);
+		} else {
+			config& filter_child = cfg.child_or_add("filter_opponent");
+			config& filter_weapon = filter_child.child_or_add("filter_weapon");
+			filter_weapon.add_child("not", filter);
+		}
+	}
+	const config& special_cth = bool_force_cth ? cfg : special;
 	//Add wml filter if "backstab" attribute used.
 	if (!special["backstab"].blank()) {
 		deprecated_message("backstab= in weapon specials", DEP_LEVEL::INDEFINITE, "", "Use [filter_opponent] with a formula instead; the code can be found in data/core/macros/ in the WEAPON_SPECIAL_BACKSTAB macro.");
 	}
-	config cfg = special;
-	if(special["backstab"].to_bool()){
+	cfg = special_cth;
+	if(special_cth["backstab"].to_bool()){
 		const std::string& backstab_formula = "enemy_of(self, flanker) and not flanker.petrified where flanker = unit_at(direction_from(loc, other.facing))";
 		config& filter_child = cfg.child_or_add("filter_opponent");
-		if(!special.has_child("filter_opponent")){
+		if(!special_cth.has_child("filter_opponent")){
 			filter_child["formula"] = backstab_formula;
 		} else {
 			config filter;
@@ -1674,10 +1691,10 @@ bool attack_type::special_active_impl(
 			filter_child.add_child("and", filter);
 		}
 	}
-	const config& special_backstab = special["backstab"].to_bool() ? cfg : special;
+	const config& special_backstab = special["backstab"].to_bool() ? cfg : special_cth;
 
 	// Filter the units involved.
-	if (!special_unit_matches(self, other, self_loc, self_attack, special, is_for_listing, filter_self))
+	if (!special_unit_matches(self, other, self_loc, self_attack, special_cth, is_for_listing, filter_self))
 		return false;
 	if (!special_unit_matches(other, self, other_loc, other_attack, special_backstab, is_for_listing, "filter_opponent"))
 		return false;


### PR DESCRIPTION


The FORCE_CHANCE_TO_HIT macrodon't overwrite a cth who using overwrite_specials attribute if [filter_weapon][not]special_id_active=forced_cth not addedin [filter_student/opponent]. i propose to add that in hard code for resolve this issue.