### PR TITLE
Fix modify_unit recall_cost indexing issue 

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/modify_unit_recall_cost.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/modify_unit_recall_cost.cfg
@@ -33,7 +33,7 @@
             [object]
                 [effect]
                     apply_to="recall_cost"
-                    increase=10
+                    increase=15
                 [/effect]
             [/object]
         [/modify_unit]
@@ -58,7 +58,7 @@
         [/store_unit]
 
         {ASSERT (
-            {VARIABLE_CONDITIONAL temp.recall_cost equals 20}
+            {VARIABLE_CONDITIONAL temp.recall_cost equals 25}
         )}
 
         # Recall Charlie next to Side 2 leader

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/modify_unit_recall_cost.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/modify_unit_recall_cost.cfg
@@ -1,12 +1,12 @@
 #textdomain wesnoth-test
 # Actions:
 # Create Charlie, belonging to side 2, on the recall list
-# Increase Charlie's recall cost 
+# Increase Charlie's recall cost
 # Recall Charlie next to his side's leader.
 ##
 # Expected end state:
 # Charlie is on the map next to side 2's leader.
-# Charlie's recall cost has increased by 10 
+# Charlie's recall cost has increased by 10
 #####
 {GENERIC_UNIT_TEST "modify_unit_recall_cost" (
     [event]
@@ -24,7 +24,7 @@
             recall_cost=10
         [/unit]
 
-        # Increase Charlie's recall cost 
+        # Increase Charlie's recall cost
         [modify_unit]
             [filter]
                 id=Charlie
@@ -49,7 +49,7 @@
             [/not]
         )}
 
-        # Check that Charlie's recall cost has increased 
+        # Check that Charlie's recall cost has increased
         [store_unit]
             [filter]
                 id=Charlie
@@ -60,8 +60,8 @@
         {ASSERT (
             {VARIABLE_CONDITIONAL temp.recall_cost equals 20}
         )}
-       
-        # Recall Charlie next to Side 2 leader 
+
+        # Recall Charlie next to Side 2 leader
         [role]
             role=TestSubject
             reassign=no

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/modify_unit_recall_cost.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/modify_unit_recall_cost.cfg
@@ -1,0 +1,83 @@
+#textdomain wesnoth-test
+# Actions:
+# Create Charlie, belonging to side 2, on the recall list
+# Increase Charlie's recall cost 
+# Recall Charlie next to his side's leader.
+##
+# Expected end state:
+# Charlie is on the map next to side 2's leader.
+# Charlie's recall cost has increased by 10 
+#####
+{GENERIC_UNIT_TEST "modify_unit_recall_cost" (
+    [event]
+        name= start
+        # Create a unit on the recall list of side 2
+        [unit]
+            x=recall
+            y=recall
+            type=Orcish Grunt
+            side=2
+            id=Charlie
+            name=_"Charlie"
+            role=TestSubject
+            canrecruit=no
+            recall_cost=10
+        [/unit]
+
+        # Increase Charlie's recall cost 
+        [modify_unit]
+            [filter]
+                id=Charlie
+                side=2
+            [/filter]
+            [object]
+                [effect]
+                    apply_to="recall_cost"
+                    increase=10
+                [/effect]
+            [/object]
+        [/modify_unit]
+
+        # Check that Charlie is still on the recall list, that modifying him
+        # hasn't moved him back to the map.
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=Charlie
+                    search_recall_list=no
+                [/have_unit]
+            [/not]
+        )}
+
+        # Check that Charlie's recall cost has increased 
+        [store_unit]
+            [filter]
+                id=Charlie
+            [/filter]
+            variable=temp
+        [/store_unit]
+
+        {ASSERT (
+            {VARIABLE_CONDITIONAL temp.recall_cost equals 20}
+        )}
+       
+        # Recall Charlie next to Side 2 leader 
+        [role]
+            role=TestSubject
+            reassign=no
+            [auto_recall][/auto_recall]
+        [/role]
+
+        # Check that Charlie has been recalled next to side 2's leader
+        {ASSERT (
+            [have_unit]
+                id=Charlie
+                [filter_location]
+                    location_id=2
+                    radius=1
+                [/filter_location]
+            [/have_unit]
+        )}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2296,7 +2296,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 	} else if(apply_to == "recall_cost") {
 		const std::string& increase = effect["increase"];
 		const std::string& set = effect["set"];
-		const int recall_cost = recall_cost_ < 0 ? resources::gameboard->teams().at(side_to_index()).recall_cost() : recall_cost_;
+		const int recall_cost = recall_cost_ < 0 ? resources::gameboard->get_team(side_).recall_cost() : recall_cost_;
 
 		if(!set.empty()) {
 			if(set.back() == '%') {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2296,7 +2296,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 	} else if(apply_to == "recall_cost") {
 		const std::string& increase = effect["increase"];
 		const std::string& set = effect["set"];
-		const int recall_cost = recall_cost_ < 0 ? resources::gameboard->teams().at(side_).recall_cost() : recall_cost_;
+		const int recall_cost = recall_cost_ < 0 ? resources::gameboard->teams().at(side_to_index()).recall_cost() : recall_cost_;
 
 		if(!set.empty()) {
 			if(set.back() == '%') {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2296,7 +2296,8 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 	} else if(apply_to == "recall_cost") {
 		const std::string& increase = effect["increase"];
 		const std::string& set = effect["set"];
-		const int recall_cost = recall_cost_ < 0 ? resources::gameboard->get_team(side_).recall_cost() : recall_cost_;
+		const int team_recall_cost = resources::gameboard ? resources::gameboard->get_team(side_).recall_cost() : 20;
+		const int recall_cost = recall_cost_ < 0 ? team_recall_cost : recall_cost_;
 
 		if(!set.empty()) {
 			if(set.back() == '%') {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -354,11 +354,6 @@ public:
 		side_ = new_side;
 	}
 
-	/** Convert from side number to container index  */
-	int side_to_index() const {
-		return side_ - 1;
-	}
-
 	/** This unit's type, accounting for gender and variation. */
 	const unit_type& type() const
 	{

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -354,6 +354,11 @@ public:
 		side_ = new_side;
 	}
 
+	/** Convert from side number to container index  */
+	int side_to_index() const {
+		return side_ - 1;
+	}
+
 	/** This unit's type, accounting for gender and variation. */
 	const unit_type& type() const
 	{

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -115,6 +115,7 @@
 0 replace_schedule_prestart
 0 modify_unit_facing
 0 modify_unit_which_recall_list
+0 modify_unit_recall_cost
 0 put_to_recall_and_modify
 0 event_handlers_in_events_1
 0 event_handlers_in_events_3


### PR DESCRIPTION
Fixed issue #7159. Bug had to do with indexing into 0 based team vector with 1 based side_ member variable as speculated in the thread. Added method to return side_ - 1 and then used in apply_to recall_cost code. 