### PR TITLE
Editor: move the text at the bottom of the screen

### DIFF
--- a/changelog_entries/editor_help_string.md
+++ b/changelog_entries/editor_help_string.md
@@ -1,0 +1,2 @@
+ ### Editor
+   * Scrolling the map north or south can move the text that overlays the map, so it doesn't always obscure the southmost hexes of the map. (issue #6422}

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -1098,7 +1098,7 @@ void editor_controller::show_menu(const std::vector<config>& items_arg, int xloc
 
 void editor_controller::preferences()
 {
-	font::clear_help_string();
+	gui_->clear_help_string();
 	gui2::dialogs::preferences_dialog::display();
 
 	gui_->queue_rerender();

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -18,12 +18,15 @@
 #include "draw.hpp"
 #include "editor/controller/editor_controller.hpp"
 #include "editor/editor_display.hpp"
+#include "floating_label.hpp"
+#include "font/sdl_ttf_compat.hpp" // for pango_line_width
 #include "lexical_cast.hpp"
 #include "overlay.hpp"
 #include "reports.hpp"
 #include "team.hpp"
 #include "terrain/builder.hpp"
 #include "units/map.hpp"
+#include "video.hpp"
 
 namespace wb {
 	class manager;
@@ -137,6 +140,43 @@ const time_of_day& editor_display::get_time_of_day(const map_location& /*loc*/) 
 display::overlay_map& editor_display::get_overlays()
 {
 	return controller_.get_current_map_context().get_overlays();
+}
+
+void editor_display::clear_help_string()
+{
+	font::remove_floating_label(help_handle_);
+	help_handle_ = 0;
+}
+
+void editor_display::set_help_string(const std::string& str)
+{
+	clear_help_string();
+
+	const color_t color{0, 0, 0, 0xbb};
+
+	int size = font::SIZE_LARGE;
+	point canvas_size = video::game_canvas_size();
+
+	while(size > 0) {
+		if(font::pango_line_width(str, size) > canvas_size.x) {
+			size--;
+		} else {
+			break;
+		}
+	}
+
+	const int border = 5;
+
+	font::floating_label flabel(str);
+	flabel.set_font_size(size);
+	flabel.set_position(canvas_size.x / 2, canvas_size.y);
+	flabel.set_bg_color(color);
+	flabel.set_border_size(border);
+
+	help_handle_ = font::add_floating_label(flabel);
+
+	const auto& r = font::get_floating_label_rect(help_handle_);
+	font::move_floating_label(help_handle_, 0.0, -double(r.h));
 }
 
 } //end namespace editor

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -130,6 +130,23 @@ void editor_display::layout()
 		refresh_report("villages");
 		refresh_report("num_units");
 	}
+
+	// If we're showing hexes near the north of the map, put the help string at the bottom of the screen.
+	// Otherwise, put it at the top.
+	if(help_handle_ != 0) {
+		const bool place_at_top = get_visible_hexes().top[0] > 2;
+
+		if(place_at_top != help_string_at_top_) {
+			const auto& r = font::get_floating_label_rect(help_handle_);
+			double delta = map_outside_area().h - r.h;
+			if(place_at_top) {
+				font::move_floating_label(help_handle_, 0.0, -delta);
+			} else {
+				font::move_floating_label(help_handle_, 0.0, delta);
+			}
+			help_string_at_top_ = place_at_top;
+		}
+	}
 }
 
 const time_of_day& editor_display::get_time_of_day(const map_location& /*loc*/) const
@@ -158,7 +175,7 @@ void editor_display::set_help_string(const std::string& str)
 	point canvas_size = video::game_canvas_size();
 
 	while(size > 0) {
-		if(font::pango_line_width(str, size) > canvas_size.x) {
+		if(font::pango_line_width(str, size) * 2 > canvas_size.x) {
 			size--;
 		} else {
 			break;
@@ -175,6 +192,9 @@ void editor_display::set_help_string(const std::string& str)
 
 	help_handle_ = font::add_floating_label(flabel);
 
+	// Put the label near the bottom of the screen. In layout() it'll be moved to the top if the
+	// user is editing hexes at the south edge of the map.
+	help_string_at_top_ = false;
 	const auto& r = font::get_floating_label_rect(help_handle_);
 	font::move_floating_label(help_handle_, 0.0, -double(r.h));
 }

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -62,8 +62,7 @@ public:
 	}
 
 	/**
-	 * Displays a help string with the given text. A 'help string' is like a tooltip,
-	 * but appears at the bottom of the screen so as to not be intrusive.
+	 * Sets and shows the tooltip-like text at the top or bottom of the map area.
 	 *
 	 * @param str                 The text to display.
 	 */
@@ -90,6 +89,12 @@ protected:
 private:
 	/** ID of the floating label that's controlled by set_help_string() / clear_help_string(). */
 	int help_handle_ = 0;
+
+	/**
+	 * Ignored when help_handle_ == 0. Othewise, true if the help label obscures the
+	 * northern hexes in the map area, false if it's over the southern hexes instead.
+	 */
+	bool help_string_at_top_ = false;
 };
 
 } //end namespace editor

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -61,6 +61,17 @@ public:
 		mouseover_hex_overlay_.reset();
 	}
 
+	/**
+	 * Displays a help string with the given text. A 'help string' is like a tooltip,
+	 * but appears at the bottom of the screen so as to not be intrusive.
+	 *
+	 * @param str                 The text to display.
+	 */
+	void set_help_string(const std::string& str);
+
+	/** Removes the help string. */
+	void clear_help_string();
+
 protected:
 	void draw_hex(const map_location& loc) override;
 
@@ -75,6 +86,10 @@ protected:
 	editor_controller& controller_;
 
 	texture mouseover_hex_overlay_;
+
+private:
+	/** ID of the floating label that's controlled by set_help_string() / clear_help_string(). */
+	int help_handle_ = 0;
 };
 
 } //end namespace editor

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -19,7 +19,6 @@
 
 #include "gettext.hpp"
 #include "font/text_formatting.hpp"
-#include "floating_label.hpp"
 #include "tooltips.hpp"
 #include "overlay.hpp"
 #include "filesystem.hpp"
@@ -191,8 +190,7 @@ void editor_palette<Item>::adjust_size(const SDL_Rect& target)
 
 	set_location(target);
 	set_dirty(true);
-	font::clear_help_string();
-	font::set_help_string(get_help_string());
+	gui_.set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -202,8 +200,7 @@ void editor_palette<Item>::select_fg_item(const std::string& item_id)
 		selected_fg_item_ = item_id;
 		set_dirty();
 	}
-	font::clear_help_string();
-	font::set_help_string(get_help_string());
+	gui_.set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -213,8 +210,7 @@ void editor_palette<Item>::select_bg_item(const std::string& item_id)
 		selected_bg_item_ = item_id;
 		set_dirty();
 	}
-	font::clear_help_string();
-	font::set_help_string(get_help_string());
+	gui_.set_help_string(get_help_string());
 }
 
 template<class Item>
@@ -239,9 +235,9 @@ void editor_palette<Item>::hide(bool hidden)
 	widget::hide(hidden);
 
 	if (!hidden) {
-		font::set_help_string(get_help_string());
+		gui_.set_help_string(get_help_string());
 	} else {
-		font::clear_help_string();
+		gui_.clear_help_string();
 	}
 
 	for (gui::widget& w : buttons_) {

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -20,7 +20,6 @@
 #include "draw.hpp"
 #include "editor/editor_common.hpp"
 #include "editor/toolkit/editor_toolkit.hpp"
-#include "floating_label.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "font/standard_colors.hpp"
 #include "formula/string_utils.hpp"
@@ -197,7 +196,7 @@ void location_palette::hide(bool hidden)
 {
 	widget::hide(hidden);
 
-	font::clear_help_string();
+	disp_.clear_help_string();
 
 	std::shared_ptr<gui::button> palette_menu_button = disp_.find_menu_button("menu-editor-terrain");
 	palette_menu_button->set_overlay("");
@@ -308,8 +307,7 @@ void location_palette::adjust_size(const SDL_Rect& target)
 
 	set_location(target);
 	set_dirty(true);
-	font::clear_help_string();
-	font::set_help_string(get_help_string());
+	disp_.set_help_string(get_help_string());
 }
 
 void location_palette::select_item(const std::string& item_id)
@@ -318,8 +316,7 @@ void location_palette::select_item(const std::string& item_id)
 		selected_item_ = item_id;
 		set_dirty();
 	}
-	font::clear_help_string();
-	font::set_help_string(get_help_string());
+	disp_.set_help_string(get_help_string());
 }
 
 std::size_t location_palette::num_items()

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -15,10 +15,9 @@
 
 #include "floating_label.hpp"
 
-#include "display.hpp"
 #include "draw.hpp"
 #include "draw_manager.hpp"
-#include "font/sdl_ttf_compat.hpp" // pango_line_width
+#include "font/standard_colors.hpp"
 #include "font/text.hpp"
 #include "log.hpp"
 #include "sdl/utils.hpp"
@@ -45,8 +44,6 @@ int label_id = 1;
 
 std::stack<std::set<int>> label_contexts;
 
-/** Curent ID of the help string. */
-int help_string_ = 0;
 }
 
 namespace font
@@ -396,43 +393,6 @@ void update_floating_labels()
 			++j;
 		}
 	}
-}
-
-void set_help_string(const std::string& str)
-{
-	remove_floating_label(help_string_);
-
-	const color_t color{0, 0, 0, 0xbb};
-
-	int size = font::SIZE_LARGE;
-	point canvas_size = video::game_canvas_size();
-
-	while(size > 0) {
-		if(pango_line_width(str, size) > canvas_size.x) {
-			size--;
-		} else {
-			break;
-		}
-	}
-
-	const int border = 5;
-
-	floating_label flabel(str);
-	flabel.set_font_size(size);
-	flabel.set_position(canvas_size.x / 2, canvas_size.y);
-	flabel.set_bg_color(color);
-	flabel.set_border_size(border);
-
-	help_string_ = add_floating_label(flabel);
-
-	const rect& r = get_floating_label_rect(help_string_);
-	move_floating_label(help_string_, 0.0, -double(r.h));
-}
-
-void clear_help_string()
-{
-	remove_floating_label(help_string_);
-	help_string_ = 0;
 }
 
 }

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -153,15 +153,4 @@ SDL_Rect get_floating_label_rect(int handle);
 void draw_floating_labels();
 void update_floating_labels();
 
-/**
- * Displays a help string with the given text. A 'help string' is like a tooltip,
- * but appears at the bottom of the screen so as to not be intrusive.
- *
- * @param str                 The text to display.
- */
-void set_help_string(const std::string& str);
-
-/** Removes the help string. */
-void clear_help_string();
-
 } // end namespace font

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -26,7 +26,6 @@
 #include "cursor.hpp"
 #include "draw.hpp"
 #include "events.hpp"
-#include "floating_label.hpp"
 #include "formula/callable.hpp"
 #include "formula/string_utils.hpp"
 #include "gettext.hpp"

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -24,7 +24,6 @@
 
 #include "actions/undo.hpp"
 #include "display_chat_manager.hpp"
-#include "floating_label.hpp"
 #include "game_display.hpp"
 #include "preferences/game.hpp"
 #include "game_data.hpp"

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -17,7 +17,6 @@
 
 #include "display.hpp"
 #include "draw_manager.hpp"
-#include "floating_label.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "font/text.hpp"
 #include "log.hpp"

--- a/src/widgets/menu.cpp
+++ b/src/widgets/menu.cpp
@@ -20,7 +20,6 @@
 #include "draw.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "font/standard_colors.hpp"
-#include "floating_label.hpp"
 #include "game_config.hpp"
 #include "language.hpp"
 #include "lexical_cast.hpp"

--- a/src/widgets/widget.cpp
+++ b/src/widgets/widget.cpp
@@ -17,7 +17,6 @@
 
 #include "draw.hpp"
 #include "draw_manager.hpp"
-#include "floating_label.hpp"
 #include "widgets/widget.hpp"
 #include "sdl/rect.hpp"
 #include "tooltips.hpp"


### PR DESCRIPTION
This is the forwardport of #7362. I'm now seeing that more cleanup is possible, but I'd prefer to merge this close to as-is, so that any cleanup that happens in later commits is separate and easily reviewable for (if necessary) backporting to 1.16 too.

Fixes: #6422

Second commit (cherry-pick of 1.16's 29d86d2c369483c45aa599076eb076c5792b7ef3)
---

Editor: let the help text switch between the top and bottom of the screen

If the northmost hexes of the map are visible, put the text on the bottom; if
the southmost are visible, put it on the top. Also, make the text smaller if
it's very wide.

It used to be fixed to the bottom of the screen, but this meant that it always
obscured the southmost hexes of the map, and the only way to avoid that is to
scroll east/west, or to add an extra row on the south. Similarly, having it at
the very top obscures the northmost hexes.

Moving it to any fixed location that isn't the edge of the screen makes it
possible to edit all the hexes, but also makes it more annoying when working
elsewhere on the map; that trade-off was rejected in review.

For very small maps, it will be at the bottom of the screen in the border
outside the map area. For any screen resolution there will be a specific
map-height that still has the old issue, but that's an improvement on it
happening for every map size.

First commit (corresponds to 1.16's 76306d3fb61da9a046087fc862d960a6ac5d4cad)
---

Move set_help_string to editor-only code

No behavior changes, this is just separating it into the editor directory.

This corresponds to 1.16's 76306d3fb61da9a046087fc862d960a6ac5d4cad, but has
additional cleanup outside the editor directory, including removing the unused
code from floating_label.cpp. Even within the editor, there are differences
because of the graphics refactor.