### PR TITLE
campaignd: Fix blank license terms if [server_info] is missing

### DIFF
--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -2051,8 +2051,8 @@ int main(int argc, char** argv)
 	} catch(const boost::program_options::error& e) {
 		PLAIN_LOG << "Error in command line: " << e.what();
 		return 10;
-	} catch(const config::error& /*e*/) {
-		PLAIN_LOG << "Could not parse config file";
+	} catch(const config::error& e) {
+		PLAIN_LOG << "Could not parse config file: " << e.message;
 		return 1;
 	} catch(const filesystem::io_exception& e) {
 		PLAIN_LOG << "File I/O error: " << e.what();

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -347,12 +347,12 @@ void server::load_config()
 	// One month probably will be fine (#TODO: testing needed)
 	update_pack_lifespan_ = cfg_["update_pack_lifespan"].to_time_t(30 * 24 * 60 * 60);
 
-	if(const auto& svinfo_cfg = server_info()) {
-		server_id_ = svinfo_cfg["id"].str();
-		feedback_url_format_ = svinfo_cfg["feedback_url_format"].str();
-		web_url_ = svinfo_cfg["web_url"].str(default_web_url);
-		license_notice_ = svinfo_cfg["license_notice"].str(default_license_notice);
-	}
+	const auto& svinfo_cfg = server_info();
+
+	server_id_ = svinfo_cfg["id"].str();
+	feedback_url_format_ = svinfo_cfg["feedback_url_format"].str();
+	web_url_ = svinfo_cfg["web_url"].str(default_web_url);
+	license_notice_ = svinfo_cfg["license_notice"].str(default_license_notice);
 
 	blacklist_file_ = cfg_["blacklist_file"].str();
 	load_blacklist();

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -207,10 +207,7 @@ private:
 									  std::string& error_data);
 
 	/** Retrieves the contents of the [server_info] WML node. */
-	const config& server_info() const { return cfg_.child("server_info"); }
-
-	/** Retrieves the contents of the [server_info] WML node. */
-	config& server_info() { return cfg_.child("server_info"); }
+	const config& server_info() const { return cfg_.child_or_empty("server_info"); }
 
 	/** Checks if the specified address should never bump download counts. */
 	bool ignore_address_stats(const std::string& addr) const;


### PR DESCRIPTION
If interacting with a campaignd instance that has a fresh configuration or is otherwise missing the `[server_info]` tag, the client will present the player with completely blank licensing terms. This was caused by a logic issue with the processing of `[server_info]` wherein no default attribute values would ever be loaded if the tag was missing.

(This has never been relevant or found on the production campaignd instances because all of them have `[server_info]` tags explicitly provided for the purpose of formatting add-on forum thread URLs.)