### PR TITLE
Only call font::set_help_string() from the editor

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -644,7 +644,7 @@ void pump()
 		case SDL_MOUSEMOTION: {
 			// Always make sure a cursor is displayed if the mouse moves or if the user clicks
 			cursor::set_focus(true);
-			raise_help_string_event(event.motion.x, event.motion.y);
+			process_tooltip_strings(event.motion.x, event.motion.y);
 			break;
 		}
 
@@ -769,11 +769,10 @@ void raise_resize_event()
 	raise_window_event(event);
 }
 
-void raise_help_string_event(int mousex, int mousey)
+void process_tooltip_strings(int mousex, int mousey)
 {
 	if(event_contexts.empty() == false) {
 		for(auto handler : event_contexts.back().handlers) {
-			handler->process_help_string(mousex, mousey);
 			handler->process_tooltip_string(mousex, mousey);
 		}
 	}

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -80,7 +80,6 @@ public:
 
 	virtual bool requires_event_focus(const SDL_Event * = nullptr) const { return false; }
 
-	virtual void process_help_string(int /*mousex*/, int /*mousey*/) {}
 	virtual void process_tooltip_string(int /*mousex*/, int /*mousey*/) {}
 
 	virtual void join(); /*joins the current event context*/
@@ -169,7 +168,11 @@ public:
 
 void raise_process_event();
 void raise_resize_event();
-void raise_help_string_event(int mousex, int mousey);
+/**
+ * Triggered by mouse-motion, sends the cursor position to all handlers to
+ * check whether a tooltip should be shown.
+ */
+void process_tooltip_strings(int mousex, int mousey);
 
 
 /**

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -155,7 +155,6 @@ menu::menu(const std::vector<std::string>& items,
   max_height_(max_height), max_width_(max_width),
   max_items_(-1), item_height_(-1),
   heading_height_(-1),
-  cur_help_(-1,-1),
   selected_(0), click_selects_(click_selects), out_(false),
   previous_button_(true), show_result_(false),
   double_clicked_(false),
@@ -201,8 +200,6 @@ void menu::fill_items(const std::vector<std::string>& items, bool strip_spaces)
 			first_item.erase(first_item.begin());
 		}
 	}
-
-	create_help_strings();
 
 	if(sortby_ >= 0) {
 		do_sort();
@@ -266,26 +263,6 @@ void menu::assert_pos()
 	assert(item_pos_.size() == sz);
 	for(std::size_t n = 0; n != sz; ++n) {
 		assert(item_pos_[n] < sz && n == items_[item_pos_[n]].id);
-	}
-}
-
-void menu::create_help_strings()
-{
-	for(std::vector<item>::iterator i = items_.begin(); i != items_.end(); ++i) {
-		i->help.clear();
-		for(std::vector<std::string>::iterator j = i->fields.begin(); j != i->fields.end(); ++j) {
-			if(std::find(j->begin(),j->end(),static_cast<char>(HELP_STRING_SEPARATOR)) == j->end()) {
-				i->help.emplace_back();
-			} else {
-				const std::vector<std::string>& items = utils::split(*j, HELP_STRING_SEPARATOR, 0);
-				if(items.size() >= 2) {
-					*j = items.front();
-					i->help.push_back(items.back());
-				} else {
-					i->help.emplace_back();
-				}
-			}
-		}
 	}
 }
 
@@ -995,21 +972,6 @@ int menu::hit_column(int x) const
 	return j;
 }
 
-std::pair<int,int> menu::hit_cell(int x, int y) const
-{
-	const int row = hit(x, y);
-	if(row < 0) {
-		return std::pair<int,int>(-1, -1);
-	}
-
-	const int col = hit_column(x);
-	if(col < 0) {
-		return std::pair<int,int>(-1, -1);
-	}
-
-	return std::pair<int,int>(x,y);
-}
-
 int menu::hit_heading(int x, int y) const
 {
 	const std::size_t height = heading_height();
@@ -1101,32 +1063,6 @@ std::size_t menu::get_item_height(int) const
 	}
 
 	return item_height_ = max_height;
-}
-
-void menu::process_help_string(int mousex, int mousey)
-{
-	if (hidden()) return;
-
-	const std::pair<int,int> loc(hit(mousex,mousey), hit_column(mousex));
-	if(loc == cur_help_) {
-		return;
-	} else if(loc.first == -1) {
-		font::clear_help_string();
-	} else {
-		font::clear_help_string();
-		if(std::size_t(loc.first) < items_.size()) {
-			const std::vector<std::string>& row = items_[item_pos_[loc.first]].help;
-			if(std::size_t(loc.second) < row.size()) {
-				const std::string& help = row[loc.second];
-				if(help.empty() == false) {
-					//PLAIN_LOG << "setting help string from menu to '" << help << "'";
-					font::set_help_string(help);
-				}
-			}
-		}
-	}
-
-	cur_help_ = loc;
 }
 
 void menu::invalidate_row(std::size_t id)

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -97,15 +97,14 @@ public:
 
 	struct item
 	{
-		item() : fields(), help(), id(0)
+		item() : fields(), id(0)
 		{}
 
 		item(const std::vector<std::string>& fields, std::size_t id)
-			: fields(fields), help(), id(id)
+			: fields(fields), id(id)
 		{}
 
 		std::vector<std::string> fields;
-		std::vector<std::string> help;
 		std::size_t id;
 	};
 
@@ -211,7 +210,6 @@ protected:
 
 	int hit(int x, int y) const;
 
-	std::pair<int,int> hit_cell(int x, int y) const;
 	int hit_column(int x) const;
 
 	int hit_heading(int x, int y) const;
@@ -236,11 +234,6 @@ private:
 
 	std::vector<std::string> heading_;
 	mutable int heading_height_;
-
-	void create_help_strings();
-	void process_help_string(int mousex, int mousey) override;
-
-	std::pair<int,int> cur_help_;
 
 	mutable std::vector<int> column_widths_;
 

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -34,7 +34,7 @@ bool widget::mouse_lock_ = false;
 widget::widget(const bool auto_join)
 	: events::sdl_handler(auto_join), focus_(true), rect_(EmptyRect),
 	  state_(UNINIT), enabled_(true), clip_(false),
-	  clip_rect_(EmptyRect), has_help_(false), mouse_lock_local_(false)
+	  clip_rect_(EmptyRect), mouse_lock_local_(false)
 {
 }
 
@@ -244,28 +244,9 @@ void widget::draw()
 	set_dirty(false);
 }
 
-void widget::set_help_string(const std::string& str)
-{
-	help_text_ = str;
-}
-
 void widget::set_tooltip_string(const std::string& str)
 {
 	tooltip_text_ = str;
-}
-
-void widget::process_help_string(int mousex, int mousey)
-{
-	if (!hidden() && rect_.contains(mousex, mousey)) {
-		if(!has_help_ && !help_text_.empty()) {
-			//PLAIN_LOG << "setting help string to '" << help_text_ << "'";
-			font::set_help_string(help_text_);
-			has_help_ = true;
-		}
-	} else if(has_help_) {
-		font::clear_help_string();
-		has_help_ = false;
-	}
 }
 
 void widget::process_tooltip_string(int mousex, int mousey)

--- a/src/widgets/widget.hpp
+++ b/src/widgets/widget.hpp
@@ -61,10 +61,8 @@ public:
 	const std::string& id() const;
 	void set_id(const std::string& id);
 
-	void set_help_string(const std::string& str);
 	void set_tooltip_string(const std::string& str);
 
-	virtual void process_help_string(int mousex, int mousey) override;
 	virtual void process_tooltip_string(int mousex, int mousey) override;
 
 protected:
@@ -106,9 +104,7 @@ private:
 	bool clip_;
 	rect clip_rect_;
 
-	std::string help_text_;
 	std::string tooltip_text_;
-	bool has_help_;
 	std::string id_;
 
 	bool mouse_lock_local_;


### PR DESCRIPTION
Remove some dead GUI1 code, leaving the editor's palettes as the only code that calls font::set_help_string. This function shows a tooltip-like text at the bottom of the editor's screen, for example when the paint tool is active it shows which terrains are assigned to the left and right mouse buttons.

There is similar functionality in GUI2, for example when hovering over the title screen's buttons, which is handled via event::MESSAGE_SHOW_TOOLTIP.

This cleanup is the groundwork for moving the label in the map editor so that it doesn't always obscure the southmost hexes of the map. The implementation of font::set_help_string() has moved during 1.17's refactoring (from CVideo in 1.16 to floating_label in 1.17.12); the intention is to replace it with editor-specific code in a later PR for #6422.

Checking that the code is dead
---

Nothing called widget::set_help_string, therefore the rest of the removed code in the widget class was effectively dead.

For the menu class, nothing set item::help. I doubt it was ever used; it was added in a commit titled "changes to wose stats" that presumably accidentally captured some work-in-progess C++ changes too: e2597cbc83.

The menu class is now only used by the help browser. The complete set of .cpp files that get recompiled after changing menu.hpp are:

* help/help.cpp
* help/help_browser.cpp
* help/help_menu.cpp
* video.cpp
* widgets/menu.cpp
* widgets/menu_style.cpp

@CelticMinstrel I'm assigning the review to you as you've recently worked on the GUI1 -> GUI2 transition for the help browser.