### PR TITLE
wmlunits: Include nested dependencies in -L for -B to process

### DIFF
--- a/data/tools/wmlunits
+++ b/data/tools/wmlunits
@@ -301,7 +301,8 @@ def list_contents():
             pass
         version = get_version(addon)
         move(options.addons, os.path.join(options.config_dir, "data", "add-ons"), addon)
-        for d in get_dependencies(addon):
+        all_dependencies = get_all_dependencies(addon)
+        for d in all_dependencies:
             move(options.addons, os.path.join(options.config_dir, "data", "add-ons"), d)
         try:
             info = search(batchlist, addon)
@@ -309,7 +310,7 @@ def list_contents():
                 sys.stdout.write("up to date\n")
                 continue
             info["parsed"] = False
-            info["dependencies"] = get_dependencies(addon)
+            info["dependencies"] = all_dependencies
             parse("{core}{multiplayer}{multiplayer/eras.cfg}{~add-ons}", "__WMLUNITS__,MULTIPLAYER,SKIP_CORE")
             info["eras"] = list_eras(batchlist, addon)
             info["campaigns"] = list_campaigns(batchlist, addon)
@@ -335,7 +336,7 @@ def list_contents():
             print("failed")
         finally:
             move(os.path.join(options.config_dir, "data", "add-ons"), options.addons, addon)
-            for d in get_dependencies(addon):
+            for d in all_dependencies:
                 move(os.path.join(options.config_dir, "data", "add-ons"), options.addons, d)
 
     yaml.safe_dump(batchlist, open(filename, "w"),


### PR DESCRIPTION
This fixes an issue of missing resources, such as seen in https://units.wesnoth.org/1.16/To_Lands_Unknown/en_US/To_Lands_Unknown.html

Closes #4124
