### PR TITLE
1.17 - Make map elevation available to [scenarios]

### DIFF
--- a/data/lua/wml/elevation_scoring.lua
+++ b/data/lua/wml/elevation_scoring.lua
@@ -1,4 +1,3 @@
-local utils = wesnoth.require "wml-utils"
 local location_groups = {}
 
 --[[ usage

--- a/data/lua/wml/elevation_scoring.lua
+++ b/data/lua/wml/elevation_scoring.lua
@@ -152,11 +152,8 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
                                         table.remove(border_locations, m)                                        
                                    end
-                                else
-                                    -- Nothing to do for high-high/low-low
                                 end
                                 al_found = 'no'
-                        else
                         end
                     end
                     if #candidate_locations < 1 then 
@@ -170,9 +167,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                         local on_border = true
                         while on_border do
                             local random_index = mathx.random(#candidate_locations)
-                            if wesnoth.current.map:on_border(anchor_hex.x, anchor_hex.y) then
-                                    --table.remove(candidate_locations, random_index)
-                            else
+                            if not (wesnoth.current.map:on_border(anchor_hex.x, anchor_hex.y)) then
                                     on_border = false
                                     anchor_hex.x, anchor_hex.y = candidate_locations[random_index].x, candidate_locations[random_index].y
                                     table.remove(candidate_locations, random_index)

--- a/data/lua/wml/elevation_scoring.lua
+++ b/data/lua/wml/elevation_scoring.lua
@@ -13,10 +13,10 @@ local location_groups = {}
 
 --[[ There are two cycles:
  - First Cycle that grows out from the marker terrains, placing each hex in an elevation group, stopping when it gets to a border or runs out of available hexes.
-   Most likely it gets itself stuck in a corner, rather than really running out of hexes to assign, so restart from some random candidate (non-repeating) hex 
+   Most likely it gets itself stuck in a corner, rather than really running out of hexes to assign, so restart from some random candidate (non-repeating) hex
    somewhere in that blob.
 
- - Second Cycle iterates over all remaining available hexes and checks if they are a border terrain type, and if next to a high-high/low-low border or not, 
+ - Second Cycle iterates over all remaining available hexes and checks if they are a border terrain type, and if next to a high-high/low-low border or not,
    to assign to one of the four non-default elevations.  If not a border terrain type, they stay default
  ]]
 
@@ -79,7 +79,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                         for mm in ipairs(available_locations) do
                             -- check that new hex is an available location
                             if (new_hexes[k][1] == available_locations[mm].x) then
-                               if (new_hexes[k][2] == available_locations[mm].y) then 
+                               if (new_hexes[k][2] == available_locations[mm].y) then
                                     al_found = 'yes'
                                     m = mm
                                     break -- escape the for mm
@@ -90,7 +90,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                             for mm in ipairs(border_locations) do
                             -- none of new hexes are available, but is one a known border of some sort?
                                 if (new_hexes[k][1] == border_locations[mm].x) then
-                                   if (new_hexes[k][2] == border_locations[mm].y) then 
+                                   if (new_hexes[k][2] == border_locations[mm].y) then
                                         al_found = 'maybe'
                                         m = mm
                                         break -- escape the for mm
@@ -99,7 +99,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                             end
                         end
                         if al_found == 'yes' then
-                                -- Whenever a non-border-type location is transfered out of available_locations into a location_group, 
+                                -- Whenever a non-border-type location is transfered out of available_locations into a location_group,
                                 -- it is copied to candidate_locations as well, so we can go back to it later if needed.
                                 -- If terrain is a border type, but this loop is the wrong location_groups for it, we assign it to a dummy group, and clean up later
                                 if wesnoth.map.matches(new_hexes[k][1], new_hexes[k][2], {terrain = high_border}) then
@@ -116,52 +116,52 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                                         else
                                                 table.insert(border_locations, {x= new_hexes[k][1], y= new_hexes[k][2], elevation= 'dummy-low'})
                                         end
-                                else 
+                                else
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
                                         table.insert(candidate_locations, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        anchor_hex.x, anchor_hex.y= new_hexes[k][1], new_hexes[k][2] 
+                                        anchor_hex.x, anchor_hex.y= new_hexes[k][1], new_hexes[k][2]
                                         -- break -- escape the for k (so we don't complete the ring around the anchor hex)
                                 end
                                 table.remove(available_locations, m)
                         elseif al_found == 'maybe' then
-                        -- this new hex is a border between two regions, and is already part of some group, 
+                        -- this new hex is a border between two regions, and is already part of some group,
                         -- check that it is the correct type (not just whatever growing blob reached it first, or a dummy group)
                                 if border_locations[m].elevation == 'low' then
-                                   if location_groups[j].elevation == 'low-low' then 
+                                   if location_groups[j].elevation == 'low-low' then
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        table.remove(border_locations, m)                                        
+                                        table.remove(border_locations, m)
                                    end
                                 elseif border_locations[m].elevation == 'high' then
-                                   if location_groups[j].elevation == 'high-high' then 
+                                   if location_groups[j].elevation == 'high-high' then
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        table.remove(border_locations, m)                                        
+                                        table.remove(border_locations, m)
                                    end
                                 elseif border_locations[m].elevation == 'dummy-high' then
-                                   if location_groups[j].elevation == 'high-high' then 
+                                   if location_groups[j].elevation == 'high-high' then
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        table.remove(border_locations, m)                                        
-                                   elseif location_groups[j].elevation == 'high' then 
+                                        table.remove(border_locations, m)
+                                   elseif location_groups[j].elevation == 'high' then
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        table.remove(border_locations, m)                                        
+                                        table.remove(border_locations, m)
                                    end
                                 elseif border_locations[m].elevation == 'dummy-low' then
-                                   if location_groups[j].elevation == 'low-low' then 
+                                   if location_groups[j].elevation == 'low-low' then
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        table.remove(border_locations, m)                                        
-                                   elseif location_groups[j].elevation == 'low' then 
+                                        table.remove(border_locations, m)
+                                   elseif location_groups[j].elevation == 'low' then
                                         table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
-                                        table.remove(border_locations, m)                                        
+                                        table.remove(border_locations, m)
                                    end
                                 end
                                 al_found = 'no'
                         end
                     end
-                    if #candidate_locations < 1 then 
-                        anchor_hex = {} 
+                    if #candidate_locations < 1 then
+                        anchor_hex = {}
                         al_found = 'blah'
                         break
                     end
-                    -- run out of available hexes, probably because we got stuck in a NW corner.  
+                    -- run out of available hexes, probably because we got stuck in a NW corner.
                     -- Go back to some random hex in the candidate_locations group (but not a map-border hex), try again
                     if al_found == 'no' then
                         local on_border = true
@@ -174,8 +174,8 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                             end
                         end
                         change_count = change_count + 1
-                    end                
-                        
+                    end
+
                     -- failsafe
                     if change_count >= max_map_iter then anchor_hex = {} end -- How many failures to find anything should be enough?
                 end
@@ -185,7 +185,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
 ----------------------------------------------------------------------------------------------------------------------------------------------------
 -- Second cycle
 -- iterate over all the remaining available_locations
-     -- This isn't very efficient, and can assign the hex to the wrong blob (but still correct elevation), 
+     -- This isn't very efficient, and can assign the hex to the wrong blob (but still correct elevation),
      -- but it would be even less efficient if we looked for the closest marker
         local available_locations_final = {}
         if #available_locations > 0 then
@@ -211,7 +211,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                        for m in ipairs (location_groups) do
                            if location_groups[m].elevation == 'high' then
                               table.insert(location_groups[m].hexes, {x= available_locations[i].x, y= available_locations[i].y})
-                              available_locations[i].x, available_locations[i].y = 0, 0 
+                              available_locations[i].x, available_locations[i].y = 0, 0
                               break
                            end
                        end
@@ -224,7 +224,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                                     for m in ipairs (location_groups) do
                                         if location_groups[m].elevation == 'low-low' then
                                             table.insert(location_groups[m].hexes, {x= available_locations[i].x, y= available_locations[i].y})
-                                            available_locations[i].x, available_locations[i].y = 0, 0 
+                                            available_locations[i].x, available_locations[i].y = 0, 0
                                             break
                                         end
                                     end
@@ -237,7 +237,7 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                        for m in ipairs (location_groups) do
                            if location_groups[m].elevation == 'low' then
                               table.insert(location_groups[m].hexes, {x= available_locations[i].x, y= available_locations[i].y})
-                              available_locations[i].x, available_locations[i].y = 0, 0 
+                              available_locations[i].x, available_locations[i].y = 0, 0
                               break
                            end
                        end

--- a/data/lua/wml/elevation_scoring.lua
+++ b/data/lua/wml/elevation_scoring.lua
@@ -1,0 +1,180 @@
+local utils = wesnoth.require "wml-utils"
+local location_set = wesnoth.require "location_set"
+local location_groups = {}
+
+--[[ usage
+    [elevation_score_map]
+        high_border = <terrain code> (default *^Qhh*)
+        low_border = <terrain code> (default *^Qhu*)
+    [/elevation_score_map]
+
+]]
+
+--[[ There are two cycles:
+ - First Cycle that grows out from the marker terrains, placing each hex in an elevation group, stopping when it gets to a border or runs out of available hexes - or more likely gets itself stuck in a corner
+ - Second Cycle iterates over all remaining hexes and existing elevation groups, filling in gaps.  It works, but is not very efficient and can cause wesnoth to choke, so we need to make First Cycle do as much as possible 
+ - (To Do) Third Cycle to clean up border disputes ('high' reached a high border before 'high-high').  Maybe this can be folded into first and second cycles?
+ ]]
+
+wesnoth.wml_actions.elevation_score_map = function(cfg)
+
+        local available_locations = {}
+        local high_border = cfg.high_border or "*^Qhh*"
+        local low_border = cfg.low_border or "*^Qhu*"
+        for u, v, terrain_code in wesnoth.current.map:iter() do
+                if string.find(terrain_code, "_mll") then
+                        table.insert(location_groups, {x=u, y=v, elevation='low-low', hexes= {{x=u, y=v}}})
+                elseif string.find(terrain_code, "_ml") then
+                        table.insert(location_groups, {x=u, y=v, elevation='low', hexes= {{x=u, y=v}}})
+                elseif string.find(terrain_code, "_mhh") then
+                        table.insert(location_groups, {x=u, y=v, elevation='high-high', hexes= {{x=u, y=v}}})
+                elseif string.find(terrain_code, "_mh") then
+                        table.insert(location_groups, {x=u, y=v, elevation='high', hexes= {{x=u, y=v}}})
+                else
+                        table.insert(available_locations, {x=u, y=v})
+                end
+        end
+
+        if #location_groups == 0 then
+                wml.error "No elevation markers found on map"
+                return
+        end
+
+        -- start with the marked hex
+        for j in ipairs(location_groups) do
+                local anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
+                local loop_i = 0
+                while anchor_hex.x do
+                    wesnoth.message("ESM Debugging", string.format("Anchor at (%d,%d)", anchor_hex.x, anchor_hex.y))
+                    loop_i = loop_i + 1
+                    local new_hexes = {}
+                    local al_found = 'no'
+                    -- this could be more compact, but whatever for now
+                    -- table.insert(new_hexes, {wesnoth.map.get_adjacent_hexes(anchor_hex.x,anchor_hex.y)})
+                    local ha, hb, hc, hd, he, hf = wesnoth.map.get_adjacent_hexes(anchor_hex.x,anchor_hex.y)
+                    table.insert(new_hexes, {x=ha[1], y=ha[2]})
+                    table.insert(new_hexes, {x=hb[1], y=hb[2]})
+                    table.insert(new_hexes, {x=hc[1], y=hc[2]})
+                    table.insert(new_hexes, {x=hd[1], y=hd[2]})
+                    table.insert(new_hexes, {x=he[1], y=he[2]})
+                    table.insert(new_hexes, {x=hf[1], y=hf[2]})
+                    for k in ipairs(new_hexes) do -- check each of the six adjacent hexes
+                        al_found = 'no'
+                        local m = 1
+                        while available_locations[m] do
+                            -- check that new hex is an available location
+                            -- wesnoth.message("ESM Debugging", string.format("available.x = %d and new_hexes[%d].x = %d", available_locations[m].x, k, new_hexes[k].x))
+                            if (new_hexes[k].x == available_locations[m].x) and (new_hexes[k].y == available_locations[m].y) then 
+                                    al_found = 'yes'
+                                    break 
+                            end
+                            m = m +1
+                        end
+                        if al_found == 'yes' then
+                        -- if wesnoth.current.map:on_board(new_hexes[k]) then
+                                -- if terrain is a border type, but there was no location_groups for it, it simply isn't assigned (stays available) for now
+                                if wesnoth.map.matches(new_hexes[k].x, new_hexes[k].y, {terrain = high_border}) then
+                                        --wesnoth.message("ESM Debugging", string.format("High border found at (%d,%d)", new_hexes[k].x, new_hexes[k].y))
+                                        if location_groups[j].elevation == 'high-high' or location_groups[j].elevation == 'high' then
+                                                table.insert(location_groups[j].hexes, {x= new_hexes[k].x, y= new_hexes[k].y})
+                                                table.remove(available_locations, m)
+                                        end
+                                elseif wesnoth.map.matches(new_hexes[k].x, new_hexes[k].y, {terrain = low_border}) then
+                                        if location_groups[j].elevation == 'low-low' or location_groups[j].elevation == 'low' then
+                                                table.insert(location_groups[j].hexes, {x= new_hexes[k].x, y= new_hexes[k].y})
+                                                table.remove(available_locations, m)
+                                        end
+                                else 
+                                        table.insert(location_groups[j].hexes, {x= new_hexes[k].x, y= new_hexes[k].y})
+                                        anchor_hex.x, anchor_hex.y= new_hexes[k].x, new_hexes[k].y
+                                        table.remove(available_locations, m)
+                                end
+                        end
+                    end
+                    -- run out of available hexes, probably because we got stuck in a NW corner.  Go back to original hex (marker), offset NE (if it is already part of the group), try again
+                    local give_up = nil
+                    -- this isn't working right now, need to figure this out next time...
+                    if al_found == 'no' and not give_up then
+                        anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
+                        anchor_hex.x = anchor_hex.x + 1
+                        anchor_hex.y = anchor_hex.y - 1
+                        for jj in ipairs(location_groups[j].hexes) do
+                            if (location_groups[j].hexes[jj].x == anchor_hex.x) and (location_groups[j].hexes[jj].y == anchor_hex.y) then
+                            -- NE hex wasn't part of the group, try SW
+                            else
+                                anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
+                                anchor_hex.x = anchor_hex.x - 1
+                                anchor_hex.y = anchor_hex.y + 1
+                                if (location_groups[j].hexes[jj].x == anchor_hex.x) and (location_groups[j].hexes[jj].y == anchor_hex.y) then
+                                else
+                                    give_up = 'yes'
+                                end
+                            end
+                        end
+                    end                
+                        
+                    if al_found == 'no' then anchor_hex = {} end 
+                    if loop_i > 2500 then anchor_hex = {} end -- just in case
+                end
+        end
+
+        -- this is not very efficient, but ideally it isn't doing most of the assigning, the first pass above should have filled in most things
+        -- check each remaining available_location to see if ... 
+        local loop_i = 0 -- debugging aid
+        while #available_locations >= 1 and loop_i < 700 do
+                loop_i = loop_i + 1
+                local al_found = 'no'
+                for j in ipairs(available_locations) do
+                         --wesnoth.message("ESM Debugging", string.format("Entering second loop, %d pass, available_location (%d,%d)", loop_i, available_locations[j].x, available_locations[j].y))
+                         for jj in ipairs(location_groups) do
+                                 for jjj in ipairs(location_groups[jj].hexes) do
+                                         -- ... it has an adjacent hex that is already in a location group ...
+                                         if wesnoth.map.are_hexes_adjacent({available_locations[j].x,available_locations[j].y}, {location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y}) then
+                                                 -- local check_hex=wesnoth.map.get({location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y})
+                                                 -- ... and not a border terrain ...
+                                                 if wesnoth.map.matches(location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y, {terrain = high_border}) or wesnoth.map.matches(location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y, {terrain = low_border}) then
+                                                 else
+                                                 -- if check_hex.terrain ~= high_border and check_hex.terrain ~= low_border then
+                                                         --wesnoth.message("ESM Debugging", string.format("(%d,%d) is terrain %s, while high_border is %s and low_border is %s", check_hex.x, check_hex.y, check_hex.terrain, high_border, low_border))
+                                                         -- then check if the available_location isn't the wrong type of border
+                                                         --check_hex=wesnoth.map.get({available_locations[j].x,available_locations[j].y})
+                                                         --if check_hex.terrain == high_border and location_groups[jj].elevation == 'low' or location_groups[jj].elevation == 'low-low' then
+                                                         if wesnoth.map.matches(available_locations[j].x,available_locations[j].y, {terrain = high_border}) and (location_groups[jj].elevation == 'low' or location_groups[jj].elevation == 'low-low') then
+                                                         --elseif check_hex.terrain == low_border and location_groups[jj].elevation == 'high' or location_groups[jj].elevation == 'high-high' then
+                                                         elseif wesnoth.map.matches(available_locations[j].x,available_locations[j].y, {terrain = low_border}) and (location_groups[jj].elevation == 'high' or location_groups[jj].elevation == 'high-high') then
+                                                         else
+                                                                 --wesnoth.message("ESM Debugging", string.format("(%d,%d) assigned to %s in second loop", available_locations[j].x, available_locations[j].y, location_groups[jj].elevation))
+                                                                 table.insert(location_groups[jj].hexes, {x = available_locations[j].x, y = available_locations[j].y})
+                                                                 table.remove(available_locations, j)
+                                                                 al_found = 'yes'
+                                                         end
+                                                 end
+                                         end
+                                         if al_found == 'yes' then break end
+                                 end
+                                 if al_found == 'yes' then break end
+                         end
+                         if al_found == 'yes' then break end
+                end
+                if al_found == 'no' then -- iterated through all available locations, none could be assigned to a group
+                        table.insert(location_groups, {x=0, y=0, elevation='default', hexes= {}})
+                        local m = #location_groups
+                        for j in ipairs(available_locations) do
+                            table.insert(location_groups[m].hexes,{available_locations[j].x,available_locations[j].y}) 
+                            --local check_hex=wesnoth.map.get({available_locations[j].x,available_locations[j].y})
+                            --if check_hex.terrain == high_border then
+                            --elseif check_hex.terrain == low_border then
+                            --        
+                            --else
+                            --end
+                            table.remove(available_locations, j)
+                        end
+                end
+        end
+        -- for now, write each location_groups to labels
+        for i in ipairs(location_groups) do
+            for j in ipairs(location_groups[i].hexes) do
+                wesnoth.map.add_label{x = location_groups[i].hexes[j].x, y = location_groups[i].hexes[j].y, text = location_groups[i].elevation}
+            end
+        end
+end

--- a/data/lua/wml/elevation_scoring.lua
+++ b/data/lua/wml/elevation_scoring.lua
@@ -1,5 +1,4 @@
 local utils = wesnoth.require "wml-utils"
-local location_set = wesnoth.require "location_set"
 local location_groups = {}
 
 --[[ usage
@@ -10,9 +9,13 @@ local location_groups = {}
 
 ]]
 
---[[ There are two cycles:
- - First Cycle that grows out from the marker terrains, placing each hex in an elevation group, stopping when it gets to a border or runs out of available hexes - or more likely gets itself stuck in a corner
- - Second Cycle iterates over all remaining hexes and existing elevation groups, filling in gaps.  It works, but is not very efficient and can cause wesnoth to choke, so we need to make First Cycle do as much as possible 
+--[[ There are three cycles:
+ - First Cycle that grows out from the marker terrains, placing each hex in an elevation group, stopping when it gets to a border or runs out of available hexes.
+   Most likely it gets itself stuck in a corner, rather than really running out of hexes to assign, so restart from some random hex somewhere in that blob
+
+ - Second Cycle iterates over all remaining hexes and existing elevation groups, filling in gaps.
+   It works, but is not very efficient and can cause wesnoth to choke, so we need to make First Cycle do as much as possible 
+
  - (To Do) Third Cycle to clean up border disputes ('high' reached a high border before 'high-high').  Maybe this can be folded into first and second cycles?
  ]]
 
@@ -21,7 +24,15 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
         local available_locations = {}
         local high_border = cfg.high_border or "*^Qhh*"
         local low_border = cfg.low_border or "*^Qhu*"
+        local max_x = 0
+        local max_y = 0
         for u, v, terrain_code in wesnoth.current.map:iter() do
+                if max_x < u then
+                    max_x = u
+                end
+                if max_y < u then
+                    max_y = v
+                end
                 if string.find(terrain_code, "_mll") then
                         table.insert(location_groups, {x=u, y=v, elevation='low-low', hexes= {{x=u, y=v}}})
                 elseif string.find(terrain_code, "_ml") then
@@ -34,147 +45,174 @@ wesnoth.wml_actions.elevation_score_map = function(cfg)
                         table.insert(available_locations, {x=u, y=v})
                 end
         end
-
+        local max_map_iter = max_x * max_y
         if #location_groups == 0 then
                 wml.error "No elevation markers found on map"
                 return
         end
 
+----------------------------------------------------------------------------------------------------------------------------------------------------
+-- First cycle
         -- start with the marked hex
         for j in ipairs(location_groups) do
                 local anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
+                local change_count = 0
                 local loop_i = 0
                 while anchor_hex.x do
-                    wesnoth.message("ESM Debugging", string.format("Anchor at (%d,%d)", anchor_hex.x, anchor_hex.y))
+                    --if wesnoth.map.matches(anchor_hex.x, anchor_hex.y, {terrain = low_border}) or wesnoth.map.matches(anchor_hex.x, anchor_hex.y, {terrain = high_border}) then
+                    --    wesnoth.message("ESM Debugging", string.format("Somehow border became anchor at (%d,%d)", anchor_hex.x, anchor_hex.y))
+                    --    anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
+                    --end
                     loop_i = loop_i + 1
-                    local new_hexes = {}
                     local al_found = 'no'
-                    -- this could be more compact, but whatever for now
-                    -- table.insert(new_hexes, {wesnoth.map.get_adjacent_hexes(anchor_hex.x,anchor_hex.y)})
-                    local ha, hb, hc, hd, he, hf = wesnoth.map.get_adjacent_hexes(anchor_hex.x,anchor_hex.y)
-                    table.insert(new_hexes, {x=ha[1], y=ha[2]})
-                    table.insert(new_hexes, {x=hb[1], y=hb[2]})
-                    table.insert(new_hexes, {x=hc[1], y=hc[2]})
-                    table.insert(new_hexes, {x=hd[1], y=hd[2]})
-                    table.insert(new_hexes, {x=he[1], y=he[2]})
-                    table.insert(new_hexes, {x=hf[1], y=hf[2]})
+                    -- If we've been here before, reshuffle the new_hexes table so the anchor hex isn't always the NW
+                    local n, ne, se, s, sw, nw = wesnoth.map.get_adjacent_hexes(anchor_hex.x,anchor_hex.y)
+                    local new_hexes = {n, ne, se, s, sw, nw}
+                    mathx.shuffle(new_hexes)
+
                     for k in ipairs(new_hexes) do -- check each of the six adjacent hexes
                         al_found = 'no'
-                        local m = 1
-                        while available_locations[m] do
+                        local m = 0
+                        for mm in ipairs(available_locations) do
                             -- check that new hex is an available location
                             -- wesnoth.message("ESM Debugging", string.format("available.x = %d and new_hexes[%d].x = %d", available_locations[m].x, k, new_hexes[k].x))
-                            if (new_hexes[k].x == available_locations[m].x) and (new_hexes[k].y == available_locations[m].y) then 
+                            if (new_hexes[k][1] == available_locations[mm].x) then
+                               if (new_hexes[k][2] == available_locations[mm].y) then 
                                     al_found = 'yes'
-                                    break 
+                                    m = mm
+                                    break -- escape the for mm
+                               end
                             end
-                            m = m +1
                         end
                         if al_found == 'yes' then
-                        -- if wesnoth.current.map:on_board(new_hexes[k]) then
                                 -- if terrain is a border type, but there was no location_groups for it, it simply isn't assigned (stays available) for now
-                                if wesnoth.map.matches(new_hexes[k].x, new_hexes[k].y, {terrain = high_border}) then
+                                if wesnoth.map.matches(new_hexes[k][1], new_hexes[k][2], {terrain = high_border}) then
                                         --wesnoth.message("ESM Debugging", string.format("High border found at (%d,%d)", new_hexes[k].x, new_hexes[k].y))
                                         if location_groups[j].elevation == 'high-high' or location_groups[j].elevation == 'high' then
                                                 table.insert(location_groups[j].hexes, {x= new_hexes[k].x, y= new_hexes[k].y})
                                                 table.remove(available_locations, m)
                                         end
-                                elseif wesnoth.map.matches(new_hexes[k].x, new_hexes[k].y, {terrain = low_border}) then
+                                elseif wesnoth.map.matches(new_hexes[k][1], new_hexes[k][2], {terrain = low_border}) then
                                         if location_groups[j].elevation == 'low-low' or location_groups[j].elevation == 'low' then
-                                                table.insert(location_groups[j].hexes, {x= new_hexes[k].x, y= new_hexes[k].y})
+                                                table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
                                                 table.remove(available_locations, m)
                                         end
                                 else 
-                                        table.insert(location_groups[j].hexes, {x= new_hexes[k].x, y= new_hexes[k].y})
-                                        anchor_hex.x, anchor_hex.y= new_hexes[k].x, new_hexes[k].y
+                                        table.insert(location_groups[j].hexes, {x= new_hexes[k][1], y= new_hexes[k][2]})
+                                        anchor_hex.x, anchor_hex.y= new_hexes[k][1], new_hexes[k][2] 
                                         table.remove(available_locations, m)
+                                        -- break -- escape the for k (so we don't complete the ring around the anchor hex)
                                 end
                         end
                     end
-                    -- run out of available hexes, probably because we got stuck in a NW corner.  Go back to original hex (marker), offset NE (if it is already part of the group), try again
-                    local give_up = nil
-                    -- this isn't working right now, need to figure this out next time...
-                    if al_found == 'no' and not give_up then
-                        anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
-                        anchor_hex.x = anchor_hex.x + 1
-                        anchor_hex.y = anchor_hex.y - 1
-                        for jj in ipairs(location_groups[j].hexes) do
-                            if (location_groups[j].hexes[jj].x == anchor_hex.x) and (location_groups[j].hexes[jj].y == anchor_hex.y) then
-                            -- NE hex wasn't part of the group, try SW
+                    -- run out of available hexes, probably because we got stuck in a NW corner.  
+                    -- Go back to some random hex in the location_group (but not a border terrain or map-border hex), try again
+                    if al_found == 'no' then
+                        local on_border = true
+                        while on_border do
+                            local random_index = mathx.random(#location_groups[j].hexes)
+                            anchor_hex={x=location_groups[j].hexes[random_index].x, y=location_groups[j].hexes[random_index].y}
+                            if wesnoth.map.matches(anchor_hex.x, anchor_hex.y, {terrain = high_border}) or wesnoth.map.matches(anchor_hex.x, anchor_hex.y, {terrain = low_border}) then
                             else
-                                anchor_hex={x=location_groups[j].x, y=location_groups[j].y}
-                                anchor_hex.x = anchor_hex.x - 1
-                                anchor_hex.y = anchor_hex.y + 1
-                                if (location_groups[j].hexes[jj].x == anchor_hex.x) and (location_groups[j].hexes[jj].y == anchor_hex.y) then
+                                if wesnoth.current.map:on_border(anchor_hex.x, anchor_hex.y) then
                                 else
-                                    give_up = 'yes'
+                                    on_border = false
                                 end
                             end
                         end
+                        change_count = change_count + 1
                     end                
                         
-                    if al_found == 'no' then anchor_hex = {} end 
+                    -- wesnoth.message("ESM Debugging", string.format("Loop number %d, attempt number %d, anchor hex (%d,%d)", loop_i, change_count, anchor_hex.x, anchor_hex.y))
+                    if change_count >= max_map_iter then anchor_hex = {} end -- how many failures to find anything should be enough?  Depends on the map size, though not sure this is the best method
                     if loop_i > 2500 then anchor_hex = {} end -- just in case
                 end
         end
 
-        -- this is not very efficient, but ideally it isn't doing most of the assigning, the first pass above should have filled in most things
-        -- check each remaining available_location to see if ... 
-        local loop_i = 0 -- debugging aid
-        while #available_locations >= 1 and loop_i < 700 do
+----------------------------------------------------------------------------------------------------------------------------------------------------
+-- Second cycle
+        -- this is not very efficient, but ideally it isn't doing much of the assigning...
+        -- check each remaining available_location to see if (*)
+        local al = #available_locations
+        local al_old = #available_locations + 1
+        -- wesnoth.message("ESM Debugging", string.format("Entering second loop, max_map_iter = %d", max_map_iter))
+        local loop_i = 0 -- debugging aid, remove before merging
+        local count = 0
+        local count2 = 0
+        while al < al_old and loop_i < 900 do 
+                al_old = al
                 loop_i = loop_i + 1
                 local al_found = 'no'
-                for j in ipairs(available_locations) do
-                         --wesnoth.message("ESM Debugging", string.format("Entering second loop, %d pass, available_location (%d,%d)", loop_i, available_locations[j].x, available_locations[j].y))
+                for j in ipairs(available_locations) do -- we shouldn't be modifying the table while we iterate through it, so this should be OK
+                     -- check if available location is surounded by other available locations, so we don't waste time checking all the location_groups.hexes against them
+                     local n, ne, se, s, sw, nw = wesnoth.map.get_adjacent_hexes(available_locations[j].x,available_locations[j].y)
+                     local adj_set = {n, ne, se, s, sw, nw}
+                     local skip = 0
+                     for k in ipairs(adj_set) do
+                         for kk in ipairs(available_locations) do
+                             if adj_set[k][1] == available_locations[kk].x then
+                                 if adj_set[k][2] == available_locations[kk].y then
+                                     skip = skip + 1
+                                     break -- escape for kk (found it, no need to keep looking)
+                                 end
+                             end
+                         end
+                     end
+                     if skip < 6 then
+                         skip = 0
                          for jj in ipairs(location_groups) do
                                  for jjj in ipairs(location_groups[jj].hexes) do
-                                         -- ... it has an adjacent hex that is already in a location group ...
+                                     count = count + 1
+                                     -- (*) it has an adjacent hex that is not a border terrain ...
+                                     if not wesnoth.map.matches(location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y, {terrain = high_border}) then
+                                     if not wesnoth.map.matches(location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y, {terrain = low_border}) then
+                                         -- ... and is already in a location group ...
                                          if wesnoth.map.are_hexes_adjacent({available_locations[j].x,available_locations[j].y}, {location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y}) then
-                                                 -- local check_hex=wesnoth.map.get({location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y})
-                                                 -- ... and not a border terrain ...
-                                                 if wesnoth.map.matches(location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y, {terrain = high_border}) or wesnoth.map.matches(location_groups[jj].hexes[jjj].x,location_groups[jj].hexes[jjj].y, {terrain = low_border}) then
-                                                 else
-                                                 -- if check_hex.terrain ~= high_border and check_hex.terrain ~= low_border then
-                                                         --wesnoth.message("ESM Debugging", string.format("(%d,%d) is terrain %s, while high_border is %s and low_border is %s", check_hex.x, check_hex.y, check_hex.terrain, high_border, low_border))
                                                          -- then check if the available_location isn't the wrong type of border
-                                                         --check_hex=wesnoth.map.get({available_locations[j].x,available_locations[j].y})
-                                                         --if check_hex.terrain == high_border and location_groups[jj].elevation == 'low' or location_groups[jj].elevation == 'low-low' then
                                                          if wesnoth.map.matches(available_locations[j].x,available_locations[j].y, {terrain = high_border}) and (location_groups[jj].elevation == 'low' or location_groups[jj].elevation == 'low-low') then
-                                                         --elseif check_hex.terrain == low_border and location_groups[jj].elevation == 'high' or location_groups[jj].elevation == 'high-high' then
                                                          elseif wesnoth.map.matches(available_locations[j].x,available_locations[j].y, {terrain = low_border}) and (location_groups[jj].elevation == 'high' or location_groups[jj].elevation == 'high-high') then
                                                          else
-                                                                 --wesnoth.message("ESM Debugging", string.format("(%d,%d) assigned to %s in second loop", available_locations[j].x, available_locations[j].y, location_groups[jj].elevation))
                                                                  table.insert(location_groups[jj].hexes, {x = available_locations[j].x, y = available_locations[j].y})
                                                                  table.remove(available_locations, j)
                                                                  al_found = 'yes'
                                                          end
-                                                 end
                                          end
-                                         if al_found == 'yes' then break end
+                                     end
+                                     end
+                                     if al_found == 'yes' then break end
                                  end
                                  if al_found == 'yes' then break end
                          end
                          if al_found == 'yes' then break end
+                     end
                 end
                 if al_found == 'no' then -- iterated through all available locations, none could be assigned to a group
-                        table.insert(location_groups, {x=0, y=0, elevation='default', hexes= {}})
-                        local m = #location_groups
-                        for j in ipairs(available_locations) do
-                            table.insert(location_groups[m].hexes,{available_locations[j].x,available_locations[j].y}) 
-                            --local check_hex=wesnoth.map.get({available_locations[j].x,available_locations[j].y})
-                            --if check_hex.terrain == high_border then
-                            --elseif check_hex.terrain == low_border then
-                            --        
-                            --else
-                            --end
-                            table.remove(available_locations, j)
-                        end
+                -- wesnoth.message("ESM Debugging", string.format("Went through (%d loops and %d times) the available locations, %d couldn't be assigned", loop_i, count, #available_locations))
                 end
+                al = #available_locations
         end
+----------------------------------------------------------------------------------------------------------------------------------------------------
+-- Third Cycle (To Do)
+-- clean up the off-by-one borders
+--[[        for i in ipairs(location_groups) do
+            for j in ipairs(location_groups[i].hexes) do
+                if (wesnoth.map.matches(location_groups[i].hexes[j].x,location_groups[i].hexes[j].y, {terrain = high_border}) then
+                end
+            end
+        end
+]]
+
+
+
+------------------------------------------------------------------------------------
+-- Implementation of data collected
         -- for now, write each location_groups to labels
         for i in ipairs(location_groups) do
             for j in ipairs(location_groups[i].hexes) do
                 wesnoth.map.add_label{x = location_groups[i].hexes[j].x, y = location_groups[i].hexes[j].y, text = location_groups[i].elevation}
             end
+        end
+        for i in ipairs(available_locations) do
+            wesnoth.map.add_label{x = available_locations[i].x, y = available_locations[i].y, text = "default"}
         end
 end

--- a/data/multiplayer/scenarios/Test_Elevation_Test.cfg
+++ b/data/multiplayer/scenarios/Test_Elevation_Test.cfg
@@ -63,4 +63,11 @@
         user_team_name= _ "teamname^Southeast"
         fog=yes
     [/side]
+
+    [event]
+        name=start
+        [elevation_score_map]
+        [/elevation_score_map]
+    [/event]
+
 [/multiplayer]

--- a/data/multiplayer/scenarios/Test_Elevation_Test.cfg
+++ b/data/multiplayer/scenarios/Test_Elevation_Test.cfg
@@ -68,24 +68,50 @@
         name=start
         [message]
             speaker=narrator
-            message = _ "Should we try to determine the map elevation data with [elevation_score_map]?  This is currently not very efficient, it might cause Wesnoth to freeze for a bit."
+            message = _ "Should we try to determine the map elevation data with [elevation_score_map]?  You can turn off the labels by unchecking the 'Elevation' option in the Actions-> Show/Hide Labels menu."
             [option]
-                message = _ "Yes!  I want to try this, I accept I may need to abort."  + "
-... And that currently, this just gets me some useless labels."
+                message = _ "Yes!  I want to try this on this example map."
                 [command]
-                     [print]
-                         text = "Checking for elevation data, this will take a while..."
-                         size = 18
-                         color = 200,200,255
-                     [/print]
-                     [delay]
-                         time = 500
-                     [/delay]
-                     [redraw]
-                         side=0
-                     [/redraw]
-                     [elevation_score_map]
-                     [/elevation_score_map]
+                    [print]
+                        text = "Checking for elevation data, this may take a few moments..."
+                        size = 18
+                        color = 200,200,255
+                    [/print]
+                    [delay]
+                        time = 500
+                    [/delay]
+                    [redraw]
+                        side=0
+                    [/redraw]
+                    [elevation_score_map]
+                    [/elevation_score_map]
+                [/command]
+            [/option]
+            [option]
+                message = _ "Yes, but I want to test a broken map..."
+                [command]
+                    [print]
+                        text = "Checking for elevation data, this may take a while..."
+                        size = 18
+                        color = 200,200,255
+                    [/print]
+                    [terrain]
+                        terrain=Gg
+                        x,y=39,22
+                    [/terrain]
+                    [terrain]
+                        terrain=Gg
+                        x,y=6-7,15
+                    [/terrain]
+                    [delay]
+                        time = 500
+                    [/delay]
+                    [redraw]
+                        side=0
+                    [/redraw]
+                    [elevation_score_map]
+                        test_labels = true
+                    [/elevation_score_map]
                 [/command]
             [/option]
             [option]
@@ -94,4 +120,130 @@
         [/message]
     [/event]
 
+#define TET_ELEVATION_UNIT_DATA TYPE BONUS
+
+    [set_variable]
+        name=x_hexes
+        literal=""
+    [/set_variable]
+    [set_variable]
+        name=y_hexes
+        literal=""
+    [/set_variable]
+    [foreach]
+        array=elevation_area
+        [do]
+            [if]
+                [variable]
+                    name=elevation_area[$i].type
+                    equals={TYPE}
+                [/variable]
+                [then]
+                    [set_variable]
+                        name=x_hexes
+                        value="$x_hexes|" + "$elevation_area[$i|].x|"
+                    [/set_variable]
+                    [set_variable]
+                        name=y_hexes
+                        value="$y_hexes|" + "$elevation_area[$i|].y|"
+                    [/set_variable]
+                    [event]
+                        name=moveto
+                        first_time_only=no
+                        delayed_variable_substitution=no
+                        [filter]
+                            #            {UNIT_FILTER}
+                            [filter_location]
+                                x = $x_hexes|
+                                y = $y_hexes|
+                            [/filter_location]
+                        [/filter]
+                        [store_unit]
+                            [filter]
+                                id=$|unit.id
+                            [/filter]
+                            kill=no
+                            variable=UNIT_AREA_TEMP
+                        [/store_unit]
+                        [set_variable]
+                            name=UNIT_AREA_TEMP.variables.elevation
+                            value={BONUS}
+                        [/set_variable]
+                        [unstore_unit]
+                            variable=UNIT_AREA_TEMP
+                            find_vacant=no
+                        [/unstore_unit]
+                        {CLEAR_VARIABLE UNIT_AREA_TEMP}
+                    [/event]
+                [/then]
+            [/if]
+        [/do]
+    [/foreach]
+
+#enddef
+
+    [event]
+        name=side 1 turn 1
+        {TET_ELEVATION_UNIT_DATA high_high 2}
+        {TET_ELEVATION_UNIT_DATA high 1}
+        {TET_ELEVATION_UNIT_DATA elevation_default 0}
+        {TET_ELEVATION_UNIT_DATA low -1}
+        {TET_ELEVATION_UNIT_DATA low_low -2}
+    [/event]
+
+#undef TET_ELEVATION_UNIT_DATA
+
+    # example usage of elevation by units
+    [event]
+        name=attack
+        [filter_condition]
+            [variable]
+                name=unit.variables.elevation
+                greater_than=$second_unit.variables.elevation
+            [/variable]
+        [/filter_condition]
+        [message]
+            speaker=unit
+            message=_"I have the high ground!"
+        [/message]
+    [/event]
+
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_condition]
+            [variable]
+                name=unit.variables.elevation
+                greater_than=$second_unit.variables.elevation
+            [/variable]
+        [/filter_condition]
+        [modify_unit]
+            [filter]
+                id=$unit.id
+            [/filter]
+            [effect]
+                apply_to=attack
+                increase_damage=2
+            [/effect]
+        [/modify_unit]
+        [event]
+            name=attack_end
+            first_time_only=no
+            [filter_condition]
+                [variable]
+                    name=unit.variables.elevation
+                    greater_than=$second_unit.variables.elevation
+                [/variable]
+            [/filter_condition]
+            [modify_unit]
+                [filter]
+                    id=$unit.id
+                [/filter]
+                [effect]
+                    apply_to=attack
+                    increase_damage=-2
+                [/effect]
+            [/modify_unit]
+        [/event]
+    [/event]
 [/multiplayer]

--- a/data/multiplayer/scenarios/Test_Elevation_Test.cfg
+++ b/data/multiplayer/scenarios/Test_Elevation_Test.cfg
@@ -66,8 +66,32 @@
 
     [event]
         name=start
-        [elevation_score_map]
-        [/elevation_score_map]
+        [message]
+            speaker=narrator
+            message = _ "Should we try to determine the map elevation data with [elevation_score_map]?  This is currently not very efficient, it might cause Wesnoth to freeze for a bit."
+            [option]
+                message = _ "Yes!  I want to try this, I accept I may need to abort."  + "
+... And that currently, this just gets me some useless labels."
+                [command]
+                     [print]
+                         text = "Checking for elevation data, this will take a while..."
+                         size = 18
+                         color = 200,200,255
+                     [/print]
+                     [delay]
+                         time = 500
+                     [/delay]
+                     [redraw]
+                         side=0
+                     [/redraw]
+                     [elevation_score_map]
+                     [/elevation_score_map]
+                [/command]
+            [/option]
+            [option]
+                message = _ "No, I cannot risk it, let's just stick with cosmetic elevation."
+            [/option]
+        [/message]
     [/event]
 
 [/multiplayer]

--- a/data/multiplayer/scenarios/Test_Elevation_Test.cfg
+++ b/data/multiplayer/scenarios/Test_Elevation_Test.cfg
@@ -73,7 +73,7 @@
                 message = _ "Yes!  I want to try this on this example map."
                 [command]
                     [print]
-                        text = "Checking for elevation data, this may take a few moments..."
+                        text = _ "Checking for elevation data, this may take a few moments..."
                         size = 18
                         color = 200,200,255
                     [/print]
@@ -91,7 +91,7 @@
                 message = _ "Yes, but I want to test a broken map..."
                 [command]
                     [print]
-                        text = "Checking for elevation data, this may take a while..."
+                        text = _ "Checking for elevation data, this may take a while..."
                         size = 18
                         color = 200,200,255
                     [/print]

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -1250,6 +1250,13 @@
 		{FILTER_TAG "filter_location" location {INSERT_TAG}}
 		{ACTION_TAG "command" min=1}
 	[/tag]
+	[tag]
+		name="elevation_score_map"
+		max=infinite
+		# {INSERT_TAG}
+		{DEFAULT_KEY high_border terrain_code "*^Qhh*"}
+		{DEFAULT_KEY low_border terrain_code "*^Qhu*"}
+	[/tag]
 	{EMPTY_TAG "break,continue,return" 0 infinite}
 	[tag]
 		name="micro_ai"

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -1256,6 +1256,7 @@
 		# {INSERT_TAG}
 		{DEFAULT_KEY high_border terrain_code "*^Qhh*"}
 		{DEFAULT_KEY low_border terrain_code "*^Qhu*"}
+		{DEFAULT_KEY test_labels s_bool no}
 	[/tag]
 	{EMPTY_TAG "break,continue,return" 0 infinite}
 	[tag]


### PR DESCRIPTION
This is to create a tag that determines the elevation data on a map that uses the feature correctly.  The five-level limit is pretty baked in, because that's how it is in the terrain graphics.  The use for this would be anything that could use a location set (group of `x,y` ) as a filter.
```
[elevation_score_map]
    high_border=<terrain code> (*^Qhh* default, key is optional)
    low_border=<terrain code> (*^Qhu* default, key is optional)
    test_labels = <boolean> ( default false )
[/elevation_score_map]
```
The effect of this tag is to create some WML variables `[elevation_area]`, one per elevation marker (the arrows in the editor) + the unassigned default elevation
It also creates a WML variable `[elevation_data]` that is basically a summary, in case that helps somehow.  Currently it is just a count of the different elevation levels.

This can be tested in the `Test_Elevation_Test.cfg` MP scenario, which has a simple example use-case, where higher-ground attacker (horseman) gets a damage boost and lower-ground attacker (wolf rider) gets a damage nerf.
![Screenshot_20230611_](https://github.com/wesnoth/wesnoth/assets/13510196/25c21ec6-d39c-42cc-8bd8-d07787325b77)



---- original post ------
I'm really not the right person to be doing this, but we've got to start somewhere.  This is a first draft, I need to reconcile it with the terrain-graphics rules better and then work on improving the efficiency (the failsafe cycle works, but it causes Wesnoth to choke, need to get the main flood-fill to work better).  It reminds me of Tron, I'm probably reinventing the wheel.

For this PR, I hope to get the elevation data available to the scenario author (for now it is a label, which is obviously just debug).  Goal is for each hex to have elevation data (low-low, low, default, high, high-high).  How this data should be used is out of scope.

This is a hack, just like the elevation terrain-graphics.  Best action would be to replace both of them with an engine update, but 1.18 isn't that far away, so this may be the best realistic option.
![Screenshot_20230529_](https://github.com/wesnoth/wesnoth/assets/13510196/a89f78f7-6fea-4601-a9a0-cbf4bb8566f4)
