### PR TITLE
Add priority and filter to overwrite specials

### DIFF
--- a/changelog_entries/extent_remove_ability_efect_to_attribute_changelog.md
+++ b/changelog_entries/extent_remove_ability_efect_to_attribute_changelog.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Add [overwrite] tags who contain 'priority' attribute for define priority between two abilities with overwrite_specials, and [overwrite][filter_specials] to filter [abilities/specials] which may or may not be overwritten by the overwrite_specials attribute.

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -552,6 +552,9 @@
                         cumulative=no
                         affect_self=yes
                         overwrite_specials=both_sides
+                        [overwrite]
+                            priority=1000
+                        [/overwrite]
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]
@@ -605,6 +608,9 @@
                         cumulative=no
                         affect_self=yes
                         overwrite_specials=both_sides
+                        [overwrite]
+                            priority=1000
+                        [/overwrite]
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -4,9 +4,9 @@
 	max=0
 	{SIMPLE_KEY id string_list}
 	{SIMPLE_KEY tag_name string_list}
-	{SIMPLE_KEY overwrite_specials string_list}
+	{SIMPLE_KEY overwrite_specials ability_overwrite}
 	{SIMPLE_KEY apply_to string_list}
-	{SIMPLE_KEY active_on string_list}
+	{SIMPLE_KEY active_on ability_context}
 	{SIMPLE_KEY value s_int_range_list}
 	{SIMPLE_KEY add s_int_range_list}
 	{SIMPLE_KEY sub s_int_range_list}

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -5,7 +5,6 @@
 		max=infinite
 		super="units/unit_type/abilities/~generic~,units/unit_type/attack/specials/" + {NAME}
 		{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
-		{DEFAULT_KEY overwrite_specials ability_overwrite none}
 	[/tag]
 #enddef
 

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -54,6 +54,12 @@
 	{SIMPLE_KEY cumulative bool}
 	{DEPRECATED_KEY backstab bool}
 	{FILTER_TAG "filter_base_value" base_value ()}
+	{DEFAULT_KEY overwrite_specials ability_overwrite none}
+	[tag]
+		name="overwrite"
+		{FILTER_TAG "filter_specials" abilities ()}
+		{SIMPLE_KEY priority real}
+	[/tag]
 [/tag]
 [tag]
 	name="attacks"
@@ -92,6 +98,12 @@
 	max=infinite
 	super="units/unit_type/attack/specials/~generic~"
 	{SIMPLE_KEY type string}
+	{DEFAULT_KEY overwrite_specials ability_overwrite none}
+	[tag]
+		name="overwrite"
+		{FILTER_TAG "filter_specials" abilities ()}
+		{SIMPLE_KEY priority real}
+	[/tag]
 [/tag]
 [tag]
 	name="swarm"

--- a/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro.cfg
+++ b/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro.cfg
@@ -42,6 +42,15 @@
                     [/chance_to_hit]
                 [/set_specials]
             [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
             [filter]
                 id=bob
             [/filter]
@@ -63,6 +72,15 @@
                         value=100
                     [/chance_to_hit]
                 [/set_specials]
+            [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
             [/effect]
             [filter]
                 id=alice

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/test_overwrite_specials_filter.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/test_overwrite_specials_filter.cfg
@@ -1,0 +1,106 @@
+#####
+# API(s) being tested: [damage]with overwrite_specials attibute and [overwrite][filter_specials]
+##
+# Actions:
+# Three [damage] abilities are added, one with value=5, other with add=11 and the last with multiply=2.
+# The one with multiply=2 have overwrite_specials=both_sides and [overwrite][filter_specials] for overwrite [damage] with add=11 but not value=5.
+# Have alice attack bob.
+##
+# Expected end state:
+# Alice has 100 - (5*2)=90 hitpoints because add=11 overwrited but not value=5 who replace 9 pt of damage of bob.
+#####
+{GENERIC_UNIT_TEST "test_overwrite_specials_filter" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=test_dmg
+                        value=5
+                    [/damage]
+                    [attacks]
+                        id=test_att
+                        value=1
+                    [/attacks]
+                    [damage]
+                        id=test_overwrite
+                        add=11
+                    [/damage]
+                    [damage]
+                        id=test_overwrite_specials
+                        multiply=2
+                        overwrite_specials=both_sides
+                        [overwrite]
+                            [filter_specials]
+                                [not]
+                                    type_value=value
+                                [/not]
+                            [/filter_specials]
+                        [/overwrite]
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+            kill=yes
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$a.x,$a.y
+                [/source]
+                [destination]
+                    x,y=$b.x,$b.y
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 90})}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1337,14 +1337,9 @@ static bool overwrite_special_affects(const config& special)
 unit_ability_list attack_type::overwrite_special_overwriter(unit_ability_list overwriters, const std::string& tag_name) const
 {
 	std::vector<double> priorityvec;
-	int list_count = 0;
-	//remove element without overwrite_specials key, if list empty after check
-	//return empty list.
-	//If element contains priority with overwrite_specials key valid,
-	//value added in vector.
+	//remove element without overwrite_specials key, if list empty after check return empty list.
 	utils::erase_if(overwriters, [&](const unit_ability& i) {
 		if(overwrite_special_affects(*i.ability_cfg)){
-			list_count += 1;
 			auto overwrite_specials = (*i.ability_cfg).optional_child("overwrite");
 			if(overwrite_specials && !overwrite_specials["priority"].empty()){
 				auto ret = std::find(priorityvec.begin(), priorityvec.end(), overwrite_specials["priority"].to_double(0));
@@ -1361,7 +1356,7 @@ unit_ability_list attack_type::overwrite_special_overwriter(unit_ability_list ov
 	}
 
 	//if vector no empty and list contain 2 or more elements, continue checking else return list.
-	if(!priorityvec.empty() && (list_count >= 2)){
+	if(!priorityvec.empty() && (overwriters.size())){
 		if(priorityvec.size() >= 2){
 			std::sort(priorityvec.begin(), priorityvec.end(),[](const double &l, const double &r)
 				{
@@ -1376,19 +1371,16 @@ unit_ability_list attack_type::overwrite_special_overwriter(unit_ability_list ov
 				bool is_overwritable = false;
 				if(overwrite_specials && overwrite_specials["priority"].to_double(0) == priority){
 					is_overwritable = overwrite_special_checking(overwriters, *i.ability_cfg, tag_name);
-					if(is_overwritable && list_count > 0){
-						list_count -= 1;
-					}
 				}
 				return (is_overwritable);
 			});
-			if(list_count <= 1){
+			if(overwriters.size() <= 1){
 				break;
 			}
 		}
 		//remove elements without priority who matches conditions
 		//determined by priority elements remaining in list.
-		if(list_count > 1){
+		if(overwriters.size() > 1){
 			utils::erase_if(overwriters, [&](const unit_ability& i) {
 				auto overwrite_specials = (*i.ability_cfg).optional_child("overwrite");
 				bool is_overwritable = false;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -136,14 +136,23 @@ private:
 	// Configured as a bit field, in case that is useful.
 	enum AFFECTS { AFFECT_SELF=1, AFFECT_OTHER=2, AFFECT_EITHER=3 };
 	/**
+	 * Filter a list of abilities or weapon specials, removing any entries that don't own
+	 * the overwrite_specials attributes.
+	 *
+	 * @param overwriters list that may have overwrite_specials attributes.
+	 * @param tag_name type of abilitie/special checked.
+	 */
+	unit_ability_list overwrite_special_overwriter(unit_ability_list overwriters, const std::string& tag_name) const;
+	/**
 	 * Filter a list of abilities or weapon specials, removing any entries that are overridden by
 	 * the overwrite_specials attributes of a second list.
 	 *
 	 * @param input list to check, a filtered copy of this list is returned by the function.
-	 * @param overwriters list that may have overwrite_specials attributes.
-	 * @param is_special if true, input contains weapon specials; if false, it contains abilities.
+	 * @param overwriters list that have overwrite_specials attributes if not empty.
+	 * @param tag_name type of abilitie/special checked.
+	 * @param list_count used for count size of input when function called in overwrite_special_overwriter.
 	 */
-	unit_ability_list overwrite_special_checking(unit_ability_list input, unit_ability_list overwriters, bool is_special) const;
+	void overwrite_special_checking(unit_ability_list& input, unit_ability_list& overwriters, const std::string& tag_name, int& list_count) const;
 	/** check_self_abilities : return an boolean value for checking of activities of abilities used like weapon
 	 * @return True if the special @a special is active.
 	 * @param cfg the config to one special ability checked.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -98,7 +98,10 @@ public:
 	int composite_value(const unit_ability_list& abil_list, int base_value) const;
 	/** Returns list for weapon like abilities for each ability type. */
 	unit_ability_list get_weapon_ability(const std::string& ability) const;
-	/** Returns list who contains get_weapon_ability and get_specials list for each ability type */
+	/**
+	 * @param special the tag name to check for
+	 * @return list which contains get_weapon_ability and get_specials list for each ability type, with overwritten items removed
+	 */
 	unit_ability_list get_specials_and_abilities(const std::string& special) const;
 	/** used for abilities used like weapon
 	 * @return True if the ability @a special is active.
@@ -144,8 +147,7 @@ private:
 	 */
 	unit_ability_list overwrite_special_overwriter(unit_ability_list overwriters, const std::string& tag_name) const;
 	/**
-	 * Filter a element of list of abilities or weapon specials, and return true if element must be removed by
-	 * the overwrite_specials attributes of a second list.
+	 * Check whether @a cfg would be overwritten by any element of @a overwriters.
 	 *
 	 * @return True if element checked is overwritable.
 	 * @param overwriters list used for check if element is overwritable.

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -144,15 +144,15 @@ private:
 	 */
 	unit_ability_list overwrite_special_overwriter(unit_ability_list overwriters, const std::string& tag_name) const;
 	/**
-	 * Filter a list of abilities or weapon specials, removing any entries that are overridden by
+	 * Filter a element of list of abilities or weapon specials, and return true if element must be removed by
 	 * the overwrite_specials attributes of a second list.
 	 *
-	 * @param input list to check, a filtered copy of this list is returned by the function.
-	 * @param overwriters list that have overwrite_specials attributes if not empty.
+	 * @return True if element checked is overwritable.
+	 * @param overwriters list used for check if element is overwritable.
+	 * @param cfg element checked.
 	 * @param tag_name type of abilitie/special checked.
-	 * @param list_count used for count size of input when function called in overwrite_special_overwriter.
 	 */
-	void overwrite_special_checking(unit_ability_list& input, unit_ability_list& overwriters, const std::string& tag_name, int& list_count) const;
+	bool overwrite_special_checking(unit_ability_list& overwriters, const config& cfg, const std::string& tag_name) const;
 	/** check_self_abilities : return an boolean value for checking of activities of abilities used like weapon
 	 * @return True if the special @a special is active.
 	 * @param cfg the config to one special ability checked.

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -94,6 +94,7 @@ public:
 	const unit_ability& front() const  { return cfgs_.front(); }
 	unit_ability&       back()         { return cfgs_.back();  }
 	const unit_ability& back()  const  { return cfgs_.back();  }
+	std::size_t         size()         { return cfgs_.size();  }
 
 	iterator erase(const iterator& erase_it)  { return cfgs_.erase(erase_it); }
 	iterator erase(const iterator& first, const iterator& last)  { return cfgs_.erase(first, last); }

--- a/src/utils/general.hpp
+++ b/src/utils/general.hpp
@@ -106,4 +106,14 @@ void erase_if(Container& container, const Predicate& predicate)
 	container.erase(std::remove_if(container.begin(), container.end(), predicate), container.end());
 }
 
+/**
+ * Convenience wrapper for using std::sort on a container.
+ *
+ */
+template<typename Container, typename Predicate>
+void sort_if(Container& container, const Predicate& predicate)
+{
+	std::sort(container.begin(), container.end(), predicate);
+}
+
 } // namespace utils

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -331,6 +331,7 @@
 0 trait_exclusion_test
 0 trait_requirement_test
 0 test_remove_ability_by_filter
+0 test_overwrite_specials_filter
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active


### PR DESCRIPTION
Since I add another feature to overwrite_specials in addition to filtering with the priority system, which obviates the need to limit its use to abilities used as weapons, I prefer to open this query to group the main commits that are related to it .