### PR TITLE
gui: Bring Open Log File button to non-Windows platforms + minor UI tweaks

### DIFF
--- a/data/gui/window/game_version.cfg
+++ b/data/gui/window/game_version.cfg
@@ -151,27 +151,14 @@
 		[column]
 			horizontal_alignment = right
 			vertical_alignment = top
+			border = all
+			border_size = 5
 
-			[grid]
-				id = "win32_paths"
-
-				[row]
-
-					[column]
-						border = all
-						border_size = 5
-
-						[button]
-							id = "open_stderr"
-							label = _ "Open Log File"
-							tooltip = _ "Opens the log file, which may contain useful debug information"
-						[/button]
-					[/column]
-
-				[/row]
-
-			[/grid]
-
+			[button]
+				id = "open_stderr"
+				label = _ "Open Log File"
+				tooltip = _ "Opens the log file, which may contain useful debug information"
+			[/button]
 		[/column]
 
 	[/row]

--- a/data/gui/window/game_version.cfg
+++ b/data/gui/window/game_version.cfg
@@ -145,23 +145,6 @@
 		[/column]
 
 	[/row]
-
-	[row]
-
-		[column]
-			horizontal_alignment = right
-			vertical_alignment = top
-			border = all
-			border_size = 5
-
-			[button]
-				id = "open_stderr"
-				label = _ "Open Log File"
-				tooltip = _ "Opens the log file, which may contain useful debug information"
-			[/button]
-		[/column]
-
-	[/row]
 #enddef
 
 #define _GUI_VERINFO_TAB_PAGE_BUILD_INFO
@@ -627,6 +610,18 @@
 									tooltip = _ "Copy the full report to clipboard"
 								[/button]
 
+							[/column]
+
+							[column]
+								horizontal_alignment = left
+								border = all
+								border_size = 5
+
+								[button]
+									id = "open_stderr"
+									label = _ "Log File"
+									tooltip = _ "Opens the log file pertaining to the current session, which may contain useful debug information"
+								[/button]
 							[/column]
 
 							[column]

--- a/src/gui/dialogs/game_version_dialog.cpp
+++ b/src/gui/dialogs/game_version_dialog.cpp
@@ -142,15 +142,9 @@ void game_version::pre_show(window& window)
 		}
 	}
 
-#ifndef _WIN32
-	for(const auto& wid : {"win32_paths"}) {
-		find_widget<widget>(&window, wid, false).set_visible(widget::visibility::invisible);
-	}
-#else
 	button& stderr_button = find_widget<button>(&window, "open_stderr", false);
 	connect_signal_mouse_left_click(stderr_button, std::bind(&game_version::browse_directory_callback, this, log_path_));
 	stderr_button.set_active(!log_path_.empty());
-#endif
 
 	//
 	// Build info tab.


### PR DESCRIPTION
This patch series brings the Open Log File button in the game version dialog to non-Windows platforms whenever logging to a file has been enabled. When logging to a file isn't enabled, the button will be greyed out rather than missing — hints at the functionality being disabled rather than removed.

It also relocates the button to avoid taking up a whole row in the dialog for it, and makes the button label more succinct in accordance with standard UI design practices.

<img width="636" alt="Screenshot 2023-06-04 at 20 19 55" src="https://github.com/wesnoth/wesnoth/assets/489895/414f8ff9-9890-4206-89bc-4fb270b40c7d">
<img width="636" alt="Screenshot 2023-06-04 at 20 23 52" src="https://github.com/wesnoth/wesnoth/assets/489895/7956c605-4e49-49e2-aa4a-fae969c541c8">
