### PR TITLE
Don't allow markup in achievement titles.

### DIFF
--- a/data/gui/macros/_initial.cfg
+++ b/data/gui/macros/_initial.cfg
@@ -80,6 +80,7 @@
 # - button captions
 # - checkbox captions
 # - menu captions
+# - achieved achievement titles
 #define GUI__FONT_COLOR_ENABLED__TITLE
 #arg ALPHA
 255#endarg

--- a/data/gui/widget/label_achievement_title.cfg
+++ b/data/gui/widget/label_achievement_title.cfg
@@ -1,0 +1,141 @@
+#textdomain "wesnoth-lib"
+
+#define _GUI_ACHIEVEMENT_TITLE_FONT_COLOR STATE
+"(
+    if(achieved,
+        [" {GUI__FONT_COLOR_{STATE}__TITLE (ALPHA=)} "text_alpha],
+        [" {GUI__FONT_COLOR_{STATE}__DEFAULT (ALPHA=)} "text_alpha])
+)"
+#enddef
+
+[label_definition]
+	id = achievement_title
+	description = "title of an achievement"
+
+    [resolution]
+		min_width = 0
+		min_height = 0
+
+		default_width = 0
+		default_height = 0
+
+		max_width = 0
+		max_height = 0
+
+		text_font_size = {GUI_FONT_SIZE_LARGE}
+
+		link_color = "255, 225, 0"
+
+		[state_enabled]
+
+			[draw]
+
+				[text]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(text_height)"
+					maximum_width = "(width)"
+					font_size = {GUI_FONT_SIZE_LARGE}
+					color = {_GUI_ACHIEVEMENT_TITLE_FONT_COLOR ENABLED}
+					text = "(text)"
+					text_markup = "(text_markup)"
+					text_alignment = "(text_alignment)"
+					text_link_aware = "(text_link_aware)"
+					text_link_color = "(text_link_color)"
+				[/text]
+
+			[/draw]
+
+		[/state_enabled]
+
+		[state_disabled]
+
+			[draw]
+
+				[text]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(text_height)"
+					maximum_width = "(width)"
+					font_size = {GUI_FONT_SIZE_LARGE}
+					color = {_GUI_ACHIEVEMENT_TITLE_FONT_COLOR DISABLED}
+					text = "(text)"
+					text_markup = "(text_markup)"
+					text_alignment = "(text_alignment)"
+					text_link_aware = "(text_link_aware)"
+					text_link_color = "(text_link_color)"
+				[/text]
+
+			[/draw]
+
+		[/state_disabled]
+
+	[/resolution]
+    [resolution]
+		{GUI_BIG_RESOLUTION}
+
+		min_width = 0
+		min_height = 0
+
+		default_width = 0
+		default_height = 0
+
+		max_width = 0
+		max_height = 0
+
+		text_font_size = {GUI_SCALE_RESOLUTION {GUI_FONT_SIZE_LARGE}}
+
+		link_color = "255, 225, 0"
+
+		[state_enabled]
+
+			[draw]
+
+				[text]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(text_height)"
+					maximum_width = "(width)"
+					font_size = {GUI_SCALE_RESOLUTION {GUI_FONT_SIZE_LARGE}}
+					color = {_GUI_ACHIEVEMENT_TITLE_FONT_COLOR ENABLED}
+					text = "(text)"
+					text_markup = "(text_markup)"
+					text_alignment = "(text_alignment)"
+					text_link_aware = "(text_link_aware)"
+					text_link_color = "(text_link_color)"
+				[/text]
+
+			[/draw]
+
+		[/state_enabled]
+
+		[state_disabled]
+
+			[draw]
+
+				[text]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(text_height)"
+					maximum_width = "(width)"
+					font_size = {GUI_SCALE_RESOLUTION {GUI_FONT_SIZE_LARGE}}
+					color = {_GUI_ACHIEVEMENT_TITLE_FONT_COLOR DISABLED}
+					text = "(text)"
+					text_markup = "(text_markup)"
+					text_alignment = "(text_alignment)"
+					text_link_aware = "(text_link_aware)"
+					text_link_color = "(text_link_color)"
+				[/text]
+
+			[/draw]
+
+		[/state_disabled]
+
+	[/resolution]
+[/label_definition]
+
+#undef _GUI_ACHIEVEMENT_TITLE_FONT_COLOR

--- a/data/gui/window/achievements_dialog.cfg
+++ b/data/gui/window/achievements_dialog.cfg
@@ -142,9 +142,8 @@
 					
 																	[label]
 																		id = "name"
-																		definition = "default_large"
+																		definition = "achievement_title"
 																		characters_per_line = 70
-																		use_markup = true
 																	[/label]
 																[/column]
 															[/row]

--- a/src/gui/dialogs/achievements_dialog.cpp
+++ b/src/gui/dialogs/achievements_dialog.cpp
@@ -73,13 +73,14 @@ void achievements_dialog::pre_show(window& win)
 				row.emplace("icon", item);
 
 				if(!ach.achieved_) {
-					std::string name = ach.name_;
+					t_string name = ach.name_;
 					if(ach.max_progress_ != 0 && ach.current_progress_ != -1) {
 						name += " ("+std::to_string(ach.current_progress_)+"/"+std::to_string(ach.max_progress_)+")";
 					}
 					item["label"] = name;
 				} else {
-					item["label"] = "<span color='khaki'>"+ach.name_completed_+"</span>";
+					item["label"] = ach.name_completed_;
+					item["definition"] = "gold_large";
 				}
 				row.emplace("name", item);
 
@@ -97,6 +98,10 @@ void achievements_dialog::pre_show(window& win)
 				} else {
 					achievement_progress->set_visible(gui2::widget::visibility::invisible);
 				}
+
+				auto name = static_cast<label*>(newrow.find("name", false));
+				auto& canvas = name->get_canvas(0);
+				canvas.set_variable("achieved", wfl::variant(ach.achieved_));
 			}
 
 			label* achieved_label = find_widget<label>(&win, "achievement_count", false, true);
@@ -141,7 +146,8 @@ void achievements_dialog::set_achievements_content()
 		if(!ach.achieved_) {
 			item["label"] = ach.name_;
 		} else {
-			item["label"] = "<span color='khaki'>"+ach.name_completed_+"</span>";
+			item["label"] = ach.name_completed_;
+			item["definition"] = "gold_large";
 		}
 		row.emplace("name", item);
 
@@ -159,6 +165,10 @@ void achievements_dialog::set_achievements_content()
 		} else {
 			achievement_progress->set_visible(gui2::widget::visibility::invisible);
 		}
+
+		auto name = static_cast<label*>(newrow.find("name", false));
+		auto& canvas = name->get_canvas(0);
+		canvas.set_variable("achieved", wfl::variant(ach.achieved_));
 	}
 
 	label* achieved_label = find_widget<label>(get_window(), "achievement_count", false, true);


### PR DESCRIPTION
This is done as a guarantee that there will always be one unambiguous way to identify that the achievement is completed.