### PR TITLE
CI: Make the Windows CI builds use separate caches

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -267,7 +267,7 @@ jobs:
           path: |
             D:/a/wesnoth/vcpkg
             D:/a/wesnoth/wesnoth/vcpkg_installed
-          key: win-cache-master-0011
+          key: win-cache-master-${{ matrix.cfg }}-0012
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1.3


### PR DESCRIPTION
Looking at recent build failures, one of Debug or Release is using the prebuilt vcpkg from the cache, and the other one is detecting it but then deciding to rebuild many of the packages.

The build logs circa 8bd8c53f9887ae2440b9a4d29ec55655de08b519 are no longer accessible, only the success/failure and time taken are still accessible. Looking at build timings around those changes is inconclusive, however my guess is that the CI is noticing that CFG is different between the two builds, and that's forcing a rebuild for one of them.