### PR TITLE
Fixed old typo in definition of unit recruit window

### DIFF
--- a/data/gui/window/unit_recruit.cfg
+++ b/data/gui/window/unit_recruit.cfg
@@ -103,7 +103,7 @@
 
 [window]
 	id = "unit_recruit"
-	description = "Unut recruit dialog."
+	description = "Unit recruit dialog."
 
 	[resolution]
 		definition = "default"


### PR DESCRIPTION
Just a typo fix. Nothing else. This should be eligible for merging (I think).