### PR TITLE
Fix the indentation in the "special_calculations" test

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_calculations.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_calculations.cfg
@@ -39,14 +39,14 @@
 
             [lua]
                 code=<<
-                local alice = wesnoth.units.find({id="alice"})[1]
-                local bob = wesnoth.units.find({id="bob"})[1]
-                local args = ...
+                    local alice = wesnoth.units.find({id="alice"})[1]
+                    local bob = wesnoth.units.find({id="bob"})[1]
+                    local args = ...
 
-                -- Bob attacks Alice, doing it this way round ensures that it's melee rather than ranged combat.
-                _, _, att_weapon, _ = wesnoth.simulate_combat(bob, alice)
-                unit_test.assert_equal(att_weapon.num_blows, args.expected, "Bob didn’t have the expected number of attacks")
-            >>
+                    -- Bob attacks Alice, doing it this way round ensures that it's melee rather than ranged combat.
+                    _, _, att_weapon, _ = wesnoth.simulate_combat(bob, alice)
+                    unit_test.assert_equal(att_weapon.num_blows, args.expected, "Bob didn’t have the expected number of attacks")
+                >>
                 [args]
                     expected={EXPECTED}
                 [/args]


### PR DESCRIPTION
Just a whitespace change, because it can't be used as a reference to cut & paste from when it's incorrectly indented.