### PR TITLE
Engine: make achievement title less bright gold

### DIFF
--- a/data/gui/window/achievements_dialog.cfg
+++ b/data/gui/window/achievements_dialog.cfg
@@ -144,7 +144,7 @@
 																		id = "name"
 																		definition = "default_large"
 																		characters_per_line = 70
-																		use_markup = false
+																		use_markup = true
 																	[/label]
 																[/column]
 															[/row]

--- a/data/gui/window/achievements_dialog.cfg
+++ b/data/gui/window/achievements_dialog.cfg
@@ -144,7 +144,7 @@
 																		id = "name"
 																		definition = "default_large"
 																		characters_per_line = 70
-																		use_markup = true
+																		use_markup = false
 																	[/label]
 																[/column]
 															[/row]

--- a/src/gui/dialogs/achievements_dialog.cpp
+++ b/src/gui/dialogs/achievements_dialog.cpp
@@ -79,7 +79,7 @@ void achievements_dialog::pre_show(window& win)
 					}
 					item["label"] = name;
 				} else {
-					item["label"] = "<span color='gold'>"+ach.name_completed_+"</span>";
+					item["label"] = "<span color='khaki'>"+ach.name_completed_+"</span>";
 				}
 				row.emplace("name", item);
 


### PR DESCRIPTION
changes from gold to khaki

The current gold looks more yellow and doesn't synergize well with the green description text.