### PR TITLE
desktop: Fix enumerate_storage_devices() inaccuracy on Linux

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
  ### Translations
  ### Units
  ### User interface
+   * Fix file dialogs (e.g. Save As dialog in the Map Editor) not listing /run/media/USER
+     as a possible file location on modern Linux distributions.
  ### WML Engine
  ### Miscellaneous and Bug Fixes
 

--- a/src/desktop/paths.cpp
+++ b/src/desktop/paths.cpp
@@ -106,7 +106,15 @@ void enumerate_storage_devices(std::vector<path_info>& res)
 	// reasoning here is that if any or all of them are non-empty, they are
 	// probably used for _something_ that might be of interest to the user (if not
 	// directly and actively controlled by the user themselves).
-	static const std::vector<std::string> candidates { "/media", "/mnt" };
+	// Note that the first candidate is actually /run/media/USERNAME -- we need
+	// to fetch the username at runtime from passwd to complete the path.
+	std::vector<std::string> candidates { "/media", "/mnt" };
+
+	// Fetch passwd entry for the effective user the current process runs as
+	if(const passwd* pw = getpwuid(geteuid()); pw && pw->pw_name && pw->pw_name[0]) {
+		candidates.emplace(candidates.begin(), "/run/media/");
+		candidates.front() += pw->pw_name;
+	}
 
 	for(const auto& mnt : candidates) {
 		bsys::error_code e;


### PR DESCRIPTION
Current Linux distributions tend to use udisks2 for storage device management, which uses `/run/media/USERNAME` instead of `/media` for gathering mount points. This commit makes this the first candidate for enumeration of mount point collections.