### PR TITLE
units: Limit energy bar sizes to the game tile size

### DIFF
--- a/changelog_entries/overlarge_unit_bars.md
+++ b/changelog_entries/overlarge_unit_bars.md
@@ -1,0 +1,2 @@
+ ### Rendering Engine
+   * Fixed a regression in 1.17.x resulting in overlarge unit HP and XP bars in some cases (issue #7171).

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -101,12 +101,18 @@ void draw_bar(int xpos, int ypos, int bar_height, double filled, const color_t& 
 	const point offset = display::scaled_to_zoom(point{19, 13});
 
 	// Full bar dimensions.
-	const rect bar_rect = display::scaled_to_zoom({
+	rect bar_rect = display::scaled_to_zoom({
 		xpos + offset.x,
 		ypos + offset.y,
 		bar_width,
 		bar_height
 	});
+
+	// Bar dimensions should not overflow 80% of the scaled hex dimensions.
+	// The 80% comes from an approximation of the length of a segment drawn
+	// inside a regular hexagon that runs parallel to its outer left side.
+	bar_rect.w = std::clamp<int>(bar_rect.w, 0, display::hex_size() * 0.80 - offset.x);
+	bar_rect.h = std::clamp<int>(bar_rect.h, 0, display::hex_size() * 0.80 - offset.y);
 
 	filled = std::clamp<double>(filled, 0.0, 1.0);
 	const int unfilled = static_cast<std::size_t>(bar_rect.h * (1.0 - filled));


### PR DESCRIPTION
Fixes #7171.

Because of the move to hardware rendering in commit afd6baa7cf1685610c72305f5c9f989078462dff, some relevant info was lost that was previously used to limit bar height in particular.

This patch re-adds a dimension check and additionally ensures that the bar width doesn't exceed the tile size either.

**Before**
<img width="624" alt="Screenshot_2023-01-19_at_20 15 43" src="https://user-images.githubusercontent.com/489895/213590901-44e7d93e-275a-4f54-85d3-a997bb0321c3.png">

**After**
<img width="380" alt="Screenshot_2023-01-19_at_21 22 12" src="https://user-images.githubusercontent.com/489895/213591142-e41a0c63-6311-443f-bf63-a2ab6e4c13c8.png">

**Note:**

This is probably not 1:1 equivalent to the check done in past stable series. However, it does ensure that the bars do not exceed the tile size at the current zoom level, so it works in practice and solves the issue at hand. Right now drawing bars that exceed the tile area is generally a bad idea anyway and leads to graphical glitches when mousing over adjacent tiles.