### PR TITLE
Just look for the toplevel dir tag

### DIFF
--- a/src/server/campaignd/addon_utils.cpp
+++ b/src/server/campaignd/addon_utils.cpp
@@ -125,10 +125,11 @@ void find_translations(const config& base_dir, config& addon)
 
 void add_license(config& cfg)
 {
-	config& dir = cfg.find_child("dir", "name", cfg["campaign_name"]);
+	config& dir = cfg.child("dir");
 
 	// No top-level directory? Hm..
 	if(!dir) {
+		LOG_CS << "Could not find toplevel [dir] tag";
 		return;
 	}
 


### PR DESCRIPTION
"campaign_name" is not an existing attribute in the given config anymore. An addon should only contain a single toplevel dir tag with the name of the addon anyway.