### PR TITLE
[1.16] Show id in "skipping duplicate variation" warning

### DIFF
--- a/changelog_entries/logs_duplicate_variants.md
+++ b/changelog_entries/logs_duplicate_variants.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Make the log messages about "Skipping duplicate unit variation ID" say which `[unit_type]` is causing the error.

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -1061,7 +1061,8 @@ void unit_type::fill_variations()
 		bool success;
 		std::tie(ut, success) = variations_.emplace(var_cfg["variation_id"].str(), std::move(*var));
 		if(!success) {
-			ERR_CF << "Skipping duplicate unit variation ID: " << var_cfg["variation_id"] << "\n";
+			ERR_CF << "Skipping duplicate unit variation ID: '" << var_cfg["variation_id"]
+				<< "' of unit_type '" << get_cfg()["id"] << "'\n";
 		}
 	}
 


### PR DESCRIPTION
The strings involved aren't translatable, so this is taking a message that's already only printed in English, and making it more helpful. (It probably should be translatable, but this isn't making anything worse).

Add a useful identifier to the message

    error config: Skipping duplicate unit variation ID: ''

This warning is generally shown because the variation_id is completely missing, and so the message appeared as above, without any hint of which unit was causing the problem.

In contrast to 19a5ce83's warning, this one is printed multiple times to stdout even if the messages are identical; therefore backporting this to 1.16 seems reasonable.

(cherry picked from commit 323ce6ec260f29f81c4cb4a703cc2202610db982)