### PR TITLE
[MP] Change Elevation Test Scenario Name and Desc

### DIFF
--- a/data/multiplayer/scenarios/Test_Elevation_Test.cfg
+++ b/data/multiplayer/scenarios/Test_Elevation_Test.cfg
@@ -1,10 +1,9 @@
 #textdomain wesnoth-multiplayer
 
-#ifdef DEBUG_MODE
 [multiplayer]
     id=multiplayer_test_Elevation_Demo
-    name= _ "Wesnoth Test — Elevated Terrain Example Scenario"
-    description= _ "This map is an example of how to use the new (BfW v1.17) elevated terrain graphics. It is not a good map for real MP use."
+    name= _ "3p - Elevation Test"
+    description= _ "This map is an example of how to use the new (BfW v1.17) elevated terrain graphics. Please be advised that it is not intended for playing."
     map_file=multiplayer/maps/3p_Elevation_Example.map
 
     {DEFAULT_SCHEDULE}
@@ -65,4 +64,3 @@
         fog=yes
     [/side]
 [/multiplayer]
-#endif

--- a/data/multiplayer/scenarios/Test_Elevation_Test.cfg
+++ b/data/multiplayer/scenarios/Test_Elevation_Test.cfg
@@ -1,5 +1,6 @@
 #textdomain wesnoth-multiplayer
 
+#ifdef DEBUG_MODE
 [multiplayer]
     id=multiplayer_test_Elevation_Demo
     name= _ "Wesnoth Test — Elevated Terrain Example Scenario"
@@ -64,3 +65,4 @@
         fog=yes
     [/side]
 [/multiplayer]
+#endif


### PR DESCRIPTION
Currently, the name of this scenario is too long, and it causes unattractive-looking width expansion of the MP scenario lists. Thus, it should be enclosed in `DEBUG_MODE` like the other three test scenarios in the MP scenarios folder. 