### PR TITLE
wmllint: Ignore labels for translation if a PNG extension is found

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2480,8 +2480,9 @@ to be called on their own".format(filename, num))
                           % (filename, i+1, key))
                     lines[i] = lines[i].replace("=_","=")
                 if markcheck and value and not value.startswith("$") and not value.startswith("{") and not has_tr_mark and not ("wmllint: ignore" in comment or "wmllint: noconvert" in comment):
-                    # [image] uses label to specify the image path so do not mark for translation in those cases
-                    if not (key == 'label' and os.path.splitext(value)[1]):
+                    # [image] sometimes uses label to specify a reference to a PNG file
+                    # so do not mark for translation in those cases
+                    if not (key == 'label' and '.png' in value):
                         print('"%s", line %d: %s needs translation mark' \
                               % (filename, i+1, key))
                         lines[i] = lines[i].replace('=', "=_ ", 1)

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -2480,9 +2480,11 @@ to be called on their own".format(filename, num))
                           % (filename, i+1, key))
                     lines[i] = lines[i].replace("=_","=")
                 if markcheck and value and not value.startswith("$") and not value.startswith("{") and not has_tr_mark and not ("wmllint: ignore" in comment or "wmllint: noconvert" in comment):
-                    print('"%s", line %d: %s needs translation mark' \
-                          % (filename, i+1, key))
-                    lines[i] = lines[i].replace('=', "=_ ", 1)
+                    # [image] uses label to specify the image path so do not mark for translation in those cases
+                    if not (key == 'label' and os.path.splitext(value)[1]):
+                        print('"%s", line %d: %s needs translation mark' \
+                              % (filename, i+1, key))
+                        lines[i] = lines[i].replace('=', "=_ ", 1)
                 nv = sentence_end.sub(" ", value)
                 if nv != value:
                     print('"%s", line %d: double space after sentence end' \


### PR DESCRIPTION
Resolves #6995.

I'd prefer to use `pathlib.PurePath.suffix` but `os.path` is already used extensively here. Also, `os.path.isfile()` doesn't work because that actually checks for the presence of the file, not just if the string is a valid file expression.

I don't really know all the details from the discussion in #6995, I just noted that this dropped remaining 'label needs translation mark' (for `[image]`s) in master and 1.16 for me (including `units/human-princess.png~TC(1,magenta)`). This may not necessarily be the 'right' solution.