### PR TITLE
bi: Fix --report SIGSEGV caused by uninitialised video

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -550,6 +550,10 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 		placeholder = "Running in non-interactive mode.";
 	}
 
+	if(!video::has_window()) {
+		placeholder = "Video not initialized yet.";
+	}
+
 	if(!placeholder.empty()) {
 		fmt.set_placeholder(placeholder);
 		return fmt;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -397,6 +397,11 @@ void init_window()
 	update_framebuffer();
 }
 
+bool has_window()
+{
+	return bool(window);
+}
+
 point output_size()
 {
 	if (testing_) {

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -85,6 +85,9 @@ bool testing();
 /* Windowing functions */
 /***********************/
 
+/** Whether the game has set up a window to render into */
+bool has_window();
+
 /** Whether we are currently in fullscreen mode */
 bool is_fullscreen();
 


### PR DESCRIPTION
There is currently a bug in master causing `--report` to raise a segmentation fault because of an attempt to dereference a null pointer to the game window to check the game's display configuration.

At some point in 1.17.x, the check for whether the game window was null disappeared. This brings it back by exposing a check through the `video` namespace so as to avoid piggybacking further on the `video::get_window()` function, which we are meant to avoid using.