### PR TITLE
Zoom-in using "+"

### DIFF
--- a/data/core/hotkeys.cfg
+++ b/data/core/hotkeys.cfg
@@ -284,6 +284,10 @@
     key="="
 [/hotkey]
 [hotkey]
+    command=zoomin
+    key="+"
+[/hotkey]
+[hotkey]
     command=zoomout
     key=-
 [/hotkey]


### PR DESCRIPTION
This adds "+" for Zoom-in as an additional hotkey (without removing the previously set value, so "=" would still work).

The "=" key doesn't seem to work when pressing it from a keyboard layout such as German QWERTZ in Windows. It's also against the user's expectations that if we accidentally press on "minus" causing the map to zoom out, the expectation would be for the opposite operation to be "plus".

I expect the only reason it's set to "=" is because, on a US keyboard layout, the "=" key is right next to the "-" key, without requiring pressing "Shift" to activate it. But this is not the case in every keyboard layout (eg. in QWERTZ you'd have to press Shift+0 for obtaining "=" and as mentioned before, this doesn't seem to be picked up by the engine, so you can't really Zoom-in).