### PR TITLE
[1.16] HttT S03: Rewrite intro, hint about training troops for S06

### DIFF
--- a/changelog_entries/httt_s03_intro.md
+++ b/changelog_entries/httt_s03_intro.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * Heir to the Throne
+     * S03: Rewrite intro text, including a hint about training troops (PR #7291)

--- a/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/03_The_Isle_of_Alduin.cfg
@@ -39,6 +39,11 @@
                 bonus=yes
                 carryover_percentage=40
             [/gold_carryover]
+
+            [note]
+                # po: a hint that the player has 3 scenarios before the first main test of their XP management
+                description= _ "You’ll need experienced troops at Elensefar."
+            [/note]
         [/objectives]
     [/event]
 
@@ -194,16 +199,21 @@
             message= _ "So this is Alduin. It looks a little... desolate."
         [/message]
         [message]
-            speaker=Delfador
-            message= _ "I fear so, Konrad. It seems that the orcs have come even here. Here to the place where I was born, where I was trained."
-        [/message]
-        [message]
             speaker="Usadar Q'kai"
             message= _ "Who is that? Oh, a party of elves has landed. We shall drive them back into the sea!"
         [/message]
         [message]
             speaker=Delfador
-            message= _ "I did not think the orcs would have come here. This island used to be so beautiful. We must recapture it! To arms!"
+            message= _ "If the orcs have come here, their forces at Elensefar must be even more numerous than I feared."
+        [/message]
+        [message]
+            speaker=Delfador
+            # po: a hint for players who are expecting campaigns to have a steadily-rising difficulty curve.
+            message= _ "Konrad, training is important. If we only have inexperienced troops when we reach Elensefar, then our journey is likely to end in sight of the city’s gates."
+        [/message]
+        [message]
+            speaker=Delfador
+            message= _ "This island is the place where I was born, and where I learned magic; it used to be so beautiful. We must recapture it! To arms!"
         [/message]
     [/event]
 


### PR DESCRIPTION
Backport of #7214, simple cherry-pick with nothing to fix up afterwards.

The island gives the player two fronts to progress on, and it's early enough to give the player time to prepare for the SoE. Hint to them about improving their recall list.

When trying to add that hint as a single-line change to the dialogue, I reviewed the existing text and felt it didn't flow well. Reading the feedback thread, Delfador should have more emotion about finding his childhood home overrun; however I've gone for practical thoughts first.

The hint isn't #ifdef to only appear on easy, because the text wouldn't flow without it - take that line out and it goes from "there are more orcs than I thought" to "we must fight these orcs, who aren't the ones at the SoE". Also, players who are already doing XP management can feel knowledgeable when they see it.

(cherry picked from commit 9f780903abfa592752cb02c767a4ef5992f6f9c7)