### PR TITLE
Orb related cleanup for preferences and game_config

### DIFF
--- a/data/game_config.cfg
+++ b/data/game_config.cfg
@@ -49,8 +49,6 @@
 
     [colors]
         ally_orb_color="lightblue"
-        # on the minimap, disengaged uses the same color as partial
-        disengaged_orb_color="brightorange"
         enemy_orb_color="black"
         moved_orb_color="red"
         partial_orb_color="brightorange"

--- a/data/schema/core/config.cfg
+++ b/data/schema/core/config.cfg
@@ -52,7 +52,6 @@
 		name="colors"
 		min=1
 		{SIMPLE_KEY ally_orb_color string}
-		{SIMPLE_KEY disengaged_orb_color string}
 		{SIMPLE_KEY enemy_orb_color string}
 		{SIMPLE_KEY moved_orb_color string}
 		{SIMPLE_KEY partial_orb_color string}

--- a/data/schema/core/config.cfg
+++ b/data/schema/core/config.cfg
@@ -42,6 +42,13 @@
 	{SIMPLE_KEY footprint_teleport_exit string}
 	{SIMPLE_KEY fog_prefix string}
 	{SIMPLE_KEY shroud_prefix string}
+	{SIMPLE_KEY show_ally_orb bool}
+	{SIMPLE_KEY show_disengaged_orb bool}
+	{SIMPLE_KEY show_enemy_orb bool}
+	{SIMPLE_KEY show_moved_orb bool}
+	{SIMPLE_KEY show_partial_orb bool}
+	{SIMPLE_KEY show_status_on_ally_orb bool}
+	{SIMPLE_KEY show_unmoved_orb bool}
 	[tag]
 		name="server"
 		max=infinite

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -170,7 +170,6 @@ std::vector<std::string> default_colors;
 namespace colors
 {
 std::string ally_orb_color;
-std::string disengaged_orb_color;
 std::string enemy_orb_color;
 std::string moved_orb_color;
 std::string partial_orb_color;
@@ -315,7 +314,6 @@ void load_config(const config &v)
 		partial_orb_color  = i["partial_orb_color"].str();
 		enemy_orb_color    = i["enemy_orb_color"].str();
 		ally_orb_color     = i["ally_orb_color"].str();
-		disengaged_orb_color = i["disengaged_orb_color"].str();
 	} // colors
 
 	show_ally_orb     = v["show_ally_orb"].to_bool(true);

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -319,7 +319,7 @@ void load_config(const config &v)
 	show_ally_orb     = v["show_ally_orb"].to_bool(true);
 	show_enemy_orb    = v["show_enemy_orb"].to_bool(false);
 	show_moved_orb    = v["show_moved_orb"].to_bool(true);
-	show_partial_orb  = v["show_partly_orb"].to_bool(true);
+	show_partial_orb  = v["show_partial_orb"].to_bool(true);
 	show_status_on_ally_orb = v["show_status_on_ally_orb"].to_bool(true);
 	show_unmoved_orb  = v["show_unmoved_orb"].to_bool(true);
 	show_disengaged_orb = v["show_disengaged_orb"].to_bool(true);

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -90,7 +90,6 @@ namespace game_config
 
 	namespace colors {
 	extern std::string ally_orb_color;
-	extern std::string disengaged_orb_color;
 	extern std::string enemy_orb_color;
 	extern std::string moved_orb_color;
 	extern std::string partial_orb_color;

--- a/src/gui/dialogs/select_orb_colors.cpp
+++ b/src/gui/dialogs/select_orb_colors.cpp
@@ -82,8 +82,6 @@ void select_orb_colors::post_show(window&)
 
 	preferences::set_unmoved_color(groups_["unmoved"].get_active_member_value());
 	preferences::set_partial_color(groups_["partial"].get_active_member_value());
-	// For the minimap, show disengaged units as partially moved
-	preferences::set_disengaged_color(groups_["partial"].get_active_member_value());
 	preferences::set_moved_color(groups_["moved"].get_active_member_value());
 	preferences::set_allied_color(groups_["ally"].get_active_member_value());
 	preferences::set_enemy_color(groups_["enemy"].get_active_member_value());

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -379,16 +379,6 @@ void set_partial_color(const std::string& color_id) {
 	prefs["partial_orb_color"] = color_id;
 }
 
-std::string disengaged_color() {
-	std::string disengaged_color = get("disengaged_orb_color");
-	if (disengaged_color.empty())
-		return game_config::colors::disengaged_orb_color;
-	return fix_orb_color_name(disengaged_color);
-}
-void set_disengaged_color(const std::string& color_id) {
-	prefs["disengaged_orb_color"] = color_id;
-}
-
 bool scroll_to_action()
 {
 	return get("scroll_to_action", true);

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -185,9 +185,6 @@ namespace preferences {
 	std::string moved_color();
 	void set_moved_color(const std::string& color_id);
 
-	std::string disengaged_color();
-	void set_disengaged_color(const std::string& color_id);
-
 	bool show_ally_orb();
 	void set_show_ally_orb(bool show_orb);
 

--- a/src/units/orb_status.cpp
+++ b/src/units/orb_status.cpp
@@ -45,7 +45,7 @@ std::string orb_status_helper::get_orb_color(orb_status os)
 	case orb_status::moved:
 		return preferences::moved_color();
 	case orb_status::disengaged:
-		return preferences::disengaged_color();
+		[[fallthrough]]; // use partial_color() for any context that wants a single color
 	case orb_status::partial:
 		return preferences::partial_color();
 	case orb_status::allied:


### PR DESCRIPTION
Assorted cleanup, fixes #7261.

* Add `game_config.cfg`'s `show_*_orb` to the schema
* Rename `show_partly_orb`
* Remove the unused `disengaged_orb_color` preference

The `show_*_orb` keys are supported in game_config.cfg, but currently they're not used in that file, instead falling back to the defaults in the C++. Add them to the schema, but not to `game_config.cfg` itself.

The name `show_partly_orb` was inconsistent - in other places, including the WML that's stored in the user's preferences file, it's called `show_partial_orb`.

Remove leftovers from the original implementation of the disengage orb, when it was a new color for the single-color orb. During the review process it became the two-color design, but these parts were left in.

The value of orb_status_helper::get_orb_color(orb_status::disengaged) is used (both before and after this commit) by the minimap; this commit changes get_orb_color to return the partial_color() directly. The result will be the same as before, because disengage_color() returned the same as partial_color(). Prior to this commit that was done by giving both orbs the same value in game_config.cfg. If the advanced preference to change orbs colors was used, the value chosen for the partial orb was passed to set_disengage_color() too.