### PR TITLE
Add Sand Scamperer

### DIFF
--- a/data/core/units/monsters/Sand_Scamperer.cfg
+++ b/data/core/units/monsters/Sand_Scamperer.cfg
@@ -1,0 +1,53 @@
+#textdomain wesnoth-units
+[unit_type]
+    id=Sand Scamperer
+    [base_unit]
+        id=Giant Scorpling
+    [/base_unit]
+    name= _ "Sand Scamperer"
+    small_profile="portraits/monsters/scorpion.webp~FL()~CROP(0,82,400,318)~CS(7,-8,-51)"
+    profile="portraits/monsters/scorpion.webp~RIGHT()~CS(7,-8,-51)"
+    image="units/monsters/scorpion/scorpling.png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51)"
+    undead_variation=sand_scorpion
+    description= _ "This impressive creature swiftly moves through the scorching desert sand. Its body is covered in a thick, sand-colored exoskeleton absorbing any impact damage. However, it is also highly flammable and vulnerable to arcane energy, making fire and magic-based attacks the most effective way to take this venomous critter down."
+    hitpoints=27
+    [resistance]
+        blade=90
+        pierce=90
+        impact=30
+        fire=200
+        cold=120
+        arcane=150
+    [/resistance]
+    advances_to=Sand Scuttler
+    {DEFENSE_ANIM "units/monsters/scorpion/scorpling-defend2.png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51)" "units/monsters/scorpion/scorpling-defend1.png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51)" hiss.wav }
+
+    [attack_anim]
+        [filter_attack]
+            name=pincers
+        [/filter_attack]
+        start_time=-300
+        offset=0:200,0~0.6:150,0.6~0:150
+        [frame]
+            image="units/monsters/scorpion/scorpling-pincer[1~7].png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51):[50,75,75,50,50,75,100]"
+        [/frame]
+        {SOUND:HIT_AND_MISS pincers.ogg {SOUND_LIST:MISS} -50}
+        [frame]
+            image="units/monsters/scorpion/scorpling.png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51):25"
+        [/frame]
+    [/attack_anim]
+    [attack_anim]
+        [filter_attack]
+            name=sting
+        [/filter_attack]
+        start_time=-250
+        offset=0:150,0~0.6:150,0.6:100,0.6~0:150
+        [frame]
+            image="units/monsters/scorpion/scorpling-sting[1~5].png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51):[75,75,150,100,150]"
+        [/frame]
+        {SOUND:HIT_AND_MISS spear.ogg {SOUND_LIST:MISS} -100}
+        [frame]
+            image="units/monsters/scorpion/scorpling.png~PAL(b6c8da,9fa9c1,8384a3,5f607f,414c5e,1d2c49>dab6c4,c19fa5,a38583,7f615f,5f414a,491d27)~CS(7,-8,-51):1"
+        [/frame]
+    [/attack_anim]
+[/unit_type]


### PR DESCRIPTION
The Sand Scuttler has been separated from the Giant Scorpion. This commit adds a Level 0 counterpart of the Giant Scorpling which advances into the Sand Scuttler.
See also: #7244 