### PR TITLE
Add unit tests for interpolated event names and end_turn

### DIFF
--- a/data/test/scenarios/premature_end_turn.cfg
+++ b/data/test/scenarios/premature_end_turn.cfg
@@ -1,0 +1,46 @@
+# wmllint: no translatables
+
+# If we were designing the API anew, then [end_turn] before side 1 has even started its turn would
+# probably be treated as an error. However, it's worked this way for ages and has been tested to
+# work this way since 1.13.11.
+
+#####
+# API(s) being tested: [event],[end_turn]
+##
+# Actions:
+# In a "turn X" event, before any side has started their "side turn", end the current side's turn.
+##
+# Expected end state:
+# It ends side 1's turn.
+#####
+{GENERIC_UNIT_TEST "premature_end_turn1" (
+    [event]
+        name="turn 1"
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name="side 2 turn 1"
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event],[end_turn]
+##
+# Actions:
+# In a "turn X" event, before any side has started their "side turn", end the current side's turn.
+##
+# Expected end state:
+# It ends side 1's turn.
+# The test times out during side 2's turn.
+#####
+{GENERIC_UNIT_TEST "premature_end_turn2" (
+    [event]
+        name="turn 1"
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name="turn 2"
+        {FAIL}
+    [/event]
+)}

--- a/data/test/scenarios/test_event_names_and_order.cfg
+++ b/data/test/scenarios/test_event_names_and_order.cfg
@@ -1,37 +1,14 @@
-{GENERIC_UNIT_TEST "order_of_variable_events1" (
-    [event]
-        name=start
-        {VARIABLE t 1}
-    [/event]
-    [event]
-        name="turn $t"
-        first_time_only=no
-        {VARIABLE_OP t add 1}
-        [end_turn][/end_turn]
-    [/event]
-    [event]
-        name=side 2 turn 1
-        {RETURN ({VARIABLE_CONDITIONAL t equals 2})}
-    [/event]
-)}
+# wmllint: no translatables
 
-{GENERIC_UNIT_TEST "order_of_variable_events2" (
-    [event]
-        name=start
-        {VARIABLE t 1}
-    [/event]
-    [event]
-        name=turn 1
-        {RETURN ({VARIABLE_CONDITIONAL t equals 1})}
-    [/event]
-    [event]
-        name="turn $t"
-        first_time_only=no
-        {VARIABLE_OP t add 1}
-        [end_turn][/end_turn]
-    [/event]
-)}
-
+#####
+# API(s) being tested: [event]
+##
+# Actions:
+# Define an event using a variable in its name attribute.
+##
+# Expected end state:
+# The variable is interpolated and the event executes.
+#####
 {GENERIC_UNIT_TEST "event_name_variable_substitution" (
     [event]
         name=start
@@ -42,7 +19,94 @@
         [end_turn][/end_turn]
     [/event]
     [event]
-        name="side 1 turn $t end"
-        {RETURN ([true][/true])}
+        name="side $t turn $t end"
+        {SUCCEED}
+    [/event]
+    [event]
+        name="side 2 turn"
+        {FAIL}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event]
+##
+# Actions:
+# Define an event using a variable in its name attribute.
+##
+# Expected end state:
+# The events execute in the order that they were defined.
+# The variable is interpolated and the "turn $t" event executes first.
+# The "turn 1" event executes afterwards.
+#####
+{GENERIC_UNIT_TEST "order_of_variable_events1" (
+    [event]
+        name=start
+        {VARIABLE t 1}
+    [/event]
+    [event]
+        name="turn $t"
+        first_time_only=no
+        {VARIABLE_OP t add 1}
+    [/event]
+    [event]
+        name=turn 1
+        {RETURN ({VARIABLE_CONDITIONAL t equals 2})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event]
+##
+# Actions:
+# Define an event using a variable in its name attribute.
+##
+# Expected end state:
+# The events execute in the order that they were defined.
+# The "turn 1" event executes first, and ends the test.
+# The "turn $t" does not execute, because the test has already ended.
+#####
+{GENERIC_UNIT_TEST "order_of_variable_events2" (
+    [event]
+        name=start
+        {VARIABLE t 1}
+    [/event]
+    [event]
+        name=turn 1
+        {SUCCEED}
+    [/event]
+    [event]
+        name="turn $t"
+        {FAIL}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event]
+##
+# Actions:
+# Define an event using a variable in its name attribute.
+##
+# Expected end state:
+# The variable is interpolated and the event executes twice - once as "turn 1" and once as "turn 2".
+#####
+{GENERIC_UNIT_TEST "order_of_variable_events3" (
+    [event]
+        name=start
+        {VARIABLE t 1}
+    [/event]
+    [event]
+        name="turn $t"
+        first_time_only=no
+        {VARIABLE_OP t add 1}
+    [/event]
+    [event]
+        name="side turn"
+        first_time_only=no
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 1 turn 2
+        {RETURN ({VARIABLE_CONDITIONAL t equals 3})}
     [/event]
 )}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -388,9 +388,12 @@
 # Changing the number of sides
 0 test_create_side
 # Event tests
+0 event_name_variable_substitution
 0 order_of_variable_events1
 0 order_of_variable_events2
-0 event_name_variable_substitution
+0 order_of_variable_events3
+0 premature_end_turn1
+2 premature_end_turn2
 # Game mechanics
 0 heal
 # Warnings about WML


### PR DESCRIPTION
Move `event_name_variable_substitution` to the top of the file, as it's testing that the event triggers at all, before the tests that check which order the events are triggered in.

The old `order_of_variable_events1` seemed to be a combination of two tests that should exist, but the code didn't quite test either of them. This replaces it with a new `order_of_variable_events1` and `order_of_variable_events3`.

Docs partially written by Pentarctagon, this started as a review comment on the documentation PR.