### PR TITLE
Grüü apparition fixed (and commits squashed)

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/14_Back_Home.cfg
@@ -196,11 +196,14 @@
         name=prestart
 
         {RENAME_IF_DEAD thelarion_dead Thelarion (_"Valan")}
-
-        [kill]
-            id=Grüü
-            side=4
-        [/kill]
+        [modify_unit]
+            [filter]
+                id=Grüü
+            [/filter]
+            x=5
+            y=34
+            side=1
+        [/modify_unit]
     [/event]
 
     {GOT_THE_GREAT_HORDE 1,2,3,4}
@@ -241,9 +244,6 @@
     [event]
         name=start
 
-        [recall]
-            id=Grüü
-        [/recall]
         [recall]
             id=Jetto
         [/recall]


### PR DESCRIPTION
Backport of #7282, this time squashing the commits instead of rebase-merging them.

This, instead of killing Grüü, moves him along with the others to participate in the conversation, and also switches him to side 1 (this side is temporary and only for narrative purposes, later on turn 7 he switches to side 4 again).

Grüü is correctly stored on the variable when the conversation ends, and restored later on turn 7.

(cherry picked from commit cccd562cc5726348530f077dd9663239ef9cddda)
(cherry picked from commit 34a5cce2b072209cbf4de128b123a3dde7e65ee5)
(cherry picked from commit f23134890009896088b8e9fe549042ee4d0553a1)
(cherry picked from commit 89dbd2d37336785c416b9e76a3a0dcf27500b0b0)