### PR TITLE
Fix 64-to-32 bits integer downcast issue

### DIFF
--- a/src/serialization/string_utils.hpp
+++ b/src/serialization/string_utils.hpp
@@ -71,8 +71,8 @@ void split_foreach_impl(std::string_view s, char sep, const F& f)
 	}
 	while(true)
 	{
-		int partend = s.find(sep);
-		if(partend == int(std::string_view::npos)) {
+		std::size_t partend = s.find(sep);
+		if(partend == std::string_view::npos) {
 			break;
 		}
 		f(s.substr(0, partend));


### PR DESCRIPTION
The affected function may return prematurely given a sufficiently large input because of a downcast to int of a size_t value, followed by a comparison.

(This was caught through a mishap with `-Wshorten-64-to-32` on Xcode.)