### PR TITLE
wmlxgettext: Error out on unused #po, #po-override directives

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/01_Saving_Parthyn.cfg
@@ -544,13 +544,13 @@
                     message= _ "Yes, yes it is. Nobody’ll support ya on yer crazy path to depravity."
                 [/message]
 
-                # po: Hint, that the loyal units stay behind
                 [message]
                     side=1
                     race=human
                     [not]
                         id=Malin Keshar,Dela Keshar,Drogan
                     [/not]
+                    # po: Hint, that the loyal units stay behind
                     message= _ "We should all be glad to see you gone, necromancer. I detest having fought by your side."
                 [/message]
 
@@ -615,13 +615,13 @@
                     message= _ "If ya go out on a quest to seek depravity, none o’ us will support ya."
                 [/message]
 
-                # po: Hint, that the loyal units stay behind
                 [message]
                     side=1
                     race=human
                     [not]
                         id=Malin Keshar,Dela Keshar,Drogan
                     [/not]
+                    # po: Hint, that the loyal units stay behind
                     message= _ "Better to die than to ally ourselves with a necromancer."
                 [/message]
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/03_A_Haunting_in_Winter.cfg
@@ -1233,9 +1233,9 @@ All sense of time and being are entombed within darkness. How long has passed si
     [event]
         name=rat eating4
 
-        #po: Malin Keshar breaks the fourth wall here and addresses the player, whom the 'you' refers to.
         [message]
             speaker=Malin Keshar
+            #po: Malin Keshar breaks the fourth wall here and addresses the player, whom the 'you' refers to.
             message= _ "You. You there behind the screen. You are the one controlling me. Why are you doing this? What did I do to deserve this torment? Please, I beg of you. End me now. Release me from my misery!"
         [/message]
     [/event]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07b_A_Small_Favor2.cfg
@@ -258,8 +258,9 @@
                 [/not]
             [/filter_location]
             [command]
+                {NAMED_NOTRAIT_UNIT 2 "$guardtypetable[$($loc.n % $guardtypetable.length)].type"
                 # po: Unit name
-                {NAMED_NOTRAIT_UNIT 2 "$guardtypetable[$($loc.n % $guardtypetable.length)].type" $loc.x $loc.y () (_ "Guard")
+                $loc.x $loc.y () (_ "Guard")
                 # po: Unit name
                 FEMALE_NAME=_"female^Guard"} {GUARDIAN}
             [/command]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07c_A_Small_Favor3.cfg
@@ -45,8 +45,9 @@
         hidden=yes
         color=purple
 
+        {NAMED_NOTRAIT_UNIT 2 (Silver Mage) 11 9 ("")
         # po: Book guards
-        {NAMED_NOTRAIT_UNIT 2 (Silver Mage) 11 9 ("") ( _ "Guardian")
+        ( _ "Guardian")
         # po: Book guards
         FEMALE_NAME=_"female^Guardian"} {GUARDIAN}
         {NAMED_NOTRAIT_UNIT 2 (Silver Mage) 13 7 ("") ( _ "Guardian") FEMALE_NAME=_"female^Guardian"} {GUARDIAN}
@@ -339,8 +340,9 @@
                 [/not]
             [/filter_location]
             [command]
+                {NAMED_NOTRAIT_UNIT 2 "$guardtypetable[$($loc.n % $guardtypetable.length)].type"
                 # po: Unit name
-                {NAMED_NOTRAIT_UNIT 2 "$guardtypetable[$($loc.n % $guardtypetable.length)].type" $loc.x $loc.y () (_ "Guard")
+                $loc.x $loc.y () (_ "Guard")
                 # po: Unit name
                 FEMALE_NAME=_"female^Guard"} {GUARDIAN}
             [/command]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -1420,9 +1420,9 @@
                 {VARIABLE metInky 1}
             [/then]
             [else]
-                # po: squiddy means "squid-like" in this sentence
                 [message]
                     speaker=Mal Keshar
+                    # po: squiddy means "squid-like" in this sentence
                     message= _ "We meet again, squiddy one."
                 [/message]
             [/else]
@@ -1464,9 +1464,9 @@
                             speaker=Mal Keshar
                             message= _ "Release me at once you oversized piece of calamari— eeeeaaaaaaaaa!"
                         [/message]
-                        # po: Mal Keshar is sinking...
                         [message]
                             speaker=narrator
+                            # po: Mal Keshar is sinking...
                             message= _ "<i>Blub... blub... blub...</i>"
                         [/message]
 

--- a/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/9_Caverns_of_Flame.cfg
@@ -816,8 +816,9 @@
             [/remove_item]
             [floating_text]
                 x,y=29,31
-                # po: Treat this as if it was a sound-effect in a comic book.
-                text="<span color='#ff7722'>" + _ "Smash!" + "</span>"
+                text="<span color='#ff7722'>" +
+                    # po: Treat this as if it was a sound-effect in a comic book.
+                    _ "Smash!" + "</span>"
             [/floating_text]
             {QUAKE "rumble.ogg"}
             [scroll_to]

--- a/data/campaigns/The_South_Guard/scenarios/06a_Into_the_Depths.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06a_Into_the_Depths.cfg
@@ -483,11 +483,11 @@
             clear_shroud=yes
         [/redraw]
 
-        # po: bad grammar/different manner of speech here for the trolls
         [message]
             speaker=Grek
             image_pos=right
             mirror=yes
+            # po: bad grammar/different manner of speech here for the trolls
             message= _ "Who go there? I see... I sees some humans and elfsies! What you doing in our caves?"
         [/message]
         [message]

--- a/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/08b_The_Tides_of_War.cfg
@@ -556,9 +556,9 @@
     [event]
         name=side 2 turn 1
 
-        # po: fleshbag refers to humans, meaning literally a "chunk of meat" here, and "pesky fly" refers to Sir Gerrick
         [message]
             speaker="Mal M'Brin"
+            # po: fleshbag refers to humans, meaning literally a "chunk of meat" here, and "pesky fly" refers to Sir Gerrick
             message= _ "So, the fleshbags have managed to mount a defense. It would seem that the pesky fly turned out to be more than a minor annoyance after all."
         [/message]
         [message]
@@ -769,9 +769,9 @@
             message= _ "These worthless humans just bested you and your armies. Your time has come, once wise sage of the elves."
         [/message]
 
-        # po: "Nooo" is like a death scream, just a drawn out no
         [message]
             speaker="Mal M'Brin"
+            # po: "Nooo" is like a death scream, just a drawn out no
             message= _ "Beaten... by mere mortals... how has it come to this..? Nooo..."
         [/message]
     [/event]
@@ -782,10 +782,9 @@
             id="Mal M'Brin"
         [/filter]
 
-        # po: very unlikely that you defeat Mebrin without destroying Mal Tera, but just in case you do, Mal Tera gets one line of text here
-
         [message]
             speaker="Mal Tera"
+            # po: very unlikely that you defeat Mebrin without destroying Mal Tera, but just in case you do, Mal Tera gets one line of text here
             message= _ "The master is slain! With him gone... my soul... is unbound from... this body..."
         [/message]
 

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -105,8 +105,9 @@ The paste tool also has some clipboard-manipulation functions:" +
 [topic]
     id=editor_tool_starting
     title= _ "Starting Locations Tool"
-    # po: the parts about "10" being shown as "Player 10" use the translatable string "Player $side_num" in the wesnoth-editor textdomain
-    text= "<img>src=icons/action/editor-tool-starting-position_60.png align=left box=yes</img>" + _ "Defines the side leader starting position.
+    text= "<img>src=icons/action/editor-tool-starting-position_60.png align=left box=yes</img>" +
+        # po: the parts about "10" being shown as "Player 10" use the translatable string "Player $side_num" in the wesnoth-editor textdomain
+        _ "Defines the side leader starting position.
 
 This tool sets the side leaders’ default starting locations, and named special locations. Both types of location are enabled in both <ref>dst='..editor_mode_terrain' text='Terrain Editor'</ref> and <ref>dst='..editor_mode_scenario' text='Scenario Editor'</ref> modes. The location names are shown as a list in the editor palette, clicking on the map will place that name on a hex, each location can only be placed on a single hex, and the editor will only allow one location per hex.
 

--- a/data/tools/pywmlx/state/lua_states.py
+++ b/data/tools/pywmlx/state/lua_states.py
@@ -33,6 +33,7 @@ class LuaCheckdomState:
 
     def run(self, xline, lineno, match):
         pywmlx.state.machine._currentdomain = match.group(3)
+        pywmlx.state.machine.checkdomain(lineno)
         xline = None
         if match.group(1) is None and pywmlx.state.machine._warnall:
             finfo = pywmlx.nodemanip.fileref + ":" + str(lineno)

--- a/data/tools/pywmlx/state/lua_states.py
+++ b/data/tools/pywmlx/state/lua_states.py
@@ -48,6 +48,9 @@ class LuaCheckpoState:
         self.iffail = 'lua_comment'
 
     def run(self, xline, lineno, match):
+        if not pywmlx.state.machine.checkdomain(lineno):
+            return (None, 'lua_idle')
+
         # on -- #po: addedinfo
         if match.group(1) == "po":
             if pywmlx.state.machine._pending_addedinfo is None:

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -84,17 +84,27 @@ _linenosub = 0
 # --------------------------------------------------------------------
 
 
-
-def checkdomain():
-    global _currentdomain
-    global _domain
+def clear_pending_infos(lineno, error=False):
     global _pending_addedinfo
     global _pending_overrideinfo
+    if error:
+        if _pending_addedinfo is not None:
+            wmlerr(pywmlx.nodemanip.fileref + ":" + str(lineno),
+                "#po directive(s) not applied: %s" % _pending_addedinfo)
+        if _pending_overrideinfo is not None:
+            wmlerr(pywmlx.nodemanip.fileref + ":" + str(lineno),
+                "#po-override directive(s) not applied: %s" % _pending_overrideinfo)
+    _pending_addedinfo = None
+    _pending_overrideinfo = None
+    
+
+def checkdomain(lineno):
+    global _currentdomain
+    global _domain
     if _currentdomain == _domain:
         return True
     else:
-        _pending_addedinfo = None
-        _pending_overrideinfo = None
+        clear_pending_infos(lineno, error=True)
         return False
 
 
@@ -194,7 +204,7 @@ class PendingLuaString:
         global _pending_addedinfo
         global _pending_overrideinfo
         global _linenosub
-        if checkdomain() and self.istranslatable:
+        if checkdomain(self.lineno) and self.istranslatable:
             _linenosub += 1
             finfo = pywmlx.nodemanip.fileref + ":" + str(self.lineno)
             fileno = pywmlx.nodemanip.fileno
@@ -242,8 +252,7 @@ class PendingLuaString:
                     ) )
         # finally PendingLuaString.store() will clear pendinginfos,
         # in any case (even if the pending string is not translatable)
-        _pending_overrideinfo = None
-        _pending_addedinfo = None
+        clear_pending_infos(self.lineno, error=(not self.istranslatable))
 
 
 
@@ -269,7 +278,7 @@ class PendingWmlString:
                 winf = _pending_winfotype + '=' + self.wmlstring
                 pywmlx.nodemanip.addWmlInfo(winf)
             _pending_winfotype = None
-        if checkdomain() and self.istranslatable:
+        if checkdomain(self.lineno) and self.istranslatable:
             finfo = pywmlx.nodemanip.fileref + ":" + str(self.lineno)
             errcode = checksentence(self.wmlstring, finfo, islua=False)
             if errcode != 1:
@@ -287,8 +296,7 @@ class PendingWmlString:
                                              lineno_sub=_linenosub,
                                              override=_pending_overrideinfo,
                                              addition=_pending_addedinfo)
-        _pending_overrideinfo = None
-        _pending_addedinfo = None
+        clear_pending_infos(self.lineno, error=(not self.istranslatable))
 
 
 

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -204,7 +204,9 @@ class PendingLuaString:
         global _pending_addedinfo
         global _pending_overrideinfo
         global _linenosub
-        if checkdomain(self.lineno) and self.istranslatable:
+        if not checkdomain(self.lineno):
+            return
+        if self.istranslatable:
             _linenosub += 1
             finfo = pywmlx.nodemanip.fileref + ":" + str(self.lineno)
             fileno = pywmlx.nodemanip.fileno
@@ -278,7 +280,9 @@ class PendingWmlString:
                 winf = _pending_winfotype + '=' + self.wmlstring
                 pywmlx.nodemanip.addWmlInfo(winf)
             _pending_winfotype = None
-        if checkdomain(self.lineno) and self.istranslatable:
+        if not checkdomain(self.lineno):
+            return
+        if self.istranslatable:
             finfo = pywmlx.nodemanip.fileref + ":" + str(self.lineno)
             errcode = checksentence(self.wmlstring, finfo, islua=False)
             if errcode != 1:

--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -81,6 +81,8 @@ class WmlCheckpoState:
     def run(self, xline, lineno, match):
         if match.group(1) == 'wmlxgettext':
             xline = match.group(2)
+        elif not pywmlx.state.machine.checkdomain(lineno):
+            xline = None
         # on  #po: addedinfo
         elif match.group(1) == "po":
             xline = None

--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -203,8 +203,7 @@ class WmlTagState:
             # xdebug_str = opentag + ': ' + str(lineno)
         # print(xdebug_str, file=xdebug)
         # xdebug.close()
-        pywmlx.state.machine._pending_addedinfo = None
-        pywmlx.state.machine._pending_overrideinfo = None
+        pywmlx.state.machine.clear_pending_infos(lineno, error=True)
         xline = xline [ match.end(): ]
         return (xline, 'wml_idle')
 

--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -67,6 +67,7 @@ class WmlCheckdomState:
 
     def run(self, xline, lineno, match):
         pywmlx.state.machine._currentdomain = match.group(1)
+        pywmlx.state.machine.checkdomain(lineno)
         xline = None
         return (xline, 'wml_idle')
 


### PR DESCRIPTION
```
# po: narrator is explaining the tale
[message]
speaker=narrator
message= "This is the story I am narrating, but I forgot to mark is a translatable"
[/message]

[message]
speaker=Delfador
message= _ "Hi. I am a mage, and my sentence will be translated"
[/message]
```

According to @AncientLich , current behavior is:
> in this situation, discarding all previous comments after the first sentence found avoids to place itself in a wrong place. If the # po wouldn't discarded, than it would be applied to the next translatable string, with the result of adding the comment "narrator is explaining the tale" in the sentence "Hi. I am a mage, and my sentence will be translated".

> This behaviour is thinked in order to prevent to misplace comments or overrides. The logic around this choice was "better dropping an information, than adding a completely wrong one that could add confusion to a translator".
The same reason is more strong when thinking about lua because wmlxgettext is even more limted on understand what lua is doinf than WML, so introducing a more strict control is even more necessary.

So this is a silent failure in the procedures ``wmlxgettext`` is expected to deal with. This PR makes them loud errors.
