### PR TITLE
Reorder WML includes so manual tests can use the unit-test macros

### DIFF
--- a/data/_main.cfg
+++ b/data/_main.cfg
@@ -56,8 +56,10 @@
 #endif
 
 #ifdef TEST
-# load tests that need manual user input to run and validate
-{test/scenarios/manual_tests}
+# Manual demonstrations or tests of the AI code. Most of these are showcases of the available
+# functionality, explaning what a parameter or Micro AI does. They can be run by binding a
+# hotkey for the main menu's "Choose Test Scenario" option, or by using the command line
+# option `-t <testname>`.
 {ai/scenarios/}
 {ai/micro_ais/scenarios/}
 #define DONT_RELOAD_CORE

--- a/data/test/_main.cfg
+++ b/data/test/_main.cfg
@@ -29,7 +29,10 @@
 #Load test macros
 {test/macros}
 
-#Load test scenarios
+# Load automated test scenarios.
+#
+# They can be run individually with Wesnoth's `-u` command line option, but are usually run by
+# the run_wml_tests script based on the list in wml_test_schedule.
 {test/scenarios/behavioral_tests}
 {test/scenarios/cve_tests}
 {test/scenarios/lua_tests}
@@ -74,7 +77,14 @@
 {test/scenarios/wml_tests/UnitsWML/Attacks}
 {test/scenarios/wml_tests/WesnothFormulaLanguage}
 
-# Load test unit wml
+# Manual tests, to run with Wesnoth's `-t <testname>` option, or by binding a hotkey for the
+# main menu's "Choose Test Scenario" option.
+#
+# Many of these are closer to workbenches than tests, allowing developers to do some action
+# that isn't automated, and then to find out whether the result matched the expectation.
+{test/scenarios/manual_tests}
+
+# Some unit_types that are only used for tests.
 {test/units.cfg}
 
 #endif


### PR DESCRIPTION
Move the line that includes data/test/scenarios/manual_tests/ below the line that includes data/test/macros/. This allows a manual test to use the setup in COMMON_KEEP_A_B_C_D_UNIT_TEST, putting units in the right position to test combat and leadership abilities.

Also improve comments in data/test/_main.cfg.