### PR TITLE
UtBS S05 add logic to the main cavern event so scouting is taken into account

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
  ### Add-ons client
  ### Add-ons server
  ### Campaigns
+   * Under the Burning Suns
+     * S05 Fixed the main cavern event not taking scouting into account. (issue #7394)
  ### Editor
  ### Multiplayer
  ### Lua API

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
@@ -946,7 +946,7 @@
                 [message]
                     speaker=$explorer.id
                     #po: "this" refers to the trolls and dwarves fighting
-                    message= _ "Whoa. Kaleh, you have to come watch this."
+                    message= _ "Whoa. Kaleh, you have to come see this."
                 [/message]
                 # if the explorer is too far ahead (x>26), put kaleh safely behind
                 [if]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/05_A_Subterranean_Struggle.cfg
@@ -843,7 +843,7 @@
 
         #2 troll whelps
         {DEFENDER 3 (Troll Whelp) 31 30 (Troll Defender) ( _ "Troll Defender")}
-        {DEFENDER 2 (Troll Whelp) 29 28 (Troll Defender) ( _ "Troll Defender")}
+        {DEFENDER 2 (Troll Whelp) 29 29 (Troll Defender) ( _ "Troll Defender")}
 
         #western reinforcements
 
@@ -930,10 +930,79 @@
         #dwarf/troll/elf dialogue
 
         {CHECK_EXPLORER}
-        [message]
-            speaker=$explorer.id
-            message= _ "Whoa."
-        [/message]
+        # {DEBUG_MSG "Explorer id is $explorer.id, position is $explorer.x , $explorer.y"}
+        [if]
+            [variable]
+                name=explorer.id
+                equals="Kaleh"
+            [/variable]
+            [then]
+                [message]
+                    speaker=$explorer.id
+                    message= _ "Whoa."
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=$explorer.id
+                    #po: "this" refers to the trolls and dwarves fighting
+                    message= _ "Whoa. Kaleh, you have to come watch this."
+                [/message]
+                # if the explorer is too far ahead (x>26), put kaleh safely behind
+                [if]
+                    [variable]
+                        name=explorer.x
+                        greater_than=26
+                    [/variable]
+                    [then]
+                        [move_unit]
+                            id=Kaleh
+                            to_x=24
+                            to_y=28
+                        [/move_unit]
+                    [/then]
+                    [else]
+                        [move_unit]
+                            id=Kaleh
+                            to_x=$explorer.x
+                            to_y=$explorer.y
+                        [/move_unit]
+                    [/else]
+                [/if]
+            [/else]
+        [/if]
+        [store_unit]
+            [filter]
+                id=Kaleh
+            [/filter]
+            variable=kaleh_restore_mp
+            kill=no
+        [/store_unit]
+#ifndef HARD
+        [modify_unit]
+            [filter]
+                id=Kaleh
+            [/filter]
+            moves=$kaleh_restore_mp.max_moves
+        [/modify_unit]
+#else
+        # Give Kaleh just a few moves, if necessary, in case he is in a dangerous position after the movement.
+        [if]
+            [variable]
+                name=kaleh_restore_mp.moves
+                less_than=3
+            [/variable]
+            [then]
+                [modify_unit]
+                    [filter]
+                        id=Kaleh
+                    [/filter]
+                    moves=3
+                [/modify_unit]
+            [/then]
+        [/if]
+#endif
+        {CLEAR_VARIABLE kaleh_restore_mp}
 
         # Unhide the dwarves' and trolls' sides
         [modify_side]


### PR DESCRIPTION
Closes #7394 

Line 846 (changing the position of the troll) is meant as a fix to a borderline issue, where Kaleh is in a position where he can't reach the keep if the player allies the dwarves, but can if he allies the trolls (because Zone of Control) - a different approach could be setting the troll in 30, 28. Not a major change anyways.

As seen in the picture, Kaleh can't get to the keep via the 6-moves that is represented with the blue line, as it crosses two tiles with ZoC and he can't reach either via the 7-moves represented with the green line, as it is too far away.
![ZoCThen](https://user-images.githubusercontent.com/30196839/221952974-f4d9529b-3684-4600-bc8b-b5fa4b858b3d.png)
Kaleh would be able to reach the keep with the new position of the troll.
![ZoCNow](https://user-images.githubusercontent.com/30196839/221952980-ddbba554-6915-4b2d-a1ac-b898f175b893.png)

Line 933 is a debug message, useful for debugging or playtesting later.

Lines 934 - 973 
- If kaleh is the explorer, he just says "Whoa." and everything else in these lines is skipped
- If other unit is the explorer and
    1. the explorer does not reach too far out (x=26 or beyond). Then Kaleh moves up to the explorer
    2. the explorer reaches too far out. Then Kaleh moves to 24,28 (the first tile that triggers the moveto event)
  
Lines 974-1005 Kaleh's movement points are fully restored in EASY and MEDIUM, partially restored (only if necessary) in HARD
