### PR TITLE
Write log output both to stderr and logfile at the same time

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -181,7 +181,7 @@ void set_log_to_file()
 	if(is_log_dir_writable_.value_or(false)) {
 		// get the log file stream and assign cerr+cout to it
 		output_file_path_ = filesystem::get_logs_dir()+"/"+unique_log_filename();
-		static std::unique_ptr<std::ostream> logfile { std::move(filesystem::ostream_file(output_file_path_)) };
+		static std::unique_ptr<std::ostream> logfile { filesystem::ostream_file(output_file_path_) };
 		static std::ostream cerr_stream{std::cerr.rdbuf()};
 		//static std::ostream cout_stream{std::cout.rdbuf()};
 		auto cerr_tee { boost::iostreams::tee(*logfile, cerr_stream) };

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -26,6 +26,8 @@
 #include "mt_rng.hpp"
 
 #include <boost/algorithm/string.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/iostreams/tee.hpp>
 
 #include <map>
 #include <sstream>
@@ -179,7 +181,11 @@ void set_log_to_file()
 	if(is_log_dir_writable_.value_or(false)) {
 		// get the log file stream and assign cerr+cout to it
 		output_file_path_ = filesystem::get_logs_dir()+"/"+unique_log_filename();
-		output_file_.reset(filesystem::ostream_file(output_file_path_).release());
+		auto logfile { filesystem::ostream_file(output_file_path_).release() };
+		static std::ostream cerr_stream{std::cerr.rdbuf()};
+		//static std::ostream cout_stream{std::cout.rdbuf()};
+		auto cerr_tee { boost::iostreams::tee(*logfile, cerr_stream) };
+		output_file_.reset(new boost::iostreams::stream<decltype(cerr_tee)>{cerr_tee, 4096, 0});
 		std::cerr.rdbuf(output_file_.get()->rdbuf());
 		std::cout.rdbuf(output_file_.get()->rdbuf());
 		rotate_logs(filesystem::get_logs_dir());

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -181,7 +181,7 @@ void set_log_to_file()
 	if(is_log_dir_writable_.value_or(false)) {
 		// get the log file stream and assign cerr+cout to it
 		output_file_path_ = filesystem::get_logs_dir()+"/"+unique_log_filename();
-		auto logfile { filesystem::ostream_file(output_file_path_).release() };
+		static std::unique_ptr<std::ostream> logfile { std::move(filesystem::ostream_file(output_file_path_)) };
 		static std::ostream cerr_stream{std::cerr.rdbuf()};
 		//static std::ostream cout_stream{std::cout.rdbuf()};
 		auto cerr_tee { boost::iostreams::tee(*logfile, cerr_stream) };


### PR DESCRIPTION
this uses tee sink from boost.iostreams