### PR TITLE
fix ability used like weapon affect placeholder weapon used in defense when not attack of same range what attacker

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1538,8 +1538,10 @@ bool attack_type::has_special_or_ability(const std::string& special, bool specia
 	//Now that filter_(second)attack in event supports special_id/type_active, including abilities used as weapons,
 	//these can be detected even in placeholder attacks generated to compensate for the lack of attack in defense against an attacker using a range attack not possessed by the defender.
 	//It is therefore necessary to check if the range is not empty (proof that the weapon is not a placeholder) to decide if has_weapon_ability can be returned or not.
-	bool real_weapon_ability = (range() != "") ? has_weapon_ability(special, special_id, special_tags) : false;
-	return (has_special(special, false, special_id, special_tags) || real_weapon_ability);
+	if(range().empty()){
+		return false;
+	}
+	return (has_special(special, false, special_id, special_tags) || has_weapon_ability(special, special_id, special_tags));
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1535,7 +1535,9 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 
 bool attack_type::has_special_or_ability(const std::string& special, bool special_id, bool special_tags) const
 {
-	return (has_special(special, false, special_id, special_tags) || has_weapon_ability(special, special_id, special_tags));
+	//check if shared_from_this() is real attack or placeholder before to use or not has_weapon_ability function.
+	bool real_weapon_ability = (range() != "") ? has_weapon_ability(special, special_id, special_tags) : false;
+	return (has_special(special, false, special_id, special_tags) || real_weapon_ability);
 }
 //end of emulate weapon special functions.
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1535,7 +1535,9 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 
 bool attack_type::has_special_or_ability(const std::string& special, bool special_id, bool special_tags) const
 {
-	//check if shared_from_this() is real attack or placeholder before to use or not has_weapon_ability function.
+	//Now that filter_(second)attack in event supports special_id/type_active, including abilities used as weapons,
+	//these can be detected even in placeholder attacks generated to compensate for the lack of attack in defense against an attacker using a range attack not possessed by the defender.
+	//It is therefore necessary to check if the range is not empty (proof that the weapon is not a placeholder) to decide if has_weapon_ability can be returned or not.
 	bool real_weapon_ability = (range() != "") ? has_weapon_ability(special, special_id, special_tags) : false;
 	return (has_special(special, false, special_id, special_tags) || real_weapon_ability);
 }


### PR DESCRIPTION
best fix what https://github.com/wesnoth/wesnoth/pull/7537 or https://github.com/wesnoth/wesnoth/pull/7535 because don't delete placeholder weapon of filter_attack and applied to weapon like ability only.