### PR TITLE
UTBS Minion and Spire XP reduced

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
@@ -15,7 +15,7 @@
         cold=90
         arcane=120
     [/resistance]
-    experience=150
+    experience=50
     {AMLA_DEFAULT}
     level=0
     alignment=chaotic

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
@@ -15,7 +15,7 @@
         cold=90
         arcane=120
     [/resistance]
-    experience=0
+    experience=150
     level=0
     alignment=chaotic
     advances_to=null

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Minion.cfg
@@ -15,8 +15,7 @@
         cold=90
         arcane=120
     [/resistance]
-    experience=50
-    {AMLA_DEFAULT}
+    experience=0
     level=0
     alignment=chaotic
     advances_to=null

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg
@@ -22,7 +22,7 @@
         cave=50
     [/defense]
     movement=1
-    experience=0
+    experience=150
     level=0
     alignment=chaotic
     advances_to=null

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg
@@ -22,8 +22,7 @@
         cave=50
     [/defense]
     movement=1
-    experience=100
-    {AMLA_DEFAULT}
+    experience=0
     level=0
     alignment=chaotic
     advances_to=null

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Alien_Spire.cfg
@@ -22,7 +22,7 @@
         cave=50
     [/defense]
     movement=1
-    experience=150
+    experience=100
     {AMLA_DEFAULT}
     level=0
     alignment=chaotic


### PR DESCRIPTION

![imagen](https://user-images.githubusercontent.com/40789364/215347397-c8c6c785-b52f-45c4-a1f4-ed974a017554.png)

All the alien units have the same experience, resulting in this disproportion, and it looks pretty ugly.

I can change the ratio of the experience bar with xp_bar_scaling, but reducing the experience is the best option, it does not affect the balance since they are low health units, it is very almost impossible for them to level up.