### PR TITLE
Remove an explicit GETTEXT_DOMAIN "wesnoth"

### DIFF
--- a/src/gui/dialogs/addon/install_dependencies.cpp
+++ b/src/gui/dialogs/addon/install_dependencies.cpp
@@ -15,8 +15,6 @@
 
 #include "install_dependencies.hpp"
 
-#define GETTEXT_DOMAIN "wesnoth"
-
 #include "gettext.hpp"
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/widgets/addon_list.hpp"


### PR DESCRIPTION
Forward-port of #7674, just doing a CI run. This isn't an issue with the CMake scripts in master, I'm just cherry picking the commit so that there isn't a "missing" commit on master.


C++ source files are considered to be in textdomain "wesnoth" by default.

The 1.16 CMake scripts that sort files into textdomains miss this file, because it treats files with no `GETTEXT_DOMAIN` as being in "wesnoth", but not ones that explicitly declare themselves in "wesnoth".

(cherry picked from commit f0ceaf2ae086bf412e56778656e3f4b95824a261)