### PR TITLE
Change Twitter link to Mastodon link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Discord:
 IRC:
   <https://wiki.wesnoth.org/Support#IRC>
 
-Twitter:
-  <https://twitter.com/Wesnoth>
+Mastodon:
+  <https://fosstodon.org/@wesnoth>
 
 Steam forums:
   <https://steamcommunity.com/app/599390/discussions/>


### PR DESCRIPTION
Pretty simple; since the project has announced a migration from Twitter to Mastodon, this updates the README to reflect it.
