### PR TITLE
HttT: give Kalenz his missing 2nd trait

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -715,6 +715,7 @@ fire:  +10%"
         random_traits=no
         [modifications]
             {TRAIT_LOYAL_HERO}
+            {TRAIT_RESILIENT}
         [/modifications]
     [/unit]
 #enddef

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -716,6 +716,7 @@ fire:  +10%"
         [modifications]
             {TRAIT_LOYAL_HERO}
             {TRAIT_RESILIENT}
+            {TRAIT_QUICK}
         [/modifications]
     [/unit]
 #enddef


### PR DESCRIPTION
Kalenz now has traits loyal, and resilient. The quick trait is part of his changed unit type after LoW's ending.

Closes #7141 