### PR TITLE
Unit tests to evaluate behavior with max_experience=0 and with no advancements

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/unit_no_advancements.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/unit_no_advancements.cfg
@@ -7,7 +7,7 @@
 # Harm Alice and Bob with 1 hitpoint to be sure that they have some damage. Delete advancements of both units and give them 999 experience. They then fight each other.
 ##
 # Expected end state:
-# Bob and Alice doesn't level up, keeps their HP, and gains experience. The default behavior should be that a unit will never advances if it has no advancements, but still can gain experience internally (seen with inspect console).
+# Bob and Alice doesn't level up, keeps their HP, and gains experience. The default behaviour should be that a unit will never advances if it has no advancements, but still can gain experience internally (seen with inspect console).
 #####
 {COMMON_KEEP_A_B_UNIT_TEST "unit_no_advancements" (
     [event]

--- a/data/test/scenarios/wml_tests/UnitsWML/unit_no_advancements.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/unit_no_advancements.cfg
@@ -1,0 +1,69 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [unit] [advancement]
+##
+# Actions:
+# Harm Alice and Bob with 1 hitpoint to be sure that they have some damage. Delete advancements of both units and give them 999 experience. They then fight each other.
+##
+# Expected end state:
+# Bob and Alice doesn't level up, keeps their HP, and gains experience. The default behavior should be that a unit will never advances if it has no advancements, but still can gain experience internally (seen with inspect console).
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "unit_no_advancements" (
+    [event]
+        name=prestart
+        [harm_unit]
+            [filter]
+                id=bob,alice
+            [/filter]
+            amount=1
+        [/harm_unit]
+        [modify_unit]
+            [filter]
+                id=alice,bob
+            [/filter]
+            [object]
+                [effect]
+                    apply_to=remove_advancement
+                    types=Orcish Warrior,Elvish Ranger,Elvish Marksman
+                [/effect]
+            [/object]
+            experience=999
+        [/modify_unit]
+    [/event]
+    [event]
+        name=start
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=5,3
+                [/source]
+                [destination]
+                    x,y=4,3
+                [/destination]
+            [/attack]
+        [/do_command]
+    [/event]
+    [event]
+        name=start
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints less_than $bob.max_hitpoints})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice.hitpoints less_than $alice.max_hitpoints})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob.experience greater_than 999})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice.experience greater_than 999})}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/unit_no_advancements.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/unit_no_advancements.cfg
@@ -1,7 +1,7 @@
 # wmllint: no translatables
 
 #####
-# API(s) being tested: [unit] [advancement]
+# API(s) being tested: [unit][advancement]
 ##
 # Actions:
 # Harm Alice and Bob with 1 hitpoint to be sure that they have some damage. Delete advancements of both units and give them 999 experience. They then fight each other.
@@ -45,9 +45,6 @@
                 [/destination]
             [/attack]
         [/do_command]
-    [/event]
-    [event]
-        name=start
         [store_unit]
             [filter]
                 id=alice

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -72,7 +72,7 @@
             [/filter]
             variable=bob
         [/store_unit]
-        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints numerical_not_equals max_hitpoints})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints numerical_not_equals $bob.max_hitpoints})}
         {ASSERT ({VARIABLE_CONDITIONAL bob.level numerical_equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL alice.level numerical_not_equals 1})}
         {SUCCEED}

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -38,8 +38,18 @@
             [/filter]
             amount=1
         [/harm_unit]
-        {ASSERT ({VARIABLE_CONDITIONAL bob.max_experience numerical_equals 1})}
-        {ASSERT ({VARIABLE_CONDITIONAL alice.max_experience numerical_equals 1})}
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=pre_alice
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=pre_bob
+        [/store_unit]
     [/event]
     [event]
         name=start
@@ -67,6 +77,8 @@
             [/filter]
             variable=bob
         [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL pre_bob.max_experience numerical_equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL pre_alice.max_experience numerical_equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL bob.max_experience numerical_equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL alice.max_experience greater_than 1})}
         {ASSERT ({VARIABLE_CONDITIONAL bob.level numerical_equals 1})}

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -1,0 +1,80 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [unit] max_experience=0
+##
+# Actions:
+# Change Alice's and Bob's max_experience to 0. Delete Bob's 'Orcish Warrior' advancement but not Alice's. Harm bob with 1 hitpoint to be sure that he have some damage. They then fight each other.
+##
+# Expected end state:
+# Alice levels up. Bob doesn't, and keeps his previous health.
+#####
+{GENERIC_UNIT_TEST "zero_experience" (
+    [event]
+        name=prestart
+        [modify_unit]
+            [filter]
+                id=alice,bob
+            [/filter]
+            [effect]
+                apply_to=max_experience
+                set=0
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [object]
+                [effect]
+                    apply_to=remove_advancement
+                    types=Orcish Warrior
+                [/effect]
+            [/object]
+        [/modify_unit]
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            amount=1
+        [/harm_unit]
+    [/event]
+    [event]
+        name=start
+        [do_command]
+            [move]
+                x=13,12,11,10,9,8
+                y=3,3,3,3,3,3
+            [/move]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=7,3
+                [/source]
+                [destination]
+                    x,y=8,3
+                [/destination]
+            [/attack]
+        [/do_command]
+    [/event]
+    [event]
+        name=turn 1
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints numerical_not_equals max_hitpoints})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob.level numerical_equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice.level numerical_not_equals 1})}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -1,13 +1,13 @@
 # wmllint: no translatables
 
 #####
-# API(s) being tested: [unit] max_experience=0
+# API(s) being tested: [unit]max_experience=0
 ##
 # Actions:
-# Change Alice's and Bob's max_experience to 0. Delete Bob's 'Orcish Warrior' advancement but not Alice's. Harm bob with 1 hitpoint to be sure that he have some damage. They then fight each other.
+# Try to set Alice's and Bob's max_experience to 0 and check that the engine applies a minimum of 1. Delete Bob's 'Orcish Warrior' advancement but not Alice's. Harm bob with 1 hitpoint to be sure that he have some damage. They then fight each other.
 ##
 # Expected end state:
-# Alice levels up and changes her max_experience to the advancement. Bob don't advances and have 1 point of max experience. The default behaviour is for a unit with max_experience 0 always changes to 1, no matter if they have advancements or not (seen with inspect console).
+# Alice levels up and changes his max_experience to the advancement. Bob don't advances and have 1 point of max experience. The default behaviour is for a unit with max_experience 0 always changes to 1, no matter if they have advancements or not (seen with inspect console).
 #####
 {COMMON_KEEP_A_B_UNIT_TEST "zero_experience" (
     [event]
@@ -38,6 +38,8 @@
             [/filter]
             amount=1
         [/harm_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL bob.max_experience numerical_equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice.max_experience numerical_equals 1})}
     [/event]
     [event]
         name=start
@@ -53,9 +55,6 @@
                 [/destination]
             [/attack]
         [/do_command]
-    [/event]
-    [event]
-        name=start
         [store_unit]
             [filter]
                 id=alice

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -7,7 +7,7 @@
 # Change Alice's and Bob's max_experience to 0. Delete Bob's 'Orcish Warrior' advancement but not Alice's. Harm bob with 1 hitpoint to be sure that he have some damage. They then fight each other.
 ##
 # Expected end state:
-# Alice levels up. Bob doesn't, and keeps his previous health.
+# Alice levels up and changes her max_experience to the advancement. Bob don't advances and have 1 point of max experience. The default behavior is for a unit with max_experience 0 allways changes to 1, no matter if they have advancements or not (seen with inspect console).
 #####
 {COMMON_KEEP_A_B_UNIT_TEST "zero_experience" (
     [event]
@@ -23,7 +23,7 @@
         [/modify_unit]
         [modify_unit]
             [filter]
-                id=bob
+                id=alice,bob
             [/filter]
             [object]
                 [effect]
@@ -34,7 +34,7 @@
         [/modify_unit]
         [harm_unit]
             [filter]
-                id=bob
+                id=bob,alice
             [/filter]
             amount=1
         [/harm_unit]
@@ -55,7 +55,7 @@
         [/do_command]
     [/event]
     [event]
-        name=turn 1
+        name=start
         [store_unit]
             [filter]
                 id=alice
@@ -68,9 +68,10 @@
             [/filter]
             variable=bob
         [/store_unit]
-        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints numerical_not_equals $bob.max_hitpoints})}
+        {ASSERT ({VARIABLE_CONDITIONAL bob.max_experience numerical_equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice.max_experience greater_than 1})}
         {ASSERT ({VARIABLE_CONDITIONAL bob.level numerical_equals 1})}
-        {ASSERT ({VARIABLE_CONDITIONAL alice.level numerical_not_equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL alice.level numerical_equals 2})}
         {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -9,7 +9,7 @@
 # Expected end state:
 # Alice levels up. Bob doesn't, and keeps his previous health.
 #####
-{GENERIC_UNIT_TEST "zero_experience" (
+{COMMON_KEEP_A_B_UNIT_TEST "zero_experience" (
     [event]
         name=prestart
         [modify_unit]
@@ -42,18 +42,14 @@
     [event]
         name=start
         [do_command]
-            [move]
-                x=13,12,11,10,9,8
-                y=3,3,3,3,3,3
-            [/move]
             [attack]
                 weapon=0
                 defender_weapon=0
                 [source]
-                    x,y=7,3
+                    x,y=5,3
                 [/source]
                 [destination]
-                    x,y=8,3
+                    x,y=4,3
                 [/destination]
             [/attack]
         [/do_command]

--- a/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/zero_experience.cfg
@@ -7,7 +7,7 @@
 # Change Alice's and Bob's max_experience to 0. Delete Bob's 'Orcish Warrior' advancement but not Alice's. Harm bob with 1 hitpoint to be sure that he have some damage. They then fight each other.
 ##
 # Expected end state:
-# Alice levels up and changes her max_experience to the advancement. Bob don't advances and have 1 point of max experience. The default behavior is for a unit with max_experience 0 allways changes to 1, no matter if they have advancements or not (seen with inspect console).
+# Alice levels up and changes her max_experience to the advancement. Bob don't advances and have 1 point of max experience. The default behaviour is for a unit with max_experience 0 always changes to 1, no matter if they have advancements or not (seen with inspect console).
 #####
 {COMMON_KEEP_A_B_UNIT_TEST "zero_experience" (
     [event]

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -431,6 +431,7 @@
 # Game mechanics
 0 heal
 0 zero_experience
+0 unit_no_advancements
 # Warnings about WML
 0 unknown_scenario_false_positives
 0 unknown_scenario_interpolated

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -430,6 +430,7 @@
 0 kill_fires_events
 # Game mechanics
 0 heal
+0 zero_experience
 # Warnings about WML
 0 unknown_scenario_false_positives
 0 unknown_scenario_interpolated


### PR DESCRIPTION
Check the behavior of units when their maximum experience is 0, with or without advancement available. The default engine behavior is that if a unit has any advancement, it can't have `max_experience=0`, so it always changes to `0/1`. If the unit have no advancements, then the experience bar will disappear and show `-` instead of `0/1`

This test is equivalent to `experience=0` on `[unit_type]` too. `[unit] max_experience=` takes by default the value of `[unit_type] experience=`

* API(s) being tested: `[unit] max_experience=0`

* Actions:
Change Alice's and Bob's max_experience to 0. Delete Bob's 'Orcish Warrior' advancement but not Alice's. Harm bob with 1 hitpoint to be sure that he have some damage. They then fight each other.

* Expected end state:
Alice levels up and changes her max_experience to the advancement. Bob don't advances and have 1 point of max experience. The default behaviour is for a unit with max_experience 0 always changes to 1, no matter if they have advancements or not (seen with inspect console).

Note: For some reason I've been forced to use `[object] [effect] apply_to=remove_advancement`, because without `[object]` it doesn't work.

![imagen](https://user-images.githubusercontent.com/40789364/215809200-7d81a040-c4e3-4345-bf31-7c10155f8c13.png)

This PR is complemented with #7339, for which it serves as a test.