### PR TITLE
bi: Re-add screen dpi report line, add information on the renderer setup

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -564,6 +564,12 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 	fmt.insert("Final render target size", geometry_to_string(video::output_size()));
 	fmt.insert("Screen refresh rate", std::to_string(video::current_refresh_rate()));
 
+	const auto& renderer_report = video::renderer_report();
+
+	for(const auto& info : renderer_report) {
+		fmt.insert(info.first, info.second);
+	}
+
 	return fmt;
 }
 

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -521,6 +521,13 @@ inline std::string geometry_to_string(point p)
 	return std::to_string(p.x) + 'x' + std::to_string(p.y);
 }
 
+template<typename coordinateType>
+inline std::string geometry_to_string(coordinateType horizontal, coordinateType vertical)
+{
+	// Use a stream in order to control significant digits in non-integers
+	return formatter() << std::fixed << std::setprecision(2) << horizontal << 'x' << vertical;
+}
+
 std::string format_sdl_driver_list(std::vector<std::string> drivers, const std::string& current_driver)
 {
 	bool found_current_driver = false;
@@ -558,11 +565,19 @@ list_formatter video_settings_report_internal(const std::string& heading = "")
 	const auto& current_driver = video::current_driver();
 	auto drivers = video::enumerate_drivers();
 
+	const auto& dpi = video::get_dpi();
+	std::string dpi_report;
+
+	dpi_report = dpi.first == 0.0f || dpi.second == 0.0f ?
+				 "<unknown>" :
+				 geometry_to_string(dpi.first, dpi.second);
+
 	fmt.insert("SDL video drivers", format_sdl_driver_list(drivers, current_driver));
 	fmt.insert("Window size", geometry_to_string(video::current_resolution()));
 	fmt.insert("Game canvas size", geometry_to_string(video::game_canvas_size()));
 	fmt.insert("Final render target size", geometry_to_string(video::output_size()));
 	fmt.insert("Screen refresh rate", std::to_string(video::current_refresh_rate()));
+	fmt.insert("Screen dpi", dpi_report);
 
 	const auto& renderer_report = video::renderer_report();
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -823,4 +823,33 @@ void update_buffers(bool autoupdate)
 	}
 }
 
+std::vector<std::pair<std::string, std::string>> renderer_report()
+{
+	std::vector<std::pair<std::string, std::string>> res;
+	SDL_Renderer* rnd;
+	SDL_RendererInfo ri;
+
+	if(window && (rnd = *window) && SDL_GetRendererInfo(rnd, &ri) == 0) {
+		std::string renderer_name = ri.name ? ri.name : "<unknown>";
+
+		if(ri.flags & SDL_RENDERER_SOFTWARE) {
+			renderer_name += " (sw)";
+		}
+
+		if(ri.flags & SDL_RENDERER_ACCELERATED) {
+			renderer_name += " (hw)";
+		}
+
+		std::string renderer_max = std::to_string(ri.max_texture_width) +
+								   'x' +
+								   std::to_string(ri.max_texture_height);
+
+		res.emplace_back("Renderer", renderer_name);
+		res.emplace_back("Maximum texture size", renderer_max);
+		res.emplace_back("VSync", ri.flags & SDL_RENDERER_PRESENTVSYNC ? "on" : "off");
+	}
+
+	return res;
+}
+
 } // namespace video

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -823,6 +823,26 @@ void update_buffers(bool autoupdate)
 	}
 }
 
+std::pair<float, float> get_dpi()
+{
+	float hdpi = 0.0f, vdpi = 0.0f;
+	if(window && SDL_GetDisplayDPI(window->get_display_index(), nullptr, &hdpi, &vdpi) == 0) {
+#ifdef TARGET_OS_OSX
+		// SDL 2.0.12 changes SDL_GetDisplayDPI. Function now returns DPI
+		// multiplied by screen's scale factor. This part of code reverts
+		// this multiplication.
+		//
+		// For more info see issue: https://github.com/wesnoth/wesnoth/issues/5019
+		if(sdl::get_version() >= version_info{2, 0, 12}) {
+			float scale_factor = desktop::apple::get_scale_factor(window->get_display_index());
+			hdpi /= scale_factor;
+			vdpi /= scale_factor;
+		}
+#endif
+	}
+	return { hdpi, vdpi };
+}
+
 std::vector<std::pair<std::string, std::string>> renderer_report()
 {
 	std::vector<std::pair<std::string, std::string>> res;

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -329,6 +329,11 @@ private:
  */
 std::vector<std::pair<std::string, std::string>> renderer_report();
 
+/**
+ * Retrieves the current game screen DPI for the @a build_info API.
+ */
+std::pair<float, float> get_dpi();
+
 
 /**************************/
 /* Implementation details */

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -319,6 +319,21 @@ private:
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(quit)
 };
 
+
+/***************/
+/* Diagnostics */
+/***************/
+
+/**
+ * Provides diagnostic information about the current renderer for the @a build_info API.
+ */
+std::vector<std::pair<std::string, std::string>> renderer_report();
+
+
+/**************************/
+/* Implementation details */
+/**************************/
+
 /* This should only be used by draw.cpp for drawing, and texture.cpp for
  * texture creation. Try not to use it for anything else. */
 SDL_Renderer* get_renderer();


### PR DESCRIPTION
This patchset re-adds a clipboard report line for the Game Version dialog showing the game screen's DPI like in 1.16. This particular bit was dropped by mesilliac in the middle of an architectural change to how DPI is handled in the game, however it really shouldn't have been part of the removal given that it's meant to be diagnostic information for developer use when processing bug reports from players.

Additionally, it adds new information on the renderer in use including its name (e.g. "metal" on macOS, "direct3d" on Windows), whether it's a software rasteriser (indicated by "sw"), whether it's hardware accelerated (indicated by "hw"), whether VSync is enabled, and the maximum renderer texture size.