### PR TITLE
Resolve Issue 7398: Crash on Attack with Planning Mode

### DIFF
--- a/src/whiteboard/attack.cpp
+++ b/src/whiteboard/attack.cpp
@@ -161,7 +161,7 @@ void attack::apply_temp_modifier(unit_map& unit_map)
 	unit& unit = *get_unit();
 	DBG_WB << unit.name() << " [" << unit.id()
 					<< "] has " << unit.attacks_left() << " attacks, decreasing by " << attack_count_;
-	assert(unit.attacks_left() > attack_count_);
+	assert(unit.attacks_left() >= attack_count_);
 
 	//Calculate movement to subtract
 	temp_movement_subtracted_ = unit.movement_left() >= attack_movement_cost_ ? attack_movement_cost_ : 0 ;


### PR DESCRIPTION
The game crashes when the player clicks the Attack button with planning mode with a console error about a failed assert on line 164 of src/whiteboard/attack.cpp.  The assert uses > but it looks like it should be >=.

This commit switches from > to >= and appears to resolve the issue.