### PR TITLE
campaignd: Fix link-time options for Xcode build

### DIFF
--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -6696,6 +6696,7 @@
 					"FIFODIR=\\\"/var/run/wesnoth_campaignd\\\"",
 				);
 				INSTALL_PATH = /usr/local/bin;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks \"@loader_path/The Battle for Wesnoth.app/Contents/Frameworks\" @loader_path/Frameworks";
 				PRODUCT_NAME = campaignd;
 			};
 			name = SignedRelease;
@@ -6775,6 +6776,7 @@
 					"FIFODIR=\\\"/var/run/wesnoth_campaignd\\\"",
 				);
 				INSTALL_PATH = /usr/local/bin;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks \"@loader_path/The Battle for Wesnoth.app/Contents/Frameworks\" @loader_path/Frameworks";
 				PRODUCT_NAME = campaignd;
 			};
 			name = Debug;
@@ -6791,6 +6793,7 @@
 					"FIFODIR=\\\"/var/run/wesnoth_campaignd\\\"",
 				);
 				INSTALL_PATH = /usr/local/bin;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks \"@loader_path/The Battle for Wesnoth.app/Contents/Frameworks\" @loader_path/Frameworks";
 				PRODUCT_NAME = campaignd;
 			};
 			name = Release;


### PR DESCRIPTION
This copies the same runpath search paths already used for wesnothd to enable campaignd to run at all.

Without this change, campaignd will not run:
```
17:40:25 iris@mia ~/Projects/wesnoth git:master % campaignd
dyld[88945]: Library not loaded: @rpath/libboost_locale-mt.dylib
  Referenced from: <4D3C727A-C2FF-30FB-B750-3EEAFFB31E03> /Users/iris/Library/Developer/Xcode/DerivedData/The_Battle_for_Wesnoth-gvcieigqfnvlbvdaxanimpkfsprs/Build/Products/Debug/campaignd
  Reason: tried: '/Users/iris/Library/Developer/Xcode/DerivedData/The_Battle_for_Wesnoth-gvcieigqfnvlbvdaxanimpkfsprs/Build/Products/Debug/../Frameworks/libboost_locale-mt.dylib' (no such file), '/Users/iris/Library/Developer/Xcode/DerivedData/The_Battle_for_Wesnoth-gvcieigqfnvlbvdaxanimpkfsprs/Build/Products/Debug/../Frameworks/libboost_locale-mt.dylib' (no such file), '/usr/local/lib/libboost_locale-mt.dylib' (no such file), '/usr/lib/libboost_locale-mt.dylib' (no such file, not in dyld cache)
/Users/iris/Tools/bin/campaignd: line 30: 88945 Abort trap: 6           "$APP_PATH/$BIN_NAME" $CMDLINE "$@"
```