### PR TITLE
Make undo work again, undeprecate on_event()

### DIFF
--- a/changelog_entries/fix_undo.md
+++ b/changelog_entries/fix_undo.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and bug fixes
+   * Fixed not being able to undo moves (bug #6898)

--- a/data/lua/diversion.lua
+++ b/data/lua/diversion.lua
@@ -1,6 +1,7 @@
 
 local _ = wesnoth.textdomain 'wesnoth-help'
 local T = wml.tag
+local on_event = wesnoth.require("on_event")
 
 local u_pos_filter = function(u_id)
 
@@ -99,7 +100,7 @@ function wesnoth.wml_actions.on_undo_diversion(cfg)
 	status_anim_update(true)
 end
 
-wesnoth.game_events.add_repeating("moveto, die, recruit, recall", function()
+on_event("moveto, die, recruit, recall", function()
         status_anim_update()
 
 end)

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -51,5 +51,5 @@ local function on_event(eventname, priority, fcn)
 	end
 end
 
-core_on_event = wesnoth.deprecate_api("on_event", "wesnoth.game_events.add_repeating", 1, nil, on_event)
-return core_on_event
+core_on_event = on_event
+return on_event

--- a/data/modifications/pick_advance/main.lua
+++ b/data/modifications/pick_advance/main.lua
@@ -1,6 +1,6 @@
 -- << pick_advance/main.lua
 
-local on_event = wesnoth.game_events.add_repeating
+local on_event = wesnoth.require "on_event"
 local F = wesnoth.require "functional"
 local T = wml.tag
 local _ = wesnoth.textdomain "wesnoth"

--- a/data/multiplayer/scenarios/2p_Dark_Forecast.lua
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.lua
@@ -1,7 +1,7 @@
 
 local _ = wesnoth.textdomain 'wesnoth-multiplayer'
 local T = wml.tag
-local on_event = wesnoth.game_events.add_repeating
+local on_event = wesnoth.require("on_event")
 
 local random_spawns = {
 	{

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.lua
@@ -1,6 +1,6 @@
 local _ = wesnoth.textdomain 'wesnoth-multiplayer'
 local T = wml.tag
-local on_event = wesnoth.game_events.add_repeating
+local on_event = wesnoth.require("on_event")
 
 local random_spawns = {
 	{


### PR DESCRIPTION
Fixes #6898. The issue is that non-WML events added through the new events API always disable undo with no equivalent of WML's `[allow_undo]`. The long-term fix is to add a way to do that; however until that's available then listeners for `moveto` need to use the old `on_event` API. The old `on_event` API can't be deprecated yet, and this is enforced by our unit tests (the build fails if there are unexpected deprecation warnings during the tests).

Reverts most of 7e234f8833282424b3535b9c334c751748f7222b. Does not revert files that only listen for non-undoable events such as `die` or `new turn`.

Reverts the deprecation part of #5663's 8cd133263058a5df85f64988e348d2cf54d13a48.