### PR TITLE
add missing stdint.h includes

### DIFF
--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 /** See https://wiki.wesnoth.org/CompatibilityStandards for more info. */

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <string>
 
 /** See https://wiki.wesnoth.org/CompatibilityStandards for more info. */

--- a/src/serialization/base64.hpp
+++ b/src/serialization/base64.hpp
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/serialization/base64.hpp
+++ b/src/serialization/base64.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <string_view>
 #include <vector>
 

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -21,7 +21,7 @@
 #include "filesystem.hpp"
 #include "game_version.hpp"
 #include <optional>
-#include <stdint.h>
+#include <cstdint>
 
 #include <iosfwd>
 #include <map>

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -21,6 +21,7 @@
 #include "filesystem.hpp"
 #include "game_version.hpp"
 #include <optional>
+#include <stdint.h>
 
 #include <iosfwd>
 #include <map>


### PR DESCRIPTION
Looks like 1.16.9 no longer compile on new compilers as Clang 16.

Due errors:
```
/builddir/build/BUILD/wesnoth-1.16.9/src/deprecation.hpp:20:24: error: unknown type name 'uint8_t'
DEBUG util.py:445:  enum class DEP_LEVEL : uint8_t { INDEFINITE = 1, PREEMPTIVE, FOR_REMOVAL, REMOVED };
DEBUG util.py:445:                         ^
DEBUG util.py:445:  In file included from /builddir/build/BUILD/wesnoth-1.16.9/src/serialization/preprocessor.cpp:25:
DEBUG util.py:445:  /builddir/build/BUILD/wesnoth-1.16.9/src/config.hpp:51:12: error: enumeration redeclared with different underlying type 'uint8_t' (aka 'unsigned char') (was 'int')
DEBUG util.py:445:  enum class DEP_LEVEL : uint8_t;
DEBUG util.py:445:             ^
DEBUG util.py:445:  /builddir/build/BUILD/wesnoth-1.16.9/src/deprecation.hpp:20:12: note: previous declaration is here
DEBUG util.py:445:  enum class DEP_LEVEL : uint8_t { INDEFINITE = 1, PREEMPTIVE, FOR_REMOVAL, REMOVED };
DEBUG util.py:445:             ^
DEBUG util.py:445:  2 errors generated.
```
etc.

Adding few missing #include <stdint.h> fixing it.