### PR TITLE
Liberty S6: Correct target hex for Shadow Mage

### DIFF
--- a/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
+++ b/data/campaigns/Liberty/scenarios/06_The_Hunters.cfg
@@ -465,7 +465,7 @@ The sun don’t really shine at all in these Grey Woods, but truth be told, I ha
         [move_unit_fake]
             type=Shadow Mage
             side=2
-            x=28,31
+            x=28,32
             y=11,9
         [/move_unit_fake]
         {GENERIC_UNIT 2 (Shadow Mage) 32 9}


### PR DESCRIPTION
Resolves #7751

Question: Would it be appropriate to back-port this to 1.16? While it's not a major bug, there doesn't appear to be high risk in making this correction either.