### PR TITLE
Make GUI.pyw translatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ find_package(ICU REQUIRED COMPONENTS data i18n uc)
 
 # no, gettext executables are not required when NLS is deactivated
 find_package(Gettext)
+find_package(Python)
 
 find_package(X11)
 
@@ -557,7 +558,7 @@ endif()
 
 add_subdirectory(doc)
 
-if(GETTEXT_FOUND AND ENABLE_NLS)
+if(GETTEXT_FOUND AND Python_FOUND AND ENABLE_NLS)
 	add_subdirectory(po)
 endif()
 

--- a/cmake/update_pot_source_dependencies.cmake
+++ b/cmake/update_pot_source_dependencies.cmake
@@ -1,7 +1,8 @@
 # Update the source file dependencies of the pot file.
 #
 # This globs all files cpp in the src directory and looks for the text domain
-# definition in that file and outputs these dependencies in POTFILES.in.
+# definition in that file and outputs these dependencies in POTFILES_CPP.in.
+# py, pyw are listed in POTFILES_PY.in
 
 # Remove the old input file.
 # Dummy target with a non existing (and not created file) is always executed.
@@ -9,71 +10,29 @@ add_custom_command(
 	OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
 	# remove the old file.
 	COMMAND ${CMAKE_COMMAND}
-			-E remove ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
-	COMMENT "pot-update [${DOMAIN}]: Removed existing POTFILES.in."
+			-E remove ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES*.in 
+	COMMENT "pot-update [${DOMAIN}]: Removing existing POTFILES*.in."
 )
 
-# Recreate the input file.
-if(DOMAIN STREQUAL ${DEFAULT_DOMAIN})
+add_custom_command(
+	OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_CPP.in
 
-	# For the default text domain.
-	add_custom_command(
-		OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
+	# Write list of matching files to POTFILES_CPP.in.
+	COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/po/FINDCPP ${DOMAIN} --initialdomain ${DEFAULT_DOMAIN} >|
+				${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_CPP.in
 
-		# Find all cpp files which are not in a .git directory, check their
-		# textdomain, and write the list of matching files to POTFILES.in.
-		COMMAND find src  -name .git -prune -o -name '*.[hc]pp' -print |
-				sort |
-				while read file\; do
-					# If the file doesn't contain a GETTEXT_DOMAIN
-					# definition it should be added to the default domain.
-					if ! grep '^\#define  *GETTEXT_DOMAIN'
-							$$file > /dev/null 2>&1\; then
+	DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
+	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+	COMMENT "pot-update [${DOMAIN}]: Creating POTFILES_CPP.in."
+)
+add_custom_command(
+	OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_PY.in
 
-						echo $$file \;
+	# Write list of matching files to PY.in.
+	COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/po/FINDPY ${DOMAIN} >|
+				${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_PY.in
 
-					# While files don't need a GETTEXT_DOMAIN to be included in
-					# the default domain, accept files that contain a
-					# GETTEXT_DOMAIN definition for the default domain too.
-					elif grep '^\#define  *GETTEXT_DOMAIN  *\"${DOMAIN}\"'
-							$$file > /dev/null 2>&1\; then
-
-						echo $$file \;
-					fi
-				done >|
-					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
-
-
-		DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
-		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-		COMMENT
-			"pot-update [${DOMAIN}]: Created POTFILES.in for default domain."
-	)
-
-else(DOMAIN STREQUAL ${DEFAULT_DOMAIN})
-
-	# For the other text domains.
-	add_custom_command(
-		OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
-
-		# Find all cpp files which are not in a .git directory, check their
-		# textdomain, and write the list of matching files to POTFILES.in.
-		COMMAND find src  -name .git -prune -o -name '*cpp' -print |
-				sort |
-				while read file\; do
-					# If the file contains a GETTEXT_DOMAIN definition for
-					# the current domain add it to the domain.
-					if grep '^\#define  *GETTEXT_DOMAIN  *\"${DOMAIN}\"'
-							$$file > /dev/null 2>&1\; then
-
-						echo $$file \;
-					fi
-				done >|
-					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
-
-		DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
-		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-		COMMENT "pot-update [${DOMAIN}]: Created POTFILES.in."
-	)
-
-endif(DOMAIN STREQUAL ${DEFAULT_DOMAIN})
+	DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in.dummy
+	WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+	COMMENT "pot-update [${DOMAIN}]: Creating POTFILES_PY.in."
+)

--- a/data/tools/GUI.pyw
+++ b/data/tools/GUI.pyw
@@ -10,11 +10,14 @@
 
 # threading and subprocess are needed to run wmllint without freezing the window
 # codecs is used to save files as UTF8
+# locale and gettext provides internationalization and localization (i18n, l10n)
 # queue is needed to exchange informations between threads
 # if we use the run_tool thread to do GUI stuff we obtain weird crashes
 # This happens because Tk is a single-thread GUI
-import sys,os,threading,subprocess,codecs
+import argparse,sys,os,threading,subprocess,codecs
 
+import locale
+import gettext
 import queue
 
 from wesnoth import version
@@ -42,6 +45,60 @@ APP_DIR,APP_NAME=os.path.split(os.path.realpath(sys.argv[0]))
 WESNOTH_ROOT_DIR=os.sep.join(APP_DIR.split(os.sep)[:-2])  # pop out "data" and "tools"
 WESNOTH_DATA_DIR=os.path.join(WESNOTH_ROOT_DIR,"data")
 WESNOTH_CORE_DIR=os.path.normpath(os.path.join(WESNOTH_DATA_DIR,"core"))
+WESNOTH_TRAN_DIR=os.path.join(WESNOTH_ROOT_DIR, "translations")
+
+_=lambda x:x
+
+def set_default_locale():
+    global _
+
+    # TODO: Replace CLI args for a proper locale selection GUI.
+    # More importantly, code to dynamically update the text/layout is missing.
+    parser = argparse.ArgumentParser(
+        description=_("Open a Graphical User Interface (GUI) to WML Tools"),
+        usage=("GUI.pyw [--lang=" + _("LANGUAGE") + "]")
+    )
+    parser.add_argument(
+        '--lang',
+        # TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+        # of underscores in the locale id. For example, use en_GB, not en-GB.
+        help=_("Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e.g. en_GB).")
+    )
+    opts = parser.parse_args(sys.argv[1:])
+    if opts.lang is not None:
+        if not os.path.isdir(WESNOTH_TRAN_DIR):
+            showerror(_("Error"),
+                # TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+                _("`{0}` folder not found. Please run the GUI.pyw executable packaged with the Wesnoth installation.").format("translations")
+            )
+        try:
+            _=gettext.translation("wesnoth-tools",WESNOTH_TRAN_DIR,languages=[opts.lang],fallback=False).gettext
+        except:
+            showerror(_("Error"),
+                # TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+                _("Locale {0} not recognized.").format(opts.lang)
+            )
+        return
+
+    try:
+        system_locale = locale.getlocale()[0]
+        _=gettext.translation("wesnoth-tools",WESNOTH_TRAN_DIR,languages=[system_locale],fallback=False).gettext
+    except Exception as ex:
+        # Needed for compat with Python <3.10, and/or Windows 7/8.
+        system_locale = locale.getdefaultlocale()[0]
+        _=gettext.translation("wesnoth-tools",WESNOTH_TRAN_DIR,languages=[system_locale],fallback=False).gettext
+
+def on_update_locale(value):
+    if value is None:
+        try:
+            set_default_locale()
+        except:
+            # _ defaults to identity lambda.
+            pass
+    else:
+        pass
+
+on_update_locale(None)
 
 def wrap_elem(line):
     """If the supplied line contains spaces, return it wrapped between double quotes"""
@@ -268,7 +325,8 @@ Self destroys when the tool thread is over"""
         frame=Frame(self)
         frame.pack(fill=BOTH,expand=YES)
         wait_label=Label(frame,
-                         text="{0} is running\nPlease wait...".format(tool),
+                         # TRANSLATORS: {0} is the name of command being executed.
+                         text=_("Running: {0}\nPlease wait...").format(tool),
                          justify=CENTER)
         wait_label.grid(row=0,
                         column=0,
@@ -282,7 +340,7 @@ Self destroys when the tool thread is over"""
                            padx=5,
                            pady=5)
         terminate_button=Button(frame,
-                                text="Terminate script",
+                                text=_("Terminate script"),
                                 image=ICONS["process-stop"],
                                 compound=LEFT,
                                 command=self.terminate)
@@ -330,24 +388,24 @@ If the widget isn't active, some options do not appear"""
         control_key = "Command" if self.tk.call('tk', 'windowingsystem') == "aqua" else "Ctrl"
         # str is necessary because in some instances a Tcl_Obj is returned instead of a string
         if str(widget.cget('state')) in (ACTIVE,NORMAL): # do not add if state is readonly or disabled
-            self.add_command(label="Cut",
+            self.add_command(label=_("Cut"),
                              image=ICONS['cut'],
                              compound=LEFT,
                              accelerator='%s+X' % (control_key),
                              command=lambda: self.widget.event_generate("<<Cut>>"))
-        self.add_command(label="Copy",
+        self.add_command(label=_("Copy"),
                          image=ICONS['copy'],
                          compound=LEFT,
                          accelerator='%s+C' % (control_key),
                          command=lambda: self.widget.event_generate("<<Copy>>"))
         if str(widget.cget('state')) in (ACTIVE,NORMAL):
-            self.add_command(label="Paste",
+            self.add_command(label=_("Paste"),
                              image=ICONS['paste'],
                              compound=LEFT,
                              accelerator='%s+V' % (control_key),
                              command=lambda: self.widget.event_generate("<<Paste>>"))
         self.add_separator()
-        self.add_command(label="Select all",
+        self.add_command(label=_("Select all"),
                          image=ICONS['select_all'],
                          compound=LEFT,
                          accelerator='%s+A' % (control_key),
@@ -409,7 +467,7 @@ class SelectDirectory(LabelFrame):
     def __init__(self,parent,textvariable=None,**kwargs):
         """A subclass of LabelFrame sporting a readonly Entry and a Button with a folder icon.
 It comes complete with a context menu and a directory selection screen"""
-        super().__init__(parent,text="Directory",**kwargs)
+        super().__init__(parent,text=_("Directory"),**kwargs)
         self.textvariable=textvariable
         self.dir_entry=EntryContext(self,
                                     width=40,
@@ -421,13 +479,13 @@ It comes complete with a context menu and a directory selection screen"""
         self.dir_button=Button(self,
                                image=ICONS['browse'],
                                compound=LEFT,
-                               text="Browse...",
+                               text=_("Browse..."),
                                command=self.on_browse)
         self.dir_button.pack(side=LEFT)
         self.clear_button=Button(self,
                                  image=ICONS['clear16'],
                                  compound=LEFT,
-                                 text="Clear",
+                                 text=_("Clear"),
                                  command=self.on_clear)
         self.clear_button.pack(side=LEFT)
     def on_browse(self):
@@ -460,13 +518,13 @@ It has a context menu and a save file selection dialog."""
         self.file_button=Button(self,
                                 image=ICONS['browse'],
                                 compound=LEFT,
-                                text="Browse...",
+                                text=_("Browse..."),
                                 command=self.on_browse)
         self.file_button.pack(side=LEFT)
         self.clear_button=Button(self,
                                  image=ICONS['clear16'],
                                  compound=LEFT,
-                                 text="Clear",
+                                 text=_("Clear"),
                                  command=self.on_clear)
         self.clear_button.pack(side=LEFT)
         self.filetypes = filetypes
@@ -509,12 +567,12 @@ class WmllintTab(Frame):
         super().__init__(parent)
         self.mode_variable=IntVar()
         self.mode_frame=LabelFrame(self,
-                                   text="wmllint mode")
+                                   text=_("wmllint mode"))
         self.mode_frame.grid(row=0,
                              column=0,
                              sticky=N+E+S+W)
         self.radio_normal=Radiobutton(self.mode_frame,
-                                      text="Normal",
+                                      text=_("Normal"),
                                       variable=self.mode_variable,
                                       value=0)
         self.radio_normal.grid(row=0,
@@ -522,9 +580,9 @@ class WmllintTab(Frame):
                                sticky=W,
                                padx=10)
         self.tooltip_normal=Tooltip(self.radio_normal,
-                                    "Perform file conversion")
+                                    _("Perform file conversion"))
         self.radio_dryrun=Radiobutton(self.mode_frame,
-                                      text="Dry run",
+                                      text=_("Dry run"),
                                       variable=self.mode_variable,
                                       value=1)
         self.radio_dryrun.grid(row=1,
@@ -532,9 +590,10 @@ class WmllintTab(Frame):
                                sticky=W,
                                padx=10)
         self.tooltip_dryrun=Tooltip(self.radio_dryrun,
-                                    "Do not perform changes")
+                                    # TRANSLATORS: Explanation for Dry run.
+                                    _("Do not perform changes"))
         self.radio_clean=Radiobutton(self.mode_frame,
-                                     text="Clean",
+                                     text=_("Clean"),
                                      variable=self.mode_variable,
                                      value=2)
         self.radio_clean.grid(row=2,
@@ -542,9 +601,10 @@ class WmllintTab(Frame):
                               sticky=W,
                               padx=10)
         self.tooltip_clean=Tooltip(self.radio_clean,
-                                   "Delete *.bak files")
+                                   # TRANSLATORS: Explanation for Clean.
+                                   _("Delete *.bak files"))
         self.radio_diff=Radiobutton(self.mode_frame,
-                                    text="Diff",
+                                    text=_("Diff"),
                                     variable=self.mode_variable,
                                     value=3)
         self.radio_diff.grid(row=3,
@@ -552,9 +612,10 @@ class WmllintTab(Frame):
                              sticky=W,
                              padx=10)
         self.tooltip_diff=Tooltip(self.radio_diff,
-                                  "Show differences in converted files")
+                                   # TRANSLATORS: Explanation for Diff.
+                                  _("Show differences in converted files"))
         self.radio_revert=Radiobutton(self.mode_frame,
-                                      text="Revert",
+                                      text=_("Revert"),
                                       variable=self.mode_variable,
                                       value=4)
         self.radio_revert.grid(row=4,
@@ -562,15 +623,16 @@ class WmllintTab(Frame):
                                sticky=W,
                                padx=10)
         self.tooltip_revert=Tooltip(self.radio_revert,
-                                    "Revert conversions using *.bak files")
+                                   # TRANSLATORS: Explanation for Revert.
+                                    _("Revert conversions using *.bak files"))
         self.verbosity_frame=LabelFrame(self,
-                                        text="Verbosity level")
+                                        text=_("Verbosity level"))
         self.verbosity_frame.grid(row=0,
                                   column=1,
                                   sticky=N+E+S+W)
         self.verbosity_variable=IntVar()
         self.radio_v0=Radiobutton(self.verbosity_frame,
-                                  text="Terse",
+                                  text=_("Terse"),
                                   variable=self.verbosity_variable,
                                   value=0)
         self.radio_v0.grid(row=0,
@@ -578,7 +640,7 @@ class WmllintTab(Frame):
                            sticky=W,
                            padx=10)
         self.radio_v1=Radiobutton(self.verbosity_frame,
-                                  text="List changes",
+                                  text=_("List changes"),
                                   variable=self.verbosity_variable,
                                   value=1)
         self.radio_v1.grid(row=1,
@@ -586,7 +648,7 @@ class WmllintTab(Frame):
                            sticky=W,
                            padx=10)
         self.radio_v2=Radiobutton(self.verbosity_frame,
-                                  text="Name files before processing",
+                                  text=_("Name files before processing"),
                                   variable=self.verbosity_variable,
                                   value=2)
         self.radio_v2.grid(row=2,
@@ -594,7 +656,7 @@ class WmllintTab(Frame):
                            sticky=W,
                            padx=10)
         self.radio_v3=Radiobutton(self.verbosity_frame,
-                                  text="Show parse details",
+                                  text=_("Show parse details"),
                                   variable=self.verbosity_variable,
                                   value=3)
         self.radio_v3.grid(row=3,
@@ -602,13 +664,14 @@ class WmllintTab(Frame):
                            sticky=W,
                            padx=10)
         self.options_frame=LabelFrame(self,
-                                      text="wmllint options")
+                                      text=_("wmllint options"))
         self.options_frame.grid(row=0,
                                 column=2,
                                 sticky=N+E+S+W)
         self.stripcr_variable=BooleanVar()
         self.stripcr_check=Checkbutton(self.options_frame,
-                                       text="Convert EOL characters to Unix style",
+                                       # TRANSLATORS: Special characters marking end of line.
+                                       text=_("Convert EOL characters to Unix style"),
                                        variable=self.stripcr_variable)
         self.stripcr_check.grid(row=0,
                                 column=0,
@@ -616,7 +679,7 @@ class WmllintTab(Frame):
                                 padx=10)
         self.missing_variable=BooleanVar()
         self.missing_check=Checkbutton(self.options_frame,
-                                        text="Don't warn about tags without side= keys",
+                                        text=_("Don't warn about tags without side= keys"),
                                         variable=self.missing_variable)
         self.missing_check.grid(row=1,
                                  column=0,
@@ -624,7 +687,7 @@ class WmllintTab(Frame):
                                  padx=10)
         self.known_variable=BooleanVar()
         self.known_check=Checkbutton(self.options_frame,
-                                     text="Disable checks for unknown units",
+                                     text=_("Disable checks for unknown units"),
                                      variable=self.known_variable)
         self.known_check.grid(row=2,
                               column=0,
@@ -632,7 +695,7 @@ class WmllintTab(Frame):
                               padx=10)
         self.spell_variable=BooleanVar()
         self.spell_check=Checkbutton(self.options_frame,
-                                     text="Disable spellchecking",
+                                     text=_("Disable spellchecking"),
                                      variable=self.spell_variable)
         self.spell_check.grid(row=3,
                               column=0,
@@ -640,7 +703,7 @@ class WmllintTab(Frame):
                               padx=10)
         self.skip_variable=BooleanVar()
         self.skip_core=Checkbutton(self.options_frame,
-                                   text="Skip core directory",
+                                   text=_("Skip core directory"),
                                    variable=self.skip_variable,
                                    command=self.skip_core_dir_callback)
         self.skip_core.grid(row=4,
@@ -664,7 +727,7 @@ class WmlscopeTab(Frame):
     def __init__(self,parent):
         super().__init__(parent)
         self.options_frame=LabelFrame(self,
-                                      text="wmlscope options")
+                                      text=_("wmlscope options"))
         self.options_frame.grid(row=0,
                                 column=0,
                                 sticky=N+E+S+W)
@@ -674,7 +737,7 @@ class WmlscopeTab(Frame):
                                  sticky=N+E+S+W)
         self.crossreference_variable=BooleanVar() # equivalent to warnlevel 1
         self.crossreference_check=Checkbutton(self.normal_options,
-                                              text="Check for duplicate macro definitions",
+                                              text=_("Check for duplicate macro definitions"),
                                               variable=self.crossreference_variable)
         self.crossreference_check.grid(row=0,
                                        column=0,
@@ -682,7 +745,7 @@ class WmlscopeTab(Frame):
                                        padx=10)
         self.collisions_variable=BooleanVar()
         self.collisions_check=Checkbutton(self.normal_options,
-                                          text="Check for duplicate resource files",
+                                          text=_("Check for duplicate resource files"),
                                           variable=self.collisions_variable)
         self.collisions_check.grid(row=1,
                                    column=0,
@@ -690,7 +753,7 @@ class WmlscopeTab(Frame):
                                    padx=10)
         self.definitions_variable=BooleanVar()
         self.definitions_check=Checkbutton(self.normal_options,
-                                           text="Make definition list",
+                                           text=_("Make definition list"),
                                            variable=self.definitions_variable)
         self.definitions_check.grid(row=2,
                                     column=0,
@@ -698,7 +761,7 @@ class WmlscopeTab(Frame):
                                     padx=10)
         self.listfiles_variable=BooleanVar()
         self.listfiles_check=Checkbutton(self.normal_options,
-                                         text="List files that will be processed",
+                                         text=_("List files that will be processed"),
                                          variable=self.listfiles_variable)
         self.listfiles_check.grid(row=3,
                                   column=0,
@@ -706,7 +769,7 @@ class WmlscopeTab(Frame):
                                   padx=10)
         self.unresolved_variable=BooleanVar()
         self.unresolved_check=Checkbutton(self.normal_options,
-                                          text="Report unresolved macro references",
+                                          text=_("Report unresolved macro references"),
                                           variable=self.unresolved_variable)
         self.unresolved_check.grid(row=4,
                                    column=0,
@@ -714,7 +777,7 @@ class WmlscopeTab(Frame):
                                    padx=10)
         self.extracthelp_variable=BooleanVar()
         self.extracthelp_check=Checkbutton(self.normal_options,
-                                           text="Extract help from macro definition comments",
+                                           text=_("Extract help from macro definition comments"),
                                            variable=self.extracthelp_variable)
         self.extracthelp_check.grid(row=5,
                                     column=0,
@@ -722,7 +785,7 @@ class WmlscopeTab(Frame):
                                     padx=10)
         self.unchecked_variable=BooleanVar()
         self.unchecked_check=Checkbutton(self.normal_options,
-                                         text="Report all macros with untyped formals",
+                                         text=_("Report all macros with untyped formals"),
                                          variable=self.unchecked_variable)
         self.unchecked_check.grid(row=6,
                                   column=0,
@@ -730,7 +793,7 @@ class WmlscopeTab(Frame):
                                   padx=10)
         self.progress_variable=BooleanVar()
         self.progress_check=Checkbutton(self.normal_options,
-                                        text="Show progress",
+                                        text=_("Show progress"),
                                         variable=self.progress_variable)
         self.progress_check.grid(row=7,
                                  column=0,
@@ -747,7 +810,7 @@ class WmlscopeTab(Frame):
                                       sticky=N+E+S+W)
         self.exclude_variable=BooleanVar()
         self.exclude_check=Checkbutton(self.options_with_regexp,
-                                       text="Exclude files matching regexp:",
+                                       text=_("Exclude files matching regexp:"),
                                        variable=self.exclude_variable,
                                        command=self.exclude_callback)
         self.exclude_check.grid(row=0,
@@ -764,7 +827,7 @@ class WmlscopeTab(Frame):
                                 padx=10)
         self.from_variable=BooleanVar()
         self.from_check=Checkbutton(self.options_with_regexp,
-                                    text="Exclude files not matching regexp:",
+                                    text=_("Exclude files not matching regexp:"),
                                     variable=self.from_variable,
                                     command=self.from_callback)
         self.from_check.grid(row=1,
@@ -781,7 +844,7 @@ class WmlscopeTab(Frame):
                              padx=10)
         self.refcount_variable=BooleanVar()
         self.refcount_check=Checkbutton(self.options_with_regexp,
-                                        text="Report only on macros referenced\nin at least n files:",
+                                        text=_("Report only on macros referenced\nin exactly n files:"),
                                         variable=self.refcount_variable,
                                         command=self.refcount_callback)
         self.refcount_check.grid(row=2,
@@ -800,7 +863,7 @@ class WmlscopeTab(Frame):
                                 padx=10)
         self.typelist_variable=BooleanVar()
         self.typelist_check=Checkbutton(self.options_with_regexp,
-                                        text="List actual & formal argtypes\nfor calls in fname",
+                                        text=_("Report macro definitions and usages in file"),
                                         variable=self.typelist_variable,
                                         command=self.typelist_callback)
         self.typelist_check.grid(row=3,
@@ -817,7 +880,8 @@ class WmlscopeTab(Frame):
                                  padx=10)
         self.force_variable=BooleanVar()
         self.force_check=Checkbutton(self.options_with_regexp,
-                                     text="Ignore refcount 0 on names\nmatching regexp:",
+                                     # TRANSLATORS: regexp is "regular expression".
+                                     text=_("Allow unused macros with names matching regexp:"),
                                      variable=self.force_variable,
                                      command=self.force_callback)
         self.force_check.grid(row=4,
@@ -872,12 +936,12 @@ class WmlindentTab(Frame):
         super().__init__(parent)
         self.mode_variable=IntVar()
         self.mode_frame=LabelFrame(self,
-                                   text="wmlindent mode")
+                                   text=_("wmlindent mode"))
         self.mode_frame.grid(row=0,
                              column=0,
                              sticky=N+E+S+W)
         self.radio_normal=Radiobutton(self.mode_frame,
-                                      text="Normal",
+                                      text=_("Normal"),
                                       variable=self.mode_variable,
                                       value=0)
         self.radio_normal.grid(row=0,
@@ -885,9 +949,10 @@ class WmlindentTab(Frame):
                                sticky=W,
                                padx=10)
         self.tooltip_normal=Tooltip(self.radio_normal,
-                                    "Perform file conversion")
+                                    # TRANSLATORS: Explanation for Normal.
+                                    _("Perform file conversion"))
         self.radio_dryrun=Radiobutton(self.mode_frame,
-                                      text="Dry run",
+                                      text=_("Dry run"),
                                       variable=self.mode_variable,
                                       value=1)
         self.radio_dryrun.grid(row=1,
@@ -895,15 +960,15 @@ class WmlindentTab(Frame):
                                sticky=W,
                                padx=10)
         self.tooltip_dryrun=Tooltip(self.radio_dryrun,
-                                    "Do not perform changes")
+                                    _("Do not perform changes"))
         self.verbosity_frame=LabelFrame(self,
-                                        text="Verbosity level")
+                                        text=_("Verbosity level"))
         self.verbosity_frame.grid(row=0,
                                   column=1,
                                   sticky=N+E+S+W)
         self.verbosity_variable=IntVar()
         self.radio_v0=Radiobutton(self.verbosity_frame,
-                                  text="Terse",
+                                  text=_("Terse"),
                                   variable=self.verbosity_variable,
                                   value=0)
         self.radio_v0.grid(row=0,
@@ -911,7 +976,7 @@ class WmlindentTab(Frame):
                            sticky=W,
                            padx=10)
         self.radio_v1=Radiobutton(self.verbosity_frame,
-                                  text="Verbose",
+                                  text=_("Verbose"),
                                   variable=self.verbosity_variable,
                                   value=1)
         self.radio_v1.grid(row=1,
@@ -919,7 +984,7 @@ class WmlindentTab(Frame):
                            sticky=W,
                            padx=10)
         self.radio_v2=Radiobutton(self.verbosity_frame,
-                                  text="Report unchanged files",
+                                  text=_("Report unchanged files"),
                                   variable=self.verbosity_variable,
                                   value=2)
         self.radio_v2.grid(row=2,
@@ -927,13 +992,13 @@ class WmlindentTab(Frame):
                            sticky=W,
                            padx=10)
         self.options_frame=LabelFrame(self,
-                                      text="wmlindent options")
+                                      text=_("wmlindent options"))
         self.options_frame.grid(row=0,
                                 column=2,
                                 sticky=N+E+S+W)
         self.exclude_variable=BooleanVar()
         self.exclude_check=Checkbutton(self.options_frame,
-                                       text="Exclude files\nmatching regexp:",
+                                       text=_("Exclude files\nmatching regexp:"),
                                        variable=self.exclude_variable,
                                        command=self.exclude_callback)
         self.exclude_check.grid(row=1,
@@ -951,7 +1016,7 @@ class WmlindentTab(Frame):
                                padx=10)
         self.quiet_variable=BooleanVar()
         self.quiet_check=Checkbutton(self.options_frame,
-                                     text="Do not generate output",
+                                     text=_("Do not generate output"),
                                      variable=self.quiet_variable)
         self.quiet_check.grid(row=2,
                               column=0,
@@ -973,36 +1038,37 @@ class WmlxgettextTab(Frame):
         self.output_wrapper_frame=Frame(self)
         self.output_wrapper_frame.grid(row=0,column=0,columnspan=2,sticky=N+E+S+W)
         self.output_label=Label(self.output_wrapper_frame,
-                                text="Output dir:")
+                                text=_("Output dir:"))
         self.output_label.grid(row=0,column=0,sticky=W)
         self.output_variable=StringVar()
         self.output_frame=SelectOutputPath(self.output_wrapper_frame,textvariable=self.output_variable)
         self.output_frame.grid(row=0,column=1,sticky=N+E+S+W)
         self.options_labelframe=LabelFrame(self,
-                                           text="Options")
+                                           text=_("Options"))
         self.options_labelframe.grid(row=1,column=0,sticky=N+E+S+W)
         self.recursive_variable=BooleanVar()
         self.recursive_variable.set(True)
         self.recursive_check=Checkbutton(self.options_labelframe,
-                                         text="Scan subdirectories",
+                                         text=_("Scan subdirectories"),
                                          variable=self.recursive_variable)
         self.recursive_check.grid(row=0,column=0,sticky=W)
         self.warnall_variable=BooleanVar()
         self.warnall_check=Checkbutton(self.options_labelframe,
-                                       text="Show optional warnings",
+                                       text=_("Show optional warnings"),
                                        variable=self.warnall_variable)
         self.warnall_check.grid(row=1,column=0,sticky=W)
         self.fuzzy_variable=BooleanVar()
         self.fuzzy_check=Checkbutton(self.options_labelframe,
-                                     text="Mark all strings as fuzzy",
+                                    # TRANSLATORS: Also called "Needs work".
+                                     text=_("Mark all strings as fuzzy"),
                                      variable=self.fuzzy_variable)
         self.fuzzy_check.grid(row=2,column=0,sticky=W)
         self.advanced_labelframe=LabelFrame(self,
-                                            text="Advanced options")
+                                            text=_("Advanced options"))
         self.advanced_labelframe.grid(row=1,column=1,sticky=N+E+S+W)
         self.package_version_variable=BooleanVar()
         self.package_version_check=Checkbutton(self.advanced_labelframe,
-                                               text="Package version",
+                                               text=_("Package version"),
                                                variable=self.package_version_variable)
         self.package_version_check.grid(row=0,column=0,sticky=W)
         self.initialdomain_variable=BooleanVar()
@@ -1019,7 +1085,7 @@ class WmlxgettextTab(Frame):
                                        textvariable=self.textdomain_name)
         self.textdomain_entry.grid(row=1,column=1,sticky=E+W)
         self.initialdomain_check=Checkbutton(self.advanced_labelframe,
-                                             text="Initial textdomain:",
+                                             text=_("Initial textdomain:"),
                                              variable=self.initialdomain_variable,
                                              command=self.initialdomain_callback)
         self.initialdomain_check.grid(row=2,column=0,sticky=W)
@@ -1062,35 +1128,35 @@ class MainFrame(Frame):
         self.run_button.pack(side=LEFT,
                              padx=5,
                              pady=5)
-        self.run_tooltip=Tooltip(self.run_button,"Run wmllint")
+        self.run_tooltip=Tooltip(self.run_button,_("Run wmllint"))
         self.save_button=Button(self.buttonbox,
                                 image=ICONS['save'],
                                 command=self.on_save)
         self.save_button.pack(side=LEFT,
                               padx=5,
                               pady=5)
-        self.save_tooltip=Tooltip(self.save_button,"Save as text...")
+        self.save_tooltip=Tooltip(self.save_button,_("Save as text..."))
         self.clear_button=Button(self.buttonbox,
                                  image=ICONS['clear'],
                                  command=self.on_clear)
         self.clear_button.pack(side=LEFT,
                                padx=5,
                                pady=5)
-        self.clear_tooltip=Tooltip(self.clear_button,"Clear output")
+        self.clear_tooltip=Tooltip(self.clear_button,_("Clear output"))
         self.about_button=Button(self.buttonbox,
                                  image=ICONS['about'],
                                  command=self.on_about)
         self.about_button.pack(side=LEFT,
                                padx=5,
                                pady=5)
-        self.about_tooltip=Tooltip(self.about_button,"About...")
+        self.about_tooltip=Tooltip(self.about_button,_("About..."))
         self.exit_button=Button(self.buttonbox,
                                 image=ICONS['exit'],
                                 command=self.on_quit)
         self.exit_button.pack(side=RIGHT,
                               padx=5,
                               pady=5)
-        self.exit_tooltip=Tooltip(self.exit_button,"Exit")
+        self.exit_tooltip=Tooltip(self.exit_button,_("Exit"))
         self.dir_variable=StringVar()
         self.dir_frame=SelectDirectory(self,
                                        textvariable=self.dir_variable)
@@ -1106,22 +1172,22 @@ class MainFrame(Frame):
                            sticky=E+W)
         self.wmllint_tab=WmllintTab(None)
         self.notebook.add(self.wmllint_tab,
-                          text="wmllint",
+                          text=_("wmllint"),
                           sticky=N+E+S+W)
         self.wmlscope_tab=WmlscopeTab(None)
         self.notebook.add(self.wmlscope_tab,
-                          text="wmlscope",
+                          text=_("wmlscope"),
                           sticky=N+E+S+W)
         self.wmlindent_tab=WmlindentTab(None)
         self.notebook.add(self.wmlindent_tab,
-                          text="wmlindent",
+                          text=_("wmlindent"),
                           sticky=N+E+S+W)
         self.wmlxgettext_tab=WmlxgettextTab(None)
         self.notebook.add(self.wmlxgettext_tab,
-                          text="wmlxgettext",
+                          text=_("wmlxgettext"),
                           sticky=N+E+S+W)
         self.output_frame=LabelFrame(self,
-                                     text="Output")
+                                     text=_("Output"))
         self.output_frame.grid(row=3,
                                column=0,
                                sticky=N+E+S+W)
@@ -1168,16 +1234,16 @@ class MainFrame(Frame):
         # the order of the tabs is pretty obvious
         active_tab=self.notebook.index(self.notebook.select())
         if active_tab==0:
-            self.run_tooltip.set_text("Run wmllint")
+            self.run_tooltip.set_text(_("Run wmllint"))
             self.run_button.configure(command=self.on_run_wmllint)
         elif active_tab==1:
-            self.run_tooltip.set_text("Run wmlscope")
+            self.run_tooltip.set_text(_("Run wmlscope"))
             self.run_button.configure(command=self.on_run_wmlscope)
         elif active_tab==2:
-            self.run_tooltip.set_text("Run wmlindent")
+            self.run_tooltip.set_text(_("Run wmlindent"))
             self.run_button.configure(command=self.on_run_wmlindent)
         elif active_tab==3:
-            self.run_tooltip.set_text("Run wmlxgettext")
+            self.run_tooltip.set_text(_("Run wmlxgettext"))
             self.run_button.configure(command=self.on_run_wmlxgettext)
 
     def on_run_wmllint(self):
@@ -1185,9 +1251,9 @@ class MainFrame(Frame):
         # if not, stop here
         umc_dir=self.dir_variable.get()
         if not umc_dir and self.wmllint_tab.skip_variable.get():
-            showerror("Error","""wmllint cannot run because there is no directory selected.
+            showerror(_("Error"),_("""wmllint cannot run because there is no directory selected.
 
-Please select a directory or disable the "Skip core directory" option""")
+Please select a directory or disable the "Skip core directory" option"""))
             return
         # build the command line
         wmllint_command_string=[]
@@ -1223,23 +1289,23 @@ Please select a directory or disable the "Skip core directory" option""")
             # the realpaths are here just in case that the user
             # attempts to fool the script by feeding it a symlink
             if os.path.realpath(WESNOTH_CORE_DIR) in os.path.realpath(umc_dir):
-                showwarning("Warning","""You selected the core directory or one of its subdirectories in the add-on selection box.
+                showwarning(_("Warning"),_("""You selected the core directory or one of its subdirectories in the add-on selection box.
 
-wmllint will be run only on the Wesnoth core directory""")
+wmllint will be run only on the Wesnoth core directory"""))
             else:
                 wmllint_command_string.append(umc_dir)
         elif not umc_dir: # path does not exists because the box was left empty
-            showwarning("Warning","""You didn't select a directory.
+            showwarning(_("Warning"),_("""You didn't select a directory.
 
-wmllint will be run only on the Wesnoth core directory""")
+wmllint will be run only on the Wesnoth core directory"""))
         else: # path doesn't exist and isn't empty
-            showerror("Error","""The selected directory does not exists""")
+            showerror(_("Error"),_("""The selected directory does not exists"""))
             return # stop here
         # start thread and wmllint subprocess
         wmllint_thread=ToolThread("wmllint",self.queue,wmllint_command_string)
         wmllint_thread.start()
         # build popup
-        dialog=Popup(self.parent,"wmllint",wmllint_thread)
+        dialog=Popup(self.parent,_("wmllint"),wmllint_thread)
 
     def on_run_wmlscope(self):
         # build the command line
@@ -1275,7 +1341,7 @@ wmllint will be run only on the Wesnoth core directory""")
             except ValueError as error:
                 # normally it should be impossible to raise this exception
                 # due to the fact that the Spinbox is read-only
-                showerror("Error","""You typed an invalid value. Value must be an integer in the range 0-999""")
+                showerror(_("Error"),_("""You typed an invalid value. Value must be an integer in the range 0-999"""))
                 return
         if self.wmlscope_tab.typelist_variable.get():
             wmlscope_command_string.append("--typelist")
@@ -1289,23 +1355,23 @@ wmllint will be run only on the Wesnoth core directory""")
             # the realpaths are here just in case that the user
             # attempts to fool the script by feeding it a symlink
             if os.path.realpath(WESNOTH_CORE_DIR) in os.path.realpath(umc_dir):
-                showwarning("Warning","""You selected the core directory or one of its subdirectories in the add-on selection box.
+                showwarning(_("Warning"),_("""You selected the core directory or one of its subdirectories in the add-on selection box.
 
-wmlscope will be run only on the Wesnoth core directory""")
+wmlscope will be run only on the Wesnoth core directory"""))
             else:
                 wmlscope_command_string.append(umc_dir)
         elif not umc_dir: # path does not exists because the box was left empty
-            showwarning("Warning","""You didn't select a directory.
+            showwarning(_("Warning"),_("""You didn't select a directory.
 
-wmlscope will be run only on the Wesnoth core directory""")
+wmlscope will be run only on the Wesnoth core directory"""))
         else: # path doesn't exist and isn't empty
-            showerror("Error","""The selected directory does not exists""")
+            showerror(_("Error"),_("""The selected directory does not exists"""))
             return # stop here
         # start thread and wmlscope subprocess
         wmlscope_thread=ToolThread("wmlscope",self.queue,wmlscope_command_string)
         wmlscope_thread.start()
         # build popup
-        dialog=Popup(self.parent,"wmlscope",wmlscope_thread)
+        dialog=Popup(self.parent,_("wmlscope"),wmlscope_thread)
 
     def on_run_wmlindent(self):
         # build the command line
@@ -1329,18 +1395,18 @@ wmlscope will be run only on the Wesnoth core directory""")
         if os.path.exists(umc_dir): # add-on exists
             wmlindent_command_string.append(umc_dir)
         elif not umc_dir: # path does not exists because the box was left empty
-            showwarning("Warning","""You didn't select a directory.
+            showwarning(_("Warning"),_("""You didn't select a directory.
 
-wmlindent will be run on the Wesnoth core directory""")
+wmlindent will be run on the Wesnoth core directory"""))
             wmlindent_command_string.append(WESNOTH_CORE_DIR)
         else: # path doesn't exist and isn't empty
-            showerror("Error","""The selected directory does not exists""")
+            showerror(_("Error"),_("""The selected directory does not exists"""))
             return # stop here
         # start thread and wmllint subprocess
         wmlindent_thread=ToolThread("wmlindent",self.queue,wmlindent_command_string)
         wmlindent_thread.start()
         # build popup
-        dialog=Popup(self.parent,"wmlindent",wmlindent_thread)
+        dialog=Popup(self.parent,_("wmlindent"),wmlindent_thread)
 
     def on_run_wmlxgettext(self):
         # build the command line and add the path of the Python interpreter
@@ -1353,26 +1419,27 @@ wmlindent will be run on the Wesnoth core directory""")
         if os.path.exists(umc_dir): # add-on exists
             wmlxgettext_command_string.append(umc_dir)
         elif not umc_dir: # path does not exists because the box was left empty
-            showwarning("Warning","""You didn't select a directory.
+            showwarning(_("Warning"),_("""You didn't select a directory.
 
-wmlxgettext won't be run""")
+wmlxgettext won't be run"""))
             return
         else: # path doesn't exist and isn't empty
-            showerror("Error","""The selected directory does not exists""")
+            showerror(_("Error"),_("""The selected directory does not exists"""))
             return
         if self.wmlxgettext_tab.recursive_variable.get():
             wmlxgettext_command_string.append("--recursive")
         output_file=self.wmlxgettext_tab.output_variable.get()
         if os.path.exists(output_file):
-            answer=askyesno(title="Overwrite confirmation",
-                            message="""File {} already exists.
-Do you want to overwrite it?""".format(output_file))
+            answer=askyesno(title=_("Overwrite confirmation"),
+                            # TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+                            message=_("""File {} already exists.
+Do you want to overwrite it?""").format(output_file))
             if not answer:
                 return
         elif not output_file:
-            showwarning("Warning","""You didn't select an output file.
+            showwarning(_("Warning"),_("""You didn't select an output file.
 
-wmlxgettext won't be run""")
+wmlxgettext won't be run"""))
             return
         wmlxgettext_command_string.extend(["-o",self.wmlxgettext_tab.output_variable.get()])
         if self.wmlxgettext_tab.warnall_variable.get():
@@ -1388,7 +1455,7 @@ wmlxgettext won't be run""")
         wmlxgettext_thread=ToolThread("wmlxgettext",self.queue,wmlxgettext_command_string)
         wmlxgettext_thread.start()
         # build popup
-        dialog=Popup(self.parent,"wmlxgettext",wmlxgettext_thread)
+        dialog=Popup(self.parent,_("wmlxgettext"),wmlxgettext_thread)
 
     def update_text(self):
         """Checks periodically if the queue is empty.
@@ -1399,9 +1466,9 @@ If it contains an error in form of a tuple, displays a message and pushes the re
             # if there's a tuple in the queue, it's because a tool exited with
             # non-zero status
             if isinstance(queue_item,tuple):
-                showerror("Error","""There was an error while executing {0}.
+                showerror(_("Error"),_("""There was an error while executing {0}.
 
-Error code: {1}""".format(queue_item[0],queue_item[1]))
+Error code: {1}""".format(queue_item[0],queue_item[1])))
             # otherwise it's just the output
             elif isinstance(queue_item,str):
                 self.text.configure(state=NORMAL)
@@ -1410,7 +1477,7 @@ Error code: {1}""".format(queue_item[0],queue_item[1]))
         self.after(100,self.update_text)
 
     def on_save(self):
-        fn=asksaveasfilename(defaultextension=".txt",filetypes=[("Text file","*.txt")],initialdir=".")
+        fn=asksaveasfilename(defaultextension=".txt",filetypes=[(_("Text file"),"*.txt")],initialdir=".")
         if fn:
             try:
                 with codecs.open(fn,"w","utf-8") as out:
@@ -1418,12 +1485,12 @@ Error code: {1}""".format(queue_item[0],queue_item[1]))
                 # the output is saved, if we close we don't lose anything
                 self.text.edit_modified(False)
             except IOError as error: # in case that we attempt to write without permissions
-                showerror("Error","""Error while writing to:
+                showerror(_("Error"),_("""Error while writing to:
 {0}
 
 Error code: {1}
 
-{2}""".format(fn,error.errno,error.strerror))
+{2}""".format(fn,error.errno,error.strerror)))
 
     def on_clear(self):
         self.text.configure(state=NORMAL)
@@ -1435,20 +1502,22 @@ Error code: {1}
         self.text.edit_modified(False)
 
     def on_about(self):
-        showinfo("About Maintenance tools GUI","""© Elvish_Hunter, 2014-2016
+        showinfo(_("About Maintenance tools GUI"),
+                # TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+                _("""© Elvish_Hunter, 2014-2016
 
 Version: {}
 
 Part of The Battle for Wesnoth project and released under the GNU GPL v2 license
 
-Icons are taken from the Tango Desktop Project (http://tango.freedesktop.org), and are released in the Public Domain""".format(version.as_string))
+Icons are taken from the Tango Desktop Project (http://tango.freedesktop.org), and are released in the Public Domain""").format(version.as_string))
 
     def on_quit(self):
         # check if the text widget contains something
         # and ask for a confirmation if so
         if self.text.edit_modified():
-            answer = askyesno("Exit confirmation",
-                              "Do you really want to quit?",
+            answer = askyesno(_("Exit confirmation"),
+                              _("Do you really want to quit?"),
                               icon = WARNING)
             if answer:
                 ICONS.clear()
@@ -1728,5 +1797,5 @@ VEPjiOPN2tys7Y04Zj8UEAA7''')
     sys.exit(0)
 else:
     root.withdraw() # avoid showing a blank Tk window
-    showerror("Error","This application must be placed into the wesnoth/data/tools directory")
+    showerror(_("Error"),_("This application must be placed into the wesnoth/data/tools directory"))
     sys.exit(1)

--- a/data/tools/wmlxgettext
+++ b/data/tools/wmlxgettext
@@ -86,6 +86,13 @@ def commandline(args):
               'every WML/Lua file should start from this directory.')
     )
     parser.add_argument(
+        '--force-po',
+        action='store_true',
+        default=False,
+        dest='force_po',
+        help=('Write PO file even if empty.')
+    )
+    parser.add_argument(
         '--initialdomain',
         default='wesnoth',
         dest='initdom',
@@ -250,6 +257,11 @@ def main():
             # Back-compat
             folder, filename = os.path.split(folder)
         os.makedirs(folder, exist_ok=True)
+
+    if args.force_po and args.domain is not None:
+        for domain in args.domain:
+            if not domain in sentlist:
+                sentlist[domain] = dict()
 
     for domain, d in sentlist.items():
         if folder is not None:

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -22,6 +22,7 @@ set(NORMAL_DOMAINS
 	wesnoth-sotbe
 	wesnoth-tb
 	wesnoth-thot
+	wesnoth-tools
 	wesnoth-trow
 	wesnoth-tsg
 	wesnoth-tutorial

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -1,7 +1,7 @@
 ############ Settings. ###########
 set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM true)
 
-# The normal domains use cpp and cfg files.
+# The normal domains use cfg, cpp, lua, py files.
 set(NORMAL_DOMAINS
 	wesnoth
 	wesnoth-anl
@@ -56,40 +56,55 @@ if(ENABLE_POT_UPDATE_TARGET)
 		# Update the source file dependencies.
 		include(update_pot_source_dependencies)
 
-		# Generate pot file for c++ data.
+		# Generate pot file for C++ strings.
 		add_custom_command(
 			# misses bug address
 			OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
 			# create the pot file make sure we always get output.
 			COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} ${GETTEXT_XGETTEXT_OPTIONS}
-					--files-from=${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
+					--files-from=${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_CPP.in
 					--output=${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
 			# replace the chartype
 			COMMAND sed -i
 				s/charset=CHARSET/charset=UTF-8/
 				${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
-			# Remove some header info - Need to test whether needed.
-			DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES.in
+			DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_CPP.in
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-			COMMENT "pot-update [${DOMAIN}]: Generated source pot file."
+			COMMENT "pot-update [${DOMAIN}]: Generating source pot file."
 		)
 
-		# Generate pot file for wml data.
+		# Generate pot file for Python strings.
+		add_custom_command(
+			OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.py.pot
+			# create the pot file make sure we always get output.
+			COMMAND ${GETTEXT_XGETTEXT_EXECUTABLE} ${GETTEXT_XGETTEXT_OPTIONS}
+					--language=Python
+					--files-from=${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_PY.in
+					--output=${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.py.pot
+			# replace the chartype
+			COMMAND sed -i
+				s/charset=CHARSET/charset=UTF-8/
+				${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.py.pot
+			DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/POTFILES_PY.in
+			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+			COMMENT "pot-update [${DOMAIN}]: Generating python pot file."
+		)
+		# Generate pot file for WML/Lua strings.
 		add_custom_command(
 			OUTPUT ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.wml.pot
 
-			COMMAND ${WMLXGETTEXT}
-				--directory=${PROJECT_SOURCE_DIR}
+			COMMAND ${Python_EXECUTABLE} ${WMLXGETTEXT}
+				--force-po
 				--domain=${DOMAIN}
 				`cd ${PROJECT_SOURCE_DIR} &&
 					sh ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/FINDCFG`
 					-o ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.wml.pot
 			DEPENDS ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/FINDCFG
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-			COMMENT "pot-update [${DOMAIN}]: Generated wml pot file."
+			COMMENT "pot-update [${DOMAIN}]: Generating wml pot file."
 		)
 
-		# Merge both pot files
+		# Merge pot files
 		add_custom_command(
 			# The old function checked for differences in the time in the header see
 			# what we need to do with it.
@@ -98,18 +113,21 @@ if(ENABLE_POT_UPDATE_TARGET)
 			COMMAND ${GETTEXT_MSGCAT_EXECUTABLE}
 				--sort-by-file
 					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
+					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.py.pot
 					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.wml.pot
 				--output ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.pot
 
 			COMMAND ${CMAKE_COMMAND} -E remove
 					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
+					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.py.pot
 					 ${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.wml.pot
 
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 			DEPENDS
 					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.cpp.pot
+					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.py.pot
 					${PROJECT_SOURCE_DIR}/po/${DOMAIN}/${DOMAIN}.wml.pot
-			COMMENT "pot-update [${DOMAIN}]: Generated pot file."
+			COMMENT "pot-update [${DOMAIN}]: Generating pot file."
 		)
 
 		# Update / generate the po files for all languages

--- a/po/FINDCPP
+++ b/po/FINDCPP
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Lists localizable CPP files.
+# Excludes files in .git folders.
+#
+# Syntax:
+# FINDCPP DOMAIN --initialdomain INITIAL_DOMAIN
+#
+# --initialdomain: Files without an explicit domain default to this value.
+
+import argparse
+import glob
+import re
+from pathlib import Path
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser()
+    ap.add_argument('domain') # Single positional argument
+    ap.add_argument('--initialdomain', dest='initdom') # Optional
+    args = ap.parse_args()
+    # Whether the input string has any explicit text domain.
+    any_regexp = re.compile("^#define  *GETTEXT_DOMAIN", re.MULTILINE)
+    # Whether the input string has defined args.domain as its text domain.
+    domain_regexp = re.compile("^#define  *GETTEXT_DOMAIN  *\"" + re.escape(args.domain) + "\"", re.MULTILINE)
+    cpp_files = glob.glob("src/**/*.cpp", recursive=True)
+    # Apparently, some people insist in adding translatable strings to header files (6bf76d940).
+    cpp_files.extend(glob.glob("src/**/*.hpp", recursive=True))
+    cpp_files.sort()
+    for p in cpp_files:
+        # In Windows, glob search yields paths with mixed separators (/\).
+        path = Path(p)
+        # Exclude any .git subdirectories.
+        if ".git" in path.parts:
+            continue
+        content = path.read_text(encoding='utf8')
+
+        # For the default domain, first check that there is no domain defined,
+        # but still search for domain_regexp otherwise.
+        if args.domain == args.initdom and not re.search(any_regexp, content):
+            # Produce output with / only.
+            print(path.as_posix())
+        elif re.search(domain_regexp, content):
+            # Produce output with / only.
+            print(path.as_posix())

--- a/po/FINDPY
+++ b/po/FINDPY
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Lists localizable Python scripts and modules.
+# Excludes files in .git folders.
+#
+# Syntax:
+# FINDPY DOMAIN
+#
+# In contrast to FINDCPP, there is no default domain.
+
+import argparse
+import glob
+import re
+from pathlib import Path
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('domain') # Single positional argument.
+    args = parser.parse_args()
+    # Whether the input string has defined args.domain as its text domain.
+    domain_regexp = re.compile(" *_ *= *gettext\\.translation\\((['\"])" + re.escape(args.domain) + "\\1")
+    py_files = glob.glob("data/tools/**/*.py", recursive=True)
+    # Executable files are hardcoded rather than scanning for +x (which doesn't exist in Windows),
+    # and matching shebang line.
+    py_files.extend([
+        "data/tools/GUI.pyw",
+        "data/tools/about_cfg_to_wiki",
+        "data/tools/check_mixed_indent" ,
+        "data/tools/extractbindings",
+        "data/tools/imgcheck",
+        "data/tools/steam-changelog",
+        "data/tools/TeamColorizer",
+        "data/tools/tmx_trackplacer",
+        "data/tools/wesnoth_addon_manager",
+        "data/tools/wmlflip",
+        "data/tools/wmlindent",
+        "data/tools/wmllint",
+        "data/tools/wmllint-1.4",
+        "data/tools/wmlscope",
+        "data/tools/wmlunits",
+        "data/tools/wmlxgettext"
+    ])
+    py_files.sort()
+    for p in py_files:
+        # In Windows, glob search yields paths with mixed separators (/\).
+        path = Path(p)
+        # Exclude any .git subdirectories.
+        if ".git" in path.parts:
+            continue
+        if re.search(domain_regexp, path.read_text(encoding='utf8')):
+            # Produce output with / only.
+            print(path.as_posix())

--- a/po/SConscript
+++ b/po/SConscript
@@ -4,7 +4,7 @@ from subprocess import Popen, PIPE
 import os, shutil
 import re
 from fnmatch import fnmatch
-from os.path import join
+from os.path import join, relpath
 Import("env")
 
 def remove_pot_cdate(path):
@@ -26,19 +26,46 @@ textdomains = glob("wesnoth*")
 po4a_domains = Split("wesnoth-manpages wesnoth-manual")
 textdomains = [domain for domain in textdomains if os.path.isdir(domain) and os.path.exists(domain+"/"+domain+".pot")]
 linguas = Split(open("LINGUAS").read())
+intermediate_exts = {
+    "cpp": "C++",
+    "py": "Python",
+}
 
 if "pot-update" in COMMAND_LINE_TARGETS:
     from collections import defaultdict
-    domain_sources = defaultdict(list)
+    domain_sources = {ext: defaultdict(list) for ext in intermediate_exts}
     for root, dirs, files in os.walk("../src"):
         for file in files:
             if fnmatch(file, "*.[hc]pp"):
-                match = re.search('^#define\\s+GETTEXT_DOMAIN\\s+"wesnoth(-.*)"', Dir(root).File(file).get_contents().decode("utf-8"), re.MULTILINE)
+                match = re.search(r'^#define\s+GETTEXT_DOMAIN\s+"(wesnoth(?:-.*)?)"', Dir(root).File(file).get_contents().decode("utf-8"), re.MULTILINE)
                 if match:
                     source_domain = match.group(1)
                 else:
-                    source_domain = ""
-                domain_sources[source_domain].append(Dir(root).File(file).path)
+                    # Default to wesnoth textdomain
+                    source_domain = "wesnoth"
+                domain_sources["cpp"][source_domain].append(Dir(root).File(file).path)
+    for root, dirs, files in os.walk("../data/tools"):
+        for file in files:
+            is_python = fnmatch(file, "*.py*")
+            file_content = None
+            if not is_python and not os.path.isdir(os.path.join(root, file)):
+                file_content = Dir(root).File(file).get_contents()
+                first_line = file_content.split(b"\n")[0]
+                is_python = first_line[0:3] == b'^#!' and b'python' in first_line
+            if is_python:
+                if file_content is None:
+                    file_content = Dir(root).File(file).get_contents()
+                try:
+                    match = re.search(r'^\s*_\s*=\s*gettext\.translation\(\s*([\'"])(wesnoth(?:-.*)?)\1', file_content.decode("utf-8"), re.MULTILINE)
+                    if match:
+                        source_domain = match.group(2)
+                        domain_sources["py"][source_domain].append(Dir(root).File(file).path)
+                    # In contrast to CPP, there is no default.
+                except UnicodeDecodeError as ex:
+                    pass
+                finally:
+                    file_content = None
+                
 
     for domain in textdomains:
         pot = File(join(domain, domain + ".pot"))
@@ -48,22 +75,28 @@ if "pot-update" in COMMAND_LINE_TARGETS:
         if domain in po4a_domains:
             continue
 
-        with open(join(domain, "POTFILES.in"), "w") as potfiles:
-            potfiles.writelines([line + "\n" for line in sorted(domain_sources[domain[7:]])])
-        sources = [Dir("#").File(x) for x in domain_sources[domain[7:]]]
-        if sources:
-            source_pot = env.Command(
-                join(domain, domain + ".cpp.pot"),
-                sources,
-                """xgettext --force-po --default-domain=%s --directory=. --add-comments=TRANSLATORS: \
-                --from-code=UTF-8 --sort-by-file \
-                --keyword=_ --keyword=N_ --keyword=sgettext --keyword=vgettext --keyword=VGETTEXT \
-                --keyword=_n:1,2 --keyword=N_n:1,2 --keyword=sngettext:1,2 --keyword=vngettext:1,2 --keyword=VNGETTEXT:1,2 \
-                --files-from=%s --copyright-holder='Wesnoth development team' --msgid-bugs-address=https://bugs.wesnoth.org/ \
-                --output=$TARGET \
-                ; sed -i s/charset=CHARSET/charset=UTF-8/ $TARGET \
-                """ % (domain, join("po", domain, "POTFILES.in"))
+        intermediate_files = []
+        for ext, language in intermediate_exts.items():
+            files_from = join("po", domain, "POTFILES_{}.in".format(ext.upper()))
+            with open(relpath(files_from, "po"), "w") as potfiles:
+                potfiles.writelines([line + "\n" for line in sorted(domain_sources[ext][domain])])
+            file_list = [Dir("#").File(x) for x in domain_sources[ext][domain]]
+            if file_list:
+                target_path = env.Command(
+                    join(domain, "{}.{}.pot".format(domain, ext)),
+                    file_list,
+                    """xgettext --force-po --default-domain={default_domain} --directory=. --add-comments=TRANSLATORS: \
+                    --from-code=UTF-8 --language={language} --sort-by-file \
+                    --keyword=_ --keyword=N_ --keyword=sgettext --keyword=vgettext --keyword=VGETTEXT \
+                    --keyword=_n:1,2 --keyword=N_n:1,2 --keyword=sngettext:1,2 --keyword=vngettext:1,2 --keyword=VNGETTEXT:1,2 \
+                    --files-from={files_from} --copyright-holder='Wesnoth development team' --msgid-bugs-address=https://bugs.wesnoth.org/ \
+                    --output=$TARGET \
+                    ; sed -i s/charset=CHARSET/charset=UTF-8/ $TARGET \
+                    """.format(default_domain=domain, language=language, files_from=files_from)
                 )
+                intermediate_files.append(target_path)
+
+        # wml/lua
         cfgs = []
         FINDCFG = join(domain, "FINDCFG")
         if os.path.exists(FINDCFG):
@@ -73,22 +106,17 @@ if "pot-update" in COMMAND_LINE_TARGETS:
             wml_pot = env.Command(
                 join(domain, domain + ".wml.pot"),
                 cfgs,
-                "data/tools/wmlxgettext --directory=. --domain=%s $SOURCES -o $TARGET" % domain
+                "data/tools/wmlxgettext --force-po --directory=. --domain=%s $SOURCES -o $TARGET" % domain
                 )
+            intermediate_files.append(wml_pot)
 
         new_pot = str(pot) + ".new"
-        if cfgs and sources:
-            env.Command(new_pot, [source_pot, wml_pot],
+
+        env.Command(new_pot, intermediate_files,
                 [
                     "msgcat --sort-by-file $SOURCES -o $TARGET",
-                    Delete(wml_pot),
-                    Delete(source_pot)
-                ]
+                ] + list(map(Delete, intermediate_files))
             )
-        elif cfgs:
-            env.Command(new_pot, wml_pot, ["msgcat --sort-by-file $SOURCES -o $TARGET", Delete(wml_pot)])
-        else:
-            env.Command(new_pot, source_pot, ["msgcat --sort-by-file $SOURCES -o $TARGET", Delete(source_pot)])
         env.Command(pot, new_pot, Action(update_pot))
 
     env.Alias("pot-update", "../translations", "python3 utils/po_stat.py --update-cfg --textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units")

--- a/po/wesnoth-tools/FINDCFG
+++ b/po/wesnoth-tools/FINDCFG
@@ -1,0 +1,2 @@
+find data -name '*.cfg' -print
+find data -name '*.lua' -print

--- a/po/wesnoth-tools/af.po
+++ b/po/wesnoth-tools/af.po
@@ -1,0 +1,495 @@
+# Afrikaans translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ang@latin.po
+++ b/po/wesnoth-tools/ang@latin.po
@@ -1,0 +1,495 @@
+# Old English translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ang@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ar.po
+++ b/po/wesnoth-tools/ar.po
@@ -1,0 +1,495 @@
+# Arabic translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/bg.po
+++ b/po/wesnoth-tools/bg.po
@@ -1,0 +1,496 @@
+# Bulgarian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ca.po
+++ b/po/wesnoth-tools/ca.po
@@ -1,0 +1,495 @@
+# Catalan translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ca_ES@valencia.po
+++ b/po/wesnoth-tools/ca_ES@valencia.po
@@ -1,0 +1,495 @@
+# Catalan translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca_ES@valencia\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/cs.po
+++ b/po/wesnoth-tools/cs.po
@@ -1,0 +1,496 @@
+# Czech translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/da.po
+++ b/po/wesnoth-tools/da.po
@@ -1,0 +1,496 @@
+# Danish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/de.po
+++ b/po/wesnoth-tools/de.po
@@ -1,0 +1,496 @@
+# German translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/el.po
+++ b/po/wesnoth-tools/el.po
@@ -1,0 +1,496 @@
+# Greek translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/en@shaw.po
+++ b/po/wesnoth-tools/en@shaw.po
@@ -1,0 +1,553 @@
+# English translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en@shaw\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr "Open a Graphical User Interface (GUI) to WML Tools"
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr "LANGUAGE"
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr "Error"
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr "Locale {0} not recognized."
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+"Running: {0}\n"
+"Please wait..."
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr "Terminate script"
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr "Cut"
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr "Copy"
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr "Paste"
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr "Select all"
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr "Directory"
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr "Browse..."
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr "Clear"
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr "wmllint mode"
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr "Normal"
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr "Perform file conversion"
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr "Dry run"
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr "Do not perform changes"
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr "Clean"
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr "Delete *.bak files"
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr "Diff"
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr "Show differences in converted files"
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr "Revert"
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr "Revert conversions using *.bak files"
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr "Verbosity level"
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr "Terse"
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr "List changes"
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr "Name files before processing"
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr "Show parse details"
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr "wmllint options"
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr "Convert EOL characters to Unix style"
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr "Don't warn about tags without side= keys"
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr "Disable checks for unknown units"
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr "Disable spellchecking"
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr "Skip core directory"
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr "wmlscope options"
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr "Check for duplicate macro definitions"
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr "Check for duplicate resource files"
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr "Make definition list"
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr "List files that will be processed"
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr "Report unresolved macro references"
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr "Extract help from macro definition comments"
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr "Report all macros with untyped formals"
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr "Show progress"
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr "Exclude files matching regexp:"
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr "Exclude files not matching regexp:"
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr "Report macro definitions and usages in file"
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr "Allow unused macros with names matching regexp:"
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr "wmlindent mode"
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr "Verbose"
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr "Report unchanged files"
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr "wmlindent options"
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+"Exclude files\n"
+"matching regexp:"
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr "Do not generate output"
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr "Output dir:"
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr "Options"
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr "Scan subdirectories"
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr "Show optional warnings"
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr "Mark all strings as fuzzy"
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr "Advanced options"
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr "Package version"
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr "Initial textdomain:"
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr "Run wmllint"
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr "Save as text..."
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr "Clear output"
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr "About..."
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr "Exit"
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr "wmllint"
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr "wmlscope"
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr "wmlindent"
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr "wmlxgettext"
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr "Output"
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr "Run wmlscope"
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr "Run wmlindent"
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr "Run wmlxgettext"
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr "Warning"
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr "The selected directory does not exists"
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+"You typed an invalid value. Value must be an integer in the range 0-999"
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr "Overwrite confirmation"
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr "Text file"
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr "About Maintenance tools GUI"
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr "Exit confirmation"
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr "Do you really want to quit?"
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr "This application must be placed into the wesnoth/data/tools directory"

--- a/po/wesnoth-tools/en_GB.po
+++ b/po/wesnoth-tools/en_GB.po
@@ -1,0 +1,553 @@
+# English translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_GB\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr "Open a Graphical User Interface (GUI) to WML Tools"
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr "LANGUAGE"
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr "Error"
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr "Locale {0} not recognized."
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+"Running: {0}\n"
+"Please wait..."
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr "Terminate script"
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr "Cut"
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr "Copy"
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr "Paste"
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr "Select all"
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr "Directory"
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr "Browse..."
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr "Clear"
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr "wmllint mode"
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr "Normal"
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr "Perform file conversion"
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr "Dry run"
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr "Do not perform changes"
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr "Clean"
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr "Delete *.bak files"
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr "Diff"
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr "Show differences in converted files"
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr "Revert"
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr "Revert conversions using *.bak files"
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr "Verbosity level"
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr "Terse"
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr "List changes"
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr "Name files before processing"
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr "Show parse details"
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr "wmllint options"
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr "Convert EOL characters to Unix style"
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr "Don't warn about tags without side= keys"
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr "Disable checks for unknown units"
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr "Disable spellchecking"
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr "Skip core directory"
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr "wmlscope options"
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr "Check for duplicate macro definitions"
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr "Check for duplicate resource files"
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr "Make definition list"
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr "List files that will be processed"
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr "Report unresolved macro references"
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr "Extract help from macro definition comments"
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr "Report all macros with untyped formals"
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr "Show progress"
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr "Exclude files matching regexp:"
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr "Exclude files not matching regexp:"
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr "Report macro definitions and usages in file"
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr "Allow unused macros with names matching regexp:"
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr "wmlindent mode"
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr "Verbose"
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr "Report unchanged files"
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr "wmlindent options"
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+"Exclude files\n"
+"matching regexp:"
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr "Do not generate output"
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr "Output dir:"
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr "Options"
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr "Scan subdirectories"
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr "Show optional warnings"
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr "Mark all strings as fuzzy"
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr "Advanced options"
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr "Package version"
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr "Initial textdomain:"
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr "Run wmllint"
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr "Save as text..."
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr "Clear output"
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr "About..."
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr "Exit"
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr "wmllint"
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr "wmlscope"
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr "wmlindent"
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr "wmlxgettext"
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr "Output"
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr "Run wmlscope"
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr "Run wmlindent"
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr "Run wmlxgettext"
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr "Warning"
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr "The selected directory does not exists"
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+"You typed an invalid value. Value must be an integer in the range 0-999"
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr "Overwrite confirmation"
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr "Text file"
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr "About Maintenance tools GUI"
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr "Exit confirmation"
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr "Do you really want to quit?"
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr "This application must be placed into the wesnoth/data/tools directory"

--- a/po/wesnoth-tools/eo.po
+++ b/po/wesnoth-tools/eo.po
@@ -1,0 +1,496 @@
+# Esperanto translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/es.po
+++ b/po/wesnoth-tools/es.po
@@ -1,0 +1,496 @@
+# Spanish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/es_419.po
+++ b/po/wesnoth-tools/es_419.po
@@ -1,0 +1,496 @@
+# Spanish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es_419\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/et.po
+++ b/po/wesnoth-tools/et.po
@@ -1,0 +1,496 @@
+# Estonian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/eu.po
+++ b/po/wesnoth-tools/eu.po
@@ -1,0 +1,495 @@
+# Basque translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/fi.po
+++ b/po/wesnoth-tools/fi.po
@@ -1,0 +1,496 @@
+# Finnish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/fr.po
+++ b/po/wesnoth-tools/fr.po
@@ -1,0 +1,496 @@
+# French translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ga.po
+++ b/po/wesnoth-tools/ga.po
@@ -1,0 +1,496 @@
+# Irish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ga\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n==2 ? 1 : 2;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/gd.po
+++ b/po/wesnoth-tools/gd.po
@@ -1,0 +1,495 @@
+# Scottish Gaelic translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gd\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/gl.po
+++ b/po/wesnoth-tools/gl.po
@@ -1,0 +1,495 @@
+# Galician translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/grc.po
+++ b/po/wesnoth-tools/grc.po
@@ -1,0 +1,495 @@
+# Language grc translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: grc\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/he.po
+++ b/po/wesnoth-tools/he.po
@@ -1,0 +1,496 @@
+# Hebrew translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/hr.po
+++ b/po/wesnoth-tools/hr.po
@@ -1,0 +1,497 @@
+# Croatian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/hu.po
+++ b/po/wesnoth-tools/hu.po
@@ -1,0 +1,496 @@
+# Hungarian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/id.po
+++ b/po/wesnoth-tools/id.po
@@ -1,0 +1,495 @@
+# Indonesian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/is.po
+++ b/po/wesnoth-tools/is.po
@@ -1,0 +1,495 @@
+# Icelandic translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/it.po
+++ b/po/wesnoth-tools/it.po
@@ -1,0 +1,496 @@
+# Italian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ja.po
+++ b/po/wesnoth-tools/ja.po
@@ -1,0 +1,496 @@
+# Japanese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ko.po
+++ b/po/wesnoth-tools/ko.po
@@ -1,0 +1,496 @@
+# Korean translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/la.po
+++ b/po/wesnoth-tools/la.po
@@ -1,0 +1,495 @@
+# Latin translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: la\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/lt.po
+++ b/po/wesnoth-tools/lt.po
@@ -1,0 +1,497 @@
+# Lithuanian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/lv.po
+++ b/po/wesnoth-tools/lv.po
@@ -1,0 +1,497 @@
+# Latvian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/mk.po
+++ b/po/wesnoth-tools/mk.po
@@ -1,0 +1,495 @@
+# Macedonian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/mr.po
+++ b/po/wesnoth-tools/mr.po
@@ -1,0 +1,495 @@
+# Marathi translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/my.po
+++ b/po/wesnoth-tools/my.po
@@ -1,0 +1,495 @@
+# Burmese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: my\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/nb_NO.po
+++ b/po/wesnoth-tools/nb_NO.po
@@ -1,0 +1,496 @@
+# Norwegian Bokmal translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/nl.po
+++ b/po/wesnoth-tools/nl.po
@@ -1,0 +1,496 @@
+# Dutch translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/pl.po
+++ b/po/wesnoth-tools/pl.po
@@ -1,0 +1,497 @@
+# Polish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/pt.po
+++ b/po/wesnoth-tools/pt.po
@@ -1,0 +1,496 @@
+# Portuguese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/pt_BR.po
+++ b/po/wesnoth-tools/pt_BR.po
@@ -1,0 +1,496 @@
+# Portuguese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/racv.po
+++ b/po/wesnoth-tools/racv.po
@@ -1,0 +1,495 @@
+# Language racv translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: racv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ro.po
+++ b/po/wesnoth-tools/ro.po
@@ -1,0 +1,497 @@
+# Romanian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/ru.po
+++ b/po/wesnoth-tools/ru.po
@@ -1,0 +1,497 @@
+# Russian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sk.po
+++ b/po/wesnoth-tools/sk.po
@@ -1,0 +1,496 @@
+# Slovak translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sl.po
+++ b/po/wesnoth-tools/sl.po
@@ -1,0 +1,497 @@
+# Slovenian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sr.po
+++ b/po/wesnoth-tools/sr.po
@@ -1,0 +1,497 @@
+# Serbian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sr@ijekavian.po
+++ b/po/wesnoth-tools/sr@ijekavian.po
@@ -1,0 +1,497 @@
+# Serbian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@ijekavian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sr@ijekavianlatin.po
+++ b/po/wesnoth-tools/sr@ijekavianlatin.po
@@ -1,0 +1,497 @@
+# Serbian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@ijekavianlatin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sr@latin.po
+++ b/po/wesnoth-tools/sr@latin.po
@@ -1,0 +1,497 @@
+# Serbian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/sv.po
+++ b/po/wesnoth-tools/sv.po
@@ -1,0 +1,496 @@
+# Swedish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/tl.po
+++ b/po/wesnoth-tools/tl.po
@@ -1,0 +1,495 @@
+# Tagalog translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/tr.po
+++ b/po/wesnoth-tools/tr.po
@@ -1,0 +1,496 @@
+# Turkish translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/uk.po
+++ b/po/wesnoth-tools/uk.po
@@ -1,0 +1,497 @@
+# Ukrainian translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/vi.po
+++ b/po/wesnoth-tools/vi.po
@@ -1,0 +1,496 @@
+# Vietnamese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/wesnoth-tools.pot
+++ b/po/wesnoth-tools/wesnoth-tools.pot
@@ -1,0 +1,496 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/zh_CN.po
+++ b/po/wesnoth-tools/zh_CN.po
@@ -1,0 +1,495 @@
+# Chinese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""

--- a/po/wesnoth-tools/zh_TW.po
+++ b/po/wesnoth-tools/zh_TW.po
@@ -1,0 +1,495 @@
+# Chinese translations for PACKAGE package.
+# Copyright (C) 2023 Wesnoth development team
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: https://bugs.wesnoth.org/\n"
+"POT-Creation-Date: 2023-05-29 16:27-0500\n"
+"PO-Revision-Date: 2023-05-29 16:27-0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: data/tools/GUI.pyw:58
+msgid "Open a Graphical User Interface (GUI) to WML Tools"
+msgstr ""
+
+#: data/tools/GUI.pyw:59
+msgid "LANGUAGE"
+msgstr ""
+
+#. TRANSLATORS: ISO 15897 "Procedures for the registration of cultural elements" specifies use
+#. of underscores in the locale id. For example, use en_GB, not en-GB.
+#: data/tools/GUI.pyw:65
+msgid ""
+"Launch GUI.pyw in the given language. Language code must follow ISO 15897 (e."
+"g. en_GB)."
+msgstr ""
+
+#: data/tools/GUI.pyw:70 data/tools/GUI.pyw:77 data/tools/GUI.pyw:1254
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1344 data/tools/GUI.pyw:1368
+#: data/tools/GUI.pyw:1403 data/tools/GUI.pyw:1427 data/tools/GUI.pyw:1469
+#: data/tools/GUI.pyw:1488 data/tools/GUI.pyw:1800
+msgid "Error"
+msgstr ""
+
+#. TRANSLATORS: {0} is "translations", the folder where compiled translation files (.mo) are stored.
+#: data/tools/GUI.pyw:72
+#, python-brace-format
+msgid ""
+"`{0}` folder not found. Please run the GUI.pyw executable packaged with the "
+"Wesnoth installation."
+msgstr ""
+
+#. TRANSLATORS: {0} is the ISO 15897 code for the language selected by the user.
+#: data/tools/GUI.pyw:79
+#, python-brace-format
+msgid "Locale {0} not recognized."
+msgstr ""
+
+#. TRANSLATORS: {0} is the name of command being executed.
+#: data/tools/GUI.pyw:329
+#, python-brace-format
+msgid ""
+"Running: {0}\n"
+"Please wait..."
+msgstr ""
+
+#: data/tools/GUI.pyw:343
+msgid "Terminate script"
+msgstr ""
+
+#: data/tools/GUI.pyw:391
+msgid "Cut"
+msgstr ""
+
+#: data/tools/GUI.pyw:396
+msgid "Copy"
+msgstr ""
+
+#: data/tools/GUI.pyw:402
+msgid "Paste"
+msgstr ""
+
+#: data/tools/GUI.pyw:408
+msgid "Select all"
+msgstr ""
+
+#: data/tools/GUI.pyw:470
+msgid "Directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:482 data/tools/GUI.pyw:521
+msgid "Browse..."
+msgstr ""
+
+#: data/tools/GUI.pyw:488 data/tools/GUI.pyw:527
+msgid "Clear"
+msgstr ""
+
+#: data/tools/GUI.pyw:570
+msgid "wmllint mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:575 data/tools/GUI.pyw:944
+msgid "Normal"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Normal.
+#: data/tools/GUI.pyw:583 data/tools/GUI.pyw:953
+msgid "Perform file conversion"
+msgstr ""
+
+#: data/tools/GUI.pyw:585 data/tools/GUI.pyw:955
+msgid "Dry run"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Dry run.
+#: data/tools/GUI.pyw:594 data/tools/GUI.pyw:963
+msgid "Do not perform changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:596
+msgid "Clean"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Clean.
+#: data/tools/GUI.pyw:605
+msgid "Delete *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:607
+msgid "Diff"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Diff.
+#: data/tools/GUI.pyw:616
+msgid "Show differences in converted files"
+msgstr ""
+
+#: data/tools/GUI.pyw:618
+msgid "Revert"
+msgstr ""
+
+#. TRANSLATORS: Explanation for Revert.
+#: data/tools/GUI.pyw:627
+msgid "Revert conversions using *.bak files"
+msgstr ""
+
+#: data/tools/GUI.pyw:629 data/tools/GUI.pyw:965
+msgid "Verbosity level"
+msgstr ""
+
+#: data/tools/GUI.pyw:635 data/tools/GUI.pyw:971
+msgid "Terse"
+msgstr ""
+
+#: data/tools/GUI.pyw:643
+msgid "List changes"
+msgstr ""
+
+#: data/tools/GUI.pyw:651
+msgid "Name files before processing"
+msgstr ""
+
+#: data/tools/GUI.pyw:659
+msgid "Show parse details"
+msgstr ""
+
+#: data/tools/GUI.pyw:667
+msgid "wmllint options"
+msgstr ""
+
+#. TRANSLATORS: Special characters marking end of line.
+#: data/tools/GUI.pyw:674
+msgid "Convert EOL characters to Unix style"
+msgstr ""
+
+#: data/tools/GUI.pyw:682
+msgid "Don't warn about tags without side= keys"
+msgstr ""
+
+#: data/tools/GUI.pyw:690
+msgid "Disable checks for unknown units"
+msgstr ""
+
+#: data/tools/GUI.pyw:698
+msgid "Disable spellchecking"
+msgstr ""
+
+#: data/tools/GUI.pyw:706
+msgid "Skip core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:730
+msgid "wmlscope options"
+msgstr ""
+
+#: data/tools/GUI.pyw:740
+msgid "Check for duplicate macro definitions"
+msgstr ""
+
+#: data/tools/GUI.pyw:748
+msgid "Check for duplicate resource files"
+msgstr ""
+
+#: data/tools/GUI.pyw:756
+msgid "Make definition list"
+msgstr ""
+
+#: data/tools/GUI.pyw:764
+msgid "List files that will be processed"
+msgstr ""
+
+#: data/tools/GUI.pyw:772
+msgid "Report unresolved macro references"
+msgstr ""
+
+#: data/tools/GUI.pyw:780
+msgid "Extract help from macro definition comments"
+msgstr ""
+
+#: data/tools/GUI.pyw:788
+msgid "Report all macros with untyped formals"
+msgstr ""
+
+#: data/tools/GUI.pyw:796
+msgid "Show progress"
+msgstr ""
+
+#: data/tools/GUI.pyw:813
+msgid "Exclude files matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:830
+msgid "Exclude files not matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:847
+msgid ""
+"Report only on macros referenced\n"
+"in exactly n files:"
+msgstr ""
+
+#: data/tools/GUI.pyw:866
+msgid "Report macro definitions and usages in file"
+msgstr ""
+
+#. TRANSLATORS: regexp is "regular expression".
+#: data/tools/GUI.pyw:884
+msgid "Allow unused macros with names matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:939
+msgid "wmlindent mode"
+msgstr ""
+
+#: data/tools/GUI.pyw:979
+msgid "Verbose"
+msgstr ""
+
+#: data/tools/GUI.pyw:987
+msgid "Report unchanged files"
+msgstr ""
+
+#: data/tools/GUI.pyw:995
+msgid "wmlindent options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1001
+msgid ""
+"Exclude files\n"
+"matching regexp:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1019
+msgid "Do not generate output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1041
+msgid "Output dir:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1047
+msgid "Options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1052
+msgid "Scan subdirectories"
+msgstr ""
+
+#: data/tools/GUI.pyw:1057
+msgid "Show optional warnings"
+msgstr ""
+
+#. TRANSLATORS: Also called "Needs work".
+#: data/tools/GUI.pyw:1063
+msgid "Mark all strings as fuzzy"
+msgstr ""
+
+#: data/tools/GUI.pyw:1067
+msgid "Advanced options"
+msgstr ""
+
+#: data/tools/GUI.pyw:1071
+msgid "Package version"
+msgstr ""
+
+#: data/tools/GUI.pyw:1088
+msgid "Initial textdomain:"
+msgstr ""
+
+#: data/tools/GUI.pyw:1131 data/tools/GUI.pyw:1237
+msgid "Run wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1138
+msgid "Save as text..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1145
+msgid "Clear output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1152
+msgid "About..."
+msgstr ""
+
+#: data/tools/GUI.pyw:1159
+msgid "Exit"
+msgstr ""
+
+#: data/tools/GUI.pyw:1175 data/tools/GUI.pyw:1308
+msgid "wmllint"
+msgstr ""
+
+#: data/tools/GUI.pyw:1179 data/tools/GUI.pyw:1374
+msgid "wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1183 data/tools/GUI.pyw:1409
+msgid "wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1187 data/tools/GUI.pyw:1458
+msgid "wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1190
+msgid "Output"
+msgstr ""
+
+#: data/tools/GUI.pyw:1240
+msgid "Run wmlscope"
+msgstr ""
+
+#: data/tools/GUI.pyw:1243
+msgid "Run wmlindent"
+msgstr ""
+
+#: data/tools/GUI.pyw:1246
+msgid "Run wmlxgettext"
+msgstr ""
+
+#: data/tools/GUI.pyw:1254
+msgid ""
+"wmllint cannot run because there is no directory selected.\n"
+"\n"
+"Please select a directory or disable the \"Skip core directory\" option"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292 data/tools/GUI.pyw:1298 data/tools/GUI.pyw:1358
+#: data/tools/GUI.pyw:1364 data/tools/GUI.pyw:1398 data/tools/GUI.pyw:1422
+#: data/tools/GUI.pyw:1440
+msgid "Warning"
+msgstr ""
+
+#: data/tools/GUI.pyw:1292
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1298
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmllint will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1302 data/tools/GUI.pyw:1368 data/tools/GUI.pyw:1403
+#: data/tools/GUI.pyw:1427
+msgid "The selected directory does not exists"
+msgstr ""
+
+#: data/tools/GUI.pyw:1344
+msgid "You typed an invalid value. Value must be an integer in the range 0-999"
+msgstr ""
+
+#: data/tools/GUI.pyw:1358
+msgid ""
+"You selected the core directory or one of its subdirectories in the add-on "
+"selection box.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1364
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlscope will be run only on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1398
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlindent will be run on the Wesnoth core directory"
+msgstr ""
+
+#: data/tools/GUI.pyw:1422
+msgid ""
+"You didn't select a directory.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1433
+msgid "Overwrite confirmation"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for a file name, and not meant to be modified.
+#: data/tools/GUI.pyw:1435
+msgid ""
+"File {} already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1440
+msgid ""
+"You didn't select an output file.\n"
+"\n"
+"wmlxgettext won't be run"
+msgstr ""
+
+#: data/tools/GUI.pyw:1469
+#, python-brace-format
+msgid ""
+"There was an error while executing {0}.\n"
+"\n"
+"Error code: {1}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1480
+msgid "Text file"
+msgstr ""
+
+#: data/tools/GUI.pyw:1488
+#, python-brace-format
+msgid ""
+"Error while writing to:\n"
+"{0}\n"
+"\n"
+"Error code: {1}\n"
+"\n"
+"{2}"
+msgstr ""
+
+#: data/tools/GUI.pyw:1505
+msgid "About Maintenance tools GUI"
+msgstr ""
+
+#. TRANSLATORS: {} is a placeholder for Wesnoth's current version, and not meant to be modified.
+#: data/tools/GUI.pyw:1507
+msgid ""
+"© Elvish_Hunter, 2014-2016\n"
+"\n"
+"Version: {}\n"
+"\n"
+"Part of The Battle for Wesnoth project and released under the GNU GPL v2 "
+"license\n"
+"\n"
+"Icons are taken from the Tango Desktop Project (http://tango.freedesktop."
+"org), and are released in the Public Domain"
+msgstr ""
+
+#: data/tools/GUI.pyw:1519
+msgid "Exit confirmation"
+msgstr ""
+
+#: data/tools/GUI.pyw:1520
+msgid "Do you really want to quit?"
+msgstr ""
+
+#: data/tools/GUI.pyw:1800
+msgid "This application must be placed into the wesnoth/data/tools directory"
+msgstr ""


### PR DESCRIPTION
- POT file with textdomain ``wesnoth-tools`` is generated with the command:
```console
xgettext --language=Python --output=wesnoth-tools.py.pot --force-po --add-comments=TRANSLATORS --copyright-holder="Wesnoth development team" --msgid-bugs-address="https://bugs.wesnoth.org/" --from-code=UTF-8 --sort-by-file --keyword=_ --keyword=N_ --keyword=sgettext --keyword=vgettext --keyword=VGETTEXT --keyword=_n:1,2 --keyword=N_n:1,2 --keyword=sngettext:1,2 --keyword=vngettext:1,2 --keyword=VNGETTEXT:1,2 data/tools/*.pyw data/tools/*.py
```