### PR TITLE
Fix indent on unit tests, and make the CI check it

### DIFF
--- a/data/test/macros/shroud.cfg
+++ b/data/test/macros/shroud.cfg
@@ -48,21 +48,21 @@
 #enddef
 
 #define ASSERT_SHROUDED FILTER STATE
-[lua]
-    code=<<
-        local locs = wesnoth.map.find(wml.get_child(..., 'filter'))
-        local state = (...).state
-        for _,loc in ipairs(locs) do
-            local x, y = loc[1], loc[2]
-            unit_test.assert_equal(wesnoth.sides.is_shrouded(1, loc), state, string.format('shroud check at (%d,%d)', loc[1], loc[2]))
-        end
-    >>
-    [args]
-        [filter]
-            include_borders=yes
-            {FILTER}
-        [/filter]
-        state={STATE}
-    [/args]
-[/lua]
+    [lua]
+        code=<<
+            local locs = wesnoth.map.find(wml.get_child(..., 'filter'))
+            local state = (...).state
+            for _,loc in ipairs(locs) do
+                local x, y = loc[1], loc[2]
+                unit_test.assert_equal(wesnoth.sides.is_shrouded(1, loc), state, string.format('shroud check at (%d,%d)', loc[1], loc[2]))
+            end
+        >>
+        [args]
+            [filter]
+                include_borders=yes
+                {FILTER}
+            [/filter]
+            state={STATE}
+        [/args]
+    [/lua]
 #enddef

--- a/data/test/macros/start_position_generic.cfg
+++ b/data/test/macros/start_position_generic.cfg
@@ -15,7 +15,7 @@
 #arg TURNS
 -1#endarg
 
-# side 1
+    # side 1
 #arg SIDE1_CONTROLLER
 human#endarg
 
@@ -28,7 +28,7 @@ human#endarg
 #arg SIDE1_LEADER
 Elvish Archer#endarg
 
-# side 2
+    # side 2
 #arg SIDE2_CONTROLLER
 human#endarg
 

--- a/data/test/scenarios/behavioral_tests/recruit_facing.cfg
+++ b/data/test/scenarios/behavioral_tests/recruit_facing.cfg
@@ -2,14 +2,13 @@
     [event]
         name=recruit
         [lua]
-            code =<<
-                    local temp = wml.variables["unit"]
-                    local result = wesnoth.sync.evaluate_single(
-                      function()
+            code=<<
+                local temp = wml.variables["unit"]
+                local result = wesnoth.sync.evaluate_single(function()
                         return { value = temp.facing }
-                      end)
-                    wml.variables["synced_temp"] = result.value
-                >>
+                    end)
+                wml.variables["synced_temp"] = result.value
+            >>
         [/lua]
         {ASSERT ({VARIABLE_CONDITIONAL unit.facing equals $synced_temp})}
         {ASSERT ({VARIABLE_CONDITIONAL unit.facing equals {FACEDIR}})}

--- a/data/test/scenarios/cve_tests/test_cve_2018_1999023.cfg
+++ b/data/test/scenarios/cve_tests/test_cve_2018_1999023.cfg
@@ -34,9 +34,9 @@
     [event]
         name = prestart
         [lua]
-        code = <<
-            wml.variables["execution_prevented"] = not rawget(_G, "bytecode_executed")
-        >>
+            code = <<
+                wml.variables["execution_prevented"] = not rawget(_G, "bytecode_executed")
+            >>
         [/lua]
         {ASSERT ({VARIABLE_CONDITIONAL execution_prevented equals yes})}
         {SUCCEED}

--- a/data/test/scenarios/lua_tests/wesnoth/sides/test_modify_shroud.cfg
+++ b/data/test/scenarios/lua_tests/wesnoth/sides/test_modify_shroud.cfg
@@ -1,15 +1,15 @@
 #textdomain wesnoth-test
 
 #define ASSERT_SHROUD_DATA DATA
-[lua]
-    code=<<
-        local data = (...).data
-        unit_test.assert_equal(data, wesnoth.sides[1].shroud_data, 'data equal')
-    >>
-    [args]
-        data={DATA}
-    [/args]
-[/lua]
+    [lua]
+        code=<<
+            local data = (...).data
+            unit_test.assert_equal(data, wesnoth.sides[1].shroud_data, 'data equal')
+        >>
+        [args]
+            data={DATA}
+        [/args]
+    [/lua]
 #enddef
 
 #####
@@ -173,7 +173,7 @@
         {ASSERT_SHROUDED x,y=9,0-6 true}
         {ASSERT_SHROUDED x,y=10,0-5 true}
         {ASSERT_SHROUDED x,y=11,1-5 true}
-        
+
         {ASSERT_SHROUDED x,y=12,2-4 false}
         {ASSERT_SHROUDED x,y=13,3-5 false}
         {ASSERT_SHROUDED x,y=14,2-4 false}
@@ -263,7 +263,7 @@
         {ASSERT_SHROUDED x,y=9,0-6 false}
         {ASSERT_SHROUDED x,y=10,0-5 false}
         {ASSERT_SHROUDED x,y=11,1-5 false}
-        
+
         {ASSERT_SHROUDED x,y=12,2-4 false}
         {ASSERT_SHROUDED x,y=13,3-5 false}
         {ASSERT_SHROUDED x,y=14,2-4 false}
@@ -311,4 +311,3 @@
 )}
 
 #undef ASSERT_SHROUD_DATA
-

--- a/data/test/scenarios/lua_tests/wesnoth/sync/break_replay_with_lua_random.cfg
+++ b/data/test/scenarios/lua_tests/wesnoth/sync/break_replay_with_lua_random.cfg
@@ -97,8 +97,7 @@
 {TEST_BREAK_REPLAY "fixed_lua_random_replay_with_sync_choice" (
     [lua]
         code =<<
-                local result = wesnoth.sync.evaluate_single(
-                  function()
+                local result = wesnoth.sync.evaluate_single(function()
                     return { value = math.random(200) }
                   end)
                 wml.variables["rnd_num"] = result.value

--- a/data/test/scenarios/lua_tests/wesnoth/sync/test_synced_side_number.cfg
+++ b/data/test/scenarios/lua_tests/wesnoth/sync/test_synced_side_number.cfg
@@ -16,8 +16,7 @@
             code =<<
                     unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'start should be synchronised')
 
-                    local result = wesnoth.sync.evaluate_multiple(
-                        function()
+                    local result = wesnoth.sync.evaluate_multiple(function()
                             unit_test.assert_equal(wesnoth.current.synced_state, 'local_choice', 'expected value to be local_choice, within synced event')
                             return { value = wesnoth.current.synced_state }
                         end,

--- a/data/test/scenarios/lua_tests/wesnoth/test_synced_state.cfg
+++ b/data/test/scenarios/lua_tests/wesnoth/test_synced_state.cfg
@@ -24,8 +24,7 @@
         [lua]
             code =<<
                     unit_test.assert_equal(wesnoth.current.synced_state, 'synced', 'start should be synchronised')
-                    local result = wesnoth.sync.evaluate_single(
-                        function()
+                    local result = wesnoth.sync.evaluate_single(function()
                             unit_test.assert_equal(wesnoth.current.synced_state, 'local_choice', 'expected value to be local_choice, within synced event')
                             return { value = wesnoth.current.synced_state }
                         end)
@@ -66,8 +65,7 @@
                     -- In 1.13.0 (commit 3b86c955616c), that changed from generating an error to a comment in the C++ that it "doesn't cause problems".
                     -- In the same commit, the multiple-side version was left generating an error.
                     -- This doesn't give me confidence that the behavior is replay-safe, but let's at least check that the behavior is consistent.
-                    local result = wesnoth.sync.evaluate_single(
-                        function()
+                    local result = wesnoth.sync.evaluate_single(function()
                             unit_test.assert_equal(wesnoth.current.synced_state, 'unsynced', 'within unsynced event')
                             return { value = wesnoth.current.synced_state }
                         end)

--- a/data/test/scenarios/lua_tests/wml-utils/test_scoped_vars.cfg
+++ b/data/test/scenarios/lua_tests/wml-utils/test_scoped_vars.cfg
@@ -13,27 +13,27 @@
 {GENERIC_UNIT_TEST "test_scoped_vars" (
     [event]
         name = prestart
-		{VARIABLE test_var 1}
-		#[inspect][/inspect]
-		{ASSERT {VARIABLE_CONDITIONAL test_var equals 1}}
+        {VARIABLE test_var 1}
+        #[inspect][/inspect]
+        {ASSERT {VARIABLE_CONDITIONAL test_var equals 1}}
         [lua]
             code = <<
-				local wml_utils = wesnoth.require "wml-utils"
-				local var <close> = wml_utils.scoped_var("test_var")
-				-- This runs the contents of [args] as WML actions
-				wml_utils.handle_event_commands(...)
-			>>
-			[args]
-				#[inspect][/inspect]
-				{ASSERT {VARIABLE_CONDITIONAL test_var equals ""}}
-				{VARIABLE test_var 5}
-				#[inspect][/inspect]
-				{ASSERT {VARIABLE_CONDITIONAL test_var equals 5}}
-			[/args]
+                local wml_utils = wesnoth.require "wml-utils"
+                local var <close> = wml_utils.scoped_var("test_var")
+                -- This runs the contents of [args] as WML actions
+                wml_utils.handle_event_commands(...)
+            >>
+            [args]
+                #[inspect][/inspect]
+                {ASSERT {VARIABLE_CONDITIONAL test_var equals ""}}
+                {VARIABLE test_var 5}
+                #[inspect][/inspect]
+                {ASSERT {VARIABLE_CONDITIONAL test_var equals 5}}
+            [/args]
         [/lua]
 
-		#[inspect][/inspect]
+        #[inspect][/inspect]
         {ASSERT {VARIABLE_CONDITIONAL test_var equals 1}}
-		{SUCCEED}
+        {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro.cfg
+++ b/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro.cfg
@@ -13,7 +13,7 @@
 {GENERIC_UNIT_TEST "test_force_chance_to_hit_macro" (
     {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 0 ()}
     {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 0 ()}
-    
+
     [event]
         name=start
 

--- a/data/test/scenarios/manual_tests/test_relative_dir.cfg
+++ b/data/test/scenarios/manual_tests/test_relative_dir.cfg
@@ -31,7 +31,7 @@
     turns = -1
     id = test_relative_dir
     is_unit_test=no
-    
+
     {DAWN}
 
     [side]
@@ -56,7 +56,7 @@
             id=bob
         [/leader]
     [/side]
-    
+
     [event]
         name=start
         [modify_unit]

--- a/data/test/scenarios/wml_tests/ScenarioWML/AiWML/_main.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/AiWML/_main.cfg
@@ -96,4 +96,3 @@ end
 #undef SPLIT
 #undef AI_ASPECT_UNIT_TEST
 #undef AI_UNIT_TEST
-

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/shroud.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/shroud.cfg
@@ -76,4 +76,3 @@
         {SUCCEED}
     [/event]
 )}
-

--- a/data/test/scenarios/wml_tests/UnitsWML/traits_exclude_include.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/traits_exclude_include.cfg
@@ -10,37 +10,36 @@
 # One of the two special traits excludes another trait to be already had by Bob.
 # Bob should either not have the trait or have only the excluded one.
 #####
-
 {GENERIC_UNIT_TEST "trait_exclusion_test" (
-	[event]
-		name=start
-		{UNIT 1 (Test Unit Exclude) 1 1 (id=excluder1)}
-	[/event]
-	[event]
-		name=side 1 turn 1
-		[store_unit]
-			[filter]
-				side=1
-				id=excluder1
-			[/filter]
-			variable=excluded
-			kill=no
-		[/store_unit]
-		[if]
-			# Check if the first randomly generated trait is the excluded one, then the
-			# next trait slot should be empty
-			{VARIABLE_CONDITIONAL excluded.modifications.trait[0].id equals "test_excluded"}
-			[then]
-				{ASSERT ({VARIABLE_CONDITIONAL excluded.modifications.trait[1].id equals $nil})}
-			[/then]
-			[else]
-				# Otherwise if it is "test_exclude" then the next slot should be empty as well
-				{ASSERT ({VARIABLE_CONDITIONAL excluded.modifications.trait[0].id equals "test_exclude"})}
-				{ASSERT ({VARIABLE_CONDITIONAL excluded.modifications.trait[1].id equals $nil})}
-			[/else]
-		[/if]
-		{SUCCEED}
-	[/event]
+    [event]
+        name=start
+        {UNIT 1 (Test Unit Exclude) 1 1 (id=excluder1)}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [store_unit]
+            [filter]
+                side=1
+                id=excluder1
+            [/filter]
+            variable=excluded
+            kill=no
+        [/store_unit]
+        [if]
+            # Check if the first randomly generated trait is the excluded one, then the
+            # next trait slot should be empty
+            {VARIABLE_CONDITIONAL excluded.modifications.trait[0].id equals "test_excluded"}
+            [then]
+                {ASSERT ({VARIABLE_CONDITIONAL excluded.modifications.trait[1].id equals $nil})}
+            [/then]
+            [else]
+                # Otherwise if it is "test_exclude" then the next slot should be empty as well
+                {ASSERT ({VARIABLE_CONDITIONAL excluded.modifications.trait[0].id equals "test_exclude"})}
+                {ASSERT ({VARIABLE_CONDITIONAL excluded.modifications.trait[1].id equals $nil})}
+            [/else]
+        [/if]
+        {SUCCEED}
+    [/event]
 )}
 
 #####
@@ -53,25 +52,23 @@
 # One of the two special traits needs another trait to be already had by Bob.
 # Bob only have the trait if it also has the one it requires one.
 #####
-
-
 {GENERIC_UNIT_TEST "trait_requirement_test" (
-	[event]
-		name=start
-		{UNIT 1 (Test Unit Require) 1 1 (id=requirer1)}
-	[/event]
-	[event]
-		name=side 1 turn 1
-		[store_unit]
-			[filter]
-				side=1
-				id=requirer1
-			[/filter]
-			variable=required
-			kill=no
-		[/store_unit]
-		# Check if the second randomly generated trait is the one requiring the other one
-		{ASSERT ({VARIABLE_CONDITIONAL required.modifications.trait[1].id equals "test_require"})}
-		{SUCCEED}
-	[/event]
+    [event]
+        name=start
+        {UNIT 1 (Test Unit Require) 1 1 (id=requirer1)}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [store_unit]
+            [filter]
+                side=1
+                id=requirer1
+            [/filter]
+            variable=required
+            kill=no
+        [/store_unit]
+        # Check if the second randomly generated trait is the one requiring the other one
+        {ASSERT ({VARIABLE_CONDITIONAL required.modifications.trait[1].id equals "test_require"})}
+        {SUCCEED}
+    [/event]
 )}

--- a/data/test/units.cfg
+++ b/data/test/units.cfg
@@ -1,36 +1,35 @@
 #textdomain wesnoth-test
 
 [units]
-	{test/units/}
-	
-		[race]
-		id=test
-		name= _ "test"
-		female_name= _ "test"
-		plural_name= _ "tests"
-		description= _ "test race"
-		num_traits=2
-		undead_variation=wolf
-		{ORCISH_NAMES}
-	[/race]
-	
-	[movetype]
-		name=fly
-		flying=yes
-		[movement_costs]
-			{FLY_MOVE}
-			cave=3
-			fungus=3
-		[/movement_costs]
-		[defense]
-			{FLY_DEFENSE 50}
-			cave=80
-			fungus=-70
-		[/defense]
-		{FLY_RESISTANCE}
-		[special_note]
-			note={INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}
-		[/special_note]
-	[/movetype]
-	
+    {test/units/}
+
+    [race]
+        id=test
+        name= _ "test"
+        female_name= _ "test"
+        plural_name= _ "tests"
+        description= _ "test race"
+        num_traits=2
+        undead_variation=wolf
+        {ORCISH_NAMES}
+    [/race]
+
+    [movetype]
+        name=fly
+        flying=yes
+        [movement_costs]
+            {FLY_MOVE}
+            cave=3
+            fungus=3
+        [/movement_costs]
+        [defense]
+            {FLY_DEFENSE 50}
+            cave=80
+            fungus=-70
+        [/defense]
+        {FLY_RESISTANCE}
+        [special_note]
+            note={INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}
+        [/special_note]
+    [/movetype]
 [/units]

--- a/data/test/units/test_unit_exclude.cfg
+++ b/data/test/units/test_unit_exclude.cfg
@@ -32,24 +32,24 @@
 # This unit is used for testing the exclude traits functionality.
 
 [unit_type]
-	id=Test Unit Exclude
-	name=_ "dummy_unit^Test Unit Exclude"
-	race=test
-	image="misc/blank-hex.png"
-	ignore_race_traits=yes
-	{TRAIT_TEST_EXCLUDE}
-	{TRAIT_TEST_EXCLUDED}
-	hitpoints=1
-	movement_type=fly
-	movement=1
-	experience=1
-	level=1
-	alignment=neutral
-	advances_to=null
-	cost=1
-	usage=scout
-	hide_help=yes
-	do_not_list=yes
+    id=Test Unit Exclude
+    name=_ "dummy_unit^Test Unit Exclude"
+    race=test
+    image="misc/blank-hex.png"
+    ignore_race_traits=yes
+    {TRAIT_TEST_EXCLUDE}
+    {TRAIT_TEST_EXCLUDED}
+    hitpoints=1
+    movement_type=fly
+    movement=1
+    experience=1
+    level=1
+    alignment=neutral
+    advances_to=null
+    cost=1
+    usage=scout
+    hide_help=yes
+    do_not_list=yes
 [/unit_type]
 
 #undef TRAIT_TEST_EXCLUDE

--- a/data/test/units/test_unit_require.cfg
+++ b/data/test/units/test_unit_require.cfg
@@ -32,24 +32,24 @@
 # This unit is used for testing the require traits functionality.
 
 [unit_type]
-	id=Test Unit Require
-	name=_ "dummy_unit^Test Unit Require"
-	race=test
-	image="misc/blank-hex.png"
-	ignore_race_traits=yes
-	{TRAIT_TEST_REQUIRE}
-	{TRAIT_TEST_REQUIRED}
-	hitpoints=1
-	movement_type=fly
-	movement=1
-	experience=1
-	level=1
-	alignment=neutral
-	advances_to=null
-	cost=1
-	usage=scout
-	hide_help=yes
-	do_not_list=yes
+    id=Test Unit Require
+    name=_ "dummy_unit^Test Unit Require"
+    race=test
+    image="misc/blank-hex.png"
+    ignore_race_traits=yes
+    {TRAIT_TEST_REQUIRE}
+    {TRAIT_TEST_REQUIRED}
+    hitpoints=1
+    movement_type=fly
+    movement=1
+    experience=1
+    level=1
+    alignment=neutral
+    advances_to=null
+    cost=1
+    usage=scout
+    hide_help=yes
+    do_not_list=yes
 [/unit_type]
 
 #undef TRAIT_TEST_REQUIRE

--- a/data/tools/Makefile
+++ b/data/tools/Makefile
@@ -71,7 +71,14 @@ unchecked:
 
 # Reindent the mainline content
 reindent:
-	@./wmlindent --exclude=../../data/languages --exclude=../../data/gui --exclude=../../data/test  --exclude=../../data/test  --exclude=../../data/schema $(DATA)
+	@./wmlindent \
+		--exclude=../../data/languages \
+		--exclude=../../data/gui \
+		--exclude=../../data/test/scenarios/cve_tests \
+		--exclude=../../data/test/scenarios/lua_tests \
+		--exclude=../../data/test/scenarios/wml_tests/TerrainWML \
+		--exclude=../../data/schema \
+		$(DATA)
 
 # Extract a table of editor keybindings from the editor theme definition
 editor_bindings:


### PR DESCRIPTION
The whole data/test directory was excluded from the CI's indentation check.
Two of the commits in this PR fix the indentation in some of the tests, and
then the final commit reduces the exclusion list to only

* data/test/scenarios/cve_tests/
* data/test/scenarios/lua_tests/
* data/test/scenarios/wml_tests/TerrainWML/

Exclude cve_tests because of the binary file that's masquerading as a .cfg;
I think it's correct to exclude the whole directory because any new tests
added there might also use weird edge cases in the parsing.

Exclude lua_tests as a "keep this PR small" thing. We should fix the bugs in
wmlindent, but I don't want to take on that work.

The exclusion of TerrainWML is again because I don't want to take on the work
of working out whether it's problems with terrain masks or bugs in wmlindent.

Most of the files in those directories wouldn't be changed, the ones that would
(or would trigger an error about not being valid UTF-8 ) are:

* data/test/scenarios/cve_tests/test_cve_2018_1999023_2.cfg
* data/test/scenarios/lua_tests/functional/lua_functional.cfg
* data/test/scenarios/lua_tests/wesnoth/map/mapgen_filter.cfg
* data/test/scenarios/wml_tests/TerrainWML/test_terrain_mask.cfg

Notes on specific files:
---

For the unit tests using sync.evaluate_single or sync.evaluate_multiple, I'm
using two wmlindent bugs against each other, putting two opening statements on
the same line to balance two closing statements on the same line. However, the
unit tests ought to be code that can be cut & pasted elsewhere without causing
indentation problems, and this is simpler than fixing wmlindent's Lua parsing.

There are two cve_2018_1999023 tests. The other one needs to be treated as a
binary file, but the one changed here is plain text that loads its attack from
a separate file.

The change in start_position_generic.cfg doesn't seem good, but it's not
particularly bad and it's what wmlindent currently does.