### PR TITLE
Add new attacks_used key to [attack]

### DIFF
--- a/changelog_entries/attacks_used.md
+++ b/changelog_entries/attacks_used.md
@@ -1,0 +1,2 @@
+ ### WML API
+   * New attacks_used key in [attack] causes the attack to deduct more than 1 from attacks left

--- a/data/schema/filters/weapon.cfg
+++ b/data/schema/filters/weapon.cfg
@@ -17,6 +17,7 @@
 	{SIMPLE_KEY parry s_range_list}
 	{SIMPLE_KEY accuracy s_range_list}
 	{SIMPLE_KEY movement_used s_range_list}
+	{SIMPLE_KEY attacks_used s_range_list}
 	{FILTER_BOOLEAN_OPS weapon}
 [/tag]
 

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -33,12 +33,14 @@
 				{SIMPLE_KEY set_parry s_int}
 				{SIMPLE_KEY set_accuracy s_int}
 				{SIMPLE_KEY set_movement_used s_int}
+				{SIMPLE_KEY set_attacks_used s_int}
 				
 				{SIMPLE_KEY increase_damage s_int_percent}
 				{SIMPLE_KEY increase_attacks s_int_percent}
 				{SIMPLE_KEY increase_parry s_int_percent}
 				{SIMPLE_KEY increase_accuracy s_int_percent}
 				{SIMPLE_KEY increase_movement_used s_int_percent}
+				{SIMPLE_KEY increase_attacks_used s_int_percent}
 
 				{SIMPLE_KEY attack_weight s_real}
 				{SIMPLE_KEY defense_weight s_real}

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -56,6 +56,7 @@
 		{SIMPLE_KEY defense_weight real}
 		{SIMPLE_KEY attack_weight real}
 		{SIMPLE_KEY movement_used int}
+		{SIMPLE_KEY attacks_used int}
         {SIMPLE_KEY accuracy int}
         {SIMPLE_KEY parry int}
 		[tag]

--- a/data/test/_main.cfg
+++ b/data/test/_main.cfg
@@ -71,6 +71,7 @@
 {test/scenarios/wml_tests/TerrainWML}
 {test/scenarios/wml_tests/UnitsWML}
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML}
+{test/scenarios/wml_tests/UnitsWML/Attacks}
 {test/scenarios/wml_tests/WesnothFormulaLanguage}
 
 # Load test unit wml

--- a/data/test/scenarios/wml_tests/UnitsWML/Attacks/test_attacks_used.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/Attacks/test_attacks_used.cfg
@@ -15,6 +15,7 @@
             [/filter]
             [effect]
                 apply_to=attack
+                range=melee
                 set_attacks_used=2
             [/effect]
             attacks_left=5
@@ -47,6 +48,24 @@
             variable=alice
         [/store_unit]
         {ASSERT {VARIABLE_CONDITIONAL alice.attacks_left numerical_equals 3}}
+        [do_command]
+            [attack]
+                weapon=1
+                [source]
+                    x,y=4,3
+                [/source]
+                [destination]
+                    x,y=5,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL alice.attacks_left numerical_equals 2}}
         {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/wml_tests/UnitsWML/Attacks/test_attacks_used.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/Attacks/test_attacks_used.cfg
@@ -1,0 +1,52 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [attack]attacks_used
+##
+# Expected end state:
+# The Elvish Archer (alice) has 3/5 attacks left after attacking the Orcish Grunt (bob)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST test_attacks_used (
+    [event]
+        name=prestart
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                set_attacks_used=2
+            [/effect]
+            attacks_left=5
+        [/modify_unit]
+    [/event]
+    [event]
+        name=start
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL alice.attacks_left numerical_equals 5}}
+        [do_command]
+            [attack]
+                weapon=0
+                [source]
+                    x,y=4,3
+                [/source]
+                [destination]
+                    x,y=5,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL alice.attacks_left numerical_equals 3}}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/Attacks/test_movement_used.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/Attacks/test_movement_used.cfg
@@ -1,0 +1,52 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [attack]movement_used
+##
+# Expected end state:
+# The Elvish Archer (alice) has 5/6 move points left after attacking the Orcish Grunt (bob)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST test_movement_used (
+    [event]
+        name=prestart
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                range=melee
+                set_movement_used=1
+            [/effect]
+        [/modify_unit]
+    [/event]
+    [event]
+        name=start
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL alice.moves numerical_equals 6}}
+        [do_command]
+            [attack]
+                weapon=0
+                [source]
+                    x,y=4,3
+                [/source]
+                [destination]
+                    x,y=5,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+        {ASSERT {VARIABLE_CONDITIONAL alice.moves numerical_equals 5}}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1382,11 +1382,10 @@ void attack::perform()
 		return;
 	}
 
-	a_.get_unit().set_attacks(a_.get_unit().attacks_left() - 1);
-
 	VALIDATE(a_.weapon_ < static_cast<int>(a_.get_unit().attacks().size()),
 			_("An invalid attacker weapon got selected."));
 
+	a_.get_unit().set_attacks(a_.get_unit().attacks_left() - a_.get_unit().attacks()[a_.weapon_].attacks_used());
 	a_.get_unit().set_movement(a_.get_unit().movement_left() - a_.get_unit().attacks()[a_.weapon_].movement_used(), true);
 	a_.get_unit().set_state(unit::STATE_NOT_MOVED, false);
 	a_.get_unit().set_resting(false);

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -107,6 +107,8 @@ variant attack_type_callable::get_value(const std::string& key) const
 		return variant(att_->parry());
 	} else if(key == "movement_used") {
 		return variant(att_->movement_used());
+	} else if(key == "attacks_used") {
+		return variant(att_->attacks_used());
 	} else if(key == "specials" || key == "special") {
 		std::vector<variant> res;
 
@@ -133,6 +135,7 @@ void attack_type_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "accuracy");
 	add_input(inputs, "parry");
 	add_input(inputs, "movement_used");
+	add_input(inputs, "attacks_used");
 	add_input(inputs, "attack_weight");
 	add_input(inputs, "defense_weight");
 	add_input(inputs, "specials");

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -264,6 +264,7 @@ static int impl_unit_attack_get(lua_State *L)
 	return_float_attrib("defense_weight", attack.defense_weight());
 	return_int_attrib("accuracy", attack.accuracy());
 	return_int_attrib("movement_used", attack.movement_used());
+	return_int_attrib("attacks_used", attack.attacks_used());
 	return_int_attrib("parry", attack.parry());
 	return_cfgref_attrib("specials", attack.specials());
 	return_cfgref_attrib("__cfg", attack.to_config());
@@ -296,6 +297,7 @@ static int impl_unit_attack_set(lua_State *L)
 	modify_int_attrib("defense_weight", attack.set_defense_weight(value));
 	modify_int_attrib("accuracy", attack.set_accuracy(value));
 	modify_int_attrib("movement_used", attack.set_movement_used(value));
+	modify_int_attrib("attacks_used", attack.set_attacks_used(value));
 	modify_int_attrib("parry", attack.set_parry(value));
 
 	if(strcmp(m, "specials") == 0) {

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -117,6 +117,8 @@ public:
 
 	int movement_used() const { return movement_used_; }
 	void set_movement_used(int value) { movement_used_ = value; }
+	int attacks_used() const { return attacks_used_; }
+	void set_attacks_used(int value) { attacks_used_ = value; }
 
 	void write(config& cfg) const;
 	inline config to_config() const { config c; write(c); return c; }
@@ -318,6 +320,7 @@ private:
 
 	int accuracy_;
 	int movement_used_;
+	int attacks_used_;
 	int parry_;
 	config specials_;
 	bool changed_;

--- a/src/whiteboard/attack.hpp
+++ b/src/whiteboard/attack.hpp
@@ -82,6 +82,8 @@ private:
 	int weapon_choice_;
 	int attack_movement_cost_;
 	int temp_movement_subtracted_;
+	int attack_count_;
+	int temp_attacks_subtracted_;
 };
 
 /** Dumps an attack on a stream, for debug purposes. */

--- a/utils/emmylua/wesnoth/units.lua
+++ b/utils/emmylua/wesnoth/units.lua
@@ -10,6 +10,7 @@
 ---@field range integer
 ---@field number integer
 ---@field movement_used integer
+---@field attacks_used integer
 ---@field attack_weight number
 ---@field defense_weight number
 ---@field accuracy integer

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -203,6 +203,7 @@
 0 special_note_from_movetype
 0 special_note_individual_unit
 0 has_achievement
+0 test_movement_used
 # Terrain mask tests
 0 test_terrain_mask_simple_nop
 0 test_terrain_mask_simple_set

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -204,6 +204,7 @@
 0 special_note_individual_unit
 0 has_achievement
 0 test_movement_used
+0 test_attacks_used
 # Terrain mask tests
 0 test_terrain_mask_simple_nop
 0 test_terrain_mask_simple_set


### PR DESCRIPTION
This implements the "uses N attacks" feature used by @Hejnewar in #7349. Since it parallels the existing `movement_used` key it seemed reasonable to handle it at the engine level.

Wiki documentation to be updated if this is merged:

* [ ] Attacks section in UnitTypeWML
* [ ] `apply_to=attack` section in EffectWML
* [ ] StandardWeaponFilter
* [ ] WFL documentation for attack objects
* [ ] Lua documentation for attack objects
