### PR TITLE
Add a unit test for the preprocessor's #ifdef handling

### DIFF
--- a/data/test/scenarios/test_preprocessor_ifdef_in_arg.cfg
+++ b/data/test/scenarios/test_preprocessor_ifdef_in_arg.cfg
@@ -1,0 +1,49 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: the preprocessor
+##
+# Expected end state:
+# This test passes. None of the FAILs happen.
+#####
+{GENERIC_UNIT_TEST "test_preprocessor_ifdef_in_arg" (
+    [event]
+        name=start
+
+        # Every {FAIL} block is removed during the preprocessing stage. Although the preprocessor
+        # does try to expand them, its output contains only the expansion of the {SUCCEED}
+        # statement, causing the test to pass. The preprocessor is aware of which blocks should be
+        # enabled, which can be seen by using a nonexistent macro in all of the four blocks which
+        # are disabled (no error), vs any of the blocks which should be enabled (it errors out).
+        #
+        # This is a test where the behavior is surprising, might be worth changing, but is being
+        # tested so that we realise if it's changed. I assume it's caused by the handling of ifdef
+        # statements inside macro arguments, as this is an argument to the GENERIC_UNIT_TEST macro.
+
+#ifdef SOMETHING_THAT_IS_NOT_DEFINED
+        {FAIL}
+#else
+        {FAIL}
+#endif
+#ifndef SOMETHING_THAT_IS_NOT_DEFINED
+        {FAIL}
+#else
+        {FAIL}
+#endif
+
+        # Now try with something that is defined
+
+#ifdef WESNOTH_VERSION
+        {FAIL}
+#else
+        {FAIL}
+#endif
+#ifndef WESNOTH_VERSION
+        {FAIL}
+#else
+        {FAIL}
+#endif
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -73,6 +73,10 @@
 8 check_victory_never_pass
 7 check_victory_never_ai_fail
 #
+# Preprocessor
+#
+0 test_preprocessor_ifdef_in_arg
+#
 # WML API tests
 #
 0 two_plus_two


### PR DESCRIPTION
This one's surprising, but it's the behavior of 1.16, so add a test for the current behavior even though I wonder if it should change in 1.17.

@CelticMinstrel @newfrenchy83 this explains my current confusion in #7157.