### PR TITLE
Language selection UI overhaul

### DIFF
--- a/changelog_entries/language-ui.md
+++ b/changelog_entries/language-ui.md
@@ -1,0 +1,4 @@
+ ### User interface
+   * Overhauled the Language selection dialog to make it more informative, including
+     displaying translation progress and making it easier to select highly-incomplete
+     translations.

--- a/data/gui/window/language_selection.cfg
+++ b/data/gui/window/language_selection.cfg
@@ -3,6 +3,142 @@
 ### Definition of the window select the language.
 ###
 
+#define _GUI_LANGUI_LIST
+	border = "all"
+	border_size = 5
+	grow_factor = 1
+
+	[listbox]
+		id = "language_list"
+		definition = "default"
+
+		[list_definition]
+			[row]
+				[column]
+					grow_factor = 1
+					horizontal_grow = true
+					vertical_grow = true
+
+					[toggle_panel]
+						definition = "default"
+						return_value_id = "ok"
+						[grid]
+							[row]
+								[column]
+									grow_factor = 1
+									horizontal_grow = true
+									vertical_alignment = "center"
+									border = "all"
+									border_size = 10
+									[label]
+										id = "language"
+										definition = "default"
+										linked_group = "language"
+									[/label]
+								[/column]
+
+								[column]
+									grow_factor = 1
+									horizontal_grow = true
+									vertical_alignment = "center"
+									border = "all"
+									border_size = 10
+									[label]
+										id = "translated_total"
+										definition = "default"
+										linked_group = "translated_total"
+										text_alignment = "right"
+									[/label]
+								[/column]
+
+							[/row]
+						[/grid]
+					[/toggle_panel]
+				[/column]
+			[/row]
+		[/list_definition]
+	[/listbox]
+#enddef
+
+#define _GUI_LANGUI_SIDE_PANEL
+	vertical_alignment = "top"
+	grow_factor = 3
+
+	[scrollbar_panel]
+		vertical_scrollbar_mode = "initial_auto"
+		horizontal_scrollbar_mode = "never"
+		[definition]
+			[row]
+				[column]
+					border = "all"
+					border_size = 5
+
+					[label]
+						use_markup = true
+						wrap = true
+						label = _ "<i>Battle for Wesnoth</i> relies on community submissions to provide an accessible game experience for players around the world. Because development of the main game can move faster than volunteer translators are able to keep up with, translations may drift behind or even become abandoned.
+
+If you are a first-time player, we recommend using a mostly-complete translation. If you are interested in translating the game yourself, we suggest visiting the following page for more information and enabling all translations while you work on your contributions:"
+					[/label]
+				[/column]
+			[/row]
+
+			[row]
+				[column]
+					border = "all"
+					border_size = 5
+					horizontal_grow = true
+
+					[panel]
+						definition = "box_display_no_blur_no_border"
+						[grid]
+							[row]
+								[column]
+									border = "all"
+									border_size = 10
+									horizontal_grow = true
+									[label]
+										# Filled in at runtime
+										id = "contrib_url"
+										use_markup = true
+										link_aware = true
+										wrap = true
+										text_alignment = "center"
+									[/label]
+								[/column]
+							[/row]
+						[/grid]
+					[/panel]
+				[/column]
+			[/row]
+
+			[row]
+				[column]
+					border = "top"
+					border_size = 10 # 20
+
+					[spacer][/spacer]
+				[/column]
+			[/row]
+
+			[row]
+				grow_factor = 0
+
+				[column]
+					border = "all"
+					border_size = 5
+					horizontal_alignment = "center"
+
+					[toggle_button]
+						id = "show_all"
+						label = _ "Show work-in-progress or abandoned translations"
+					[/toggle_button]
+				[/column]
+			[/row]
+		[/definition]
+	[/scrollbar_panel]
+#enddef
+
 [window]
 	id = "language_selection"
 	description = "Language selection dialog."
@@ -14,6 +150,7 @@
 		vertical_placement = "center"
 		horizontal_placement = "center"
 
+		maximum_width = 900
 		maximum_height = 600
 
 		[tooltip]
@@ -23,6 +160,18 @@
 		[helptip]
 			id = "tooltip"
 		[/helptip]
+
+		[linked_group]
+			id = "language"
+			fixed_width = true
+			fixed_height = true
+		[/linked_group]
+
+		[linked_group]
+			id = "translated_total"
+			fixed_width = true
+			fixed_height = true
+		[/linked_group]
 
 		[grid]
 
@@ -46,25 +195,6 @@
 			[/row]
 
 			[row]
-				grow_factor = 0
-
-				[column]
-					grow_factor = 1
-
-					border = "all"
-					border_size = 5
-					horizontal_alignment = "left"
-					[label]
-						definition = "default"
-
-						label = _ "Choose your preferred language:"
-					[/label]
-
-				[/column]
-
-			[/row]
-
-			[row]
 				grow_factor = 1
 
 				[column]
@@ -72,54 +202,17 @@
 					horizontal_grow = true
 					vertical_grow = true
 
-					border = "all"
-					border_size = 5
+					[grid]
+						[row]
+							[column]
+								{_GUI_LANGUI_LIST}
+							[/column]
 
-					[listbox]
-						id = "language_list"
-						definition = "default"
-						[list_definition]
-
-							[row]
-
-								[column]
-									grow_factor = 1
-									horizontal_grow = true
-
-									[toggle_panel]
-										definition = "default"
-										return_value_id = "ok"
-
-										[grid]
-
-											[row]
-
-												[column]
-													grow_factor = 1
-													horizontal_grow = true
-													border = "all"
-													border_size = 10
-
-													[label]
-														id = "language"
-														definition = "default"
-													[/label]
-
-												[/column]
-
-											[/row]
-
-										[/grid]
-
-									[/toggle_panel]
-
-								[/column]
-
-							[/row]
-
-						[/list_definition]
-
-					[/listbox]
+							[column]
+								{_GUI_LANGUI_SIDE_PANEL}
+							[/column]
+						[/row]
+					[/grid]
 
 				[/column]
 
@@ -177,3 +270,6 @@
 	[/resolution]
 
 [/window]
+
+#undef _GUI_LANGUI_SIDE_PANEL
+#undef _GUI_LANGUI_LIST

--- a/data/gui/window/language_selection.cfg
+++ b/data/gui/window/language_selection.cfg
@@ -238,7 +238,7 @@ If you are a first-time player, we recommend using a mostly-complete translation
 									id = "ok"
 									definition = "default"
 
-									label = _ "OK"
+									label = _ "Select"
 								[/button]
 
 							[/column]

--- a/data/gui/window/language_selection.cfg
+++ b/data/gui/window/language_selection.cfg
@@ -164,7 +164,7 @@ If you are a first-time player, we recommend using a mostly-complete translation
 		[linked_group]
 			id = "language"
 			fixed_width = true
-			fixed_height = true
+			fixed_height = false
 		[/linked_group]
 
 		[linked_group]

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -40,12 +40,10 @@ REGISTER_DIALOG(language_selection)
 
 language_selection::language_selection()
 	: modal_dialog(window_id())
-	, show_all_(get_min_translation_percent() == 0)
 	, langs_(get_languages(true))
 	, complete_langs_(langs_.size())
 {
-	// Markup needs to be enabled for the link to be highlighted
-	register_label("contrib_url", true, translations_wiki_url, true);
+	bool show_all = get_min_translation_percent() == 0;
 
 	const language_def& current_language = get_language();
 
@@ -57,12 +55,16 @@ language_selection::language_selection()
 			// too, regardless of what the initial threshold setting is.
 			complete_langs_[i] = true;
 			if(langs_[i].percent < get_min_translation_percent()) {
-				show_all_ = true;
+				show_all = true;
 			}
 		} else {
 			complete_langs_[i] = langs_[i].percent >= get_min_translation_percent();
 		}
 	}
+
+	register_bool("show_all", true, show_all);
+	// Markup needs to be enabled for the link to be highlighted
+	register_label("contrib_url", true, translations_wiki_url, true);
 }
 
 void language_selection::shown_filter_callback()
@@ -70,11 +72,9 @@ void language_selection::shown_filter_callback()
 	window& window = *get_window();
 
 	toggle_button& show_all_toggle = find_widget<toggle_button>(&window, "show_all", false);
-	show_all_ = show_all_toggle.get_value_bool();
-
 	listbox& list = find_widget<listbox>(&window, "language_list", false);
 
-	if(show_all_) {
+	if(show_all_toggle.get_value_bool()) {
 		list.set_row_shown(boost::dynamic_bitset<>{langs_.size(), ~0UL});
 	} else {
 		list.set_row_shown(complete_langs_);
@@ -89,7 +89,6 @@ void language_selection::pre_show(window& window)
 	toggle_button& show_all_toggle = find_widget<toggle_button>(&window, "show_all", false);
 	connect_signal_mouse_left_click(show_all_toggle, std::bind(
 			&language_selection::shown_filter_callback, this));
-	show_all_toggle.set_value(show_all_);
 
 	const language_def& current_language = get_language();
 

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -19,38 +19,97 @@
 
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/listbox.hpp"
+#include "gui/widgets/toggle_button.hpp"
 #include "gui/widgets/window.hpp"
+#include "game_config.hpp"
+#include "gettext.hpp"
 #include "language.hpp"
 #include "preferences/general.hpp"
 
 namespace gui2::dialogs
 {
 
-/**
- * @todo show we also reset the translations and is the tips of day call
- * really needed?
- */
+namespace
+{
+
+const std::string translations_wiki_url = "https://wiki.wesnoth.org/WesnothTranslations";
+
+}
 
 REGISTER_DIALOG(language_selection)
+
+language_selection::language_selection()
+	: modal_dialog(window_id())
+	, show_all_(get_min_translation_percent() == 0)
+	, langs_(get_languages(true))
+	, complete_langs_(langs_.size())
+{
+	// Markup needs to be enabled for the link to be highlighted
+	register_label("contrib_url", true, translations_wiki_url, true);
+
+	const language_def& current_language = get_language();
+
+	// Build language list and completion filter
+	for(std::size_t i = 0; i < langs_.size(); ++i) {
+		if(langs_[i] == current_language) {
+			// Always show the initial language regardless of completion. If it's under
+			// threshold then it probably means we should start by showing all languages
+			// too, regardless of what the initial threshold setting is.
+			complete_langs_[i] = true;
+			if(langs_[i].percent < get_min_translation_percent()) {
+				show_all_ = true;
+			}
+		} else {
+			complete_langs_[i] = langs_[i].percent >= get_min_translation_percent();
+		}
+	}
+}
+
+void language_selection::shown_filter_callback()
+{
+	window& window = *get_window();
+
+	toggle_button& show_all_toggle = find_widget<toggle_button>(&window, "show_all", false);
+	show_all_ = show_all_toggle.get_value_bool();
+
+	listbox& list = find_widget<listbox>(&window, "language_list", false);
+
+	if(show_all_) {
+		list.set_row_shown(boost::dynamic_bitset<>{langs_.size(), ~0UL});
+	} else {
+		list.set_row_shown(complete_langs_);
+	}
+}
 
 void language_selection::pre_show(window& window)
 {
 	listbox& list = find_widget<listbox>(&window, "language_list", false);
 	window.keyboard_capture(&list);
 
-	const std::vector<language_def>& languages = get_languages();
+	toggle_button& show_all_toggle = find_widget<toggle_button>(&window, "show_all", false);
+	connect_signal_mouse_left_click(show_all_toggle, std::bind(
+			&language_selection::shown_filter_callback, this));
+	show_all_toggle.set_value(show_all_);
+
 	const language_def& current_language = get_language();
-	for(const auto & lang : languages)
-	{
+
+	for(const auto& lang : langs_) {
 		widget_data data;
 
 		data["language"]["label"] = lang.language;
+		data["translated_total"]["label"] = "<span color='" + game_config::red_to_green(lang.percent).to_hex_string() + "'>" + std::to_string(lang.percent) + "%</span>";
+		data["translated_total"]["use_markup"] = "true";
 
 		list.add_row(data);
+
 		if(lang == current_language) {
 			list.select_last_row();
 		}
 	}
+
+	// The view filter needs to be set after building the list to take the Show
+	// All toggle value + language completion stats into account as needed.
+	shown_filter_callback();
 }
 
 void language_selection::post_show(window& window)
@@ -61,9 +120,8 @@ void language_selection::post_show(window& window)
 
 		assert(res != -1);
 
-		const std::vector<language_def>& languages = get_languages();
-		::set_language(languages[res]);
-		preferences::set_language(languages[res].localename);
+		::set_language(langs_[res]);
+		preferences::set_language(langs_[res].localename);
 	}
 }
 

--- a/src/gui/dialogs/language_selection.hpp
+++ b/src/gui/dialogs/language_selection.hpp
@@ -51,7 +51,6 @@ private:
 
 	void shown_filter_callback();
 
-	bool show_all_;
 	const std::vector<language_def> langs_;
 	boost::dynamic_bitset<> complete_langs_;
 };

--- a/src/gui/dialogs/language_selection.hpp
+++ b/src/gui/dialogs/language_selection.hpp
@@ -17,6 +17,10 @@
 
 #include "gui/dialogs/modal_dialog.hpp"
 
+#include <boost/dynamic_bitset.hpp>
+
+struct language_def;
+
 namespace gui2::dialogs
 {
 
@@ -33,10 +37,7 @@ namespace gui2::dialogs
 class language_selection : public modal_dialog
 {
 public:
-	language_selection()
-		: modal_dialog(window_id())
-	{
-	}
+	language_selection();
 
 	/** The execute function. See @ref modal_dialog for more information. */
 	DEFINE_SIMPLE_EXECUTE_WRAPPER(language_selection)
@@ -47,6 +48,12 @@ private:
 	virtual void pre_show(window& window) override;
 
 	virtual void post_show(window& window) override;
+
+	void shown_filter_callback();
+
+	bool show_all_;
+	const std::vector<language_def> langs_;
+	boost::dynamic_bitset<> complete_langs_;
 };
 
 } // namespace dialogs

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -140,6 +140,11 @@ language_list get_languages(bool all)
 	return result;
 }
 
+int get_min_translation_percent()
+{
+	return min_translation_percent;
+}
+
 void set_min_translation_percent(int percent) {
 	min_translation_percent = percent;
 }

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -120,4 +120,5 @@ bool init_strings(const game_config_view& cfg);
 
 bool load_language_list();
 
+int get_min_translation_percent();
 void set_min_translation_percent(int percent);


### PR DESCRIPTION
(Please ignore the first commit including a separate bugfix.)

This overhaul introduces a GUI option to show all languages regardless of their completion threshold, as well as a side panel including a general explanation of community translations and how players can potentially contribute to them, plus a link to the main translations page on the wiki.

<img width="922" alt="Screenshot 2023-05-19 at 01 23 16" src="https://github.com/wesnoth/wesnoth/assets/489895/e1af8962-978b-48c0-8655-31f270d9dfa7">
<img width="922" alt="Screenshot 2023-05-19 at 01 23 38" src="https://github.com/wesnoth/wesnoth/assets/489895/b588766a-81af-4309-9c7b-25201b5fde56">

A few points to make here:

* The URL points to the main page on purpose, since it's meant to be a catch-all for all languages regardless of which one the player has got selected or configured (those are two different things at the moment).

* There's an issue where when showing all translations, some of the non-Latin translation names cause the baseline of the language name labels to end up entirely misaligned with the completion labels. I am not entirely sure how to fix this right now.

* Showing all translations alters the dialog's layout permanently. I believe there's no way out of this with the current GUI API.

* We use the stock text colouring function used for unit defence values. This might not be entirely ideal because they are all very green for translation stats above the minimum threshold, so there's basically no variance by default until all translations are shown together.

* An idea could be to add a link to the gettext.wesnoth.org stats page in the dialog.

Additionally, I'd like to look into potentially reflecting the selection in the dialog or the entire Wesnoth UI without having to press OK, but I'm not entirely sure how feasible that is.