### PR TITLE
Add [test_do_attack_by_id], a wrapper for [do_command][attack]

### DIFF
--- a/data/test/_main.cfg
+++ b/data/test/_main.cfg
@@ -29,6 +29,10 @@
 #Load test macros
 {test/macros}
 
+[lua]
+    code = "wesnoth.dofile 'test/lua/wml_tags.lua'"
+[/lua]
+
 # Load automated test scenarios.
 #
 # They can be run individually with Wesnoth's `-u` command line option, but are usually run by

--- a/data/test/lua/wml_tags.lua
+++ b/data/test/lua/wml_tags.lua
@@ -1,0 +1,48 @@
+--! #textdomain wesnoth-test
+
+local T = wml.tag
+
+---Wrapper for [do_command][attack] that takes unit ids instead of map coordinates,
+---as tests are likely to already know the id.
+---
+---cfg.attacker,cfg.defender are unit ids, and map to [attack]source,destination=
+---cfg.weapon,cfg.defender_weapon are optional, and map to [attack]weapon,defender_weapon=
+---
+---cfg.resupply_attacks_left is an optional int, if set then it will ensure the attacker has
+---at least that many attacks_left before calling [do_command][attack].
+function wesnoth.wml_actions.test_do_attack_by_id(cfg)
+	-- can't be called "source", otherwise wmllint wants to add translation marks
+	if not cfg.attacker then
+		wml.error("[test_do_attack] missing required attacker= attribute")
+	end
+	local attacker = wesnoth.units.find_on_map { id = cfg.attacker }[1]
+	if not attacker or not attacker.valid then
+		wml.error("[test_do_attack] attacker did not match a unit")
+	end
+
+	if not cfg.defender then
+		wml.error("[test_do_attack] missing required defender= attribute")
+	end
+	local defender = wesnoth.units.find_on_map { id = cfg.defender }[1]
+	if not defender or not defender.valid then
+		wml.error("[test_do_attack] defender did not match a unit")
+	end
+
+	local weapon = cfg.weapon or ""
+	local defender_weapon = cfg.defender_weapon or ""
+
+	-- Avoid needing to modify units to give them multiple attacks per round
+	-- This attribute is a number rather than a boolean, to support [attack]attacks_used=
+	if cfg.resupply_attacks_left and attacker.attacks_left < cfg.resupply_attacks_left then
+		attacker.attacks_left = cfg.resupply_attacks_left
+	end
+
+	wesnoth.wml_actions.do_command {
+		T.attack {
+			T.source { x = attacker.x, y = attacker.y },
+			T.destination { x = defender.x, y = defender.y },
+			weapon = weapon,
+			defender_weapon = defender_weapon,
+		}
+	}
+end

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/plague_without_priority.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/plague_without_priority.cfg
@@ -1,0 +1,170 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [specials][plague],[abilities][plague]affect_allies=yes
+##
+# Actions:
+# This uses a "common keep" map, with Alice and Bob already adjacent to the other units.
+# Give Bob a plague weapon special that creates Blood Bats.
+# Make Charlie teach a plague ability that creates Chocobones.
+# Make Dave teach a plague ability that creates Dragonguards.
+# Create targets around Alice and Bob.
+# Have Alice and Bob kill 1 target each.
+# Remove Charlie and Dave.
+# Have Alice and Bob kill 1 target each.
+##
+# Expected end state:
+# Alice's attacks created 1 unit of a type taught by Charlie or Dave.
+# Bob's own weapon special had priority over Charlie and Dave's teaching ability.
+# Bob's attacks created 2 Blood Bats.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST plague_without_priority (
+    [event]
+        name=start
+
+        [object]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    {WEAPON_SPECIAL_PLAGUE_TYPE (Blood Bat)}
+                [/set_specials]
+            [/effect]
+        [/object]
+
+        [object]
+            [filter]
+                id=charlie
+            [/filter]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    {WEAPON_SPECIAL_PLAGUE_TYPE Chocobone}
+                    [+plague]
+                        affect_self=yes
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                    [/plague]
+                [/abilities]
+            [/effect]
+        [/object]
+
+        [object]
+            [filter]
+                id=dave
+            [/filter]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    {WEAPON_SPECIAL_PLAGUE_TYPE (Dwarvish Dragonguard)}
+                    [+plague]
+                        [filter_student]
+                        [/filter_student]
+                        affect_self=yes
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                    [/plague]
+                [/abilities]
+            [/effect]
+        [/object]
+
+        # Create some targets
+        [for]
+            start=1
+            end=2
+            [do]
+                [unit]
+                    location_id=1
+                    id=target_for_alice_$i
+                    type=Test Melee Quintain
+                    side=2
+                    hitpoints=1
+                [/unit]
+                [unit]
+                    location_id=2
+                    id=target_for_bob_$i
+                    type=Test Melee Quintain
+                    side=1
+                    hitpoints=1
+                [/unit]
+            [/do]
+        [/for]
+
+        # With Charlie and Dave teaching plague
+        # The test isn't checking priority between Charlie and Dave, just that one of the teaching abilities takes effect,
+        # however it needs 2 teachers to check that Bob's weapon special takes priority over both left and right.
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=target_for_alice_1
+            weapon=0
+        [/test_do_attack_by_id]
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=target_for_bob_1
+            weapon=0
+        [/test_do_attack_by_id]
+
+        {ASSERT (
+            [have_unit]
+                type=Blood Bat
+                count=1
+            [/have_unit]
+        )}
+        {ASSERT (
+            [have_unit]
+                type=Chocobone,Dwarvish Dragonguard
+                count=1
+            [/have_unit]
+        )}
+
+        # With neither Charlie nor Dave
+        [store_unit]
+            [filter]
+                id=charlie
+            [/filter]
+            variable=stored_charlie
+            kill=yes
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=dave
+            [/filter]
+            variable=stored_dave
+            kill=yes
+        [/store_unit]
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=target_for_alice_2
+            weapon=0
+            resupply_attacks_left=1
+        [/test_do_attack_by_id]
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=target_for_bob_2
+            weapon=0
+            resupply_attacks_left=1
+        [/test_do_attack_by_id]
+
+        {ASSERT (
+            [have_unit]
+                type=Blood Bat
+                count=2
+            [/have_unit]
+        )}
+        {ASSERT (
+            [have_unit]
+                type=Chocobone,Dwarvish Dragonguard
+                count=1
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/units.cfg
+++ b/data/test/units.cfg
@@ -10,7 +10,6 @@
         plural_name= _ "tests"
         description= _ "test race"
         num_traits=2
-        undead_variation=wolf
         {ORCISH_NAMES}
     [/race]
 
@@ -31,5 +30,49 @@
         [special_note]
             note={INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}
         [/special_note]
+    [/movetype]
+
+    # The main feature of this movetype is that it has 0% defense on all terrains,
+    # so there's no need to use CHANCE_TO_HIT macros.
+    [movetype]
+        name=test_movetype_no_defense
+        [movement_costs]
+            shallow_water=2
+            reef=2
+            swamp_water=2
+            flat=2
+            sand=2
+            forest=2
+            hills=2
+            village=2
+            castle=2
+            cave=2
+            frozen=2
+            fungus=2
+        [/movement_costs]
+
+        [defense]
+            shallow_water=100
+            reef=100
+            swamp_water=100
+            flat=100
+            sand=100
+            forest=100
+            hills=100
+            village=100
+            castle=100
+            cave=100
+            frozen=100
+            fungus=100
+        [/defense]
+
+        [resistance]
+            blade=100
+            pierce=100
+            impact=100
+            fire=100
+            cold=100
+            arcane=100
+        [/resistance]
     [/movetype]
 [/units]

--- a/data/test/units/test_melee_quintain.cfg
+++ b/data/test/units/test_melee_quintain.cfg
@@ -1,0 +1,34 @@
+#textdomain wesnoth-test
+
+# A Unit with simple stats for testing attack & ability releated functions.
+#
+# Neutral, and a single melee attack that only has one strike.
+[unit_type]
+    id=Test Melee Quintain
+    name=_ "test_unit^Test Melee Quintain"
+    race=test
+    # Image is a sword, to fit the melee-blade attack type. The icon is a non-flaming
+    # sword, because "-bare" is the version before the flames are added.
+    image="items/flame-sword-bare.png"
+    ignore_race_traits=yes
+    hitpoints=100
+    movement_type=test_movetype_no_defense
+    movement=20
+    experience=50
+    level=1
+    alignment=neutral
+    advances_to=null
+    cost=1
+    hide_help=yes
+    do_not_list=yes
+    num_traits=0
+    [attack]
+        name="melee_attack"
+        description=_"Melee Attack"
+        icon=attacks/sword-human.png
+        type=blade
+        range=melee
+        damage=10
+        number=1
+    [/attack]
+[/unit_type]

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -335,6 +335,7 @@
 0 effect_increase_attacks
 0 opponent_weapon_has_no_special
 0 opponent_weapon_has_special
+0 plague_without_priority
 0 student_teacher_are_same
 # Math operations in ability or specials tags
 0 special_calculation_add


### PR DESCRIPTION
Just a draft for the moment, as several different improvements have ended up intertwined with each other. If anyone wants to use one of these on its own, please shout, because I feel this PR is going to be in draft for about a month (other things in life are currently higher priority).

The new tag takes ids instead of needing coordinates. So instead of storing units or hardcoding values, an attack can be done like this:

```
[test_do_attack_by_id]
	attacker=alice
	defender=bob
	weapon=0
[/test_do_attack_by_id]
```

Add a simpler unit for unit tests than the Elvish Archer / Orcish Grunt combo, cherry-picked from gfgtdf's PR #7589. This is a unit with a 10x1 melee attack, and 0% defense on all terrains.

Edit on 29th June: this now includes a test for plague abilities, to see if a plague weapon special always takes priority over a taught plague ability.