### PR TITLE
Add a CMake and SCons flag for GLIBCXX_ASSERTIONS without GLIBCXX_DEBUG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,8 @@ option(ENABLE_PEDANTIC_COMPILATION "Sets the pedantic compilation mode" OFF)
 option(ENABLE_DEBUG_WINDOW_LAYOUT "Add the debug option to allow the generation of debug layout files in dot format" OFF)
 option(ENABLE_DESIGN_DOCUMENTS "Enables the generation of design documents, and has additional dependencies" OFF)
 option(ENABLE_LTO "Sets Link Time Optimization for Release builds" OFF)
-option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC" OFF)
+option(GLIBCXX_ASSERTIONS "Whether to define _GLIBCXX_ASSERTIONS" OFF)
+option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC. Requires a version of Boost's program_options that's compiled with __GLIBCXX_DEBUG too." OFF)
 option(ENABLE_POT_UPDATE_TARGET "Enables the tools to update the pot files and manuals. This target has extra dependencies." OFF)
 option(FORCE_COLOR_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
 
@@ -399,7 +400,14 @@ if(NOT MSVC)
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG -ggdb3 ${EXTRA_FLAGS_CONFIG} ${EXTRA_FLAGS_DEBUG}" CACHE STRING "change cmake's Debug flags to match scons' flags" FORCE)
 	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${LINK_EXTRA_FLAGS_CONFIG} ${LINK_EXTRA_FLAGS_DEBUG}" CACHE STRING "" FORCE)
 
-# adds GLIBCXX_DEBUG definitions
+# Enabling GLIBCXX_ASSERTIONS puts bounds-checks on std::vector::operator[], etc
+	if(GLIBCXX_ASSERTIONS)
+		MESSAGE("Defining _GLIBCXX_ASSERTIONS")
+		add_definitions(-D_GLIBCXX_ASSERTIONS)
+	endif()
+
+# GLIBCXX_DEBUG enables more checks that GLIBCXX_ASSERTIONS, but changes the ABI of Boost's program_options library.
+# When _GLIBCXX_DEBUG is defined, _GLIBCXX_ASSERTIONS is automatically implied (Gnu's c++config.h will define it).
 	if(GLIBCXX_DEBUG)
 		MESSAGE("Defining _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC")
 		add_definitions(-D_GLIBCXX_DEBUG)

--- a/SConstruct
+++ b/SConstruct
@@ -57,7 +57,8 @@ opts.AddVariables(
     ('arch', 'What -march option to use for build=release, will default to pentiumpro on Windows', ""),
     ('opt', 'override for the build\'s optimization level', ""),
     BoolVariable('harden', 'Whether to enable options to harden the executables', True),
-    BoolVariable('glibcxx_debug', 'Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for build=debug', False),
+    BoolVariable('glibcxx_assertions', 'Whether to define _GLIBCXX_ASSERTIONS for build=debug', False),
+    BoolVariable('glibcxx_debug', "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for build=debug. Requires a version of Boost's program_options that's compiled with __GLIBCXX_DEBUG too.", False),
     EnumVariable('profiler', 'profiler to be used', "", ["", "gprof", "gcov", "gperftools", "perf"]),
     EnumVariable('pgo_data', 'whether to generate profiling data for PGO, or use existing profiling data', "", ["", "generate", "use"]),
     BoolVariable('use_srcdir', 'Whether to place object files in src/ or not', False),
@@ -552,10 +553,11 @@ for env in [test_env, client_env, env]:
             debug_flags = Split(debug_flags)
             debug_flags.append("${ '-O3' if TARGET.name == 'gettext.o' else '' }") # workaround for "File too big" errors
 
+        glibcxx_debug_flags = ""
+        if env["glibcxx_assertions"] == True:
+            glibcxx_debug_flags = " ".join([glibcxx_debug_flags, "_GLIBCXX_ASSERTIONS"])
         if env["glibcxx_debug"] == True:
-            glibcxx_debug_flags = "_GLIBCXX_DEBUG _GLIBCXX_DEBUG_PEDANTIC"
-        else:
-            glibcxx_debug_flags = ""
+            glibcxx_debug_flags = " ".join([glibcxx_debug_flags, "_GLIBCXX_DEBUG", "_GLIBCXX_DEBUG_PEDANTIC"])
 
 # #
 # End determining options for debug build

--- a/changelog_entries/glibcxx_assertions.md
+++ b/changelog_entries/glibcxx_assertions.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Linux SCons and CMake scripts now support enabling `_GLIBCXX_ASSERTIONS`.


### PR DESCRIPTION
Turning GLIBCXX_ASSERTIONS adds some bounds checks, such as checking in std::string::operator[]. It's a subset of the checks that GLIBCXX_DEBUG adds, but has the advantage that it doesn't require a rebuild of the Boost libraries.

None of the CI builds enable these assertions, as they slow down the code which makes the unit tests time out.

This makes it easy to replicate #7412.