### PR TITLE
Stop removing manually-added labels on Github PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,4 +9,4 @@ jobs:
     - uses: actions/labeler@main
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: "true"
+        sync-labels: "false"


### PR DESCRIPTION
Setting sync-labels to "true" means that it removes labels which people have added, but which aren't implied by the filelist.