### PR TITLE
Bump vcpkg baseline to use a non-obsolete version of libtool

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -267,7 +267,7 @@ jobs:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: win-cache-master-0010
+          key: win-cache-master-0011
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1.3

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -537,8 +537,13 @@ int icompare(const std::string& s1, const std::string& s2)
 	std::scoped_lock lock(get_mutex());
 
 	try {
+#if BOOST_VERSION < 108100
 		return std::use_facet<bl::collator<char>>(get_manager().get_locale()).compare(
 			bl::collator_base::secondary, s1, s2);
+#else
+		return std::use_facet<bl::collator<char>>(get_manager().get_locale()).compare(
+			bl::collate_level::secondary, s1, s2);
+#endif
 	} catch(const std::bad_cast&) {
 		static bool bad_cast_once = false;
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "wesnoth-dependencies",
   "version": "0.0.1",
-  "builtin-baseline": "b6b5c0b9a44819b095b369f507599c79ac885ec5",
+  "builtin-baseline": "877e3dc2323a4d4c3c75e7168c22a0c4e921d4db",
   "dependencies": [
     "sdl2",
     {


### PR DESCRIPTION
The vital commit is fd766eba2b4cf59c7123d46189be373e2cee959d, but I'm taking the most recent version of vcpkg as the new baseline because it might as well use the latest.