### PR TITLE
Test attack_filter with melee-only vs ranged-only units

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_attack_no_defense.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_attack_no_defense.cfg
@@ -1,0 +1,108 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [event][filter_attack]
+##
+# Actions:
+# Remove Alice's melee attack.
+# Give Alice an ability that adds a drain special to all of his weapons.
+# Define events that use filter_attack matching Alice's drain special.
+# Have Alice use a ranged attack against Bob, who only has a melee attack.
+# Have Bob use a melee attack against Alice.
+##
+# Expected end state:
+# An event triggers when Alice attacks during side 1's turn.
+# No event triggers when Bob attacks Alice.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_no_defense (
+    [event]
+        name=turn 1
+        [object]
+            silent=yes
+            [effect]
+                apply_to=remove_attacks
+                range=melee
+            [/effect]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [drains]
+                        id=test_ability_drain
+                    [/drains]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        [do_command]
+            [move]
+                x=7,13
+                y=3,4
+            [/move]
+            [attack]
+                [source]
+                    x,y=13,4
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [do_command]
+            [attack]
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=13,4
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            special_id_active=test_ability_drain
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers_on_attack add 1}
+    [/event]
+
+    # As Alice only has a ranged attack, this shouldn't fire in response to Bob's melee attack.
+    #
+    # Inside the engine, [second]name=none has been passed to the filter code, and a placeholder
+    # [attack]damage,num_attacks=0,0 generated. Alice's ability gives the drain ability to all of
+    # his attacks, this checks that the drain ability isn't given to the dummy one when filtering.
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_second_attack]
+            special_id_active=test_ability_drain
+        [/filter_second_attack]
+        {FAIL}
+    [/event]
+
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 1})}
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -144,6 +144,7 @@
 0 test_ability_id_active
 0 test_ability_id_not_active
 0 event_test_filter_attack
+0 event_test_filter_attack_no_defense
 0 event_test_filter_attack_specials
 0 event_test_filter_attack_opponent_weapon_condition
 0 event_test_filter_wfl


### PR DESCRIPTION
A new test of what happens when a unit with only a ranged weapon fights a unit with only a melee weapon, along with a code change to ignore the placeholder attack that caused the new test to fail.

(The next paragraph is a suggestion for future work, I'm not intending to add it to this PR.)
This only affects the filtering so far, there should probably be another additional test to check what the combat results are. Not added in this commit, as the test here is specific to the code path being fixed; also testing the actual results would need an ability such as the Deep Elves' Stardust that passively affects the amount of damage taken, and doesn't need the defender to hit with a slows ability.

@newfrenchy83 I'm suggesting this instead of #7535, please would you review it?