### PR TITLE
Make rng::get_random_element return an index, not an int

### DIFF
--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -1501,8 +1501,10 @@ void monte_carlo_combat_matrix::simulate()
 		bool b_slowed = rng.get_random_bool(b_initially_slowed_chance_);
 		const std::vector<double>& a_initial = a_slowed ? a_initial_slowed_ : a_initial_;
 		const std::vector<double>& b_initial = b_slowed ? b_initial_slowed_ : b_initial_;
-		unsigned int a_hp = rng.get_random_element(a_initial.begin(), a_initial.end());
-		unsigned int b_hp = rng.get_random_element(b_initial.begin(), b_initial.end());
+		// In the a_initial vector, a_initial[x] is the chance of having exactly x hp.
+		// Thus the index returned by get_random_element corresponds directly to an amount of hp.
+		auto a_hp = static_cast<unsigned int>(rng.get_random_element(a_initial.begin(), a_initial.end()));
+		auto b_hp = static_cast<unsigned int>(rng.get_random_element(b_initial.begin(), b_initial.end()));
 		unsigned int a_strikes = calc_blows_a(a_hp);
 		unsigned int b_strikes = calc_blows_b(b_hp);
 

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -73,7 +73,7 @@ namespace randomness
 		 * @return		The index of the selected number
 		 */
 		template <typename T>
-		unsigned int get_random_element(T first, T last);
+		typename T::difference_type get_random_element(T first, T last);
 
 		// For compatibility with the C++ UniformRandomBitGenerator concept
 		using result_type = uint32_t;
@@ -109,7 +109,7 @@ namespace randomness
 	extern rng* generator;
 
 	template <typename T>
-	unsigned int rng::get_random_element(T first, T last)
+	typename T::difference_type rng::get_random_element(T first, T last)
 	{
 		double target = get_random_double();
 		double sum = 0.0;


### PR DESCRIPTION
This makes it match the documentation, although it makes no practical difference, other than solving one of the -Wshorten-64-to-32 warnings.