### PR TITLE
Fix HP lost with dehydrated on tooltip

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/lua/theme.lua
+++ b/data/campaigns/Under_the_Burning_Suns/lua/theme.lua
@@ -7,11 +7,12 @@ function wesnoth.interface.game_display.unit_status()
 	local u = wesnoth.interface.get_displayed_unit()
 	if not u then return {} end
 	local s = old_unit_status()
+	local dehydration_loss = wml.variables["dehydration_loss"]
 
 	if u.status.dehydrated then
 		table.insert(s, { "element", {
 			image = "misc/dehydration-status.png",
-			tooltip = _ "dehydrated: This unit is dehydrated. It will lose 4 HP and have its damage reduced by 1 each turn during the day unless prevented by healers or cured by water at an oasis.\n\nUnits cannot be killed or deal no damage as a result of dehydration."
+			tooltip = stringx.vformat(_"dehydrated: This unit is dehydrated. It will lose $dehydration HP and have its damage reduced by 1 each turn during the day unless prevented by healers or cured by water at an oasis.\n\nUnits cannot be killed or deal no damage as a result of dehydration.", {dehydration = dehydration_loss})
 		} })
 	end
 


### PR DESCRIPTION
It's simple, only a variable substitution, and I just tested it. The only problem is that the string will have to be translated again in all languages.
![imagen](https://user-images.githubusercontent.com/40789364/213886939-47ace831-cb5e-4c4e-9c54-6d2cc42169a0.png)
To be more sure, I've tried the spanish translation, and it works.
![imagen](https://user-images.githubusercontent.com/40789364/213887060-14ea41aa-a222-4bfb-8ed7-ad721cce47f3.png)

This should resolve #7295 
