### PR TITLE
Add screenshots directory to game version dialogue

### DIFF
--- a/data/gui/window/game_version.cfg
+++ b/data/gui/window/game_version.cfg
@@ -138,6 +138,8 @@
 
 				{_GUI_GAME_PATHS_ENTRY logs       ( _ "Logs:")}
 
+				{_GUI_GAME_PATHS_ENTRY screenshots ( _ "Screenshots:")}
+
 			[/grid]
 
 		[/column]

--- a/src/gui/dialogs/game_version_dialog.cpp
+++ b/src/gui/dialogs/game_version_dialog.cpp
@@ -73,6 +73,7 @@ game_version::game_version()
 	path_map_["cache"] = filesystem::get_cache_dir();
 	// path to logs directory
 	path_map_["logs"] = filesystem::get_logs_dir();
+	path_map_["screenshots"] = filesystem::get_screenshot_dir();
 
 	for(unsigned k = 0; k < game_config::LIB_COUNT; ++k) {
 		const game_config::LIBRARY_ID lib = game_config::LIBRARY_ID(k);


### PR DESCRIPTION
Honestly, I'm not sure if this addition is a good idea - it is possible to have too much information displayed - but it was requested and it looked relatively straightforward to implement, so here it is. Of course, I could have missed something somewhere.

Resolves #7096.