### PR TITLE
Test fire_event of kill unit on recall list

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
@@ -1,0 +1,41 @@
+#####
+# API(s) being tested: [kill]fire_event=yes
+##
+# Actions:
+# Put Alice on recall, kill Bob and Alice.
+##
+# Expected end state:
+# A last breath event and a die event is triggered for bob but not for alice.
+#####
+{GENERIC_UNIT_TEST "kill_fires_events" (
+    [event]
+        name=last_breath
+		[set_variable]
+			name=$unit.id|_breath
+			value=yes
+		[/set_variable]
+    [/event]
+    [event]
+        name=die
+		[set_variable]
+			name=$unit.id|_die
+			value=yes
+		[/set_variable]
+    [/event]
+    [event]
+        name=start
+		[put_to_recall_list]
+			id=alice
+		[/put_to_recall_list]
+		[kill]
+			id=alice,bob
+			fire_event=yes
+		[/kill]
+        {ASSERT ({VARIABLE_CONDITIONAL bob_die equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice_die not_equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob_breath equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice_breath not_equals yes})}
+        {SUCCEED}
+    [/event]
+)}
+

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
@@ -1,3 +1,5 @@
+# wmllint: no translatables
+
 #####
 # API(s) being tested: [kill]fire_event=yes
 ##
@@ -5,34 +7,34 @@
 # Create a last breath and die events. Put Alice to the recall list. Kill Bob and Alice, and detect with a variable which events have been triggered for whom.
 ##
 # Expected end state:
-# A last breath event and a die event is triggered for Bob but not for Alice.
+# A last breath event and a die event are triggered for Bob but not for Alice.
 #####
 {GENERIC_UNIT_TEST "kill_fires_events" (
     [event]
         name=last_breath
-		first_time_only=no
-		[set_variable]
-			name=$unit.id|_breath
-			value=yes
-		[/set_variable]
+        first_time_only=no
+        [set_variable]
+            name=$unit.id|_breath
+            value=yes
+        [/set_variable]
     [/event]
     [event]
         name=die
-		first_time_only=no
-		[set_variable]
-			name=$unit.id|_die
-			value=yes
-		[/set_variable]
+        first_time_only=no
+        [set_variable]
+            name=$unit.id|_die
+            value=yes
+        [/set_variable]
     [/event]
     [event]
         name=start
-		[put_to_recall_list]
-			id=alice
-		[/put_to_recall_list]
-		[kill]
-			id=alice,bob
-			fire_event=yes
-		[/kill]
+        [put_to_recall_list]
+            id=alice
+        [/put_to_recall_list]
+        [kill]
+            id=alice,bob
+            fire_event=yes
+        [/kill]
         {ASSERT ({VARIABLE_CONDITIONAL bob_die boolean_equals yes})}
         {ASSERT ({VARIABLE_CONDITIONAL alice_die boolean_not_equals yes})}
         {ASSERT ({VARIABLE_CONDITIONAL bob_breath boolean_equals yes})}
@@ -40,4 +42,3 @@
         {SUCCEED}
     [/event]
 )}
-

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
@@ -2,10 +2,10 @@
 # API(s) being tested: [kill]fire_event=yes
 ##
 # Actions:
-# Put Alice on recall, kill Bob and Alice.
+# Create a last breath and die events. Put Alice on recall. Kill Bob and Alice, and detect with a variable which events have been triggered for whom.
 ##
 # Expected end state:
-# A last breath event and a die event is triggered for bob but not for alice.
+# A last breath event and a die event is triggered for Bob but not for Alice.
 #####
 {GENERIC_UNIT_TEST "kill_fires_events" (
     [event]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
@@ -10,6 +10,7 @@
 {GENERIC_UNIT_TEST "kill_fires_events" (
     [event]
         name=last_breath
+		first_time_only=no
 		[set_variable]
 			name=$unit.id|_breath
 			value=yes
@@ -17,6 +18,7 @@
     [/event]
     [event]
         name=die
+		first_time_only=no
 		[set_variable]
 			name=$unit.id|_die
 			value=yes

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
@@ -2,7 +2,7 @@
 # API(s) being tested: [kill]fire_event=yes
 ##
 # Actions:
-# Create a last breath and die events. Put Alice on recall. Kill Bob and Alice, and detect with a variable which events have been triggered for whom.
+# Create a last breath and die events. Put Alice to the recall list. Kill Bob and Alice, and detect with a variable which events have been triggered for whom.
 ##
 # Expected end state:
 # A last breath event and a die event is triggered for Bob but not for Alice.

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/kill_fires_events.cfg
@@ -31,10 +31,10 @@
 			id=alice,bob
 			fire_event=yes
 		[/kill]
-        {ASSERT ({VARIABLE_CONDITIONAL bob_die equals yes})}
-        {ASSERT ({VARIABLE_CONDITIONAL alice_die not_equals yes})}
-        {ASSERT ({VARIABLE_CONDITIONAL bob_breath equals yes})}
-        {ASSERT ({VARIABLE_CONDITIONAL alice_breath not_equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob_die boolean_equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice_die boolean_not_equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob_breath boolean_equals yes})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice_breath boolean_not_equals yes})}
         {SUCCEED}
     [/event]
 )}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -423,6 +423,7 @@
 0 order_of_variable_events3
 0 premature_end_turn1
 2 premature_end_turn2
+0 kill_fires_events 
 # Game mechanics
 0 heal
 # Warnings about WML

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -423,7 +423,7 @@
 0 order_of_variable_events3
 0 premature_end_turn1
 2 premature_end_turn2
-0 kill_fires_events 
+0 kill_fires_events
 # Game mechanics
 0 heal
 # Warnings about WML


### PR DESCRIPTION
This test checks if the last_breath and die events are triggered when a unit on the recall list is killed.
As you can see, with **equals yes** on all variables Alice does not trigger the last_breath and die events when she is on the recall list. This is the default behavior on 1.16 and 1.17
I send a version of the test that is supposed to pass, with Alice not firing the event.

![imagen](https://user-images.githubusercontent.com/40789364/212325587-e83f4ee1-97ed-40a5-be94-d5edb0be49ba.png)
![imagen](https://user-images.githubusercontent.com/40789364/212325621-eb7ae7ea-ff4d-4d4e-9b40-6f0301e69753.png)


Note: Sorry for sending the pull request again, since in the previous one I used a fork, and it is better to use a branch, since I cannot create more than one fork.
https://github.com/wesnoth/wesnoth/pull/7272