### PR TITLE
Make fix_whitespace complain about mixing tabs and spaces

### DIFF
--- a/data/ai/micro_ais/mai-defs/animals.lua
+++ b/data/ai/micro_ais/mai-defs/animals.lua
@@ -2,13 +2,13 @@ local AH = wesnoth.require "ai/lua/ai_helper.lua"
 local MAIH = wesnoth.require("ai/micro_ais/micro_ai_helper.lua")
 
 function wesnoth.micro_ais.big_animals(cfg)
-    local required_keys = { filter = 'tag' }
-    local optional_keys = { avoid_unit = 'tag', filter_location = 'tag', filter_location_wander = 'tag' }
-    local CA_parms = {
-        ai_id = 'mai_big_animals',
-        { ca_id = "move", location = 'ca_big_animals.lua', score = cfg.ca_score or 300000 }
-    }
-    return required_keys, optional_keys, CA_parms
+	local required_keys = { filter = 'tag' }
+	local optional_keys = { avoid_unit = 'tag', filter_location = 'tag', filter_location_wander = 'tag' }
+	local CA_parms = {
+		ai_id = 'mai_big_animals',
+		{ ca_id = "move", location = 'ca_big_animals.lua', score = cfg.ca_score or 300000 }
+	}
+	return required_keys, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.wolves(cfg)
@@ -62,7 +62,7 @@ function wesnoth.micro_ais.wolves(cfg)
 			MAIH.add_aspects(cfg.side, wolves_aspects)
 		end
 	end
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.herding(cfg)
@@ -71,7 +71,7 @@ function wesnoth.micro_ais.herding(cfg)
 	end
 	local required_keys = { filter_location = 'tag', filter = 'tag', filter_second = 'tag' }
 	local optional_keys = { attention_distance = 'integer', attack_distance = 'integer',
-	    herd_loc = 'string', herd_x = 'integer', herd_y = 'integer'
+		herd_loc = 'string', herd_x = 'integer', herd_y = 'integer'
 	}
 	local score = cfg.ca_score or 300000
 	local CA_parms = {
@@ -84,7 +84,7 @@ function wesnoth.micro_ais.herding(cfg)
 		{ ca_id = "dog_move", location = 'ca_herding_dog_move.lua', score = score - 5 },
 		{ ca_id = "dog_stopmove", location = 'ca_herding_dog_stopmove.lua', score = score - 6 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end
 
 local rabbit_registry_counter = 0;
@@ -115,8 +115,8 @@ end
 
 function wesnoth.micro_ais.forest_animals(cfg)
 	local optional_keys = { rabbit_type = 'string', rabbit_number = 'integer',
-	    rabbit_enemy_distance = 'integer', rabbit_hole_img = 'string', tusker_type = 'string',
-	    tusklet_type = 'string', deer_type = 'string', filter_location = 'tag'
+		rabbit_enemy_distance = 'integer', rabbit_hole_img = 'string', tusker_type = 'string',
+		tusklet_type = 'string', deer_type = 'string', filter_location = 'tag'
 	}
 	local score = cfg.ca_score or 300000
 	local CA_parms = {
@@ -145,12 +145,12 @@ function wesnoth.micro_ais.forest_animals(cfg)
 		register_rabbit_commands()
 	end
 
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.swarm(cfg)
 	local optional_keys = { avoid = 'tag', filter = 'tag', scatter_distance = 'integer',
-	    vision_distance = 'integer', enemy_distance = 'integer'
+		vision_distance = 'integer', enemy_distance = 'integer'
 	}
 	local score = cfg.ca_score or 300000
 	local CA_parms = {
@@ -158,7 +158,7 @@ function wesnoth.micro_ais.swarm(cfg)
 		{ ca_id = "scatter", location = 'ca_swarm_scatter.lua', score = score },
 		{ ca_id = "move", location = 'ca_swarm_move.lua', score = score - 1 }
 	}
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.wolves_multipacks(cfg)
@@ -169,23 +169,23 @@ function wesnoth.micro_ais.wolves_multipacks(cfg)
 		{ ca_id = "attack", location = 'ca_wolves_multipacks_attack.lua', score = score },
 		{ ca_id = "wander", location = 'ca_wolves_multipacks_wander.lua', score = score - 1 }
 	}
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.hunter(cfg)
 	if (cfg.action ~= 'delete') then
-	    if (not cfg.id) and (not wml.get_child(cfg, "filter")) then
+		if (not cfg.id) and (not wml.get_child(cfg, "filter")) then
 			wml.error("Hunter [micro_ai] tag requires either id= key or [filter] tag")
 		end
 		AH.get_named_loc_xy('home', cfg, 'Hunter [micro_ai] tag')
 	end
 	local required_keys = {}
 	local optional_keys = { id = 'string', filter = 'tag', filter_location = 'tag', home_loc = 'string',
-	    home_x = 'integer', home_y = 'integer', rest_turns = 'integer', show_messages = 'boolean'
+		home_x = 'integer', home_y = 'integer', rest_turns = 'integer', show_messages = 'boolean'
 	}
 	local CA_parms = {
 		ai_id = 'mai_hunter',
 		{ ca_id = "move", location = 'ca_hunter.lua', score = cfg.ca_score or 300000 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/bottleneck.lua
+++ b/data/ai/micro_ais/mai-defs/bottleneck.lua
@@ -8,7 +8,7 @@ function wesnoth.micro_ais.bottleneck_defense(cfg)
 
 	local required_keys = {}
 	local optional_keys = { location_id = 'string', x = 'integer_list', y = 'integer_list',
-	    enemy_loc = 'string', enemy_x = 'integer_list', enemy_y = 'integer_list',
+		enemy_loc = 'string', enemy_x = 'integer_list', enemy_y = 'integer_list',
 		healer_loc = 'string', healer_x = 'integer_list', healer_y = 'integer_list',
 		leadership_loc = 'string', leadership_x = 'integer_list', leadership_y = 'integer_list',
 		filter = 'tag', active_side_leader = 'boolean'
@@ -19,5 +19,5 @@ function wesnoth.micro_ais.bottleneck_defense(cfg)
 		{ ca_id = 'move', location = 'ca_bottleneck_move.lua', score = score },
 		{ ca_id = 'attack', location = 'ca_bottleneck_attack.lua', score = score - 1 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/escort.lua
+++ b/data/ai/micro_ais/mai-defs/escort.lua
@@ -9,7 +9,7 @@ function wesnoth.micro_ais.messenger_escort(cfg)
 	end
 	local required_keys = {}
 	local optional_keys = { avoid = 'tag', id = 'string', enemy_death_chance = 'float', filter = 'tag', filter_second = 'tag',
-	    invert_order = 'boolean', messenger_death_chance = 'float', waypoint_loc = 'string', waypoint_x = 'integer_list', waypoint_y = 'integer_list'
+		invert_order = 'boolean', messenger_death_chance = 'float', waypoint_loc = 'string', waypoint_x = 'integer_list', waypoint_y = 'integer_list'
 	}
 	local score = cfg.ca_score or 300000
 	local CA_parms = {
@@ -18,5 +18,5 @@ function wesnoth.micro_ais.messenger_escort(cfg)
 		{ ca_id = 'move', location = 'ca_messenger_move.lua', score = score - 1 },
 		{ ca_id = 'escort_move', location = 'ca_messenger_escort_move.lua', score = score - 2 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/fast.lua
+++ b/data/ai/micro_ais/mai-defs/fast.lua
@@ -133,5 +133,5 @@ function wesnoth.micro_ais.fast_ai(cfg)
 			end
 		end
 	end
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/guardian.lua
+++ b/data/ai/micro_ais/mai-defs/guardian.lua
@@ -9,8 +9,8 @@ function wesnoth.micro_ais.stationed_guardian(cfg)
 	end
 	local required_keys = { distance = 'integer' }
 	local optional_keys = { id = 'string', filter = 'tag',
-	    guard_loc = 'string', guard_x = 'integer', guard_y = 'integer',
-	    station_loc = 'string', station_x = 'integer', station_y = 'integer'
+		guard_loc = 'string', guard_x = 'integer', guard_y = 'integer',
+		station_loc = 'string', station_x = 'integer', station_y = 'integer'
 	}
 	local CA_parms = {
 		ai_id = 'mai_stationed_guardian',
@@ -25,7 +25,7 @@ function wesnoth.micro_ais.zone_guardian(cfg)
 	end
 	local required_keys = { filter_location = 'tag' }
 	local optional_keys = { id = 'string', filter = 'tag', filter_location_enemy = 'tag',
-	    station_loc = 'string', station_x = 'integer', station_y = 'integer'
+		station_loc = 'string', station_x = 'integer', station_y = 'integer'
 	}
 	local CA_parms = {
 		ai_id = 'mai_zone_guardian',
@@ -43,7 +43,7 @@ function wesnoth.micro_ais.return_guardian(cfg)
 	end
 	local required_keys = {}
 	local optional_keys = { id = 'string', filter = 'tag',
-	    return_loc = 'string', return_x = 'integer', return_y = 'integer'
+		return_loc = 'string', return_x = 'integer', return_y = 'integer'
 	}
 	local CA_parms = {
 		ai_id = 'mai_return_guardian',
@@ -58,8 +58,8 @@ function wesnoth.micro_ais.coward(cfg)
 	end
 	local required_keys = { distance = 'integer' }
 	local optional_keys = { attack_if_trapped = 'boolean', id = 'string', filter = 'tag',
-	    filter_second = 'tag', seek_loc = 'string', seek_x = 'integer', seek_y = 'integer',
-	    avoid_loc = 'string', avoid_x = 'integer', avoid_y = 'integer'
+		filter_second = 'tag', seek_loc = 'string', seek_x = 'integer', seek_y = 'integer',
+		avoid_loc = 'string', avoid_x = 'integer', avoid_y = 'integer'
 	}
 	local CA_parms = {
 		ai_id = 'mai_coward',

--- a/data/ai/micro_ais/mai-defs/healers.lua
+++ b/data/ai/micro_ais/mai-defs/healers.lua
@@ -1,7 +1,7 @@
 
 function wesnoth.micro_ais.healer_support(cfg)
 	local optional_keys = { aggression = 'float', injured_units_only = 'boolean',
-	    max_threats = 'integer', filter = 'tag', filter_second = 'tag'
+		max_threats = 'integer', filter = 'tag', filter_second = 'tag'
 	}
 	-- Scores for this AI need to be hard-coded, it does not work otherwise
 	local CA_parms = {
@@ -15,5 +15,5 @@ function wesnoth.micro_ais.healer_support(cfg)
 	if (cfg.action == 'delete') or (tonumber(cfg.aggression) ~= 0) then
 		table.insert(CA_parms, { ca_id = 'may_attack', location = 'ca_healer_may_attack.lua', score = 99900 })
 	end
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/misc.lua
+++ b/data/ai/micro_ais/mai-defs/misc.lua
@@ -6,7 +6,7 @@ function wesnoth.micro_ais.assassin(cfg)
 		{ ca_id = 'attack', location = 'ca_simple_attack.lua', score = 110001 },
 		{ ca_id = 'move', location = 'ca_assassin_move.lua', score = 110000 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.lurkers(cfg)
@@ -16,7 +16,7 @@ function wesnoth.micro_ais.lurkers(cfg)
 		ai_id = 'mai_lurkers',
 		{ ca_id = 'move', location = 'ca_lurkers.lua', score = cfg.ca_score or 300000 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end
 
 -- goto is a keyword, so need to use index operator directly
@@ -30,17 +30,17 @@ wesnoth.micro_ais["goto"] = function(cfg)
 		ai_id = 'mai_goto',
 		{ ca_id = 'move', location = 'ca_goto.lua', score = cfg.ca_score or 300000 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.hang_out(cfg)
 	local optional_keys = { filter = 'tag', filter_location = 'tag', avoid = 'tag',
-	    mobilize_condition = 'tag', mobilize_on_gold_less_than = 'integer' }
+		mobilize_condition = 'tag', mobilize_on_gold_less_than = 'integer' }
 	local CA_parms = {
 		ai_id = 'mai_hang_out',
 		{ ca_id = 'move', location = 'ca_hang_out.lua', score = cfg.ca_score or 170000 }
 	}
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.simple_attack(cfg)
@@ -49,5 +49,5 @@ function wesnoth.micro_ais.simple_attack(cfg)
 		ai_id = 'mai_simple_attack',
 		{ ca_id = 'move', location = 'ca_simple_attack.lua', score = cfg.ca_score or 110000 }
 	}
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/patrol.lua
+++ b/data/ai/micro_ais/mai-defs/patrol.lua
@@ -9,12 +9,12 @@ function wesnoth.micro_ais.patrol(cfg)
 	end
 	local required_keys = {}
 	local optional_keys = { id = 'string', filter = 'tag', attack = 'string',
-	    attack_range = 'integer', attack_invisible_enemies = 'boolean', one_time_only = 'boolean',
-	    out_and_back = 'boolean', waypoint_loc = 'string', waypoint_x = 'integer_list', waypoint_y = 'integer_list'
+		attack_range = 'integer', attack_invisible_enemies = 'boolean', one_time_only = 'boolean',
+		out_and_back = 'boolean', waypoint_loc = 'string', waypoint_x = 'integer_list', waypoint_y = 'integer_list'
 	}
 	local CA_parms = {
 		ai_id = 'mai_patrol',
 		{ ca_id = "move", location = 'ca_patrol.lua', score = cfg.ca_score or 300000 }
 	}
-    return required_keys, optional_keys, CA_parms
+	return required_keys, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/protect.lua
+++ b/data/ai/micro_ais/mai-defs/protect.lua
@@ -59,5 +59,5 @@ function wesnoth.micro_ais.protect_unit(cfg)
 		MAIH.add_aspects(cfg.side, aspect_parms)
 	end
 
-    return { unit = 'tag' }, { disable_move_leader_to_keep = 'boolean' }, CA_parms
+	return { unit = 'tag' }, { disable_move_leader_to_keep = 'boolean' }, CA_parms
 end

--- a/data/ai/micro_ais/mai-defs/recruiting.lua
+++ b/data/ai/micro_ais/mai-defs/recruiting.lua
@@ -25,7 +25,7 @@ function wesnoth.micro_ais.recruit_rushers(cfg)
 	}
 
 	handle_default_recruitment(cfg)
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end
 
 function wesnoth.micro_ais.recruit_random(cfg)
@@ -36,5 +36,5 @@ function wesnoth.micro_ais.recruit_random(cfg)
 	}
 
 	handle_default_recruitment(cfg)
-    return {}, optional_keys, CA_parms
+	return {}, optional_keys, CA_parms
 end

--- a/data/ai/micro_ais/micro_ai_helper.lua
+++ b/data/ai/micro_ais/micro_ai_helper.lua
@@ -235,21 +235,21 @@ function micro_ai_helper.micro_ai_setup(cfg, CA_parms, required_keys, optional_k
     for k_name,k_type in pairs(required_keys) do
         if (type(k_name) == 'number') then
             -- Old syntax is supported for Wesnoth 1.17/1.18
-			if k_type:match('%[[a-zA-Z0-9_]+%]')  then
-				k_type = k_type:sub(2,-2)
-				if not wml.get_child(cfg, k_type) then
-					wml.error("[micro_ai] tag (" .. cfg.ai_type .. ") is missing required parameter: [" .. k_type .. "]")
-				end
-				for child in wml.child_range(cfg, k_type) do
-					table.insert(CA_cfg, T[k_type](child))
-				end
-			else
-				if not cfg[k_type] then
-					wml.error("[micro_ai] tag (" .. cfg.ai_type .. ") is missing required parameter: " .. k_type .."=")
-				end
-				CA_cfg[k_type] = cfg[k_type]
-			end
-			show_deprecation_message(cfg.ai_type)
+            if k_type:match('%[[a-zA-Z0-9_]+%]')  then
+                k_type = k_type:sub(2,-2)
+                if not wml.get_child(cfg, k_type) then
+                    wml.error("[micro_ai] tag (" .. cfg.ai_type .. ") is missing required parameter: [" .. k_type .. "]")
+                end
+                for child in wml.child_range(cfg, k_type) do
+                    table.insert(CA_cfg, T[k_type](child))
+                end
+            else
+                if not cfg[k_type] then
+                    wml.error("[micro_ai] tag (" .. cfg.ai_type .. ") is missing required parameter: " .. k_type .."=")
+                end
+                CA_cfg[k_type] = cfg[k_type]
+            end
+            show_deprecation_message(cfg.ai_type)
         elseif (k_type == 'tag') then
             -- Check that this is not a scalar parameter
             if cfg[k_name] then
@@ -274,15 +274,15 @@ function micro_ai_helper.micro_ai_setup(cfg, CA_parms, required_keys, optional_k
     for k_name,k_type in pairs(optional_keys) do
         if (type(k_name) == 'number') then
             -- Old syntax is supported for Wesnoth 1.17/1.18
-			if k_type:match('%[[a-zA-Z0-9_]+%]')  then
-				k_type = k_type:sub(2,-2)
-				for child in wml.child_range(cfg, k_type) do
-					table.insert(CA_cfg, T[k_type](child))
-				end
-			else
-				CA_cfg[k_type] = cfg[k_type]
-			end
-			show_deprecation_message(cfg.ai_type)
+            if k_type:match('%[[a-zA-Z0-9_]+%]')  then
+                k_type = k_type:sub(2,-2)
+                for child in wml.child_range(cfg, k_type) do
+                    table.insert(CA_cfg, T[k_type](child))
+                end
+            else
+                CA_cfg[k_type] = cfg[k_type]
+            end
+            show_deprecation_message(cfg.ai_type)
         elseif (k_type == 'tag') then
             -- Check that this is not a scalar parameter
             if cfg[k_name] then

--- a/data/ai/micro_ais/micro_ai_unit_variables.lua
+++ b/data/ai/micro_ais/micro_ai_unit_variables.lua
@@ -13,9 +13,9 @@
 -- sub-tables in WML format, but there is no need for that at this time.
 
 function wesnoth.custom_synced_commands.MAI_set_unit_variable(cfg)
-	local unit = wesnoth.units.find_on_map { id = cfg.id }[1]
-	local value = wml.get_child(cfg, "value")
-	unit.variables['micro_ai_' .. cfg.ai_id] = value
+    local unit = wesnoth.units.find_on_map { id = cfg.id }[1]
+    local value = wml.get_child(cfg, "value")
+    unit.variables['micro_ai_' .. cfg.ai_id] = value
 end
 
 local function MAI_set_unit_variable(unit, ai_id, value)

--- a/data/campaigns/World_Conquest/lua/game_mechanics/bonus.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/bonus.lua
@@ -54,21 +54,21 @@ end
 function bonus.remove_current_item(ec)
 	wc2_dropping.remove_current_item()
 	--TODO: i don't think its worth to keep this code, to alos allow bonus points to use terrains instead of overlays.
-    wesnoth.wml_actions.terrain {
-        x = ec.x1,
+	wesnoth.wml_actions.terrain {
+		x = ec.x1,
 		y = ec.y1,
-        wml.tag["and"] {
-            terrain = "*^Ecf",
-        },
-        terrain = "Gs",
-        layer = "overlay",
-    }
-    wesnoth.wml_actions.item {
-        x = ec.x1,
+		wml.tag["and"] {
+			terrain = "*^Ecf",
+		},
+		terrain = "Gs",
+		layer = "overlay",
+	}
+	wesnoth.wml_actions.item {
+		x = ec.x1,
 		y = ec.y1,
-        image = "scenery/rubble.png",
+		image = "scenery/rubble.png",
 		z_order = -10,
-    }
+	}
 end
 
 -- check to be overwritten by other mods.

--- a/data/campaigns/World_Conquest/lua/map/scenario_utils/bonus_points.lua
+++ b/data/campaigns/World_Conquest/lua/map/scenario_utils/bonus_points.lua
@@ -1,4 +1,3 @@
-
 ----------------------------------------------------------
 ---- Chooses the location for the bonus points,       ----
 ---- the correct sceneries and creates events to      ----
@@ -60,7 +59,6 @@ function random_placement(locs, orig_num_items, min_distance, command)
 			end
 		end
 	end
-
 end
 
 function get_f_wct_bonus_location_filter(map)
@@ -386,7 +384,7 @@ end
 function world_conquest_tek_bonus_points(theme)
 	local res = {}
 	local scenario_num = wml.variables.wc2_scenario or 1
-    -- wc2_player_count is not available for the first scenario, place bonus points for 3 players
+	-- wc2_player_count is not available for the first scenario, place bonus points for 3 players
 	local player_num =  wml.variables.wc2_player_count or 3
 	oceanic = get_oceanic()
 	f_wct_bonus_location_filter = wesnoth.map.filter(get_f_wct_bonus_location_filter(map), { oceanic = oceanic })

--- a/data/campaigns/World_Conquest/lua/map/scenario_utils/side_definitions.lua
+++ b/data/campaigns/World_Conquest/lua/map/scenario_utils/side_definitions.lua
@@ -1,4 +1,3 @@
-
 ---------------------------------------------------------
 ---- Code to add the [side]s to the [scenario]       ----
 ---- And the wml events to initilize the enemy sides ----
@@ -8,12 +7,12 @@ _ = wesnoth.textdomain "wesnoth-wc"
 
 local function table_join(t1, t2)
 	local r = {}
-    for i=1,#t1 do
-        r[#r+1] = t1[i]
-    end
-    for i=1,#t2 do
-        r[#r+1] = t2[i]
-    end
+	for i=1,#t1 do
+		r[#r+1] = t1[i]
+	end
+	for i=1,#t2 do
+		r[#r+1] = t2[i]
+	end
 	return r
 end
 

--- a/data/lua/diversion.lua
+++ b/data/lua/diversion.lua
@@ -40,10 +40,10 @@ end
 
 local status_anim_update = function(is_undo)
 
-	local ec = wesnoth.current.event_context
-	local changed_something  = false
+        local ec = wesnoth.current.event_context
+        local changed_something  = false
 
-	if not ec.x1 or not ec.y1 then
+        if not ec.x1 or not ec.y1 then
                 return
         end
 
@@ -56,7 +56,7 @@ local status_anim_update = function(is_undo)
         for index, ec_unit in ipairs(div_candidates) do
                 local filter_result = u_pos_filter(ec_unit.id)
                 if filter_result then
-		    changed_something = true
+                    changed_something = true
                     ec_unit.status.diversion = true
                     ec_unit:extract()
                     ec_unit:to_map(false)
@@ -77,7 +77,7 @@ local status_anim_update = function(is_undo)
         for index, ec_unit in ipairs(stop_candidates) do
                 local filter_result = u_pos_filter(ec_unit.id)
                 if not filter_result then
-		    changed_something = true
+                    changed_something = true
                     ec_unit.status.diversion = false
                     ec_unit:extract()
                     ec_unit:to_map(false)
@@ -88,16 +88,16 @@ local status_anim_update = function(is_undo)
                     }
                 end
         end
-	if changed_something and not is_undo then
-		wesnoth.wml_actions.on_undo {
-			wml.tag.on_undo_diversion {
-			}
-		}
-	end
+        if changed_something and not is_undo then
+                wesnoth.wml_actions.on_undo {
+                        wml.tag.on_undo_diversion {
+                        }
+                }
+        end
 end
 
 function wesnoth.wml_actions.on_undo_diversion(cfg)
-	status_anim_update(true)
+        status_anim_update(true)
 end
 
 on_event("moveto, die, recruit, recall", function()

--- a/data/lua/functional.lua
+++ b/data/lua/functional.lua
@@ -8,15 +8,15 @@ local functional = {}
 ---@param condition fun(val:T):boolean
 ---@return T[]
 function functional.filter(input, condition)
-    local filtered_table = {}
+	local filtered_table = {}
 
-    for _,v in ipairs(input) do
-        if condition(v) then
-            table.insert(filtered_table, v)
-        end
-    end
+	for _,v in ipairs(input) do
+		if condition(v) then
+			table.insert(filtered_table, v)
+		end
+	end
 
-    return filtered_table
+	return filtered_table
 end
 
 ---Filter a map for elements matching a certain condition
@@ -26,15 +26,15 @@ end
 ---@param condition fun(key:K, val:V):boolean
 ---@return table<K, V>
 function functional.filter_map(input, condition)
-    local filtered_table = {}
+	local filtered_table = {}
 
-    for k,v in pairs(input) do
-        if condition(k, v) then
-            filtered_table[k] = v
-        end
-    end
+	for k,v in pairs(input) do
+		if condition(k, v) then
+			filtered_table[k] = v
+		end
+	end
 
-    return filtered_table
+	return filtered_table
 end
 
 ---Search an array for an element matching a certain condition
@@ -73,9 +73,9 @@ end
 ---@return number
 ---@return integer
 function functional.choose(input, value)
-    -- Equivalent of choose() function in Formula AI
-    -- Returns element of a table with the largest @value (a function)
-    -- Also returns the max value and the index
+	-- Equivalent of choose() function in Formula AI
+	-- Returns element of a table with the largest @value (a function)
+	-- Also returns the max value and the index
 	if value == nil then
 		value = function(v) return v end
 	elseif type(value) ~= 'function' then
@@ -83,15 +83,15 @@ function functional.choose(input, value)
 		value = function(v) return v[key] end
 	end
 
-    local max_value, best_input, best_key = -math.huge, nil, nil
-    for k,v in ipairs(input) do
+	local max_value, best_input, best_key = -math.huge, nil, nil
+	for k,v in ipairs(input) do
 		local v2 = value(v)
-        if v2 > max_value then
-            max_value, best_input, best_key = v2, v, k
-        end
-    end
+		if v2 > max_value then
+			max_value, best_input, best_key = v2, v, k
+		end
+	end
 
-    return best_input, max_value, best_key
+	return best_input, max_value, best_key
 end
 
 ---Find the key-value pair in a map with the largest value
@@ -102,9 +102,9 @@ end
 ---@return {[1]:K, [2]:V}
 ---@return number
 function functional.choose_map(input, value)
-    -- Equivalent of choose() function in Formula AI
-    -- Returns element of a table with the largest @value (a function)
-    -- Also returns the max value and the index
+	-- Equivalent of choose() function in Formula AI
+	-- Returns element of a table with the largest @value (a function)
+	-- Also returns the max value and the index
 	if value == nil then
 		value = function(k, v) return v end
 	elseif type(value) ~= 'function' then
@@ -112,15 +112,15 @@ function functional.choose_map(input, value)
 		value = function(k, v) return v[key] end
 	end
 
-    local max_value, best_input, best_key = -math.huge, nil, nil
-    for k,v in pairs(input) do
+	local max_value, best_input, best_key = -math.huge, nil, nil
+	for k,v in pairs(input) do
 		local v2 = value(k, v)
-        if v2 > max_value then
-            max_value, best_input, best_key = v2, v, k
-        end
-    end
+		if v2 > max_value then
+			max_value, best_input, best_key = v2, v, k
+		end
+	end
 
-    return {key = best_key, value = best_input}, max_value
+	return {key = best_key, value = best_input}, max_value
 end
 
 ---Map the elements of an array according to an operation

--- a/data/lua/ilua.lua
+++ b/data/lua/ilua.lua
@@ -95,7 +95,7 @@ function ilua.val2str(val)
     elseif tp == 'string' then
         return "'"..val.."'"
     elseif tp == 'number' then
-	-- removed numeric precision features, but we might actually want these... might put them back
+        -- removed numeric precision features, but we might actually want these... might put them back
         return tostring(val)
     else
         return tostring(val)

--- a/data/lua/location_set.lua
+++ b/data/lua/location_set.lua
@@ -352,15 +352,15 @@ end
 ---The third element of each location is used as the value.
 ---@param t location_triple[]
 function methods:of_triples(t)
-    -- Create a location set from a table of 3-element tables
-    -- Elements 1 and 2 are x,y coordinates, #3 is value to be inserted
-    for k,v in pairs(t) do
+	-- Create a location set from a table of 3-element tables
+	-- Elements 1 and 2 are x,y coordinates, #3 is value to be inserted
+	for k,v in pairs(t) do
 		if #v == 0 then
 			self:insert(v.x, v.y, v.value)
 		else
 			self:insert(v[1], v[2], v[3])
 		end
-    end
+	end
 end
 
 --- Add values from a table of location->element mappings
@@ -434,11 +434,11 @@ end
 ---Convert the set to an array of triples - locations with an extra element for the value.
 ---@return location_triple[]
 function methods:to_triples()
-    local res = {}
-    self:iter(function(x, y, v)
+	local res = {}
+	self:iter(function(x, y, v)
 		table.insert(res, wesnoth.named_tuple({ x, y, v }, {"x", "y", "value"}))
 	end)
-    return res
+	return res
 end
 
 ---Convert the set to a map of location -> value
@@ -513,9 +513,9 @@ end
 ---@param t location_triple[]
 ---@return location_set
 function location_set.of_triples(t)
-    local s = location_set.create()
-    s:of_triples(t)
-    return s
+	local s = location_set.create()
+	s:of_triples(t)
+	return s
 end
 
 --- Create a set from a table of location->element mappings

--- a/data/tools/check_mixed_indent
+++ b/data/tools/check_mixed_indent
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+"""
+Flag an error if a single file uses both tabs and spaces for indenting.
+
+This does not change files, on the assumption that the mess is better
+handled with a text editor or a code reformatting tool.
+"""
+
+import  argparse, re, sys
+
+def check_indent(file):
+    has_tabs = False
+    with open(file, encoding="utf8") as lines:
+        for line in lines:
+            if re.match("\t", line):
+                has_tabs = True
+                break
+
+        if has_tabs:
+            lines.seek(0)
+            for line in lines:
+                if re.match("    ", line):
+                    print("{file} uses both tabs and spaces for indents".format(file=file))
+                    return False
+
+        # Only one type of indent appears at the start of each line, so this only needs to
+        # check one way round for mixtures on the same line.
+        if has_tabs:
+            mixed_line_re = re.compile("\t+ ")
+        else:
+            mixed_line_re = re.compile(" +\t")
+        lines.seek(0)
+        for line in lines:
+            if mixed_line_re.match(line):
+                print("{file} indents with tabs and spaces on the same line".format(file=file))
+                return False
+
+    return True
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(usage=__doc__)
+    ap.add_argument("files", metavar="string", nargs="*", help="Read input from these files")
+    options = ap.parse_args()
+
+    all_files_ok = True
+
+    for file in options.files:
+        try:
+            if not check_indent(file):
+                all_files_ok = False
+        except UnicodeDecodeError:
+            all_files_ok = False
+            print("{file}: invalid utf-8".format(file=file))
+        except:
+            all_files_ok = False
+            print("{file}: raised exception {error}".format(file=file, error=sys.exc_info()[0]))
+
+    if not all_files_ok:
+        sys.exit(1)
+
+    sys.exit(0)

--- a/utils/CI/fix_whitespace.sh
+++ b/utils/CI/fix_whitespace.sh
@@ -11,3 +11,5 @@ else
   find src/ -name \*.\[ch\]pp -print0 | xargs -0 sed -i '' 's/[[:blank:]]*$//'
   find data/ -name \*.lua -print0 | xargs -0 sed -i '' 's/[[:blank:]]*$//'
 fi
+
+find data/ -name \*.lua -print0 | xargs -0 data/tools/check_mixed_indent


### PR DESCRIPTION
Ensures that files either use tabs for indentation or spaces for indentation, but don't switch between the two within the same file.

This doesn't fix the whitespace, it's a simple check to flag it up on the assumption that it's better to use an editor or code formatter to clean up the file.

Elsewhere in the CI we use the luacheck tool - while that can detect mixing tabs and spaces in a single line's indent, it doesn't check for inconsistent indentation within a file.