### PR TITLE
SoF: Convert Ias terrain codes missed in #7042

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -496,7 +496,7 @@
             [terrain]
                 x=26,28
                 y=19,20
-                terrain=Ias
+                terrain=Isa
             [/terrain]
             [remove_shroud]
                 side=1
@@ -602,7 +602,7 @@
             [terrain]
                 x=26,28
                 y=20,19
-                terrain=Ias
+                terrain=Isa
             [/terrain]
             [remove_shroud]
                 side=1
@@ -842,7 +842,7 @@
             [terrain]
                 x=27,27
                 y=19,21
-                terrain=Ias
+                terrain=Isa
             [/terrain]
             [redraw]
                 side=1
@@ -1067,7 +1067,7 @@
                 side=1
                 race=dwarf
                 [filter_location]
-                    terrain=Ias*
+                    terrain=Isa*
                 [/filter_location]
             [/filter]
             [message]

--- a/data/campaigns/Sceptre_of_Fire/utils/terrain.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/terrain.cfg
@@ -5,17 +5,17 @@
     id=sof_ancient_stone_floor
     symbol_image=interior/stone-ancient
     editor_name= _ "Ancient Stone Floor"
-    string=Iasy
+    string=Isay
     aliasof=Gt
     editor_group=sof
     hide_help=yes
 [/terrain_type]
 
-{NEW:BASE               Iasy                                                       interior/stone-ancient LAYER=-88}
-{NEW:TRANSITION            (!,Ql*,Ias*)        Iasy                       -87                 flat/dirt-dark FLAG=inside}
-{NEW:TRANSITION            Iasy                       (!,Ql*,Ias*)        -87                 flat/dirt-dark}
-{NEW:TRANSITION_INTRA   Iasy                            -87     volcano/edge ADJACENT=Ql}
-{NEW:TRANSITION_INTRA   Iasy                            -89     volcano/edge ADJACENT=Ql FLAG=transition2}
+{NEW:BASE               Isay                                                       interior/stone-ancient LAYER=-88}
+{NEW:TRANSITION            (!,Ql*,Isa*)        Isay                       -87                 flat/dirt-dark FLAG=inside}
+{NEW:TRANSITION            Isay                       (!,Ql*,Isa*)        -87                 flat/dirt-dark}
+{NEW:TRANSITION_INTRA   Isay                            -87     volcano/edge ADJACENT=Ql}
+{NEW:TRANSITION_INTRA   Isay                            -89     volcano/edge ADJACENT=Ql FLAG=transition2}
 
 [terrain_graphics]
     map="
@@ -26,12 +26,12 @@
 , 3"
     [tile]
         pos=1
-        type=Iasy^Qov
+        type=Isay^Qov
         set_no_flag=sof_rune-@R0
     [/tile]
     [tile]
         pos=2
-        type=Ias^Qov
+        type=Isa^Qov
         set_no_flag=sof_rune-@R3
     [/tile]
     [tile]


### PR DESCRIPTION
Resolves #7210

I think this is all the remaining instances of `Ias*` codes, aside from code specifically to mark or handle deprecated terrains.

At least I can confirm SoF S9 loads properly with this change.