### PR TITLE
Units/Nibbler: set resistances to be same as level ups

### DIFF
--- a/data/core/units/monsters/Caribe_Nibbler.cfg
+++ b/data/core/units/monsters/Caribe_Nibbler.cfg
@@ -14,6 +14,8 @@ units/monsters/caribe#enddef
     movement_type=deepsea
     [resistance]
         arcane=100
+        pierce=90
+        impact=80
     [/resistance]
     [movement_costs]
         deep_water=1


### PR DESCRIPTION
Closes #7516

## Summary

Nibbler now has the same resistances as the level 1 (Caribe) and level 2 (Hunter Caribe)