### PR TITLE
Units: Giant Ant advances to Soldier Ant

### DIFF
--- a/changelog_entries/ant_advancement.md
+++ b/changelog_entries/ant_advancement.md
@@ -1,0 +1,6 @@
+### Units:
+  * Giant Ant now advances to Soldier Ant
+  * Giant Ant XP requirements is now 26
+  * Soldier Ant HP is now 35
+  * Soldier Ant XP is now 50
+  * Soldier Ant cost is now 16

--- a/data/core/units/monsters/Ant.cfg
+++ b/data/core/units/monsters/Ant.cfg
@@ -9,11 +9,10 @@
     hitpoints=22
     movement_type=orcishfoot
     movement=4
-    experience=25
+    experience=26
     level=0
     alignment=neutral
-    advances_to=null
-    {AMLA_DEFAULT}
+    advances_to=Soldier Ant
     cost=7
     usage=fighter
     description= _ "Giant Ants are common in almost any environment, from caverns deep under the earth to the tops of tall mountains. Though normally not hostile, they can bite at close range."

--- a/data/core/units/monsters/Ant_Soldier.cfg
+++ b/data/core/units/monsters/Ant_Soldier.cfg
@@ -6,15 +6,15 @@
     image="units/monsters/ant/soldier.png"
     profile="portraits/monsters/ant-soldier.webp"
     {DEFENSE_ANIM "units/monsters/ant/soldier-defend.png" "units/monsters/ant/soldier.png" hiss.wav }
-    hitpoints=22
+    hitpoints=35
     movement_type=orcishfoot
     movement=6
-    experience=80
     level=1
     alignment=neutral
+    experience=50
     advances_to=null
     {AMLA_DEFAULT}
-    cost=14
+    cost=16
     usage=fighter
     description= _ "Giant Ants are common in almost any environment, from caverns deep under the earth to the tops of tall mountains. Most common are the nondescript workers and scouts, but in times of conflict, a more dangerous Soldier caste enters the fray."
     die_sound=hiss-die.wav


### PR DESCRIPTION
Adds the missing advancement, unless there is argument that soldier ants and worker (Giant) ants should be different unit-lines as Darwinism goes.