### PR TITLE
Minor fixes filesystem

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -18,14 +18,14 @@
  * Routines to set up the display, scroll and zoom the map.
  */
 
+#include "display.hpp"
+
 #include "arrow.hpp"
 #include "color.hpp"
 #include "cursor.hpp"
-#include "display.hpp"
 #include "draw.hpp"
 #include "draw_manager.hpp"
 #include "fake_unit_manager.hpp"
-#include "filesystem.hpp"
 #include "font/sdl_ttf_compat.hpp"
 #include "font/text.hpp"
 #include "preferences/game.hpp"

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -232,6 +232,40 @@ bool is_filename_case_correct(const std::string& /*fname*/, const boost::iostrea
 namespace filesystem
 {
 
+const blacklist_pattern_list default_blacklist{
+	{
+		/* Blacklist dot-files/dirs, which are hidden files in UNIX platforms */
+		".+",
+		"#*#",
+		"*~",
+		"*-bak",
+		"*.swp",
+		"*.pbl",
+		"*.ign",
+		"_info.cfg",
+		"*.exe",
+		"*.bat",
+		"*.cmd",
+		"*.com",
+		"*.scr",
+		"*.sh",
+		"*.js",
+		"*.vbs",
+		"*.o",
+		"*.ini",
+		/* Remove junk created by certain file manager ;) */
+		"Thumbs.db",
+		/* Eclipse plugin */
+		"*.wesnoth",
+		"*.project",
+	},
+	{
+		".+",
+		/* macOS metadata-like cruft (http://floatingsun.net/2007/02/07/whats-with-__macosx-in-zip-files/) */
+		"__MACOSX",
+	}
+};
+
 static void push_if_exists(std::vector<std::string>* vec, const bfs::path& file, bool full)
 {
 	if(vec != nullptr) {

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -94,39 +94,7 @@ private:
 	std::vector<std::string> directory_patterns_;
 };
 
-static const blacklist_pattern_list default_blacklist{
-	{
-		/* Blacklist dot-files/dirs, which are hidden files in UNIX platforms */
-		".+",
-		"#*#",
-		"*~",
-		"*-bak",
-		"*.swp",
-		"*.pbl",
-		"*.ign",
-		"_info.cfg",
-		"*.exe",
-		"*.bat",
-		"*.cmd",
-		"*.com",
-		"*.scr",
-		"*.sh",
-		"*.js",
-		"*.vbs",
-		"*.o",
-		"*.ini",
-		/* Remove junk created by certain file manager ;) */
-		"Thumbs.db",
-		/* Eclipse plugin */
-		"*.wesnoth",
-		"*.project",
-	},
-	{
-		".+",
-		/* macOS metadata-like cruft (http://floatingsun.net/2007/02/07/whats-with-__macosx-in-zip-files/) */
-		"__MACOSX",
-	}
-};
+extern const blacklist_pattern_list default_blacklist;
 
 /**
  * Get a list of all files and/or directories in a given directory.

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -23,7 +23,6 @@
 
 #include "buffered_istream.hpp"
 #include "config.hpp"
-#include "filesystem.hpp"
 #include "log.hpp"
 #include "serialization/binary_or_text.hpp"
 #include "serialization/parser.hpp"

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -20,10 +20,11 @@
 #include "exceptions.hpp"
 #include "filesystem.hpp"
 #include "game_version.hpp"
-#include <optional>
 
 #include <iosfwd>
 #include <map>
+#include <string>
+#include <optional>
 #include <vector>
 
 class config_writer;


### PR DESCRIPTION
Remove a couple cases where the same header was included in both .cpp and .hpp of some modules. No harm really, but it looks like it was either the result of a merge conflict resolution or simply an omission.
Since I was there, remove copying of `default_blacklist` in multiple TUs, which include `filesystem.hpp`, by using extern (instead of a static const) inside the header. TBH `inline` would have worked just the same, but since the filesystem module already has a .cpp might as well just put it to use.