### PR TITLE
Show the log directory in the build info on non-windows platforms.

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -633,6 +633,7 @@ std::string full_build_report()
 		{"Saves dir",       filesystem::get_saves_dir()},
 		{"Add-ons dir",     filesystem::get_addons_dir()},
 		{"Cache dir",       filesystem::get_cache_dir()},
+		{"Logs dir",        filesystem::get_logs_dir()},
 	};
 
 	// Obfuscate usernames in paths

--- a/src/gui/dialogs/game_version_dialog.cpp
+++ b/src/gui/dialogs/game_version_dialog.cpp
@@ -58,9 +58,7 @@ game_version::game_version()
 	, copy_wid_stem_("copy_")
 	, browse_wid_stem_("browse_")
 	, path_map_()
-#ifdef _WIN32
-	, log_path_(lg::log_file_path())
-#endif
+	, log_path_(lg::get_log_file_path())
 	, deps_()
 	, opts_(game_config::optional_features_table())
 	, report_()
@@ -73,9 +71,8 @@ game_version::game_version()
 	path_map_["saves"] = filesystem::get_saves_dir();
 	path_map_["addons"] = filesystem::get_addons_dir();
 	path_map_["cache"] = filesystem::get_cache_dir();
-#ifdef _WIN32
+	// path to logs directory
 	path_map_["logs"] = filesystem::get_logs_dir();
-#endif
 
 	for(unsigned k = 0; k < game_config::LIB_COUNT; ++k) {
 		const game_config::LIBRARY_ID lib = game_config::LIBRARY_ID(k);
@@ -110,9 +107,7 @@ void game_version::pre_show(window& window)
 	os_label.set_label(VGETTEXT("Running on $os", i18n_syms));
 
 	button& copy_all = find_widget<button>(&window, "copy_all", false);
-	connect_signal_mouse_left_click(
-			copy_all,
-			std::bind(&game_version::report_copy_callback, this));
+	connect_signal_mouse_left_click(copy_all, std::bind(&game_version::report_copy_callback, this));
 
 	//
 	// Game paths tab.
@@ -123,26 +118,19 @@ void game_version::pre_show(window& window)
 		const std::string& path_id = path_ent.first;
 		const std::string& path_path = filesystem::normalize_path(path_ent.second, true);
 
-		text_box_base& path_w
-				= find_widget<text_box_base>(&window, path_wid_stem_ + path_id, false);
-		button& copy_w = find_widget<button>(
-				&window, copy_wid_stem_ + path_id, false);
-		button& browse_w = find_widget<button>(
-				&window, browse_wid_stem_ + path_id, false);
+		text_box_base& path_w = find_widget<text_box_base>(&window, path_wid_stem_ + path_id, false);
+		button& copy_w = find_widget<button>(&window, copy_wid_stem_ + path_id, false);
+		button& browse_w = find_widget<button>(&window, browse_wid_stem_ + path_id, false);
 
 		path_w.set_value(path_path);
 		path_w.set_active(false);
 
 		connect_signal_mouse_left_click(
 				copy_w,
-				std::bind(&game_version::copy_to_clipboard_callback,
-							this,
-							path_path));
+				std::bind(&game_version::copy_to_clipboard_callback, this, path_path));
 		connect_signal_mouse_left_click(
 				browse_w,
-				std::bind(&game_version::browse_directory_callback,
-							this,
-							path_path));
+				std::bind(&game_version::browse_directory_callback, this, path_path));
 
 		if(!desktop::open_object_is_supported()) {
 			// No point in displaying these on platforms that can't do
@@ -157,17 +145,12 @@ void game_version::pre_show(window& window)
 	}
 
 #ifndef _WIN32
-	for(const auto& wid : {"win32_paths", "label_logs", "path_logs", "copy_logs", "browse_logs"}) {
+	for(const auto& wid : {"win32_paths"}) {
 		find_widget<widget>(&window, wid, false).set_visible(widget::visibility::invisible);
 	}
 #else
-	button& stderr_button
-			= find_widget<button>(&window, "open_stderr", false);
-	connect_signal_mouse_left_click(
-			stderr_button,
-			std::bind(&game_version::browse_directory_callback,
-						this,
-						log_path_));
+	button& stderr_button = find_widget<button>(&window, "open_stderr", false);
+	connect_signal_mouse_left_click(stderr_button, std::bind(&game_version::browse_directory_callback, this, log_path_));
 	stderr_button.set_active(!log_path_.empty());
 #endif
 

--- a/src/gui/dialogs/game_version_dialog.hpp
+++ b/src/gui/dialogs/game_version_dialog.hpp
@@ -65,9 +65,8 @@ private:
 
 	std::map<std::string, std::string> path_map_;
 
-#ifdef _WIN32
+	/** path to current log file */
 	const std::string log_path_;
-#endif
 
 	typedef std::array<std::string, 4> deplist_entry;
 	std::vector<deplist_entry> deps_;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -75,6 +75,7 @@ static std::unique_ptr<std::ostream, void(*)(std::ostream*)> output_file_(nullpt
 	std::cerr.rdbuf(nullptr);
 	std::cout.rdbuf(nullptr);
 });
+static std::string output_file_path_ = "";
 
 namespace lg {
 
@@ -134,9 +135,19 @@ std::string unique_log_filename()
 void set_log_to_file()
 {
 	// get the log file stream and assign cerr+cout to it
-	output_file_.reset(filesystem::ostream_file(filesystem::get_logs_dir()+"/"+unique_log_filename()).release());
+	output_file_path_ = filesystem::get_logs_dir()+"/"+unique_log_filename();
+	output_file_.reset(filesystem::ostream_file(output_file_path_).release());
 	std::cerr.rdbuf(output_file_.get()->rdbuf());
 	std::cout.rdbuf(output_file_.get()->rdbuf());
+}
+
+std::string& get_log_file_path()
+{
+	return output_file_path_;
+}
+void set_log_file_path(const std::string& path)
+{
+	output_file_path_ = path;
 }
 
 redirect_output_setter::redirect_output_setter(std::ostream& stream)

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -191,6 +191,8 @@ void precise_timestamps(bool);
 std::string get_timestamp(const std::time_t& t, const std::string& format="%Y%m%d %H:%M:%S ");
 std::string get_timespan(const std::time_t& t);
 std::string sanitize_log(const std::string& logstr);
+std::string& get_log_file_path();
+void set_log_file_path(const std::string& path);
 
 logger &err(), &warn(), &info(), &debug();
 log_domain& general();

--- a/src/log_windows.hpp
+++ b/src/log_windows.hpp
@@ -43,14 +43,6 @@ namespace lg
 {
 
 /**
- * Returns the path to the current log file.
- *
- * An empty string is returned if the log file has not been set up yet or it
- * was disabled (e.g. by --wconsole).
- */
-std::string log_file_path();
-
-/**
  * Sets up the initial temporary log file.
  *
  * This has to be done on demand (preferably as early as possible) from a


### PR DESCRIPTION
Also moves the last bit of potentially common code from log_windows into the base logger.

---

To be honest I'm tempted to tinker with it more to see if any more of the windows-specific code needs to be windows-specific, but I also don't have a Windows machine to actually test it out. Also a lot of it is around that weird console behavior windows has.

@Vultraz Can you build this PR and just make sure that the Windows logging to file still works?