### PR TITLE
Extend ability removal with remove_ability by attributes and no longer just by id

### DIFF
--- a/changelog_entries/extent_remove_ability_efect_to_attribute_changelog.md
+++ b/changelog_entries/extent_remove_ability_efect_to_attribute_changelog.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Add [filter_ability] usable instead of [abilities][tag name] to filter attributes including the type of ability used.

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -535,6 +535,54 @@
             [/and]
         [/filter_condition]
 
+        [store_unit]
+            [filter]
+                [filter_adjacent]
+                    x,y=$x1,$y1
+                [/filter_adjacent]
+                [not]
+                    x,y=$x2,$y2
+                [/not]
+                [not]
+                    x,y=$x1,$y1
+                [/not]
+            [/filter]
+            variable=force_remove
+        [/store_unit]
+
+        [foreach]
+            array=force_remove
+            [do]
+                [object]
+                    id=forced_re
+                    [filter]
+                        id=$force_remove[$i].id
+                    [/filter]
+                    silent=yes
+                    duration=turn end
+                    take_only_once=no
+                    [effect]
+                        apply_to=remove_ability
+                        [filter_ability]
+                            tag_name=chance_to_hit
+                            [and]
+                                overwrite_specials=both_sides,one_side
+                            [/and]
+                            [and]
+                                affect_allies=yes
+                                [or]
+                                    affect_enemies=yes
+                                [/or]
+                            [/and]
+                            [not]
+                                apply_to=opponent,defender
+                            [/not]
+                        [/filter_ability]
+                    [/effect]
+                [/object]
+            [/do]
+        [/foreach]
+
         [object]
             id=forced_cth
             [filter]
@@ -543,6 +591,18 @@
             silent=yes
             duration=turn end
             take_only_once=no
+            [effect]
+                apply_to=remove_ability
+                [filter_ability]
+                    tag_name=chance_to_hit
+                    [and]
+                        overwrite_specials=both_sides,one_side
+                    [/and]
+                    [not]
+                        apply_to=opponent,defender
+                    [/not]
+                [/filter_ability]
+            [/effect]
             [effect]
                 apply_to=new_ability
                 [abilities]
@@ -564,6 +624,10 @@
             [remove_object]
                 object_id=forced_cth
             [/remove_object]
+            [remove_object]
+                object_id=forced_re
+            [/remove_object]
+            {CLEAR_VARIABLE force_remove}
         [/event]
     [/event]
 
@@ -587,6 +651,53 @@
                 {EXTRA_CONDITIONS_WML}
             [/and]
         [/filter_condition]
+        [store_unit]
+            [filter]
+                [filter_adjacent]
+                    x,y=$x2,$y2
+                [/filter_adjacent]
+                [not]
+                    x,y=$x2,$y2
+                [/not]
+                [not]
+                    x,y=$x1,$y1
+                [/not]
+            [/filter]
+            variable=force_remove
+        [/store_unit]
+
+        [foreach]
+            array=force_remove
+            [do]
+                [object]
+                    id=forced_re
+                    [filter]
+                        id=$force_remove[$i].id
+                    [/filter]
+                    silent=yes
+                    duration=turn end
+                    take_only_once=no
+                    [effect]
+                        apply_to=remove_ability
+                        [filter_ability]
+                            tag_name=chance_to_hit
+                            [and]
+                                overwrite_specials=both_sides,one_side
+                            [/and]
+                            [and]
+                                affect_allies=yes
+                                [or]
+                                    affect_enemies=yes
+                                [/or]
+                            [/and]
+                            [not]
+                                apply_to=opponent,attacker
+                            [/not]
+                        [/filter_ability]
+                    [/effect]
+                [/object]
+            [/do]
+        [/foreach]
 
         [object]
             id=forced_cth
@@ -596,6 +707,18 @@
             silent=yes
             duration=turn end
             take_only_once=no
+            [effect]
+                apply_to=remove_ability
+                [filter_ability]
+                    tag_name=chance_to_hit
+                    [and]
+                        overwrite_specials=both_sides,one_side
+                    [/and]
+                    [not]
+                        apply_to=opponent,attacker
+                    [/not]
+                [/filter_ability]
+            [/effect]
             [effect]
                 apply_to=new_ability
                 [abilities]
@@ -617,6 +740,10 @@
             [remove_object]
                 object_id=forced_cth
             [/remove_object]
+            [remove_object]
+                object_id=forced_re
+            [/remove_object]
+            {CLEAR_VARIABLE force_remove}
         [/event]
     [/event]
     [event]
@@ -633,12 +760,10 @@
     [/event]
     [event]
         name=prestart,start,victory
-        [filter_condition]
-            [have_unit]
-                ability=forced_cth
-            [/have_unit]
-        [/filter_condition]
 
+        [remove_object]
+            object_id=forced_re
+        [/remove_object]
         [remove_object]
             object_id=forced_cth
         [/remove_object]

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -1,0 +1,20 @@
+
+[tag]
+	name="$filter_abilities"
+	max=0
+	{SIMPLE_KEY id string_list}
+	{SIMPLE_KEY tag_name string_list}
+	{SIMPLE_KEY overwrite_specials string_list}
+	{SIMPLE_KEY apply_to string_list}
+	{SIMPLE_KEY active_on string_list}
+	{SIMPLE_KEY value string_list}
+	{SIMPLE_KEY add string_list}
+	{SIMPLE_KEY sub string_list}
+	{SIMPLE_KEY multiply string_list}
+	{SIMPLE_KEY divide string_list}
+	{SIMPLE_KEY affect_self s_bool}
+	{SIMPLE_KEY affect_allies s_bool}
+	{SIMPLE_KEY affect_enemies s_bool}
+	{DEFAULT_KEY type_value value_type empty}
+	{FILTER_BOOLEAN_OPS abilities}
+[/tag]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -41,6 +41,10 @@
         value="none|one_side|both_sides"
     [/type]
     [type]
+        name="value_type"
+        value="empty|value|add|sub|multiply|divide"
+    [/type]
+    [type]
         name="addon_type"
         value="sp|mp|hybrid"
     [/type]

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -138,8 +138,13 @@
 				[/tag]
 			[/case]
 			[case]
-				value=new_ability,remove_ability
+				value=new_ability
 				{LINK_TAG "units/unit_type/abilities"}
+			[/case]
+			[case]
+				value=remove_ability
+				{LINK_TAG "units/unit_type/abilities"}
+				{FILTER_TAG "filter_ability" abilities ()}
 			[/case]
 			[case]
 				value=new_animation

--- a/data/test/scenarios/test_force_chance_to_hit_macro.cfg
+++ b/data/test/scenarios/test_force_chance_to_hit_macro.cfg
@@ -1,9 +1,4 @@
-# This unit test defines a WML object based implementation of the "unupgradable" ability
-# https://github.com/ProditorMagnus/Ageless-for-1-14/blob/52c1eaf31722bb58046a1b459d4f29daa8d88487/data/general_data/weapon_specials/unupgradable.cfg
-# and checks that it works. What is being tested here is that
 # FORCE_CHANCE_TO_HIT macro must doing misses all attacks then what [chance_to_hit] value equals 100%
-# - through [attacks]
-# - through [effect] increase_attacks
 
 {GENERIC_UNIT_TEST "test_force_chance_to_hit_macro" (
     {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 0 ()}
@@ -37,6 +32,15 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
             [filter]
                 id=bob
             [/filter]
@@ -57,6 +61,15 @@
                         value=100
                     [/chance_to_hit]
                 [/set_specials]
+            [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
             [/effect]
             [filter]
                 id=alice

--- a/data/test/scenarios/test_remove_ability_by_filter.cfg
+++ b/data/test/scenarios/test_remove_ability_by_filter.cfg
@@ -1,0 +1,124 @@
+# API(s) being tested: [effect]apply_to=remove_ability[filter_ability]
+##
+# Actions:
+# Two [chance_to_hit] abilities are added, setting the chance to 0 and 100 respectively.
+# The one setting the chance to 100 is removed, filtering by id and tag_name.
+# Alice attacks Bob.
+##
+# Expected end state:
+# Alice is unharmed, because all of Bob's attacks missed.
+
+{GENERIC_UNIT_TEST "test_remove_ability_by_filter" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        id=test_cth_0
+                        value=0
+                    [/chance_to_hit]
+                    [chance_to_hit]
+                        id=test_cth
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        id=test_cth_0
+                        value=0
+                    [/chance_to_hit]
+                    [chance_to_hit]
+                        id=test_cth
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [object]
+            [filter]
+                id=bob
+            [/filter]
+            silent=yes
+            [effect]
+                apply_to=remove_ability
+                [filter_ability]
+                    id=test_cth
+                    tag_name=chance_to_hit
+                [/filter_ability]
+            [/effect]
+        [/object]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+            kill=yes
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$a.x,$a.y
+                [/source]
+                [destination]
+                    x,y=$b.x,$b.y
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 100})}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1408,6 +1408,136 @@ void unit::remove_ability_by_id(const std::string& ability)
 	}
 }
 
+static bool bool_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, bool def)
+{
+	if(filter[attribute].empty()) {
+		return true;
+	}
+
+	return filter[attribute].to_bool() == cfg[attribute].to_bool(def);
+}
+
+static bool string_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, const std::string& def)
+{
+	if(filter[attribute].empty()) {
+		return true;
+	}
+
+	const std::vector<std::string> filter_attribute = utils::split(filter[attribute]);
+	return ( std::find(filter_attribute.begin(), filter_attribute.end(), cfg[attribute].str(def)) != filter_attribute.end() );
+}
+
+static bool type_value_if_present(const config& filter, const config& cfg)
+{
+	if(filter["type_value"].empty()) {
+		return true;
+	}
+
+	std::string cfg_type_value;
+	const std::vector<std::string> filter_attribute = utils::split(filter["type_value"]);
+	if(!cfg["value"].empty()){
+		cfg_type_value ="value";
+	} else if(!cfg["add"].empty()){
+		cfg_type_value ="add";
+	} else if(!cfg["sub"].empty()){
+		cfg_type_value ="sub";
+	} else if(!cfg["multiply"].empty()){
+		cfg_type_value ="multiply";
+	} else if(!cfg["divide"].empty()){
+		cfg_type_value ="divide";
+	}
+	return ( std::find(filter_attribute.begin(), filter_attribute.end(), cfg_type_value) != filter_attribute.end() );
+}
+
+static bool matches_ability_filter(const config & cfg, const std::string& tag_name, const config & filter)
+{
+	if(!bool_matches_if_present(filter, cfg, "affect_self", true))
+		return false;
+
+	if(!bool_matches_if_present(filter, cfg, "affect_allies", true))
+		return false;
+
+	if(!bool_matches_if_present(filter, cfg, "affect_enemies", false))
+		return false;
+
+	if(!bool_matches_if_present(filter, cfg, "cumulative", false))
+		return false;
+
+	const std::vector<std::string> filter_type = utils::split(filter["tag_name"]);
+	if ( !filter_type.empty() && std::find(filter_type.begin(), filter_type.end(), tag_name) == filter_type.end() )
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "id", ""))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "apply_to", "self"))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "overwrite_specials", "none"))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "active_on", "both"))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "value", ""))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "add", ""))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "sub", ""))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "multiply", ""))
+		return false;
+
+	if(!string_matches_if_present(filter, cfg, "divide", ""))
+		return false;
+
+	if(!type_value_if_present(filter, cfg))
+		return false;
+
+	// Passed all tests.
+	return true;
+}
+
+bool unit::ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const
+{
+	// Handle the basic filter.
+	bool matches = matches_ability_filter(cfg, tag_name, filter);
+
+	// Handle [and], [or], and [not] with in-order precedence
+	for (const config::any_child condition : filter.all_children_range() )
+	{
+		// Handle [and]
+		if ( condition.key == "and" )
+			matches = matches && ability_matches_filter(cfg, tag_name, condition.cfg);
+
+		// Handle [or]
+		else if ( condition.key == "or" )
+			matches = matches || ability_matches_filter(cfg, tag_name, condition.cfg);
+
+		// Handle [not]
+		else if ( condition.key == "not" )
+			matches = matches && !ability_matches_filter(cfg, tag_name, condition.cfg);
+	}
+
+	return matches;
+}
+
+void unit::remove_ability_by_attribute(const config& filter)
+{
+	set_attr_changed(UA_ABILITIES);
+	config::all_children_iterator i = abilities_.ordered_begin();
+	while (i != abilities_.ordered_end()) {
+		if(ability_matches_filter(i->cfg, i->key, filter)) {
+			i = abilities_.erase(i);
+		} else {
+			++i;
+		}
+	}
+}
+
 bool unit::get_attacks_changed() const
 {
 	for(const auto& a_ptr : attacks_) {
@@ -2115,9 +2245,13 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		}
 	} else if(apply_to == "remove_ability") {
 		if(const config& ab_effect = effect.child("abilities")) {
+			deprecated_message("[effect]apply_to=remove_ability [abilities]", DEP_LEVEL::INDEFINITE, "", "Use [filter_ability] instead in [effect]apply_to=remove_ability");
 			for(const config::any_child ab : ab_effect.all_children_range()) {
 				remove_ability_by_id(ab.cfg["id"]);
 			}
+		}
+		if(const config& fab_effect = effect.child("filter_ability")) {
+			remove_ability_by_attribute(fab_effect);
 		}
 	} else if(apply_to == "image_mod") {
 		LOG_UT << "applying image_mod";

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1772,6 +1772,20 @@ public:
 	 */
 	void remove_ability_by_id(const std::string& ability);
 
+	/**
+	 * Removes a unit's abilities with a specific ID or other attribute.
+	 * @param filter the config of ability to remove.
+	 */
+	void remove_ability_by_attribute(const config& filter);
+
+	/**
+	 * Verify what abilities attributes match with filter.
+	 * @param cfg the config of ability to check.
+	 * @param tag_name the tag name of ability to check.
+	 * @param filter the filter used for checking.
+	 */
+	bool ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const;
+
 
 private:
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -309,6 +309,7 @@
 0 unslowable_status_test
 0 unpetrifiable_status_test
 0 test_force_chance_to_hit_macro
+0 test_remove_ability_by_filter
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active


### PR DESCRIPTION


using the id to designate the ability to remove can be quite tedious and especially incomplete when you want to use remove_ability to remove a whole type of ability with common characteristics. For this I suggest 1, to be able to filter the abilities by type. (we still need to place the id in the tag but this one cannot be differentiated from another) 2) filter by attribute in addition to id (name, affect_self/allies/enemies, active_on or apply_to or overwrite_specials for combat ability equivalent to a special 3) be able to place attributes outside ability tags to filter multiple types (works when no tag used in filtering)

the type of ability used is also filtered.

i apply hese modification in FORCE_CHANCE_TO_HIT macro for test.