### PR TITLE
Chat message overlap

### DIFF
--- a/src/display_chat_manager.cpp
+++ b/src/display_chat_manager.cpp
@@ -114,8 +114,8 @@ void display_chat_manager::add_chat_message(const std::time_t& time, const std::
 
 	int ypos = chat_message_x;
 	for(std::vector<chat_message>::const_iterator m = chat_messages_.begin(); m != chat_messages_.end(); ++m) {
-		ypos += std::max(font::get_floating_label_rect(m->handle).h,
-			font::get_floating_label_rect(m->speaker_handle).h);
+		ypos += std::max(font::get_floating_label_rect(m->handle).h, font::get_floating_label_rect(m->speaker_handle).h)
+			+ (chat_message_border * 2);
 	}
 	color_t speaker_color {255,255,255,SDL_ALPHA_OPAQUE};
 	if(side >= 1) {
@@ -169,8 +169,8 @@ void display_chat_manager::add_chat_message(const std::time_t& time, const std::
 	font::floating_label msg_flabel(message_str.str());
 	msg_flabel.set_font_size(font::SIZE_15);
 	msg_flabel.set_color(message_color);
-	msg_flabel.set_position(rect.x + chat_message_x + font::get_floating_label_rect(speaker_handle).w,
-	rect.y + ypos);
+	msg_flabel.set_position(rect.x + chat_message_x + font::get_floating_label_rect(speaker_handle).w
+		+ (chat_message_border * 2), rect.y + ypos);
 	msg_flabel.set_clip_rect(rect);
 	msg_flabel.set_alignment(font::LEFT_ALIGN);
 	msg_flabel.set_bg_color(chat_message_bg);
@@ -207,7 +207,7 @@ void display_chat_manager::prune_chat_messages(bool remove_all)
 		        chat_messages_.size() > max_chat_messages))
 		{
 			const chat_message &old = chat_messages_.front();
-			movement += font::get_floating_label_rect(old.handle).h;
+			movement += font::get_floating_label_rect(old.handle).h + (chat_message_border * 2);
 			font::remove_floating_label(old.speaker_handle);
 			font::remove_floating_label(old.handle);
 			chat_messages_.erase(chat_messages_.begin());

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -100,12 +100,11 @@ int floating_label::xpos(std::size_t width) const
 
 rect floating_label::get_bg_rect(const rect& text_rect) const
 {
-	const int zf = display::get_singleton()->get_zoom_factor();
 	return {
-		text_rect.x - (border_ * zf),
-		text_rect.y - (border_ * zf),
-		text_rect.w + (border_ * zf * 2),
-		text_rect.h + (border_ * zf * 2)
+		text_rect.x - border_,
+		text_rect.y - border_,
+		text_rect.w + (border_ * 2),
+		text_rect.h + (border_ * 2)
 	};
 }
 


### PR DESCRIPTION
**Draft because there is a lingering redraw issue**.

1.16.6 release (no difference with zoom):
![1 16 6](https://user-images.githubusercontent.com/13679322/204066735-f71ad8bb-4ada-4f6a-b5cb-239df42459bc.png)

1.17.10 release - 100% and 200% zoom (issue #7100):
![1 17 10](https://user-images.githubusercontent.com/13679322/204066806-5267e6b9-a2a2-4bb1-a424-035c667aea2d.png) ![1 17 10-zoomed](https://user-images.githubusercontent.com/13679322/204066815-bdf0f62f-d36e-45c9-9fe9-aa1cdcc7ff6a.png)

This PR (at 200% zoom):
![1 17 10-branch](https://user-images.githubusercontent.com/13679322/204066846-9b8dc4c2-49a2-4867-98de-da6023150383.png)

However, I still need some help with the undraw calls, when the chat messages are scrolled up (as subsequent messages are displayed):
![1 17 10-undraw](https://user-images.githubusercontent.com/13679322/204066893-3d0f1161-833e-4e57-9097-333bc9ef1a6f.png)

`display_chat_manager::prune_chat_messages()` calls `remove_floating_label()`:
https://github.com/wesnoth/wesnoth/blob/710867e010a73c4dfe6b78a52908670b23e2d091/src/display_chat_manager.cpp#L203-L215

`remove_floating_label()` then calls `floating_label::undraw()`:
https://github.com/wesnoth/wesnoth/blob/710867e010a73c4dfe6b78a52908670b23e2d091/src/floating_label.cpp#L309

...and then `undraw()` calls `floating_label::get_bg_rect()`:
https://github.com/wesnoth/wesnoth/blob/710867e010a73c4dfe6b78a52908670b23e2d091/src/floating_label.cpp#L159-L164

I've verified that `get_bg_rect()` properly accounts for the border padding for the chat messages, so I'm not sure why they are not being undrawn properly (I'm not really familiar with the graphics code). Help? I accept this may not be the 'right' or 'best' way to resolve #7100.