### PR TITLE
DiD: Correct inconsistency between AMLA description and its actual effect

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/utils/amlas.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/amlas.cfg
@@ -304,7 +304,7 @@
         [effect]
             apply_to=attack
             name=shadow wave
-            increase_damage=2
+            increase_damage=1
         [/effect]
         [effect]
             apply_to=hitpoints


### PR DESCRIPTION
Resolves #7767.

Not sure if it could be back-ported. Perhaps not, since it's a bug that works in the player's favour.

Alternative would be to change the description to match the actual effect.