### PR TITLE
1.17 - add primary key to some unit animations that need it

### DIFF
--- a/data/core/units/monsters/Jinn.cfg
+++ b/data/core/units/monsters/Jinn.cfg
@@ -76,6 +76,7 @@ units/monsters/jinn#enddef
         [top_frame]
             image="{IMG_PATH_TEMP}/jinn-top.png:400,{IMG_PATH_TEMP}/jinn-top-hi.png:400,{IMG_PATH_TEMP}/jinn-top.png:600,{IMG_PATH_TEMP}/jinn-top-lo.png:600,"
             auto_vflip=no
+            primary=yes
         [/top_frame]
     [/standing_anim]
     [movement_anim]

--- a/data/core/units/monsters/Wild_Wyvern.cfg
+++ b/data/core/units/monsters/Wild_Wyvern.cfg
@@ -25,6 +25,7 @@
             image="units/monsters/wyvern/wild-wyvern-fly[1~7].png:[100*3,120,130,140,110]"
             auto_vflip=no
             layer=60 # taken from bat, may need adjustment
+            primary=yes
         [/wyvern_frame]
         [frame]
             image="units/monsters/wyvern/wild-wyvern-fly-shadow.png:800"
@@ -68,6 +69,7 @@ Wyverns are social creatures, usually traveling in pairs or small groups. Their 
             image="units/monsters/wyvern/wild-wyvern-fly[1~7].png:[100*3,120,130,140,110]"
             auto_vflip=no
             layer=60 # taken from bat, may need adjustment
+            primary=yes
         [/wyvern_frame]
         [frame]
             image="units/monsters/wyvern/wild-wyvern-fly-shadow.png:800"

--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -190,6 +190,7 @@
             [bird_frame]
                 image="units/undead/soulless-falcon.png:1600"
                 auto_vflip=no
+                primary=yes
             [/bird_frame]
         [/standing_anim]
         [movement_anim]

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -191,6 +191,7 @@ NOP#endarg
             [bird_frame]
                 image="units/undead/zombie-falcon.png:1600"
                 auto_vflip=no
+                primary=yes
             [/bird_frame]
         [/standing_anim]
         [movement_anim]


### PR DESCRIPTION
Some units still didn't change color when they were supposed to (poisoned or petrified*, anything else?)
 - Jinn 
 - Wild Wyvern
 - WC & Soulless Falcon

I think this is it, but if anyone finds something, I can add it to the list.

partially deals with #7709 

[*] via debug, they do turn gray under most circumstances.