### PR TITLE
[Campaign] [WoF] Enable Saurian Spearthrower

### DIFF
--- a/data/campaigns/Winds_of_Fate/_main.cfg
+++ b/data/campaigns/Winds_of_Fate/_main.cfg
@@ -27,6 +27,8 @@
     {CAMPAIGN_DIFFICULTY NIGHTMARE "units/drakes/armageddon-melee-6.png~CROP(0,19,62,64)~RC(magenta>red)" ( _ "Ancestor")  ( _ "Nightmare")}
 
     {ENABLE_ADVANCEMENT "Cuttle Fish" "Kraken" (set_experience=80)}
+    # enable saurian spearthrower
+    {ENABLE_SAURIAN_SPEARTHROWER}
 
     {./about.cfg}
 [/campaign]

--- a/data/campaigns/Winds_of_Fate/scenarios/10_Fire_Meets_Steel.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/10_Fire_Meets_Steel.cfg
@@ -34,7 +34,7 @@
     [side]
         side=1
         controller=human
-        recruit=Drake Burner, Drake Clasher, Drake Fighter, Drake Glider, Saurian Augur, Saurian Skirmisher, Fire Drake, Drake Flare, Drake Arbiter, Drake Thrasher, Drake Warrior, Sky Drake, Saurian Ambusher, Saurian Oracle, Saurian Soothsayer
+        recruit=Drake Burner, Drake Clasher, Drake Fighter, Drake Glider, Saurian Augur, Saurian Skirmisher, Fire Drake, Drake Flare, Drake Arbiter, Drake Thrasher, Drake Warrior, Sky Drake, Saurian Ambusher, Saurian Spearthrower, Saurian Oracle, Saurian Soothsayer
         {GOLD4 160 120 80 40}
         village_gold=4 # More income since the eyrie has been established.
         save_id=Player

--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -33,7 +33,7 @@
     [side]
         side=1
         controller=human
-        recruit=Drake Burner, Drake Clasher, Drake Fighter, Drake Glider, Saurian Augur, Saurian Skirmisher, Fire Drake, Drake Flare, Drake Arbiter, Drake Thrasher, Drake Warrior, Sky Drake, Saurian Ambusher, Saurian Oracle, Saurian Soothsayer
+        recruit=Drake Burner, Drake Clasher, Drake Fighter, Drake Glider, Saurian Augur, Saurian Skirmisher, Fire Drake, Drake Flare, Drake Arbiter, Drake Thrasher, Drake Warrior, Sky Drake, Saurian Ambusher, Saurian Spearthrower, Saurian Oracle, Saurian Soothsayer
         {GOLD4 500 375 250 125}
         village_gold=4 # More income since the eyrie has been established.
         save_id=Player


### PR DESCRIPTION
Since the unit has been (finally) added to core, I believe it should be made be available for players in _Winds of Fate_.