### PR TITLE
Escape < and > even if only one of them exists

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1595,10 +1595,10 @@ def pangoize(message, filename, line):
         if "<" in reduced or ">" in reduced:
             if message == reduced: # No pango markup
                 here = message.find('<')
-                if message[here:here+4] != "&lt;":
+                if here != -1 and message[here:here+4] != "&lt;":
                     message = message[:here] + "&lt;" + message[here+1:]
                 here = message.find('>')
-                if message[here:here+4] != "&gt;":
+                if here != -1 and message[here:here+4] != "&gt;":
                     message = message[:here] + "&gt;" + message[here+1:]
             else:
                 print('"%s", line %d: < or > in pango string requires manual fix.' % (filename, line))

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1592,14 +1592,9 @@ def pangoize(message, filename, line):
     # Check for unescaped < and >
     if "<" in message or ">" in message:
         reduced = pangostrip(message)
-        if "<" in reduced or ">" in reduced:
+        if ("<" in reduced or ">" in reduced) and not rgb :
             if message == reduced: # No pango markup
-                here = message.find('<')
-                if here != -1 and message[here:here+4] != "&lt;":
-                    message = message[:here] + "&lt;" + message[here+1:]
-                here = message.find('>')
-                if here != -1 and message[here:here+4] != "&gt;":
-                    message = message[:here] + "&gt;" + message[here+1:]
+                message = message.replace("<", "&lt;").replace(">", "&gt;")
             else:
                 print('"%s", line %d: < or > in pango string requires manual fix.' % (filename, line))
     return message


### PR DESCRIPTION
In python negative index counts from the end, so without this change or another solution 
`example with only < one side` would be converted to  
`example with only < one sid&gt;example with only < one side`