### PR TITLE
WML Tools: Retain file owner, group, and permissions when writing new file

### DIFF
--- a/data/tools/wmlindent
+++ b/data/tools/wmlindent
@@ -288,41 +288,51 @@ def convertor(linefilter, arglist, exclude):
                         print("wmlindent: %s excluded" % filename, file=sys.stderr)
                     continue
                 else:
+                    backup = f'{filename}-bak'
+                    if sys.platform == 'win32' and os.path.exists(backup):
+                        os.remove(backup)
+                    os.rename(filename, backup)
+
                     try:
-                        with codecs.open(filename,"r","utf8") as infp, codecs.open(filename + ".out", "w","utf8") as outfp:
+                        with codecs.open(backup, "r", "utf8") as infp,\
+                                codecs.open(filename, "w", "utf8") as outfp:
                             linefilter(filename, infp, outfp)
+
                     except bailout as e:
+                        os.remove(filename)
+                        os.rename(backup, filename)
                         print('wmlindent: "%s", %d: %s' % (e.filename, e.lineno, e.msg), file=sys.stderr)
-                        os.remove(filename + ".out")
+
                     except UnicodeDecodeError as e:
-                        os.remove(filename + ".out")
+                        os.remove(filename)
+                        os.rename(backup, filename)
                         print('wmlindent: "{}" is not a valid UTF-8 file'.format(filename), file=sys.stderr)
+
                     except KeyboardInterrupt:
-                        os.remove(filename + ".out")
+                        os.remove(filename)
+                        os.rename(backup, filename)
                         print("wmlindent: %s interrupted" % filename, file=sys.stderr)
+
                     else:
-                        if filecmp.cmp(filename, filename + ".out"):
+                        if filecmp.cmp(filename, backup):
                             if verbose >= 2:
                                 print("wmlindent: %s unchanged" % filename, file=sys.stderr)
-                            os.remove(filename + ".out")
+                            os.remove(filename)
+                            os.rename(backup, filename)
+
                         else:
                             if not quiet:
                                 print("wmlindent: %s changed" % filename, file=sys.stderr)
+
                             if dryrun:
-                                os.remove(filename + ".out")
+                                os.remove(filename)
+                                os.rename(backup, filename)
+
                             else:
-                                file_stat = os.stat(filename)
-
-                                os.remove(filename) # For Windows portability
-                                # There's a tiny window open if you keyboard-
-                                # interrupt here. It's unavoidable, because
-                                # there's no known way to do an atomic rename
-                                # under Windows when the target exists -- see
-                                # Python manual 14.1.4::rename()
-                                os.rename(filename + ".out", filename)
-
+                                file_stat = os.stat(backup)
                                 os.chmod(filename, file_stat.st_mode)
                                 os.chown(filename, file_stat.st_uid, file_stat.st_gid)
+                                os.remove(backup)
 
         else: # in a for .. else cycle, else is always executed after the for cycle ends
             if not found_valid_path:

--- a/data/tools/wmlindent
+++ b/data/tools/wmlindent
@@ -28,7 +28,7 @@ wmlindent will ignore them.  You may need to do this for unbalanced
 macros (it's better, though, to get rid of those where possible).
 Use 'wmlindent: {start,stop} ignoring' anywhere in a comment.
 
-It is also possible to declare custom openers an closers, e.g for macros
+It is also possible to declare custom openers and closers, e.g. for macros
 that are actually control constructs.  To do this, use declarations
 
     # wmlindent: opener "{EXCEPTIONAL_OPENER "
@@ -113,7 +113,7 @@ def strip_comment(line, in_string):
     split = line.split('"')
     result = split[0]
     if not in_string and '#' in result:
-        return result.split('#')[0].rstrip();
+        return result.split('#')[0].rstrip()
     split.pop(0)
     for component in split:
         in_string = not in_string
@@ -311,6 +311,8 @@ def convertor(linefilter, arglist, exclude):
                             if dryrun:
                                 os.remove(filename + ".out")
                             else:
+                                file_stat = os.stat(filename)
+
                                 os.remove(filename) # For Windows portability
                                 # There's a tiny window open if you keyboard-
                                 # interrupt here. It's unavoidable, because
@@ -318,6 +320,10 @@ def convertor(linefilter, arglist, exclude):
                                 # under Windows when the target exists -- see
                                 # Python manual 14.1.4::rename()
                                 os.rename(filename + ".out", filename)
+
+                                os.chmod(filename, file_stat.st_mode)
+                                os.chown(filename, file_stat.st_uid, file_stat.st_gid)
+
         else: # in a for .. else cycle, else is always executed after the for cycle ends
             if not found_valid_path:
                 print("wmlindent: no WML file found, exiting", file=sys.stderr)

--- a/data/tools/wmlindent
+++ b/data/tools/wmlindent
@@ -43,10 +43,10 @@ The public utility macros "{FOREACH" and "{NEXT" come as wired-in exceptions,
 because it is not guaranteed that their indent declarations will be processed
 before the macro library is reached.
 
-Interrupting will be safe, as each reindenting will be done to a copy
-that is atomically renamed when it's done.  If the output file is identical
-to the input, the output file will simply be deleted, so the timestamp
-on the input file won't be touched.
+Interrupting is not safe, as each reindenting will be done against the original
+file, with a back-up that is only removed when it's done.  If the output file
+is identical to the input, the output file will simply be deleted, so the
+timestamp on the input file won't be touched.
 
 The --dryrun option detects and reports files that would be changed
 without changing them. The --verbose or -v option enables reporting
@@ -61,9 +61,17 @@ if there's an indent open at end of file or if a closer occurs with
 indent already zero; these two conditions strongly suggest unbalanced WML.
 """
 
-import sys, os, argparse, filecmp, re, codecs, signal
-from wesnoth import wmltools3 as wmltools
+import argparse
+import codecs
+import filecmp
+import os
+import re
+import shutil
+import signal
+import sys
+
 from wesnoth import version
+from wesnoth import wmltools3 as wmltools
 
 closer_prefixes = ["{NEXT "]
 opener_prefixes = ["{FOREACH "]
@@ -89,7 +97,7 @@ def opener(str):
     # This logic is a bit obscure. The 'not "[/" in str' catches the
     # obvious case of a closing tag, but it also catches the idiom
     # [allow_undo][/allow_undo] which we want to treat as a no-op.
-    elif (str.startswith("[") and not closer(str) and not "[/" in str):
+    elif str.startswith("[") and not closer(str) and not "[/" in str:
         return True
     # Trailing ( opens a scope to be closed by ).
     elif str.endswith("(\n") and '#' not in str:
@@ -288,10 +296,12 @@ def convertor(linefilter, arglist, exclude):
                         print("wmlindent: %s excluded" % filename, file=sys.stderr)
                     continue
                 else:
+                    # wmlindent originally output to a new file and if the change was kept the new file was renamed to
+                    # the original. However, this causes issues with things like file permissions (GitHub issue #7708),
+                    # so instead copy the original to a back-up and use that as the source, with the original file as
+                    # the output.
                     backup = f'{filename}-bak'
-                    if sys.platform == 'win32' and os.path.exists(backup):
-                        os.remove(backup)
-                    os.rename(filename, backup)
+                    shutil.copy2(filename, backup)  # copy2 differs from copy in that it attempts to retain meta-data
 
                     try:
                         with codecs.open(backup, "r", "utf8") as infp,\
@@ -299,39 +309,31 @@ def convertor(linefilter, arglist, exclude):
                             linefilter(filename, infp, outfp)
 
                     except bailout as e:
-                        os.remove(filename)
-                        os.rename(backup, filename)
                         print('wmlindent: "%s", %d: %s' % (e.filename, e.lineno, e.msg), file=sys.stderr)
+                        os.replace(backup, filename)
 
                     except UnicodeDecodeError as e:
-                        os.remove(filename)
-                        os.rename(backup, filename)
                         print('wmlindent: "{}" is not a valid UTF-8 file'.format(filename), file=sys.stderr)
+                        os.replace(backup, filename)
 
                     except KeyboardInterrupt:
-                        os.remove(filename)
-                        os.rename(backup, filename)
                         print("wmlindent: %s interrupted" % filename, file=sys.stderr)
+                        os.replace(backup, filename)
 
                     else:
                         if filecmp.cmp(filename, backup):
                             if verbose >= 2:
                                 print("wmlindent: %s unchanged" % filename, file=sys.stderr)
-                            os.remove(filename)
-                            os.rename(backup, filename)
+                            os.replace(backup, filename)
 
                         else:
                             if not quiet:
                                 print("wmlindent: %s changed" % filename, file=sys.stderr)
 
                             if dryrun:
-                                os.remove(filename)
-                                os.rename(backup, filename)
+                                os.replace(backup, filename)
 
                             else:
-                                file_stat = os.stat(backup)
-                                os.chmod(filename, file_stat.st_mode)
-                                os.chown(filename, file_stat.st_uid, file_stat.st_gid)
                                 os.remove(backup)
 
         else: # in a for .. else cycle, else is always executed after the for cycle ends

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -177,11 +177,20 @@
 # code.
 #
 
-import sys, os, re, argparse, string, copy, difflib, time, gzip, codecs
-from wesnoth.wmltools3 import *
-from wesnoth.wmliterator3 import *
-from collections import defaultdict
+import argparse
+import codecs
+import copy
+import difflib
+import gzip
+import os
+import re
+import shutil
+import sys
+import time
+
 from wesnoth import version
+from wesnoth.wmliterator3 import *
+from wesnoth.wmltools3 import *
 
 # Changes meant to be done on maps and .cfg lines.
 mapchanges = (
@@ -2441,7 +2450,7 @@ to be called on their own".format(filename, num))
             # Recognize units when unstored
             if (in_scenario or in_multiplayer) and in_store:
                 if key == 'id' and not in_not:
-                    if storeid is not None:
+                    if storeid:
                         storeid = storeid + ',' + value
                     else:
                         storeid = value
@@ -3752,15 +3761,7 @@ In your case, your system interprets your arguments as:
                         elif revert:
                             print("wmllint: reverting %s" % backup)
                             if not dryrun:
-                                file_stat = os.stat(fn)
-
-                                if sys.platform == 'win32':
-                                    os.remove(fn)
-                                os.rename(backup, fn)
-
-                                os.chmod(fn, file_stat.st_mode)
-                                os.chown(fn, file_stat.st_uid, file_stat.st_gid)
-
+                                os.replace(backup, fn)
                 elif diffs:
                     # Display diffs
                     if os.path.exists(backup):
@@ -3782,17 +3783,17 @@ In your case, your system interprets your arguments as:
                         if changed:
                             print("wmllint: converting", fn)
                             if not dryrun:
-                                if sys.platform == 'win32' and os.path.exists(backup):
-                                    os.remove(backup)
-                                os.rename(fn, backup)
+                                # copy2 differs from copy in that it attempts to retain meta-data
+                                shutil.copy2(fn, backup)
+
                                 if fn.endswith(".gz"):
                                     with gzip.open(fn, "w") as ofp:
                                         ofp.write(changed)
+
                                 else:
                                     with codecs.open(fn, "w", "utf8") as ofp:
                                         ofp.write(changed)
-                    #except maptransform_error, e:
-                    #    print("wmllint: " + repr(e), file=sys.stderr)
+
                     except:
                         print("wmllint: internal error on %s" % fn, file=sys.stderr)
                         (exc_type, exc_value, exc_traceback) = sys.exc_info()

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1482,7 +1482,7 @@ mainline = ("Dead_Water",
             "World_Conquest",
             )
 
-spellcheck_these = (\
+spellcheck_these = (
     "cannot_use_message=",
     "caption=",
     "description=",
@@ -2383,10 +2383,7 @@ to be called on their own".format(filename, num))
             if macname in whopairs:
                 for who in whopairs[macname].split(","):
                     if who.strip().startswith("--"):
-                        try:
-                            present.remove(who.replace('--', '', 1).strip())
-                        except:
-                            ValueError
+                        present.remove(who.replace('--', '', 1).strip())
                     else:
                         present.append(who.strip())
             elif not leadmac.group().endswith('}'):
@@ -2444,8 +2441,8 @@ to be called on their own".format(filename, num))
             # Recognize units when unstored
             if (in_scenario or in_multiplayer) and in_store:
                 if key == 'id' and not in_not:
-                    if not storeid == None:
-                        storeid == storeid + ',' + value
+                    if storeid is not None:
+                        storeid = storeid + ',' + value
                     else:
                         storeid = value
                 elif key == 'variable' and '{' not in value:
@@ -2582,7 +2579,7 @@ def condition_match(p, q):
     nq = False
     if sq.startswith("!"):
         sq = sp[1:]
-        nq == True
+        nq = True
     return (sp != sq) and (np != nq)
 
 def consistency_check():
@@ -3600,9 +3597,9 @@ directory.""")
         # Handle SingleUnitWML or Standard Unit Filter or SideWML
         # Also, when macro calls have description= in them, the arg is
         # a SUF being passed in.
-        if tagstack and ((under("unit") and "units" not in filename) or \
-               standard_unit_filter() or \
-               under("side") or \
+        if tagstack and ((under("unit") and "units" not in filename) or
+               standard_unit_filter() or
+               under("side") or
                re.search("{[A-Z]+.*description=.*}", line)):
             if "id" not in tagstack[-1][1] and "_" not in line:
                 line = re.sub(r"\bdescription\s*=", "id=", line)
@@ -3755,9 +3752,15 @@ In your case, your system interprets your arguments as:
                         elif revert:
                             print("wmllint: reverting %s" % backup)
                             if not dryrun:
+                                file_stat = os.stat(fn)
+
                                 if sys.platform == 'win32':
                                     os.remove(fn)
                                 os.rename(backup, fn)
+
+                                os.chmod(fn, file_stat.st_mode)
+                                os.chown(fn, file_stat.st_uid, file_stat.st_gid)
+
                 elif diffs:
                     # Display diffs
                     if os.path.exists(backup):


### PR DESCRIPTION
Resolves #7708

I only tested on Linux, not sure if there needs to be other things done to accommodate Windows platform (as with `os.rename`).

Would also appreciate review of the other changes too - some really weird code here, I'm guessing due to age, like use of equality operations where it looks like it's meant to be an assignment, plus a nonsensical try-except block that doesn't do anything with the exception.