### PR TITLE
Nr: Dialog/ Story Rewrite : Scenario One (Fix) and herodeaths

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -20,7 +20,7 @@
             {PROLOGUE_STAGE1}
         [/part]
         [part]
-            story= _  "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The people who called it home, dwarven and human alike, knew that the wealth of their city might arouse envy from afar — hence they kept their weapons sharp, and reckoned themselves well able to fight off any bandit gang or petty warlord that could arise in the thinly-settled Northlands."
+            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar --hence they kept their weapons sharp, and thought themselves able to fight off any bandit game or petty warlord."
 
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
@@ -31,12 +31,12 @@
             {PROLOGUE_STAGE1_END}
         [/part]
         [part]
-            story= _ "At first, the incursions were mere rabble that were easily felled. Complacent in their own prowess, the people of the Dwarven Doors ignored the orcs even as the raids grew more numerous and threatening. In time, the raiding parties became companies and full war-bands. Then at last, there arose a mighty warlord of the Bloody Sword tribe, Khazg Black-Tusk, who surrounded the entirety of their defenses with a great host of warriors."
+            story= _ "At first, the incursions were mere rabble that were easily felled. Complacent in their own prowess, the people of the Dwarven Doors ignored the orcs even as the raids grew more numerous and threatening. However in time, the raiding parties became larger until they were more akin to war bands. At last, there arose a mighty warlord of the Bloody Sword tribe, Khazg Black-Tusk, who surrounded the entirety of their defenses with a great host of warriors."
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
         [/part]
         [part]
-            story= _ "It was a time of doom and great deeds, of fire and blood and slaughter. The men and dwarves fought valiantly. But there were always, it seemed, more orcs to replace the slain, while the defenders could find no succor. Pleas for help went unheeded in other lands for men, elves and even dwarves, were wrapped up in their own affairs and struggles or deemed the orcs too far away to bring unto them harm."
+            story= _ "It was a time of doom and great deeds, of fire and blood and slaughter. The men and dwarves fought valiantly. But there were always, it seemed, more orcs to replace the slain, while the defenders could find no succor. Pleas for help went unheeded in other lands for men, elves, and even dwarves, were wrapped up in their own affairs and struggles or deemed the orcs too far away to bring unto them harm."
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
         [/part]

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -20,7 +20,7 @@
             {PROLOGUE_STAGE1}
         [/part]
         [part]
-            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar --hence they kept their weapons sharp, and thought themselves able to fight off any bandit game or petty warlord."
+            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar --hence they kept their weapons sharp, and considered themselves able to fight off any bandit gang or petty warlord."
 
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
@@ -31,7 +31,7 @@
             {PROLOGUE_STAGE1_END}
         [/part]
         [part]
-            story= _ "At first, the incursions were mere rabble that were easily felled. Complacent in their own prowess, the people of the Dwarven Doors ignored the orcs even as the raids grew more numerous and threatening. However in time, the raiding parties became larger until they were more akin to war bands. At last, there arose a mighty warlord of the Bloody Sword tribe, Khazg Black-Tusk, who surrounded the entirety of their defenses with a great host of warriors."
+            story= _ "At first, the incursions were mere rabble that were easily felled. Complacent in their own prowess, the people of the Dwarven Doors ignored the orcs even as the raids grew more numerous and threatening. With time, however, the raiding parties grew larger until they were more akin to war bands. At last, there arose a mighty warlord of the Bloody Sword tribe, Khazg Black-Tusk, who surrounded the entirety of their defenses with a great host of warriors."
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
         [/part]

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -20,7 +20,7 @@
             {PROLOGUE_STAGE1}
         [/part]
         [part]
-            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar —hence they kept their weapons sharp, and reckoned themselves able to fight off any bandit gang or petty warlord."
+            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar — hence they kept their weapons sharp, and reckoned themselves able to fight off any bandit gang or petty warlord."
 
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -31,7 +31,7 @@
             {PROLOGUE_STAGE1_END}
         [/part]
         [part]
-            story= _ "At first, the incursions were mere rabble that were easily felled. Complacent in their own prowess, the people of the Dwarven Doors ignored the orcs even as the raids grew more numerous and threatening. With time, however, the raiding parties grew larger until they were more akin to war bands. At last, there arose a mighty warlord of the Bloody Sword tribe, Khazg Black-Tusk, who surrounded the entirety of their defenses with a great host of warriors."
+            story= _ "At first, the incursions were mere rabble that were easily felled. Complacent in their own prowess, the people of the Dwarven Doors ignored the orcs even as the raids grew more numerous and threatening. With time, the raiding parties grew into war bands; then at last, there arose a mighty warlord of the Bloody Sword tribe, Khazg Black-Tusk, who surrounded the entirety of their defenses with a great host of warriors."
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}
         [/part]

--- a/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/01_Breaking_the_Chains.cfg
@@ -20,7 +20,7 @@
             {PROLOGUE_STAGE1}
         [/part]
         [part]
-            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar --hence they kept their weapons sharp, and considered themselves able to fight off any bandit gang or petty warlord."
+            story= _ "The dwarves of Knalga, cannily reckoning the gains from trade, built strong fortifications around Dwarven Doors. The dwarves and humans who called it home knew that the wealth of the city might arouse envy from afar —hence they kept their weapons sharp, and reckoned themselves able to fight off any bandit gang or petty warlord."
 
             {NR_BIGMAP}
             {PROLOGUE_STAGE1_END}

--- a/data/campaigns/Northern_Rebirth/utils/herodeaths.cfg
+++ b/data/campaigns/Northern_Rebirth/utils/herodeaths.cfg
@@ -129,7 +129,7 @@
 
         [message]
             speaker=Tallin
-            message= _ "Blast it, we have lost a valuable ally."
+            message= _ "Blast it! We have lost a valuable ally!"
         [/message]
 
         [message]
@@ -396,7 +396,7 @@
                 value=5
                 [message]
                     speaker=Sister Thera
-                    message= _ "There we go, let’s give this one more shot!"
+                    message= _ "There we go. Let’s give this one more shot!"
                 [/message]
 
                 [message]


### PR DESCRIPTION
So this is another part of the northern rebirth editing /rewrite I'm doing. The last one was #7454. This one isn't the next scenario but I should be able to get that soon. This one is fixing a couple editing problems I didn't catch in scenario one and I real quick checked the herodeaths.

The main thing is in scenario one I rewrote a paragraph in order to fix issue #6510. I also changed a sentence that seemed to really pop out to be confusing. The bit about raiding parties becoming companies becoming war-bands. Because while you can have a company of orc soldiers, it's different from a war band.

I also added an oxford comma. Are we using oxford comas in wesnoth? If not I'll change it back. 

The hero death changes are pretty self explanatory.