### PR TITLE
[1.17]further simplification of overwrite_specials attribute code

### DIFF
--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -134,7 +134,7 @@ private:
 	 * @param filter_self name of [filter_"self/student"] if is abilities or specials who are checked
 	 * @param is_special for determine if list is a special or a ability.
 	 */
-	unit_ability_list overwrite_special_checking(const std::string& ability, const unit_ability_list& temp_list, const unit_ability_list& abil_list, const std::string& filter_self, bool is_special) const;
+	unit_ability_list overwrite_special_checking(const std::string& ability, unit_ability_list temp_list, unit_ability_list abil_list, const std::string& filter_self, bool is_special) const;
 	/** check_self_abilities : return an boolean value for checking of activities of abilities used like weapon
 	 * @return True if the special @a special is active.
 	 * @param cfg the config to one special ability checked.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -127,7 +127,7 @@ private:
 
 	// Configured as a bit field, in case that is useful.
 	enum AFFECTS { AFFECT_SELF=1, AFFECT_OTHER=2, AFFECT_EITHER=3 };
-		/**
+	/**
 	 * Filter a list of abilities or weapon specials, removing any entries that are overridden by
 	 * the overwrite_specials attributes of a second list.
 	 *

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -127,14 +127,17 @@ private:
 
 	// Configured as a bit field, in case that is useful.
 	enum AFFECTS { AFFECT_SELF=1, AFFECT_OTHER=2, AFFECT_EITHER=3 };
-	/** overwrite_special_checking : return an unit_ability_list list after checking presence or not of overwrite_specials
+		/**
+	 * Filter a list of abilities or weapon specials, removing any entries that are overridden by
+	 * the overwrite_specials attributes of a second list.
+	 *
 	 * @param ability The special ability type who is being checked.
-	 * @param temp_list the list checked and returned.
-	 * @param abil_list list checked for verify presence of overwrite_specials .
-	 * @param filter_self name of [filter_"self/student"] if is abilities or specials who are checked
-	 * @param is_special for determine if list is a special or a ability.
+	 * @param input list to check, a filtered copy of this list is returned by the function.
+	 * @param overwriters list that may have overwrite_specials attributes.
+	 * @param filter_self name of [filter_"self/student"] if is abilities or specials who are checked.
+	 * @param is_special if true, input contains weapon specials; if false, it contains abilities.
 	 */
-	unit_ability_list overwrite_special_checking(const std::string& ability, unit_ability_list temp_list, unit_ability_list abil_list, const std::string& filter_self, bool is_special) const;
+	unit_ability_list overwrite_special_checking(const std::string& ability, unit_ability_list input, unit_ability_list overwriters, const std::string& filter_self, bool is_special) const;
 	/** check_self_abilities : return an boolean value for checking of activities of abilities used like weapon
 	 * @return True if the special @a special is active.
 	 * @param cfg the config to one special ability checked.


### PR DESCRIPTION
I know that I have already proposed a simplification of the code of this attribute, but several things lead me to propose this second rewrite.

First, using the first loop to define three boolean variables is more complicated than simply eliminating from the 'overwrite_specials' list the abilities not carrying the attribute then; if an ability with the attribute is present define a double for loop inside each other, where for each ability with overwrite_specials the type of ability removal from the returned list is defined at that time (one_side or both_sides). The code is even more readable than with the previous work in my opinion.

The second reason is that I eventually want to be able to use the request code https://github.com/wesnoth/wesnoth/pull/7050 to be even more selective about the abilities that can be removed or not and extend the use of the attribute beyond chance_to_hit (when (and if) these two PRs will be merged in master, I will have to add 3-4 lines of code in hadcoding to implement the filtering). Building a list instead of splicing the existing one is incompatible with this project.