### PR TITLE
gui: Handle SDL_WINDOWEVENT_SIZE_CHANGED instead of SDL_WINDOWEVENT_RESIZED

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@
  ### User interface
    * Fixed main menu Language button not being refreshed after switching languages
      without relaunching the game (issue #7437).
+   * Fixed changing game resolution in Preferences not refreshing the user interface
+     as expected (issue #7436).
  ### WML Engine
    * Add support for distinct sub-achievements.
  ### Miscellaneous and Bug Fixes

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -441,7 +441,10 @@ void sdl_event_handler::handle_event(const SDL_Event& event)
 
 		case SDL_WINDOWEVENT:
 			switch(event.window.event) {
-				case SDL_WINDOWEVENT_RESIZED:
+				// Always precedes SDL_WINDOWEVENT_RESIZED, but the latter does not always
+				// happen; in particular when we change the game resolution via
+				// SDL_SetWindowSize() <https://github.com/wesnoth/wesnoth/issues/7436>
+				case SDL_WINDOWEVENT_SIZE_CHANGED:
 					video_resize(video::game_canvas_size());
 					break;
 


### PR DESCRIPTION
The documentation is a bit unclear, but `SDL_WINDOWEVENT_RESIZED` seems not to trigger under certain circumstances, specifically when changing resolution via `SDL_SetWindowSize()`; `SDL_WINDOWEVENT_SIZE_CHANGED` meanwhile is implied to trigger any time the window size changes whether it's from an API call, or the operating system, or a user action.

<https://wiki.libsdl.org/SDL2/SDL_WindowEventID>

We need to translate at least one of these events into a GUI2 event in order for dialogs to be properly re-laid out after the window size changes, but we should not handle both because that could result in unnecessary work recalculating all dialog layouts.

Closes #7436.

Tested on macOS Ventura and openSUSE Tumbleweed so far. I want to properly test this on Windows just in case so don't merge yet.