### PR TITLE
Balance for Rebels 1.18

### DIFF
--- a/data/core/units/elves/Avenger.cfg
+++ b/data/core/units/elves/Avenger.cfg
@@ -7,7 +7,7 @@
     image="units/elves-wood/avenger.png"
     small_profile="portraits/elves/ranger.webp~CROP(20,20,400,400)"
     profile="portraits/elves/ranger.webp"
-    hitpoints=55
+    hitpoints=59
     movement_type=woodland
     movement=6
     experience=150
@@ -15,7 +15,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=53
+    cost=66
     usage=mixed fighter
     description= _ "The curious name of the Elvish ‘Avengers’ comes from a tactic often employed by these master rangers. The enemy is allowed to break through a feint defense and when the vulnerable troops behind the front line follow, these archers break cover and attack, cutting supply lines and surrounding the enemy in one fell stroke. This has, at times, been interpreted as a form of vengeance for their brethren lost earlier in the battle. While not so base in design, it is not at all inaccurate."
     [special_note]
@@ -49,7 +49,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=10
+        damage=11
         number=4
     [/attack]
     {DEFENSE_ANIM_RANGE "units/elves-wood/avenger-sword-defend.png" "units/elves-wood/avenger-sword.png" {SOUND_LIST:ELF_HIT} melee}

--- a/data/core/units/elves/Captain.cfg
+++ b/data/core/units/elves/Captain.cfg
@@ -16,7 +16,7 @@
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}
-    experience=90
+    experience=85
     level=2
     alignment=neutral
     advances_to=Elvish Marshal

--- a/data/core/units/elves/Champion.cfg
+++ b/data/core/units/elves/Champion.cfg
@@ -5,7 +5,7 @@
     race=elf
     image="units/elves-wood/champion.png"
     profile="portraits/elves/hero.webp"
-    hitpoints=70
+    hitpoints=72
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}
@@ -14,7 +14,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=48
+    cost=61
     usage=fighter
     description= _ "Elves are typically peaceable by nature and most will attack only in retaliation for some wrongdoing wrought upon them. However, there are some elves who deliberately seek battle, purposeful or otherwise, for their own enjoyment. Through constant combat, these warriors either learn to hone their swordsmanship to a level far beyond most of their peers or perish in the volatile frenzy of melee. Those capable of persisting eventually grow skilled enough to wholly conquer the battlegrounds, becoming veritable champions of war as they mercilessly cut through their foes. Having spent their whole lives refining their prowess with the blade, these elves are exceptionally dangerous and should never be underestimated."
     die_sound={SOUND_LIST:ELF_HIT}
@@ -24,8 +24,9 @@
         icon=attacks/greatsword-elven.png
         type=blade
         range=melee
-        damage=9
+        damage=8
         number=5
+        accuracy=10
     [/attack]
     [attack]
         name=bow

--- a/data/core/units/elves/Druid.cfg
+++ b/data/core/units/elves/Druid.cfg
@@ -10,11 +10,11 @@
     hitpoints=36
     movement_type=woodland
     movement=5
-    experience=80
+    experience=85
     level=2
     alignment=neutral
     advances_to=Elvish Shyde
-    cost=27
+    cost=25
     usage=healer
     description= _ "Some elves choose to deepen their connection to the corporeal world, thereby enhancing their already potent abilities to foster and manipulate natural energies. Perhaps the most notable effect of these druids’ magic is the marked sense of motion in the deep woodlands that they preserve. Outsiders wandering through Elven woods often speak of entangling roots and vines, moving nearly as fast as a warrior’s marching pace, or the creaking shamble of ancient trees, lumbering across entire camps in just a single night. The forest and the earth become almost like a connected entity, something that lives and breathes like a single massive organism. As it flourishes under the druids’ careful tending, the forest kindles their magics in turn, symbiotically enhancing the already potent powers that these elves possess."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}

--- a/data/core/units/elves/Enchantress.cfg
+++ b/data/core/units/elves/Enchantress.cfg
@@ -14,7 +14,7 @@
     level=3
     alignment=neutral
     advances_to=Elvish Sylph
-    cost=55
+    cost=70
     usage=mixed fighter
     description= _ "In the context of Elven magic, the notion of enchanting is a little bit misleading since it almost always refers to manipulation of an object’s essence for the purpose of divination or insight. A favorite among the corresponding enchantresses is imbuing their natural surroundings with the breath of the arcane, yielding secret groves that exist at the juncture between the corporeal and ethereal worlds. These mysterious domains are kept by their equally enigmatic caretakers, who mostly keep to themselves away from prying eyes. Though rather reserved and unsociable, these elves are well-regarded by most of their kin and sometimes called upon for guidance especially in unusual or peculiar matters."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
@@ -38,7 +38,7 @@
         [specials]
             {WEAPON_SPECIAL_SLOW}
         [/specials]
-        damage=5
+        damage=7
         number=4
         range=ranged
     [/attack]
@@ -46,7 +46,7 @@
         name=faerie fire
         description=_"faerie fire"
         type=arcane
-        damage=9
+        damage=13
         number=4
         range=ranged
         [specials]

--- a/data/core/units/elves/Fighter.cfg
+++ b/data/core/units/elves/Fighter.cfg
@@ -9,7 +9,7 @@
     movement_type=woodland
     {LESS_NIMBLE_ELF}
     movement=5
-    experience=36
+    experience=37
     level=1
     alignment=neutral
     advances_to=Elvish Captain,Elvish Hero

--- a/data/core/units/elves/Fighter.cfg
+++ b/data/core/units/elves/Fighter.cfg
@@ -9,7 +9,7 @@
     movement_type=woodland
     {LESS_NIMBLE_ELF}
     movement=5
-    experience=40
+    experience=36
     level=1
     alignment=neutral
     advances_to=Elvish Captain,Elvish Hero

--- a/data/core/units/elves/Hero.cfg
+++ b/data/core/units/elves/Hero.cfg
@@ -9,7 +9,7 @@
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}
-    experience=90
+    experience=80
     level=2
     alignment=neutral
     advances_to=Elvish Champion

--- a/data/core/units/elves/Marksman.cfg
+++ b/data/core/units/elves/Marksman.cfg
@@ -14,7 +14,7 @@
     level=2
     alignment=neutral
     advances_to=Elvish Sharpshooter
-    cost=31
+    cost=34
     usage=archer
     description= _ "Elves have an intimate connection to the world of faerie, which innately imbues them with highly acute senses and incredibly keen vision. This, combined with years of hunting in the deep forests, contributes greatly to the elves’ mastery of the bow. An elf practiced at marksmanship is capable of hitting a pinhole-sized target from dozens of paces away and can shoot quickly and precisely enough to split falling branches in midair. Of course, training the body to keep up with the eyes is no easy feat, and realizing this prodigious skill does come with the cost of weakness in close quarters."
     die_sound={SOUND_LIST:ELF_HIT}

--- a/data/core/units/elves/Marshal.cfg
+++ b/data/core/units/elves/Marshal.cfg
@@ -12,7 +12,7 @@
             image="units/elves-wood/marshal-leading.png:300"
         [/frame]
     [/leading_anim]
-    hitpoints=62
+    hitpoints=68
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}
@@ -21,7 +21,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=54
+    cost=67
     usage=fighter
     description= _ "Elves are not often the instigators of open war, but will not shy away when the time comes to do battle. To this end, they maintain a small number of strategically-minded marshals at all times. Selected from the most talented patrol captains, these commanders undergo extensive training in various military styles, including those of the humans and orcs. They are unorthodox, but brilliant strategists who excel at breaking down large battlefronts into smaller skirmishes, transforming ordinary campaigns into dispersed guerrilla warfare. Engaging elves in their own homes is a daunting task for any invasion force, precisely because of the skillful maneuvering of the marshals who are entrusted with the protection of their people."
     die_sound={SOUND_LIST:ELF_HIT}

--- a/data/core/units/elves/Outrider.cfg
+++ b/data/core/units/elves/Outrider.cfg
@@ -5,15 +5,15 @@
     race=elf
     image="units/elves-wood/outrider/outrider.png"
     profile="portraits/elves/scout.webp"
-    hitpoints=57
+    hitpoints=60
     movement_type=woodland
-    movement=10
+    movement=11
     experience=150
     level=3
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=58
     undead_variation=mounted
     usage=scout
     description= _ "There once was an elf by the name of Beirand, who set out on a journey to a distant land.
@@ -46,7 +46,7 @@ The truth of this tale, one can only surmise, but doubtless, Outriders the faste
         icon=attacks/sword-elven.png
         type=blade
         range=melee
-        damage=7
+        damage=8
         number=4
     [/attack]
     [attack]
@@ -55,7 +55,7 @@ The truth of this tale, one can only surmise, but doubtless, Outriders the faste
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=8
+        damage=11
         number=3
     [/attack]
     {DEFENSE_ANIM "units/elves-wood/outrider/outrider-defend2.png" "units/elves-wood/outrider/outrider-defend1.png" {SOUND_LIST:HORSE_HIT} }

--- a/data/core/units/elves/Outrider.cfg
+++ b/data/core/units/elves/Outrider.cfg
@@ -7,7 +7,7 @@
     profile="portraits/elves/scout.webp"
     hitpoints=60
     movement_type=woodland
-    movement=11
+    movement=10
     experience=150
     level=3
     alignment=neutral

--- a/data/core/units/elves/Ranger.cfg
+++ b/data/core/units/elves/Ranger.cfg
@@ -10,7 +10,7 @@
     hitpoints=42
     movement_type=woodland
     movement=6
-    experience=90
+    experience=85
     level=2
     alignment=neutral
     advances_to=Elvish Avenger

--- a/data/core/units/elves/Rider.cfg
+++ b/data/core/units/elves/Rider.cfg
@@ -5,7 +5,7 @@
     race=elf
     image="units/elves-wood/rider/rider.png"
     profile="portraits/elves/scout.webp"
-    hitpoints=46
+    hitpoints=49
     movement_type=woodland
     movement=10
     experience=75
@@ -42,7 +42,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=9
+        damage=11
         number=2
     [/attack]
     {DEFENSE_ANIM "units/elves-wood/rider/rider-defend2.png" "units/elves-wood/rider/rider-defend1.png" {SOUND_LIST:HORSE_HIT} }

--- a/data/core/units/elves/Scout.cfg
+++ b/data/core/units/elves/Scout.cfg
@@ -11,7 +11,7 @@
     #are bad at defending in villages
     #they are weak against piercing attacks
     movement=9
-    experience=32
+    experience=42
     level=1
     alignment=neutral
     advances_to=Elvish Rider

--- a/data/core/units/elves/Sharpshooter.cfg
+++ b/data/core/units/elves/Sharpshooter.cfg
@@ -15,7 +15,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=51
+    cost=62
     usage=archer
     description= _ "Though not a formal title, ‘Sharpshooter’ is the epithet given to the most gifted Elvish marksmen. These expert archers are capable of feats that, even by Elven standards, border on miraculous — they have the precision to split incoming arrows midair and can loose a second arrow before the first hits, all while maintaining enough power to damage full plate armor. A single volley of their arrows is enough to bring down a knight on horseback, and even heavily-armored infantry will survive few additional shots. The sharpshooters of the elves have honed their art to its highest form and are the undisputed masters of archery."
     die_sound={SOUND_LIST:ELF_HIT}
@@ -37,7 +37,7 @@
             {WEAPON_SPECIAL_MARKSMAN}
         [/specials]
         range=ranged
-        damage=10
+        damage=12
         number=5
     [/attack]
     {DEFENSE_ANIM_RANGE "units/elves-wood/sharpshooter-sword-defend.png" "units/elves-wood/sharpshooter-sword.png" {SOUND_LIST:ELF_HIT} melee }

--- a/data/core/units/elves/Shyde.cfg
+++ b/data/core/units/elves/Shyde.cfg
@@ -9,7 +9,7 @@
     small_profile="portraits/elves/shyde.webp~CROP(110,60,390,390)"
     profile="portraits/elves/shyde.webp"
     halo=halo/elven/shyde-stationary-halo[1~6].png:150
-    hitpoints=46
+    hitpoints=51
     movement_type=woodlandfloat
     movement=6
     experience=150
@@ -17,7 +17,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=69
     usage=healer
     description= _ "As an elf maiden entwines herself more and more with nature, the essence of earth begins to transform her body. The butterfly wings that sprout on the back of a Shyde are a direct manifestation of her connection to the faerie, granting her their characteristic ethereal aura of both serenity and fear. Shydes are masters of the mundane, guided by a power which is little understood, yet greatly respected by others of their kind. Often mistaken for true faerie or ‘forest spirits’, these stewards of the forests epitomize their people’s mysterious connection with the natural order."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
@@ -33,7 +33,7 @@
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
         range=melee
-        damage=6
+        damage=7
         number=2
         range=melee
     [/attack]
@@ -44,7 +44,7 @@
         [specials]
             {WEAPON_SPECIAL_SLOW}
         [/specials]
-        damage=6
+        damage=8
         number=3
         range=ranged
         icon=attacks/entangle.png
@@ -56,7 +56,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=8
+        damage=14
         number=3
         range=ranged
     [/attack]

--- a/data/core/units/elves/Sorceress.cfg
+++ b/data/core/units/elves/Sorceress.cfg
@@ -10,11 +10,11 @@
     hitpoints=41
     movement_type=woodland
     movement=5
-    experience=100
+    experience=90
     level=2
     alignment=neutral
     advances_to=Elvish Enchantress
-    cost=32
+    cost=34
     usage=mixed fighter
     description= _ "Elven magic most commonly diverges among two paths — manipulation of the natural, or corporeal world, and divination into the arcane plane. The latter, as a power that is difficult to control and ill-understood even by most of its practitioners, is not often sought after by the Elves. Wielders of the arcane face significant risk in studying the volatile nature of their discipline and quickly learn to respect the disruptive power of their craft. This destructive nature most commonly manifests itself as gouts of ‘faerie fire’, which is among the most readily mastered skills for an Elvish sorceress. While a rather superficial application of this art, the Elves nonetheless hold the arcane flame in high regard and are careful to utilize it with judicious caution."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}

--- a/data/core/units/elves/Sylph.cfg
+++ b/data/core/units/elves/Sylph.cfg
@@ -8,7 +8,7 @@
     small_profile="portraits/elves/sylph.webp~CROP(26,30,420,420)"
     profile="portraits/elves/sylph.webp~RIGHT()"
     halo=halo/elven/shyde-stationary-halo[1~6].png:150
-    hitpoints=60
+    hitpoints=68
     movement_type=woodlandfloat
     movement=6
     experience=200
@@ -16,7 +16,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=67
+    cost=148
     usage=mixed fighter
     description= _ "Tremendously powerful in unfathomable ways, the sage-like Sylphs are masters of manipulating the bridge between the mundane and arcane worlds. Long years spent peering into the ethereal realm have eroded the ability of these elves to view the physical world; in return, they are granted an abstract sight, gaining the ability to view one or even several different aspects of reality’s essence. Like the many shards of a broken mirror, the myriad fractures of the material world reflect the light of the arcane through its many different facets. Careful practice allows one to follow these strands of light from pane to pane, observing how the outcome of physical reality evolves with each choice made of free will. While direct weaving of the connecting fabric is usually impossible to achieve, indirect manipulation is feasible by machination in the corporeal plane where the reflection of the arcane plane is strongest. The ability of a Sylph to locate these ‘reflection pools’ and steer them is one of her greatest — and most feared — abilities."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
@@ -43,7 +43,7 @@
         [specials]
             {WEAPON_SPECIAL_SLOW}
         [/specials]
-        damage=6
+        damage=7
         number=5
         range=ranged
         icon=attacks/web.png
@@ -55,7 +55,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=10
+        damage=16
         number=5
         range=ranged
         icon=attacks/faerie-fire.png

--- a/data/core/units/merfolk/Entangler.cfg
+++ b/data/core/units/merfolk/Entangler.cfg
@@ -14,7 +14,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=46
+    cost=42
     usage=mixed fighter
     description= _ "Merfolk tend to use a combination of both nets and clubs in fishing; nets to collect the fish, and clubs to finish the kill. Both of these tools have seen adaptation for warfare, and are valuable enough that auxiliaries who specialize in using them are deliberately brought to battle.
 

--- a/data/core/units/merfolk/Hunter.cfg
+++ b/data/core/units/merfolk/Hunter.cfg
@@ -9,7 +9,7 @@
     hitpoints=33
     movement_type=swimmer
     movement=6
-    experience=35
+    experience=33
     level=1
     alignment=lawful
     advances_to=Merman Spearman,Merman Netcaster

--- a/data/core/units/merfolk/Javelineer.cfg
+++ b/data/core/units/merfolk/Javelineer.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=48
+    cost=55
     usage=mixed fighter
     description= _ "Those merfolk who master the art of the javelin can become nearly as effective as an archer — though the heft of their weapons impedes their range, the impact of one is considerably greater. In the water, the mobility of the merfolk more than makes up for this when facing foes who cannot swim."
     die_sound=mermen-die.ogg

--- a/data/core/units/merfolk/Netcaster.cfg
+++ b/data/core/units/merfolk/Netcaster.cfg
@@ -9,11 +9,11 @@
     hitpoints=40
     movement_type=swimmer
     movement=7
-    experience=80
+    experience=54
     level=2
     alignment=lawful
     advances_to=Merman Entangler
-    cost=27
+    cost=26
     usage=mixed fighter
     description= _ "Fishing, as practiced by merfolk, is largely a matter of chasing schools of fish into waiting nets, where oar-like clubs are used to dispatch the prey. The improvisation of using these against soldiers proved very effective; most land-native creatures are already quite awkward when waist-deep in water, and getting caught in a net can render them nearly helpless.
 

--- a/data/core/units/merfolk/Spearman.cfg
+++ b/data/core/units/merfolk/Spearman.cfg
@@ -8,11 +8,11 @@
     hitpoints=43
     movement_type=swimmer
     movement=7
-    experience=85
+    experience=54
     level=2
     alignment=lawful
     advances_to=Merman Javelineer
-    cost=27
+    cost=22
     usage=mixed fighter
     description= _ "Archery is little favored by the merfolk, for whom use of javelins serves a similar function. Though thrown javelins are of little use under the water, they are extremely effective at the surface, where their weight allows them to plunge several feet below the water while retaining enough momentum to wreak damage. They are also useful in melee, even deep under the surface, which is something that certainly cannot be said of arrows."
     die_sound=mermen-die.ogg

--- a/data/core/units/wose/Ancient.cfg
+++ b/data/core/units/wose/Ancient.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=48
+    cost=50
     description= _ "There is a curious story of a farmer who had a great oak in his lawn, a tree which had stood when his father first broke the soil on that land, and under which his family had many memories. It was thus a shock to him, one morning, when he awoke to find nothing but a bare patch of earth where the tree once stood, as though it had been spirited away in the wee hours of the night.
 
 Such encounters are all that is known of what are presumably the most ancient of woses."

--- a/data/core/units/wose/Elder.cfg
+++ b/data/core/units/wose/Elder.cfg
@@ -9,11 +9,11 @@
     hitpoints=64
     movement_type=treefolk
     movement=4
-    experience=100
+    experience=80
     level=2
     alignment=lawful
     advances_to=Ancient Wose
-    cost=27
+    cost=28
     description= _ "Woses have been said to possess many shapes, all of them tree-like in form, and as they age, to increase in size. Tales tell of woses who resemble trees in this respect as well, towering over the creatures who walk beneath them. This is the greater part of why they are so rarely seen — standing in the slumber which they so often do, a wose of that stature appears to be nothing more than an oddly-shaped tree. Even a careless elf can sometimes be fooled.
 
 Woses are not warriors by any means, but their great strength can easily be turned to violence, should someone manage to raise the ire of these creatures."


### PR DESCRIPTION
Level 1: 
Fighter - xp cost changed from 40 to 37.
Merman Hunter - xp changed from 35 to 33.
Scout - xp changed from 32 to 42.

Level 2: 
Hero - xp changed from 90 to 80.
Captain - xp changed from 90 to 85.
Marksman - cost changed from 31 to 34, xp changed from 80 to 80.
Ranger - xp changed from 90 to 85. 
Rider - ranged damage changed from 9 to 11, hp changed form 46 to 49, cost changed from 28 to 35, xp changed from 53 to 75.
Druid - cost changed from 27 to 25, xp changed from 80 to 85.
Sorceress - cost changed from 32 to 34, xp changed from 100 to 90. 
Elder Wose - cost changed from 27 to 28, xp changed from 100 to 80.
Merman Netcaster - cost changed from 27 to 26, xp changed from 85 to 54.
Merman Spearman - cost changed from 27 to 22, xp changed from 85 to 54.

Level 3:
Champion - melee damage changed from 9 to 8. added 10 melee accuracy, hp changed from 70 to 72, cost changed from 48 to 61.
Marshal - hp changed from 62 to 68, cost changed from 54 to 67.
Sharpshooter - ranged damage changed from 10 to 12. cost changed from 51 to 62.
Avenger - ranged damage changed from 10 to 11, hp changed from 55 to 59, cost changed from 53 to 66.
Outrider - ranged damage changed from 8 to 11, melee damage changed from 7 to 8,  hp changed form 57 to 60, mp from 10 to 11, cost changed from 43 to 58.
Shyde - hp changed from 46 to 51, melee damage changed from 6 to 7, ranged slow (entangle) changed from 6 to 8, ranged magical (thorns) changed from 8 to 14, cost changed from 52 to 69.
Enchantress - cost changed from 55 to 70, ranged slow damage changed from 5 to 7, ranged magical damage changed from 9 to 13, xp changed from 180 to 180.
Ancient Wose - cost changed from 48 to 50.
Entangler - cost changed from 46 to 42.
Javelineer - cost changed from 48 to 55.

Level 4:
Sylph - hp changed from 60 to 68, ranged slow damage changed from 6 to 7, ranged magical damage changed from 10 to 16, cost changed from 67 to 148 (this is wrong but as commited will fix latter).
