### PR TITLE
Exclude nonvillages from outer_villages array

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -926,7 +926,7 @@
         # There is a number of houses inside the oasis and even more tents
         # by the necromancer's fort, we need to make sure that these are
         # ignored. To do this we store coordinates ([store_locations]) of
-        # all desert villages (Dd^Vt) that are not ([not]) within
+        # all desert villages (*^Vda, *^Vdr, *^Vdt) that are not ([not]) within
         # rectangle defined by points 34,1 50,12 (x=34-50, y=1-12) or
         # ([or]) rectangle defined by 13,37 20,34 . First rectangle
         # includes all villages near necromancer, the second covers whole
@@ -934,7 +934,7 @@
         # outer_villages (variable=outer_villages).
         [store_locations]
             variable=outer_villages
-            terrain=*^Vdt,*^Vda,*^
+            terrain=*^Vdt,*^Vda,*^Vdr
             [not]
                 x,y=32-50,1-12
                 [or]


### PR DESCRIPTION
Fixes #7202 

@nemaara could confirm that Gd^Vdt, Rd^Vdt, Re^Vda are intended to be included.

V terrains in that map:
Dd^Vda
Dd^Vdr
Dd^Vdt
Ds^Vda
Ds^Vdr
Ds^Vdt
Gd^Vdt
Rd^Vdt
Re^Vda