### PR TITLE
Delete an out-of-date comment in data/themes/default.cfg

### DIFF
--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -586,9 +586,6 @@
             font_size={DEFAULT_FONT_TINY}
             rect="=,+0,=,+{DEFAULT_FONT_TINY_HEIGHT}"
         [/change]
-        # # # placing the unit level right of the alignment
-        # # # doing it the other way around leads to a strange problem sometimes having the alingment not being displayed
-        # # # this does not happen with this order
         [change]
             id=unit-level
             font_size={DEFAULT_FONT_TINY}


### PR DESCRIPTION
The level isn't to the right of the alignment any more, the workaround that the comment refers was removed in ca2eec45b9.