### PR TITLE
Improve docs about pango_text's high-dpi encapsulation

### DIFF
--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -140,13 +140,6 @@ surface pango_text::render_surface(const SDL_Rect& viewport)
 	return create_surface(viewport);
 }
 
-surface pango_text::render_surface()
-{
-	update_pixel_scale(); // TODO: this should be in recalculate()
-	recalculate();
-	return create_surface();
-}
-
 texture pango_text::with_draw_scale(const texture& t) const
 {
 	texture res(t);


### PR DESCRIPTION
A couple of functions become private. Although render_texture(viewport) is dead code I think it's useful enough as documentation to leave it in, at least until we work out how to fix #6952, the crash when trying to show the long text in the end_credits screen.

The removed render_surface() would be private because it returns a surface with render-space width and height, however it was also never called and wouldn't be useful as documentation.

While I understand the implementation of this class, I've not spent time to understand the overview of the design for the high-dpi support; please review assuming that I'm not going to be looking further at this area of the GUI code in the near future, so if you want more explanation about the implementation or if I've used the wrong terminology please ask now.

@mesilliac I'd welcome a review from you, but I've set @Vultraz as the reviewer because as the GUI maintainer he's the person that I'm expecting to fix the credits crash.