### PR TITLE
Liberty S5: Make the loss of Hans a lose-condition

### DIFF
--- a/changelog_entries/liberty_s5.md
+++ b/changelog_entries/liberty_s5.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * Liberty
+     * S5: Make the loss of Hans a lose-condition (#7750).

--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -148,7 +148,7 @@ Been a tough few days since we left Elensefar with all them patrols running arou
         [objectives]
             side=1
             [objective]
-                description= _ "Enter the Grey Woods"
+                description= _ "Enter the Grey Woods with Hans"
                 condition=win
             [/objective]
             [objective]
@@ -157,6 +157,10 @@ Been a tough few days since we left Elensefar with all them patrols running arou
             [/objective]
             [objective]
                 description= _ "Death of Harper"
+                condition=lose
+            [/objective]
+            [objective]
+                description= _ "Death of Hans"
                 condition=lose
             [/objective]
 
@@ -711,6 +715,27 @@ Been a tough few days since we left Elensefar with all them patrols running arou
         [message]
             speaker=Baldras
             message= _ "Blast it, we was too slow! With the sun rising already, them guards will have no trouble spotting us now..."
+        [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
+    [/event]
+
+    #
+    # Death of Hans
+    #
+    [event]
+        name=last breath
+        [filter]
+            id=Hans
+        [/filter]
+        [message]
+            speaker=Hans
+            message= _ "You fools! You weren’t supposed to lead them to me..."
+        [/message]
+        [message]
+            speaker=Baldras
+            message= _ "Blast it! We gots no chance against the Crown on our own..."
         [/message]
         [endlevel]
             result=defeat

--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -733,10 +733,6 @@ Been a tough few days since we left Elensefar with all them patrols running arou
             speaker=Hans
             message= _ "You fools! You weren’t supposed to lead them to me..."
         [/message]
-        [message]
-            speaker=Baldras
-            message= _ "Blast it! We gots no chance against the Crown on our own..."
-        [/message]
         [endlevel]
             result=defeat
         [/endlevel]


### PR DESCRIPTION
Hans only makes an appearance in this scenario and isn't even mentioned afterwards (that I could see). Still, Link explicitly states that Hans will guide Baldras and Harper to the Grey Woods so I suppose it does make sense to make a consequence of Hans' death.

I'm not a writer, happy for the dialogue to be updated directly without my input. But the change itself should address @Konrad22's concern in #7750.