### PR TITLE
DiD: Remove invalid syntax

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -1095,7 +1095,6 @@
         female_name= _ "female^masochism"
         description= _ "This unit gains up to 50% damage as its hitpoints are reduced."
         affect_self=yes
-        affect_adjacent=no
     [/leadership]
 #enddef
 
@@ -1108,7 +1107,6 @@
         female_name= _ "female^masochism"
         description= _ "This unit gains up to 100% damage as its hitpoints are reduced."
         affect_self=yes
-        affect_adjacent=no
     [/leadership]
 #enddef
 


### PR DESCRIPTION
Not really sure what's correct here (hence the PR for the CI check), but https://wiki.wesnoth.org/AbilitiesWML#Common_keys_and_tags_for_every_ability seems to suggest that no `[affect_adjacent]` tags is sufficient to disable the affect-adjacent functionality.