### PR TITLE
Fix FORCE_CHANCE_TO_HIT macro

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -536,7 +536,6 @@
         [/filter_condition]
 
         [if]
-            #This is to mute a warning message about retrieving a member of non-existant wml container.
             [variable]
                 name=unit.abilities.length
                 greater_than=0
@@ -594,7 +593,6 @@
             find_vacant=no
         [/unstore_unit]
         [if]
-            #This is to mute a warning message about retrieving a member of non-existant wml container.
             [variable]
                 name=second_unit.abilities.length
                 greater_than=0
@@ -652,12 +650,10 @@
                 [/then]
                 [else]
                     {CLEAR_VARIABLE unit.abilities.chance_to_hit}
-
                     [set_variables]
                         name=unit.abilities.chance_to_hit
                         to_variable=original_chance_to_hit
                     [/set_variables]
-
                     {CLEAR_VARIABLE original_chance_to_hit}
 
                     [unstore_unit]
@@ -675,12 +671,10 @@
                 [/then]
                 [else]
                     {CLEAR_VARIABLE second_unit.abilities.chance_to_hit}
-
                     [set_variables]
                         name=second_unit.abilities.chance_to_hit
                         to_variable=second_original_chance_to_hit
                     [/set_variables]
-
                     {CLEAR_VARIABLE second_original_chance_to_hit}
 
                     [unstore_unit]
@@ -689,8 +683,6 @@
                     [/unstore_unit]
                 [/else]
             [/if]
-
-
         [/event]
     [/event]
 
@@ -716,7 +708,6 @@
         [/filter_condition]
 
         [if]
-            #This is to mute a warning message about retrieving a member of non-existant wml container.
             [variable]
                 name=second_unit.abilities.length
                 greater_than=0
@@ -774,7 +765,6 @@
             find_vacant=no
         [/unstore_unit]
         [if]
-            #This is to mute a warning message about retrieving a member of non-existant wml container.
             [variable]
                 name=unit.abilities.length
                 greater_than=0
@@ -832,12 +822,10 @@
                 [/then]
                 [else]
                     {CLEAR_VARIABLE second_unit.abilities.chance_to_hit}
-
                     [set_variables]
                         name=second_unit.abilities.chance_to_hit
                         to_variable=original_chance_to_hit
                     [/set_variables]
-
                     {CLEAR_VARIABLE original_chance_to_hit}
 
                     [unstore_unit]
@@ -855,12 +843,10 @@
                 [/then]
                 [else]
                     {CLEAR_VARIABLE unit.abilities.chance_to_hit}
-
                     [set_variables]
                         name=unit.abilities.chance_to_hit
                         to_variable=second_original_chance_to_hit
                     [/set_variables]
-
                     {CLEAR_VARIABLE second_original_chance_to_hit}
 
                     [unstore_unit]

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -535,46 +535,107 @@
             [/and]
         [/filter_condition]
 
-        [foreach]
-            array=unit
-            [do]
-                [if]
-                    #This is to mute a warning message about retrieving a member of non-existant wml container.
-                    [variable]
-                        name=this_item.abilities.length
-                        greater_than=0
-                    [/variable]
+        [if]
+            #This is to mute a warning message about retrieving a member of non-existant wml container.
+            [variable]
+                name=unit.abilities.length
+                greater_than=0
+            [/variable]
 
-                    [variable]
-                        name=this_item.abilities.chance_to_hit.length
-                        greater_than=0
-                    [/variable]
+            [variable]
+                name=unit.abilities.chance_to_hit.length
+                greater_than=0
+            [/variable]
 
-                    [then]
-                        [set_variables]
-                            name=this_item.abilities.original_chance_to_hit
-                            to_variable=this_item.abilities.chance_to_hit
-                        [/set_variables]
-
-                        {CLEAR_VARIABLE this_item.abilities.chance_to_hit}
-                    [/then]
-                [/if]
-
+            [then]
                 [set_variables]
-                    name=this_item.abilities.chance_to_hit
-
-                    [value]
-                        id=forced_cth
-                        value={CTH_NUMBER}
-                        cumulative=no
-                        overwrite_specials=both_sides
-                    [/value]
+                    name=original_chance_to_hit
+                    to_variable=unit.abilities.chance_to_hit
                 [/set_variables]
-            [/do]
-        [/foreach]
+                [for]
+                    array=unit.abilities.chance_to_hit
+                    [do]
+                        [if]
+                            [not]
+                                [variable]
+                                    name=unit.abilities.chance_to_hit[$i].apply_to
+                                    equals=opponent
+                                [/variable]
+                            [/not]
+                            [not]
+                                [variable]
+                                    name=unit.abilities.chance_to_hit[$i].apply_to
+                                    equals=defender
+                                [/variable]
+                            [/not]
+                            [then]
+                                {CLEAR_VARIABLE unit.abilities.chance_to_hit[$i]}
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
+            [/then]
+        [/if]
+
+        [set_variables]
+            name=unit.abilities.chance_to_hit
+            mode=insert
+
+            [value]
+                id=forced_cth
+                value={CTH_NUMBER}
+                cumulative=no
+                overwrite_specials=both_sides
+            [/value]
+        [/set_variables]
 
         [unstore_unit]
             variable=unit
+            find_vacant=no
+        [/unstore_unit]
+        [if]
+            #This is to mute a warning message about retrieving a member of non-existant wml container.
+            [variable]
+                name=second_unit.abilities.length
+                greater_than=0
+            [/variable]
+
+            [variable]
+                name=second_unit.abilities.chance_to_hit.length
+                greater_than=0
+            [/variable]
+
+            [then]
+                [set_variables]
+                    name=second_original_chance_to_hit
+                    to_variable=second_unit.abilities.chance_to_hit
+                [/set_variables]
+                [for]
+                    array=second_unit.abilities.chance_to_hit
+                    [do]
+                        [if]
+                            [variable]
+                                name=second_unit.abilities.chance_to_hit[$i].apply_to
+                                equals=opponent
+                            [/variable]
+                            [or]
+                                [variable]
+                                    name=second_unit.abilities.chance_to_hit[$i].apply_to
+                                    equals=attacker
+                                [/variable]
+                            [/or]
+
+                            [then]
+                                {CLEAR_VARIABLE second_unit.abilities.chance_to_hit[$i]}
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
+            [/then]
+        [/if]
+
+        [unstore_unit]
+            variable=second_unit
             find_vacant=no
         [/unstore_unit]
 
@@ -588,29 +649,48 @@
                     numerical_equals=0
                 [/variable]
                 [then]
-                    # Unit vanished mid-fight
-                    [return][/return]
                 [/then]
-            [/if]
-
-            [foreach]
-                array=unit
-                [do]
+                [else]
                     {CLEAR_VARIABLE unit.abilities.chance_to_hit}
 
                     [set_variables]
-                        name=this_item.abilities.chance_to_hit
-                        to_variable=this_item.abilities.original_chance_to_hit
+                        name=unit.abilities.chance_to_hit
+                        to_variable=original_chance_to_hit
                     [/set_variables]
 
-                    {CLEAR_VARIABLE this_item.abilities.original_chance_to_hit}
-                [/do]
-            [/foreach]
+                    {CLEAR_VARIABLE original_chance_to_hit}
 
-            [unstore_unit]
-                variable=unit
-                find_vacant=no
-            [/unstore_unit]
+                    [unstore_unit]
+                        variable=unit
+                        find_vacant=no
+                    [/unstore_unit]
+                [/else]
+            [/if]
+            [if]
+                [variable]
+                    name=second_unit.length
+                    numerical_equals=0
+                [/variable]
+                [then]
+                [/then]
+                [else]
+                    {CLEAR_VARIABLE second_unit.abilities.chance_to_hit}
+
+                    [set_variables]
+                        name=second_unit.abilities.chance_to_hit
+                        to_variable=second_original_chance_to_hit
+                    [/set_variables]
+
+                    {CLEAR_VARIABLE second_original_chance_to_hit}
+
+                    [unstore_unit]
+                        variable=second_unit
+                        find_vacant=no
+                    [/unstore_unit]
+                [/else]
+            [/if]
+
+
         [/event]
     [/event]
 
@@ -635,46 +715,107 @@
             [/and]
         [/filter_condition]
 
-        [foreach]
-            array=second_unit
-            [do]
-                [if]
-                    #This is to mute a warning message about retrieving a member of non-existant wml container.
-                    [variable]
-                        name=this_item.abilities.length
-                        greater_than=0
-                    [/variable]
+        [if]
+            #This is to mute a warning message about retrieving a member of non-existant wml container.
+            [variable]
+                name=second_unit.abilities.length
+                greater_than=0
+            [/variable]
 
-                    [variable]
-                        name=this_item.abilities.chance_to_hit.length
-                        greater_than=0
-                    [/variable]
+            [variable]
+                name=second_unit.abilities.chance_to_hit.length
+                greater_than=0
+            [/variable]
 
-                    [then]
-                        [set_variables]
-                            name=this_item.abilities.original_chance_to_hit
-                            to_variable=this_item.abilities.chance_to_hit
-                        [/set_variables]
-
-                        {CLEAR_VARIABLE this_item.abilities.chance_to_hit}
-                    [/then]
-                [/if]
-
+            [then]
                 [set_variables]
-                    name=this_item.abilities.chance_to_hit
-
-                    [value]
-                        id=forced_cth
-                        value={CTH_NUMBER}
-                        cumulative=no
-                        overwrite_specials=both_sides
-                    [/value]
+                    name=original_chance_to_hit
+                    to_variable=second_unit.abilities.chance_to_hit
                 [/set_variables]
-            [/do]
-        [/foreach]
+                [for]
+                    array=second_unit.abilities.chance_to_hit
+                    [do]
+                        [if]
+                            [not]
+                                [variable]
+                                    name=second_unit.abilities.chance_to_hit[$i].apply_to
+                                    equals=opponent
+                                [/variable]
+                            [/not]
+                            [not]
+                                [variable]
+                                    name=second_unit.abilities.chance_to_hit[$i].apply_to
+                                    equals=attacker
+                                [/variable]
+                            [/not]
+                            [then]
+                                {CLEAR_VARIABLE second_unit.abilities.chance_to_hit[$i]}
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
+            [/then]
+        [/if]
+
+        [set_variables]
+            name=second_unit.abilities.chance_to_hit
+            mode=insert
+
+            [value]
+                id=forced_cth
+                value={CTH_NUMBER}
+                cumulative=no
+                overwrite_specials=both_sides
+            [/value]
+        [/set_variables]
 
         [unstore_unit]
             variable=second_unit
+            find_vacant=no
+        [/unstore_unit]
+        [if]
+            #This is to mute a warning message about retrieving a member of non-existant wml container.
+            [variable]
+                name=unit.abilities.length
+                greater_than=0
+            [/variable]
+
+            [variable]
+                name=unit.abilities.chance_to_hit.length
+                greater_than=0
+            [/variable]
+
+            [then]
+                [set_variables]
+                    name=second_original_chance_to_hit
+                    to_variable=unit.abilities.chance_to_hit
+                [/set_variables]
+                [for]
+                    array=unit.abilities.chance_to_hit
+                    [do]
+                        [if]
+                            [variable]
+                                name=unit.abilities.chance_to_hit[$i].apply_to
+                                equals=opponent
+                            [/variable]
+                            [or]
+                                [variable]
+                                    name=unit.abilities.chance_to_hit[$i].apply_to
+                                    equals=defender
+                                [/variable]
+                            [/or]
+
+                            [then]
+                                {CLEAR_VARIABLE unit.abilities.chance_to_hit[$i]}
+                            [/then]
+                        [/if]
+                    [/do]
+                [/for]
+            [/then]
+        [/if]
+
+        [unstore_unit]
+            variable=unit
             find_vacant=no
         [/unstore_unit]
 
@@ -688,29 +829,46 @@
                     numerical_equals=0
                 [/variable]
                 [then]
-                    # Unit vanished mid-fight
-                    [return][/return]
                 [/then]
-            [/if]
-
-            [foreach]
-                array=second_unit
-                [do]
-                    {CLEAR_VARIABLE this_item.abilities.chance_to_hit}
+                [else]
+                    {CLEAR_VARIABLE second_unit.abilities.chance_to_hit}
 
                     [set_variables]
-                        name=this_item.abilities.chance_to_hit
-                        to_variable=this_item.abilities.original_chance_to_hit
+                        name=second_unit.abilities.chance_to_hit
+                        to_variable=original_chance_to_hit
                     [/set_variables]
 
-                    {CLEAR_VARIABLE this_item.abilities.original_chance_to_hit}
-                [/do]
-            [/foreach]
+                    {CLEAR_VARIABLE original_chance_to_hit}
 
-            [unstore_unit]
-                variable=second_unit
-                find_vacant=no
-            [/unstore_unit]
+                    [unstore_unit]
+                        variable=second_unit
+                        find_vacant=no
+                    [/unstore_unit]
+                [/else]
+            [/if]
+            [if]
+                [variable]
+                    name=unit.length
+                    numerical_equals=0
+                [/variable]
+                [then]
+                [/then]
+                [else]
+                    {CLEAR_VARIABLE unit.abilities.chance_to_hit}
+
+                    [set_variables]
+                        name=unit.abilities.chance_to_hit
+                        to_variable=second_original_chance_to_hit
+                    [/set_variables]
+
+                    {CLEAR_VARIABLE second_original_chance_to_hit}
+
+                    [unstore_unit]
+                        variable=unit
+                        find_vacant=no
+                    [/unstore_unit]
+                [/else]
+            [/if]
         [/event]
     [/event]
 #enddef

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -535,35 +535,82 @@
             [/and]
         [/filter_condition]
 
-        [object]
-            id=forced_cth
-            [filter]
-                id=$unit.id
-            [/filter]
-            silent=yes
-            duration=turn end
-            take_only_once=no
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [chance_to_hit]
+        [foreach]
+            array=unit
+            [do]
+                [if]
+                    #This is to mute a warning message about retrieving a member of non-existant wml container.
+                    [variable]
+                        name=this_item.abilities.length
+                        greater_than=0
+                    [/variable]
+
+                    [variable]
+                        name=this_item.abilities.chance_to_hit.length
+                        greater_than=0
+                    [/variable]
+
+                    [then]
+                        [set_variables]
+                            name=this_item.abilities.original_chance_to_hit
+                            to_variable=this_item.abilities.chance_to_hit
+                        [/set_variables]
+
+                        {CLEAR_VARIABLE this_item.abilities.chance_to_hit}
+                    [/then]
+                [/if]
+
+                [set_variables]
+                    name=this_item.abilities.chance_to_hit
+
+                    [value]
                         id=forced_cth
                         value={CTH_NUMBER}
                         cumulative=no
-                        affect_self=yes
                         overwrite_specials=both_sides
-                        [filter_opponent]
-                            {SECOND_FILTER}
-                        [/filter_opponent]
-                    [/chance_to_hit]
-                [/abilities]
-            [/effect]
-        [/object]
+                    [/value]
+                [/set_variables]
+            [/do]
+        [/foreach]
+
+        [unstore_unit]
+            variable=unit
+            find_vacant=no
+        [/unstore_unit]
+
         [event]
             name=attack end
-            [remove_object]
-                object_id=forced_cth
-            [/remove_object]
+            delayed_variable_substitution=yes
+
+            [if]
+                [variable]
+                    name=unit.length
+                    numerical_equals=0
+                [/variable]
+                [then]
+                    # Unit vanished mid-fight
+                    [return][/return]
+                [/then]
+            [/if]
+
+            [foreach]
+                array=unit
+                [do]
+                    {CLEAR_VARIABLE unit.abilities.chance_to_hit}
+
+                    [set_variables]
+                        name=this_item.abilities.chance_to_hit
+                        to_variable=this_item.abilities.original_chance_to_hit
+                    [/set_variables]
+
+                    {CLEAR_VARIABLE this_item.abilities.original_chance_to_hit}
+                [/do]
+            [/foreach]
+
+            [unstore_unit]
+                variable=unit
+                find_vacant=no
+            [/unstore_unit]
         [/event]
     [/event]
 
@@ -588,60 +635,83 @@
             [/and]
         [/filter_condition]
 
-        [object]
-            id=forced_cth
-            [filter]
-                id=$second_unit.id
-            [/filter]
-            silent=yes
-            duration=turn end
-            take_only_once=no
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [chance_to_hit]
+        [foreach]
+            array=second_unit
+            [do]
+                [if]
+                    #This is to mute a warning message about retrieving a member of non-existant wml container.
+                    [variable]
+                        name=this_item.abilities.length
+                        greater_than=0
+                    [/variable]
+
+                    [variable]
+                        name=this_item.abilities.chance_to_hit.length
+                        greater_than=0
+                    [/variable]
+
+                    [then]
+                        [set_variables]
+                            name=this_item.abilities.original_chance_to_hit
+                            to_variable=this_item.abilities.chance_to_hit
+                        [/set_variables]
+
+                        {CLEAR_VARIABLE this_item.abilities.chance_to_hit}
+                    [/then]
+                [/if]
+
+                [set_variables]
+                    name=this_item.abilities.chance_to_hit
+
+                    [value]
                         id=forced_cth
                         value={CTH_NUMBER}
                         cumulative=no
-                        affect_self=yes
                         overwrite_specials=both_sides
-                        [filter_opponent]
-                            {SECOND_FILTER}
-                        [/filter_opponent]
-                    [/chance_to_hit]
-                [/abilities]
-            [/effect]
-        [/object]
+                    [/value]
+                [/set_variables]
+            [/do]
+        [/foreach]
+
+        [unstore_unit]
+            variable=second_unit
+            find_vacant=no
+        [/unstore_unit]
+
         [event]
             name=attack end
-            [remove_object]
-                object_id=forced_cth
-            [/remove_object]
+            delayed_variable_substitution=yes
+
+            [if]
+                [variable]
+                    name=second_unit.length
+                    numerical_equals=0
+                [/variable]
+                [then]
+                    # Unit vanished mid-fight
+                    [return][/return]
+                [/then]
+            [/if]
+
+            [foreach]
+                array=second_unit
+                [do]
+                    {CLEAR_VARIABLE this_item.abilities.chance_to_hit}
+
+                    [set_variables]
+                        name=this_item.abilities.chance_to_hit
+                        to_variable=this_item.abilities.original_chance_to_hit
+                    [/set_variables]
+
+                    {CLEAR_VARIABLE this_item.abilities.original_chance_to_hit}
+                [/do]
+            [/foreach]
+
+            [unstore_unit]
+                variable=second_unit
+                find_vacant=no
+            [/unstore_unit]
         [/event]
-    [/event]
-    [event]
-        name=unit placed
-        first_time_only=no
-
-        [filter]
-            ability=forced_cth
-        [/filter]
-
-        [remove_object]
-            object_id=forced_cth
-        [/remove_object]
-    [/event]
-    [event]
-        name=prestart,start,victory
-        [filter_condition]
-            [have_unit]
-                ability=forced_cth
-            [/have_unit]
-        [/filter_condition]
-
-        [remove_object]
-            object_id=forced_cth
-        [/remove_object]
     [/event]
 #enddef
 

--- a/data/test/scenarios/test_force_chance_to_hit_macro.cfg
+++ b/data/test/scenarios/test_force_chance_to_hit_macro.cfg
@@ -1,9 +1,4 @@
-# This unit test defines a WML object based implementation of the "unupgradable" ability
-# https://github.com/ProditorMagnus/Ageless-for-1-14/blob/52c1eaf31722bb58046a1b459d4f29daa8d88487/data/general_data/weapon_specials/unupgradable.cfg
-# and checks that it works. What is being tested here is that
 # FORCE_CHANCE_TO_HIT macro must doing misses all attacks then what [chance_to_hit] value equals 100%
-# - through [attacks]
-# - through [effect] increase_attacks
 
 {GENERIC_UNIT_TEST "test_force_chance_to_hit_macro" (
     {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 0 ()}
@@ -37,6 +32,15 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
             [filter]
                 id=bob
             [/filter]
@@ -57,6 +61,15 @@
                         value=100
                     [/chance_to_hit]
                 [/set_specials]
+            [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
             [/effect]
             [filter]
                 id=alice


### PR DESCRIPTION
with this fix, FORCE_CHANCE_TO_HIT macro work when unit affected using a cth ability with overwrite_specials.(But not if opponent using a cth ability with overwrite_specials and apply_to=opponent).