### PR TITLE
Add "all_others" option to overwrite_specials attribute for overwrite all specials of same type

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -551,7 +551,7 @@
                         value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
-                        overwrite_specials=both_sides
+                        overwrite_specials=all_others
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]
@@ -604,7 +604,7 @@
                         value={CTH_NUMBER}
                         cumulative=no
                         affect_self=yes
-                        overwrite_specials=both_sides
+                        overwrite_specials=all_others
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -38,7 +38,7 @@
     [/type]
     [type]
         name="ability_overwrite"
-        value="none|one_side|both_sides"
+        value="none|one_side|both_sides|all_others"
     [/type]
     [type]
         name="addon_type"

--- a/data/test/scenarios/test_force_chance_to_hit_macro.cfg
+++ b/data/test/scenarios/test_force_chance_to_hit_macro.cfg
@@ -37,6 +37,15 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
             [filter]
                 id=bob
             [/filter]
@@ -57,6 +66,15 @@
                         value=100
                     [/chance_to_hit]
                 [/set_specials]
+            [/effect]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
             [/effect]
             [filter]
                 id=alice

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1301,18 +1301,34 @@ unit_ability_list attack_type::overwrite_special_checking(const std::string& abi
 {
 	bool overwrite_self = false;
 	bool overwrite_either = false;
+	bool overwrite_ultimate = false;
 
 	for(const auto& i : abil_list) {
+		if((*i.ability_cfg)["overwrite_specials"] == "all_others") {
+			overwrite_ultimate = true;
+			break;
+		}
 		if((*i.ability_cfg)["overwrite_specials"] == "both_sides") {
 			overwrite_either = true;
-			break;
 		}
 		if(overwrite_special_affects(*i.ability_cfg) && (special_active(*i.ability_cfg, AFFECT_SELF, ability, "filter_student") || special_active_impl(other_attack_, shared_from_this(), *i.ability_cfg, AFFECT_OTHER, ability, "filter_student"))) {
 			overwrite_self = true;
 		}
 	}
-	if(!overwrite_either && !overwrite_self){
+	if(!overwrite_either && !overwrite_self && !overwrite_ultimate){
 		return temp_list;
+	} else if(overwrite_ultimate){
+		for(unit_ability_list::iterator i = temp_list.begin(); i != temp_list.end();) {
+			bool overwrite = false;
+			if(filter_self == "filter_student"){
+				overwrite = (*i->ability_cfg)["overwrite_specials"] == "all_others";
+			}
+			if(!overwrite) {
+				i = temp_list.erase(i);
+			} else {
+				++i;
+			}
+		}
 	} else if(overwrite_either){
 		for(unit_ability_list::iterator i = temp_list.begin(); i != temp_list.end();) {
 			bool overwrite = false;


### PR DESCRIPTION


when overwrite_specials used with "all_others" all specials/abilities of same type wh don't have overwrite_specials=all_others will be overwrited.

Can resolve force_chance_to_hit macro can't overwrite chance_to_hit ability using overwrite_specials.