### PR TITLE
GUI: fix indentation that uses both tabs and spaces on the same line

### DIFF
--- a/data/gui/window/core_dialog.cfg
+++ b/data/gui/window/core_dialog.cfg
@@ -77,7 +77,7 @@
 
 										[row]
 
-											 [column]
+											[column]
 												grow_factor = 1
 												horizontal_grow = true
 
@@ -101,7 +101,7 @@
 																[image]
 																	id = "image"
 																	definition = "default"
-																    label = "icons/icon-game.png"
+																	label = "icons/icon-game.png"
 																[/image]
 															[/column]
 

--- a/data/gui/window/debug_clock.cfg
+++ b/data/gui/window/debug_clock.cfg
@@ -207,7 +207,7 @@
 
 									[row]
 
-										 [column]
+										[column]
 
 											grow_factor = 1
 											horizontal_grow = true

--- a/data/gui/window/drop_down_list.cfg
+++ b/data/gui/window/drop_down_list.cfg
@@ -78,7 +78,7 @@ min(
 
 							[row]
 
-								 [column]
+								[column]
 									grow_factor = 1
 									horizontal_grow = true
 

--- a/data/gui/window/editor_edit_scenario.cfg
+++ b/data/gui/window/editor_edit_scenario.cfg
@@ -177,12 +177,12 @@
 								border_size = 5
 								horizontal_alignment = "left"
 								[slider]
-								    id = "experience_modifier"
-								    definition = "default"
-								    best_slider_length = 250
-								    minimum_value = 30
-								    maximum_value = 200
-								    step_size = 5
+									id = "experience_modifier"
+									definition = "default"
+									best_slider_length = 250
+									minimum_value = 30
+									maximum_value = 200
+									step_size = 5
 								[/slider]
 							[/column]
 
@@ -209,12 +209,12 @@
 								horizontal_alignment = "left"
 
 								[slider]
-								    id = "turns"
-								    definition = "default"
-								    best_slider_length = 250
-								    minimum_value = -1
-								    maximum_value = 99
-								    step_size = 1
+									id = "turns"
+									definition = "default"
+									best_slider_length = 250
+									minimum_value = -1
+									maximum_value = 99
+									step_size = 1
 								[/slider]
 							[/column]
 
@@ -242,7 +242,7 @@
 					[/toggle_button]
 
 				[/column]
-		    [/row]
+			[/row]
 
 			[row]
 				grow_factor = 0
@@ -260,7 +260,7 @@
 					[/toggle_button]
 
 				[/column]
-		    [/row]
+			[/row]
 
 			[row]
 				grow_factor = 0

--- a/data/gui/window/editor_edit_side.cfg
+++ b/data/gui/window/editor_edit_side.cfg
@@ -255,12 +255,12 @@
 								horizontal_grow = true
 
 								[slider]
-								    id = "gold"
-								    definition = "default"
-								    best_slider_length = 200
-								    minimum_value = 0
-								    maximum_value = 1000
-								    step_size = 5
+									id = "gold"
+									definition = "default"
+									best_slider_length = 200
+									minimum_value = 0
+									maximum_value = 1000
+									step_size = 5
 								[/slider]
 							[/column]
 						[/row]
@@ -283,12 +283,12 @@
 								horizontal_grow = true
 
 								[slider]
-								    id = "village_income"
-								    definition = "default"
-								    best_slider_length = 200
-								    minimum_value = 1
-								    maximum_value = 10
-								    step_size = 1
+									id = "village_income"
+									definition = "default"
+									best_slider_length = 200
+									minimum_value = 1
+									maximum_value = 10
+									step_size = 1
 								[/slider]
 							[/column]
 						[/row]
@@ -311,12 +311,12 @@
 								horizontal_grow = true
 
 								[slider]
-								    id = "income"
-								    definition = "default"
-								    best_slider_length = 200
-								    minimum_value = -2
-								    maximum_value = 20
-								    step_size = 1
+									id = "income"
+									definition = "default"
+									best_slider_length = 200
+									minimum_value = -2
+									maximum_value = 20
+									step_size = 1
 								[/slider]
 							[/column]
 						[/row]
@@ -339,12 +339,12 @@
 								horizontal_grow = true
 
 								[slider]
-								    id = "village_support"
-								    definition = "default"
-								    best_slider_length = 200
-								    minimum_value = 0
-								    maximum_value = 20
-								    step_size = 1
+									id = "village_support"
+									definition = "default"
+									best_slider_length = 200
+									minimum_value = 0
+									maximum_value = 20
+									step_size = 1
 								[/slider]
 							[/column]
 						[/row]

--- a/data/gui/window/editor_resize_map.cfg
+++ b/data/gui/window/editor_resize_map.cfg
@@ -60,12 +60,12 @@
 								border_size = 5
 								horizontal_alignment = "left"
 								[slider]
-								    id = "width"
-								    definition = "default"
-								    best_slider_length = 250
-								    minimum_value = 1
-								    maximum_value = 200
-								    step_size = 1
+									id = "width"
+									definition = "default"
+									best_slider_length = 250
+									minimum_value = 1
+									maximum_value = 200
+									step_size = 1
 								[/slider]
 							[/column]
 							[column]
@@ -107,12 +107,12 @@
 								border_size = 5
 								horizontal_alignment = "left"
 								[slider]
-								    id = "height"
-								    definition = "default"
-								    best_slider_length = 250
-								    minimum_value = 1
-								    maximum_value = 200
-								    step_size = 1
+									id = "height"
+									definition = "default"
+									best_slider_length = 250
+									minimum_value = 1
+									maximum_value = 200
+									step_size = 1
 								[/slider]
 							[/column]
 							[column]

--- a/data/gui/window/language_selection.cfg
+++ b/data/gui/window/language_selection.cfg
@@ -82,7 +82,7 @@
 
 							[row]
 
-								 [column]
+								[column]
 									grow_factor = 1
 									horizontal_grow = true
 

--- a/data/gui/window/mp_create_game.cfg
+++ b/data/gui/window/mp_create_game.cfg
@@ -241,7 +241,7 @@
 
 								[row]
 
-									 [column]
+									[column]
 										grow_factor = 1
 										horizontal_grow = true
 
@@ -797,7 +797,7 @@
 
 					[row]
 
-						 [column]
+						[column]
 							grow_factor = 1
 							horizontal_grow = true
 

--- a/data/gui/window/unit_recall.cfg
+++ b/data/gui/window/unit_recall.cfg
@@ -413,8 +413,8 @@
 									label = _ "Dismiss"
 								[/button]
 							[/column]
-						 [/row]
-					 [/grid]
+						[/row]
+					[/grid]
 				[/column]
 			[/row]
 

--- a/data/gui/window/wml_message.cfg
+++ b/data/gui/window/wml_message.cfg
@@ -252,7 +252,7 @@ where calculated_width = {__GUI_IMAGE_WIDTH}
 
 		[row]
 
-			 [column]
+			[column]
 				grow_factor = 1
 				horizontal_grow = true
 


### PR DESCRIPTION
This isn't the complete set needed to allow `check_mixed_indent` to run over the data/gui directory, it's just these small changes:

* Remove the single space from lines indented "tab ... tab space".
* Convert lines indented with "tab ... tab four_spaces".

Although these are WML files, the coding standard for the data/gui directory is to indent with tabs instead of spaces.

These are whitespace-only changes, so I'm planning to merge after 24 hours unless someone comments on it.