### PR TITLE
gui: Use true labelless checkboxes in the dropdown menu implementation

### DIFF
--- a/data/gui/widget/toggle_button_no_label.cfg
+++ b/data/gui/widget/toggle_button_no_label.cfg
@@ -1,6 +1,8 @@
 #textdomain wesnoth-lib
 ###
 ### Definition of a toggle button without a label.
+### (Note that this is also used by the implementation of the dropdown menu on
+### the C++ side.)
 ###
 
 #define _GUI_RESOLUTION RESOLUTION WIDTH HEIGHT

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -195,7 +195,7 @@ void drop_down_menu::pre_show(window& window)
 		find_widget<toggle_panel>(&new_row, "panel", false).set_tooltip(entry.tooltip);
 
 		if(entry.checkbox) {
-			auto checkbox = build_single_widget_instance<toggle_button>();
+			auto checkbox = build_single_widget_instance<toggle_button>(config{"definition", "no_label"});
 			checkbox->set_id("checkbox");
 			checkbox->set_value_bool(*entry.checkbox);
 


### PR DESCRIPTION
Using checkboxes with an empty label doesn't quite do the trick and it results in some (minimal) wasted horizontal space.

I wrote the labelless checkbox definition a few years ago precisely to solve a similar issue in the MP alerts configuration dialog, so it makes sense to use it here as well since the real label is a different widget on a different column.

**Before:**
<img width="796" alt="Screenshot 2023-05-22 at 03 43 17" src="https://github.com/wesnoth/wesnoth/assets/489895/b1a652f5-8018-4d52-90e9-4133a5970aa3">

**After:**
<img width="796" alt="Screenshot 2023-05-22 at 03 42 33" src="https://github.com/wesnoth/wesnoth/assets/489895/93a88db9-0e1a-4afa-a1e8-f61a6a664cf8">
