### PR TITLE
[1.16] Ally orb color preferences

### DIFF
--- a/changelog_entries/ally_orbs.md
+++ b/changelog_entries/ally_orbs.md
@@ -1,0 +1,4 @@
+ ### Multiplayer
+   * Allied units’ orbs no longer look like the player’s own units’ orbs (issue #7108).
+       * By default, they are now two-color during the ally’s turn.
+       * Added an advanced setting to always show them as single-color (the ally color).

--- a/changelog_entries/orb_prefs_layout.md
+++ b/changelog_entries/orb_prefs_layout.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * Improved the layout of the orb colors dialog, and added tooltips.

--- a/data/gui/window/select_orb_colors.cfg
+++ b/data/gui/window/select_orb_colors.cfg
@@ -149,7 +149,9 @@
 			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP moved (_"Show moved orb")}
 			{_GUI_ORB_SPACER_ROW}
-			{_GUI_ORB_GROUP ally (_"Show ally orb")}
+			{_GUI_ORB_TWO_COLOR ally
+				(_"Show ally orb")
+				(_"During ally’s turn, use a two-color orb to show movement") (_"During your allies’ turns, their units have a two-color orb. One half is the ally orb color, and the other half shows whether the unit is unmoved, partially moved or fully moved.")}
 			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP enemy (_"Show enemy orb")}
 			[row]

--- a/data/gui/window/select_orb_colors.cfg
+++ b/data/gui/window/select_orb_colors.cfg
@@ -1,8 +1,19 @@
 #textdomain wesnoth-lib
 
+#define _GUI_ORB_SPACER_ROW
+	[row]
+		grow_factor = 0
+		[column]
+			[spacer]
+				height = 15
+			[/spacer]
+		[/column]
+	[/row]
+#enddef
+
 #define _GUI_ORB_CELL PURPOSE COLOR
 	[column]
-		border = "all"
+		border = "left,right,bottom"
 		border_size = 5
 		[toggle_button]
 			id = "orb_{PURPOSE}_{COLOR}"
@@ -51,7 +62,7 @@
 	[/row]
 #enddef
 
-#define _GUI_ORB_NO_COLOR PURPOSE LABEL NO_COLOR_REASON
+#define _GUI_ORB_TWO_COLOR PURPOSE LABEL_SHOW LABEL_TWO_COLOR TOOLTIP_TWO_COLOR
 	[row]
 		[column]
 			horizontal_alignment = "left"
@@ -60,19 +71,42 @@
 			[toggle_button]
 				id = "orb_{PURPOSE}_show"
 				definition = "default"
-				label = {LABEL}
+				label = {LABEL_SHOW}
 			[/toggle_button]
 		[/column]
 	[/row]
+
+	[row]
+		[column]
+			horizontal_grow = true
+			[grid]
+				[row]
+					[column]
+						horizontal_alignment = "left"
+						border = "all"
+						border_size = 5
+						[toggle_button]
+							id = "orb_{PURPOSE}_two_color"
+							definition = "default"
+							label = {LABEL_TWO_COLOR}
+							tooltip = {TOOLTIP_TWO_COLOR}
+						[/toggle_button]
+					[/column]
+
+					[column]
+						grow_factor = 1
+						[spacer]
+						[/spacer]
+					[/column]
+				[/row]
+			[/grid]
+		[/column]
+	[/row]
+
 	[row]
 		[column]
 			horizontal_alignment = "left"
-			border = "all"
-			border_size = 5
-			[label]
-				definition = "default"
-				label = {NO_COLOR_REASON}
-			[/label]
+			{_GUI_ORB_ROW {PURPOSE}}
 		[/column]
 	[/row]
 #enddef
@@ -108,11 +142,16 @@
 				[/column]
 			[/row]
 			{_GUI_ORB_GROUP unmoved (_"Show unmoved orb")}
-			{_GUI_ORB_GROUP partial (_"Show partial moved orb")}
+			{_GUI_ORB_SPACER_ROW}
+			{_GUI_ORB_TWO_COLOR partial
+				(_"Show partially moved orb")
+				(_"Use a two-color orb for disengaged units") (_"If a unit can move but can’t attack, show a two-color orb with the colors for partially and fully moved.")}
+			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP moved (_"Show moved orb")}
+			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP ally (_"Show ally orb")}
+			{_GUI_ORB_SPACER_ROW}
 			{_GUI_ORB_GROUP enemy (_"Show enemy orb")}
-			{_GUI_ORB_NO_COLOR disengaged (_"Show disengaged orb") (_"This uses the colors for partial and moved orbs.")}
 			[row]
 				[column]
 					horizontal_grow = true
@@ -159,7 +198,8 @@
 	[/resolution]
 [/window]
 
-#undef _GUI_ORB_NO_COLOR
+#undef _GUI_ORB_TWO_COLOR
 #undef _GUI_ORB_GROUP
 #undef _GUI_ORB_ROW
 #undef _GUI_ORB_CELL
+#undef _GUI_ORB_SPACER_ROW

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -138,6 +138,7 @@ bool show_disengaged_orb;
 bool show_enemy_orb;
 bool show_moved_orb;
 bool show_partial_orb;
+bool show_status_on_ally_orb;
 bool show_unmoved_orb;
 
 //
@@ -321,6 +322,7 @@ void load_config(const config &v)
 	show_enemy_orb    = v["show_enemy_orb"].to_bool(false);
 	show_moved_orb    = v["show_moved_orb"].to_bool(true);
 	show_partial_orb  = v["show_partly_orb"].to_bool(true);
+	show_status_on_ally_orb = v["show_status_on_ally_orb"].to_bool(true);
 	show_unmoved_orb  = v["show_unmoved_orb"].to_bool(true);
 	show_disengaged_orb = v["show_disengaged_orb"].to_bool(true);
 

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -103,6 +103,7 @@ namespace game_config
 	extern bool show_enemy_orb;
 	extern bool show_moved_orb;
 	extern bool show_partial_orb;
+	extern bool show_status_on_ally_orb;
 	extern bool show_unmoved_orb;
 
 	namespace images {

--- a/src/gui/dialogs/select_orb_colors.cpp
+++ b/src/gui/dialogs/select_orb_colors.cpp
@@ -55,8 +55,7 @@ select_orb_colors::select_orb_colors()
 void select_orb_colors::pre_show(window& window)
 {
 	setup_orb_group("unmoved", show_unmoved_, preferences::unmoved_color());
-	setup_orb_group("partial", show_partial_, preferences::partial_color());
-	setup_orb_toggle("disengaged", show_disengaged_);
+	setup_orb_group_two_color("partial", show_partial_, show_disengaged_, preferences::partial_color());
 	setup_orb_group("moved", show_moved_, preferences::moved_color());
 	setup_orb_group("ally", show_ally_, preferences::allied_color());
 	setup_orb_group("enemy", show_enemy_, preferences::enemy_color());
@@ -119,7 +118,18 @@ void select_orb_colors::setup_orb_group(const std::string& base_id, bool& shown,
 	group.set_member_states(initial);
 }
 
-void select_orb_colors::reset_orb_toggle(const std::string& base_id, bool& shown)
+void select_orb_colors::setup_orb_group_two_color(const std::string& base_id, bool& shown, bool& two_color, const std::string& initial)
+{
+	setup_orb_group(base_id, shown, initial);
+
+	const std::string prefix = get_orb_widget_prefix(base_id);
+	toggle_button& toggle = find_widget<toggle_button>(get_window(), prefix + "two_color", false);
+	toggle.set_value_bool(two_color);
+
+	connect_signal_mouse_left_click(toggle, std::bind(&select_orb_colors::toggle_orb_callback, this, std::ref(two_color)));
+}
+
+void select_orb_colors::reset_orb_toggle(const std::string& base_id, bool shown)
 {
 	const std::string prefix = get_orb_widget_prefix(base_id);
 
@@ -127,14 +137,26 @@ void select_orb_colors::reset_orb_toggle(const std::string& base_id, bool& shown
 	toggle.set_value_bool(shown);
 }
 
-void select_orb_colors::reset_orb_group(const std::string& base_id, bool& shown, const std::string& initial)
+void select_orb_colors::reset_orb_group(const std::string& base_id, bool shown, const std::string& initial)
 {
 	reset_orb_toggle(base_id, shown);
 	groups_[base_id].set_member_states(initial);
 }
 
+void select_orb_colors::reset_orb_group_two_color(const std::string& base_id, bool shown, bool two_color, const std::string& initial)
+{
+	reset_orb_group(base_id, shown, initial);
+
+	const std::string prefix = get_orb_widget_prefix(base_id);
+
+	toggle_button& toggle = find_widget<toggle_button>(get_window(), prefix + "two_color", false);
+	toggle.set_value_bool(two_color);
+}
+
 void select_orb_colors::toggle_orb_callback(bool& storage)
 {
+	// The code for the two-color groups uses this for both the main setting and the two_color setting - if
+	// you add any extra logic here, check that it's still also applicable to the two_color setting.
 	storage = !storage;
 }
 
@@ -148,8 +170,7 @@ void select_orb_colors::reset_orb_callback()
 	show_enemy_ = game_config::show_enemy_orb;
 
 	reset_orb_group("unmoved", show_unmoved_, game_config::colors::unmoved_orb_color);
-	reset_orb_group("partial", show_partial_, game_config::colors::partial_orb_color);
-	reset_orb_toggle("disengaged", show_disengaged_);
+	reset_orb_group_two_color("partial", show_partial_, show_disengaged_, game_config::colors::partial_orb_color);
 	reset_orb_group("moved", show_moved_, game_config::colors::moved_orb_color);
 	reset_orb_group("ally", show_ally_, game_config::colors::ally_orb_color);
 	reset_orb_group("enemy", show_enemy_, game_config::colors::enemy_orb_color);

--- a/src/gui/dialogs/select_orb_colors.cpp
+++ b/src/gui/dialogs/select_orb_colors.cpp
@@ -47,7 +47,8 @@ select_orb_colors::select_orb_colors()
 	, show_partial_(preferences::show_partial_orb())
 	, show_disengaged_(preferences::show_disengaged_orb())
 	, show_moved_(preferences::show_moved_orb())
-	, show_ally_(preferences::show_allied_orb())
+	, show_ally_(preferences::show_ally_orb())
+	, two_color_ally_(preferences::show_status_on_ally_orb())
 	, show_enemy_(preferences::show_enemy_orb())
 {
 }
@@ -57,7 +58,7 @@ void select_orb_colors::pre_show(window& window)
 	setup_orb_group("unmoved", show_unmoved_, preferences::unmoved_color());
 	setup_orb_group_two_color("partial", show_partial_, show_disengaged_, preferences::partial_color());
 	setup_orb_group("moved", show_moved_, preferences::moved_color());
-	setup_orb_group("ally", show_ally_, preferences::allied_color());
+	setup_orb_group_two_color("ally", show_ally_, two_color_ally_, preferences::allied_color());
 	setup_orb_group("enemy", show_enemy_, preferences::enemy_color());
 
 	connect_signal_mouse_left_click(
@@ -74,7 +75,8 @@ void select_orb_colors::post_show(window&)
 	preferences::set_show_partial_orb(show_partial_);
 	preferences::set_show_disengaged_orb(show_disengaged_);
 	preferences::set_show_moved_orb(show_moved_);
-	preferences::set_show_allied_orb(show_ally_);
+	preferences::set_show_ally_orb(show_ally_);
+	preferences::set_show_status_on_ally_orb(two_color_ally_);
 	preferences::set_show_enemy_orb(show_enemy_);
 
 	preferences::set_unmoved_color(groups_["unmoved"].get_active_member_value());
@@ -167,12 +169,13 @@ void select_orb_colors::reset_orb_callback()
 	show_disengaged_ = game_config::show_disengaged_orb;
 	show_moved_ = game_config::show_moved_orb;
 	show_ally_ = game_config::show_ally_orb;
+	two_color_ally_ = game_config::show_status_on_ally_orb;
 	show_enemy_ = game_config::show_enemy_orb;
 
 	reset_orb_group("unmoved", show_unmoved_, game_config::colors::unmoved_orb_color);
 	reset_orb_group_two_color("partial", show_partial_, show_disengaged_, game_config::colors::partial_orb_color);
 	reset_orb_group("moved", show_moved_, game_config::colors::moved_orb_color);
-	reset_orb_group("ally", show_ally_, game_config::colors::ally_orb_color);
+	reset_orb_group_two_color("ally", show_ally_, two_color_ally_, game_config::colors::ally_orb_color);
 	reset_orb_group("enemy", show_enemy_, game_config::colors::enemy_orb_color);
 }
 

--- a/src/gui/dialogs/select_orb_colors.hpp
+++ b/src/gui/dialogs/select_orb_colors.hpp
@@ -34,11 +34,31 @@ public:
 	DEFINE_SIMPLE_DISPLAY_WRAPPER(select_orb_colors)
 
 private:
+	/**
+	 * Sets up the checkbox that's common to the no-color, one-color and two-color settings.
+	 * Sets its ticked/unticked state and connects the callback for user interaction.
+	 */
 	void setup_orb_toggle(const std::string& base_id, bool& shown);
+	/**
+	 * Sets up the checkbox and row of color buttons for the one-color options, including
+	 * connecting the callbacks for user interaction.
+	 *
+	 * @param base_id which group of checkboxes and buttons to affect
+	 * @param shown the checkbox's ticked state (input and asynchronous output)
+	 * @param initial which color to select (input only)
+	 */
 	void setup_orb_group(const std::string& base_id, bool& shown, const std::string& initial);
+	/**
+	 * Sets up two checkboxes and a row of color buttons.
+	 */
+	void setup_orb_group_two_color(const std::string& base_id, bool& shown, bool& two_color, const std::string& initial);
 
-	void reset_orb_toggle(const std::string& base_id, bool& shown);
-	void reset_orb_group(const std::string& base_id, bool& shown, const std::string& initial);
+	/**
+	 * Change the UI's ticked/unticked state. Neither sets up nor triggers callbacks.
+	 */
+	void reset_orb_toggle(const std::string& base_id, bool shown);
+	void reset_orb_group(const std::string& base_id, bool shown, const std::string& initial);
+	void reset_orb_group_two_color(const std::string& base_id, bool shown, bool two_color, const std::string& initial);
 
 	void toggle_orb_callback(bool& storage);
 	void reset_orb_callback();

--- a/src/gui/dialogs/select_orb_colors.hpp
+++ b/src/gui/dialogs/select_orb_colors.hpp
@@ -68,6 +68,7 @@ private:
 	bool show_disengaged_;
 	bool show_moved_;
 	bool show_ally_;
+	bool two_color_ally_;
 	bool show_enemy_;
 
 	std::map<std::string, group<std::string>> groups_;

--- a/src/preferences/general.cpp
+++ b/src/preferences/general.cpp
@@ -257,11 +257,18 @@ void load_base_prefs() {
 }
 
 
-bool show_allied_orb() {
+bool show_ally_orb() {
 	return get("show_ally_orb", game_config::show_ally_orb);
 }
-void set_show_allied_orb(bool show_orb) {
+void set_show_ally_orb(bool show_orb) {
 	prefs["show_ally_orb"] = show_orb;
+}
+
+bool show_status_on_ally_orb() {
+	return get("show_status_on_ally_orb", game_config::show_status_on_ally_orb);
+}
+void set_show_status_on_ally_orb(bool show_orb) {
+	prefs["show_status_on_ally_orb"] = show_orb;
 }
 
 bool show_enemy_orb() {

--- a/src/preferences/general.hpp
+++ b/src/preferences/general.hpp
@@ -173,8 +173,11 @@ namespace preferences {
 	std::string disengaged_color();
 	void set_disengaged_color(const std::string& color_id);
 
-	bool show_allied_orb();
-	void set_show_allied_orb(bool show_orb);
+	bool show_ally_orb();
+	void set_show_ally_orb(bool show_orb);
+
+	bool show_status_on_ally_orb();
+	void set_show_status_on_ally_orb(bool show_orb);
 
 	bool show_enemy_orb();
 	void set_show_enemy_orb(bool show_orb);

--- a/src/units/orb_status.cpp
+++ b/src/units/orb_status.cpp
@@ -28,7 +28,7 @@ bool orb_status_helper::prefs_show_orb(orb_status os)
 	case orb_status::partial:
 		return preferences::show_partial_orb();
 	case orb_status::allied:
-		return preferences::show_allied_orb();
+		return preferences::show_ally_orb();
 	case orb_status::enemy:
 		return preferences::show_enemy_orb();
 	default:


### PR DESCRIPTION
Backports of #7266 and #7189.

Use spacing to improve the orb color preferences dialog (backport of #7266)

Use two-color orbs for allies' units, configurable by preferences (backport of #7189)

These orbs no longer look the same as the player's own orbs, so they won't cause confusion in multiplayer.

The relevant part of the advanced preference now shows:

```
[ ] - Show ally orb
[ ] - During ally’s turn, use a two-color orb to show movement
Radio buttons for colors: ( )  ( )  ( )  ( )  ( )  ( )  ( )
```

That offers these choices:

* Don't show ally orbs at all
* Always use the one-color (with ally color, not status)
* Use the two-color when that ally is playing, single color at other times
* Use the two-color when that ally is playing, no orb at other times

This probably doesn't need a change to the in-game help, at least for the en_US version of the documentation. The current text in data/core/help.cfg is:

* Blue for allied units, except during that ally's own turn.
* During the ally's own turn, their units will be shown with the colors showing whether the units can still move and attack; however their moves, and the corresponding orb changes, are delayed as explained in "Shroud and Fog of War'.