### PR TITLE
WoF S03,S08 - Added animation when units go to recall list

### DIFF
--- a/data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/03_The_Contention.cfg
@@ -329,6 +329,13 @@ You shall learn a pivotal lesson in humility!"
                 id=Gorlack,Karron
             [/not]
         [/filter]
+        [animate_unit]
+            [filter]
+                id=$unit.id
+            [/filter]
+            flag=pre_teleport
+            with_bars=no
+        [/animate_unit]
         [put_to_recall_list]
             id=$unit.id
             heal=yes

--- a/data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg
@@ -774,6 +774,13 @@ Yet I shall not forsake them to such a place as this."
                     [/filter]
                     moves=full
                 [/heal_unit]
+                [animate_unit]
+                    [filter]
+                        id=$unit.id
+                    [/filter]
+                    flag=pre_teleport
+                    with_bars=no
+                [/animate_unit]
                 [store_unit]
                     [filter]
                         id=$unit.id


### PR DESCRIPTION
This resolves #7410  and the same situation on S08 Overlook, when the units escapes from the cave on 31,1
Uses the pre_teleport animation (in the absence of another specific animation for drakes), which does a smooth fade effect and is automatically generated on any unit.