### PR TITLE
Made flatpak ci job upload bundle too

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -174,6 +174,14 @@ jobs:
         run: |
           jq '.modules |= map(select(.name == "wesnoth").sources[0]+={"path":"."}) | ."build-options".env.FLATPAK_BUILDER_N_JOBS="2"' packaging/flatpak/org.wesnoth.Wesnoth.json > org.wesnoth.Wesnoth.json
           flatpak-builder --force-clean --disable-rofiles-fuse wesnoth-app org.wesnoth.Wesnoth.json
+          flatpak build-export export wesnoth-app
+          flatpak build-bundle export wesnoth.flatpak org.wesnoth.Wesnoth --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+      - name: Upload flatpak bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: Flatpak-Bundle
+          path: |
+            wesnoth.flatpak
 
   translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Flatpak
         run: |
           jq '.modules |= map(select(.name == "wesnoth").sources[0]={"type":"dir","path":"."}) | ."build-options".env.FLATPAK_BUILDER_N_JOBS="2"' packaging/flatpak/org.wesnoth.Wesnoth.json > org.wesnoth.Wesnoth.json
-          flatpak-builder --force-clean --disable-rofiles-fuse wesnoth-app org.wesnoth.Wesnoth.json
+          flatpak-builder --force-clean --default-branch=ci --disable-rofiles-fuse wesnoth-app org.wesnoth.Wesnoth.json
           flatpak build-export export wesnoth-app
           flatpak build-bundle export wesnoth.flatpak org.wesnoth.Wesnoth --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
       - name: Upload flatpak bundle

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Flatpak
         run: |
-          jq '.modules |= map(select(.name == "wesnoth").sources[0]+={"path":"."}) | ."build-options".env.FLATPAK_BUILDER_N_JOBS="2"' packaging/flatpak/org.wesnoth.Wesnoth.json > org.wesnoth.Wesnoth.json
+          jq '.modules |= map(select(.name == "wesnoth").sources[0]={"type":"dir","path":"."}) | ."build-options".env.FLATPAK_BUILDER_N_JOBS="2"' packaging/flatpak/org.wesnoth.Wesnoth.json > org.wesnoth.Wesnoth.json
           flatpak-builder --force-clean --disable-rofiles-fuse wesnoth-app org.wesnoth.Wesnoth.json
           flatpak build-export export wesnoth-app
           flatpak build-bundle export wesnoth.flatpak org.wesnoth.Wesnoth --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           jq '.modules |= map(select(.name == "wesnoth").sources[0]={"type":"dir","path":"."}) | ."build-options".env.FLATPAK_BUILDER_N_JOBS="2"' packaging/flatpak/org.wesnoth.Wesnoth.json > org.wesnoth.Wesnoth.json
           flatpak-builder --force-clean --default-branch=ci --disable-rofiles-fuse wesnoth-app org.wesnoth.Wesnoth.json
-          flatpak build-export export wesnoth-app
+          flatpak build-export export wesnoth-app ci
           flatpak build-bundle export wesnoth.flatpak org.wesnoth.Wesnoth ci --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
       - name: Upload flatpak bundle
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -175,7 +175,7 @@ jobs:
           jq '.modules |= map(select(.name == "wesnoth").sources[0]={"type":"dir","path":"."}) | ."build-options".env.FLATPAK_BUILDER_N_JOBS="2"' packaging/flatpak/org.wesnoth.Wesnoth.json > org.wesnoth.Wesnoth.json
           flatpak-builder --force-clean --default-branch=ci --disable-rofiles-fuse wesnoth-app org.wesnoth.Wesnoth.json
           flatpak build-export export wesnoth-app
-          flatpak build-bundle export wesnoth.flatpak org.wesnoth.Wesnoth --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+          flatpak build-bundle export wesnoth.flatpak org.wesnoth.Wesnoth ci --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
       - name: Upload flatpak bundle
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This adds new CI artifact containing file wesnoth.flatpak. It can be installed and run like this:
`flatpak --user install wesnoth.flatpak`
`flatpak run --branch=ci org.wesnoth.Wesnoth`
After done with with testing it can be removed to save disk space:
`flatpak uninstall org.wesnoth.Wesnoth` and choose install from branch `ci` if there are other installs.