### PR TITLE
WML: Adjust the weapon selection logic for [kill]

### DIFF
--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -54,10 +54,10 @@ function wesnoth.wml_actions.kill(cfg)
 				if secondary_unit then
 					found_attack = secondary_unit:find_attack(primary)
 				end
-				if not found_attack then
-					primary = wesnoth.units.create_weapon(primary)
-				else
+				if found_attack then
 					primary = found_attack
+				else
+					primary = wesnoth.units.create_weapon(primary)
 				end
 				wesnoth.log('err', "Primary weapon:\n" .. wml.tostring(primary.__cfg))
 			end
@@ -66,10 +66,10 @@ function wesnoth.wml_actions.kill(cfg)
 				if primary then
 					found_weapon = unit:find_attack(secondary)
 				end
-				if not found_weapon then
-					found_weapon = wesnoth.units.create_weapon(secondary)
-				else
+				if found_weapon then
 					secondary = found_weapon
+				else
+					found_weapon = wesnoth.units.create_weapon(secondary)
 				end
 				wesnoth.log('err', "Secondary weapon:\n" .. wml.tostring(secondary.__cfg))
 			end

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -59,7 +59,7 @@ function wesnoth.wml_actions.kill(cfg)
 				else
 					primary = wesnoth.units.create_weapon(primary)
 				end
-				wesnoth.log('err', "Primary weapon:\n" .. wml.tostring(primary.__cfg))
+				wesnoth.log('info', "Primary weapon:\n" .. wml.tostring(primary.__cfg))
 			end
 			if secondary then
 				local found_weapon = nil
@@ -71,7 +71,7 @@ function wesnoth.wml_actions.kill(cfg)
 				else
 					found_weapon = wesnoth.units.create_weapon(secondary)
 				end
-				wesnoth.log('err', "Secondary weapon:\n" .. wml.tostring(secondary.__cfg))
+				wesnoth.log('info', "Secondary weapon:\n" .. wml.tostring(secondary.__cfg))
 			end
 			anim:add(unit, "death", "kill", {primary = primary, secondary = secondary})
 			if secondary_unit then

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -56,8 +56,9 @@ function wesnoth.wml_actions.kill(cfg)
 				end
 				if not found_attack then
 					primary = wesnoth.units.create_weapon(primary)
+				else
+					primary = found_attack
 				end
-				primary = found_attack
 				wesnoth.log('err', "Primary weapon:\n" .. wml.tostring(primary.__cfg))
 			end
 			if secondary then
@@ -67,8 +68,9 @@ function wesnoth.wml_actions.kill(cfg)
 				end
 				if not found_weapon then
 					found_weapon = wesnoth.units.create_weapon(secondary)
+				else
+					secondary = found_weapon
 				end
-				secondary = found_weapon
 				wesnoth.log('err', "Secondary weapon:\n" .. wml.tostring(secondary.__cfg))
 			end
 			anim:add(unit, "death", "kill", {primary = primary, secondary = secondary})

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -69,7 +69,7 @@ function wesnoth.wml_actions.kill(cfg)
 				if found_weapon then
 					secondary = found_weapon
 				else
-					found_weapon = wesnoth.units.create_weapon(secondary)
+					secondary = wesnoth.units.create_weapon(secondary)
 				end
 				wesnoth.log('info', "Secondary weapon:\n" .. wml.tostring(secondary.__cfg))
 			end

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -50,19 +50,25 @@ function wesnoth.wml_actions.kill(cfg)
 			-- In other words, the attacker's weapon. The attacker is the secondary unit.
 			-- In the victory animation, this is simply swapped.
 			if primary then
+				local found_attack = nil
 				if secondary_unit then
-					primary = secondary_unit:find_attack(primary)
-				else
+					found_attack = secondary_unit:find_attack(primary)
+				end
+				if not found_attack then
 					primary = wesnoth.units.create_weapon(primary)
 				end
+				primary = found_attack
 				wesnoth.log('err', "Primary weapon:\n" .. wml.tostring(primary.__cfg))
 			end
 			if secondary then
+				local found_weapon = nil
 				if primary then
-					secondary = unit:find_attack(secondary)
-				else
-					secondary = wesnoth.units.create_weapon(secondary)
+					found_weapon = unit:find_attack(secondary)
 				end
+				if not found_weapon then
+					found_weapon = wesnoth.units.create_weapon(secondary)
+				end
+				secondary = found_weapon
 				wesnoth.log('err', "Secondary weapon:\n" .. wml.tostring(secondary.__cfg))
 			end
 			anim:add(unit, "death", "kill", {primary = primary, secondary = secondary})


### PR DESCRIPTION
The previous logic simply did not make sense, especially for the secondary weapon. For example, it would ignore the secondary weapon specification if the primary weapon was not found on the secondary unit, which does not make any sense.

The cases that this changes are:
- There is a secondary unit and a primary attack, but no matching attack was found. Previously it would use the default, now it pretends that attack exists.
- There is a secondary attack specified, but no primary attack, either because it was unspecified or because it didn't match any attack on the secondary unit

In both these cases, the animation runs as if a matching attack exists, rather than using no attack and choosing the default animation.