### PR TITLE
[LoW] S3: fix mismatched coords of Urudin retreat

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -188,6 +188,7 @@
         [ai]
             [engine]
                 name=lua
+                # Note that the move_full co-ordinates should match the moveto event for Urudin below
                 code=<<
                 local my_ai = { }
 
@@ -453,6 +454,7 @@
         [filter]
             id=Urudin
             [filter_location]
+                # Note that these co-ordinates should match the AI code for Urudin's side declared above
                 x=12
                 y=4
                 radius=3

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -197,7 +197,7 @@
                         local mhp, hp = urudin.max_hitpoints, urudin.hitpoints
                         local turn = wesnoth.current.turn
                         if turn >= 3 or hp < mhp / 2 then
-                            ai.move_full(urudin, 20, 6)
+                            ai.move_full(urudin, 12, 4)
                         end
                     end
                 end

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -451,9 +451,12 @@
     [event]
         name=moveto
         [filter]
-            x=12
-            y=4
             id=Urudin
+            [filter_location]
+                x=12
+                y=4
+                radius=3
+            [filter_location]
         [/filter]
         [if]
             [variable]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter1/03_Kalian_under_Attack.cfg
@@ -456,7 +456,7 @@
                 x=12
                 y=4
                 radius=3
-            [filter_location]
+            [/filter_location]
         [/filter]
         [if]
             [variable]


### PR DESCRIPTION
Urudin the Slayer is supposed to move to 12,4 (next to the castle of one of the warlords), instead he is set to move to 20,6 which makes little sense. The event of Urudin moving at 12,4 was supposedly never triggered.

Reported on Discord

> Hi
In the file 03_Kalian_under_Attack.cfg, the coordinates of line 200 and 454/455 are not the same. Is that just a typo or intentional?
Steam 1.16.6