### PR TITLE
[1.16] Inspect console: fix infinite loop in pagination

### DIFF
--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -109,14 +109,21 @@ private:
 	{
 		pages.clear();
 		std::size_t start = 0;
-		while(start < data.size()) {
+		while(start + max_inspect_win_len < data.size()) {
+			// This could search into data that's already on a previous page, which is why the result
+			// is then checked for end < start.
 			std::size_t end = data.find_last_of('\n', start + max_inspect_win_len);
-			if(end == std::string::npos) {
-				end = data.size() - 1;
+			int len;
+			if(end == std::string::npos || end < start) {
+				len = max_inspect_win_len;
+			} else {
+				len = end - start + 1;
 			}
-			int len = end - start + 1;
 			pages.emplace_back(start, len);
 			start += len;
+		}
+		if(start < data.size()) {
+			pages.emplace_back(start, data.size() - start);
 		}
 	}
 	static const unsigned int max_inspect_win_len = 20000;


### PR DESCRIPTION
Backport of #1795, will merge when CI passes.

When given a string that includes newlines but doesn't end with a newline, the old code would get stuck in an infinite loop.

Fixes #7194.

(cherry picked from commit b5ff5c3ddc706f1281bbbe2f235b16c4b00f92db)