### PR TITLE
fix filter_second_attack matche when_no defense.

### DIFF
--- a/src/game_events/handlers.cpp
+++ b/src/game_events/handlers.cpp
@@ -249,6 +249,9 @@ struct filter_attack : public event_filter {
 			const auto u = unit_a->shared_from_this();
 			auto temp_weapon = event_info.data.optional_child(first_ ? "first" : "second");
 			if(temp_weapon){
+				if(!first_ && temp_weapon["range"].empty()){
+					return false;
+				}
 				const_attack_ptr attack = std::make_shared<const attack_type>(*temp_weapon);
 				if(unit_d != units.end() && loc_d.matches_unit(unit_d)) {
 					const auto opp = unit_d->shared_from_this();


### PR DESCRIPTION
if a unit in defense has no attack of range of attacker and under influence of abilitie used like weapon a filter_second_attack can matche it. This PR is a fix for this bug encountered with https://github.com/wesnoth/wesnoth/pull/7534/files#diff-8d03fe35ba9cd63a235a745ba5739e4f37f175915e73324125d3881953968b3c who succed then it must fail