### PR TITLE
Revert WML workarounds on mainline replay OOS issues

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -342,6 +342,15 @@
     [event]
         name=enemies defeated
 
+        [endlevel]
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 40}
+        [/endlevel]
+    [/event]
+
+    [event]
+        name=victory
+
         [message]
             speaker=Tallin
             message= _ "<i>Yes</i>! We did it! We are free!"
@@ -384,11 +393,6 @@
         [/move_unit_fake]
 
         [redraw][/redraw]
-
-        [endlevel]
-            bonus=yes
-            {NEW_GOLD_CARRYOVER 40}
-        [/endlevel]
     [/event]
 
     # Death events

--- a/data/campaigns/The_South_Guard/scenarios/04_Vale_of_Tears.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/04_Vale_of_Tears.cfg
@@ -716,22 +716,6 @@
                 boolean_equals=yes
             [/variable]
             [then]
-                [if]
-                    [variable]
-                        name=have_bodyguard
-                        boolean_not_equals=yes
-                    [/variable]
-                    [then]
-                        [message]
-                            speaker=Ethiliel
-                            message= _ "Come, my bodyguards! We must make haste to follow this trail and find Mebrin."
-                        [/message]
-
-                        [fire_event]
-                            name=bodyguard
-                        [/fire_event]
-                    [/then]
-                [/if]
                 [endlevel]
                     result=victory
                     bonus=yes
@@ -767,6 +751,24 @@
 
     [event]
         name=victory
+
+        [if]
+            [variable]
+                name=have_bodyguard
+                boolean_not_equals=yes
+            [/variable]
+            [then]
+                [message]
+                    speaker=Ethiliel
+                    message= _ "Come, my bodyguards! We must make haste to follow this trail and find Mebrin."
+                [/message]
+
+                [fire_event]
+                    name=bodyguard
+                [/fire_event]
+            [/then]
+        [/if]
+
         {CLEAR_VARIABLE mebrin_found,undead_defeated,bandits_defeated,have_bodyguard}
     [/event]
 [/scenario]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -4184,9 +4184,11 @@
             message= _ "Good, until then we’ll settle around that oasis and set up as good a defense as we can. Until I know what’s out there, I’m not taking any chances."
         [/message]
 
-        [fire_event]
-            name=victory_event
-        [/fire_event]
+        [endlevel]
+            result=victory
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 40}
+        [/endlevel]
     [/event]
 
     # Flooding algorithm
@@ -4409,7 +4411,7 @@
     #victory event
 
     [event]
-        name=victory_event
+        name=victory
 
         # reveal map in-between starting valley and location elves move to
         [remove_shroud]
@@ -4671,12 +4673,6 @@
         {CLEAR_VARIABLE healing_rune1,healing_rune2}
 
         {CLEAR_VARIABLE messenger_timer,messengers_incoming}
-
-        [endlevel]
-            result=victory
-            bonus=yes
-            {NEW_GOLD_CARRYOVER 40}
-        [/endlevel]
     [/event]
 
     # set time for all underground areas to be always night/underground


### PR DESCRIPTION
Retested all scenarios in #6832 all are working fine, including the scenarios having the fixes reverted.

c1b6bfba34d777c6d854eb49af37db645c256c0b and cd9e92c3c3323ccc6ce41243cac01720d29d849b don't include changes to the changelog file, that's why the commits are different from bb2de96d71b88ee5561ab6b67c4a29c422244f23.

Closes #6832