### PR TITLE
[1.2] Fix unit/unit_map include circular dependency and force use of std=c++03 for g++ compiler.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+CXXFLAGS=-std=c++03
 ISUBDIRS = icons
 SUBDIRS = po m4 src doc $(ISUBDIRS)
 pkgdatadir=$(datadir)/@DATADIR@

--- a/src/actions.hpp
+++ b/src/actions.hpp
@@ -23,6 +23,7 @@ struct combatant;
 
 #include "map.hpp"
 #include "unit.hpp"
+#include "unit_map.hpp"
 
 #include <deque>
 

--- a/src/ai_dfool.hpp
+++ b/src/ai_dfool.hpp
@@ -5,6 +5,7 @@
 
 #include "ai_interface.hpp"
 #include "map.hpp"
+#include "unit_map.hpp"
 #include <vector>
 #include <map>
 #include <string>

--- a/src/config_adapter.cpp
+++ b/src/config_adapter.cpp
@@ -12,6 +12,7 @@
 */
 
 #include "global.hpp"
+#include "unit_map.hpp"
 
 #include <sstream>
 #include "config_adapter.hpp"

--- a/src/game_events.hpp
+++ b/src/game_events.hpp
@@ -21,6 +21,7 @@ class display;
 #include "map.hpp"
 #include "team.hpp"
 #include "unit.hpp"
+#include "unit_map.hpp"
 #include "variable.hpp"
 
 #include <vector>

--- a/src/pathfind.cpp
+++ b/src/pathfind.cpp
@@ -19,6 +19,7 @@ See the COPYING file for more details.
 #include "log.hpp"
 #include "pathfind.hpp"
 #include "util.hpp"
+#include "unit_map.hpp"
 #include "wassert.hpp"
 
 class gamestatus;

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -24,6 +24,7 @@
 #include "preferences.hpp"
 #include "sound.hpp"
 #include "util.hpp"
+#include "unit_map.hpp"
 #include "video.hpp" // non_interactive()
 #include "wassert.hpp"
 #include "wesconfig.h"

--- a/src/unit.hpp
+++ b/src/unit.hpp
@@ -19,9 +19,9 @@
 #include "team.hpp"
 #include "unit_types.hpp"
 #include "image.hpp"
-#include "unit_map.hpp"
 
 class unit;
+class unit_map;
 class display;
 class gamestatus;
 
@@ -396,16 +396,7 @@ void sort_units(std::vector< unit > &);
 
 int team_units(const unit_map& units, unsigned int team_num);
 int team_upkeep(const unit_map& units, unsigned int team_num);
-unit_map::const_iterator team_leader(unsigned int side, const unit_map& units);
-std::string team_name(int side, const unit_map& units);
-unit_map::iterator find_visible_unit(unit_map& units,
-		const gamemap::location loc,
-		const gamemap& map,
-		const std::vector<team>& teams, const team& current_team);
-unit_map::const_iterator find_visible_unit(const unit_map& units,
-		const gamemap::location loc,
-		const gamemap& map,
-		const std::vector<team>& teams, const team& current_team);
+
 
 struct team_data
 {

--- a/src/unit_abilities.cpp
+++ b/src/unit_abilities.cpp
@@ -12,6 +12,7 @@
 */
 
 #include "unit.hpp"
+#include "unit_map.hpp"
 #include "unit_abilities.hpp"
 
 #include "wassert.hpp"

--- a/src/unit_map.hpp
+++ b/src/unit_map.hpp
@@ -14,6 +14,7 @@
 #define UNIT_MAP_H_INCLUDED
 
 #include <cstring>
+#include <algorithm>
 #include "map.hpp"
 #include "unit.hpp"
 
@@ -148,5 +149,16 @@ private:
 	// A map of pairs is redundant, but makes it possible to imitate a map of location,unit.
 	std::map<gamemap::location,std::pair<gamemap::location,unit>*> map_;
 };
+
+unit_map::const_iterator team_leader(unsigned int side, const unit_map& units);
+std::string team_name(int side, const unit_map& units);
+unit_map::iterator find_visible_unit(unit_map& units,
+		const gamemap::location loc,
+		const gamemap& map,
+		const std::vector<team>& teams, const team& current_team);
+unit_map::const_iterator find_visible_unit(const unit_map& units,
+		const gamemap::location loc,
+		const gamemap& map,
+		const std::vector<team>& teams, const team& current_team);
 
 #endif	// UNIT_MAP_H_INCLUDED

--- a/src/upload_log.cpp
+++ b/src/upload_log.cpp
@@ -23,6 +23,7 @@
 #include "upload_log.hpp"
 #include "wesconfig.h"
 #include "wml_separators.hpp"
+#include "unit_map.hpp"
 
 #include "SDL_net.h"
 


### PR DESCRIPTION
Fix unit/unit_map include circular dependency (thanks to moi1392 on LinuxFR.org) Support of modern compiler (thanks to remico on LinuxFR.org)
Thanks to gnombat and Pentarctagon.