### PR TITLE
HttT S03: Rewrite intro text, hint about training troops for S06

### DIFF
--- a/changelog_entries/httt_s03_intro.md
+++ b/changelog_entries/httt_s03_intro.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * Heir to the Throne
+     * S03: Rewrite intro text, including a hint about training troops (PR #7214)

--- a/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
@@ -39,6 +39,11 @@
                 bonus=yes
                 carryover_percentage=40
             [/gold_carryover]
+
+            [note]
+                # po: a hint that the player has 3 scenarios before the first main test of their XP management
+                description= _ "You’ll need experienced troops at Elensefar."
+            [/note]
         [/objectives]
     [/event]
 
@@ -194,16 +199,21 @@
             message= _ "So this is Alduin. It looks a little... desolate."
         [/message]
         [message]
-            speaker=Delfador
-            message= _ "I fear so, Konrad. It seems that the orcs have come even here. Here to the place where I was born, where I was trained."
-        [/message]
-        [message]
             speaker="Usadar Q'kai"
             message= _ "Who is that? Oh, a party of elves has landed. We shall drive them back into the sea!"
         [/message]
         [message]
             speaker=Delfador
-            message= _ "I did not think the orcs would have come here. This island used to be so beautiful. We must recapture it! To arms!"
+            message= _ "If the orcs have come here, their forces at Elensefar must be even more numerous than I feared."
+        [/message]
+        [message]
+            speaker=Delfador
+            # po: a hint for players who are expecting campaigns to have a steadily-rising difficulty curve.
+            message= _ "Konrad, training is important. If we only have inexperienced troops when we reach Elensefar, then our journey is likely to end in sight of the city’s gates."
+        [/message]
+        [message]
+            speaker=Delfador
+            message= _ "This island is the place where I was born, and where I learned magic; it used to be so beautiful. We must recapture it! To arms!"
         [/message]
     [/event]
 


### PR DESCRIPTION
The Isle of Alduin doesn't have much dialogue at the start, it's a map where the island gives the player two fronts to progress on, and it's early enough to give the player time to prepare for the SoE.