### PR TITLE
Wmllint: add new terrain code updaters

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -193,6 +193,13 @@ mapchanges = (
     ("^Vch",  "^Vc"),
     ("^Vcm",  "^Vc"),
     ("Qv",  "Mv"),
+
+    # new to 1.17.8
+    ("Ior", "Iwo"),
+    ("Icn", "Iwc"),
+    ("Irs", "Isr"),
+    ("Ias", "Isa"),
+    ("Icr", "Isc"),
     )
 
 # These terrains were changed from just base to base + overlay


### PR DESCRIPTION
Allows updating terrain codes for stone floors and wooden floors by Wmllint tool. Accommodates #7042