### PR TITLE
Reimplement the end_credits with a [listbox]

### DIFF
--- a/data/gui/window/end_credits.cfg
+++ b/data/gui/window/end_credits.cfg
@@ -3,6 +3,93 @@
 ### Definition of the credits screen
 ###
 
+#define GUI_CREDITS_LIST_DEFINITION
+	# Contents of the [listbox], split with a macro to reduce the levels of indentation
+	[list_definition]
+
+		[row]
+
+			[column]
+				vertical_grow = true
+				horizontal_grow = true
+
+				[toggle_panel]
+					definition = "default"
+					return_value_id = "ok"
+					[grid]
+
+						[row]
+
+							[column]
+								vertical_grow = true
+								horizontal_alignment = "center"
+
+								grow_factor = 1
+								border = "all"
+								border_size = 5
+
+								[label]
+									id = "group_header"
+									definition = "default_huge"
+									text_alignment = "center"
+									use_markup = true
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+
+							[column]
+								vertical_grow = true
+								horizontal_alignment = "center"
+
+								grow_factor = 1
+								border = "all"
+								border_size = 5
+
+								[label]
+									id = "section_title"
+									definition = "default_large"
+									text_alignment = "center"
+									use_markup = true
+								[/label]
+
+							[/column]
+
+						[/row]
+
+						[row]
+							[column]
+								vertical_grow = true
+								horizontal_alignment = "center"
+
+								grow_factor = 1
+								border = "all"
+								border_size = 5
+
+								[label]
+									id = "contributor_name"
+									definition = "default"
+									text_alignment = "center"
+									use_markup = true
+								[/label]
+
+							[/column]
+
+						[/row]
+					[/grid]
+
+				[/toggle_panel]
+
+			[/column]
+
+		[/row]
+
+	[/list_definition]
+#enddef
+
 [window_definition]
 
 	id = "end_credits_window"
@@ -95,13 +182,14 @@
 									grow_factor = 1
 									horizontal_alignment = "center"
 
-									[scroll_label]
-										id = "text"
-										definition = "default_small"
-										text_alignment = "center"
+									[listbox]
+										id = "listbox"
+										definition = "default"
+										has_minimum = false
 
-										horizontal_scrollbar_mode = "never"
-									[/scroll_label]
+										{GUI_CREDITS_LIST_DEFINITION}
+
+									[/listbox]
 
 								[/column]
 
@@ -167,3 +255,5 @@
 	[/resolution]
 
 [/window]
+
+#undef GUI_CREDITS_LIST_DEFINITION

--- a/src/gui/dialogs/end_credits.hpp
+++ b/src/gui/dialogs/end_credits.hpp
@@ -24,8 +24,6 @@ class display;
 namespace gui2
 {
 
-class scroll_label;
-
 namespace dialogs
 {
 
@@ -50,8 +48,6 @@ private:
 	const std::string& focus_on_;
 
 	std::vector<std::string> backgrounds_;
-
-	scroll_label* text_widget_;
 
 	// The speed of auto-scrolling, specified as px/s
 	int scroll_speed_;


### PR DESCRIPTION
The UX here is terrible, but at least it doesn't crash. My intention here is to provide a stepping stone which I hope someone familiar with the GUI2 widgets will take and then improve the UX to solve the bug which this is just a part of, #6952.

UX issues include:
* It sets the background of an item to blue.
* Mousing over the list can make the background shadowed.
* Pressing "up" at the start jumps to the bottom of the list.

I'd be happy if someone takes this and reworks it. No need to keep this as a separate commit, cherry-pick bits from it as you wish. Alternatively, maybe there are already better widgets to use, or it could be merged with the expectation that it'll be improved before 1.18 releases.