### PR TITLE
Editor palettes: fix -Wshorten-64-to-32 and improve docs

### DIFF
--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -162,7 +162,10 @@ std::size_t editor_palette<Item>::active_group_index()
 template<class Item>
 void editor_palette<Item>::adjust_size(const SDL_Rect& target)
 {
-	const int items_fitting = (target.h / item_space_) * columns_;
+	// The number of columns is passed to the constructor, and isn't changed afterwards. It's likely to be
+	// exactly 4, but will always be a small number which makes the next cast reasonable.
+	const int items_fitting = static_cast<int>((target.h / item_space_) * columns_);
+
 	// This might be called while the palette is not visible onscreen.
 	// If that happens, no items will fit and we'll have a negative number here.
 	// Just skip it in that case.
@@ -183,8 +186,8 @@ void editor_palette<Item>::adjust_size(const SDL_Rect& target)
 	dstrect.w = item_size_ + 2;
 	dstrect.h = item_size_ + 2;
 	for(std::size_t i = 0; i < buttons_.size(); ++i) {
-		dstrect.x = target.x + (i % columns_) * item_space_;
-		dstrect.y = target.y + (i / columns_) * item_space_;
+		dstrect.x = target.x + static_cast<int>(i % columns_) * item_space_;
+		dstrect.y = target.y + static_cast<int>(i / columns_) * item_space_;
 		buttons_[i].set_location(dstrect);
 	}
 

--- a/src/editor/palette/editor_palettes.hpp
+++ b/src/editor/palette/editor_palettes.hpp
@@ -29,7 +29,7 @@ class editor_palette : public tristate_palette {
 public:
 
 	editor_palette(editor_display &gui, const game_config_view& /*cfg*/
-	             , std::size_t item_size, std::size_t columns, editor_toolkit &toolkit)
+	             , int item_size, std::size_t columns, editor_toolkit &toolkit)
 		: tristate_palette()
 		, groups_()
 		, gui_(gui)
@@ -150,10 +150,13 @@ protected:
 
 	/**
 	 * Both the width and the height of the square buttons.
+	 *
+	 * This is a size measured in pixels, and should match the type of
+	 * SDL_rect.w and SDL_rect.h.
 	 */
 	int item_size_;
 	/**
-	 * item_space_ plus some padding.
+	 * item_size_ plus some padding.
 	 */
 	int item_space_;
 

--- a/src/editor/palette/location_palette.cpp
+++ b/src/editor/palette/location_palette.cpp
@@ -301,7 +301,7 @@ void location_palette::adjust_size(const SDL_Rect& target)
 	dstrect.h = item_size_ + 2;
 	for(std::size_t i = 0; i < buttons_.size(); ++i) {
 		dstrect.x = target.x;
-		dstrect.y = target.y + i * item_space_;
+		dstrect.y = target.y + static_cast<int>(i) * item_space_;
 		buttons_[i].set_location(dstrect);
 	}
 

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -90,9 +90,6 @@ private:
 	/** Scroll the editor-palette to the top. */
 	void scroll_top();
 
-	/** Scroll the editor-palette to the bottom. */
-	void scroll_bottom();
-
 	virtual bool is_selected_item(const std::string& id);
 
 	/** Return the number of items in the palette. */

--- a/src/editor/palette/palette_manager.cpp
+++ b/src/editor/palette/palette_manager.cpp
@@ -94,16 +94,6 @@ common_palette& palette_manager::active_palette()
 	return toolkit_.get_palette();
 }
 
-void palette_manager::scroll_bottom()
-{
-	unsigned int old_start   = active_palette().num_items();
-	unsigned int items_start = active_palette().start_num();
-	while (old_start != items_start) {
-		old_start = items_start;
-		scroll_down();
-	}
-}
-
 void palette_manager::layout()
 {
 	if (!dirty()) {

--- a/src/editor/palette/palette_manager.hpp
+++ b/src/editor/palette/palette_manager.hpp
@@ -50,10 +50,6 @@ public:
 	bool can_scroll_down();
 
 	void scroll_top();
-	void scroll_bottom();
-
-//TODO
-//	void swap();
 
 	void adjust_size();
 


### PR DESCRIPTION
Use int for measurements of pixels, vs std::size_t for container sizes.

The scroll_bottom() methods were never called, although scroll_top() is used when switching between subgroups. The logic is scroll_bottom() was broken; items_start wasn't changed inside the loop, so the loop would run at most once.