### PR TITLE
Give Kraken submerge ability

### DIFF
--- a/data/campaigns/Winds_of_Fate/scenarios/04_Journey.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/04_Journey.cfg
@@ -404,9 +404,18 @@ I must advise against it."
             name=water-blast.wav
         [/sound]
         {LOYAL_UNIT 4 Kraken        3  3} {FACING se}
+        [+unit]
+            animate=yes
+            [status]
+                uncovered=yes
+            [/status]
+        [/unit]
         {NAMED_LOYAL_UNIT 4 Kraken  1 19 $kraken_id $kraken_name} {FACING se}
         [+unit]
             animate=yes
+            [status]
+                uncovered=yes
+            [/status]
         [/unit]
         [message]
             speaker=$kraken_id
@@ -463,6 +472,9 @@ I must advise against it."
             name=water-blast.wav
         [/sound]
         {LOYAL_UNIT 3 (Sea Serpent)       21  2} {FACING sw}
+        [+unit]
+            animate=yes
+        [/unit]
         {NAMED_LOYAL_UNIT 3 (Sea Serpent) 25 20 $serpent_id $serpent_name} {FACING sw}
         [+unit]
             animate=yes

--- a/data/campaigns/Winds_of_Fate/scenarios/04_Journey.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/04_Journey.cfg
@@ -77,6 +77,9 @@
             type=Merman Warrior
             facing=sw
         [/leader]
+        [ai]
+            aggression=0.7
+        [/ai]
     [/side]
 
     [side]
@@ -95,7 +98,7 @@
             facing=sw
         [/leader]
         [ai]
-            aggression=0.6
+            aggression=0.7
             passive_leader=yes # So he does not get himself killed.
         [/ai]
     [/side]
@@ -116,7 +119,6 @@
             facing=se
         [/leader]
         [ai]
-            aggression=0.6
             passive_leader=yes # So he does not get himself killed.
         [/ai]
     [/side]

--- a/data/core/units/monsters/Kraken.cfg
+++ b/data/core/units/monsters/Kraken.cfg
@@ -15,11 +15,14 @@
     advances_to=null
     attacks=1
     {AMLA_DEFAULT}
-    cost=62
+    cost=64
     undead_variation=swimmer
     usage=fighter
     description= _ "Krakens are gigantic creatures of the seas. They can grab their opponents with strong tentacles, or spit a poisonous black ink from a distance. The best way to survive an encounter with these monsters is to remain ashore."
     die_sound=water-blast.wav
+    [abilities]
+        {ABILITY_SUBMERGE}
+    [/abilities]
     {DEFENSE_ANIM "units/monsters/kraken/kraken-defend2.png" "units/monsters/kraken/kraken-defend1.png" squishy-hit.wav}
     [attack]
         name=tentacle


### PR DESCRIPTION
Similar to #3414 this moves the Kraken from DW and WoF into core as the level 3 advancement for the Cuttle Fish.

The cuttlefish has perhaps the most sophisticated camouflage ability in the animal kingdom and no need to breathe air, so there may be no better fit for the submerge stealth ability than this unit.

Slightly increases the gold costs for both units to compensate (just let me know if this or experience needs further adjustment). Tweaks campaign scenarios sufficiently affected due to having large areas of deep water terrain and multiple individuals of these unit types, Note that DW S6 is partly counter balanced by the increased Cuttle Fish cost.