### PR TITLE
SotBE S14 Grüü apparition fixed

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -202,7 +202,7 @@
 			[/filter]
 			x=5
 			y=34
-			side=4
+			side=1
 		[/modify_unit]
     [/event]
 

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -196,14 +196,14 @@
         name=prestart
 
         {RENAME_IF_DEAD thelarion_dead Thelarion (_"Valan")}
-		[modify_unit]
-			[filter]
-				id=Grüü
-			[/filter]
-			x=5
-			y=34
-			side=1
-		[/modify_unit]
+        [modify_unit]
+            [filter]
+                id=Grüü
+            [/filter]
+            x=5
+            y=34
+            side=1
+        [/modify_unit]
     [/event]
 
     {GOT_THE_GREAT_HORDE 1,2,3,4}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -245,9 +245,6 @@
         name=start
 
         [recall]
-            id=Grüü
-        [/recall]
-        [recall]
             id=Jetto
         [/recall]
         [recall]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -196,11 +196,14 @@
         name=prestart
 
         {RENAME_IF_DEAD thelarion_dead Thelarion (_"Valan")}
-
-        [kill]
-            id=Grüü
-            side=4
-        [/kill]
+		[modify_unit]
+			[filter]
+				id=Grüü
+			[/filter]
+			x=5
+			y=34
+			side=4
+		[/modify_unit]
     [/event]
 
     {GOT_THE_GREAT_HORDE 1,2,3,4}


### PR DESCRIPTION
This, instead of killing Grüü, moves him along with the others to participate in the conversation, and also switches him to side 1 (this side is temporary and only for narrative purposes, later on turn 7 he switches to side 4 again).
Grüü is correctly stored on the variable when the conversation ends, and restored later on turn 7.