### PR TITLE
Fix mixed indents in the schema, and verify new additions

### DIFF
--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -1,4 +1,3 @@
-
 #define ACTION_TAG NAME EXTRA
 	[tag]
 		name="{NAME}"
@@ -366,8 +365,8 @@
 		{LINK_TAG "units/$modifications/advancement"}
 		{LINK_TAG "units/$modifications/object"}
 		{LINK_TAG "units/$modifications/base/effect"}
-        {LINK_TAG "$action_wml/clear_variable"}
-        {LINK_TAG "$action_wml/set_variable"}
+		{LINK_TAG "$action_wml/clear_variable"}
+		{LINK_TAG "$action_wml/set_variable"}
 	[/tag]
 	[tag]
 		name="transform_unit"
@@ -518,7 +517,7 @@
 		# Don't link from SaveWML schema since these accept variable substitution
 		[tag]
 			name="attack"
-            max=infinite
+			max=infinite
 			{INSERT_TAG}
 			{SIMPLE_KEY weapon s_int}
 			{SIMPLE_KEY defender_weapon s_int}
@@ -535,14 +534,14 @@
 		[/tag]
 		[tag]
 			name="move"
-            max=infinite
+			max=infinite
 			{SIMPLE_KEY x s_range_list}
 			{SIMPLE_KEY y s_range_list}
 			{SIMPLE_KEY skip_sighted string} # TODO: Make this an enum type
 		[/tag]
 		[tag]
 			name="recruit"
-            max=infinite
+			max=infinite
 			{INSERT_TAG}
 			{SIMPLE_KEY type string}
 			{SIMPLE_KEY x s_int}
@@ -555,7 +554,7 @@
 		[/tag]
 		[tag]
 			name="recall"
-            max=infinite
+			max=infinite
 			{INSERT_TAG}
 			{SIMPLE_KEY value string}
 			{SIMPLE_KEY x s_int}
@@ -569,12 +568,12 @@
 		[/tag]
 		[tag]
 			name="disband"
-            max=infinite
+			max=infinite
 			{SIMPLE_KEY value string}
 		[/tag]
 		[tag]
 			name="fire_event"
-            max=infinite
+			max=infinite
 			{INSERT_TAG}
 			{SIMPLE_KEY raise string}
 			[tag]
@@ -591,13 +590,13 @@
 		[/tag]
 		[tag]
 			name="lua_ai"
-            max=infinite
+			max=infinite
 			deprecated=yes
 			{SIMPLE_KEY code string}
 		[/tag]
 		[tag]
 			name="custom_command"
-            max=infinite
+			max=infinite
 			{SIMPLE_KEY name string}
 			{DATA_TAG "data" 1 1 string}
 		[/tag]

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -1,4 +1,3 @@
-
 #define ADDON_DESCRIPTION
 	{SIMPLE_KEY name t_string}
 	{SIMPLE_KEY description t_string}
@@ -450,8 +449,8 @@
 		{SIMPLE_KEY visible_in_shroud s_bool}
 		{SIMPLE_KEY team_name string}
 		{SIMPLE_KEY color s_color}
-        {SIMPLE_KEY category s_t_string}
-        {SIMPLE_KEY creator s_int}
+		{SIMPLE_KEY category s_t_string}
+		{SIMPLE_KEY creator s_int}
 	[/tag]
 	[tag]
 		name="item"

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -1,4 +1,3 @@
-
 [tag]
 	name="unit_type~core"
 	max=0
@@ -57,8 +56,8 @@
 		{SIMPLE_KEY attack_weight real}
 		{SIMPLE_KEY movement_used int}
 		{SIMPLE_KEY attacks_used int}
-        {SIMPLE_KEY accuracy int}
-        {SIMPLE_KEY parry int}
+		{SIMPLE_KEY accuracy int}
+		{SIMPLE_KEY parry int}
 		[tag]
 			name="specials"
 			{./specials.cfg}

--- a/data/tools/Makefile
+++ b/data/tools/Makefile
@@ -70,6 +70,9 @@ unchecked:
 	@./wmlscope --unchecked $(MAINLINE) $(UMC)
 
 # Reindent the mainline content
+#
+# The schema and GUI directories are currently mainly indented with tabs.
+# Although the schema isn't reindented here, it's at least checked for consistency.
 reindent:
 	@./wmlindent \
 		--exclude=../../data/languages \
@@ -79,6 +82,7 @@ reindent:
 		--exclude=../../data/test/scenarios/wml_tests/TerrainWML \
 		--exclude=../../data/schema \
 		$(DATA)
+	@find ../../data/schema -name \*.cfg -print0 | xargs -0 ./check_mixed_indent
 
 # Extract a table of editor keybindings from the editor theme definition
 editor_bindings:


### PR DESCRIPTION
This uses tabs instead of spaces, because although that's not our coding standard, it is only a few lines of changes.

The alternative of running wmlindent on these files changes 4700 lines; while I'm in favor of doing it, it's discussed in #5709.