### PR TITLE
[1.16] UtBS: Make the name of the dark assassin translatable again

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -2557,7 +2557,8 @@
 
         [set_variable]
             name=cloaked_figure.name
-            value="Keratur"
+            # po: Name of the dark assassin who uses "speaker=Cloaked Figure" when talking
+            value= _ "Keratur"
         [/set_variable]
 
         [set_variable]


### PR DESCRIPTION
It needs to be translatable because it needs to match the other strings that call him by name. It was translatable until 1.15.4, and several of the .po files that are already in the 1.16 still include it as an obsolete message, so the next pot-update run will turn this back into a translated text in Bulgarian, Greek, Irish, Galician, Latin, Lithuanian, Russian, Serbian and Traditional Chinese.

Opening as a PR, but will be linking to this from the forum thread about translations.