### PR TITLE
Fix -Wshorten-64-to-32: math.hpp

### DIFF
--- a/src/utils/math.hpp
+++ b/src/utils/math.hpp
@@ -190,14 +190,6 @@ inline int rounded_division(int a, int b)
 }
 
 /**
- * Converts a double to a fixed point.
- */
-constexpr int32_t floating_to_fixed_point(double n)
-{
-	return int32_t(n * (1 << 8));
-}
-
-/**
  * @param n1 The first number to multiply.
  * @param n2 The second number to multiply.
  * @return The unsigned result of n1 * n2, then bitshifting the result to the right.


### PR DESCRIPTION
The last uses of this were removed in 0fbc12ea01986bc97ef6426e0edc89f12224a0d5.

The only uses of the other fixed-point functions from math.hpp are in src/sdl/utils.cpp. That should probably move to using color.hpp instead, but this commit is just to solve the -Wshorten-64-to-32 warning.