### PR TITLE
enable linger mode in replays

### DIFF
--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -294,7 +294,8 @@ void advance_unit_at(const advance_unit_params& params)
 			}
 		}
 		//we don't want to let side 1 decide it during start/prestart.
-		int side_for = resources::gamedata->phase() == game_data::PLAY ? 0: u->side();
+		//The "0" parameter here is the default and gets resolves to "current player"
+		int side_for = resources::gamedata->has_current_player() ? 0: u->side();
 		config selected = mp_sync::get_user_choice("choose",
 			unit_advancement_choice(params.loc_, unit_helper::number_of_possible_advances(*u), u->side(), params.force_dialog_), side_for);
 		//calls actions::advance_unit.

--- a/src/carryover_show_gold.cpp
+++ b/src/carryover_show_gold.cpp
@@ -33,7 +33,7 @@ static lg::log_domain log_engine("engine");
 #define ERR_NG LOG_STREAM(err, log_engine)
 
 
-void carryover_show_gold(game_state& state, bool is_observer, bool is_test)
+void carryover_show_gold(game_state& state, bool hidden, bool is_observer, bool is_test)
 {
 	assert(state.end_level_data_);
 	game_board& board = state.board_;
@@ -153,7 +153,7 @@ void carryover_show_gold(game_state& state, bool is_observer, bool is_test)
 		}
 	}
 
-	if(end_level.transient.carryover_report) {
+	if(end_level.transient.carryover_report && !hidden) {
 		gui2::show_transient_message(title, report.str(), "", true);
 	}
 }

--- a/src/carryover_show_gold.hpp
+++ b/src/carryover_show_gold.hpp
@@ -16,4 +16,4 @@
 class game_state;
 /// calculates the amount of gold carried over for each team,
 /// stores the data in the team object and shows the carryover message
-void carryover_show_gold(game_state& state, bool is_observer, bool is_test);
+void carryover_show_gold(game_state& state, bool hidden, bool is_observer, bool is_test);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -116,25 +116,6 @@ static int get_zoom_levels_index(unsigned int zoom_level)
 	return std::distance(zoom_levels.begin(), iter);
 }
 
-void display::parse_team_overlays()
-{
-	const team& curr_team = dc_->teams()[playing_team()];
-	const team& prev_team = playing_team() == 0
-		? dc_->teams().back()
-		: dc_->get_team(playing_team());
-	for (const auto& i : get_overlays()) {
-		for(const overlay& ov : i.second) {
-			if(!ov.team_name.empty() &&
-				((ov.team_name.find(curr_team.team_name()) + 1) != 0) !=
-				((ov.team_name.find(prev_team.team_name()) + 1) != 0))
-			{
-				invalidate(i.first);
-			}
-		}
-	}
-}
-
-
 void display::add_overlay(const map_location& loc, const std::string& img, const std::string& halo, const std::string& team_name, const std::string& item_id, bool visible_under_fog, float submerge, float z_order)
 {
 	halo::handle halo_handle;

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -146,12 +146,6 @@ public:
 	std::string remove_exclusive_draw(const map_location& loc);
 
 	/**
-	 * Check the overlay_map for proper team-specific overlays to be
-	 * displayed/hidden
-	 */
-	void parse_team_overlays();
-
-	/**
 	 * Functions to add and remove overlays from locations.
 	 *
 	 * An overlay is an image that is displayed on top of the tile.

--- a/src/game_data.cpp
+++ b/src/game_data.cpp
@@ -126,6 +126,7 @@ void game_data::clear_variable(const std::string& varname)
 
 void game_data::write_snapshot(config& cfg) const
 {
+	write_phase(cfg, phase_);
 	cfg["next_scenario"] = next_scenario_;
 	cfg["id"] = id_;
 	cfg["theme"] = theme_;
@@ -168,4 +169,39 @@ void game_data::activate_scope_variable(std::string var_name) const
 			break;
 		}
 	}
+}
+
+game_data::PHASE game_data::read_phase(const config& cfg)
+{
+	if(cfg["playing_team"].empty()) {
+		return game_data::PRELOAD;
+	}
+	if(!cfg["init_side_done"]) {
+		return game_data::TURN_STARTING_WAITING;
+	}
+	if(cfg.has_child("end_level_data")) {
+		return game_data::GAME_ENDED;
+	}
+	return game_data::TURN_PLAYING;
+}
+
+
+bool game_data::has_current_player() const
+{
+	return phase() == TURN_STARTING || phase() == TURN_PLAYING || phase() == TURN_ENDED;
+}
+
+bool game_data::is_before_screen() const
+{
+	return phase() == INITIAL || phase() == PRELOAD || phase() == PRESTART;
+}
+
+bool game_data::is_after_start() const
+{
+	return !(phase() == INITIAL || phase() == PRELOAD || phase() == PRESTART || phase() == START);
+}
+
+void game_data::write_phase(config& cfg, game_data::PHASE phase)
+{
+	cfg["init_side_done"] = !(phase == INITIAL || phase == PRELOAD || phase == PRESTART || phase == TURN_STARTING_WAITING);
 }

--- a/src/game_data.hpp
+++ b/src/game_data.hpp
@@ -69,15 +69,50 @@ public:
 	randomness::mt_rng& rng() { return rng_; }
 
 	enum PHASE {
+		/// creating intitial [unit]s, executing toplevel [lua] etc.
+		/// next phase: PRELOAD
 		INITIAL,
+		/// the preload [event] is fired
+		/// next phase: PRESTART (normal game), TURN_STARTING_WAITING (reloaded game), TURN_PLAYING (reloaded game) or GAME_ENDED (reloadedgame)
 		PRELOAD,
+		/// the prestart [event] is fired
+		/// next phase: START (default), GAME_ENDING
 		PRESTART,
+		/// the start [event] is fired
+		/// next phase: TURN_STARTING_WAITING (default), GAME_ENDING
 		START,
-		PLAY
+		/// we are waiting for the turn to start.
+		/// The game can be saved here.
+		/// next phase: TURN_STARTING
+		TURN_STARTING_WAITING,
+		/// the turn, side turn etc. [event]s are being fired
+		/// next phase: TURN_PLAYING (default), GAME_ENDING
+		TURN_STARTING,
+		/// The User is controlling the game and invoking actions
+		/// The game can be saved here.
+		/// next phase: TURN_PLAYING (default), GAME_ENDING
+		TURN_PLAYING,
+		/// The turn_end, side_turn_end etc [events] are fired
+		/// next phase: TURN_STARTING_WAITING (default), GAME_ENDING
+		TURN_ENDED,
+		/// The victory etc. [event]s are fired.
+		/// next phase: GAME_ENDED
+		GAME_ENDING,
+		/// The game has ended and the user is observing the final state "lingering"
+		/// The game can be saved here.
+		GAME_ENDED,
 	};
 
 	PHASE phase() const { return phase_; }
 	void set_phase(PHASE phase) { phase_ = phase; }
+	/// returns where there is currently a well defiend "current player",
+	/// that is for example not the case during start events or during linger mode.
+	bool has_current_player() const;
+	bool is_before_screen() const;
+	bool is_after_start() const;
+
+	static PHASE read_phase(const config& cfg);
+	static void write_phase(config& cfg, game_data::PHASE phase);
 
 	const t_string& cannot_end_turn_reason() {
 		return cannot_end_turn_reason_;

--- a/src/game_end_exceptions.cpp
+++ b/src/game_end_exceptions.cpp
@@ -28,7 +28,7 @@ end_level_data::end_level_data()
 	, replay_save(true)
 	, proceed_to_next_level(false)
 	, is_victory(true)
-	, test_result(level_result::result_not_set)
+	, test_result("")
 	, transient()
 {
 }

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -286,27 +286,17 @@ WML_HANDLER_FUNCTION(do_command,, cfg)
 
 	static const std::set<std::string> allowed_tags {"attack", "move", "recruit", "recall", "disband", "fire_event", "custom_command"};
 
-	const bool is_too_early = resources::gamedata->phase() != game_data::START && resources::gamedata->phase() != game_data::PLAY;
-	const bool is_unsynced_too_early = resources::gamedata->phase() != game_data::PLAY;
+	const bool is_too_early = resources::gamedata->phase() == game_data::INITIAL || resources::gamedata->phase() == game_data::PRELOAD;
+	const bool is_during_turn = resources::gamedata->phase() == game_data::TURN_PLAYING;
 	const bool is_unsynced = synced_context::get_synced_state() == synced_context::UNSYNCED;
 	if(is_too_early)
 	{
 		ERR_NG << "[do_command] called too early, only allowed at START or later";
 		return;
 	}
-	if(is_unsynced && resources::controller->is_lingering())
+	if(is_unsynced && !is_during_turn)
 	{
-		ERR_NG << "[do_command] cannot be used in linger mode";
-		return;
-	}
-	if(is_unsynced && !resources::controller->gamestate().init_side_done())
-	{
-		ERR_NG << "[do_command] cannot be used before the turn has started";
-		return;
-	}
-	if(is_unsynced && is_unsynced_too_early)
-	{
-		ERR_NG << "[do_command] called too early";
+		ERR_NG << "[do_command] can only be used during a turn when a user woudl also be able to invoke commands";
 		return;
 	}
 	if(is_unsynced && events::commands_disabled)

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -85,12 +85,6 @@ level_result::type campaign_controller::playsingle_scenario(end_level_data &end_
 	}
 
 	end_level = playcontroller.get_end_level_data();
-	carryover_show_gold(playcontroller.gamestate(), playcontroller.is_observer(), is_unit_test_);
-
-	if(!video::headless()) {
-		playcontroller.maybe_linger();
-	}
-
 	state_.set_snapshot(playcontroller.to_config());
 	return res;
 }
@@ -107,13 +101,6 @@ level_result::type campaign_controller::playmp_scenario(end_level_data &end_leve
 
 	end_level = playcontroller.get_end_level_data();
 
-	if(res != level_result::type::observer_end) {
-		// We need to call this before linger because it prints the defeated/victory message.
-		//(we want to see that message before entering the linger mode)
-		carryover_show_gold(playcontroller.gamestate(), playcontroller.is_observer(), is_unit_test_);
-	}
-
-	playcontroller.maybe_linger();
 	playcontroller.update_savegame_snapshot();
 
 	if(mp_info_) {
@@ -162,6 +149,7 @@ level_result::type campaign_controller::play_game()
 #endif
 			{
 				res = playmp_scenario(end_level);
+				//todo: i removed the code that could return observer_end
 			}
 		} catch(const leavegame_wesnothd_error&) {
 			LOG_NG << "The game was remotely ended";

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -59,8 +59,6 @@ game_state::game_state(const config& level, play_controller& pc)
 	, player_number_(level["playing_team"].to_int() + 1)
 	, next_player_number_(level["next_player_number"].to_int(player_number_ + 1))
 	, do_healing_(level["do_healing"].to_bool(false))
-	, init_side_done_(level["init_side_done"].to_bool(false))
-	, start_event_fired_(!level["playing_team"].empty())
 	, server_request_number_(level["server_request_number"].to_int())
 	, first_human_team_(-1)
 {
@@ -226,8 +224,9 @@ void game_state::set_game_display(game_display * gd)
 
 void game_state::write(config& cfg) const
 {
-	cfg["init_side_done"] = init_side_done_;
-	if(gamedata_.phase() == game_data::PLAY) {
+	// dont write this before we fired the (pre)start events
+	// This is the case for the 'replay_start' part of the savegame.
+	if(!in_phase(game_data::INITIAL, game_data::PRELOAD)) {
 		cfg["playing_team"] = player_number_ - 1;
 		cfg["next_player_number"] = next_player_number_;
 	}

--- a/src/game_state.hpp
+++ b/src/game_state.hpp
@@ -63,11 +63,8 @@ public:
 	bool do_healing_;
 
 	std::optional<end_level_data> end_level_data_;
-	bool init_side_done_;
-	bool start_event_fired_;
 	// used to sync with the mpserver
 	int server_request_number_;
-	bool& init_side_done() { return init_side_done_; }
 
 
 	game_events::wmi_manager& get_wml_menu_items();
@@ -109,6 +106,18 @@ public:
 	virtual game_lua_kernel* get_lua_kernel() const override
 	{
 		return lua_kernel_.get();
+	}
+
+
+	bool in_phase(game_data::PHASE phase) const
+	{
+		return gamedata_.phase() == phase;
+	}
+
+	template< typename... Arguments >
+	bool in_phase(game_data::PHASE phase, Arguments ... args) const
+	{
+		return in_phase(phase) || in_phase(args...);
 	}
 
 	/** Checks to see if a leader at @a leader_loc could recruit somewhere. */

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -63,7 +63,7 @@ const game_state & play_controller::hotkey_handler::gamestate() const {
 }
 
 bool play_controller::hotkey_handler::browse() const { return play_controller_.is_browsing(); }
-bool play_controller::hotkey_handler::linger() const { return play_controller_.is_lingering(); }
+bool play_controller::hotkey_handler::linger() const { return play_controller_.is_linger_mode(); }
 
 const team & play_controller::hotkey_handler::viewing_team() const { return play_controller_.get_teams()[gui()->viewing_team()]; }
 bool play_controller::hotkey_handler::viewing_team_is_playing() const { return gui()->viewing_team() == gui()->playing_team(); }

--- a/src/hotkey/hotkey_handler_sp.cpp
+++ b/src/hotkey/hotkey_handler_sp.cpp
@@ -224,7 +224,9 @@ bool playsingle_controller::hotkey_handler::can_execute_command(const hotkey::ho
 		case hotkey::HOTKEY_RECALL:
 			return (!browse() || whiteboard_manager_->is_active()) && !linger() && !events::commands_disabled;
 		case hotkey::HOTKEY_ENDTURN:
-			return (!browse() || linger()) && !events::commands_disabled;
+			//TODO: Its unclear to me under which cirumstances the other clients can remain in linger mode
+			//      when the host pressed scenario, some codes suggest that tha can be the case some don't.
+			return (!browse() || (linger() && playsingle_controller_.is_host())) && !events::commands_disabled;
 
 		case hotkey::HOTKEY_DELAY_SHROUD:
 			return !linger()

--- a/src/hotkey/hotkey_handler_sp.cpp
+++ b/src/hotkey/hotkey_handler_sp.cpp
@@ -18,6 +18,7 @@
 #include "filesystem.hpp" // for get_saves_dir()
 #include "font/standard_colors.hpp"
 #include "formula/string_utils.hpp"
+#include "gui/dialogs/message.hpp"
 #include "hotkey/hotkey_command.hpp"
 #include "hotkey/hotkey_item.hpp"
 #include "map/label.hpp"
@@ -28,7 +29,7 @@
 #include "game_events/wmi_manager.hpp"
 #include "map/map.hpp"
 #include "save_index.hpp"
-#include "gui/dialogs/message.hpp"
+#include "saved_game.hpp"
 #include "resources.hpp"
 #include "replay.hpp"
 
@@ -318,6 +319,12 @@ void playsingle_controller::hotkey_handler::load_autosave(const std::string& fil
 			gui2::show_error_message(_("The file you have tried to load is corrupt: '") + error_log);
 			return;
 		}
+
+		if(!playsingle_controller_.get_saved_game().get_replay().is_ancestor(savegame.child_or_empty("replay"))) {
+			gui2::show_error_message(_("The file you have tried to load is not from the current session"));
+			return;
+		}
+
 		std::shared_ptr<config> res(new config(savegame.child_or_empty("snapshot")));
 		std::shared_ptr<config> stats(new config(savegame.child_or_empty("statistics")));
 		throw reset_gamestate_exception(res, stats, true);

--- a/src/hotkey/hotkey_handler_sp.hpp
+++ b/src/hotkey/hotkey_handler_sp.hpp
@@ -24,7 +24,7 @@
 #include "playsingle_controller.hpp"
 
 #include "hotkey/hotkey_handler.hpp"
-
+#include "replay_controller.hpp"
 class playsingle_controller::hotkey_handler : public play_controller::hotkey_handler {
 
 protected:

--- a/src/level_result.hpp
+++ b/src/level_result.hpp
@@ -22,11 +22,9 @@ struct level_result_defines
 	static constexpr const char* const defeat = "defeat";
 	static constexpr const char* const quit = "quit";
 	static constexpr const char* const observer_end = "observer_end";
-	static constexpr const char* const result_not_set = "result_not_set";
 	static constexpr const char* const pass = "pass";
 	static constexpr const char* const fail = "fail";
-	static constexpr const char* const test_invalid = "test_invalid";
 
-	ENUM_AND_ARRAY(victory, defeat, quit, observer_end, result_not_set, pass, fail, test_invalid)
+	ENUM_AND_ARRAY(victory, defeat, quit, observer_end, pass, fail)
 };
 using level_result = string_enums::enum_base<level_result_defines>;

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -72,6 +72,7 @@
 #include "preferences/credentials.hpp"
 #include "preferences/display.hpp"
 #include "replay.hpp"
+#include "replay_controller.hpp"
 #include "replay_helper.hpp"
 #include "resources.hpp"
 #include "save_index.hpp"

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -539,29 +539,22 @@ void play_controller::do_init_side()
 
 	check_victory();
 	sync.do_final_checkup();
+	gamestate().gamedata_.set_phase(game_data::TURN_PLAYING);
 
 	init_side_end();
+
+	if(!is_skipping_replay() && current_team().get_scroll_to_leader()) {
+		gui_->scroll_to_leader(current_side(), game_display::ONSCREEN, false);
+	}
 }
 
 void play_controller::init_side_end()
 {
-
 	if(	did_tod_sound_this_turn_) {
 		did_tod_sound_this_turn_ = true;
 		const time_of_day& tod = gamestate().tod_manager_.get_time_of_day();
 		sound::play_sound(tod.sounds, sound::SOUND_SOURCES);
 	}
-
-	if(!is_skipping_replay()) {
-		gui_->invalidate_all();
-	}
-
-	if(!is_skipping_replay() && current_team().get_scroll_to_leader() && !map_start_.valid()) {
-		gui_->scroll_to_leader(current_side(), game_display::ONSCREEN, false);
-	}
-
-	map_start_ = map_location();
-	gamestate().gamedata_.set_phase(game_data::TURN_PLAYING);
 	whiteboard_manager_->on_init_side();
 }
 

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1318,12 +1318,10 @@ void play_controller::play_side()
 {
 	do {
 		update_viewing_player();
-		{
-			save_blocker blocker;
-			maybe_do_init_side();
-			if(is_regular_game_end()) {
-				return;
-			}
+
+		maybe_do_init_side();
+		if(is_regular_game_end()) {
+			return;
 		}
 		// This flag can be set by derived classes (in overridden functions).
 		player_type_changed_ = false;

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -1316,9 +1316,6 @@ std::set<std::string> play_controller::all_players() const
 
 void play_controller::play_side()
 {
-	// check for team-specific items in the scenario
-	gui_->parse_team_overlays();
-
 	do {
 		update_viewing_player();
 		{

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -52,7 +52,6 @@
 #include "replay.hpp"
 #include "reports.hpp"
 #include "resources.hpp"
-#include "save_blocker.hpp"
 #include "save_index.hpp"
 #include "saved_game.hpp"
 #include "savegame.hpp"
@@ -906,59 +905,37 @@ replay& play_controller::get_replay()
 
 void play_controller::save_game()
 {
-	if(save_blocker::try_block()) {
-		// Saving while an event is running isn't supported
-		// because it may lead to expired event handlers being saved.
-		assert(!gamestate().events_manager_->is_event_running());
+	// Saving while an event is running isn't supported
+	// because it may lead to expired event handlers being saved.
+	assert(!gamestate().events_manager_->is_event_running());
 
-		save_blocker::save_unblocker unblocker;
-		scoped_savegame_snapshot snapshot(*this);
-		savegame::ingame_savegame save(saved_game_, preferences::save_compression_format());
-		save.save_game_interactive("", savegame::savegame::OK_CANCEL);
-	} else {
-		save_blocker::on_unblock(this, &play_controller::save_game);
-	}
+	scoped_savegame_snapshot snapshot(*this);
+	savegame::ingame_savegame save(saved_game_, preferences::save_compression_format());
+	save.save_game_interactive("", savegame::savegame::OK_CANCEL);
 }
 
 void play_controller::save_game_auto(const std::string& filename)
 {
-	if(save_blocker::try_block()) {
-		save_blocker::save_unblocker unblocker;
-
-		scoped_savegame_snapshot snapshot(*this);
-		savegame::ingame_savegame save(saved_game_, preferences::save_compression_format());
-		save.save_game_automatic(false, filename);
-	}
+	scoped_savegame_snapshot snapshot(*this);
+	savegame::ingame_savegame save(saved_game_, preferences::save_compression_format());
+	save.save_game_automatic(false, filename);
 }
 
 void play_controller::save_replay()
 {
-	if(save_blocker::try_block()) {
-		save_blocker::save_unblocker unblocker;
-		savegame::replay_savegame save(saved_game_, preferences::save_compression_format());
-		save.save_game_interactive("", savegame::savegame::OK_CANCEL);
-	} else {
-		save_blocker::on_unblock(this, &play_controller::save_replay);
-	}
+	savegame::replay_savegame save(saved_game_, preferences::save_compression_format());
+	save.save_game_interactive("", savegame::savegame::OK_CANCEL);
 }
 
 void play_controller::save_replay_auto(const std::string& filename)
 {
-	if(save_blocker::try_block()) {
-		save_blocker::save_unblocker unblocker;
-		savegame::replay_savegame save(saved_game_, preferences::save_compression_format());
-		save.save_game_automatic(false, filename);
-	}
+	savegame::replay_savegame save(saved_game_, preferences::save_compression_format());
+	save.save_game_automatic(false, filename);
 }
 
 void play_controller::save_map()
 {
-	if(save_blocker::try_block()) {
-		save_blocker::save_unblocker unblocker;
-		menu_handler_.save_map();
-	} else {
-		save_blocker::on_unblock(this, &play_controller::save_map);
-	}
+	menu_handler_.save_map();
 }
 
 void play_controller::load_game()

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -229,7 +229,6 @@ public:
 
 	bool is_skipping_replay() const { return skip_replay_; }
 	void toggle_skipping_replay();
-	bool is_linger_mode() const { return linger_; }
 	void do_autosave();
 
 	bool is_skipping_story() const { return skip_story_; }
@@ -256,8 +255,7 @@ public:
 	actions::undo_list& get_undo_stack() { return undo_stack(); }
 
 	bool is_browsing() const override;
-	bool is_lingering() const { return linger_; }
-
+#
 	class hotkey_handler;
 
 	virtual replay_controller * get_replay_controller() const { return nullptr; }
@@ -288,12 +286,7 @@ public:
 		return is_regular_game_end();
 	}
 
-	void maybe_throw_return_to_play_side() const
-	{
-		if(should_return_to_play_side() && !linger_ ) {
-			throw return_to_play_side_exception();
-		}
-	}
+	void maybe_throw_return_to_play_side() const;
 
 	virtual void play_side_impl() {}
 
@@ -328,6 +321,9 @@ public:
 	};
 
 	saved_game& get_saved_game() { return saved_game_; }
+
+	bool is_during_turn() const;
+	bool is_linger_mode() const;
 
 protected:
 	friend struct scoped_savegame_snapshot;
@@ -394,7 +390,6 @@ protected:
 
 	bool skip_replay_;
 	bool skip_story_;
-	bool linger_;
 	/**
 	 * Whether we did init sides in this session
 	 * (false = we did init sides before we reloaded the game).

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -394,7 +394,8 @@ protected:
 	 * Whether we did init sides in this session
 	 * (false = we did init sides before we reloaded the game).
 	 */
-	bool init_side_done_now_;
+	bool did_autosave_this_turn_;
+	bool did_tod_sound_this_turn_;
 	//the displayed location when we load a game.
 	map_location map_start_;
 	// Whether to start with the display faded to black

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -146,6 +146,8 @@ public:
 		return gamestate().end_level_data_.has_value();
 	}
 
+	bool check_regular_game_end();
+
 	const end_level_data& get_end_level_data() const
 	{
 		return *gamestate().end_level_data_;
@@ -340,7 +342,7 @@ protected:
 	void fire_start();
 	void start_game();
 	virtual void init_gui();
-	void finish_side_turn();
+	void finish_side_turn_events();
 	void finish_turn(); //this should not throw an end turn or end level exception
 	bool enemies_visible() const;
 
@@ -433,5 +435,4 @@ protected:
 	virtual void sync_end_turn() {}
 	virtual void check_time_over();
 	virtual void update_viewing_player() = 0;
-	void play_turn();
 };

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -101,6 +101,12 @@ void playmp_controller::remove_blindfold()
 
 void playmp_controller::play_linger_turn()
 {
+	if(replay_controller_.get() != nullptr) {
+		// We have probably been using the mp "back to turn" feature
+		// We continue play since we have reached the end of the replay.
+		replay_controller_.reset();
+	}
+
 	while( gamestate().in_phase(game_data::GAME_ENDED) && !end_turn_requested_) {
 		config cfg;
 		if(network_reader_.read(cfg)) {

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -456,7 +456,7 @@ void playmp_controller::send_user_choice()
 
 void playmp_controller::play_slice(bool is_delay_enabled)
 {
-	if(!is_linger_mode() && !is_replay()) {
+	if(!is_linger_mode() && !is_replay() && !network_processing_stopped_) {
 		// receive chat during animations and delay
 		process_network_data(true);
 		// cannot use turn_data_.send_data() here.

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -234,7 +234,6 @@ void playmp_controller::reset_end_scenario_button()
 void playmp_controller::linger()
 {
 	LOG_NG << "beginning end-of-scenario linger";
-	gamestate().gamedata_.set_phase(game_data::GAME_ENDED);
 
 	// If we need to set the status depending on the completion state
 	// we're needed here.
@@ -448,6 +447,7 @@ void playmp_controller::maybe_linger()
 	} else {
 		linger();
 	}
+	end_turn_requested_ = true;
 }
 
 void playmp_controller::surrender(int side_number)

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -101,10 +101,6 @@ void playmp_controller::remove_blindfold()
 
 void playmp_controller::play_linger_turn()
 {
-	if(is_host()) {
-		end_turn_enable(true);
-	}
-
 	while( gamestate().in_phase(game_data::GAME_ENDED) && !end_turn_requested_) {
 		config cfg;
 		if(network_reader_.read(cfg)) {
@@ -211,38 +207,15 @@ void playmp_controller::play_idle_loop()
 	}
 }
 
-void playmp_controller::set_end_scenario_button()
-{
-	// Modify the end-turn button
-	if(!is_host()) {
-		std::shared_ptr<gui::button> btn_end = gui_->find_action_button("button-endturn");
-		btn_end->enable(false);
-	}
-
-	gui_->get_theme().refresh_title2("button-endturn", "title2");
-	gui_->queue_rerender();
-}
-
-void playmp_controller::reset_end_scenario_button()
-{
-	// revert the end-turn button text to its normal label
-	gui_->get_theme().refresh_title2("button-endturn", "title");
-	gui_->queue_rerender();
-	gui_->set_game_mode(game_display::RUNNING);
-}
-
 void playmp_controller::linger()
 {
 	LOG_NG << "beginning end-of-scenario linger";
 
-	// If we need to set the status depending on the completion state
-	// we're needed here.
-	gui_->set_game_mode(game_display::LINGER);
-
 	// End all unit moves
 	gamestate().board_.set_all_units_user_end_turn();
 
-	set_end_scenario_button();
+	update_gui_linger();
+
 	assert(is_regular_game_end());
 
 	if(get_end_level_data().transient.reveal_map) {
@@ -282,8 +255,6 @@ void playmp_controller::linger()
 			quit = false;
 		}
 	} while(!quit);
-
-	reset_end_scenario_button();
 
 	LOG_NG << "ending end-of-scenario linger";
 }

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -486,7 +486,6 @@ void playmp_controller::process_network_data(bool chat_only)
 	} else if(res == turn_info::PROCESS_RESTART_TURN) {
 		player_type_changed_ = true;
 	} else if(res == turn_info::PROCESS_END_TURN) {
-		gamestate().gamedata_.set_phase(game_data::TURN_ENDED);
 	} else if(res == turn_info::PROCESS_END_LEVEL) {
 	} else if(res == turn_info::PROCESS_END_LINGER) {
 		replay::process_error("Received unexpected next_scenario during the game");

--- a/src/playmp_controller.hpp
+++ b/src/playmp_controller.hpp
@@ -26,7 +26,6 @@ class playmp_controller : public playsingle_controller, public syncmp_handler
 public:
 	playmp_controller(const config& level, saved_game& state_of_game, mp_game_metadata* mp_info);
 	virtual ~playmp_controller();
-
 	void maybe_linger() override;
 	void process_oos(const std::string& err_msg) const override;
 

--- a/src/playmp_controller.hpp
+++ b/src/playmp_controller.hpp
@@ -61,13 +61,11 @@ protected:
 	mutable bool network_processing_stopped_;
 
 	virtual void on_not_observer() override;
-	bool is_host() const;
+	virtual bool is_host() const override;
 	void remove_blindfold();
 
 	blindfold blindfold_;
 private:
-	void set_end_scenario_button();
-	void reset_end_scenario_button();
 	void process_network_data(bool chat_only = false);
 	mp_game_metadata* mp_info_;
 };

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -398,8 +398,6 @@ void playsingle_controller::play_side_impl()
 		end_turn_requested_ = false;
 	}
 	if(replay_controller_.get() != nullptr) {
-		init_side_done_now_ = false;
-
 		REPLAY_RETURN res = replay_controller_->play_side_impl();
 		if(res == REPLAY_FOUND_END_TURN) {
 			gamestate().gamedata_.set_phase(game_data::TURN_ENDED);
@@ -454,7 +452,8 @@ void playsingle_controller::before_human_turn()
 		return;
 	}
 
-	if(init_side_done_now_ && !game_config::disable_autosave && preferences::autosavemax() > 0) {
+	if(!did_autosave_this_turn_ && !game_config::disable_autosave && preferences::autosavemax() > 0) {
+		did_autosave_this_turn_ = true;
 		scoped_savegame_snapshot snapshot(*this);
 		savegame::autosave_savegame save(saved_game_, preferences::save_compression_format());
 		save.autosave(game_config::disable_autosave, preferences::autosavemax(), preferences::INFINITE_AUTO_SAVES);

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -298,8 +298,6 @@ level_result::type playsingle_controller::play_scenario(const config& level)
 		const end_level_data& end_level = get_end_level_data();
 
 		if(get_teams().empty()) {
-			// store persistent teams
-			saved_game_.set_snapshot(config());
 
 			// this is probably only a story scenario, i.e. has its endlevel in the prestart event
 			return level_result::type::victory;
@@ -307,8 +305,6 @@ level_result::type playsingle_controller::play_scenario(const config& level)
 
 		if(linger_) {
 			LOG_NG << "resuming from loaded linger state...";
-			// as carryover information is stored in the snapshot, we have to re-store it after loading a linger state
-			saved_game_.set_snapshot(config());
 			if(!is_observer()) {
 				persist_.end_transaction();
 			}

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -77,7 +77,6 @@ playsingle_controller::playsingle_controller(const config& level, saved_game& st
 	, network_reader_([this](config& cfg) { return receive_from_wesnothd(cfg); })
 	, turn_data_(replay_sender_, network_reader_)
 	, end_turn_requested_(false)
-	, skip_next_turn_(false)
 	, ai_fallback_(false)
 	, replay_controller_()
 {
@@ -273,6 +272,7 @@ void playsingle_controller::finish_side_turn()
 	}
 	gamestate().gamedata_.set_phase(game_data::TURN_STARTING_WAITING);
 	did_autosave_this_turn_ = false;
+	end_turn_requested_ = false;
 	init_side_begin();
 }
 
@@ -478,9 +478,6 @@ void playsingle_controller::play_idle_loop()
 
 void playsingle_controller::play_side_impl()
 {
-	if(!skip_next_turn_) {
-		end_turn_requested_ = false;
-	}
 	if(replay_controller_.get() != nullptr) {
 		replay_controller_->play_side_impl();
 
@@ -733,7 +730,6 @@ void playsingle_controller::end_turn()
 
 void playsingle_controller::force_end_turn()
 {
-	skip_next_turn_ = true;
 	end_turn_requested_ = true;
 }
 
@@ -778,7 +774,6 @@ void playsingle_controller::sync_end_turn()
 
 
 	assert(gamestate().in_phase(game_data::TURN_ENDED));
-	skip_next_turn_ = false;
 
 	if(ai_fallback_) {
 		current_team().make_ai();

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -327,6 +327,8 @@ void playsingle_controller::play_scenario_main_loop()
 				resources::gameboard->teams()[i].set_local(local_players[i]);
 			}
 
+			// TODO: we currently don't set the music to the initial playlist, should we?
+
 			play_scenario_init(*ex.level);
 
 			if(replay_controller_ == nullptr) {

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -353,12 +353,7 @@ level_result::type playsingle_controller::play_scenario(const config& level)
 
 		persist_.end_transaction();
 
-		level_result::type res = level_result::get_enum(end_level.test_result).value_or(level_result::type::test_invalid);
-		if(res == level_result::type::result_not_set) {
-			return is_victory ? level_result::type::victory : level_result::type::defeat;
-		} else {
-			return res;
-		}
+		return level_result::get_enum(end_level.test_result).value_or(is_victory ? level_result::type::victory : level_result::type::defeat);
 	} catch(const savegame::load_game_exception&) {
 		// Loading a new game is effectively a quit.
 		saved_game_.clear();

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -73,7 +73,6 @@ static lg::log_domain log_enginerefac("enginerefac");
 playsingle_controller::playsingle_controller(const config& level, saved_game& state_of_game, bool skip_replay)
 	: play_controller(level, state_of_game, skip_replay, true) // start faded
 	, cursor_setter_(cursor::NORMAL)
-	, textbox_info_()
 	, replay_sender_(*resources::recorder)
 	, network_reader_([this](config& cfg) { return receive_from_wesnothd(cfg); })
 	, turn_data_(replay_sender_, network_reader_)

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -289,25 +289,6 @@ void playsingle_controller::play_scenario_main_loop()
 		try {
 			play_some();
 		} catch(const reset_gamestate_exception& ex) {
-			//
-			// TODO:
-			//
-			// The MP replay feature still doesn't work properly (causes OOS)
-			// because:
-			//
-			// 1) The undo stack is not reset along with the gamestate (fixed).
-			// 2) The server_request_number_ is not reset along with the
-			//    gamestate (fixed).
-			// 3) chat and other unsynced actions are inserted in the middle of
-			//    the replay bringing the replay_pos in unorder (fixed).
-			// 4) untracked changes in side controllers are lost when resetting
-			//    gamestate (fixed).
-			// 5) The game should have a stricter check for whether the loaded
-			//    game is actually a parent of this game.
-			// 6) If an action was undone after a game was saved it can cause
-			//    OOS if the undone action is in the snapshot of the saved
-			//    game (luckily this is never the case for autosaves).
-			//
 			boost::dynamic_bitset<> local_players;
 			local_players.resize(get_teams().size(), true);
 			// Preserve side controllers, because we won't get the side controoller updates again when replaying.

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -393,10 +393,7 @@ void playsingle_controller::do_end_level()
 	}
 
 	persist_.end_transaction();
-	if(!is_observer()) {
-		//TODO: passing is_observer() when is_observer() is false seems wrong.
-		carryover_show_gold(gamestate(), is_observer(), saved_game_.classification().is_test());
-	}
+	carryover_show_gold(gamestate(), is_observer(), saved_game_.classification().is_test());
 
 }
 

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -482,10 +482,7 @@ void playsingle_controller::play_side_impl()
 		end_turn_requested_ = false;
 	}
 	if(replay_controller_.get() != nullptr) {
-		REPLAY_RETURN res = replay_controller_->play_side_impl();
-		if(res == REPLAY_FOUND_END_TURN) {
-			gamestate().gamedata_.set_phase(game_data::TURN_ENDED);
-		}
+		replay_controller_->play_side_impl();
 
 		if(player_type_changed_) {
 			replay_controller_.reset();

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -429,7 +429,8 @@ level_result::type playsingle_controller::play_scenario(const config& level)
 
 	try {
 		play_scenario_init(level);
-		// clears level config;
+		// clears level config (the intention was probably just to save some ram),
+		// Note: this might clear 'level', so don't use level after this.
 		saved_game_.remove_snapshot();
 
 		play_scenario_main_loop();

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -41,8 +41,10 @@
 #include "playturn.hpp"
 #include "preferences/game.hpp"
 #include "random_deterministic.hpp"
+#include "replay_controller.hpp"
 #include "replay_helper.hpp"
 #include "resources.hpp"
+#include "saved_game.hpp"
 #include "savegame.hpp"
 #include "scripting/plugins/context.hpp"
 #include "sound.hpp"
@@ -87,6 +89,10 @@ playsingle_controller::playsingle_controller(const config& level, saved_game& st
 	plugins_context_->set_accessor_string("level_result", std::bind(&playsingle_controller::describe_result, this));
 	plugins_context_->set_accessor_int("turn", std::bind(&play_controller::turn, this));
 }
+
+///Defined here to reduce file includes.
+playsingle_controller::~playsingle_controller() = default;
+
 
 std::string playsingle_controller::describe_result() const
 {

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -176,6 +176,10 @@ void playsingle_controller::play_scenario_init(const config& level)
 
 	start_game();
 
+	if(gamestate().in_phase(game_data::TURN_PLAYING)) {
+		init_side_end();
+	}
+
 	if(!saved_game_.classification().random_mode.empty() && is_networked_mp()) {
 		// This won't cause errors later but we should notify the user about it in case he didn't knew it.
 		gui2::show_transient_message(
@@ -202,10 +206,6 @@ void playsingle_controller::play_some()
 	assert(is_regular_game_end() || gamestate().in_phase(game_data::TURN_STARTING_WAITING, game_data::TURN_PLAYING, game_data::TURN_ENDED, game_data::GAME_ENDED));
 
 	if (!is_regular_game_end() && gamestate().in_phase(game_data::TURN_STARTING_WAITING, game_data::TURN_PLAYING)) {
-		if(gamestate().in_phase(game_data::TURN_PLAYING)) {
-			// If we are here we have probably reloaded a savegame
-			init_side_end();
-		}
 		play_side();
 		assert(is_regular_game_end() || gamestate().in_phase(game_data::TURN_ENDED));
 	}

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -616,6 +616,12 @@ void playsingle_controller::linger()
 	update_gui_linger();
 
 	try {
+		if(replay_controller_.get() != nullptr) {
+			replay_controller_->play_side_impl();
+			if(player_type_changed_) {
+				replay_controller_.reset();
+			}
+		}
 		while(!end_turn_requested_) {
 			play_slice();
 		}

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -402,7 +402,7 @@ void playsingle_controller::do_end_level()
 	}
 
 	persist_.end_transaction();
-	carryover_show_gold(gamestate(), is_observer(), saved_game_.classification().is_test());
+	carryover_show_gold(gamestate(), is_observer() || is_replay(), is_observer(), saved_game_.classification().is_test());
 
 }
 

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -22,10 +22,11 @@
 #include "playturn_network_adapter.hpp"
 #include "playturn.hpp"
 #include "replay.hpp"
-#include "saved_game.hpp"
-#include "replay_controller.hpp"
 
 #include <exception>
+
+class replay_controller;
+class saved_game;
 
 struct reset_gamestate_exception : public std::exception
 {
@@ -40,6 +41,7 @@ class playsingle_controller : public play_controller
 public:
 	playsingle_controller(const config& level, saved_game& state_of_game, bool skip_replay);
 
+	~playsingle_controller();
 	level_result::type play_scenario(const config& level);
 	void play_scenario_init(const config& level);
 	void skip_empty_sides(int& side_num);

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -84,7 +84,6 @@ protected:
 	virtual void init_gui() override;
 
 	const cursor::setter cursor_setter_;
-	gui::floating_textbox textbox_info_;
 
 	/// Helper to send our actions to the server
 	/// Used by turn_data_

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -42,6 +42,10 @@ public:
 
 	level_result::type play_scenario(const config& level);
 	void play_scenario_init(const config& level);
+	void skip_empty_sides(int& side_num);
+	void play_some();
+	void finish_side_turn();
+	void do_end_level();
 	void play_scenario_main_loop();
 
 	virtual void handle_generic_event(const std::string& name) override;

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -41,7 +41,7 @@ public:
 	playsingle_controller(const config& level, saved_game& state_of_game, bool skip_replay);
 
 	level_result::type play_scenario(const config& level);
-	void play_scenario_init();
+	void play_scenario_init(const config& level);
 	void play_scenario_main_loop();
 
 	virtual void handle_generic_event(const std::string& name) override;
@@ -52,6 +52,7 @@ public:
 
 	void end_turn();
 	void force_end_turn() override;
+	void require_end_turn();
 
 	class hotkey_handler;
 	std::string describe_result() const;
@@ -86,17 +87,9 @@ protected:
 	playturn_network_adapter network_reader_;
 	/// Helper to read and execute (in particular replay data/ user actions ) messsages from the server
 	turn_info turn_data_;
-	enum END_TURN_STATE
-	{
-		/** The turn was not ended yet */
-		END_TURN_NONE,
-		/** And endturn was required eigher by the player, by the ai or by [end_turn] */
-		END_TURN_REQUIRED,
-		/** An [end_turn] was added to the replay. */
-		END_TURN_SYNCED,
-	};
-
-	END_TURN_STATE end_turn_;
+	/// true iff the user has pressed the end turn button this turn.
+	/// (or wants to end linger mode, which is implemented via the same button)
+	bool end_turn_requested_;
 	bool skip_next_turn_;
 	/// true when the current side is actually an ai side but was taken over by a human (usually for debugging purposes),
 	/// we need this variable to remember to give the ai control back next turn.

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -54,6 +54,7 @@ public:
 
 	virtual void check_objectives() override;
 	virtual void on_not_observer() override {}
+	virtual bool is_host() const { return true; }
 	virtual void maybe_linger();
 
 	void end_turn();
@@ -102,6 +103,7 @@ protected:
 	/// non-null when replay mode in active, is used in singleplayer and for the "back to turn" feature in multiplayer.
 	std::unique_ptr<replay_controller> replay_controller_;
 	void linger();
+	void update_gui_linger();
 	void sync_end_turn() override;
 	void update_viewing_player() override;
 	void reset_replay();

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -96,7 +96,6 @@ protected:
 	/// true iff the user has pressed the end turn button this turn.
 	/// (or wants to end linger mode, which is implemented via the same button)
 	bool end_turn_requested_;
-	bool skip_next_turn_;
 	/// true when the current side is actually an ai side but was taken over by a human (usually for debugging purposes),
 	/// we need this variable to remember to give the ai control back next turn.
 	bool ai_fallback_;

--- a/src/playsingle_controller.hpp
+++ b/src/playsingle_controller.hpp
@@ -19,6 +19,7 @@
 #include "play_controller.hpp"
 
 #include "cursor.hpp"
+#include "lua_jailbreak_exception.hpp"
 #include "playturn_network_adapter.hpp"
 #include "playturn.hpp"
 #include "replay.hpp"
@@ -28,12 +29,16 @@
 class replay_controller;
 class saved_game;
 
-struct reset_gamestate_exception : public std::exception
+struct reset_gamestate_exception : public lua_jailbreak_exception, public std::exception
 {
 	reset_gamestate_exception(std::shared_ptr<config> l, std::shared_ptr<config> stats, bool s = true) : level(l), stats_(stats), start_replay(s) {}
 	std::shared_ptr<config> level;
 	std::shared_ptr<config> stats_;
 	bool start_replay;
+	const char * what() const noexcept { return "reset_gamestate_exception"; }
+private:
+
+	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(reset_gamestate_exception)
 };
 
 class playsingle_controller : public play_controller

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -365,10 +365,6 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 		if(chat_only) {
 			return PROCESS_CANNOT_HANDLE;
 		}
-		std::shared_ptr<gui::button> btn_end = display::get_singleton()->find_action_button("button-endturn");
-		if(btn_end) {
-			btn_end->enable(true);
-		}
 		return PROCESS_END_LINGER;
 	}
 

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -823,6 +823,7 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 					verify(resources::gameboard->units(), cfg_verify);
 				}
 				resources::controller->gamestate().next_player_number_ = end_turn["next_player_number"];
+				resources::controller->gamestate().gamedata_.set_phase(game_data::TURN_ENDED);
 				return REPLAY_FOUND_END_TURN;
 			}
 		}

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -154,7 +154,7 @@ bool replay_controller::recorder_at_end() const
 	return resources::recorder->at_end();
 }
 
-REPLAY_RETURN replay_controller::play_side_impl()
+void replay_controller::play_side_impl()
 {
 	update_enabled_buttons();
 	while(!return_to_play_side_ && !static_cast<playsingle_controller&>(controller_).get_player_type_changed())
@@ -171,10 +171,10 @@ REPLAY_RETURN replay_controller::play_side_impl()
 					stop_condition_->move_done();
 				}
 				if(controller_.is_regular_game_end()) {
-					return REPLAY_FOUND_END_LEVEL;
+					return;
 				}
 				if(res == REPLAY_FOUND_END_TURN) {
-					return res;
+					return;
 				}
 				// TODO: how can this be the case when we just checked for "resources::recorder->at_end()" above?
 				if(res == REPLAY_RETURN_AT_END) {
@@ -200,7 +200,7 @@ REPLAY_RETURN replay_controller::play_side_impl()
 			controller_.play_slice(true);
 		}
 	}
-	return REPLAY_FOUND_END_MOVE;
+	return;
 }
 bool replay_controller::can_execute_command(const hotkey::hotkey_command& cmd, int) const
 {

--- a/src/replay_controller.cpp
+++ b/src/replay_controller.cpp
@@ -170,9 +170,13 @@ REPLAY_RETURN replay_controller::play_side_impl()
 				if(res == REPLAY_FOUND_END_MOVE) {
 					stop_condition_->move_done();
 				}
+				if(controller_.is_regular_game_end()) {
+					return REPLAY_FOUND_END_LEVEL;
+				}
 				if(res == REPLAY_FOUND_END_TURN) {
 					return res;
 				}
+				// TODO: how can this be the case when we just checked for "resources::recorder->at_end()" above?
 				if(res == REPLAY_RETURN_AT_END) {
 					stop_replay();
 				}

--- a/src/replay_controller.hpp
+++ b/src/replay_controller.hpp
@@ -41,7 +41,7 @@ public:
 	void replay_next_turn();
 	void replay_next_side();
 	void replay_next_move();
-	REPLAY_RETURN play_side_impl();
+	void play_side_impl();
 
 	bool recorder_at_end() const;
 	bool should_stop() const { return stop_condition_->should_stop(); }

--- a/src/replay_recorder_base.cpp
+++ b/src/replay_recorder_base.cpp
@@ -144,6 +144,20 @@ void replay_recorder_base::delete_upcoming_commands()
 	commands_.resize(pos_);
 }
 
+bool replay_recorder_base::is_ancestor(const config& other_replay) const
+{
+	auto other_commands = other_replay.child_range("command");
+	if(other_commands.size() > commands_.size()) {
+		return false;
+	}
+	for(size_t index = 0; index < other_commands.size(); ++index) {
+		if(commands_[index] != other_commands[index]) {
+			return false;
+		}
+	}
+	return true;
+}
+
 void swap(replay_recorder_base& lhs, replay_recorder_base& rhs)
 {
 	lhs.swap(rhs);

--- a/src/replay_recorder_base.hpp
+++ b/src/replay_recorder_base.hpp
@@ -54,6 +54,10 @@ public:
 	void write(config& out) const;
 
 	void delete_upcoming_commands();
+
+	/// checks whether the parameter is an earlier state in the
+	/// same "savegame gamestate branch"
+	bool is_ancestor(const config& other_replay) const;
 protected:
 	config upload_log_;
 	boost::ptr_vector<config> commands_;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1697,7 +1697,7 @@ int game_lua_kernel::impl_current_get(lua_State *L)
 	return_int_attrib("side", play_controller_.current_side());
 	return_int_attrib("turn", play_controller_.turn());
 	return_string_attrib("synced_state", synced_state());
-	return_bool_attrib("user_can_invoke_commands", !play_controller_.is_lingering() && play_controller_.gamestate().init_side_done() && !events::commands_disabled && gamedata().phase() == game_data::PLAY);
+	return_bool_attrib("user_can_invoke_commands", !events::commands_disabled && gamedata().phase() == game_data::TURN_PLAYING);
 
 	if(strcmp(m, "map") == 0) {
 		return intf_terrainmap_get(L);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1651,7 +1651,7 @@ int game_lua_kernel::impl_scenario_set(lua_State *L)
 		data.transient.linger_mode = cfg["linger_mode"].to_bool(true) && !teams().empty();
 		data.transient.reveal_map = cfg["reveal_map"].to_bool(true);
 		data.is_victory = cfg["result"] == level_result::victory;
-		data.test_result = cfg["test_result"].str(level_result::result_not_set);
+		data.test_result = cfg["test_result"].str();
 		play_controller_.set_end_level_data(data);
 
 		return 1;


### PR DESCRIPTION
With this pr the replay the replay viewer doesn't stop anymore before the victory event is fired but replay until the game has ended "Linger mode".

This Fixes
- #4667 
- #6180 (only tested for non-story-only scenarios)
- #4236 "Back to turn" feature not working in mp linger mode

This also contains a few cleanups that made these changes easier.
