### PR TITLE
Add unit tests for [break] and [return] during [fire_event]

### DIFF
--- a/data/test/scenarios/interrupts.cfg
+++ b/data/test/scenarios/interrupts.cfg
@@ -104,6 +104,31 @@
 )}
 
 #####
+# API(s) being tested: [fire_event], [break]
+##
+# Expected end state:
+# [break] outside a loop is documented to be the same as [return], so skips the entire rest of the firing event, not just fired event.
+#####
+{GENERIC_UNIT_TEST check_interrupts_break_nested_event (
+    [event]
+        name=function_with_interrupt
+        [break][/break]
+        {FAIL}
+    [/event]
+    [event]
+        name=start
+        [fire_event]
+            name=function_with_interrupt
+        [/fire_event]
+        {FAIL}
+    [/event]
+    [event]
+        name=start
+        {SUCCEED}
+    [/event]
+)}
+
+#####
 # API(s) being tested: wesnoth.wml_actions.continue
 ##
 # Actions:
@@ -149,13 +174,38 @@
 # Expected end state:
 # [return] skips the entire rest of the event, not just the [command] it's nested in.
 #####
-{GENERIC_UNIT_TEST check_interrupts_return_nested (
+{GENERIC_UNIT_TEST check_interrupts_return_nested_command (
     [event]
         name=start
         [command]
             [return][/return]
             {FAIL}
         [/command]
+        {FAIL}
+    [/event]
+    [event]
+        name=start
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [fire_event], [return]
+##
+# Expected end state:
+# [return] skips the entire rest of the firing event, not just fired event.
+#####
+{GENERIC_UNIT_TEST check_interrupts_return_nested_event (
+    [event]
+        name=function_with_interrupt
+        [return][/return]
+        {FAIL}
+    [/event]
+    [event]
+        name=start
+        [fire_event]
+            name=function_with_interrupt
+        [/fire_event]
         {FAIL}
     [/event]
     [event]

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -337,7 +337,9 @@
 0 check_interrupts_return
 0 check_interrupts_continue
 0 check_interrupts_break_global
-0 check_interrupts_return_nested
+0 check_interrupts_break_nested_event
+0 check_interrupts_return_nested_command
+0 check_interrupts_return_nested_event
 9 check_interrupts_continue_global
 0 check_interrupts_elseif
 0 check_interrupts_case


### PR DESCRIPTION
I've backported this and confirmed that the behavior is the same on 1.16 (using a binary built around 2 weeks ago).

Fixes #7084.