### PR TITLE
Units: Try to avoid hard-coding of size of known boolean states

### DIFF
--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -868,6 +868,7 @@ public:
 		STATE_UNHEALABLE,   /** The unit cannot be healed */
 		STATE_GUARDIAN,     /** The unit is a guardian - it won't move unless a target is sighted */
 		STATE_INVULNERABLE, /** The unit is invulnerable - it cannot be hit by any attack */
+		NUMBER_OF_STATES,   /** To set the size of known_boolean_states_ */
 		STATE_UNKNOWN = -1  /** A status effect not known to the engine */
 	};
 
@@ -1908,7 +1909,7 @@ private:
 
 	std::set<std::string> states_;
 
-	static const std::size_t num_bool_states = 7;
+	static const std::size_t num_bool_states = state_t::NUMBER_OF_STATES;
 
 	std::bitset<num_bool_states> known_boolean_states_;
 	static std::map<std::string, state_t> known_boolean_state_names_;


### PR DESCRIPTION
#7363 added a new invulnerable state but neglected to increment the number of states.

I'm not sure if there's a better way of doing this.