### PR TITLE
Add a unit test for scoped arrays

### DIFF
--- a/data/test/scenarios/lua_tests/wml-utils/test_scoped_array.cfg
+++ b/data/test/scenarios/lua_tests/wml-utils/test_scoped_array.cfg
@@ -1,0 +1,54 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: wml_utils.scoped_var
+##
+# Actions:
+# Create a WML container array called test_var.
+# Using Lua, run a block of WML with a scoped var shadowing test_var.
+# Check that the shadow is initialized to an empty array.
+# Check that the reading non-existent elements of the shadow does not access the original.
+# Write to the shadow.
+# Check that the shadow contains the new values.
+# Exit the scope of the temporary shadow.
+##
+# Expected end state:
+# Changes to the shadow did not change the original.
+#####
+{GENERIC_UNIT_TEST "test_scoped_array" (
+    [event]
+        name = prestart
+
+        {VARIABLE test_var[0].value 2}
+        {VARIABLE test_var[1].value 3}
+
+        {ASSERT {VARIABLE_CONDITIONAL test_var[0].value equals 2}}
+        {ASSERT {VARIABLE_CONDITIONAL test_var[1].value equals 3}}
+
+        [lua]
+            code = <<
+                local wml_utils = wesnoth.require "wml-utils"
+                local shadow_var <close> = wml_utils.scoped_var("test_var")
+                -- This runs the contents of [args] as WML actions
+                wml_utils.handle_event_commands(...)
+            >>
+            [args]
+                {ASSERT {VARIABLE_CONDITIONAL test_var.length equals 0}}
+
+                {ASSERT {VARIABLE_CONDITIONAL test_var[0].value equals ""}}
+                {ASSERT {VARIABLE_CONDITIONAL test_var[1].value equals ""}}
+
+                {VARIABLE test_var[0].value 6}
+                {VARIABLE test_var[1].value 7}
+
+                {ASSERT {VARIABLE_CONDITIONAL test_var[0].value equals 6}}
+                {ASSERT {VARIABLE_CONDITIONAL test_var[1].value equals 7}}
+            [/args]
+        [/lua]
+
+        {ASSERT {VARIABLE_CONDITIONAL test_var[0].value equals 2}}
+        {ASSERT {VARIABLE_CONDITIONAL test_var[1].value equals 3}}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/lua_tests/wml-utils/test_scoped_scalar.cfg
+++ b/data/test/scenarios/lua_tests/wml-utils/test_scoped_scalar.cfg
@@ -1,39 +1,45 @@
+# wmllint: no translatables
+
 #####
 # API(s) being tested: wml_utils.scoped_var
 ##
 # Actions:
-# Set test_var to 1.
-# Declare a scoped variable of test_var.
-# Set test_var to 5.
+# Create a WML scalar called test_var.
+# Using Lua, run a block of WML with a scoped var shadowing test_var.
+# Check that the shadowing variable is either uninitialised or initialised to "".
+# Write to the shadow.
+# Check that the shadow contains the new value.
+# Exit the scope of the temporary shadow.
 ##
 # Expected end state:
-# After the scoped variable is declared, test_var has no assigned value.
-# After the scope of the scoped variable ends, test_var's value is back to being 1 rather than 5.
+# Changes to the shadow did not change the original.
 #####
-{GENERIC_UNIT_TEST "test_scoped_vars" (
+{GENERIC_UNIT_TEST "test_scoped_scalar" (
     [event]
         name = prestart
+
         {VARIABLE test_var 1}
-        #[inspect][/inspect]
+
         {ASSERT {VARIABLE_CONDITIONAL test_var equals 1}}
+
         [lua]
             code = <<
                 local wml_utils = wesnoth.require "wml-utils"
-                local var <close> = wml_utils.scoped_var("test_var")
+                local shadow_var <close> = wml_utils.scoped_var("test_var")
                 -- This runs the contents of [args] as WML actions
                 wml_utils.handle_event_commands(...)
             >>
             [args]
-                #[inspect][/inspect]
                 {ASSERT {VARIABLE_CONDITIONAL test_var equals ""}}
+
                 {VARIABLE test_var 5}
-                #[inspect][/inspect]
+
                 {ASSERT {VARIABLE_CONDITIONAL test_var equals 5}}
             [/args]
         [/lua]
 
-        #[inspect][/inspect]
         {ASSERT {VARIABLE_CONDITIONAL test_var equals 1}}
+
         {SUCCEED}
     [/event]
 )}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -229,7 +229,8 @@
 0 test_wml_actions
 0 test_wml_conditionals
 0 lua_wml_tagnames
-0 test_scoped_vars
+0 test_scoped_array
+0 test_scoped_scalar
 0 as_text
 0 test_lua_version_api
 #


### PR DESCRIPTION
The existing test for scoped vars is both copied and renamed.

This passes on 1.16 too (after moving the files to the old directory).