### PR TITLE
[1.16] Editor: Move the text at the bottom of the screen

### DIFF
--- a/changelog_entries/editor_help_string.md
+++ b/changelog_entries/editor_help_string.md
@@ -1,0 +1,2 @@
+ ### Editor
+   * Scrolling the map north or south can move the text that overlays the map, so it doesn't always obscure the southmost hexes of the map. (issue #6422}

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -1099,7 +1099,7 @@ void editor_controller::show_menu(const std::vector<config>& items_arg, int xloc
 
 void editor_controller::preferences()
 {
-	gui_->video().clear_all_help_strings();
+	gui_->clear_help_string();
 	gui2::dialogs::preferences_dialog::display();
 
 	gui_->redraw_everything();

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -71,6 +71,22 @@ void editor_display::rebuild_terrain(const map_location &loc) {
 
 void editor_display::pre_draw()
 {
+	// If we're showing hexes near the north of the map, put the help string at the bottom of the screen.
+	// Otherwise, put it at the top.
+	if(help_handle_ != 0) {
+		const bool place_at_top = get_visible_hexes().top[0] > 2;
+
+		if(place_at_top != help_string_at_top_) {
+			const auto& r = font::get_floating_label_rect(help_handle_);
+			double delta = map_outside_area().h - r.h;
+			if(place_at_top) {
+				font::move_floating_label(help_handle_, 0.0, -delta);
+			} else {
+				font::move_floating_label(help_handle_, 0.0, delta);
+			}
+			help_string_at_top_ = place_at_top;
+		}
+	}
 }
 
 image::TYPE editor_display::get_image_type(const map_location& loc)
@@ -152,7 +168,7 @@ void editor_display::set_help_string(const std::string& str)
 	int size = font::SIZE_LARGE;
 
 	while(size > 0) {
-		if(font::pango_line_width(str, size) > video().get_width()) {
+		if(font::pango_line_width(str, size) * 2 > video().get_width()) {
 			size--;
 		} else {
 			break;
@@ -169,6 +185,9 @@ void editor_display::set_help_string(const std::string& str)
 
 	help_handle_ = font::add_floating_label(flabel);
 
+	// Put the label near the bottom of the screen. In pre_draw it'll be moved to the top if the
+	// user is editing hexes at the south edge of the map.
+	help_string_at_top_ = false;
 	const auto& r = font::get_floating_label_rect(help_handle_);
 	font::move_floating_label(help_handle_, 0.0, -double(r.h));
 }

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -17,6 +17,8 @@
 
 #include "editor/controller/editor_controller.hpp"
 #include "editor/editor_display.hpp"
+#include "floating_label.hpp"
+#include "font/sdl_ttf_compat.hpp" // for pango_line_width
 #include "lexical_cast.hpp"
 #include "overlay.hpp"
 #include "reports.hpp"
@@ -133,6 +135,42 @@ const time_of_day& editor_display::get_time_of_day(const map_location& /*loc*/) 
 display::overlay_map& editor_display::get_overlays()
 {
 	return controller_.get_current_map_context().get_overlays();
+}
+
+void editor_display::clear_help_string()
+{
+	font::remove_floating_label(help_handle_);
+	help_handle_ = 0;
+}
+
+void editor_display::set_help_string(const std::string& str)
+{
+	clear_help_string();
+
+	const color_t color{0, 0, 0, 0xbb};
+
+	int size = font::SIZE_LARGE;
+
+	while(size > 0) {
+		if(font::pango_line_width(str, size) > video().get_width()) {
+			size--;
+		} else {
+			break;
+		}
+	}
+
+	const int border = 5;
+
+	font::floating_label flabel(str);
+	flabel.set_font_size(size);
+	flabel.set_position(video().get_width() / 2, video().get_height());
+	flabel.set_bg_color(color);
+	flabel.set_border_size(border);
+
+	help_handle_ = font::add_floating_label(flabel);
+
+	const auto& r = font::get_floating_label_rect(help_handle_);
+	font::move_floating_label(help_handle_, 0.0, -double(r.h));
 }
 
 } //end namespace editor

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -43,8 +43,7 @@ public:
 	}
 
 	/**
-	 * Displays a help string with the given text. A 'help string' is like a tooltip,
-	 * but appears at the bottom of the screen so as to not be intrusive.
+	 * Sets and shows the tooltip-like text at the top or bottom of the map area.
 	 *
 	 * @param str                 The text to display.
 	 */
@@ -76,6 +75,12 @@ protected:
 private:
 	/** ID of the floating label that's controlled by set_help_string() / clear_help_string(). */
 	int help_handle_ = 0;
+
+	/**
+	 * Ignored when help_handle_ == 0. Othewise, true if the help label obscures the
+	 * northern hexes in the map area, false if it's over the southern hexes instead.
+	 */
+	bool help_string_at_top_ = false;
 };
 
 } //end namespace editor

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -42,6 +42,17 @@ public:
 		return controller_;
 	}
 
+	/**
+	 * Displays a help string with the given text. A 'help string' is like a tooltip,
+	 * but appears at the bottom of the screen so as to not be intrusive.
+	 *
+	 * @param str                 The text to display.
+	 */
+	void set_help_string(const std::string& str);
+
+	/** Removes the help string. */
+	void clear_help_string();
+
 protected:
 	void pre_draw() override;
 	/**
@@ -61,6 +72,10 @@ protected:
 
 	/* The controller that owns this display. */
 	editor_controller& controller_;
+
+private:
+	/** ID of the floating label that's controlled by set_help_string() / clear_help_string(). */
+	int help_handle_ = 0;
 };
 
 } //end namespace editor

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -192,8 +192,7 @@ void editor_palette<Item>::adjust_size(const SDL_Rect& target)
 
 	set_location(target);
 	set_dirty(true);
-	gui_.video().clear_help_string(help_handle_);
-	help_handle_ = gui_.video().set_help_string(get_help_string());
+	gui_.set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -203,8 +202,7 @@ void editor_palette<Item>::select_fg_item(const std::string& item_id)
 		selected_fg_item_ = item_id;
 		set_dirty();
 	}
-	gui_.video().clear_help_string(help_handle_);
-	help_handle_ = gui_.video().set_help_string(get_help_string());
+	gui_.set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -214,8 +212,7 @@ void editor_palette<Item>::select_bg_item(const std::string& item_id)
 		selected_bg_item_ = item_id;
 		set_dirty();
 	}
-	gui_.video().clear_help_string(help_handle_);
-	help_handle_ = gui_.video().set_help_string(get_help_string());
+	gui_.set_help_string(get_help_string());
 }
 
 template<class Item>

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -46,7 +46,6 @@ public:
 		, selected_bg_item_()
 		, toolkit_(toolkit)
 		, buttons_()
-		, help_handle_(-1)
 	{
 	}
 
@@ -119,9 +118,11 @@ private:
 
 	void hide(bool hidden) override {
 		widget::hide(hidden);
-		if (!hidden)
-			help_handle_ = gui_.video().set_help_string(get_help_string());
-		else gui_.video().clear_help_string(help_handle_);
+		if (!hidden) {
+			gui_.set_help_string(get_help_string());
+		} else {
+			gui_.clear_help_string();
+		}
 		for (gui::widget& w : buttons_) {
 			w.hide(hidden);
 		}
@@ -183,8 +184,6 @@ private:
 
     editor_toolkit& toolkit_;
     std::vector<gui::tristate_button> buttons_;
-
-    int help_handle_;
 };
 
 

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -173,7 +173,6 @@ location_palette::location_palette(editor_display &gui, const game_config_view& 
 		, button_add_()
 		, button_delete_()
 		, button_goto_()
-		, help_handle_(-1)
 		, disp_(gui)
 	{
 		for (int i = 1; i < 10; ++i) {
@@ -198,7 +197,7 @@ void location_palette::hide(bool hidden)
 {
 	widget::hide(hidden);
 
-	disp_.video().clear_help_string(help_handle_);
+	disp_.clear_help_string();
 
 	std::shared_ptr<gui::button> palette_menu_button = disp_.find_menu_button("menu-editor-terrain");
 	palette_menu_button->set_overlay("");
@@ -309,8 +308,7 @@ void location_palette::adjust_size(const SDL_Rect& target)
 
 	set_location(target);
 	set_dirty(true);
-	disp_.video().clear_help_string(help_handle_);
-	help_handle_ = disp_.video().set_help_string(get_help_string());
+	disp_.set_help_string(get_help_string());
 }
 
 void location_palette::select_item(const std::string& item_id)
@@ -319,8 +317,7 @@ void location_palette::select_item(const std::string& item_id)
 		selected_item_ = item_id;
 		set_dirty();
 	}
-	disp_.video().clear_help_string(help_handle_);
-	help_handle_ = disp_.video().set_help_string(get_help_string());
+	disp_.set_help_string(get_help_string());
 }
 
 std::size_t location_palette::num_items()

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -120,7 +120,6 @@ private:
 	std::unique_ptr<location_palette_button> button_add_;
 	std::unique_ptr<location_palette_button> button_delete_;
 	std::unique_ptr<location_palette_button> button_goto_;
-    int help_handle_;
 	editor_display& disp_;
 };
 


### PR DESCRIPTION
Having it at the very bottom means that it will always obscure the southmost hexes
of the map, and the only way to avoid that is to scroll east/west, or to add an extra
row on the south. Moving it upwards makes it more annoying when working elsewhere on
the map, but it's a trade-off for being able to edit those southmost hexes.

Also, make the text smaller if it's very wide.

This is the 1.16 fix for #6422, with the idea that the second commit will be cherry-picked to 1.17 and then possibly expanded upon. I've also looked at moving the label between the top and bottom of the screen, but that would feature-creep into adding additional functionality to the floating_label support.

![help_string_800x600](https://user-images.githubusercontent.com/101462/216923012-73802cd3-2382-4a98-9985-cd44252271b5.png)
![help_string_1280x1024](https://user-images.githubusercontent.com/101462/216923023-b94b9737-9fdb-4dc6-ad1c-7b0e431eabec.png)
![help_string_2560x1440](https://user-images.githubusercontent.com/101462/216923025-3fe60a7f-b262-4284-9fbb-8e82907a37da.png)


The first commit of the two in this PR
--

Use an editor-only copy of font::set_help_string

This function shows a tooltip-like text at the bottom of the editor's screen,
for example when the paint tool is active it shows which terrains are assigned
to the left and right mouse buttons. There is similar functionality in GUI2,
for example when hovering over the title screen's buttons, which is handled via
event::MESSAGE_SHOW_TOOLTIP.

In the 1.17 branch's 3900419f9230189c699cf2cddb06b31f5025a5f9, I checked that
nothing outside the editor was calling the function. However, that analysis was
done after 1.17's refactoring of the graphics system. For 1.16 I'm not going to
repeat that analysis; the copy that's left in video.cpp is probably dead code,
but I see little reason to remove it from the stable branch.