### PR TITLE
Remove an explicit GETTEXT_DOMAIN "wesnoth"

### DIFF
--- a/src/gui/dialogs/addon/install_dependencies.cpp
+++ b/src/gui/dialogs/addon/install_dependencies.cpp
@@ -15,8 +15,6 @@
 
 #include "install_dependencies.hpp"
 
-#define GETTEXT_DOMAIN "wesnoth"
-
 #include "gettext.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/addon_list.hpp"


### PR DESCRIPTION
C++ source files are considered to be in textdomain "wesnoth" by default.

The 1.16 CMake scripts that sort files into textdomains miss this file, because it treats files with no `GETTEXT_DOMAIN` as being in "wesnoth", but not ones that explicitly declare themselves in "wesnoth".

Doing a pot-update with SCons includes this file anyway, so the official "pot-update and regenerate doc files" commits already include it, even without this fix.