### PR TITLE
Update deprecation but postpone removal of the SPECIAL_NOTES macro

### DIFF
--- a/data/core/macros/special-notes.cfg
+++ b/data/core/macros/special-notes.cfg
@@ -1,10 +1,9 @@
 #textdomain wesnoth-help
 
-# SPECIAL_NOTES_* are the deprecated versions that provide the strings.
-# INTERNAL:SPECIAL_NOTES_* contain the strings shared by deprecated and non-deprecated macros. Do not use them directly.
-# NOTE_* are the new versions that provide an entire tag.
-# For now, the new are defined in terms of the old, but when adding new special notes,
-# only a NOTE_* form should be added.
+# The SPECIAL_NOTES macro and ability-specific SPECIAL_NOTES_* macros are deprecated, they are strings that were historically included directly in [unit_type]description.
+# Since 1.16 these special notes are found in the abilities, movetypes and weapon specials themselves, and in [language]special_note_damage_type_arcane.
+#
+# The INTERNAL:SPECIAL_NOTES_* macros contain the strings shared by the deprecated macros and the non-deprecated uses. They aren't intended to be reused outside mainline.
 
 #define INTERNAL:SPECIAL_NOTES_SPIRIT
 _"Spirits have very unusual resistances to damage, and move quite slowly over open water."#enddef
@@ -109,132 +108,137 @@ _"This unit has a defense cap on certain terrain types — it cannot achieve a h
 
 # Deprecated versions here
 
+# wmlindent: start ignoring
 #define SPECIAL_NOTES
-#deprecated 4 Use [special_note]note= tags instead to apply special notes, or use the {NOTE_*} macros (note the singular).
+#deprecated 4 Use [special_note]note= tags and special_note= attributes instead.
     "
 
-"+_"Special Notes:"#enddef
+"+
+        # po: User-visible string, but only shown in the help pages of UMC units that haven't yet been updated to the 1.16 special notes format.
+        # Don't use markup in this, because it's shown by both Pango (in the sidebar's tooltips) and the GUI1 help browser (for unit descriptions).
+        _"Special Notes (1.14-style, please update to the new list format to avoid duplicates):"#enddef
+# wmlindent: stop ignoring
 
 #define SPECIAL_NOTES_SPIRIT
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SPIRIT}#enddef
 
 #define SPECIAL_NOTES_ARCANE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_ARCANE}#enddef
 
 #define SPECIAL_NOTES_HEALS
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_HEALS}#enddef
 
 #define SPECIAL_NOTES_EXTRA_HEAL
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_EXTRA_HEAL}#enddef
 
 #define SPECIAL_NOTES_CURES
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_CURES}#enddef
 
 #define SPECIAL_NOTES_UNPOISON
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_UNPOISON}#enddef
 
 #define SPECIAL_NOTES_REGENERATES
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_REGENERATES}#enddef
 
 #define SPECIAL_NOTES_STEADFAST
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_STEADFAST}#enddef
 
 #define SPECIAL_NOTES_LEADERSHIP
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_LEADERSHIP}#enddef
 
 #define SPECIAL_NOTES_SKIRMISHER
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SKIRMISHER}#enddef
 
 #define SPECIAL_NOTES_ILLUMINATES
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_ILLUMINATES}#enddef
 
 #define SPECIAL_NOTES_TELEPORT
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_TELEPORT}#enddef
 
 #define SPECIAL_NOTES_AMBUSH
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_AMBUSH}#enddef
 
 #define SPECIAL_NOTES_NIGHTSTALK
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_NIGHTSTALK}#enddef
 
 #define SPECIAL_NOTES_CONCEALMENT
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_CONCEALMENT}#enddef
 
 #define SPECIAL_NOTES_SUBMERGE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SUBMERGE}#enddef
 
 #define SPECIAL_NOTES_FEEDING
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_FEEDING}#enddef
 
 #define SPECIAL_NOTES_BERSERK
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_BERSERK}#enddef
 
 #define SPECIAL_NOTES_BACKSTAB
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_BACKSTAB}#enddef
 
 #define SPECIAL_NOTES_PLAGUE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_PLAGUE}#enddef
 
 #define SPECIAL_NOTES_SLOW
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SLOW}#enddef
 
 #define SPECIAL_NOTES_PETRIFY
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_PETRIFY}#enddef
 
 #define SPECIAL_NOTES_STONE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_PETRIFY}#enddef
 
 #define SPECIAL_NOTES_MARKSMAN
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_MARKSMAN}#enddef
 
 #define SPECIAL_NOTES_MAGICAL
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_MAGICAL}#enddef
 
 #define SPECIAL_NOTES_SWARM
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SWARM}#enddef
 
 #define SPECIAL_NOTES_CHARGE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_CHARGE}#enddef
 
 #define SPECIAL_NOTES_DRAIN
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_DRAIN}#enddef
 
 #define SPECIAL_NOTES_FIRSTSTRIKE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_FIRSTSTRIKE}#enddef
 
 #define SPECIAL_NOTES_POISON
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_POISON}#enddef
 
 #define SPECIAL_NOTES_DEFENSE_CAP
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}#enddef


### PR DESCRIPTION
Units still using this in their descriptions will have the player-visible header change from "Special Notes:" to "Special Notes (1.14-style, please update to the new list format)".

The SPECIAL_NOTES macro was originally removed early in the 1.17 dev cycle. That removal was reverted and postponed in the roadmap until Jan 2023, on the grounds that it's a lot easier to test 1.17 when the big add-ons from 1.16 can run on it.

In 1.16, UMC that hasn't upgraded yet already has a cosmetic bug - the help pages of units still using the {SPECIAL_NOTES} macro will include duplicate notes (assuming the expected usage of {SPECIAL_NOTES} as a heading in [unit_type]description=, which is followed by old-style notes). These are minor cosmetic bugs, which are expected to be removed as UMC gets updated.

That leaves the issue of what to do with the deprecated macro in 1.18. My feeling is that we can easily continue to support the macro, albeit with the cosmetic bug, so we should keep it for 1.18. However we could make it clearer that the duplicated notes should be removed from the UMC.

This also removes some docs about NOTE_*s, those macros have already been removed after being deprecated in 3568b5ff66ece00ec09f40059e552123f356d962.

Example help page of a unit still using this macro, but using mainline abilities that already include the special note. We can't simply remove all old-style special notes, because UMC abilities of affected units probably haven't been updated to include the notes in the ability.
![image](https://user-images.githubusercontent.com/101462/207022159-828b7c5a-2572-4859-aff6-6b6334529628.png)
