### PR TITLE
Pin comments chat

### DIFF
--- a/src/chat_command_handler.cpp
+++ b/src/chat_command_handler.cpp
@@ -154,4 +154,13 @@ void chat_command_handler::do_mp_report() {
 	}
 }
 
+void chat_command_handler::do_pin_message() {
+	chat_handler_.pin_message(get_data(), "", allies_only_);
 }
+
+void chat_command_handler::do_unpin_messages() {
+	//chat_handler_.unpin_messages();
+}
+
+}
+

--- a/src/chat_command_handler.cpp
+++ b/src/chat_command_handler.cpp
@@ -155,11 +155,11 @@ void chat_command_handler::do_mp_report() {
 }
 
 void chat_command_handler::do_pin_message() {
-	chat_handler_.pin_message(get_data(), "", allies_only_);
+	chat_handler_.pin_message(get_data(), "");
 }
 
 void chat_command_handler::do_unpin_messages() {
-	//chat_handler_.unpin_messages();
+	chat_handler_.unpin_messages();
 }
 
 }

--- a/src/chat_command_handler.hpp
+++ b/src/chat_command_handler.hpp
@@ -43,7 +43,9 @@ protected:
 	void do_version();
 	void do_clear_messages();
 	void do_mp_report();
-
+	void do_pin_message();
+	void do_unpin_messages();
+	
 	/** Request information about a user from the server. */
 	void do_info();
 
@@ -119,6 +121,11 @@ protected:
 			_("Request information about a nickname."), _("<nickname>"));
 		register_command("clear", &chat_command_handler::do_clear_messages,
 			_("Clear chat history."));
+		register_command("pin", &chat_command_handler::do_pin_message,
+			_("Pin a message."), _("<message>"));
+		register_command("unpin", &chat_command_handler::do_unpin_messages,
+			_("Unpin a message."), _("<message>"));
+
 	}
 private:
 	chat_handler& chat_handler_;

--- a/src/chat_command_handler.hpp
+++ b/src/chat_command_handler.hpp
@@ -45,7 +45,7 @@ protected:
 	void do_mp_report();
 	void do_pin_message();
 	void do_unpin_messages();
-	
+
 	/** Request information about a user from the server. */
 	void do_info();
 

--- a/src/chat_events.hpp
+++ b/src/chat_events.hpp
@@ -55,7 +55,11 @@ protected:
 
 	virtual void add_chat_room_message_received(const std::string& room,
 		const std::string& speaker, const std::string& message);
+	
+	virtual void pin_message(const std::string& message, const std::string& speaker, bool allies_only) = 0;
 
+	//virtual void unpin_messages(const std::string& message, bool allies_only);
+	
 	/**
 	 * Called when a processed command results in a relation (friend/ignore) change
 	 * for a user whose name is passed as the 'name' arg
@@ -65,7 +69,7 @@ protected:
 	void change_logging(const std::string& data);
 
 	virtual void clear_messages() = 0;
-
+	
 	friend class chat_command_handler;
 };
 

--- a/src/chat_events.hpp
+++ b/src/chat_events.hpp
@@ -55,11 +55,11 @@ protected:
 
 	virtual void add_chat_room_message_received(const std::string& room,
 		const std::string& speaker, const std::string& message);
-	
-	virtual void pin_message(const std::string& message, const std::string& speaker, bool allies_only) = 0;
 
-	//virtual void unpin_messages(const std::string& message, bool allies_only);
-	
+	virtual void pin_message(const std::string& message, const std::string& speaker) = 0;
+
+	virtual void unpin_messages() = 0;
+
 	/**
 	 * Called when a processed command results in a relation (friend/ignore) change
 	 * for a user whose name is passed as the 'name' arg
@@ -69,7 +69,7 @@ protected:
 	void change_logging(const std::string& data);
 
 	virtual void clear_messages() = 0;
-	
+
 	friend class chat_command_handler;
 };
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -19,6 +19,7 @@
 #include "game_initialization/lobby_data.hpp"
 #include "game_initialization/lobby_info.hpp"
 #include "gui/widgets/container_base.hpp"
+#include "gui/widgets/button.hpp"
 
 #include <map>
 #include <string>
@@ -135,7 +136,7 @@ private:
 	std::function<void(void)> active_window_changed_callback_;
 
 	std::map<std::string, chatroom_log>* log_;
-
+	
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
 	static const std::string& type();
@@ -194,6 +195,8 @@ private:
 public:
 	/** Inherited form @ref chat_handler */
 	virtual void send_chat_message(const std::string& message, bool allies_only) override;
+	
+	void pin_message(const std::string& message, const std::string& speaker, bool allies_only) override;
 
 	virtual void clear_messages() override;
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -136,7 +136,7 @@ private:
 	std::function<void(void)> active_window_changed_callback_;
 
 	std::map<std::string, chatroom_log>* log_;
-	
+
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
 	static const std::string& type();
@@ -190,13 +190,16 @@ private:
 		const std::string& message,
 		const bool force_scroll = false);
 
+	void pin_message_in_box(const std::string& message, const std::string& speaker);
+	unsigned short pinned_messages = 0;
 	void close_window(std::size_t idx);
 
 public:
 	/** Inherited form @ref chat_handler */
 	virtual void send_chat_message(const std::string& message, bool allies_only) override;
-	
-	void pin_message(const std::string& message, const std::string& speaker, bool allies_only) override;
+
+	void pin_message(const std::string& message, const std::string& speaker) override;
+	void unpin_messages();
 
 	virtual void clear_messages() override;
 
@@ -233,7 +236,7 @@ public:
 
 	void close_window_button_callback(std::string room_name, bool& handled, bool& halt);
 
-	void process_message(const ::config& data, bool whisper = false);
+	void process_message(const ::config& data, bool whisper = false, bool pin = false);
 
 	void process_network_data(const ::config& data);
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -198,7 +198,7 @@ public:
 	virtual void send_chat_message(const std::string& message, bool allies_only) override;
 
 	void pin_message(const std::string& message, const std::string& speaker) override;
-	void unpin_messages();
+	void unpin_messages() override;
 
 	virtual void clear_messages() override;
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -190,9 +190,8 @@ private:
 		const std::string& message,
 		const bool force_scroll = false);
 
-	void pin_message_in_box(const std::string& message, const std::string& speaker);
-	unsigned short pinned_messages = 0;
 	void close_window(std::size_t idx);
+	bool pin_message_in_box(const std::string& message, const std::string& speaker);
 
 public:
 	/** Inherited form @ref chat_handler */

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -98,7 +98,8 @@ public:
 	void ai_formula();
 	virtual void clear_messages() override;
 	std::vector<std::string> get_commands_list();
-	virtual void pin_message(const std::string& message, const std::string& speaker, bool allies_only) override {if (message == "") return; if (allies_only == true) return; if (speaker == "") return;};
+	virtual void pin_message(const std::string& message, const std::string& speaker) override {if (message == "") return; if (speaker == "") return;};
+	virtual void unpin_messages() override {return;};
 
 	unit_map::iterator current_unit();
 	unit_map::const_iterator current_unit() const

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -98,7 +98,7 @@ public:
 	void ai_formula();
 	virtual void clear_messages() override;
 	std::vector<std::string> get_commands_list();
-	virtual void pin_message(const std::string& message, const std::string& speaker) override {if (message == "") return; if (speaker == "") return;};
+	virtual void pin_message(const std::string& message, const std::string& speaker) override {if (message.empty()) return; if (speaker.empty()) return;};
 	virtual void unpin_messages() override {return;};
 
 	unit_map::iterator current_unit();

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -98,6 +98,7 @@ public:
 	void ai_formula();
 	virtual void clear_messages() override;
 	std::vector<std::string> get_commands_list();
+	virtual void pin_message(const std::string& message, const std::string& speaker, bool allies_only) override {if (message == "") return; if (allies_only == true) return; if (speaker == "") return;};
 
 	unit_map::iterator current_unit();
 	unit_map::const_iterator current_unit() const

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -904,13 +904,13 @@ void game::handle_pin(player_iterator player, simple_wml::node& pin) {
 	// Then: add pin to pin vector, then, if new player joins, send it to him after the fact
 	std::string sender = player->name().c_str();
 	std::string message = msg.to_string();
-	pin_queue.push_back(std::pair<std::string, std::string>(sender, message));
+	pin_queue_.push_back(std::pair<std::string, std::string>(sender, message));
 	return;
 }
 
 void game::handle_unpin(player_iterator player) {
 	const std::string name = player->name();
-	pin_queue.erase(std::remove_if(pin_queue.begin(), pin_queue.end(), [name](std::pair<std::string, std::string> i) {return (i.first == name);}), pin_queue.end());
+	pin_queue_.erase(std::remove_if(pin_queue_.begin(), pin_queue_.end(), [name](std::pair<std::string, std::string> i) {return (i.first == name);}), pin_queue_.end());
 	return;
 }
 
@@ -1458,11 +1458,11 @@ bool game::add_player(player_iterator player, bool observer)
 	}
 
 	// Lastly, send the user the pinned chat messages
-	for (unsigned int i = 0; i < pin_queue.size(); i++) {
+	for (unsigned int i = 0; i < pin_queue_.size(); i++) {
 		simple_wml::document cpin;
 		simple_wml::node& pin = cpin.root().add_child("pin");
-		const simple_wml::string_span& sender = pin_queue[i].first.c_str();
-		const simple_wml::string_span& msg = pin_queue[i].second.c_str();
+		const simple_wml::string_span& sender = pin_queue_[i].first.c_str();
+		const simple_wml::string_span& msg = pin_queue_[i].second.c_str();
 		pin.set_attr_dup("sender", sender);
 		pin.set_attr_dup("message", msg);
 		server.send_to_player(player, cpin);

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -588,6 +588,9 @@ public:
 		observers_.clear();
 	}
 
+	void handle_pin(player_iterator player, simple_wml::node& pin);
+	void handle_unpin(player_iterator player);
+
 private:
 	// forbidden operations
 	game(const game&) = delete;
@@ -705,6 +708,8 @@ private:
 	void send_data_sides(simple_wml::document& data,
 			const simple_wml::string_span& sides,
 			std::optional<player_iterator> exclude = {});
+
+	std::vector<std::pair<std::string, std::string>> pin_queue;
 
 	/**
 	 * Send a document per observer in the game.
@@ -898,6 +903,10 @@ private:
 	 * New requests should never have a lower value than this.
 	 */
 	int last_choice_request_id_;
+	/**
+	 * The queue of pinned messages in this game's chat.
+	 * */
+	std::vector<std::pair<std::string, std::string>> pin_queue_;
 };
 
 } // namespace wesnothd

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -709,8 +709,6 @@ private:
 			const simple_wml::string_span& sides,
 			std::optional<player_iterator> exclude = {});
 
-	std::vector<std::pair<std::string, std::string>> pin_queue;
-
 	/**
 	 * Send a document per observer in the game.
 	 * If @a player is blank, send these documents to everyone, else send them to just the observer who joined.

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -53,7 +53,6 @@ private:
 	template<class SocketPtr> bool authenticate(SocketPtr socket, const std::string& username, const std::string& password, bool name_taken, bool& registered);
 	template<class SocketPtr> void send_password_request(SocketPtr socket, const std::string& msg, const char* error_code = "", bool force_confirmation = false);
 	bool accepting_connections() const { return !graceful_restart; }
-	std::vector<std::pair<std::string, std::string>> pin_queue;
 
 	template<class SocketPtr> void handle_player(boost::asio::yield_context yield, SocketPtr socket, const player& player);
 	void handle_player_in_lobby(player_iterator player, simple_wml::document& doc);

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -53,11 +53,14 @@ private:
 	template<class SocketPtr> bool authenticate(SocketPtr socket, const std::string& username, const std::string& password, bool name_taken, bool& registered);
 	template<class SocketPtr> void send_password_request(SocketPtr socket, const std::string& msg, const char* error_code = "", bool force_confirmation = false);
 	bool accepting_connections() const { return !graceful_restart; }
+	std::vector<std::pair<std::string, std::string>> pin_queue;
 
 	template<class SocketPtr> void handle_player(boost::asio::yield_context yield, SocketPtr socket, const player& player);
 	void handle_player_in_lobby(player_iterator player, simple_wml::document& doc);
 	void handle_player_in_game(player_iterator player, simple_wml::document& doc);
 	void handle_whisper(player_iterator player, simple_wml::node& whisper);
+	void handle_pin(player_iterator player, simple_wml::node& pin);
+	void handle_unpin(player_iterator player);
 	void handle_query(player_iterator player, simple_wml::node& query);
 	void handle_nickserv(player_iterator player, simple_wml::node& nickserv);
 	void handle_message(player_iterator player, simple_wml::node& message);

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -979,6 +979,8 @@ class fake_chat_handler : public events::chat_handler {
 	void send_chat_message(const std::string&, bool) {}
 	void send_to_server(const config&) {}
 	void clear_messages() {}
+	void pin_message(const std::string&, const std::string&) {}
+	void unpin_messages() {}
 };
 
 template<>


### PR DESCRIPTION
This is my first shot at the "pinning comments" functionality:
https://github.com/wesnoth/wesnoth/issues/6974

Open questions:

1. I need to overload the two functions I implement in `chat_events.hpp`, which I need for `chatbox.cpp` also in `menu_events.hpp` where they effectively are not doing anything. Maybe there is a better way of doing this
2. Still searching for a good place for a client after leaving a game to tell it to delete its logs. Otherwise the players will always have access to the last game's chat logs
