### PR TITLE
gui2/title_screen: Fix Version label translation not updating

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,8 +11,8 @@
    * Updated translations: Arabic, British English, Czech, French, Italian, Spanish
  ### Units
  ### User interface
-   * Fixed main menu Language button not being refreshed after switching languages
-     without relaunching the game (issue #7437).
+   * Fixed main menu Language button and Version label not being refreshed after
+     switching languages without relaunching the game (issue #7437).
    * Fixed changing game resolution in Preferences not refreshing the user interface
      as expected (issue #7436).
  ### WML Engine
@@ -143,10 +143,10 @@
  ### Campaigns
    * Sceptre of Fire
      * S9: Update for terrain codes introduced in 1.17.9 (issue #7210)
-   * Heir to the Throne: 
+   * Heir to the Throne:
      * S05B: Delurin now has traits Loyal + resilient + intelligent
    * Liberty:
-     * The non-loyal character Delurin now has traits resilient + intelligent 
+     * The non-loyal character Delurin now has traits resilient + intelligent
  ### Translations
    * Updated translations: Arabic, British English, Finnish, French
  ### Units

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -195,17 +195,6 @@ void title_screen::init_callbacks()
 	find_widget<image>(this, "logo", false).set_image(game_config::images::game_logo);
 
 	//
-	// Version string
-	//
-	const std::string& version_string = VGETTEXT("Version $version", {{ "version", game_config::revision }});
-
-	if(label* version_label = find_widget<label>(this, "revision_number", false, false)) {
-		version_label->set_label(version_string);
-	}
-
-	get_canvas(0).set_variable("revision_number", wfl::variant(version_string));
-
-	//
 	// Tip-of-the-day browser
 	//
 	multi_page* tip_pages = find_widget<multi_page>(this, "tips", false, false);
@@ -316,14 +305,12 @@ void title_screen::init_callbacks()
 		try {
 			if(game_.change_language()) {
 				on_resize();
-				update_language_label();
+				update_static_labels();
 			}
 		} catch(const std::runtime_error& e) {
 			gui2::show_error_message(e.what());
 		}
 	});
-
-	update_language_label();
 
 	//
 	// Preferences
@@ -360,10 +347,29 @@ void title_screen::init_callbacks()
 	if(clock) {
 		clock->set_visible(show_debug_clock_button ? widget::visibility::visible : widget::visibility::invisible);
 	}
+
+	//
+	// Static labels (version and language)
+	//
+	update_static_labels();
 }
 
-void title_screen::update_language_label()
+void title_screen::update_static_labels()
 {
+	//
+	// Version menu label
+	//
+	const std::string& version_string = VGETTEXT("Version $version", {{ "version", game_config::revision }});
+
+	if(label* version_label = find_widget<label>(this, "revision_number", false, false)) {
+		version_label->set_label(version_string);
+	}
+
+	get_canvas(0).set_variable("revision_number", wfl::variant(version_string));
+
+	//
+	// Language menu label
+	//
 	if(auto* lang_button = find_widget<button>(this, "language", false, false); lang_button) {
 		const auto& locale = translation::get_effective_locale_info();
 		// Just assume everything is UTF-8 (it should be as long as we're called Wesnoth)

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -103,8 +103,8 @@ private:
 	 */
 	void update_tip(const bool previous);
 
-	/** Updates the Language button label. */
-	void update_language_label();
+	/** Updates UI labels that are not t_string after a language change. */
+	void update_static_labels();
 
 	/** Shows the debug clock. */
 	void show_debug_clock_window();


### PR DESCRIPTION
This unifies both the Version and the Language menu labels into a single method for both that is called both during construction and after switching languages. Both have this issue where they aren't `t_string` instances, so changing languages has no effect on them for that reason and they need to be manually re-translated.