### PR TITLE
Fix male Dark Horse unit name

### DIFF
--- a/data/core/units/monsters/Horse.cfg
+++ b/data/core/units/monsters/Horse.cfg
@@ -211,7 +211,7 @@
         {SOUND:HIT wail-sml.wav -100}
     [/attack_anim]
     [male]
-        name= _ "female^Dark Horse"
+        name= _ "male^Dark Horse"
         {TRAIT_STRONG}
     [/male]
     [female]


### PR DESCRIPTION
The male variation of the dark horse unit is using the female translatable string.
Fix by making a male specific string to allow accurate translation.