### PR TITLE
SotBE: Replace unfortunate wording

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/03_Toward_Mountains_of_Haag.cfg
@@ -201,7 +201,7 @@
 
         [message]
             speaker="Kapou'e"
-            message= _ "Whatever else happens, we have to pass through these mountains and I dislike leaving enemies in our rear. Stab, smite, and slay!"
+            message= _ "Whatever else happens, we have to pass through these mountains and I dislike leaving enemies to our rear. Stab, smite, and slay!"
         [/message]
 
         {HIGHLIGHT_IMAGE 1 5 scenery/signpost.png ()}

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/05_To_the_Harbor_of_Tirigaz.cfg
@@ -237,7 +237,7 @@
 
         [message]
             speaker="Kapou'e"
-            message= _ "Grüü is right. It is not wise to let these undead remain here, cutting off our supply lines and path of retreat. In these days of turmoil, we don’t know what lies ahead, so it is best not to leave any threats in our rear."
+            message= _ "Grüü is right. It is not wise to let these undead remain here, cutting off our supply lines and path of retreat. In these days of turmoil, we don’t know what lies ahead, so it is best not to leave any threats to our rear."
         [/message]
 
         [message]


### PR DESCRIPTION
Kapou'e does not appear to be making a comical statement, 'our rear' could be interpreted (admittedly, in a juvenile fashion) as 'rear end', or posterior.

Since #7454 was accepted I think this is a good time to make this change as well (noted this a long time ago but refrained from changing due to the complaints about re-translation overhead).