### PR TITLE
SoF S9: Separate Toomak's last breath message from the events following his death

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -560,7 +560,7 @@
             image=scenery/monolith1.png
         [/item]
         [event]
-            name=die
+            name=last breath
             [filter]
                 id=Toomak
             [/filter]
@@ -568,6 +568,12 @@
                 speaker=unit
                 message= _ "All these years we stood guard... to protect these tunnels... and it comes to this..."
             [/message]
+        [/event]
+        [event]
+            name=die
+            [filter]
+                id=Toomak
+            [/filter]
             [message]
                 speaker=narrator
                 message= _ "As the troll collapsed, a stone tile it had been wearing hit the floor and shattered."


### PR DESCRIPTION
Visually, this makes more sense: on the game board Toomak isn't killed until he's said his final piece. This also resolves the `wmllint` flag against a unit speaking in their `die` event, probably so-flagged precisely because of a unit speaking after they've already been removed from the board is a visual inconsistency.