### PR TITLE
Language string duplicate removal

### DIFF
--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -408,7 +408,7 @@ void addon_manager::pre_show(window& window)
 			language_strings_available.insert(lang_code_string);
 		}
 	}
-	for (const auto& i: language_strings_available) {
+	for (auto& i: language_strings_available) {
 		language_filter_types_.emplace_back(language_filter_types_.size(), std::move(i));
 	}
 	// The language filter

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -399,15 +399,18 @@ void addon_manager::pre_show(window& window)
 			languages_available.insert(b);
 		}
 	}
-
+	std::set<std::string> language_strings_available;
 	for (const auto& i: languages_available) {
 		// Only show languages, which have a translation as per langcode_to_string() method
 		// Do not show tranlations with their langcode e.g. "sv_SV"
+		// Also put them into a set, so same lang strings are not producing doublettes
 		if (std::string lang_code_string = langcode_to_string(i); !lang_code_string.empty()) {
-			language_filter_types_.emplace_back(language_filter_types_.size(), std::move(lang_code_string));
+			language_strings_available.insert(lang_code_string);
 		}
 	}
-
+	for (const auto& i: language_strings_available) {
+		language_filter_types_.emplace_back(language_filter_types_.size(), std::move(i));
+	}
 	// The language filter
 	multimenu_button& language_filter = find_widget<multimenu_button>(&window, "language_filter", false);
 	std::vector<config> language_filter_entries;


### PR DESCRIPTION
Attempts to fix this issue here: https://github.com/wesnoth/wesnoth/issues/7169
I just push the output of `langcode_to_string()` through another set, which removes duplicates of the display string.