### PR TITLE
UtBS: improve po hints

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/02_Across_the_Harsh_Sands.cfg
@@ -364,6 +364,7 @@
 #define SCORPION_PLACEMENT
     {SCATTER_UNITS {ON_DIFFICULTY 6 7 8} "Sand Scuttler" 0 x,y,radius=29,62,2 (
         side=3
+        # po: a variant of the Giant Scorpion unit type
         name= _ "Scuttler"
         ai_special=guardian
         animate=yes

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
@@ -657,6 +657,16 @@
         [/message]
         [message]
             speaker=Garak
+            # po: Garak dies in this scenario, and the important part of this conversation is to tell the player that.
+            #
+            # The English text is currently wrong, it's meant to say "dreams this night" not "dreams of this night", a
+            # typo that will be corrected in 1.18 but not 1.16. The next paragraph is talking about what the text should
+            # mean, not what it currently is.
+            #
+            # This is said at LONGDARK4, with the moon on the schedule picture as if the next turn will be dawn. Garak
+            # has had the dreams tonight while they were camped here, he hasn't had premonitions beforehand; that's
+            # probably just because of the nearby undead, not some prophetic vision. Neither Garak nor a first-time
+            # player know that the scenario will extend the night indefinitely until the enemies are defeated.
             message=_"I had dreams of this night Kaleh, full of gloom and darkness, my journey will end here one way or another."
         [/message]
         [message]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06b_In_the_Domain_of_Dwarves.cfg
@@ -672,6 +672,7 @@
 
         [message]
             x,y=10,34
+            # po: "you" is singular and referring to a superior officer
             message= _ "But sir, behind you...!"
         [/message]
 
@@ -730,6 +731,7 @@
                 [/modify_unit]
                 [message]
                     speaker=Dwarf Sergeant
+                    # po: the human is female (Elyssa), but even if gender matters then the speaker is probably already speaking while turning to see her
                     message= _ "What is a human doing here? Come on, boys, kill the intruder!"
                 [/message]
             [/case]
@@ -737,7 +739,7 @@
                 value=monster
                 [message]
                     x,y=10,34
-                    #po: "it" is referring to the dust devil
+                    # po: "it" is referring to the dust devil
                     message= _ "No, it’s a... what is that?"
                 [/message]
                 [modify_unit]
@@ -748,7 +750,7 @@
                 [/modify_unit]
                 [message]
                     speaker=Dwarf Sergeant
-                    #po: 'earth’s guts' references the underground. What is being talked about is the dust devil.
+                    # po: 'earth’s guts' references the underground. What is being talked about is the dust devil.
                     message= _ "What in the earth’s guts is that? Kill it!"
                 [/message]
             [/case]
@@ -787,6 +789,7 @@
 
         [message]
             speaker=unit
+            # po: "Sarge" is short for "Sergeant". This is intended to be a funny death message.
             message= _ "I love you, Sarge..."
         [/message]
     [/event]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/08_Out_of_the_Frying_Pan.cfg
@@ -626,6 +626,7 @@
 
                 [message]
                     role=avenger
+                    # po: The grammar here is troll speech, and its second sentence merges the second and third sentences of the dwarven equivalent.
                     message= _ "Foul elves, you not escaped us yet. Great Leader will be avenged! We plugged river and you all drown with us!"
                 [/message]
             [/then]
@@ -2555,9 +2556,9 @@
                     [/variable]
                 [/and]
                 [then]
-                    # Nym is blocked by deep water
                     [message]
                         speaker=Nym
+                        # po: Nym is blocked by deep water, and drowning is inevitable
                         message= _ "Kaleh? Zhul? I’m still stuck back here..."
                         image=portraits/nym_moody.webp
                     [/message]
@@ -2606,9 +2607,9 @@
                             numerical_equals=0
                         [/variable]
                         [then]
-                            # Kaleh is blocked by deep water
                             [message]
                                 speaker=Kaleh
+                                # po: Kaleh is blocked by deep water, and drowning is inevitable
                                 message= _ "Ack, I’m surrounded by water!"
                             [/message]
 
@@ -4594,10 +4595,9 @@
             message= _ "Don’t try to explain, Esanoo. We’ll have to show them instead."
         [/message]
 
-        # original dialog makes extensive use of "my master" for Esanoo, which might makes sense for a goblin, but seems a bit off here
-        # I went with "wise leader", can probably be improved
         [message]
             speaker=Esanoo
+            # po: Esanoo is a merman, his leader (Melusand) is female, and his brethren on this mission include a mix of genders.
             message= _ "It’s not important. What’s important is that I am an emissary from one who much desires to speak with you, Kaleh. Despite the danger, our wise leader sent me and my brethren to scour the dry land searching for you."
         [/message]
 


### PR DESCRIPTION
Forward-port of #7697, so assuming that just waiting 24 hours for the CI and any comments is OK.

po: The rest of this commit message is for the translators' changelog, because it's notes about what changed recently, as found by looking at fuzzies while updating the German translation.

S01 "Come on, Kaleh, we have to go see if anyone is hurt or needs help. ..." was just a grammar fix, of "answer to the call".

UtBS S08's dialogue had Esanoo refer to Melusand as "my master" repeatedly. That changed to "leader" or "wise leader" in 1.15.4, mainly without other changes in the text.

Other lines should have changed "master" to "leader". I'm planning to do that later, but this commit is just the cherry-pick.
* S08 Zhul's "You don’t know where to find your master?"
* S08 Kaleh's two game-over lines because "too many merfolk have died"

UtBS S08 "You dare defy me?!..." : the change is just a typo fix

UtBS S10 "This will go much faster if you don’t interrupt me. ..." the one-word change is from "the many" to "many" in the last sentence.

UtBS unit type Dawarf: the unit description had a grammar correction of "it's isn't"

(cherry picked from commit b42a1b83a1f318222f58bb206eabfd1656043c29)