### PR TITLE
Support po4a version 0.68-1 (cmake part)

### DIFF
--- a/cmake/FindTranslationTools.cmake
+++ b/cmake/FindTranslationTools.cmake
@@ -17,7 +17,6 @@ This module defines the following variables:
 	DOS2UNIX_EXECUTABLE
 	PO4A-TRANSLATE_EXECUTABLE
 	PO4A-UPDATEPO_EXECUTABLE
-	PO4A-GETTEXTIZE_EXECUTABLE
 	XSLTPROC_EXECUTABLE
 
 #]=======================================================================]
@@ -81,14 +80,6 @@ set(PO4A-TRANSLATE_OPTIONS
 _find_translation_tool(PO4A-UPDATEPO_EXECUTABLE po4a-updatepo)
 set(PO4A-UPDATEPO_OPTIONS
 	-M utf-8
-)
-
-_find_translation_tool(PO4A-GETTEXTIZE_EXECUTABLE po4a-gettextize)
-set(PO4A-GETTEXTIZE_OPTIONS
-	--copyright-holder "Wesnoth Development Team"
-	-f docbook
-	-M utf-8
-	-L utf-8
 )
 
 _find_translation_tool(XSLTPROC_EXECUTABLE xsltproc)

--- a/doc/manual/CMakeLists.txt
+++ b/doc/manual/CMakeLists.txt
@@ -34,7 +34,9 @@ if(ENABLE_POT_UPDATE_TARGET)
 
 	add_custom_command(
 		OUTPUT ${PROJECT_SOURCE_DIR}/po/wesnoth-manual/wesnoth-manual.pot
-		COMMAND ${PO4A-GETTEXTIZE_EXECUTABLE} ${PO4A-GETTEXTIZE_OPTIONS}
+		COMMAND ${PO4A-UPDATEPO_EXECUTABLE} ${PO4A-UPDATEPO_OPTIONS}
+				--copyright-holder "Wesnoth Development Team"
+				-f docbook
 				-m ${CMAKE_CURRENT_SOURCE_DIR}/manual.en.xml
 				-p wesnoth-manual.pot
 		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/manual.en.xml


### PR DESCRIPTION
This and @loonycyborg's #7648 are both working on #7149. Ended up with this being the CMake one, and the other being the SCons one.

The po4a tool's author considers running po4a-gettextize to be a once-and-done operation, however it seems to be moving towards acting as its own build system, expecting to be run with a config file telling it which files to build.

See https://bugs.debian.org/1020821