### PR TITLE
NR S07 - Arthian > Ro'Arthian typo

### DIFF
--- a/data/campaigns/Northern_Rebirth/utils/utils.cfg
+++ b/data/campaigns/Northern_Rebirth/utils/utils.cfg
@@ -157,7 +157,7 @@
 
 #define STORY_PART_ARTHIAN SPEECH_STRING
     [part]
-        story={CAPTION _"Ro'Arthian"} + {SPEECH_STRING}
+        story={CAPTION _"Ro’Arthian"} + {SPEECH_STRING}
         background=portraits/Arthian.webp
         scale_background=no
     [/part]

--- a/data/campaigns/Northern_Rebirth/utils/utils.cfg
+++ b/data/campaigns/Northern_Rebirth/utils/utils.cfg
@@ -157,7 +157,7 @@
 
 #define STORY_PART_ARTHIAN SPEECH_STRING
     [part]
-        story={CAPTION _"Arthian"} + {SPEECH_STRING}
+        story={CAPTION _"Ro'Arthian"} + {SPEECH_STRING}
         background=portraits/Arthian.webp
         scale_background=no
     [/part]


### PR DESCRIPTION
In only one place Ro'Arthian has an error in his name:

#. [part]
#: data/campaigns/Northern_Rebirth/utils/utils.cfg:160
msgid "Arthian"
msgstr "Arthian"

I realized it by checking the translations.