### PR TITLE
Implement macro to feature-test translations in ActionWML

### DIFF
--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -268,6 +268,96 @@
     [/if]
 #enddef
 
+#define CHECK_TRANSLATION DOMAIN MSGID ACTION
+#arg VERBATIM_LOCALES
+en_US en_GB#endarg
+    # Calls this to check whether a given string is translated for the user locale,
+    # and perform an action if it is.
+    #
+    # Example that displays a hint only if it's already translated in the
+    # Heir to the Throne text domain.
+    #! {CHECK_TRANSLATION "wesnoth-httt" "You may now recruit horsemen!" (
+    #!     [message]
+    #!         speaker=narrator
+    #!         image="wesnoth-icon.png"
+    #!         message= _ "You may now recruit horsemen!"
+    #!     [/message]
+    #! )}
+    {VARIABLE CHECK_TRANSLATION_store_has 0}
+    {VARIABLE CHECK_TRANSLATION_store_accept_default 0}
+    [lua]
+        # _ functions return userdata, so let's roundtrip through the engine
+        # to cast their return values to strings we can manipulate.
+        code = <<
+            local t = ...
+            local _ = wesnoth.textdomain("wesnoth-lib")
+            wml.variables["CHECK_TRANSLATION_store_locale"] = _("language code for localized resources^en_US")
+            local _external = wesnoth.textdomain(t.domain)
+            wml.variables["CHECK_TRANSLATION_store_trans"] = _external(t.msgid)
+        >>
+        [args]
+            msgid={MSGID}
+            domain={DOMAIN}
+        [/args]
+    [/lua]
+    [lua]
+        code = <<
+            local t = ...
+            local trans_default = t.msgid
+            local trans_actual = t.msgstr
+            local current_lang = t.locale
+            local id_caret_index = string.find(trans_default, '^', 1, true)
+            local lang_comma_index = string.find(current_lang, ',', 1, true)
+            local lang
+            if id_caret_index ~= nil then
+                trans_default = string.sub(trans_default, id_caret_index + 1)
+            end
+            if lang_comma_index ~= nil then
+                current_lang = string.sub(current_lang, 1, lang_comma_index - 1)
+            end
+            if trans_default ~= trans_actual then
+                wml.variables["CHECK_TRANSLATION_store_has"] = 1
+            else
+                for lang in t.verbatim_locales:gmatch("%S+") do
+                    if lang == current_lang then
+                        wml.variables["CHECK_TRANSLATION_store_accept_default"] = 1
+                        break
+                    end
+                end
+            end
+        >>
+        [args]
+            msgid={MSGID}
+            msgstr="$CHECK_TRANSLATION_store_trans"
+            locale="$CHECK_TRANSLATION_store_locale"
+            verbatim_locales={VERBATIM_LOCALES}
+        [/args]
+    [/lua]
+    {CLEAR_VARIABLE CHECK_TRANSLATION_store_trans}
+    {CLEAR_VARIABLE CHECK_TRANSLATION_store_locale}
+    [if]
+        # Already translated
+        [variable]
+            name=CHECK_TRANSLATION_store_has
+            equals=1
+        [/variable]
+        [or]
+            # In these languages, the translated string is the same as in English.
+            [variable]
+                name=CHECK_TRANSLATION_store_accept_default
+                equals=1
+            [/variable]
+        [/or]
+        [then]
+            # Branch including a message that shall be omitted if untranslated.
+            # But if it's translated, then by all means please proceed and display it.
+            {ACTION}
+        [/then]
+    [/if]
+    {CLEAR_VARIABLE CHECK_TRANSLATION_store_has}
+    {CLEAR_VARIABLE CHECK_TRANSLATION_store_accept_default}
+#enddef
+
 #define MODIFY_UNIT FILTER VAR VALUE
     # Alters a unit variable (such as unit.x, unit.type,
     # unit.side), handling all the storing and unstoring.

--- a/data/test/scenarios/macro_tests/test_check_translation_macro.cfg
+++ b/data/test/scenarios/macro_tests/test_check_translation_macro.cfg
@@ -1,0 +1,31 @@
+#####
+# API(s) being tested: CHECK_TRANSLATION
+##
+# Actions:
+# Run macro on a non-existent sentence.
+# Run macro on an identically-translated sentence for an unexpected language.
+# Run macro on an identically-translated sentence for an expected language.
+##
+# Expected end state:
+# Only the last case should run the ACTION parameter of CHECK_TRANSLATION.
+#####
+{GENERIC_UNIT_TEST "test_check_translation_macro" (
+    [event]
+        name=start
+
+        {CHECK_TRANSLATION "wesnoth-none" "non-existent" (
+            {FAIL}
+        ) VERBATIM_LOCALES=none}
+
+        {CHECK_TRANSLATION "wesnoth" "The Battle for Wesnoth" (
+            {FAIL}
+        ) VERBATIM_LOCALES=none}
+
+        {CHECK_TRANSLATION "wesnoth" "The Battle for Wesnoth" (
+            {VARIABLE translation_exists 1}
+        )}
+
+        {FAIL_IF_NOT translation_exists 1}
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -322,6 +322,7 @@
 0 unslowable_status_test
 0 unpetrifiable_status_test
 0 test_force_chance_to_hit_macro
+0 test_check_translation_macro
 0 trait_exclusion_test
 0 trait_requirement_test
 0 test_remove_ability_by_filter


### PR DESCRIPTION
There are [concerns ](https://forums.wesnoth.org/viewtopic.php?p=681745#p681745)about new English dialogues and/or hints popping up in the middle of otherwise fully-translated campaigns, so this provides a standard way to check whether given sentences are already translated.