### PR TITLE
DiD S8: Disallow undead bat from retrieving the Book

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/08_Alone_at_Last.cfg
@@ -950,6 +950,10 @@
                 type_adv_tree=Ghost,Vampire Bat
             [/not]
             [not]
+                type_adv_tree=Walking Corpse
+                variation=bat
+            [/not]
+            [not]
                 # this unit does not advance normally so each type has to be listed individually
                 type=Spectral Servant,Phantom,Eidolon
             [/not]
@@ -1025,6 +1029,28 @@
             speaker=unit
             # po: this is just a squeaking sound a bat might make
             message= _ "Neep! Neep!"
+        [/message]
+
+        [message]
+            speaker=Malin Keshar
+            message= _ "It’s impossible for a bat to carry a book that heavy."
+        [/message]
+    [/event]
+
+    [event]
+        name=moveto
+        first_time_only=no
+        [filter]
+            x=$bookX
+            y=$bookY
+            side=1
+            type_adv_tree=Walking Corpse
+            variation=bat
+        [/filter]
+
+        [message]
+            speaker=unit
+            message= _ "..."
         [/message]
 
         [message]


### PR DESCRIPTION
Resolves #7485.

I tested with 'Walking' Corpse Bat, Soulless Bat, and regular (humanoid) Walking Corpse and regular Soulless. First two behave the same as live bats (aside from not squeaking) while the latter two behave as a regular unit picking up the book normally. Re-using Malin's line about the bat avoids translation overhead.

I think this should be back-ported too.