### PR TITLE
[1.16] Backport the fixes for running pot-update with recent versions of po4a

### DIFF
--- a/doc/manual/CMakeLists.txt
+++ b/doc/manual/CMakeLists.txt
@@ -34,7 +34,9 @@ if(ENABLE_POT_UPDATE_TARGET)
 
 	add_custom_command(
 		OUTPUT ${PROJECT_SOURCE_DIR}/po/wesnoth-manual/wesnoth-manual.pot
-		COMMAND ${PO4A-GETTEXTIZE_EXECUTABLE} ${PO4A-GETTEXTIZE_OPTIONS}
+		COMMAND ${PO4A-UPDATEPO_EXECUTABLE} ${PO4A-UPDATEPO_OPTIONS}
+				--copyright-holder "Wesnoth Development Team"
+				-f docbook
 				-m ${CMAKE_CURRENT_SOURCE_DIR}/manual.en.xml
 				-p wesnoth-manual.pot
 		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/manual.en.xml

--- a/po/SConscript
+++ b/po/SConscript
@@ -115,7 +115,7 @@ if "update-po" in COMMAND_LINE_TARGETS or "pot-update" in COMMAND_LINE_TARGETS o
 #
 
 if "update-po4a" in COMMAND_LINE_TARGETS or "pot-update" in COMMAND_LINE_TARGETS:
-    env.Po4aGettextize("wesnoth-manual/wesnoth-manual.pot", "../doc/manual/manual.en.xml", PO4A_FORMAT = "docbook")
+    env.Po4aUpdatePo("wesnoth-manual/wesnoth-manual.pot", "../doc/manual/manual.en.xml", PO4A_FORMAT = "docbook")
     for lingua in linguas:
         env.Po4aTranslate("../doc/manual/manual." + lingua + ".xml",
             ["../doc/manual/manual.en.xml", join("wesnoth-manual", lingua + ".po")],
@@ -123,7 +123,7 @@ if "update-po4a" in COMMAND_LINE_TARGETS or "pot-update" in COMMAND_LINE_TARGETS
     Alias("update-po4a", Alias("manual"))
 
     manpages = Split("wesnoth.6 wesnothd.6")
-    env.Po4aGettextize("wesnoth-manpages/wesnoth-manpages.pot",
+    env.Po4aUpdatePo("wesnoth-manpages/wesnoth-manpages.pot",
         [join("../doc/man", man) for man in manpages], PO4A_FORMAT = "man")
     for lingua in linguas:
         for man in manpages:

--- a/scons/gettext_tool.py
+++ b/scons/gettext_tool.py
@@ -46,11 +46,11 @@ def generate(env):
             return env.MsgInit(target, source, **kw)
     env.AddMethod(MsgInitMerge)
 
-    env["PO4A_GETTEXTIZE"] = WhereIs("po4a-gettextize")
-    po4a_gettextize = Builder(
-        action = "$PO4A_GETTEXTIZE -f $PO4A_FORMAT ${''.join([' -m ' + str(source) for source in SOURCES])} -p $TARGET",
+    env["PO4A_UPDATEPO"] = WhereIs("po4a-updatepo")
+    po4a_update_po = Builder(
+        action = "$PO4A_UPDATEPO -f $PO4A_FORMAT ${''.join([' -m ' + str(source) for source in SOURCES])} -p $TARGET",
         )
-    env["BUILDERS"]["Po4aGettextize"] = po4a_gettextize
+    env["BUILDERS"]["Po4aUpdatePo"] = po4a_update_po
 
     env["PO4A_TRANSLATE"] = WhereIs("po4a-translate")
     po4a_translate = Builder(


### PR DESCRIPTION
Backport the SCons fix from https://github.com/wesnoth/wesnoth/pull/7648 and the CMake fix from https://github.com/wesnoth/wesnoth/pull/7649.

Fixes #7149.

This cherry-picks only the important part of #7649 from master, making the script use `PO4A-UPDATEPO_EXECUTABLE` instead of `PO4A-GETTEXTIZE_EXECUTABLE`. In contrast to the master branch's commit, this makes no changes to  findTranslationTools.cmake, so `PO4A-GETTEXTIZE_EXECUTABLE` will still be defined in that script. It's simply that that script has been extensively rewritten in master, and I don't see a point in porting that part of the change.