### PR TITLE
SotA: change textdomain of zombie-utils.cfg

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/zombie-utils.cfg
@@ -1,4 +1,4 @@
-#textdomain wesnoth-units
+#textdomain wesnoth-help
 #define WEAPON_SPECIAL_SOTA_PLAGUE
     # Written this way to allow overwriting the base Necromancer weapon in the SotA Necromancer implementation
     [plague]


### PR DESCRIPTION
Weapon specials usually are on wesnoth-help texdomain, as this case.
Before, appears on english on all languages.