### PR TITLE
Rewrite macOS version report again

### DIFF
--- a/src/desktop/apple_version.mm
+++ b/src/desktop/apple_version.mm
@@ -37,25 +37,18 @@ namespace apple {
 		// Standard Apple version
 		//
 
-		std::string version_string = "";
-
-		NSArray *version_array = [[[NSProcessInfo processInfo] operatingSystemVersionString] componentsSeparatedByString:@" "];
-
+		std::string version_string;
 #if defined(__IPHONEOS__)
-		std::string version_string = "iOS ";
+		version_string = "Apple iOS ";
 #else
-		const version_info version_info([[version_array objectAtIndex:1] UTF8String]);
-
-		if (version_info.major_version() == 10 && version_info.minor_version() < 12) {
-			version_string = "Apple OS X ";
-		} else {
+		if (@available(macOS 10.12, *)) {
 			version_string = "Apple macOS ";
+		} else {
+			version_string = "Apple OS X ";
 		}
 #endif
-
-		version_string += [[version_array objectAtIndex:1] UTF8String];
-		version_string += " (";
-		version_string += [[version_array objectAtIndex:3] UTF8String];
+		NSOperatingSystemVersion os_ver = [[NSProcessInfo processInfo] operatingSystemVersion];
+		version_string += version_info(os_ver.majorVersion, os_ver.minorVersion, os_ver.patchVersion);
 
 		return version_string;
 	}


### PR DESCRIPTION
This version doesn't rely on custom parsing of the version number from the (notably **not meant to be parsed**) `operatingSystemVersionString` property, and explicitly appends the version number components to the reported string instead so we don't get weirdness like `Apple macOS 13.3.1 ((Build` from an `operatingSystemVersionString` value like `Version 13.3.1 (a) (Build 22E772610a)` (found after the early May 2023 rapid response patch to Ventura).

Additionally, this replaces the clunky version comparison to decide whether to use the macOS or OS X branding with the `@available` syntax.

<https://developer.apple.com/library/archive/releasenotes/AppKit/RN-AppKit/index.html> (Under "Runtime Version Check")

(**Note:** 1.16 also needs this patch)