### PR TITLE
Make Nightblade the default advancement for Slayer

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
+++ b/data/campaigns/Dead_Water/scenarios/05_Tirigaz.cfg
@@ -115,7 +115,7 @@
         canrecruit=yes
         moves=0
         type=Orcish Sovereign
-        recruit=Wolf Rider, Goblin Knight, Goblin Pillager, Orcish Archer, Orcish Grunt, Orcish Crossbowman, Orcish Assassin, Orcish Warrior, Orcish Slurbow, Orcish Warlord, Orcish Slayer
+        recruit=Wolf Rider, Goblin Knight, Goblin Pillager, Orcish Archer, Orcish Crossbowman, Orcish Slurbow, Orcish Assassin, Orcish Slayer, Orcish Nightblade, Orcish Grunt, Orcish Warrior, Orcish Warlord
 
         [ai]
             [goal]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter2/07_Elves_Last_Stand.cfg
@@ -235,7 +235,7 @@
             x=6
             y=23
 #ifdef HARD
-            extra_recruit=Orcish Archer, Orcish Crossbowman, Orcish Slurbow, Orcish Assassin, Orcish Slayer, Orcish Grunt, Orcish Warrior, Orcish Warlord, Goblin Spearman, Goblin Impaler, Goblin Rouser, Wolf Rider, Goblin Knight, Goblin Pillager, Direwolf Rider
+            extra_recruit=Orcish Archer, Orcish Crossbowman, Orcish Slurbow, Orcish Assassin, Orcish Slayer, Orcish Nightblade, Orcish Grunt, Orcish Warrior, Orcish Warlord, Goblin Spearman, Goblin Impaler, Goblin Rouser, Wolf Rider, Goblin Knight, Goblin Pillager, Direwolf Rider
 #endif
 #ifdef NORMAL
             extra_recruit=Orcish Archer, Orcish Crossbowman, Orcish Assassin, Orcish Slayer, Orcish Grunt, Orcish Warrior, Goblin Spearman, Goblin Impaler, Goblin Rouser, Wolf Rider, Goblin Knight, Goblin Pillager, Direwolf Rider

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/16_The_Coward.cfg
@@ -175,7 +175,7 @@
 
             [else]
                 [recall]
-                    type=Orcish Warlord,Orcish Slurbow,Saurian Flanker,Troll Warrior,Orcish Warrior,Orcish Crossbowman,Saurian Oracle,Saurian Soothsayer,Saurian Ambusher,Troll,Troll Rocklobber,Orcish Slayer
+                    race=orc,troll,lizard
                     x,y=44,9
                 [/recall]
             [/else]
@@ -188,7 +188,7 @@
 
             [else]
                 [recall]
-                    type=Orcish Warlord,Orcish Slurbow,Saurian Flanker,Troll Warrior,Orcish Warrior,Orcish Crossbowman,Saurian Oracle,Saurian Soothsayer,Saurian Ambusher,Troll,Troll Rocklobber,Orcish Slayer
+                    race=orc,troll,lizard
                     x,y=44,10
                 [/recall]
             [/else]
@@ -280,7 +280,10 @@
 
         [role]
             side=1
-            type=Orcish Warlord, Orcish Slurbow, Direwolf Rider, Orcish Warrior, Orcish Crossbowman, Orcish Slayer, Goblin Knight, Goblin Pillager, Orcish Grunt, Orcish Archer, Orcish Assassin, Goblin Wolfrider, Saurian Flanker, Saurian Soothsayer, Saurian Oracle, Saurian Ambusher, Saurian Augur, Saurian Skirmisher
+            race=orc,wolf,lizard
+            [not]
+                type_adv_tree=Orcish Leader
+            [/not]
             role=Helper
         [/role]
 

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/11_Battle_for_Zocthanol_Isle.cfg
@@ -175,7 +175,7 @@
 #endif
 
 #ifdef HARD
-        recruit=Orcish Warrior, Orcish Crossbowman, Orcish Slayer, Goblin Knight, Goblin Pillager, Direwolf Rider, Orcish Warlord, Orcish Slurbow
+        recruit=Orcish Warrior, Orcish Crossbowman, Orcish Slayer, Goblin Knight, Goblin Pillager, Direwolf Rider, Orcish Warlord, Orcish Slurbow, Orcish Nightblade
 #endif
 
         [ai]

--- a/data/core/macros/deprecated-utils.cfg
+++ b/data/core/macros/deprecated-utils.cfg
@@ -386,3 +386,7 @@ _"No gold carried over to the next scenario."#enddef
     # no interruption of movement, yet prevent the move from being undone.
     {DEPRECATE_ACTION_MACRO "NO_INTERRUPT_NO_UNDO" 3 "1.16" ""}
 #enddef
+
+#define ENABLE_NIGHTBLADE
+#deprecated 2 1.17 This advancement is now enabled by default.
+#enddef

--- a/data/core/macros/optional_unit_advancements.cfg
+++ b/data/core/macros/optional_unit_advancements.cfg
@@ -57,11 +57,6 @@
     {ENABLE_ADVANCEMENT "Great Wolf" "Direwolf" (set_experience=65)}
 #enddef
 
-#define ENABLE_NIGHTBLADE
-    # Place in a campaign or scenario definition to allow Orcish Slayer to advance to Orcish Nightblade.
-    {ENABLE_ADVANCEMENT "Orcish Slayer" "Orcish Nightblade" (set_experience=100)}
-#enddef
-
 #define ENABLE_TROLL_SHAMAN
     # Place in a campaign or scenario definition to allow Troll Whelp to advance to Troll Shaman.
     {ENABLE_ADVANCEMENT "Troll Whelp" "Troll Shaman" ()}

--- a/data/core/units/orcs/Slayer.cfg
+++ b/data/core/units/orcs/Slayer.cfg
@@ -11,11 +11,10 @@
         arcane=100
     [/resistance]
     movement=6
-    experience=100
+    experience=64
     level=2
     alignment=chaotic
-    advances_to=null
-    {AMLA_DEFAULT}
+    advances_to=Orcish Nightblade
     cost=26
     usage=mixed fighter
     description= _ "Skilled orcish assassins are surprisingly nimble covert troops who achieve great agility by forgoing the heavy armor of their brethren. Their weapon of choice, poison, is often criticized as a vicious tool unsuited for the established customs of typical warfare. Most orcs, however, recognize no such laws of combat and seek to attain victory by any means necessary. Defeat, no matter the reason, is usually treated as the greatest dishonor possible. The brutal nature of the total war that orcs engage in is precisely what gives rise to these ruthless soldiers, rightly dubbed ‘Slayers’ by their enemies."

--- a/data/multiplayer/factions/northerners-aoh.cfg
+++ b/data/multiplayer/factions/northerners-aoh.cfg
@@ -4,7 +4,7 @@
     name= _"Northerners"
     image="units/orcs/warlord.png"
     type=random
-    leader=Orcish Warlord,Troll Warrior,Orcish Slurbow,Orcish Slayer
+    leader=Orcish Warlord,Troll Warrior,Orcish Slurbow,Orcish Nightblade
     random_leader=Orcish Warlord,Troll Warrior,Orcish Slurbow
     recruit=Orcish Grunt,Orcish Warrior,Troll Whelp,Troll,Troll Rocklobber,Wolf Rider,Goblin Knight,Goblin Pillager,Orcish Archer,Orcish Crossbowman,Orcish Assassin,Orcish Slayer,Naga Fighter,Naga Warrior,Goblin Spearman,Goblin Impaler,Goblin Rouser
     terrain_liked=Hh, Ha, Mm, Ss


### PR DESCRIPTION
Similarly to #6911 this gives a level 3 advancement to a default unit that is still missing one. Except in this case the advancement was already in core, just not fully utilized.

Also adds the Orcish Nightblade as a leader for Age of Heroes era and to campaign side recruit lists wherever the other level 3 orcish units are found.