### PR TITLE
EBO for unique_ptr with SDL_RWops

### DIFF
--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -39,7 +39,13 @@ namespace filesystem {
 using scoped_istream = std::unique_ptr<std::istream>;
 using scoped_ostream = std::unique_ptr<std::ostream>;
 
-typedef std::unique_ptr<SDL_RWops, void(*)(SDL_RWops*)> rwops_ptr;
+struct sdl_rwops_deleter
+{
+	void operator()(SDL_RWops*) const noexcept;
+};
+
+using rwops_ptr = std::unique_ptr<SDL_RWops, sdl_rwops_deleter>;
+static_assert(sizeof(rwops_ptr) == 8);
 
 rwops_ptr make_read_RWops(const std::string &path);
 rwops_ptr make_write_RWops(const std::string &path);

--- a/src/filesystem_sdl.cpp
+++ b/src/filesystem_sdl.cpp
@@ -41,8 +41,13 @@ static std::size_t SDLCALL ofs_write(struct SDL_RWops *context, const void *ptr,
 static int SDLCALL ifs_close(struct SDL_RWops *context);
 static int SDLCALL ofs_close(struct SDL_RWops *context);
 
+void sdl_rwops_deleter::operator()(SDL_RWops* p) const noexcept
+{
+	SDL_FreeRW(p);
+}
+
 rwops_ptr make_read_RWops(const std::string &path) {
-	rwops_ptr rw(SDL_AllocRW(), &SDL_FreeRW);
+	rwops_ptr rw(SDL_AllocRW());
 
 	rw->size = &ifs_size;
 	rw->seek = &ifs_seek;
@@ -65,7 +70,7 @@ rwops_ptr make_read_RWops(const std::string &path) {
 }
 
 rwops_ptr make_write_RWops(const std::string &path) {
-	rwops_ptr rw(SDL_AllocRW(), &SDL_FreeRW);
+	rwops_ptr rw(SDL_AllocRW());
 
 	rw->size = &ofs_size;
 	rw->seek = &ofs_seek;

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -624,7 +624,7 @@ static surface load_image_data_uri(const image::locator& loc)
 		ERR_IMG << "Data URI not of image MIME type: " << parsed.mime;
 	} else {
 		const std::vector<uint8_t> image_data = base64::decode(parsed.data);
-		filesystem::rwops_ptr rwops{SDL_RWFromConstMem(image_data.data(), image_data.size()), &SDL_FreeRW};
+		filesystem::rwops_ptr rwops{SDL_RWFromConstMem(image_data.data(), image_data.size())};
 
 		if(image_data.empty()) {
 			ERR_IMG << "Invalid encoding in data URI";


### PR DESCRIPTION
unique_ptr is designed to allow EBO (empty base class optimization)
for the use case of SDL_RWops this fits well and allows the UP to be half the size it is now (8 bytes vs 16 bytes on x86-64)

see this compiler explorer link:
https://godbolt.org/z/KjnTeqhbv

it also allows easier construction of the unique_ptrs as the ctor no longer requires passing the address of the function to call
since runtime setting of the deleter is not required, that's an added bonus