### PR TITLE
LoW S9: Remove standard enemies-defeated as a victory condition

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -537,7 +537,6 @@ Chapter Three"
 #endif
     [/event]
 
-    {DEFAULT_VICTORY 0.3}
     {campaigns/Legend_of_Wesmere/utils/deaths.cfg}
 [/scenario]
 


### PR DESCRIPTION
Resolves #7130.

Enforcing the river crossing seems to be the better option (as opposed to just adding defeat enemies as an alternative victory objective) since there are monsters to contend with when arriving at the river.