### PR TITLE
Fix 'attacks' abilities not checked(1.17).

### DIFF
--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1762,7 +1762,7 @@ public:
 
 private:
 
-	const std::set<std::string> checking_tags_{"damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
+	const std::set<std::string> checking_tags_{"attacks", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
 	/**
 	 * Check if an ability is active.
 	 * @param ability The type (tag name) of the ability


### PR DESCRIPTION
the 'attacks' abilities don't be checked by special-id/type_active