### PR TITLE
Slightly reduce merfolk forest and hill move cost

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -911,8 +911,8 @@ The life span of the wose is unknown, although the most ancient members of this 
             swamp_water=1
             flat=2
             sand=2
-            forest=5
-            hills=5
+            forest=4
+            hills=4
             village=1
             castle=1
             cave=3


### PR DESCRIPTION
From 5 to 4. Makes moving them from one water body to another somewhat less tedious. Likewise makes merfolk units a bit more viable on maps with separated waterways.

Just as it was before this change, the merfolk remain twice as slow as naga at moving through these two terrains.