### PR TITLE
Avoid throwing exceptions internally to lexical_cast when parsing an empty string

### DIFF
--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -220,6 +220,14 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To long long - From std::string");
 
+		if(value.empty()) {
+			if(fallback) {
+				return *fallback;
+			} else {
+				throw bad_lexical_cast();
+			}
+		}
+
 		try {
 			return std::stoll(value);
 		} catch(const std::invalid_argument&) {
@@ -274,6 +282,14 @@ struct lexical_caster<
 	To operator()(const std::string& value, std::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To signed - From std::string");
+
+		if(value.empty()) {
+			if(fallback) {
+				return *fallback;
+			} else {
+				throw bad_lexical_cast();
+			}
+		}
 
 		try {
 			long res = std::stol(value);
@@ -332,6 +348,14 @@ struct lexical_caster<
 	To operator()(const std::string& value, std::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To floating point - From std::string");
+
+		if(value.empty()) {
+			if(fallback) {
+				return *fallback;
+			} else {
+				throw bad_lexical_cast();
+			}
+		}
 
 		// Explicitly reject hexadecimal values. Unit tests of the config class require that.
 		if(value.find_first_of("Xx") != std::string::npos) {
@@ -404,6 +428,14 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To unsigned long long - From std::string");
 
+		if(value.empty()) {
+			if(fallback) {
+				return *fallback;
+			} else {
+				throw bad_lexical_cast();
+			}
+		}
+
 		try {
 			return std::stoull(value);
 		} catch(const std::invalid_argument&) {
@@ -458,6 +490,14 @@ struct lexical_caster<
 	To operator()(const std::string& value, std::optional<To> fallback) const
 	{
 		DEBUG_THROW("specialized - To unsigned - From std::string");
+
+		if(value.empty()) {
+			if(fallback) {
+				return *fallback;
+			} else {
+				throw bad_lexical_cast();
+			}
+		}
 
 		try {
 			unsigned long res = std::stoul(value);

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -220,17 +220,10 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To long long - From std::string");
 
-		// Using the C API instead of the C++ API to avoid exceptions,
-		// as this function is called frequently.
-		errno = 0;
-		char* end;
-		long long result = std::strtoll(value.c_str(), &end, 10);
-		const bool out_of_range = errno == ERANGE;
-		const bool invalid_argument = *end > 0 || end == value.c_str();
-		const bool failure = out_of_range || invalid_argument;
-
-		if(!failure) {
-			return result;
+		try {
+			return std::stoll(value);
+		} catch(const std::invalid_argument&) {
+		} catch(const std::out_of_range&) {
 		}
 
 		if(fallback) {
@@ -282,17 +275,13 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To signed - From std::string");
 
-		// Using the C API instead of the C++ API to avoid exceptions,
-		// as this function is called frequently.
-		errno = 0;
-		char* end;
-		long result = std::strtol(value.c_str(), &end, 10);
-		const bool out_of_range = errno == ERANGE || result < static_cast<long>(std::numeric_limits<To>::min()) || result > static_cast<long>(std::numeric_limits<To>::max());
-		const bool invalid_argument = *end > 0 || end == value.c_str();
-		const bool failure = out_of_range || invalid_argument;
-
-		if(!failure) {
-			return result;
+		try {
+			long res = std::stol(value);
+			if(std::numeric_limits<To>::lowest() <= res && std::numeric_limits<To>::max() >= res) {
+				return static_cast<To>(res);
+			}
+		} catch(const std::invalid_argument&) {
+		} catch(const std::out_of_range&) {
 		}
 
 		if(fallback) {
@@ -353,17 +342,13 @@ struct lexical_caster<
 			}
 		}
 
-		// Using the C API instead of the C++ API to avoid exceptions,
-		// as this function is called frequently.
-		errno = 0;
-		char* end;
-		long double result = std::strtold(value.c_str(), &end);
-		const bool out_of_range = errno == ERANGE || result < static_cast<long double>(std::numeric_limits<To>::lowest()) || result > static_cast<long double>(std::numeric_limits<To>::max());
-		const bool invalid_argument = *end > 0 || end == value.c_str();
-		const bool failure = out_of_range || invalid_argument;
-
-		if(!failure) {
-			return result;
+		try {
+			long double res = std::stold(value);
+			if((static_cast<long double>(std::numeric_limits<To>::lowest()) <= res) && (static_cast<long double>(std::numeric_limits<To>::max()) >= res)) {
+				return static_cast<To>(res);
+			}
+		} catch(const std::invalid_argument&) {
+		} catch(const std::out_of_range&) {
 		}
 
 		if(fallback) {
@@ -419,17 +404,10 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To unsigned long long - From std::string");
 
-		// Using the C API instead of the C++ API to avoid exceptions,
-		// as this function is called frequently.
-		errno = 0;
-		char* end;
-		unsigned long long result = std::strtoull(value.c_str(), &end, 10);
-		const bool out_of_range = errno == ERANGE;
-		const bool invalid_argument = *end > 0 || end == value.c_str();
-		const bool failure = out_of_range || invalid_argument;
-
-		if(!failure) {
-			return result;
+		try {
+			return std::stoull(value);
+		} catch(const std::invalid_argument&) {
+		} catch(const std::out_of_range&) {
 		}
 
 		if(fallback) {
@@ -481,17 +459,14 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To unsigned - From std::string");
 
-		// Using the C API instead of the C++ API to avoid exceptions,
-		// as this function is called frequently.
-		errno = 0;
-		char* end;
-		unsigned long result = std::strtoul(value.c_str(), &end, 10);
-		const bool out_of_range = errno == ERANGE || result < static_cast<unsigned long>(std::numeric_limits<To>::min()) || result > static_cast<unsigned long>(std::numeric_limits<To>::max());
-		const bool invalid_argument = *end > 0 || end == value.c_str();
-		const bool failure = out_of_range || invalid_argument;
-
-		if(!failure) {
-			return result;
+		try {
+			unsigned long res = std::stoul(value);
+			// No need to check the lower bound, it's zero for all unsigned types.
+			if(std::numeric_limits<To>::max() >= res) {
+				return static_cast<To>(res);
+			}
+		} catch(const std::invalid_argument&) {
+		} catch(const std::out_of_range&) {
 		}
 
 		if(fallback) {

--- a/src/lexical_cast.hpp
+++ b/src/lexical_cast.hpp
@@ -220,10 +220,17 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To long long - From std::string");
 
-		try {
-			return std::stoll(value);
-		} catch(const std::invalid_argument&) {
-		} catch(const std::out_of_range&) {
+		// Using the C API instead of the C++ API to avoid exceptions,
+		// as this function is called frequently.
+		errno = 0;
+		char* end;
+		long long result = std::strtoll(value.c_str(), &end, 10);
+		const bool out_of_range = errno == ERANGE;
+		const bool invalid_argument = *end > 0 || end == value.c_str();
+		const bool failure = out_of_range || invalid_argument;
+
+		if(!failure) {
+			return result;
 		}
 
 		if(fallback) {
@@ -275,13 +282,17 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To signed - From std::string");
 
-		try {
-			long res = std::stol(value);
-			if(std::numeric_limits<To>::lowest() <= res && std::numeric_limits<To>::max() >= res) {
-				return static_cast<To>(res);
-			}
-		} catch(const std::invalid_argument&) {
-		} catch(const std::out_of_range&) {
+		// Using the C API instead of the C++ API to avoid exceptions,
+		// as this function is called frequently.
+		errno = 0;
+		char* end;
+		long result = std::strtol(value.c_str(), &end, 10);
+		const bool out_of_range = errno == ERANGE || result < static_cast<long>(std::numeric_limits<To>::min()) || result > static_cast<long>(std::numeric_limits<To>::max());
+		const bool invalid_argument = *end > 0 || end == value.c_str();
+		const bool failure = out_of_range || invalid_argument;
+
+		if(!failure) {
+			return result;
 		}
 
 		if(fallback) {
@@ -342,13 +353,17 @@ struct lexical_caster<
 			}
 		}
 
-		try {
-			long double res = std::stold(value);
-			if((static_cast<long double>(std::numeric_limits<To>::lowest()) <= res) && (static_cast<long double>(std::numeric_limits<To>::max()) >= res)) {
-				return static_cast<To>(res);
-			}
-		} catch(const std::invalid_argument&) {
-		} catch(const std::out_of_range&) {
+		// Using the C API instead of the C++ API to avoid exceptions,
+		// as this function is called frequently.
+		errno = 0;
+		char* end;
+		long double result = std::strtold(value.c_str(), &end);
+		const bool out_of_range = errno == ERANGE || result < static_cast<long double>(std::numeric_limits<To>::lowest()) || result > static_cast<long double>(std::numeric_limits<To>::max());
+		const bool invalid_argument = *end > 0 || end == value.c_str();
+		const bool failure = out_of_range || invalid_argument;
+
+		if(!failure) {
+			return result;
 		}
 
 		if(fallback) {
@@ -404,10 +419,17 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To unsigned long long - From std::string");
 
-		try {
-			return std::stoull(value);
-		} catch(const std::invalid_argument&) {
-		} catch(const std::out_of_range&) {
+		// Using the C API instead of the C++ API to avoid exceptions,
+		// as this function is called frequently.
+		errno = 0;
+		char* end;
+		unsigned long long result = std::strtoull(value.c_str(), &end, 10);
+		const bool out_of_range = errno == ERANGE;
+		const bool invalid_argument = *end > 0 || end == value.c_str();
+		const bool failure = out_of_range || invalid_argument;
+
+		if(!failure) {
+			return result;
 		}
 
 		if(fallback) {
@@ -459,14 +481,17 @@ struct lexical_caster<
 	{
 		DEBUG_THROW("specialized - To unsigned - From std::string");
 
-		try {
-			unsigned long res = std::stoul(value);
-			// No need to check the lower bound, it's zero for all unsigned types.
-			if(std::numeric_limits<To>::max() >= res) {
-				return static_cast<To>(res);
-			}
-		} catch(const std::invalid_argument&) {
-		} catch(const std::out_of_range&) {
+		// Using the C API instead of the C++ API to avoid exceptions,
+		// as this function is called frequently.
+		errno = 0;
+		char* end;
+		unsigned long result = std::strtoul(value.c_str(), &end, 10);
+		const bool out_of_range = errno == ERANGE || result < static_cast<unsigned long>(std::numeric_limits<To>::min()) || result > static_cast<unsigned long>(std::numeric_limits<To>::max());
+		const bool invalid_argument = *end > 0 || end == value.c_str();
+		const bool failure = out_of_range || invalid_argument;
+
+		if(!failure) {
+			return result;
 		}
 
 		if(fallback) {


### PR DESCRIPTION
The motivation for this is that `lexical_cast` is called very frequently, even to the point of being called repeatedly in the main loop. By relying on exceptions internally, it becomes a hindrance to debugging.

This PR is mainly opened solely for CI purposes. Unless there are objections before the CI successfully completes, I will merge it immediately.