### PR TITLE
Orb color preferences dialog layout and tooltip

### DIFF
--- a/changelog_entries/orb_prefs_layout.md
+++ b/changelog_entries/orb_prefs_layout.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * Improved the layout of the orb colors dialog, and added tooltips.

--- a/data/gui/window/select_orb_colors.cfg
+++ b/data/gui/window/select_orb_colors.cfg
@@ -1,8 +1,19 @@
 #textdomain wesnoth-lib
 
+#define _GUI_ORB_SPACER_ROW
+	[row]
+		grow_factor = 0
+		[column]
+			[spacer]
+				height = 15
+			[/spacer]
+		[/column]
+	[/row]
+#enddef
+
 #define _GUI_ORB_CELL PURPOSE COLOR
 	[column]
-		border = "all"
+		border = "left,right,bottom"
 		border_size = 5
 		[toggle_button]
 			id = "orb_{PURPOSE}_{COLOR}"
@@ -51,7 +62,7 @@
 	[/row]
 #enddef
 
-#define _GUI_ORB_NO_COLOR PURPOSE LABEL NO_COLOR_REASON
+#define _GUI_ORB_TWO_COLOR PURPOSE LABEL_SHOW LABEL_TWO_COLOR TOOLTIP_TWO_COLOR
 	[row]
 		[column]
 			horizontal_alignment = "left"
@@ -60,19 +71,42 @@
 			[toggle_button]
 				id = "orb_{PURPOSE}_show"
 				definition = "default"
-				label = {LABEL}
+				label = {LABEL_SHOW}
 			[/toggle_button]
 		[/column]
 	[/row]
+
+	[row]
+		[column]
+			horizontal_grow = true
+			[grid]
+				[row]
+					[column]
+						horizontal_alignment = "left"
+						border = "all"
+						border_size = 5
+						[toggle_button]
+							id = "orb_{PURPOSE}_two_color"
+							definition = "default"
+							label = {LABEL_TWO_COLOR}
+							tooltip = {TOOLTIP_TWO_COLOR}
+						[/toggle_button]
+					[/column]
+
+					[column]
+						grow_factor = 1
+						[spacer]
+						[/spacer]
+					[/column]
+				[/row]
+			[/grid]
+		[/column]
+	[/row]
+
 	[row]
 		[column]
 			horizontal_alignment = "left"
-			border = "all"
-			border_size = 5
-			[label]
-				definition = "default"
-				label = {NO_COLOR_REASON}
-			[/label]
+			{_GUI_ORB_ROW {PURPOSE}}
 		[/column]
 	[/row]
 #enddef
@@ -108,11 +142,16 @@
 				[/column]
 			[/row]
 			{_GUI_ORB_GROUP unmoved (_"Show unmoved orb")}
-			{_GUI_ORB_GROUP partial (_"Show partial moved orb")}
+			{_GUI_ORB_SPACER_ROW}
+			{_GUI_ORB_TWO_COLOR partial
+				(_"Show partially moved orb")
+				(_"Use a two-color orb for disengaged units") (_"If a unit can move but can’t attack, show a two-color orb with the colors for partially and fully moved.")}
+			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP moved (_"Show moved orb")}
+			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP ally (_"Show ally orb")}
+			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP enemy (_"Show enemy orb")}
-			{_GUI_ORB_NO_COLOR disengaged (_"Show disengaged orb") (_"This uses the colors for partial and moved orbs.")}
 			[row]
 				[column]
 					horizontal_grow = true
@@ -159,7 +198,8 @@
 	[/resolution]
 [/window]
 
-#undef _GUI_ORB_NO_COLOR
+#undef _GUI_ORB_TWO_COLOR
 #undef _GUI_ORB_GROUP
 #undef _GUI_ORB_ROW
 #undef _GUI_ORB_CELL
+#undef _GUI_ORB_SPACER_ROW

--- a/src/gui/dialogs/select_orb_colors.cpp
+++ b/src/gui/dialogs/select_orb_colors.cpp
@@ -56,8 +56,7 @@ select_orb_colors::select_orb_colors()
 void select_orb_colors::pre_show(window& window)
 {
 	setup_orb_group("unmoved", show_unmoved_, preferences::unmoved_color());
-	setup_orb_group("partial", show_partial_, preferences::partial_color());
-	setup_orb_toggle("disengaged", show_disengaged_);
+	setup_orb_group_two_color("partial", show_partial_, show_disengaged_, preferences::partial_color());
 	setup_orb_group("moved", show_moved_, preferences::moved_color());
 	setup_orb_group("ally", show_ally_, preferences::allied_color());
 	setup_orb_group("enemy", show_enemy_, preferences::enemy_color());
@@ -120,7 +119,18 @@ void select_orb_colors::setup_orb_group(const std::string& base_id, bool& shown,
 	group.set_member_states(initial);
 }
 
-void select_orb_colors::reset_orb_toggle(const std::string& base_id, bool& shown)
+void select_orb_colors::setup_orb_group_two_color(const std::string& base_id, bool& shown, bool& two_color, const std::string& initial)
+{
+	setup_orb_group(base_id, shown, initial);
+
+	const std::string prefix = get_orb_widget_prefix(base_id);
+	toggle_button& toggle = find_widget<toggle_button>(get_window(), prefix + "two_color", false);
+	toggle.set_value_bool(two_color);
+
+	connect_signal_mouse_left_click(toggle, std::bind(&select_orb_colors::toggle_orb_callback, this, std::ref(two_color)));
+}
+
+void select_orb_colors::reset_orb_toggle(const std::string& base_id, bool shown)
 {
 	const std::string prefix = get_orb_widget_prefix(base_id);
 
@@ -128,14 +138,26 @@ void select_orb_colors::reset_orb_toggle(const std::string& base_id, bool& shown
 	toggle.set_value_bool(shown);
 }
 
-void select_orb_colors::reset_orb_group(const std::string& base_id, bool& shown, const std::string& initial)
+void select_orb_colors::reset_orb_group(const std::string& base_id, bool shown, const std::string& initial)
 {
 	reset_orb_toggle(base_id, shown);
 	groups_[base_id].set_member_states(initial);
 }
 
+void select_orb_colors::reset_orb_group_two_color(const std::string& base_id, bool shown, bool two_color, const std::string& initial)
+{
+	reset_orb_group(base_id, shown, initial);
+
+	const std::string prefix = get_orb_widget_prefix(base_id);
+
+	toggle_button& toggle = find_widget<toggle_button>(get_window(), prefix + "two_color", false);
+	toggle.set_value_bool(two_color);
+}
+
 void select_orb_colors::toggle_orb_callback(bool& storage)
 {
+	// The code for the two-color groups uses this for both the main setting and the two_color setting - if
+	// you add any extra logic here, check that it's still also applicable to the two_color setting.
 	storage = !storage;
 }
 
@@ -149,8 +171,7 @@ void select_orb_colors::reset_orb_callback()
 	show_enemy_ = game_config::show_enemy_orb;
 
 	reset_orb_group("unmoved", show_unmoved_, game_config::colors::unmoved_orb_color);
-	reset_orb_group("partial", show_partial_, game_config::colors::partial_orb_color);
-	reset_orb_toggle("disengaged", show_disengaged_);
+	reset_orb_group_two_color("partial", show_partial_, show_disengaged_, game_config::colors::partial_orb_color);
 	reset_orb_group("moved", show_moved_, game_config::colors::moved_orb_color);
 	reset_orb_group("ally", show_ally_, game_config::colors::ally_orb_color);
 	reset_orb_group("enemy", show_enemy_, game_config::colors::enemy_orb_color);

--- a/src/gui/dialogs/select_orb_colors.hpp
+++ b/src/gui/dialogs/select_orb_colors.hpp
@@ -34,11 +34,31 @@ public:
 	DEFINE_SIMPLE_DISPLAY_WRAPPER(select_orb_colors)
 
 private:
+	/**
+	 * Sets up the checkbox that's common to the no-color, one-color and two-color settings.
+	 * Sets its ticked/unticked state and connects the callback for user interaction.
+	 */
 	void setup_orb_toggle(const std::string& base_id, bool& shown);
+	/**
+	 * Sets up the checkbox and row of color buttons for the one-color options, including
+	 * connecting the callbacks for user interaction.
+	 *
+	 * @param base_id which group of checkboxes and buttons to affect
+	 * @param shown the checkbox's ticked state (input and asynchronous output)
+	 * @param initial which color to select (input only)
+	 */
 	void setup_orb_group(const std::string& base_id, bool& shown, const std::string& initial);
+	/**
+	 * Sets up two checkboxes and a row of color buttons.
+	 */
+	void setup_orb_group_two_color(const std::string& base_id, bool& shown, bool& two_color, const std::string& initial);
 
-	void reset_orb_toggle(const std::string& base_id, bool& shown);
-	void reset_orb_group(const std::string& base_id, bool& shown, const std::string& initial);
+	/**
+	 * Change the UI's ticked/unticked state. Neither sets up nor triggers callbacks.
+	 */
+	void reset_orb_toggle(const std::string& base_id, bool shown);
+	void reset_orb_group(const std::string& base_id, bool shown, const std::string& initial);
+	void reset_orb_group_two_color(const std::string& base_id, bool shown, bool two_color, const std::string& initial);
 
 	void toggle_orb_callback(bool& storage);
 	void reset_orb_callback();


### PR DESCRIPTION
Add some spacing to make it clearer what is grouped with what, move the disengage orb's setting to be part of the partial orb's group, and add tooltip.

There's only one tooltip so far, does anyone feel the "Show ... orb" checkboxes should have them too?

This dialog uses checkbox labels as section headers to indicate what the rows of colors refer to. This commit doesn't change that, but it makes the grouping clearer. Actual section headers would take additional space and probably not look any better.

The intention would be to backport it, and then backport a rebased PR #7189 on top of it. The image below shows the intended final destination, the current PR doesn't include the "During ally's turn, use a two-colored orb with status" line.
![image](https://user-images.githubusercontent.com/101462/211196159-d62eae8d-3f29-4200-a94c-aad22f02cd2d.png)