### PR TITLE
Test the correct unit in swarms_effects_not_checkable

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/ConditionalActionsWML/swarms_effects_not_checkable.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/ConditionalActionsWML/swarms_effects_not_checkable.cfg
@@ -5,7 +5,7 @@
 ##
 # Actions:
 # Give bob an ability that gives adjacent allied units the swarm ability with a min and max strikes of 1, if they are Orcish Grunts.
-# Spawn an allied Orcish Grunt next to bob.
+# Spawn an allied Orcish Grunt (with id="charlie") next to bob.
 ##
 # Expected end state:
 # Although on the UI the Orcish Grunt will show it has 1 strike, when checking via WML it still has 2 strikes.
@@ -37,12 +37,12 @@
             [/filter]
         [/object]
 
-        {NOTRAIT_UNIT 2 "Orcish Grunt" 12 3}
+        {NAMED_NOTRAIT_UNIT 2 "Orcish Grunt" 12 3 "charlie" (_ "Charlie")}
 
         {ASSERT (
             [not]
                 [have_unit]
-                    id=alice
+                    id=charlie
                     [has_attack]
                         number=1
                     [/has_attack]
@@ -51,7 +51,7 @@
         )}
         {ASSERT (
             [have_unit]
-                id=alice
+                id=charlie
                 [has_attack]
                     number=2
                 [/has_attack]
@@ -60,7 +60,7 @@
 
         [store_unit]
             [filter]
-                id=alice
+                id=charlie
             [/filter]
             variable=grunt
         [/store_unit]


### PR DESCRIPTION
The test spawns a new unit, this commit makes it test that new unit instead of the Elvish Archer with a 5x2 melee attack.

@newfrenchy83 please would you review this?