### PR TITLE
[1.16] Reduce log spam about the postponed removal of the SPECIAL_NOTES macro

### DIFF
--- a/changelog_entries/special_note_macro_postponed_removal.md
+++ b/changelog_entries/special_note_macro_postponed_removal.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Postponed the removal of the `SPECIAL_NOTES` macro, which means there will be fewer log messages.

--- a/data/core/macros/special-notes.cfg
+++ b/data/core/macros/special-notes.cfg
@@ -1,15 +1,16 @@
 #textdomain wesnoth-help
 #define SPECIAL_NOTES
-#deprecated 4 Use [special_note]note= tags or special_note= in an ability or weapon special to apply special notes.
+#deprecated 2 1.19 Use [special_note]note= tags or special_note= in an ability or weapon special to apply special notes.
     "
 
 "+_"Special Notes:"#enddef
 
-# SPECIAL_NOTES_* are the deprecated versions that provide the strings.
-# INTERNAL:SPECIAL_NOTES_* contain the strings shared by deprecated and non-deprecated macros. Do not use them directly.
-# NOTE_* are the new versions that provide an entire tag.
-# For now, the new are defined in terms of the old, but when adding new special notes,
-# only a NOTE_* form should be added.
+# The SPECIAL_NOTES macro and ability-specific SPECIAL_NOTES_* macros are deprecated, they are strings that were historically included directly in [unit_type]description.
+# Since 1.16 these special notes are found in the abilities, movetypes and weapon specials themselves, and in [language]special_note_damage_type_arcane.
+#
+# The INTERNAL:SPECIAL_NOTES_* macros contain the strings shared by the deprecated macros and the non-deprecated uses. They aren't intended to be reused outside mainline.
+#
+# There are also NOTE_* macros, which are deprecated (they were an implementation that was both introduced and replaced in the 1.15 cycle).
 
 #define INTERNAL:SPECIAL_NOTES_SPIRIT
 _"Spirits have very unusual resistances to damage, and move quite slowly over open water."#enddef
@@ -239,125 +240,125 @@ _"This unit has a defense cap on certain terrain types — it cannot achieve a h
 # Deprecated versions here
 
 #define SPECIAL_NOTES_SPIRIT
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SPIRIT}#enddef
 
 #define SPECIAL_NOTES_ARCANE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_ARCANE}#enddef
 
 #define SPECIAL_NOTES_HEALS
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_HEALS}#enddef
 
 #define SPECIAL_NOTES_EXTRA_HEAL
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_EXTRA_HEAL}#enddef
 
 #define SPECIAL_NOTES_CURES
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_CURES}#enddef
 
 #define SPECIAL_NOTES_UNPOISON
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_UNPOISON}#enddef
 
 #define SPECIAL_NOTES_REGENERATES
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_REGENERATES}#enddef
 
 #define SPECIAL_NOTES_STEADFAST
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_STEADFAST}#enddef
 
 #define SPECIAL_NOTES_LEADERSHIP
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_LEADERSHIP}#enddef
 
 #define SPECIAL_NOTES_SKIRMISHER
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SKIRMISHER}#enddef
 
 #define SPECIAL_NOTES_ILLUMINATES
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_ILLUMINATES}#enddef
 
 #define SPECIAL_NOTES_TELEPORT
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_TELEPORT}#enddef
 
 #define SPECIAL_NOTES_AMBUSH
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_AMBUSH}#enddef
 
 #define SPECIAL_NOTES_NIGHTSTALK
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_NIGHTSTALK}#enddef
 
 #define SPECIAL_NOTES_CONCEALMENT
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_CONCEALMENT}#enddef
 
 #define SPECIAL_NOTES_SUBMERGE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SUBMERGE}#enddef
 
 #define SPECIAL_NOTES_FEEDING
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_FEEDING}#enddef
 
 #define SPECIAL_NOTES_BERSERK
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_BERSERK}#enddef
 
 #define SPECIAL_NOTES_BACKSTAB
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_BACKSTAB}#enddef
 
 #define SPECIAL_NOTES_PLAGUE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_PLAGUE}#enddef
 
 #define SPECIAL_NOTES_SLOW
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SLOW}#enddef
 
 #define SPECIAL_NOTES_PETRIFY
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_PETRIFY}#enddef
 
 #define SPECIAL_NOTES_STONE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_PETRIFY}#enddef
 
 #define SPECIAL_NOTES_MARKSMAN
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_MARKSMAN}#enddef
 
 #define SPECIAL_NOTES_MAGICAL
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_MAGICAL}#enddef
 
 #define SPECIAL_NOTES_SWARM
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SWARM}#enddef
 
 #define SPECIAL_NOTES_CHARGE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_CHARGE}#enddef
 
 #define SPECIAL_NOTES_DRAIN
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_DRAIN}#enddef
 
 #define SPECIAL_NOTES_FIRSTSTRIKE
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_FIRSTSTRIKE}#enddef
 
 #define SPECIAL_NOTES_POISON
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_POISON}#enddef
 
 #define SPECIAL_NOTES_DEFENSE_CAP
-#deprecated 2 1.17 This note is now added automatically.
+#deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}#enddef


### PR DESCRIPTION
This is a partial cherry-pick of b9e4fdffb46b9933a602ed2601b051c642e7ba07, merely reflecting that the removal has been postponed from 1.17 to 1.19 along with updating some outdated comments.

The motivation for backporting this is to make other warnings that are printed to stdout/stderr more visible, instead of being scrolled offscreen by the SPECIAL_NOTES messages.