### PR TITLE
Fix game data dir search for Visual Studio builds on Windows

### DIFF
--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -986,12 +986,19 @@ static std::string autodetect_game_data_dir(std::string exe_dir)
 	else if(filesystem::file_exists(exe_dir + "/../data/_main.cfg")) {
 		auto_dir = filesystem::normalize_path(exe_dir + "/..");
 	}
-	// In Windows debug builds, the EXE is placed away from the game data dir
-	// (in projectfiles\VCx\Debug), but the working directory is set to the
-	// game data dir. Thus, check if the working dir is the game data dir.
+	// Allow using the current working directory as the game data dir
 	else if(filesystem::file_exists(filesystem::get_cwd() + "/data/_main.cfg")) {
 		auto_dir = filesystem::get_cwd();
 	}
+#ifdef _WIN32
+	// In Windows builds made using Visual Studio and its CMake
+	// integration, the EXE is placed a few levels below the game data
+	// dir (e.g. .\out\build\x64-Debug).
+	else if(filesystem::file_exists(exe_dir + "/../../build") && filesystem::file_exists(exe_dir + "/../../../out")
+		&& filesystem::file_exists(exe_dir + "/../../../data/_main.cfg")) {
+		auto_dir = filesystem::normalize_path(exe_dir + "/../../..");
+	}
+#endif
 
 	return auto_dir;
 }


### PR DESCRIPTION
The logic we used here hasn't had the desired results since the move from using custom Visual Studio project files to using the CMake integration system, so this patch updates it to match the layout we get with the CMake integration on Visual Studio 2019 and 2022.

Note that without this patch, the game is unable to detect a valid game directory by default when launched by MSVC++ without an explicit path, which results in an assertion failure somewhere in the filesystem API.