### PR TITLE
wmllint: convert `^Uf` to `^Tf`

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -195,7 +195,7 @@ mapchanges = (
     ("Qv",  "Mv"),
 
     # mushroom
-    ("Uu^Uf",  "Tb^Tf"),
+    ("^Uf",  "^Tf"),
 
     # new to 1.17.8
     ("Ior", "Iwo"),

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -195,7 +195,7 @@ mapchanges = (
     ("Qv",  "Mv"),
 
     # mushroom
-    ("Qv",  "Mv"),
+    ("Uu^Uf",  "Tb^Tf"),
 
     # new to 1.17.8
     ("Ior", "Iwo"),

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -194,6 +194,9 @@ mapchanges = (
     ("^Vcm",  "^Vc"),
     ("Qv",  "Mv"),
 
+    # mushroom
+    ("Qv",  "Mv"),
+
     # new to 1.17.8
     ("Ior", "Iwo"),
     ("Icn", "Iwc"),


### PR DESCRIPTION
## Summary

`^Uf` has been deprecated since 1.15.x
`^Tf` is the new and current one.