### PR TITLE
[1.16] Handle out-of-bounds side numbers in Lua's sync.evaluate_multiple

### DIFF
--- a/changelog_entries/bounds_synced_eval.md
+++ b/changelog_entries/bounds_synced_eval.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Fix a crash when an out-of-bounds side number is used in Lua’s `sync.evaluate_multiple` (PR #7222)

--- a/data/test/scenarios/test_synced_side_number.cfg
+++ b/data/test/scenarios/test_synced_side_number.cfg
@@ -1,0 +1,37 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: wesnoth.sync.evaluate_multiple
+##
+# Actions:
+# Request a synchronised choice from 3 sides in a game with only 2 sides.
+##
+# Expected end state:
+# A Lua warning triggers a BROKE STRICT result.
+#####
+{GENERIC_UNIT_TEST "test_synced_side_number" (
+    [event]
+        name = start
+        [lua]
+            code =<<
+                    unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'start should be synchronised')
+
+                    local result = wesnoth.sync.evaluate_multiple(
+                        function()
+                            unit_test.assert_equal(wesnoth.current.synced_state, 'local_choice', 'expected value to be local_choice, within synced event')
+                            return { value = wesnoth.current.synced_state }
+                        end,
+                        {1,2,3})
+                    unit_test.assert_equal(result[1].value, 'local_choice', 'wrong value returned, within synced event')
+                    unit_test.assert_equal(result[2].value, 'local_choice', 'wrong value returned, within synced event')
+                >>
+        [/lua]
+    [/event]
+
+    # Separate SUCCEED event, because the first one will end with an error
+    [event]
+        name = start
+
+        {SUCCEED}
+    [/event]
+)}

--- a/src/synced_user_choice.cpp
+++ b/src/synced_user_choice.cpp
@@ -114,13 +114,21 @@ std::map<int,config> mp_sync::get_user_choice_multiple_sides(const std::string &
 		return std::map<int,config>();
 	}
 
+	for(int side : sides)
+	{
+		if(1 > side || side > max_side)
+		{
+			replay::process_error("MP synchronization with an invalid side number.\n");
+			return std::map<int,config>();
+		}
+	}
+
 	/*
 		for empty sides we want to use random choice instead.
 	*/
 	std::set<int> empty_sides;
 	for(int side : sides)
 	{
-		assert(1 <= side && side <= max_side);
 		if( resources::gameboard->get_team(side).is_empty())
 		{
 			empty_sides.insert(side);

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -39,6 +39,7 @@
 #
 4 break_replay_with_lua_random
 0 fixed_lua_random_replay_with_sync_choice
+9 test_synced_side_number
 0 test_synced_state
 #
 # Security test


### PR DESCRIPTION
Backport of #7197.

Change the C++ to show a Lua error instead of crashing with an assert.

Cherry picked from commit a9d5c6ac6d8364f2fb3a6cd24dc55593d5b6f924, with a changelog entry added.