### PR TITLE
Add start script to force the correct arch.

### DIFF
--- a/data/campaigns/tutorial/achievements.cfg
+++ b/data/campaigns/tutorial/achievements.cfg
@@ -2,5 +2,12 @@
 [achievement_group]
     display_name=_"Tutorial"
     content_for=tutorial
-    {ACHIEVEMENT "completed" _"Complete the Tutorial" _"Complete all scenarios of the Tutorial campaign."}
+    [achievement]
+        id="completed"
+        name=_"Complete the Tutorial"
+        description=_"Complete all scenarios of the Tutorial campaign."
+        icon="data/core/images/icons/potion_red_small.png"
+        icon_completed="data/core/images/icons/potion_green_small.png"
+        max_progress=2
+    [/achievement]
 [/achievement_group]

--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -1183,6 +1183,13 @@
             caption= _ "Victory"
             message= _ "After your victory notice, the map will be grayed out to indicate that the scenario is over; this is called <i>linger mode</i>. You will still be able to examine the final positions and state of your troops and any surviving enemies. When you’re finished, click the <b>End Scenario</b> button to go on to the next scenario in the campaign."
         [/hint_message]
+
+        [progress_achievement]
+            content_for=tutorial
+            id="completed"
+            amount=1
+            limit=1
+        [/progress_achievement]
     [/event]
 
     [event]

--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -1498,10 +1498,11 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
             message= _ "You can also refer to the in-game help browser if you ever need to refresh your memory on gameplay mechanics."
         [/message]
 
-        [set_achievement]
+        [progress_achievement]
             content_for=tutorial
             id="completed"
-        [/set_achievement]
+            amount=1
+        [/progress_achievement]
 
         {CLEAR_VARIABLE low_hp_unit_message,lhpu_msg_i}
         {CLEAR_VARIABLE spoke_about_income,spoke_about_orcs_crossing_river}

--- a/data/gui/window/achievements_dialog.cfg
+++ b/data/gui/window/achievements_dialog.cfg
@@ -50,20 +50,6 @@
 								[/label]
 			
 							[/column]
-
-							[column]
-								horizontal_alignment = "right"
-								grow_factor = 0
-
-								border = "all"
-								border_size = 5
-
-								[label]
-									definition = "default"
-									label = _ "Content:"
-								[/label]
-
-							[/column]
 							
 							[column]
 								horizontal_alignment = "right"
@@ -180,6 +166,32 @@
 														[/grid]
 													[/column]
 												[/row]
+
+												[row]
+													[column]
+														grow_factor = 0
+														border = "all"
+														border_size = 5
+														horizontal_alignment = "left"
+		
+														[label]
+															id = "progress_label"
+															definition = "default"
+														[/label]
+													[/column]
+
+													[column]
+														grow_factor = 1
+														horizontal_grow = true
+														border = "all"
+														border_size = 5
+									
+														[progress_bar]
+															id = "achievement_progress"
+															definition = "default"
+														[/progress_bar]
+													[/column]
+												[/row]
 											[/grid]
 										[/toggle_panel]
 
@@ -206,7 +218,7 @@
 						id = "ok"
 						definition = "default"
 
-						label = _ "OK"
+						label = _ "Close"
 					[/button]
 
 				[/column]

--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -1020,3 +1020,11 @@ function wml_actions.set_achievement(cfg)
 		gui.show_popup(achievement.name_completed, achievement.description_completed, achievement.icon_completed)
 	end
 end
+
+function wml_actions.progress_achievement(cfg)
+	local pcfg = wesnoth.achievements.progress(cfg.content_for, cfg.id, cfg.amount, cfg.limit or 999999999)
+	-- if this update completes the achievement, mark it as complete and show the popup
+	if pcfg.progress ~= -1 and pcfg.max_progress > 0 and pcfg.progress >= pcfg.max_progress then
+		wml_actions.set_achievement(cfg)
+	end
+end

--- a/src/achievements.cpp
+++ b/src/achievements.cpp
@@ -102,7 +102,7 @@ achievement_group::achievement_group(const config& cfg)
 		if(id.empty()) {
 			ERR_CONFIG << content_for_ + " achievement missing id attribute:\n" << ach.debug();
 		} else {
-			achievements_.emplace_back(ach, preferences::achievement(content_for_, id));
+			achievements_.emplace_back(ach, preferences::achievement(content_for_, id), preferences::progress_achievement(content_for_, id));
 		}
 	}
 }

--- a/src/achievements.hpp
+++ b/src/achievements.hpp
@@ -49,8 +49,12 @@ struct achievement
 	t_string hidden_hint_;
 	/** Whether the achievement has been completed. */
 	bool achieved_;
+	/** When the achievement's current progress matches or equals this value, then it should be marked as completed */
+	int max_progress_;
+	/** The current progress value of the achievement */
+	int current_progress_;
 
-	achievement(const config& cfg, bool achieved)
+	achievement(const config& cfg, bool achieved, int progress)
 		: id_(cfg["id"].str())
 		, name_(cfg["name"].t_str())
 		, name_completed_(cfg["name_completed"].t_str())
@@ -62,6 +66,8 @@ struct achievement
 		, hidden_name_(cfg["hidden_name"].t_str())
 		, hidden_hint_(cfg["hidden_hint"].t_str())
 		, achieved_(achieved)
+		, max_progress_(cfg["max_progress"].to_int(0))
+		, current_progress_(progress)
 	{
 		if(name_completed_.empty()) {
 			name_completed_ = name_;
@@ -70,7 +76,8 @@ struct achievement
 			description_completed_ = description_;
 		}
 		if(icon_completed_.empty()) {
-			icon_completed_ = icon_;
+			// avoid the ~GS() appended to icon_
+			icon_completed_ = cfg["icon"].str();
 		}
 	}
 };

--- a/src/gui/dialogs/achievements_dialog.cpp
+++ b/src/gui/dialogs/achievements_dialog.cpp
@@ -20,6 +20,9 @@
 #include "game_config_manager.hpp"
 #include "gettext.hpp"
 #include "gui/auxiliary/find_widget.hpp"
+#include "gui/widgets/grid.hpp"
+#include "gui/widgets/label.hpp"
+#include "gui/widgets/progress_bar.hpp"
 #include "gui/widgets/window.hpp"
 #include "log.hpp"
 
@@ -44,9 +47,7 @@ void achievements_dialog::pre_show(window& win)
 
 	achievements_box_ = find_widget<listbox>(&win, "achievements_list", false, true);
 
-auto* a = game_config_manager::get();
-auto b = a->get_achievements();
-	for(const auto& list : b) {
+	for(const auto& list : game_config_manager::get()->get_achievements()) {
 		// populate all possibilities into the dropdown
 		content_list.emplace_back("label", list.display_name_);
 
@@ -77,7 +78,16 @@ auto b = a->get_achievements();
 				}
 				row.emplace("description", item);
 
-				achievements_box_->add_row(row);
+				grid& newrow = achievements_box_->add_row(row);
+				label* progress_label = static_cast<label*>(newrow.find("progress_label", false));
+				progress_bar* achievement_progress = static_cast<progress_bar*>(newrow.find("achievement_progress", false));
+				if(ach.max_progress_ != 0 && ach.current_progress_ != -1) {
+					progress_label->set_label(std::to_string(ach.current_progress_)+"/"+std::to_string(ach.max_progress_));
+					achievement_progress->set_percentage((ach.current_progress_/double(ach.max_progress_))*100);
+				} else {
+					progress_label->set_visible(gui2::widget::visibility::invisible);
+					achievement_progress->set_visible(gui2::widget::visibility::invisible);
+				}
 			}
 		}
 	}

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -1047,10 +1047,16 @@ void set_achievement(const std::string& content_for, const std::string& id)
 		if(ach["content_for"].str() == content_for)
 		{
 			std::vector<std::string> ids = utils::split(ach["ids"]);
-			if(std::find(ids.begin(), ids.end(), id) == ids.end())
+
+			if(ids.empty())
+			{
+				ach["ids"] = id;
+			}
+			else if(std::find(ids.begin(), ids.end(), id) == ids.end())
 			{
 				ach["ids"] = ach["ids"].str() + "," + id;
 			}
+			ach.remove_children("in_progress", [&id](config cfg){return cfg["id"].str() == id;});
 			return;
 		}
 	}
@@ -1062,5 +1068,61 @@ void set_achievement(const std::string& content_for, const std::string& id)
 	prefs.add_child("achievements", ach);
 }
 
+int progress_achievement(const std::string& content_for, const std::string& id, int limit, int max_progress, int amount)
+{
+	bool completed = achievement(content_for, id);
+
+	if(!completed)
+	{
+		for(config& ach : prefs.child_range("achievements"))
+		{
+			// if achievements already exist for this content and the achievement has not already been set, add it
+			if(ach["content_for"].str() == content_for)
+			{
+				// check if this achievement has progressed before - if so then increment it
+				for(config& in_progress : ach.child_range("in_progress"))
+				{
+					if(in_progress["id"].str() == id)
+					{
+						in_progress["progress_at"] = std::clamp(in_progress["progress_at"].to_int() + amount, 0, std::min(limit, max_progress));
+						return in_progress["progress_at"].to_int();
+					}
+				}
+
+				// else this is the first time this achievement is progressing
+				if(amount != 0)
+				{
+					config set_progress;
+					set_progress["id"] = id;
+					set_progress["progress_at"] = std::clamp(amount, 0, std::min(limit, max_progress));
+
+					config& child = ach.add_child("in_progress", set_progress);
+					return child["progress_at"].to_int();
+				}
+				return 0;
+			}
+		}
+
+		// else not only has this achievement not progressed before, this is the first achievement for this achievement group to be added
+		if(amount != 0)
+		{
+			config ach;
+			config set_progress;
+
+			set_progress["id"] = id;
+			set_progress["progress_at"] = std::clamp(amount, 0, std::min(limit, max_progress));
+
+			ach["content_for"] = content_for;
+			ach["ids"] = "";
+
+			config& child = ach.add_child("in_progress", set_progress);
+			prefs.add_child("achievements", ach);
+			return child["progress_at"].to_int();
+		}
+		return 0;
+	}
+
+	return -1;
+}
 
 } // end namespace preferences

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -277,7 +277,32 @@ namespace preferences {
 	sort_order::type addon_manager_saved_order_direction();
 	void set_addon_manager_saved_order_direction(sort_order::type value);
 
+	/**
+	 * @param content_for The achievement group the achievement is part of.
+	 * @param id The ID of the achievement within the achievement group.
+	 * @return True if the achievement exists and is completed, false otherwise.
+	 */
 	bool achievement(const std::string& content_for, const std::string& id);
+	/**
+	 * Marks the specified achievement as completed.
+	 * 
+	 * @param content_for The achievement group the achievement is part of.
+	 * @param id The ID of the achievement within the achievement group.
+	 */
 	void set_achievement(const std::string& content_for, const std::string& id);
+
+	/**
+	 * Increments the achievement's current progress by @a amount if it hasn't already been completed.
+	 * If you only want to check the achievement's current progress, then omit the last three arguments.
+	 * @a amount defaults to 0, which will result in the current progress value being returned without being changed (x + 0 == x).
+	 * 
+	 * @param content_for The id of the achievement group this achievement is in.
+	 * @param id The id for the specific achievement in the achievement group.
+	 * @param limit The maximum value that a specific call to this function can increase the achievement progress value.
+	 * @param max_progress The value when the achievement is considered completed.
+	 * @param amount The amount to progress the achievement.
+	 * @return The achievement's current progress, or -1 if it has already been completed.
+	 */
+	int progress_achievement(const std::string& content_for, const std::string& id, int limit = 999999, int max_progress = 999999, int amount = 0);
 
 } // end namespace preferences

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -3145,6 +3145,8 @@ int game_lua_kernel::intf_get_achievement(lua_State *L)
 					cfg["hidden_name"] = achieve.hidden_name_;
 					cfg["hidden_hint"] = achieve.hidden_hint_;
 					cfg["achieved"] = achieve.achieved_;
+					cfg["max_progress"] = achieve.max_progress_;
+					cfg["current_progress"] = achieve.current_progress_;
 					luaW_pushconfig(L, cfg);
 					return 1;
 				}
@@ -3156,6 +3158,55 @@ int game_lua_kernel::intf_get_achievement(lua_State *L)
 		}
 	}
 	// return empty config - non-existing achievement group
+	ERR_LUA << "Achievement group " << content_for << " not found";
+	luaW_pushconfig(L, cfg);
+	return 1;
+}
+
+/**
+ * Progresses the provided achievement.
+ * - Arg 1: string - content_for.
+ * - Arg 2: string - id.
+ * - Arg 3: int - the amount to progress the achievement.
+ * - Arg 4: int - the limit the achievement can progress by
+ * - Ret 1: WML table returned by the function.
+ */
+int game_lua_kernel::intf_progress_achievement(lua_State *L)
+{
+	const char *content_for = luaL_checkstring(L, 1);
+	const char *id = luaL_checkstring(L, 2);
+	int amount = luaL_checkinteger(L, 3);
+	int limit = luaL_checkinteger(L, 4);
+
+	config cfg;
+	cfg["progress"] = 0;
+	cfg["max_progress"] = 0;
+
+	for(achievement_group& group : game_config_manager::get()->get_achievements()) {
+		if(group.content_for_ == content_for) {
+			for(achievement& achieve : group.achievements_) {
+				if(achieve.id_ == id) {
+					// found the achievement
+					if(!achieve.achieved_) {
+						int progress = preferences::progress_achievement(content_for, id, limit, achieve.max_progress_, amount);
+						cfg["progress"] = progress;
+						achieve.current_progress_ = progress;
+					} else {
+						cfg["progress"] = -1;
+					}
+					cfg["max_progress"] = achieve.max_progress_;
+					luaW_pushconfig(L, cfg);
+					return 1;
+				}
+			}
+			// achievement not found - existing achievement group but non-existing achievement id
+			ERR_LUA << "Achievement " << id << " not found for achievement group " << content_for;
+			luaW_pushconfig(L, cfg);
+			return 1;
+		}
+	}
+
+	// achievement group not found
 	ERR_LUA << "Achievement group " << content_for << " not found";
 	luaW_pushconfig(L, cfg);
 	return 1;
@@ -4988,6 +5039,7 @@ game_lua_kernel::game_lua_kernel(game_state & gs, play_controller & pc, reports 
 		{ "set", &dispatch<&game_lua_kernel::intf_set_achievement> },
 		{ "has", &dispatch<&game_lua_kernel::intf_has_achievement> },
 		{ "get", &dispatch<&game_lua_kernel::intf_get_achievement> },
+		{ "progress", &dispatch<&game_lua_kernel::intf_progress_achievement> },
 		{ nullptr, nullptr }
 	};
 	lua_getglobal(L, "wesnoth");

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -122,6 +122,7 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_set_achievement(lua_State *L);
 	int intf_has_achievement(lua_State *L);
 	int intf_get_achievement(lua_State *L);
+	int intf_progress_achievement(lua_State *L);
 	int intf_set_floating_label(lua_State* L, bool spawn);
 	int intf_remove_floating_label(lua_State* L);
 	int intf_move_floating_label(lua_State* L);


### PR DESCRIPTION
Since Steam itself is not a native ARM app, for macOS it launches Wesnoth using the x86_64 version instead of the ARM version. This script forces the correct arch to be used which leads to improved performance (especially for 1.16) when using ARM-based Macs.

---

@hrubymar10 - The main question I have is where this file needs to be in order for it to work with how Wesnoth is packaged. I assume putting it in the repository root won't actually work.
@irydacea Do you know if additional arguments can be provided to `"The Battle for Wesnoth"` when used with the `arch` command?