### PR TITLE
[1.17] - make engine-bobbing sprites use the correct primary frame

### DIFF
--- a/data/core/units/monsters/Caribe.cfg
+++ b/data/core/units/monsters/Caribe.cfg
@@ -71,6 +71,7 @@ units/monsters/caribe#enddef
             image={CARIBE_IMAGE_PATH}/caribe-small-[hi,default,lo,default].png~MASK({CARIBE_IMAGE_PATH}/caribe-mask.png):[400*4]
             auto_vflip=no
             # submerge=0.45
+            primary=yes
         [/fish_frame]
         [frame]
             image={CARIBE_IMAGE_PATH}/caribe-shadow.png:1600
@@ -94,6 +95,7 @@ units/monsters/caribe#enddef
             image={CARIBE_IMAGE_PATH}/caribe-small-[hi,default,lo,default].png~MASK({CARIBE_IMAGE_PATH}/caribe-mask.png):[400*4]
             auto_vflip=no
             # submerge=0.45
+            primary=yes
         [/fish_frame]
         [frame]
             image={CARIBE_IMAGE_PATH}/caribe-shadow.png:1600

--- a/data/core/units/monsters/Caribe_Hunter.cfg
+++ b/data/core/units/monsters/Caribe_Hunter.cfg
@@ -72,6 +72,7 @@ units/monsters/caribe#enddef
             image={CARIBE_IMAGE_PATH}/caribe-[hi,default,lo,default].png~MASK({CARIBE_IMAGE_PATH}/caribe-mask.png):[400*4]
             auto_vflip=no
             # submerge=0.45
+            primary=yes
         [/fish_frame]
         [frame]
             image={CARIBE_IMAGE_PATH}/caribe-shadow.png:1600
@@ -95,6 +96,7 @@ units/monsters/caribe#enddef
             image={CARIBE_IMAGE_PATH}/caribe-[hi,default,lo,default].png~MASK({CARIBE_IMAGE_PATH}/caribe-mask.png):[400*4]
             auto_vflip=no
             # submerge=0.45
+            primary=yes
         [/fish_frame]
         [frame]
             image={CARIBE_IMAGE_PATH}/caribe-shadow.png:1600

--- a/data/core/units/monsters/Caribe_Nibbler.cfg
+++ b/data/core/units/monsters/Caribe_Nibbler.cfg
@@ -86,6 +86,7 @@ units/monsters/caribe#enddef
             image={CARIBE_IMAGE_PATH}/nibbler-[hi,default,lo,default].png~MASK({CARIBE_IMAGE_PATH}/caribe-mask.png):[400*4]
             auto_vflip=no
             # submerge=0.45
+            primary=yes
         [/fish_frame]
         [frame]
             image={CARIBE_IMAGE_PATH}/nibbler-shadow.png:1600
@@ -109,6 +110,7 @@ units/monsters/caribe#enddef
             image={CARIBE_IMAGE_PATH}/nibbler-[hi,default,lo,default].png~MASK({CARIBE_IMAGE_PATH}/caribe-mask.png):[400*4]
             auto_vflip=no
             # submerge=0.45
+            primary=yes
         [/fish_frame]
         [frame]
             image={CARIBE_IMAGE_PATH}/nibbler-shadow.png:1600

--- a/data/core/units/monsters/Dragonfly.cfg
+++ b/data/core/units/monsters/Dragonfly.cfg
@@ -48,6 +48,7 @@
         [bug_frame]
             image="units/monsters/dragonfly/young/dragonfly-flying[1,2,1,2,1,2,1,2,1,2,1,2].png:50"
             auto_vflip=no
+            primary=yes
         [/bug_frame]
     [/standing_anim]
     [standing_anim]
@@ -61,6 +62,7 @@
         [bug_frame]
             image="units/monsters/dragonfly/young/dragonfly-n-flying[1,2,1,2,1,2,1,2,1,2,1,2].png:50"
             auto_vflip=no
+            primary=yes
         [/bug_frame]
     [/standing_anim]
     {DEFENSE_ANIM_FILTERED "units/monsters/dragonfly/young/dragonfly-defend2.png" "units/monsters/dragonfly/young/dragonfly-defend1.png" {SOUND_LIST:BAT_HIT} (
@@ -87,6 +89,7 @@
             [bug_frame]
                 image="units/monsters/dragonfly/young/dragonfly-flying[1,2].png:80"
                 auto_vflip=no
+                primary=yes
             [/bug_frame]
         [/if]
         [else]
@@ -97,6 +100,7 @@
             [bug_frame]
                 image="units/monsters/dragonfly/young/dragonfly-n-flying[1,2].png:80"
                 auto_vflip=no
+                primary=yes
             [/bug_frame]
         [/else]
     [/movement_anim]

--- a/data/core/units/monsters/Dragonfly_Grand.cfg
+++ b/data/core/units/monsters/Dragonfly_Grand.cfg
@@ -62,6 +62,7 @@
         [bug_frame]
             image="units/monsters/dragonfly/grand/dragonfly-flying[1,2,1,2,1,2,1,2,1,2,1,2].png:50"
             auto_vflip=no
+            primary=yes
         [/bug_frame]
     [/standing_anim]
     [standing_anim]
@@ -75,6 +76,7 @@
         [bug_frame]
             image="units/monsters/dragonfly/grand/dragonfly-n-flying[1,2,1,2,1,2,1,2,1,2,1,2].png:50"
             auto_vflip=no
+            primary=yes
         [/bug_frame]
     [/standing_anim]
     {DEFENSE_ANIM_FILTERED "units/monsters/dragonfly/grand/dragonfly-defend2.png" "units/monsters/dragonfly/grand/dragonfly-defend1.png" {SOUND_LIST:BAT_HIT} (
@@ -94,6 +96,7 @@
         [bug_frame]
             image="units/monsters/dragonfly/grand/dragonfly-flying[1~2].png:80"
             auto_vflip=no
+            primary=yes
         [/bug_frame]
     [/movement_anim]
     [movement_anim]
@@ -107,6 +110,7 @@
         [bug_frame]
             image="units/monsters/dragonfly/grand/dragonfly-n-flying[1~2].png:80"
             auto_vflip=no
+            primary=yes
         [/bug_frame]
     [/movement_anim]
 

--- a/data/core/units/monsters/Elder_Falcon.cfg
+++ b/data/core/units/monsters/Elder_Falcon.cfg
@@ -67,6 +67,7 @@
         [/frame]
         [bird_frame]
             image="units/monsters/falcon/elder-falcon-soar[1~5,4~2,1~5,4~2].png:[200*5,300,400,500,300*5,400*2,300]"
+            primary=yes
             auto_vflip=no
         [/bird_frame]
     [/standing_anim]

--- a/data/core/units/monsters/Falcon.cfg
+++ b/data/core/units/monsters/Falcon.cfg
@@ -43,6 +43,7 @@
         [bird_frame]
             image="units/monsters/falcon/falcon-soar[1~5,4~2,1~5,4~2].png:[200*5,300,400,500,300*5,400*2,300]"
             auto_vflip=no
+            primary=yes
         [/bird_frame]
     [/standing_anim]
     die_sound={SOUND_LIST:GRYPHON_DIE}
@@ -74,6 +75,7 @@
         [bird_frame]
             image="units/monsters/falcon/falcon-soar[1~4].png:[100*4]"
             auto_vflip=no
+            primary=yes
         [/bird_frame]
     [/defend]
     [defense]
@@ -116,6 +118,7 @@
         [bird_frame]
             image="units/monsters/falcon/falcon-attack-[1,2,beak,end].png:[100,100,250,350]"
             auto_vflip=no
+            primary=yes
         [/bird_frame]
 
         {SOUND:HIT_AND_MISS claws.ogg {SOUND_LIST:MISS} -100}
@@ -136,6 +139,7 @@
         [bird_frame]
             image="units/monsters/falcon/falcon-attack-[1,2,claws,end].png:[100,100,200,300]"
             auto_vflip=no
+            primary=yes
         [/bird_frame]
 
         {SOUND:HIT_AND_MISS spear.ogg {SOUND_LIST:MISS} -100}

--- a/data/core/units/monsters/Seahorse.cfg
+++ b/data/core/units/monsters/Seahorse.cfg
@@ -58,6 +58,7 @@
         [horse_frame]
             image="units/monsters/seahorse.png~MASK(units/monsters/seahorse-mask.png):1200"
             auto_vflip=no
+            primary=yes
         [/horse_frame]
     [/standing_anim]
     [movement_anim]
@@ -72,6 +73,7 @@
         [horse_frame]
             image="units/monsters/seahorse.png~MASK(units/monsters/seahorse-mask.png):1200"
             auto_vflip=no
+            primary=yes
         [/horse_frame]
     [/movement_anim]
     [death]


### PR DESCRIPTION
To keep the ellipses and status indicators from bobbing/drifting with the base frame, I'd put the body sprite in an alternate frame, but did not think to check for status effect color-shifts like poison or slows.  This is a simple fix for that, only question is if I missed some unit.

fixes #7551 