### PR TITLE
Display Preferences touch-ups

### DIFF
--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -375,11 +375,21 @@
 			border_size = 5
 			horizontal_alignment = "left"
 
-			[button]
-				id = choose_theme
-				label = _ "Theme"
+			[label]
+				label = _ "Theme:"
+				definition = "default_small"
+			[/label]
+		[/column]
+
+		[column]
+			border = "all"
+			border_size = 5
+			horizontal_alignment = "left"
+
+			[menu_button]
+				id = "choose_theme"
 				tooltip = _ "Change the in-game theme"
-			[/button]
+			[/menu_button]
 		[/column]
 	[/row]
 #enddef

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -211,7 +211,7 @@
 
 						[toggle_button]
 							id = "show_ellipses"
-							label = _ "Show team colors"
+							label = _ "Team colors"
 							tooltip = _ "Show a colored circle around the base of each unit to show which side it is on"
 						[/toggle_button]
 					[/column]
@@ -225,7 +225,7 @@
 
 						[toggle_button]
 							id = "show_grid"
-							label = _ "Show grid"
+							label = _ "Grid"
 							tooltip = _ "Overlay a grid over the map"
 						[/toggle_button]
 					[/column]
@@ -290,7 +290,7 @@
 
 			[toggle_button]
 				id = "animate_units_standing"
-				label = _ "Show unit standing animations"
+				label = _ "Unit standing animations"
 				tooltip = _ "Continuously animate standing units on the battlefield"
 			[/toggle_button]
 		[/column]
@@ -309,7 +309,7 @@
 
 						[toggle_button]
 							id = "animate_units_idle"
-							label = _ "Show unit idle animations"
+							label = _ "Unit idle animations"
 							tooltip = _ "Play short random animations for idle units"
 						[/toggle_button]
 					[/column]

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -12,7 +12,7 @@
 			horizontal_alignment = "left"
 
 			[label]
-				label = _ "Resolution:"
+				label = _ "Window size:"
 				definition = "default_small"
 			[/label]
 		[/column]
@@ -70,7 +70,7 @@
 			[menu_button]
 				id = "resolution_set"
 				definition = "default"
-				tooltip = _ "Change the game resolution"
+				tooltip = _ "Change the game window size"
 			[/menu_button]
 		[/column]
 
@@ -111,7 +111,7 @@
 
 			[toggle_button]
 				id = "auto_pixel_scale"
-				label = _ "Automatic pixel scale multiplier"
+				label = _ "pixel_scale_multiplier^Automatic scale"
 				tooltip = _ "Choose pixel scale multiplier automatically based on current resolution"
 			[/toggle_button]
 		[/column]
@@ -165,7 +165,7 @@
 						horizontal_alignment = "left"
 
 						[label]
-							label = _ "Theme:"
+							label = _ "Interface theme:"
 							definition = "default_small"
 						[/label]
 					[/column]
@@ -178,7 +178,7 @@
 
 						[menu_button]
 							id = "choose_theme"
-							tooltip = _ "Change the in-game theme"
+							tooltip = _ "Change the in-game interface theme"
 						[/menu_button]
 					[/column]
 				[/row]

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -211,7 +211,7 @@
 
 						[toggle_button]
 							id = "show_ellipses"
-							label = _ "Team colors"
+							label = _ "Team color indicators"
 							tooltip = _ "Show a colored circle around the base of each unit to show which side it is on"
 						[/toggle_button]
 					[/column]
@@ -225,7 +225,7 @@
 
 						[toggle_button]
 							id = "show_grid"
-							label = _ "Grid"
+							label = _ "Grid overlay"
 							tooltip = _ "Overlay a grid over the map"
 						[/toggle_button]
 					[/column]

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -197,8 +197,8 @@
 
 						[toggle_button]
 							id = "show_floating_labels"
-							label = _ "Show floating labels"
-							tooltip = _ "Show damage and healing amounts above a unit"
+							label = _ "Combat damage indicators"
+							tooltip = _ "Show amount of damage inflicted or healed as fading labels above units"
 						[/toggle_button]
 					[/column]
 				[/row]

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -3,9 +3,23 @@
 ### Preferences dialog, Display page
 ###
 
-#define _GUI_PREFERENCES_DISPLAY_GRID_1
+#define _GUI_PREFERENCES_DISPLAY_RESOLUTION_GRID
 	[row]
 
+		[column]
+			border = "top,left,right"
+			border_size = 5
+			horizontal_alignment = "left"
+
+			[label]
+				label = _ "Resolution:"
+				definition = "default_small"
+			[/label]
+		[/column]
+
+		# We don't use _GUI_PREFERENCES_MAIN_COMPOSITE_SLIDER because we want
+		# to split the slider and label into different grids in order to align
+		# with the resolution button
 		[column]
 			horizontal_grow = true
 
@@ -14,113 +28,28 @@
 				[row]
 
 					[column]
+						grow_factor = 0
 						border = "top,left,right"
 						border_size = 5
 						horizontal_alignment = "left"
 
 						[label]
-							label = _ "Resolution:"
+							id = "help_text"
 							definition = "default_small"
+							label = _ "Pixel scale multiplier:"
 						[/label]
 					[/column]
 
-					# We don't use _GUI_PREFERENCES_MAIN_COMPOSITE_SLIDER because we want
-					# to split the slider and label into different grids in order to align
-					# with the resolution button
 					[column]
-						horizontal_grow = true
-
-						[grid]
-
-							[row]
-
-								[column]
-									grow_factor = 0
-									border = "top,left,right"
-									border_size = 5
-									horizontal_alignment = "left"
-
-									[label]
-										id = "help_text"
-										definition = "default_small"
-										label = _ "Pixel scale multiplier:"
-									[/label]
-								[/column]
-
-								[column]
-									grow_factor = 1
-									border = "top,right"
-									border_size = 5
-									horizontal_grow = true
-
-									[label]
-										id = "pixel_scale_slider_label"
-										definition = "default_small"
-									[/label]
-								[/column]
-
-							[/row]
-
-						[/grid]
-
-					[/column]
-
-				[/row]
-
-				[row]
-
-					[column]
-						border = "all"
-						border_size = 5
-						horizontal_alignment = "left"
-
-						[menu_button]
-							id = "resolution_set"
-							definition = "default"
-							tooltip = _ "Change the game resolution"
-						[/menu_button]
-					[/column]
-
-					[column]
-						border = "all"
+						grow_factor = 1
+						border = "top,right"
 						border_size = 5
 						horizontal_grow = true
 
-						[slider]
-							id = "pixel_scale_slider"
-							definition = "minimal"
-							minimum_value,maximum_value = 1,4
-							step_size = 1
-							tooltip = _ "Set the global pixel scale multiplier. A pixel scale multiplier of 2 will make everything look twice as large."
-						[/slider]
-					[/column]
-
-				[/row]
-
-				[row]
-
-					[column]
-						border = "all"
-						border_size = 5
-						horizontal_alignment = "left"
-
-						[toggle_button]
-							id = "fullscreen"
-							label = _ "Full screen"
-							tooltip = _ "Toggle between fullscreen and window mode"
-						[/toggle_button]
-					[/column]
-
-					[column]
-						border = "all"
-						border_size = 5
-						horizontal_alignment = "left"
-
-						[toggle_button]
-							id = "auto_pixel_scale"
-							label = _ "Automatic pixel scale multiplier"
-							tooltip = _ "Choose pixel scale multiplier automatically based on current resolution"
-						[/toggle_button]
+						[label]
+							id = "pixel_scale_slider_label"
+							definition = "default_small"
+						[/label]
 					[/column]
 
 				[/row]
@@ -131,20 +60,62 @@
 
 	[/row]
 
-	{_GUI_PREFERENCES_SPACER_ROW}
+	[row]
+
+		[column]
+			border = "all"
+			border_size = 5
+			horizontal_alignment = "left"
+
+			[menu_button]
+				id = "resolution_set"
+				definition = "default"
+				tooltip = _ "Change the game resolution"
+			[/menu_button]
+		[/column]
+
+		[column]
+			border = "all"
+			border_size = 5
+			horizontal_grow = true
+
+			[slider]
+				id = "pixel_scale_slider"
+				definition = "minimal"
+				minimum_value,maximum_value = 1,4
+				step_size = 1
+				tooltip = _ "Set the global pixel scale multiplier. A pixel scale multiplier of 2 will make everything look twice as large."
+			[/slider]
+		[/column]
+
+	[/row]
 
 	[row]
+
 		[column]
 			border = "all"
 			border_size = 5
 			horizontal_alignment = "left"
 
 			[toggle_button]
-				id = "show_floating_labels"
-				label = _ "Show floating labels"
-				tooltip = _ "Show damage and healing amounts above a unit"
+				id = "fullscreen"
+				label = _ "Full screen"
+				tooltip = _ "Toggle between fullscreen and window mode"
 			[/toggle_button]
 		[/column]
+
+		[column]
+			border = "all"
+			border_size = 5
+			horizontal_alignment = "left"
+
+			[toggle_button]
+				id = "auto_pixel_scale"
+				label = _ "Automatic pixel scale multiplier"
+				tooltip = _ "Choose pixel scale multiplier automatically based on current resolution"
+			[/toggle_button]
+		[/column]
+
 	[/row]
 
 	[row]
@@ -154,14 +125,14 @@
 			horizontal_alignment = "left"
 
 			[toggle_button]
-				id = "show_ellipses"
-				label = _ "Show team colors"
-				tooltip = _ "Show a colored circle around the base of each unit to show which side it is on"
+				id = "vsync"
+				label = _ "VSync"
+				tooltip = _ "Reduces tearing by synchronizing rendering with the screen refresh rate (requires restart to take effect)"
 			[/toggle_button]
 		[/column]
-	[/row]
 
-	{_GUI_PREFERENCES_SPACER_ROW}
+		{GUI_FILLER}
+	[/row]
 
 	[row]
 		[column]
@@ -170,14 +141,116 @@
 			horizontal_alignment = "left"
 
 			[toggle_button]
-				id = "show_grid"
-				label = _ "Show grid"
-				tooltip = _ "Overlay a grid over the map"
+				id = "fps_limiter"
+				label = _ "Limit FPS"
+				tooltip = _ "Disabling this increases CPU usage, but may slightly improve performance (requires restart to take effect)"
 			[/toggle_button]
 		[/column]
-	[/row]
 
-	{_GUI_PREFERENCES_SPACER_ROW}
+		{GUI_FILLER}
+	[/row]
+#enddef
+
+#define _GUI_PREFERENCES_DISPLAY_UI_GRID
+	[row]
+		[column]
+			horizontal_alignment = "left"
+			vertical_alignment = "top"
+
+			[grid]
+				[row]
+					[column]
+						border = "top,right,left"
+						border_size = 5
+						horizontal_alignment = "left"
+
+						[label]
+							label = _ "Theme:"
+							definition = "default_small"
+						[/label]
+					[/column]
+				[/row]
+				[row]
+					[column]
+						border = "all"
+						border_size = 5
+						horizontal_alignment = "left"
+
+						[menu_button]
+							id = "choose_theme"
+							tooltip = _ "Change the in-game theme"
+						[/menu_button]
+					[/column]
+				[/row]
+			[/grid]
+		[/column]
+
+		[column]
+			horizontal_alignment = "left"
+
+			[grid]
+				[row]
+					[column]
+						border = "all"
+						border_size = 5
+						horizontal_alignment = "left"
+
+						[toggle_button]
+							id = "show_floating_labels"
+							label = _ "Show floating labels"
+							tooltip = _ "Show damage and healing amounts above a unit"
+						[/toggle_button]
+					[/column]
+				[/row]
+
+				[row]
+					[column]
+						border = "all"
+						border_size = 5
+						horizontal_alignment = "left"
+
+						[toggle_button]
+							id = "show_ellipses"
+							label = _ "Show team colors"
+							tooltip = _ "Show a colored circle around the base of each unit to show which side it is on"
+						[/toggle_button]
+					[/column]
+				[/row]
+
+				[row]
+					[column]
+						border = "all"
+						border_size = 5
+						horizontal_alignment = "left"
+
+						[toggle_button]
+							id = "show_grid"
+							label = _ "Show grid"
+							tooltip = _ "Overlay a grid over the map"
+						[/toggle_button]
+					[/column]
+				[/row]
+			[/grid]
+		[/column]
+	[/row]
+#enddef
+
+#define _GUI_PREFERENCES_DISPLAY_GRID
+
+	[row]
+		[column]
+			horizontal_grow = true
+
+			[grid]
+				# NOTE:
+				# These are in the same grid to keep their columns aligned.
+
+				{_GUI_PREFERENCES_DISPLAY_RESOLUTION_GRID}
+
+				{_GUI_PREFERENCES_DISPLAY_UI_GRID}
+			[/grid]
+		[/column]
+	[/row]
 
 	[row]
 		[column]
@@ -206,6 +279,8 @@
 			[/toggle_button]
 		[/column]
 	[/row]
+
+	{_GUI_PREFERENCES_SPACER_ROW}
 
 	[row]
 		[column]
@@ -336,62 +411,6 @@
 	#		[/grid]
 	#	[/column]
 	#[/row]
-
-	{_GUI_PREFERENCES_SPACER_ROW}
-
-	[row]
-		[column]
-			border = "all"
-			border_size = 5
-			horizontal_alignment = "left"
-
-			[toggle_button]
-				id = "vsync"
-				label = _ "VSync"
-				tooltip = _ "Reduces tearing by synchronizing rendering with the screen refresh rate (requires restart to take effect)"
-			[/toggle_button]
-		[/column]
-	[/row]
-
-	[row]
-		[column]
-			border = "all"
-			border_size = 5
-			horizontal_alignment = "left"
-
-			[toggle_button]
-				id = "fps_limiter"
-				label = _ "Limit FPS"
-				tooltip = _ "Disabling this increases CPU usage, but may slightly improve performance (requires restart to take effect)"
-			[/toggle_button]
-		[/column]
-	[/row]
-#enddef
-
-#define _GUI_PREFERENCES_DISPLAY_GRID_2
-	[row]
-		[column]
-			border = "all"
-			border_size = 5
-			horizontal_alignment = "left"
-
-			[label]
-				label = _ "Theme:"
-				definition = "default_small"
-			[/label]
-		[/column]
-
-		[column]
-			border = "all"
-			border_size = 5
-			horizontal_alignment = "left"
-
-			[menu_button]
-				id = "choose_theme"
-				tooltip = _ "Change the in-game theme"
-			[/menu_button]
-		[/column]
-	[/row]
 #enddef
 
 [layer]
@@ -404,27 +423,13 @@
 			vertical_alignment = "top"
 
 			[grid]
-				{_GUI_PREFERENCES_DISPLAY_GRID_1}
-			[/grid]
-		[/column]
-	[/row]
-
-	{_GUI_PREFERENCES_SPACER_ROW}
-
-	[row]
-		grow_factor = 1
-
-		[column]
-			horizontal_alignment = "left"
-			vertical_alignment = "top"
-
-			[grid]
-				{_GUI_PREFERENCES_DISPLAY_GRID_2}
+				{_GUI_PREFERENCES_DISPLAY_GRID}
 			[/grid]
 		[/column]
 	[/row]
 
 [/layer]
 
-#undef _GUI_PREFERENCES_DISPLAY_GRID_1
-#undef _GUI_PREFERENCES_DISPLAY_GRID_2
+#undef _GUI_PREFERENCES_DISPLAY_GRID
+#undef _GUI_PREFERENCES_DISPLAY_UI_GRID
+#undef _GUI_PREFERENCES_DISPLAY_RESOLUTION_GRID

--- a/data/gui/window/preferences/03_display.cfg
+++ b/data/gui/window/preferences/03_display.cfg
@@ -178,7 +178,7 @@
 
 						[menu_button]
 							id = "choose_theme"
-							tooltip = _ "Change the in-game interface theme"
+							tooltip = _ "Change the in-game interface theme. Additional themes may be provided by community-made add-ons"
 						[/menu_button]
 					[/column]
 				[/row]

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -23,6 +23,7 @@
 #include "filesystem.hpp"
 #include "formatter.hpp"
 #include "formula/string_utils.hpp"
+#include "game_data.hpp"
 #include "gettext.hpp"
 #include "hotkey/hotkey_item.hpp"
 #include "lexical_cast.hpp"
@@ -31,6 +32,8 @@
 #include "preferences/game.hpp"
 #include "preferences/general.hpp"
 #include "preferences/lobby.hpp"
+#include "resources.hpp"
+#include "theme.hpp"
 #include "video.hpp"
 
 // Sub-dialog includes
@@ -114,6 +117,7 @@ preferences_dialog::preferences_dialog(const PREFERENCE_VIEW initial_view)
 	: modal_dialog(window_id())
 	, adv_preferences_(preferences::get_advanced_preferences())
 	, resolutions_() // should be populated by set_resolution_list before use
+	, themes_() // populated by set_theme_list
 	, last_selected_item_(0)
 	, accl_speeds_({0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 3, 4, 8, 16})
 	, visible_hotkeys_()
@@ -148,6 +152,23 @@ void preferences_dialog::set_resolution_list(menu_button& res_list)
 		resolutions_.begin(), resolutions_.end(), video::current_resolution()));
 
 	res_list.set_values(options, current_res);
+}
+
+void preferences_dialog::set_theme_list(menu_button& theme_list)
+{
+	themes_ = theme::get_basic_theme_info();
+
+	std::vector<config> options;
+	for(const auto& theme : themes_) {
+		options.emplace_back("label", theme.name, "tooltip", theme.description);
+	}
+
+	const unsigned current_theme = std::distance(themes_.begin(),
+		std::find_if(themes_.begin(), themes_.end(), [](const auto& theme) {
+			return theme.id == preferences::theme();
+		}));
+
+	theme_list.set_values(options, current_theme);
 }
 
 widget_data preferences_dialog::get_friends_list_row_data(const acquaintance& entry)
@@ -498,9 +519,13 @@ void preferences_dialog::initialize_callbacks()
 	register_bool("vsync", true, vsync, set_vsync);
 
 	/* SELECT THEME */
-	connect_signal_mouse_left_click(
-			find_widget<button>(this, "choose_theme", false),
-			std::bind(&show_theme_dialog));
+	menu_button& theme_list = find_widget<menu_button>(this, "choose_theme", false);
+	set_theme_list(theme_list);
+	connect_signal_notify_modified(theme_list,
+		std::bind(&preferences_dialog::handle_theme_select, this));
+	//connect_signal_mouse_left_click(
+	//		find_widget<button>(this, "choose_theme", false),
+	//		std::bind(&show_theme_dialog));
 
 	//
 	// SOUND PANEL
@@ -1100,6 +1125,21 @@ void preferences_dialog::handle_res_select()
 	if(video::set_resolution(resolutions_[res_list.get_value()])) {
 		set_resolution_list(res_list);
 	}
+}
+
+void preferences_dialog::handle_theme_select()
+{
+	menu_button& theme_list = find_widget<menu_button>(this, "choose_theme", false);
+
+	const auto selection = theme_list.get_value();
+	const auto& theme = themes_.at(selection);
+	auto* display = display::get_singleton();
+
+	preferences::set_theme(theme.id);
+	if(display && resources::gamedata && resources::gamedata->get_theme().empty()) {
+		display->set_theme(theme.id);
+	}
+
 }
 
 void preferences_dialog::on_page_select()

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -22,6 +22,7 @@
 #include "hotkey/hotkey_command.hpp"
 #include "preferences/advanced.hpp"
 #include "preferences/game.hpp"
+#include "theme.hpp"
 
 // This file is not named preferences.hpp in order -I conflicts with
 // src/preferences.hpp.
@@ -31,6 +32,7 @@ namespace hotkey {
 }
 
 struct point;
+//struct theme_info;
 
 namespace preferences {
 	enum PREFERENCE_VIEW {
@@ -84,6 +86,7 @@ private:
 	void initialize_callbacks();
 	void initialize_tabs(listbox& selector);
 	void set_resolution_list(menu_button& res_list);
+	void set_theme_list(menu_button& theme_list);
 	listbox& setup_hotkey_list();
 
 	template<bool(*toggle_getter)(), bool(*toggle_setter)(bool), int(*vol_getter)(), void(*vol_setter)(int)>
@@ -108,6 +111,7 @@ private:
 
 	/** Special callback functions */
 	void handle_res_select();
+	void handle_theme_select();
 	void fullscreen_toggle_callback();
 	void add_hotkey_callback(listbox& hotkeys);
 	void remove_hotkey_callback(listbox& hotkeys);
@@ -119,6 +123,7 @@ private:
 	const preferences::advanced_pref_list& adv_preferences_;
 
 	std::vector<point> resolutions_;
+	std::vector<theme_info> themes_;
 
 	int last_selected_item_;
 


### PR DESCRIPTION
This PR started out as a reorganisation of the Theme selection in the Preferences -> Display section but now includes other layout/label changes in the same section.

<img width="796" alt="Screenshot 2023-06-05 at 01 00 00" src="https://github.com/wesnoth/wesnoth/assets/489895/e679b151-e619-4541-9ed8-831b6618b9be">

## General changes

* The Theme selection is now a dropdown menu in the Preferences panel rather than a sub-dialog (sub-dialogs are not ideal), and the labels clarify it's the Interface theme
* The Show grid/team colours/floating labels options are now grouped with the theme selection as part of a general UI options group
* The Automatic pixel scale multiplier checkbox has a shorter label to avoid redundancy
* The Resolution options now refer to the window size instead, matching the current implementation of Fullscreen which is really Borderless windowed and always uses the desktop resolution, meaning the game's "resolution" is nothing but the non-fullscreen window size
* The VSync and Limit FPS options are grouped together with the Window size options
* The Animated map/water and Show unit standing/idle animations are in two separate groups of their own now

## Other ideas

* Relabel Show team colors as Show team color ellipses?
* Relabel Show floating labels as Show damage indicators? (The game implementation uses "floating labels" to refer to map labels and the like, which are not affected by this option in any way. Even if the internal name were different, the fact is that static labels still "float" in a way)
* Drop "Show" from several options (It is rather redundant)

## Note

* The old Theme selection menu and the `show_theme_dialog()` function are **not** gone and can still be triggered using the in-game console via the `:theme` command
* I left in some commented-out fragments in the first commit I need to remove before merging