### PR TITLE
modify calling of unit_abilities::effect and get_composite_value()

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -176,9 +176,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_specials_and_abilities("chance_to_hit");
-	unit_abilities::effect cth_effects(cth_specials, cth, weapon);
-	cth = cth_effects.get_composite_value();
+	cth = weapon->composite_value(weapon->get_specials_and_abilities("chance_to_hit"), cth);
 
 
 	if(opp.get_state("invulnerable")) {
@@ -216,16 +214,12 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 
 	// Compute drain amounts only if draining is possible.
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_specials_and_abilities("drains");
 		// Compute the drain percent (with 50% as the base for backward compatibility)
-		unit_abilities::effect drain_percent_effects(drain_specials, 50, weapon);
-		drain_percent = drain_percent_effects.get_composite_value();
+		drain_percent = weapon->composite_value(weapon->get_specials_and_abilities("drains"), 50);
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_specials_and_abilities("heal_on_hit");
-	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, weapon);
-	drain_constant += heal_on_hit_effects.get_composite_value();
+	drain_constant += weapon->composite_value(weapon->get_specials_and_abilities("heal_on_hit"), 0);
 
 	drains = drain_constant || drain_percent;
 
@@ -321,9 +315,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	signed int cth = 100 - opp_terrain_defense + weapon->accuracy() - (opp_weapon ? opp_weapon->parry() : 0);
 	cth = std::clamp(cth, 0, 100);
 
-	unit_ability_list cth_specials = weapon->get_specials("chance_to_hit");
-	unit_abilities::effect cth_effects(cth_specials, cth, weapon);
-	cth = cth_effects.get_composite_value();
+	cth = weapon->composite_value(weapon->get_specials("chance_to_hit"), cth);
 
 	chance_to_hit = std::clamp(cth, 0, 100);
 
@@ -337,17 +329,12 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 	slow_damage = round_damage(base_damage, damage_multiplier, 20000);
 
 	if(drains) {
-		unit_ability_list drain_specials = weapon->get_specials("drains");
-
 		// Compute the drain percent (with 50% as the base for backward compatibility)
-		unit_abilities::effect drain_percent_effects(drain_specials, 50, weapon);
-		drain_percent = drain_percent_effects.get_composite_value();
+		drain_percent = weapon->composite_value(weapon->get_specials("drains"), 50);
 	}
 
 	// Add heal_on_hit (the drain constant)
-	unit_ability_list heal_on_hit_specials = weapon->get_specials("heal_on_hit");
-	unit_abilities::effect heal_on_hit_effects(heal_on_hit_specials, 0, weapon);
-	drain_constant += heal_on_hit_effects.get_composite_value();
+	drain_constant += weapon->composite_value(weapon->get_specials("heal_on_hit"), 0);
 
 	drains = drain_constant || drain_percent;
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1123,9 +1123,7 @@ void attack_type::modified_attacks(unsigned & min_attacks,
                                    unsigned & max_attacks) const
 {
 	// Apply [attacks].
-	unit_abilities::effect attacks_effect(get_specials_and_abilities("attacks"),
-	                                      num_attacks(), shared_from_this());
-	int attacks_value = attacks_effect.get_composite_value();
+	int attacks_value = composite_value(get_specials_and_abilities("attacks"), num_attacks());
 
 	if ( attacks_value < 0 ) {
 		attacks_value = num_attacks();
@@ -1148,8 +1146,7 @@ void attack_type::modified_attacks(unsigned & min_attacks,
  */
 int attack_type::modified_damage() const
 {
-	unit_abilities::effect dmg_effect(get_specials_and_abilities("damage"), damage(), shared_from_this());
-	int damage_value = dmg_effect.get_composite_value();
+	int damage_value = composite_value(get_specials_and_abilities("damage"), damage());
 	return damage_value;
 }
 
@@ -1300,6 +1297,11 @@ unit_ability_list attack_type::get_specials_and_abilities(const std::string& spe
 		abil_list.append(spe_list);
 	}
 	return abil_list;
+}
+
+int attack_type::composite_value(const unit_ability_list& abil_list, int base_value) const
+{
+	return unit_abilities::effect(abil_list, base_value, shared_from_this()).get_composite_value();
 }
 
 static bool overwrite_special_affects(const config& special)

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -90,6 +90,12 @@ public:
 	                      unsigned & max_attacks) const;
 	/** Returns the damage per attack of this weapon, considering specials. */
 	int modified_damage() const;
+
+	/** Return the special weapon value, considering specials.
+	 * @param abil_list The list of special checked.
+	 * @param base_value The value modified or not by function.
+	 */
+	int composite_value(const unit_ability_list& abil_list, int base_value) const;
 	/** Returns list for weapon like abilities for each ability type. */
 	unit_ability_list get_weapon_ability(const std::string& ability) const;
 	/** Returns list who contains get_weapon_ability and get_specials list for each ability type */


### PR DESCRIPTION
in addition to simplify the calling of calculation function for int weapon specials, it also because an commit what i want push in https://github.com/wesnoth/wesnoth/pull/6968 a attribute  require this function.