### PR TITLE
Checksums: accept 1.16's checksums during replays

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -516,6 +516,14 @@ namespace { // Helpers for place_recruit()
 		bool checksum_equals = checkup_instance->local_checkup(config {"checksum", checksum},original_checksum_config);
 		if(!checksum_equals)
 		{
+			// This can't call local_checkup() again, but local_checkup() should have already stored the
+			// expected value in original_checksum_config. If it hasn't then the result will be the same as
+			// if the checksum didn't match, which is a reasonably graceful failure.
+			const std::string alternate_checksum = get_checksum(new_unit, backwards_compatibility::unit_checksum_version::version_1_16_or_older);
+			checksum_equals = original_checksum_config["checksum"] == alternate_checksum;
+		}
+		if(!checksum_equals)
+		{
 			const std::string old_checksum = original_checksum_config["checksum"];
 			std::stringstream error_msg;
 			error_msg << "SYNC: In recruit " << new_unit.type_id() <<

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2684,7 +2684,7 @@ std::vector<t_string> unit::unit_special_notes() const {
 
 // Filters unimportant stats from the unit config and returns a checksum of
 // the remaining config.
-std::string get_checksum(const unit& u)
+std::string get_checksum(const unit& u, backwards_compatibility::unit_checksum_version version)
 {
 	config unit_config;
 	config wcfg;
@@ -2738,9 +2738,11 @@ std::string get_checksum(const unit& u)
 			config& child_spec = child.add_child("specials", spec);
 
 			child_spec.recursive_clear_value("description");
-			child_spec.recursive_clear_value("description_inactive");
-			child_spec.recursive_clear_value("name");
-			child_spec.recursive_clear_value("name_inactive");
+			if(version != backwards_compatibility::unit_checksum_version::version_1_16_or_older) {
+				child_spec.recursive_clear_value("description_inactive");
+				child_spec.recursive_clear_value("name");
+				child_spec.recursive_clear_value("name_inactive");
+			}
 		}
 	}
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -2014,6 +2014,19 @@ private:
 	int moves_;
 };
 
+namespace backwards_compatibility
+{
+/**
+ * Optional parameter for get_checksum to use the algorithm of an older version of Wesnoth,
+ * thus preventing spurious OOS warnings while watching old replays.
+ */
+enum class unit_checksum_version {
+	current,
+	version_1_16_or_older /**< Included some of the flavortext from weapon specials. */
+};
+
+} // namespace backwards_compatibility
+
 /**
  * Gets a checksum for a unit.
  *
@@ -2022,7 +2035,9 @@ private:
  * same problem.
  *
  *  @param u                    this unit
+ *  @param version              allows the checksum expected in older replays to be used
  *
  *  @returns                    the checksum for a unit
  */
-std::string get_checksum(const unit& u);
+std::string get_checksum(const unit& u,
+	backwards_compatibility::unit_checksum_version version = backwards_compatibility::unit_checksum_version::current);


### PR DESCRIPTION
Looking at the discussion in #7188, I thought it wouldn't be hard to have a fallback which only triggers when the normal checksum fails, and sees if the unit passes a 1.16 style checksum instead. Took a bit longer than expected, but looks like a reasonable solution to that problem without adding a maintenance burden.

This will also accept them during multiplayer matches, but it will still warn if the unit's stats have changed. When using the new option, the checksum includes data that has been ignored since 93fe5607a658c74b987.