### PR TITLE
Catch invalid argument exception for stoi in unit advancement

### DIFF
--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -478,7 +478,13 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_unit, child,  use_undo, /*show*/, /*error_
 		return false;
 	}
 	if (name == "advances" ) {
-		int int_value = std::stoi(value);
+		int int_value = 0;
+		try {
+			int_value = std::stoi(value);
+		} catch (const std::invalid_argument&) {
+			WRN_REPLAY << "Warning: Invalid unit advancement argument: " << value;
+			return false;
+		}
 		for (int levels=0; levels<int_value; levels++) {
 			i->set_experience(i->max_experience());
 


### PR DESCRIPTION
Resolves #7402.

Took me a while to find the relevant `stoi` call - not sure if 'replay' is the right log domain but I'm just following the convention used elsewhere in this file.

When I checked, normal (debug) unit advancement still works and attempting to use a string argument does nothing (but logs the warning) instead of completely crashing.

Could be back-ported as the bug is present for 1.16 as well.