### PR TITLE
1.17 - make north-breathing drakes face se instead of s

### DIFF
--- a/data/core/macros/animation-utils.cfg
+++ b/data/core/macros/animation-utils.cfg
@@ -1048,6 +1048,7 @@
     [/attack_anim]
 #enddef
 
+# as long as there are no north-facing frames, we will use se (not s)
 #define DRAKE_FIRE_ANIM_N_CURRENT DRAKE_NAME OFFSET_POSITION
     [attack_anim]
         [filter_attack]
@@ -1068,7 +1069,7 @@
         [/frame]
         {SOUND:HIT_AND_MISS flame-big.ogg flame-big-miss.ogg -480}
         [frame]
-            image="units/drakes/{DRAKE_NAME}-fire-s-[1~3,2,1].png:100"
+            image="units/drakes/{DRAKE_NAME}-fire-se-[1~3,2,1].png:100"
         [/frame]
     [/attack_anim]
 #enddef


### PR DESCRIPTION
Drakes attacking to the north with their fire breath face south and bend over, is this some sort of long running joke?
Using the se frames instead still doesn't look great, but it's not quite as bad.