### PR TITLE
WoF make recall of some unit type trees undoable

### DIFF
--- a/data/campaigns/Winds_of_Fate/utils/macros.cfg
+++ b/data/campaigns/Winds_of_Fate/utils/macros.cfg
@@ -8,23 +8,21 @@
         [filter]
             type_adv_tree=Drake Warrior
         [/filter]
-        [if]
+        [filter_condition]
             [not]
                 [have_unit]
                     role=fighter_intendant
                     search_recall_list=yes
                 [/have_unit]
             [/not]
-            [then]
-                [modify_unit]
-                    [filter]
-                        id=$unit.id
-                    [/filter]
-                    role=fighter_intendant
-                    {TRAIT_LOYAL}
-                [/modify_unit]
-            [/then]
-        [/if]
+        [/filter_condition]
+        [modify_unit]
+            [filter]
+                id=$unit.id
+            [/filter]
+            role=fighter_intendant
+            {TRAIT_LOYAL}
+        [/modify_unit]
     [/event]
     [event]
         name=recall
@@ -32,23 +30,21 @@
         [filter]
             type_adv_tree=Drake Arbiter, Drake Thrasher
         [/filter]
-        [if]
+        [filter_condition]
             [not]
                 [have_unit]
                     role=clasher_intendant
                     search_recall_list=yes
                 [/have_unit]
             [/not]
-            [then]
-                [modify_unit]
-                    [filter]
-                        id=$unit.id
-                    [/filter]
-                    role=clasher_intendant
-                    {TRAIT_LOYAL}
-                [/modify_unit]
-            [/then]
-        [/if]
+        [/filter_condition]
+        [modify_unit]
+            [filter]
+                id=$unit.id
+            [/filter]
+            role=clasher_intendant
+            {TRAIT_LOYAL}
+        [/modify_unit]
     [/event]
 #enddef
 


### PR DESCRIPTION
The way it's written prevents undoing the recall action of the filtered unit trees (Drake Arbiter, Drake Thrasher and Drake Warrior). It is better to activate the event only if the other conditional is also fulfilled, it is unnecessary in the rest of the cases.
What I have done is simply moved the conditional from [if] to the [filter_condition] of the event itself

Just to clarify for those who don't know, the code makes the unit loyal if the original loyal of the same type tree died or was removed from the recall list. I've tested all cases with the new filters and works fine.