### PR TITLE
Add macros support to wmlxgettext

### DIFF
--- a/data/tools/pywmlx/nodemanip.py
+++ b/data/tools/pywmlx/nodemanip.py
@@ -23,14 +23,18 @@ def _closenode_update_dict(podict):
                 # be ignored, then wrong context info would be attached to these sentences,
                 # or to an undetermined future sentence.
                 wmlerr(*unbalanced_wml)
+
+            # Get the relevant catalog d for this sentence. Initialize it if needed.
             if i.domain in podict:
                 d = podict[i.domain]
             else:
                 podict[i.domain] = dict()
                 d = podict[i.domain]
-            posentence = d.get(i.sentence)
+
+            dict_key = i.sentence_id
+            posentence = d.get(dict_key)
             if posentence is None:
-                d[i.sentence] = (
+                d[dict_key] = (
                        nodes[-1].nodesentence_to_posentence(i) )
             else:
                 posentence.update_with_commented_string(

--- a/data/tools/pywmlx/nodemanip.py
+++ b/data/tools/pywmlx/nodemanip.py
@@ -119,13 +119,13 @@ def closenode(closetag, mydict, lineno):
             nodes = None
 
 
-def addNodeSentence(sentence, *, domain, ismultiline, lineno, lineno_sub,
-                    override, addition, plural=None):
+def addNodeSentence(sentence, *, domain, macro=None, ismultiline,
+                    lineno, lineno_sub, override, addition, plural=None):
     global nodes
     if nodes is None:
         nodes = [pos.WmlNode(fileref=fileref, fileno=fileno,
                               tagname="", autowml=False)]
-    nodes[-1].add_sentence(sentence, domain=domain, ismultiline=ismultiline,
+    nodes[-1].add_sentence(sentence, domain=domain, macro=macro, ismultiline=ismultiline,
                            lineno=lineno, lineno_sub=lineno_sub,
                            override=override, addition=addition,
                            plural=plural)

--- a/data/tools/pywmlx/postring.py
+++ b/data/tools/pywmlx/postring.py
@@ -84,8 +84,13 @@ class WmlNodeSentence:
     def __init__(self, sentence, *, domain, macro=None, ismultiline,
                  lineno, lineno_sub=0, plural=None,
                  override=None, addition=None):
-        self.sentence = sentence
         self.domain = domain
+        self.sentence = sentence
+        self.sentence_id = sentence
+        if macro is None:
+            self.sentence_id = '\x01' + sentence
+        else:
+            self.sentence_id = '\x00' + '\x00'.join(map(str, macro)) + '\x00\x00' + sentence
         # Say if it is multiline or not.
         self.ismultiline = ismultiline
         self.macro = macro

--- a/data/tools/pywmlx/postring.py
+++ b/data/tools/pywmlx/postring.py
@@ -15,12 +15,13 @@ class PoCommentedStringPL:
 
 class PoCommentedString:
     def __init__(self, sentence, domain, *, orderid, ismultiline,
-                 wmlinfos, finfos, addedinfos, plural=None):
+                 wmlinfos, finfos, macro = None, addedinfos, plural=None):
         self.sentence = sentence
         self.domain = domain
         self.wmlinfos = wmlinfos
         self.addedinfos = addedinfos
         self.finfos = finfos
+        self.macro = macro
         self.orderid = orderid
         self.ismultiline = ismultiline
         self.plural = None
@@ -80,12 +81,14 @@ class PoCommentedString:
 
 # WmlNodeSentence use PoCommentedStringPL for 'plural' parameter
 class WmlNodeSentence:
-    def __init__(self, sentence, *, domain, ismultiline, lineno, lineno_sub=0,
-                 plural=None, override=None, addition=None):
+    def __init__(self, sentence, *, domain, macro=None, ismultiline,
+                 lineno, lineno_sub=0, plural=None,
+                 override=None, addition=None):
         self.sentence = sentence
         self.domain = domain
         # Say if it is multiline or not.
         self.ismultiline = ismultiline
+        self.macro = macro
         self.lineno = lineno
         # lineno_sub:
         # used only in WmlNodeSentence. This parameter is actually used
@@ -128,8 +131,8 @@ class WmlNode:
         self.wmlinfos = None
         self.autowml = autowml
 
-    def add_sentence(self, sentence, *, domain, ismultiline, lineno,
-                     lineno_sub=0, plural=None, override=None, addition=None):
+    def add_sentence(self, sentence, *, domain, macro=None, ismultiline, lineno, lineno_sub=0,
+                     plural=None, override=None, addition=None):
         if self.sentences is None:
             self.sentences = []
         # 'plural' parameter accepted by WmlNode.add_sentence can be:
@@ -157,6 +160,7 @@ class WmlNode:
                 plural = None
         self.sentences.append( WmlNodeSentence(sentence,
                                           domain=domain,
+                                          macro=macro,
                                           ismultiline=ismultiline,
                                           lineno=lineno,
                                           lineno_sub=lineno_sub,
@@ -208,6 +212,7 @@ class WmlNode:
                                wmlinfos=[],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=nodesentence.addedinfo,
                                plural=nodesentence.plural )
                 else:
@@ -218,6 +223,7 @@ class WmlNode:
                                wmlinfos=[],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=[],
                                plural=nodesentence.plural )
             else: # having a non-empty override
@@ -230,6 +236,7 @@ class WmlNode:
                                wmlinfos=[nodesentence.overrideinfo],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=nodesentence.addedinfo,
                                plural=nodesentence.plural )
                 else:
@@ -240,6 +247,7 @@ class WmlNode:
                                wmlinfos=[nodesentence.overrideinfo],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=[],
                                plural=nodesentence.plural )
         # if you don't have override and autowml is true
@@ -254,6 +262,7 @@ class WmlNode:
                                wmlinfos=[self.assemble_wmlinfo()],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=nodesentence.addedinfo,
                                plural=nodesentence.plural )
             else:
@@ -264,6 +273,7 @@ class WmlNode:
                                wmlinfos=[self.assemble_wmlinfo()],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=[],
                                plural=nodesentence.plural )
         # if you don't have override and autowml is false
@@ -278,6 +288,7 @@ class WmlNode:
                                wmlinfos=[],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=nodesentence.addedinfo,
                                plural=nodesentence.plural )
             else:
@@ -288,5 +299,6 @@ class WmlNode:
                                wml_infos=[],
                                finfos=[self.fileref +
                                         str(nodesentence.lineno)],
+                               macro=nodesentence.macro,
                                addedinfos=[],
                                plural=nodesentence.plural )

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -249,7 +249,7 @@ class PendingLuaString:
                     _dictionary[_currentdomain] = dict()
                 loc_posentence = _dictionary[_currentdomain].get(self.luastring)
                 if loc_posentence is None:
-                    _dictionary[_currentdomain][self.luastring] = PoCommentedString(
+                    _dictionary[_currentdomain]['\x01' + self.luastring] = PoCommentedString(
                                 self.luastring,
                                 _currentdomain,
                                 orderid=(fileno, self.lineno, _linenosub),

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -127,19 +127,13 @@ def switchdomain(lineno, domain):
         _currentdomain = domain
 
 
-def checksentence(mystring, finfo, *, islua=False):
+def checksentence(mystring, finfo, *, israw=False):
     m = re.match(r'\s*$', mystring)
     if m:
         wmlwarn(finfo, "found an empty translatable message")
         return 1
-    elif warnall() and not islua:
-        if "}" in mystring:
-            wmsg = ("found a translatable string containing a WML macro. "
-                    " Translation for this string will NEVER work")
-            wmlwarn(finfo, wmsg)
-            return 2
-        else:
-            return 0
+    elif not israw and "{" in mystring:
+        return 2
     else:
         return 0
 
@@ -228,7 +222,7 @@ class PendingLuaString:
             _linenosub += 1
             finfo = pywmlx.nodemanip.fileref + ":" + str(self.lineno)
             fileno = pywmlx.nodemanip.fileno
-            errcode = checksentence(self.luastring, finfo, islua=True)
+            errcode = checksentence(self.luastring, finfo, israw=True)
             if errcode != 1:
                 # when errcode is equal to 1, the translatable string is empty
                 # so, using "if errcode != 1"
@@ -297,6 +291,8 @@ class PendingWmlString:
         global _pending_overrideinfo
         global _linenosub
         global _pending_winfotype
+        global _pending_wmacroname
+        global _pending_wmacroline
         if _pending_winfotype is not None:
             if self.ismultiline is False and self.istranslatable is False:
                 winf = _pending_winfotype + '=' + self.wmlstring
@@ -306,7 +302,10 @@ class PendingWmlString:
             return
         if self.istranslatable:
             finfo = pywmlx.nodemanip.fileref + ":" + str(self.lineno)
-            errcode = checksentence(self.wmlstring, finfo, islua=False)
+            errcode = checksentence(self.wmlstring, finfo, israw=self.israw)
+            macro = None
+            if errcode == 2:
+                macro = (_pending_wmacroname, pywmlx.nodemanip.fileref, _pending_wmacroline)
             if errcode != 1:
                 # when errcode is equal to 1, the translatable string is empty
                 # so, using "if errcode != 1"
@@ -318,6 +317,7 @@ class PendingWmlString:
                     self.wmlstring = re.sub('""', r'\"', self.wmlstring)
                 pywmlx.nodemanip.addNodeSentence(self.wmlstring,
                                              domain=_currentdomain,
+                                             macro=macro,
                                              ismultiline=self.ismultiline,
                                              lineno=self.lineno,
                                              lineno_sub=_linenosub,

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -70,6 +70,11 @@ _pending_winfotype = None
 # If no lua functions already encountered, this var will be None
 _pending_luafuncname = None
 
+# the macro definition currently analyzed in a wml code (if any).
+# If outside of any macros, this var will be None
+_pending_wmacroname = None
+_pending_wmacroline = None
+
 # ----------
 
 # pending lua/wml string (they will be evaluated, and if translatable it will

--- a/data/tools/wesnoth/wmliterator3.py
+++ b/data/tools/wesnoth/wmliterator3.py
@@ -141,6 +141,13 @@ Important Attributes:
         self.reset()
         self.seek(begin)
 
+    @property
+    def element(self):
+        if type(self._element) != list:
+            return self._element[0]
+
+        return list(map(lambda t:t[0], self._element))
+
     def parseQuotes(self, lines):
         """Return the line or multiline text if a quote spans multiple lines"""
         text = lines[self.lineno]
@@ -325,7 +332,7 @@ Important Attributes:
             while scopeDelta > 0:
                 openedScopes.append(elem)
                 scopeDelta -= 1
-            resultElements.append(elem)
+            resultElements.append((elem, sortPos))
         return resultElements, openedScopes
 
     def printScopeError(self, elementType):
@@ -351,7 +358,7 @@ Important Attributes:
         self.nextScopes = []
         self.text = ""
         self.span = 1
-        self.element = ""
+        self._element = ("",-1)
         return self
 
     def seek(self, lineno, clearEnd=True):
@@ -423,17 +430,17 @@ Important Attributes:
         self.lineno = self.lineno + self.span
         self.text, self.span = self.parseQuotes(self.lines)
         self.scopes.extend(self.nextScopes)
-        self.element, nextScopes = self.parseElements(self.text)
+        self._element, nextScopes = self.parseElements(self.text)
         self.nextScopes = []
         for elem in nextScopes:
         # remember scopes by storing a copy of the iterator
             copyItor = self.copy()
-            copyItor.element = elem
+            copyItor._element = (elem,)
             self.nextScopes.append(copyItor)
             copyItor.nextScopes.append(copyItor)
-        if(len(self.element) == 1):
+        if(len(self._element) == 1):
             # currently we only wish to handle simple single assignment syntax
-            self.element = self.element[0]
+            self._element = self._element[0]
         if self.endScope is not None and not self.scopes.count(self.endScope):
             raise StopIteration
         return self

--- a/data/tools/wesnoth/wmlmacro.py
+++ b/data/tools/wesnoth/wmlmacro.py
@@ -1,0 +1,511 @@
+"""
+   Copyright (C) 2023 by Leonardo Julca <ivojulca@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY.
+
+   See the COPYING file for more details.
+"""
+
+# This library provides classes required to model macros.
+# - Macro calls - modeled by an Abstract Syntax Tree (AST class).
+# - Macro positions - modeled by the Macro class.
+#
+# It also exports auxiliary static methods that interface with
+# CrossRef, Reference, and Macro.
+
+import itertools
+import os
+import re
+from .wmltools3 import CrossRef, Reference
+from .wmliterator3 import WmlIterator
+
+# Universe - convenient singleton for which
+# `x in Universe` is always True
+# Passing it to a filter is equivalent to not filtering.
+class UniversalSet:
+    def __contains__(self, element):
+        return True
+
+Universe = UniversalSet()
+
+# memoize - Memoizes a binary function with support for
+# a non-hashable as second argument.
+def memoize(f):
+    memo = {}
+    def wrapper(i, j):
+        if i not in memo or memo[i][0] != j:
+            memo[i] = (j, f(i, j))
+        return memo[i][1]
+    return wrapper
+
+def extend_no_override(target, source):
+    for key, value in source.items():
+        if key in target:
+            continue
+        target[key] = value
+
+class WmlIteratorException(Exception):
+    pass
+
+class StrictWmlIterator(WmlIterator):
+    "Raise exceptions rather than writing to stdout."
+    def printError(self, *misc):
+        raise WmlIteratorException("|".join(map(str, misc)))
+
+# Default parameter for AST|ExpandableNode.replace()
+NO_ARGS = ({}, None)
+
+# LiteralNode - fragment without own expansion semantics.
+# It may be subordinated to a MacroCallNode as an argument.
+#
+# Properties
+#  is_root - always false, used to inspect AST parse status.
+#  parent - ExpandableNode or AST.
+#  value - the literal content of the node.
+#  children - always None, used to inspect AST parse status.
+class LiteralNode:
+    def __init__(self, parent, value):
+        self.is_root = False
+        self.parent = parent
+        self.value = value
+        self.children = None
+
+    def __repr__(self):
+        return "LiteralNode(\"%s\")" % self.value
+
+    def __str__(self):
+        return self.value
+
+    def get_root(self):
+        parent = self.parent
+        while parent.parent is not None:
+            parent = parent.parent
+        return parent
+
+    def replace(self, args_set=NO_ARGS):
+        if len(self.value) == 0:
+            return "()"
+        return self.value
+
+# ExpandableNode - fragment with own expansion semantics.
+# It may be a parameter inside a macro definition, or a
+# macro call. Discriminating between them depends on
+# context information.
+#
+# Properties
+#  is_root - always false, used to inspect AST parse status.
+#  parent - ExpandableNode or AST
+#  name - the name of the parameter or macro call.
+#  children - a list of any macro parameters, may be empty but not None.
+#  _search - index plus 1 of the last parsed closing brace for a children.
+
+class ExpandableNode:
+    def __init__(self, parent, name, start, search):
+        self.is_root = False
+        self.parent = parent
+        self.name = name
+        self.children = []
+        self._search = search
+
+    def __repr__(self):
+        return "ExpandableNode([*%d children])" % len(self.children)
+
+    def __str__(self):
+        return self.replace()
+
+    def get_root(self):
+        parent = self.parent
+        while not parent.is_root:
+            parent = parent.parent
+        return parent
+
+    def replace(self, args_set=NO_ARGS):
+        if self.name in args_set[0]:
+            sub = args_set[0][self.name]
+            # print("Subbed parameter %s -> %s" % (self.name, sub))
+            return sub
+
+        out = ["{" + self.name]
+        is_first = True
+        for child in self.children:
+            if not is_first:
+                # Add whitespace between arguments.
+                out.append(" ")
+            out.append(child.replace(args_set))
+            is_first = False
+        return " ".join(out) + "}"
+
+naive_arg_regexp = re.compile(r'(?<=\()[^)]*(?=\))|".+?"|\w+')
+
+class AST:
+    def __init__(self):
+        self.children = []
+        self.active_node = self
+        self.parent = None
+        self.is_root = True
+        self._search = 0
+
+    def fill_literals(self, text, end):
+        assert not type(self.active_node) == str
+        start = self.active_node._search
+        source = text[start:end]
+        if len(source) == 0:
+            return
+
+        if self.active_node.is_root:
+            # Preserve whitespace.
+            literal_node = LiteralNode(self.active_node, source)
+            self.active_node.children.append(literal_node)
+        else:
+            for literal in naive_arg_regexp.findall(source):
+                literal_node = LiteralNode(self.active_node, literal)
+                self.active_node.children.append(literal_node)
+
+    def __repr__(self):
+        return "AST([*%d children])" % len(self.children)
+
+    def __str__(self):
+        return self.replace()
+
+    def get_root(self):
+        return self
+
+    def replace(self, args_set=NO_ARGS):
+        # args_set: (dict<str, str>, Macro)
+        # return: str
+        out = []
+        for child in self.children:
+            out.append(child.replace(args_set))
+        return "".join(out)
+
+    @staticmethod
+    def parse(input, on_macro = None):
+        lines = input.split("\n")
+        ast = AST()
+        try:
+            for state in StrictWmlIterator(lines=lines):
+                elements, _scopes = state.parseElements(state.text)
+                for elem, start in elements:
+                    length = 1 if elem == "end of macro" else len(elem)
+                    end = start + length
+                    if elem == "end of macro" and ast.active_node.is_root:
+                        continue
+                    if elem == "end of macro":
+                        ast.fill_literals(input, start)
+                        if on_macro is not None:
+                            on_macro(ast.active_node)
+                        ast.active_node = ast.active_node.parent
+                        ast.active_node._search = end
+                    elif elem[0] == "{":
+                        ast.fill_literals(input, start)
+                        assert not type(ast.active_node) == str
+                        macro_node = ExpandableNode(ast.active_node, elem[1:], start, end)  
+                        ast.active_node.children.append(macro_node)
+                        ast.active_node = macro_node
+                    else:
+                        pass
+                ast.fill_literals(input, len(input))
+        except WmlIteratorException as ex:
+            print("%s while parsing \"%s\"" % (ex.args + (input,)))
+
+        # print("AST parsed %s <-> %s" % (input, ast))
+        return ast
+
+    @staticmethod
+    def parse_sentence_and_ids(sentence, lone_ids, complex_ids):
+        # Mutates lone_ids.
+        # Mutates complex_ids.
+        def on_macro(node):
+            nonlocal lone_ids
+            nonlocal complex_ids
+
+            if len(node.children) == 0:
+                # Either parameters or constant macros.
+                lone_ids.add(node.name)
+            else:
+                # Definitely macros.
+                complex_ids.add(node.name)
+
+        return AST.parse(sentence, on_macro)
+
+    @staticmethod
+    def parse_with_ctx(arg, in_macro_xref, used_parameters=set(), used_macros=set()):
+        # Mutates used_parameters.
+        # Mutates used_macros.
+        def on_macro(node):
+            nonlocal in_macro_xref
+            nonlocal used_parameters
+            nonlocal used_macros
+
+            if len(node.children) == 0 and \
+                (node.name in in_macro_xref.args or node.name in in_macro_xref.optional_args):
+                used_parameters.add(node.name)
+            else:
+                used_macros.add(node.name)
+
+        return AST.parse(arg, on_macro)
+
+    @staticmethod
+    def evaluate_many_on_one(ast, args_sets_in):
+        # ast: AST
+        # return: list<(str, Macro|NoneType)>
+
+        out = []
+        for args_with_ctx in args_sets_in:
+            sub = ast.replace(args_with_ctx)
+            out.append((sub, args_with_ctx[1]))
+
+        return out
+
+    @staticmethod
+    def evaluate_many_on_many(parameters_asts, args_sets_in):
+        # - parameters_asts : dict<str, AST>
+        # - args_sets_in    : list<(dict<str, str>, Macro|NoneType)>
+        # - args_sets_out   : list<(dict<str, str>, Macro|NoneType)>
+
+        args_sets_out = []
+        for args_with_ctx in args_sets_in:
+            assert(isinstance(args_with_ctx[0], dict))
+            # assert(isinstance(args_with_ctx[1], Macro|NoneType))
+            parameters_out = {}
+            for parameter_name, ast in parameters_asts.items():
+                parameters_out[parameter_name] = ast.replace(args_with_ctx)
+
+            args_sets_out.append((parameters_out, args_with_ctx[1]))
+
+        return args_sets_out
+
+
+def has_brace(arg):
+    return "{" in arg
+
+def has_quotes(arg):
+    return "\"" in arg
+
+# Macro - wrapper around a 3-tuple, which identifies a
+# macro definition.
+# Elements (name, file reference, line number)
+class Macro:
+    def __init__(self, name, fileref, line):
+        self.name = name
+        self.fileref = fileref
+        self.line = line
+
+    def __iter__(self):
+        yield self.name
+        yield self.fileref
+        yield self.line
+
+    def __repr__(self):
+        return "Macro(\"%s\", \"%s\", %d)" % tuple(self)
+
+    def __str__(self):
+        return "%s@%s:%d" % tuple(self)
+
+    def __eq__(self, other):
+        return tuple(self) == tuple(other)
+
+    def __getitem__(self, key):
+        return tuple(self)[key]
+
+    def __hash__(self):
+        # Only use macros with relative file references
+        # as dictionary keys to avoid mismatches.
+        # Those are built from Macro(PoCommentedString.macro)
+        # Note that CrossRef contains absolute references.
+        assert not os.path.isabs(self.fileref)
+        return hash(tuple(self))
+
+    def to_abs(self, root_path):
+        return Macro(self.name, os.path.normpath(os.path.join(root_path, self.fileref)), self.line)
+
+    def to_rel(self, root_path):
+        return Macro(self.name, os.path.relpath(root_path, self.fileref), self.line)
+
+    def get_ref(self, xrefs):
+        assert isinstance(xrefs, CrossRef)
+        if not self.name in xrefs.xref:
+            print("Macro %s not found" % self)
+            return None
+
+        for xref in xrefs.xref[self.name]:
+            if xref.filename != self.fileref or xref.lineno != self.line:
+                # print("Excluded %s@%s#%d" % (self.name, xref.filename, xref.lineno))
+                continue
+
+            assert isinstance(xref, Reference)
+            return xref 
+
+        return None
+
+class CrossRefHelper:
+    @staticmethod
+    # get_macro_at - Given a file reference and line number,
+    # return the Macro that contains it, if any.
+    def get_macro_at(xrefs, fileref, lineno):
+        assert(isinstance(xrefs, CrossRef))
+        for macro_name in xrefs.xref.keys():
+            for xref in xrefs.xref[macro_name]:
+                if xref.filename != fileref:
+                    continue
+                if xref.lineno < lineno and lineno < xref.lineno_end:
+                    return Macro(macro_name, xref.filename, xref.lineno)
+
+        return None
+
+
+
+class ReferenceHelper:
+    @staticmethod
+    def is_embeddable_macro(xref):
+        return xref.lineno + 1 == xref.lineno_end and not "\"" in xref.body[0]
+
+    @staticmethod
+    # get_arguments - Given a Reference for a macro definition,
+    # return a list of call site representations.
+    # Each call is a tuple (dictionary, Macro|None):
+    # - dictionary contains passed and default arguments.
+    # - second element is the macro containing that call, if any.
+    #
+    # filter_parameters is an optional bag to filter only relevant
+    # parameters. Parameters not matched will be set to the string
+    # `_ignored_`.
+    def get_arguments(xref, xrefs, filter_parameters = Universe):
+        assert(isinstance(xref, Reference))
+        assert(isinstance(xrefs, CrossRef))
+        variants = []
+        for xref_file_name, references in xref.references.items():
+            assert(type(xref_file_name) == str)
+            for call_site in references:
+                # call_site == (int, str[], dict<str, str>)
+                # call_site == (lineno, args, optional_args)
+                parent_macro = CrossRefHelper.get_macro_at(xrefs, xref_file_name, call_site[0]) # Macro|None
+                called_args = {}
+                untranslatable_arg = None
+                if call_site[1] is not None:
+                    for i, called_arg in enumerate(call_site[1]):
+                        if i >= len(xref.args):
+                            # Macro called with too many args.
+                            print("Macro called with more arguments (%d) than expected at %s:%d. " % (len(call_site[1]), xref_file_name, call_site[0]))
+                            break
+                        parameter_name = xref.args[i]
+                        if parameter_name in filter_parameters:
+                            if has_quotes(called_arg):
+                                untranslatable_arg = called_arg
+                                break
+                            called_args[parameter_name] = called_arg
+                        else:
+                            # _ignored_ has no magic meaning.
+                            # Any other string without braces may be used instead.
+                            called_args[parameter_name] = "_ignored_"
+
+                if untranslatable_arg is None and call_site[2] is not None:
+                    for parameter_name, called_arg in call_site[2].items():
+                        if not parameter_name in xref.optional_args:
+                            # Invalid parameter name.
+                            print("Macro called with invalid optional parameter \"%s\" at %s:%d." % (parameter_name, xref_file_name, call_site[0]))
+                            continue
+                        if parameter_name in filter_parameters:
+                            if has_quotes(called_arg):
+                                untranslatable_arg = called_arg
+                                break
+                            called_args[parameter_name] = called_arg
+                        else:
+                            # _ignored_ has no magic meaning.
+                            # Any other string without braces may be used instead.
+                            called_args[parameter_name] = "_ignored_"
+
+                if untranslatable_arg is None:
+                    for parameter_name, default_value in xref.optional_args.items():
+                        if parameter_name in filter_parameters and not parameter_name in called_args:
+                            if has_quotes(default_value):
+                                untranslatable_arg = called_arg
+                                break
+                            called_args[parameter_name] = default_value
+
+                if untranslatable_arg is None:
+                    variants.append((called_args, parent_macro))
+
+                if untranslatable_arg is not None:
+                    print("Untranslatable quoted argument %s at %s:%d" % (untranslatable_arg, xref_file_name, call_site[0]))
+
+        # list<(dictionary<str, str>, Macro|None)>
+        return variants
+
+    # get_param_replaceables - Generator function to iterate over variants with braces.
+    # variants is an unsorted mutable list.
+    @staticmethod
+    def get_param_replaceables(variants):
+        # Mutates variants
+        index = 0
+        while index < len(variants):
+            next = variants[index]
+            # next: (dictionary<str, str>, Macro)
+            if next[1] is None:
+                # Signals that this sentence cannot be expanded anymore.
+                index += 1
+                continue
+
+            if not any(has_brace(arg) for arg in next[0].values()):
+                index += 1
+                continue
+
+            last = variants.pop()
+            if index != len(variants):
+                assert index < len(variants)
+                variants[index] = last
+            else:
+                # `next` removed in variants.pop().
+                assert next == last
+                
+            yield next
+
+    # deep_replace_arguments - Iterates over variants over and over.
+    # Each turn, an expandable variant is processed and readded to the pool,
+    # with an updated Macro context.
+    # Ends when no more expandable variants are left.
+    @staticmethod
+    def deep_replace_arguments(variants, xrefs):
+        # Mutates variants
+        assert(isinstance(xrefs, CrossRef))
+        for args, macro in ReferenceHelper.get_param_replaceables(variants):
+            # (args, macro): (dictionary<str, str>, Macro)
+            assert(isinstance(macro, Macro))
+            assert(os.path.isabs(macro.fileref))
+            xref = macro.get_ref(xrefs)
+
+            # asts - dict<str, AST>
+            # Dictionary for AST representations of each argument in args.
+            asts = {}
+
+            # Sets listing parameters and macros used by args.
+
+            # used_params - set<str>
+            used_params = set()
+            for parameter_name, arg_value in args.items():
+                if has_brace(arg_value):
+                    # Fill-in used_params
+                    asts[parameter_name] = AST.parse_with_ctx(arg_value, xref, used_params)
+                else:
+                    asts[parameter_name] = LiteralNode(None, arg_value)
+
+            resolved_args = args
+            if len(used_params) > 0:                
+                # parent_args: list<(dict, Macro)>
+                resolved_args = ReferenceHelper.get_arguments(xref, xrefs, used_params)
+                for parent_args, parent_macro in resolved_args:
+                    extend_no_override(parent_args, args)
+
+            if len(resolved_args) == 0:
+                # Unable to expand this argument further.
+                # Clear macro context so that get_param_replaceables()
+                # won't yield it anymore.
+                variants.append((args, None))
+            else:
+                #arg_substitution_sets: list<(dict, Macro)>
+                for variant in AST.evaluate_many_on_many(asts, resolved_args):
+                    variants.append(variant)
+

--- a/data/tools/wesnoth/wmlmacro.py
+++ b/data/tools/wesnoth/wmlmacro.py
@@ -20,6 +20,7 @@
 import itertools
 import os
 import re
+import sys
 from .wmltools3 import CrossRef, Reference
 from .wmliterator3 import WmlIterator
 
@@ -145,7 +146,7 @@ class ExpandableNode:
     def replace(self, args_set=NO_ARGS, macro_defs=None):
         if self.name in args_set[0]:
             sub = args_set[0][self.name]
-            # print("Subbed parameter %s -> %s" % (self.name, sub))
+            # print("Subbed parameter %s -> %s" % (self.name, sub), file=sys.stderr)
             return sub
 
         if macro_defs is not None and self.name in macro_defs:
@@ -159,7 +160,7 @@ class ExpandableNode:
             for i in range(0, min(len(macro_args), len(self.children))):
                 # For each formal parameter, replace it by its value.
                 result = re.sub('{'+macro_args[i]+'}', str(self.children[i]), result)
-            # print("Subbed macro %s -> %s" % (self, result))
+            # print("Subbed macro %s -> %s" % (self, result), file=sys.stderr)
 
             return result
 
@@ -244,9 +245,9 @@ class AST:
                         pass
                 ast.fill_literals(input, len(input))
         except WmlIteratorException as ex:
-            print("%s while parsing \"%s\"" % (ex.args + (input,)))
+            print("%s while parsing \"%s\"" % (ex.args + (input,)), file=sys.stderr)
 
-        # print("AST parsed %s <-> %s" % (input, ast))
+        # print("AST parsed %s <-> %s" % (input, ast), file=sys.stderr)
         return ast
 
     @staticmethod
@@ -363,12 +364,12 @@ class Macro:
     def get_ref(self, xrefs):
         assert isinstance(xrefs, CrossRef)
         if not self.name in xrefs.xref:
-            print("Macro %s not found" % self)
+            print("Macro %s not found" % self, file=sys.stderr)
             return None
 
         for xref in xrefs.xref[self.name]:
             if xref.filename != self.fileref or xref.lineno != self.line:
-                # print("Excluded %s@%s#%d" % (self.name, xref.filename, xref.lineno))
+                # print("Excluded %s@%s#%d" % (self.name, xref.filename, xref.lineno), file=sys.stderr)
                 continue
 
             assert isinstance(xref, Reference)
@@ -405,9 +406,9 @@ class CrossRefHelper:
                 if any(map(ReferenceHelper.is_embeddable_macro, xrefs.xref[name])):
                     macros.append(name)
                 else:
-                    print("Macro {%s} cannot be embedded in a translatable string (only simple single-line macros may.)")
+                    print("Macro {%s} cannot be embedded in a translatable string (only simple single-line macros may.)", file=sys.stderr)
             else:
-                print("Macro {%s} not defined. Strings containing it will NOT be processed in the generated .pot file." % name)
+                print("Macro {%s} not defined. Strings containing it will NOT be processed in the generated .pot file." % name, file=sys.stderr)
 
         return tuple(macros)
 
@@ -523,7 +524,7 @@ class CrossRefHelper:
 
         if iterations >= max_iterations:
             print("Unable to generate msgid for \"%s\" (Macro replacement stack limit exceeded.) \
-Ensure there are no circular macro references." % input_sentence)
+Ensure there are no circular macro references." % input_sentence, file=sys.stderr)
 
 class ReferenceHelper:
     @staticmethod
@@ -556,7 +557,7 @@ class ReferenceHelper:
                     for i, called_arg in enumerate(call_site[1]):
                         if i >= len(xref.args):
                             # Macro called with too many args.
-                            print("Macro called with more arguments (%d) than expected at %s:%d. " % (len(call_site[1]), xref_file_name, call_site[0]))
+                            print("Macro called with more arguments (%d) than expected at %s:%d. " % (len(call_site[1]), xref_file_name, call_site[0]), file=sys.stderr)
                             break
                         parameter_name = xref.args[i]
                         if parameter_name in filter_parameters:
@@ -573,7 +574,7 @@ class ReferenceHelper:
                     for parameter_name, called_arg in call_site[2].items():
                         if not parameter_name in xref.optional_args:
                             # Invalid parameter name.
-                            print("Macro called with invalid optional parameter \"%s\" at %s:%d." % (parameter_name, xref_file_name, call_site[0]))
+                            print("Macro called with invalid optional parameter \"%s\" at %s:%d." % (parameter_name, xref_file_name, call_site[0]), file=sys.stderr)
                             continue
                         if parameter_name in filter_parameters:
                             if has_quotes(called_arg):
@@ -597,7 +598,7 @@ class ReferenceHelper:
                     variants.append((called_args, parent_macro))
 
                 if untranslatable_arg is not None:
-                    print("Untranslatable quoted argument %s at %s:%d" % (untranslatable_arg, xref_file_name, call_site[0]))
+                    print("Untranslatable quoted argument %s at %s:%d" % (untranslatable_arg, xref_file_name, call_site[0]), file=sys.stderr)
 
         # list<(dictionary<str, str>, Macro|None)>
         return variants

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -32,14 +32,15 @@
 # http://wmlxgettext-unoff.readthedocs.org/en/latest/srcdoc/index.html
 
 import argparse
+from copy import copy
 from datetime import datetime
 import os
 import signal
 import sys
 import warnings
 import pywmlx
-
-
+from wesnoth.wmltools3 import CrossRef
+from wesnoth.wmlmacro import AST, Macro, CrossRefHelper, ReferenceHelper
 
 def commandline(args):
     parser = argparse.ArgumentParser(
@@ -170,6 +171,9 @@ def commandline(args):
 
 
 
+class AnalysisTooNarrowException(Exception):
+    pass
+
 def extractor(files, fileref_root, offset = 0):
     for fileno, fx in enumerate(files):
         if fileno < offset:
@@ -192,6 +196,238 @@ def extractor(files, fileref_root, offset = 0):
                             fileno=fileno, startstate='lua_idle', waitwml=False)
             infile.close()
 
+
+
+def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_root="", outfile=None, fuzzy=False):
+    # In fact, Wesnoth's engine expands macros in the preprocessor step.
+    # Therefore, the input below ran through wmlxgettext should output
+    #
+    # msgid "Hello, world."
+    # msgstr ""
+    #
+    # # define GREET MODE WHOM
+    # [{MODE}]
+    #     {MODE} = _ "Hello, {WHOM}."
+    # [/{MODE}]
+    # # enddef
+    #
+    # {GREET message world}
+    #
+    # To accomplish that through all macro calls and subcalls, we identify
+    # three types of macro calls according to their context.
+    # A. Inside translatable strings.
+    # B. Inside macro definitions, but not inside a string.
+    # C. Every other macro call (top level).
+    #
+    # The simplest case is that macro type A is called directly by
+    # a single macro type C. In that case, we:
+    # 1. Identify the parameter index "n" in the definition of macro C,
+    #    associated with the call of macro A.
+    # 2. Substitute the nth parameter of macro C into the string containing
+    #    macro call A.
+    #
+    # There are several factors that complicate it:
+    # 1. There may be one or more macros of type B. We need to track their
+    #    parameters as well.
+    # 2. There may be more than one macro of type C. Each of them represents
+    #    a new string in the output.
+    # 3. It's possible the parameters of macro(s) type B and C aren't a 1:1
+    #    match.
+    # 4. Since Wesnoth 1.13.7, named optional macro parameters are available.
+    #    through the directive #arg
+    # 5. Macros may be deleted with #undef and later redefined.
+    #
+    # For example, let
+    #
+    # # define MOODY_GREET MODE QUALIFIER WHOM
+    #   {GREET {MODE} (very {QUALIFIER} {WHOM})}
+    # # enddef
+    #
+    # {MOODY_GREET message good world}
+    # {MOODY_GREET message bad world}
+    #
+    # We know that GREET's relevant parameter is the second, and it's affected by
+    # the second and third parameters of MOODY_GREET. Fortunately, MOODY_GREET has
+    # a finite universe of possible parameters, so we iterate through all of them,
+    # and we get
+    #
+    # msgid "Hello, very good world."
+    # msgstr ""
+    #
+    # msgid "Hello, very bad world."
+    # msgstr ""
+    #
+    # Note that $substitutions are bad practice for localizable strings,
+    # as the translator will only be able to relocate the variable, and not
+    # act according to their possible values. Many languages have lots of
+    # conditional declensions, which warrant exhausting all combinations.
+    # Those *are* provided by macros.
+    #
+    #
+    # Strategy:
+    # 1. Identify all strings which require preprocessing, as well as their
+    #    reference (file name, line number), and parent macro definition.
+    #    These are passed to handle_macro_po_sentences.
+    #
+    # 2. Use wmltools3.CrossRef to parse macro definitions and callsites.
+    #    2.1 Note whether there's an #undef in the same file (i.e whether 
+    #        the macro is local or global).
+    #    2.2. If any of the macros from (1) is non-local, fall back to (3).
+    #    2.3. Otherwise, go to (4).
+    #
+    # 3. Use wmltools3.CrossRef to parse macro definitions and callsites on the entire addon.
+    #    3.1. Note whether the macro contains quote marks or is multiline (error out if so.)
+    #    3.2. Go to (4).
+    # 
+    # 4. Deeply identify all macro callsites with expansions that include
+    #    strings in (1).
+    # 5. Propagate macro parameters.
+    # 6. Evaluate macro expansions.
+    #
+    ctx_macros = {}
+    ids_by_sentence = {}
+    asts_by_sentence = {}
+    (sentences_by_file, sentences_by_macro) = po_sentences
+    for fileref, sentences in sentences_by_file.items():
+        for posentence in sentences:
+            lone_identifiers, complex_identifiers = set(), set()
+            # Fill-in lone_identifiers, complex_identifiers
+            ast = AST.parse_sentence_and_ids(posentence.sentence, lone_identifiers, complex_identifiers)
+            macro = Macro(*posentence.macro)
+
+            ctx_macros[macro] = True
+            asts_by_sentence[posentence.sentence] = ast
+            ids_by_sentence[posentence.sentence] = (lone_identifiers, complex_identifiers)
+
+    args_by_macro = {}
+    xrefs_by_file = {}
+    xrefs_all = None
+
+    def resolve_strings_at(dirpath=None, single_file=None):
+        nonlocal xrefs_all
+
+        if dirpath is None:
+            # 2. Use wmltools3.CrossRef to parse macro definitions and callsites.
+            filelist = [os.path.normpath(os.path.join(fileref_root, single_file))]
+            xrefs = CrossRef(filelist=filelist)
+            xrefs_by_file[filelist[0]] = xrefs # filelist[0] abs path
+        else:
+            # 3. Use wmltools3.CrossRef to parse macro definitions and callsites on the entire addon.
+            xrefs = CrossRef(dirpath=dirpath)
+            xrefs_all = xrefs
+
+        for macro in ctx_macros:
+            if single_file and macro.fileref != single_file:
+                # Ignore in single-file analysis
+                continue
+
+            # print("Tracing %s..." % macro)
+            xref = macro.to_abs(fileref_root).get_ref(xrefs)
+            assert xref is not None, ("Macro %s not referenced" % macro)
+
+            is_local = xref.undef is not None
+            if not is_local and single_file is not None:
+                # 2.1 Note whether there's an #undef in the same file (i.e whether 
+                #     the macro is local or global).
+                # 2.2. If any of the macros from (1) is non-local, fall back to (3).
+                raise AnalysisTooNarrowException("Macro %s is exported." % macro)
+
+            contained_sentences = sentences_by_macro[macro]
+
+            # Intermediate values in extraction of parameters and macros
+            # used by translatable sentences.
+
+            # lone identifiers    : list<set<string>>
+            all_params_sets = [ids_by_sentence[s.sentence][0] for s in contained_sentences]
+            # complex identifiers : list<set<string>>
+            complex_id_sets = [ids_by_sentence[s.sentence][1] for s in contained_sentences]
+            # maybe_parameters    : set<str>
+            maybe_parameters = set.union(*all_params_sets)
+
+            # parameters: set<str>
+            # Use set to ease look-up when using them as filter.
+            parameters = set(id for id in maybe_parameters if id in xref.args or id in xref.optional_args)
+
+            # We will need to iterate over constant_macros and variable_macros.
+            # Note that it's possible for a macro with optional arguments to be listed in both.
+
+            # macro names with 0 arguments : set<str>
+            constant_macros = maybe_parameters.difference(parameters)
+            # macro names with 1+ arguments: set<str>
+            variable_macros = set.union(*complex_id_sets)
+
+            for callee_name in set.union(constant_macros, variable_macros):
+                if not callee_name in xrefs.xref:
+                    if single_file is None:
+                        print("Unknown macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro))
+                    else:
+                        raise AnalysisTooNarrowException("Macro {%s} not found at %s." % (callee_name, single_file))
+                if not any(map(ReferenceHelper.is_embeddable_macro, xrefs.xref[callee_name])):
+                    if single_file is None:
+                        print("No valid embeddable expansion for macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro))
+                    else:
+                        raise AnalysisTooNarrowException("No valid definition for macro {%s} found at %s." % (callee_name, single_file))
+
+            args_variants = ReferenceHelper.get_arguments(xref, xrefs, parameters)
+            if len(args_variants) != 0:
+                # 4. Deeply identify all macro callsites with expansions that include
+                #    strings in (1).
+                # 5. Propagate macro parameters.
+                ReferenceHelper.deep_replace_arguments(args_variants, xrefs)
+
+            args_by_macro[macro] = args_variants
+
+    try:
+        for fileref in sentences_by_file:
+            resolve_strings_at(dirpath=None, single_file=fileref)
+    except AnalysisTooNarrowException as ex:
+        print("%s Falling back to full-tree analysis." % ex.args)
+        try:
+            resolve_strings_at(dirpath=[start_path])
+        except Exception as ex:
+            # Remove the trace for AnalysisTooNarrowException.
+            raise ex from None
+            
+
+    # 2.3. Otherwise, go to (4).
+    # 3.3. Go to (4).
+    new_sentences = {}
+    for macro, sentences in sentences_by_macro.items():
+        args_variants = args_by_macro[macro]
+        file_path_abs = os.path.normpath(os.path.join(fileref_root, macro[1]))
+        xrefs = xrefs_by_file[file_path_abs] if file_path_abs in xrefs_by_file else xrefs_all
+        for po_sentence in sentences:
+            ast = asts_by_sentence[po_sentence.sentence]
+            # print("raw sentence: (%s <-> %s)" % (po_sentence.sentence, ast))
+
+            # 5. Propagate macro parameters.
+            # sub_sentences: list<(str, Macro|NoneType)>
+            sub_sentences = []
+
+            if len(ids_by_sentence[po_sentence.sentence][0]) > 0:
+                # No lone_identifiers -> No parameters
+                # Only evaluate parameters if there is at least one lone identifier.
+                sub_sentences = AST.evaluate_many_on_one(ast, args_variants)
+
+            for sub_sentence, ctx in sub_sentences:
+                po_sentence_variant = copy(po_sentence)
+                po_sentence_variant.finfos = copy(po_sentence_variant.finfos)
+                po_sentence_variant.sentence = sub_sentence
+                if '\x01' + po_sentence_variant.sentence in sentlist:
+                    # print("Ignored ref to raw sentence %s" % po_sentence_variant.sentence)
+                    # Output has already been written. TODO: FIXME?
+                    # sentlist['\x01' + po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
+                    pass
+                elif po_sentence_variant.sentence in new_sentences:
+                    # print("New ref in processed sentence %s" % po_sentence_variant.sentence)
+                    new_sentences[po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
+                else:
+                    # print("New sentence %s" % po_sentence_variant.sentence)
+                    new_sentences[po_sentence_variant.sentence] = po_sentence_variant
+
+    for posentence in new_sentences.values():
+        posentence.write(outfile, fuzzy)
+        print('', file=outfile)
 
 
 def main():
@@ -245,31 +481,11 @@ def main():
  
     extractor(filelist, fileref_root)
 
-    outfile = None
-    if args.outfile is None:
-        outfile = sys.stdout
-    else:
-        outfile_name = os.path.realpath(os.path.normpath(args.outfile))
-        try:
-            outfile = open(outfile_name, 'w', encoding="utf-8")
-        except OSError as e:
-            errmsg = 'cannot write file: ' + e.args[1]
-            pywmlx.wmlerr(e.filename, errmsg, OSError)
-    pkgversion = args.package_version + '\\n"'
-    print('msgid ""\nmsgstr ""', file=outfile)
-    print('"Project-Id-Version:', pkgversion, file=outfile)
-    print('"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\\n"', file=outfile)
-    now = datetime.utcnow()
-    cdate = '{:04d}-{:02d}-{:02d} {:02d}:{:02d} UTC\\n"'.format(now.year,
-                                                                now.month,
-                                                                now.day,
-                                                                now.hour,
-                                                                now.minute)
-
     folder = None
     filename = None
     outfile = sys.stdout
     now = datetime.utcnow()
+    cdate = '{:04d}-{:02d}-{:02d} {:02d}:{:02d} UTC\\n"'.format(now.year, now.month, now.day, now.hour, now.minute)
     if args.folder is not None:
         folder = os.path.realpath(os.path.normpath(args.folder))
         if not os.path.isdir(folder) and "." in os.path.basename(folder):
@@ -277,7 +493,7 @@ def main():
             folder, filename = os.path.split(folder)
         os.makedirs(folder, exist_ok=True)
 
-    for domain, d in sentlist.items():
+    for domain, catalog in sentlist.items():
         if folder is not None:
             try:
                 outfile = open(os.path.join(folder, "{}.pot".format(domain) if filename is None else filename), 'w', encoding="utf-8")
@@ -288,12 +504,6 @@ def main():
         print('msgid ""\nmsgstr ""', file=outfile)
         print('"Project-Id-Version:', pkgversion, file=outfile)
         print('"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\\n"', file=outfile)
-        cdate = '{:04d}-{:02d}-{:02d} {:02d}:{:02d} UTC\\n"'.format(now.year,
-                                                                    now.month,
-                                                                    now.day,
-                                                                    now.hour,
-                                                                    now.minute)
-
         print('"POT-Creation-Date:', cdate, file=outfile)
         print('"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"', file=outfile)
         print('"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"', file=outfile)
@@ -302,9 +512,29 @@ def main():
         print('"Content-Type: text/plain; charset=UTF-8\\n"', file=outfile)
         print('"Content-Transfer-Encoding: 8bit\\n"\n', file=outfile)
 
-        for posentence in sorted(d.values(), key=lambda x: x.orderid):
-            posentence.write(outfile, args.fuzzy)
-            print('', file=outfile)
+        sentences_wmacro_by_file = {}
+        sentences_wmacro_by_macro = {}
+        macro_po_sentences = (sentences_wmacro_by_file, sentences_wmacro_by_macro)
+        for posentence in sorted(catalog.values(), key=lambda x: x.orderid):
+            macro = posentence.macro
+            if macro is None:
+                posentence.write(outfile, args.fuzzy)
+                print('', file=outfile)
+            else:
+                # 1. Identify all strings which require preprocessing, as well as their
+                #    reference (file name, line number), and parent macro definition.
+                #    These are passed to handle_macro_po_sentences.
+                if not macro[1] in sentences_wmacro_by_file:
+                    sentences_wmacro_by_file[macro[1]] = []
+                sentences_wmacro_by_file[macro[1]].append(posentence)
+                if not macro in sentences_wmacro_by_macro:
+                    sentences_wmacro_by_macro[macro] = []
+                sentences_wmacro_by_macro[macro].append(posentence)
+
+        if len(sentences_wmacro_by_file) > 0:
+            print("Translatable strings with macros found in %d files." % len(sentences_wmacro_by_file))
+            handle_macro_po_sentences(catalog, macro_po_sentences, start_path=startPath, fileref_root=fileref_root, outfile=outfile, fuzzy=args.fuzzy)
+
         if args.folder is not None:
             outfile.close()
         if args.debugmode:

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -31,13 +31,12 @@
 # that point, the source code is mainly explained on source documentation at:
 # http://wmlxgettext-unoff.readthedocs.org/en/latest/srcdoc/index.html
 
-import os
-import re
-import sys
-import signal
-import warnings
 import argparse
 from datetime import datetime
+import os
+import signal
+import sys
+import warnings
 import pywmlx
 
 
@@ -171,6 +170,30 @@ def commandline(args):
 
 
 
+def extractor(files, fileref_root, offset = 0):
+    for fileno, fx in enumerate(files):
+        if fileno < offset:
+            continue
+
+        fname = os.path.normpath(os.path.join(fileref_root, fx))
+        is_file = os.path.isfile(fname)
+        if is_file:
+            infile = None
+            try:
+                infile = open(fname, 'r', encoding="utf-8")
+            except OSError as e:
+                errmsg = 'cannot read file: ' + e.args[1]
+                pywmlx.wmlerr(e.filename, errmsg, OSError)
+            if fname.lower().endswith('.cfg'):
+                pywmlx.statemachine.run(filebuf=infile, fileref=fx,
+                            fileno=fileno, startstate='wml_idle', waitwml=True)
+            if fname.lower().endswith('.lua'):
+                pywmlx.statemachine.run(filebuf=infile, fileref=fx,
+                            fileno=fileno, startstate='lua_idle', waitwml=False)
+            infile.close()
+
+
+
 def main():
     signal.signal(signal.SIGINT, sigint_handler)
     args = commandline(sys.argv[1:])
@@ -178,8 +201,8 @@ def main():
     pywmlx.wincol_setEnabled(args.text_col)
     pywmlx.set_warnall(args.warnall)
     startPath = os.path.realpath(os.path.normpath(args.start_path))
+    fileref_root = startPath
     sentlist = dict()
-    fileno = 0
     fdebug = None
     if args.folder == '-':
         args.folder = None
@@ -212,33 +235,36 @@ def main():
         # values:
         #   the first one is the parent directory of the original startPath
         #   the second one is the filelist (with the "fixed" file references)
-        # This way, we can override startPath with its parent directory
-        # containing the main directory of the wesnoth add-on, without
-        # introducing bugs.
-        startPath, filelist = pywmlx.autof.autoscan(startPath)
+        fileref_root, filelist = pywmlx.autof.autoscan(startPath)
     # this last case is equal to:
     # if args.recursive is True and args.filelist is None:
     else:
-        startPath, filelist = pywmlx.autof.autoscan(startPath)
+        fileref_root, filelist = pywmlx.autof.autoscan(startPath)
     if args.sort_by_file:
         filelist.sort()
-    for fileno, fx in enumerate(filelist):
-        fname = os.path.join(startPath, os.path.normpath(fx))
-        is_file = os.path.isfile(fname)
-        if is_file:
-            infile = None
-            try:
-                infile = open(fname, 'r', encoding="utf-8")
-            except OSError as e:
-                errmsg = 'cannot read file: ' + e.args[1]
-                pywmlx.wmlerr(e.filename, errmsg, OSError)
-            if fname.lower().endswith('.cfg'):
-                pywmlx.statemachine.run(filebuf=infile, fileref=fx,
-                            fileno=fileno, startstate='wml_idle', waitwml=True)
-            if fname.lower().endswith('.lua'):
-                pywmlx.statemachine.run(filebuf=infile, fileref=fx,
-                            fileno=fileno, startstate='lua_idle', waitwml=False)
-            infile.close()
+ 
+    extractor(filelist, fileref_root)
+
+    outfile = None
+    if args.outfile is None:
+        outfile = sys.stdout
+    else:
+        outfile_name = os.path.realpath(os.path.normpath(args.outfile))
+        try:
+            outfile = open(outfile_name, 'w', encoding="utf-8")
+        except OSError as e:
+            errmsg = 'cannot write file: ' + e.args[1]
+            pywmlx.wmlerr(e.filename, errmsg, OSError)
+    pkgversion = args.package_version + '\\n"'
+    print('msgid ""\nmsgstr ""', file=outfile)
+    print('"Project-Id-Version:', pkgversion, file=outfile)
+    print('"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\\n"', file=outfile)
+    now = datetime.utcnow()
+    cdate = '{:04d}-{:02d}-{:02d} {:02d}:{:02d} UTC\\n"'.format(now.year,
+                                                                now.month,
+                                                                now.day,
+                                                                now.hour,
+                                                                now.minute)
 
     folder = None
     filename = None

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -40,7 +40,7 @@ import sys
 import warnings
 import pywmlx
 from wesnoth.wmltools3 import CrossRef
-from wesnoth.wmlmacro import AST, Macro, CrossRefHelper, ReferenceHelper
+from wesnoth.wmlmacro import AST, Macro, CrossRefHelper, ReferenceHelper, GlobalWMLMacros
 
 def commandline(args):
     parser = argparse.ArgumentParser(
@@ -270,7 +270,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
     #    These are passed to handle_macro_po_sentences.
     #
     # 2. Use wmltools3.CrossRef to parse macro definitions and callsites.
-    #    2.1 Note whether there's an #undef in the same file (i.e whether 
+    #    2.1 Note whether there's an #undef in the same file (i.e whether
     #        the macro is local or global).
     #    2.2. If any of the macros from (1) is non-local, fall back to (3).
     #    2.3. Otherwise, go to (4).
@@ -278,7 +278,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
     # 3. Use wmltools3.CrossRef to parse macro definitions and callsites on the entire addon.
     #    3.1. Note whether the macro contains quote marks or is multiline (error out if so.)
     #    3.2. Go to (4).
-    # 
+    #
     # 4. Deeply identify all macro callsites with expansions that include
     #    strings in (1).
     # 5. Propagate macro parameters.
@@ -294,10 +294,9 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
             # Fill-in lone_identifiers, complex_identifiers
             ast = AST.parse_sentence_and_ids(posentence.sentence, lone_identifiers, complex_identifiers)
             macro = Macro(*posentence.macro)
-
-            ctx_macros[macro] = True
             asts_by_sentence[posentence.sentence] = ast
             ids_by_sentence[posentence.sentence] = (lone_identifiers, complex_identifiers)
+            if macro.name is not None: ctx_macros[macro] = True
 
     args_by_macro = {}
     xrefs_by_file = {}
@@ -317,6 +316,9 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
             xrefs_all = xrefs
 
         for macro in ctx_macros:
+            if macro.name is None:
+                # Outside any macro definitions.
+                continue
             if single_file and macro.fileref != single_file:
                 # Ignore in single-file analysis
                 continue
@@ -327,7 +329,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
 
             is_local = xref.undef is not None
             if not is_local and single_file is not None:
-                # 2.1 Note whether there's an #undef in the same file (i.e whether 
+                # 2.1 Note whether there's an #undef in the same file (i.e whether
                 #     the macro is local or global).
                 # 2.2. If any of the macros from (1) is non-local, fall back to (3).
                 raise AnalysisTooNarrowException("Macro %s is exported." % macro)
@@ -357,6 +359,8 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
             variable_macros = set.union(*complex_id_sets)
 
             for callee_name in set.union(constant_macros, variable_macros):
+                if callee_name in GlobalWMLMacros:
+                    continue
                 if not callee_name in xrefs.xref:
                     if single_file is None:
                         print("Unknown macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro))
@@ -387,13 +391,13 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
         except Exception as ex:
             # Remove the trace for AnalysisTooNarrowException.
             raise ex from None
-            
+
 
     # 2.3. Otherwise, go to (4).
     # 3.3. Go to (4).
     new_sentences = {}
     for macro, sentences in sentences_by_macro.items():
-        args_variants = args_by_macro[macro]
+        args_variants = args_by_macro[macro] if macro in args_by_macro else []
         file_path_abs = os.path.normpath(os.path.join(fileref_root, macro[1]))
         xrefs = xrefs_by_file[file_path_abs] if file_path_abs in xrefs_by_file else xrefs_all
         for po_sentence in sentences:
@@ -409,21 +413,43 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
                 # Only evaluate parameters if there is at least one lone identifier.
                 sub_sentences = AST.evaluate_many_on_one(ast, args_variants)
 
-            for sub_sentence, ctx in sub_sentences:
-                po_sentence_variant = copy(po_sentence)
-                po_sentence_variant.finfos = copy(po_sentence_variant.finfos)
-                po_sentence_variant.sentence = sub_sentence
-                if '\x01' + po_sentence_variant.sentence in sentlist:
-                    # print("Ignored ref to raw sentence %s" % po_sentence_variant.sentence)
-                    # Output has already been written. TODO: FIXME?
-                    # sentlist['\x01' + po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
-                    pass
-                elif po_sentence_variant.sentence in new_sentences:
-                    # print("New ref in processed sentence %s" % po_sentence_variant.sentence)
-                    new_sentences[po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
-                else:
-                    # print("New sentence %s" % po_sentence_variant.sentence)
-                    new_sentences[po_sentence_variant.sentence] = po_sentence_variant
+            if len(sub_sentences) == 0:
+                # Ensure loop runs at least once
+                sub_sentences.append((po_sentence.sentence, None))
+
+            for sentence_after_args, ctx in sub_sentences:
+                used_macros = set()
+                ast = AST.parse_sentence_and_ids(sentence_after_args, used_macros, used_macros)
+                # print("sentence after args: (%s <-> %s)" % (sentence_after_args, ast))
+
+                # 6. Evaluate macro expansions.
+                # macro_replacements: list<(Reference|ReferenceLike, True, None)>
+                macro_replacements = []
+                if len(used_macros) > 0:
+                    valid_macros = CrossRefHelper.get_valid_macros(used_macros, xrefs)
+                    macro_replacements = CrossRefHelper.get_macro_variants(valid_macros, xrefs)
+                    CrossRefHelper.deep_replace_macros(sentence_after_args, macro_replacements, xrefs)
+
+                if len(macro_replacements) == 0:
+                    # Ensure loop runs at least once
+                    macro_replacements.append(({}, None, sentence_after_args))
+                for defs, ended, sentence_after_macro in macro_replacements:
+                    # print("sentence after macro: %s" % sentence_after_macro)
+                    # assert(isinstance(ctx, Macro|NoneType))
+                    po_sentence_variant = copy(po_sentence)
+                    po_sentence_variant.finfos = copy(po_sentence_variant.finfos)
+                    po_sentence_variant.sentence = sentence_after_macro
+                    if '\x01' + po_sentence_variant.sentence in sentlist:
+                        # print("Ignored ref to raw sentence %s" % po_sentence_variant.sentence)
+                        # Output has already been written. TODO: FIXME?
+                        # sentlist['\x01' + po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
+                        pass
+                    elif po_sentence_variant.sentence in new_sentences:
+                        # print("New ref in processed sentence %s" % po_sentence_variant.sentence)
+                        new_sentences[po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
+                    else:
+                        # print("New sentence %s" % po_sentence_variant.sentence)
+                        new_sentences[po_sentence_variant.sentence] = po_sentence_variant
 
     for posentence in new_sentences.values():
         posentence.write(outfile, fuzzy)
@@ -478,7 +504,7 @@ def main():
         fileref_root, filelist = pywmlx.autof.autoscan(startPath)
     if args.sort_by_file:
         filelist.sort()
- 
+
     extractor(filelist, fileref_root)
 
     folder = None
@@ -543,7 +569,7 @@ def main():
 
 
 def sigint_handler(signal, frame):
-    """This function defines what happens when the SIGINT signal is encountered by pressing ctrl-c during runtime. 
+    """This function defines what happens when the SIGINT signal is encountered by pressing ctrl-c during runtime.
     When ctrl-c is pressed, a one-line message is displayed and Python exits with Status 1.
     This overrides Python's default behavior of displaying a traceback when ctrl-c is pressed.
     """

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -323,7 +323,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
                 # Ignore in single-file analysis
                 continue
 
-            # print("Tracing %s..." % macro)
+            # print("Tracing %s..." % macro, file=sys.stderr)
             xref = macro.to_abs(fileref_root).get_ref(xrefs)
             assert xref is not None, ("Macro %s not referenced" % macro)
 
@@ -363,12 +363,12 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
                     continue
                 if not callee_name in xrefs.xref:
                     if single_file is None:
-                        print("Unknown macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro))
+                        print("Unknown macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro), file=sys.stderr)
                     else:
                         raise AnalysisTooNarrowException("Macro {%s} not found at %s." % (callee_name, single_file))
                 if not any(map(ReferenceHelper.is_embeddable_macro, xrefs.xref[callee_name])):
                     if single_file is None:
-                        print("No valid embeddable expansion for macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro))
+                        print("No valid embeddable expansion for macro {%s} called by %s. Strings using it will not be translated." % (callee_name, macro), file=sys.stderr)
                     else:
                         raise AnalysisTooNarrowException("No valid definition for macro {%s} found at %s." % (callee_name, single_file))
 
@@ -385,7 +385,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
         for fileref in sentences_by_file:
             resolve_strings_at(dirpath=None, single_file=fileref)
     except AnalysisTooNarrowException as ex:
-        print("%s Falling back to full-tree analysis." % ex.args)
+        print("%s Falling back to full-tree analysis." % ex.args, file=sys.stderr)
         try:
             resolve_strings_at(dirpath=[start_path])
         except Exception as ex:
@@ -402,7 +402,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
         xrefs = xrefs_by_file[file_path_abs] if file_path_abs in xrefs_by_file else xrefs_all
         for po_sentence in sentences:
             ast = asts_by_sentence[po_sentence.sentence]
-            # print("raw sentence: (%s <-> %s)" % (po_sentence.sentence, ast))
+            # print("raw sentence: (%s <-> %s)" % (po_sentence.sentence, ast), file=sys.stderr)
 
             # 5. Propagate macro parameters.
             # sub_sentences: list<(str, Macro|NoneType)>
@@ -420,7 +420,7 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
             for sentence_after_args, ctx in sub_sentences:
                 used_macros = set()
                 ast = AST.parse_sentence_and_ids(sentence_after_args, used_macros, used_macros)
-                # print("sentence after args: (%s <-> %s)" % (sentence_after_args, ast))
+                # print("sentence after args: (%s <-> %s)" % (sentence_after_args, ast), file=sys.stderr)
 
                 # 6. Evaluate macro expansions.
                 # macro_replacements: list<(Reference|ReferenceLike, True, None)>
@@ -434,21 +434,21 @@ def handle_macro_po_sentences(sentlist, po_sentences, start_path="", fileref_roo
                     # Ensure loop runs at least once
                     macro_replacements.append(({}, None, sentence_after_args))
                 for defs, ended, sentence_after_macro in macro_replacements:
-                    # print("sentence after macro: %s" % sentence_after_macro)
+                    # print("sentence after macro: %s" % sentence_after_macro, file=sys.stderr)
                     # assert(isinstance(ctx, Macro|NoneType))
                     po_sentence_variant = copy(po_sentence)
                     po_sentence_variant.finfos = copy(po_sentence_variant.finfos)
                     po_sentence_variant.sentence = sentence_after_macro
                     if '\x01' + po_sentence_variant.sentence in sentlist:
-                        # print("Ignored ref to raw sentence %s" % po_sentence_variant.sentence)
+                        # print("Ignored ref to raw sentence %s" % po_sentence_variant.sentence, file=sys.stderr)
                         # Output has already been written. TODO: FIXME?
                         # sentlist['\x01' + po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
                         pass
                     elif po_sentence_variant.sentence in new_sentences:
-                        # print("New ref in processed sentence %s" % po_sentence_variant.sentence)
+                        # print("New ref in processed sentence %s" % po_sentence_variant.sentence, file=sys.stderr)
                         new_sentences[po_sentence_variant.sentence].update_with_commented_string(po_sentence_variant)
                     else:
-                        # print("New sentence %s" % po_sentence_variant.sentence)
+                        # print("New sentence %s" % po_sentence_variant.sentence, file=sys.stderr)
                         new_sentences[po_sentence_variant.sentence] = po_sentence_variant
 
     for posentence in new_sentences.values():
@@ -558,7 +558,7 @@ def main():
                 sentences_wmacro_by_macro[macro].append(posentence)
 
         if len(sentences_wmacro_by_file) > 0:
-            print("Translatable strings with macros found in %d files." % len(sentences_wmacro_by_file))
+            print("Translatable strings with macros found in %d files." % len(sentences_wmacro_by_file), file=sys.stderr)
             handle_macro_po_sentences(catalog, macro_po_sentences, start_path=startPath, fileref_root=fileref_root, outfile=outfile, fuzzy=args.fuzzy)
 
         if args.folder is not None:


### PR DESCRIPTION
e.g.

```c++
#textdomain wesnoth-test

#define GREET MODE WHOM
[{MODE}]
    {MODE} = _ "Hello, {WHOM}."
[/{MODE}]
#enddef

{GREET message world}

#define MOODY_GREET MODE WHOM
#arg QUALIFIER
meh#endarg
   {GREET {MODE} (very {QUALIFIER} {WHOM})}
#enddef

{MOODY_GREET message world QUALIFIER=good}
{MOODY_GREET message world QUALIFIER=bad}
{MOODY_GREET message world}
```

Outputs:
```
#: test/test.cfg:5
msgid "Hello, world."
msgstr ""

#: test/test.cfg:5
msgid "Hello, very good world."
msgstr ""

#: test/test.cfg:5
msgid "Hello, very bad world."
msgstr ""

#: test/test.cfg:5
msgid "Hello, very meh world."
msgstr ""
```