### PR TITLE
Add a test for formulas in taught abilities

### DIFF
--- a/data/test/macros/start_position_common_keep_a_b.cfg
+++ b/data/test/macros/start_position_common_keep_a_b.cfg
@@ -9,6 +9,13 @@
 # There is no free castle hex to recruit onto.
 ##
 #define COMMON_KEEP_A_B_UNIT_TEST NAME CONTENT
+
+#arg SIDE1_LEADER
+Elvish Archer#endarg
+
+#arg SIDE2_LEADER
+Orcish Grunt#endarg
+
     [test]
         name=_ "Unit Test " + {NAME}
         map_file=test/maps/2p_single_castle.map
@@ -23,7 +30,7 @@
             side=1
             controller=human
             name=_ "Alice"
-            type=Elvish Archer
+            type={SIDE1_LEADER}
             id=alice
             fog=no
             team_name=West
@@ -32,7 +39,7 @@
             side=2
             controller=human
             name=_ "Bob"
-            type=Orcish Grunt
+            type={SIDE2_LEADER}
             id=bob
             fog=no
             team_name=East

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/teacher_damage_formula.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/teacher_damage_formula.cfg
@@ -1,0 +1,76 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]value=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# Create a third unit, "teacher", adjacent to Alice but not Bob.
+# The teacher's ability sets the opponent's damage to a formula which uses data from all three units.
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Alice has taken 6 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "teacher_damage_formula" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            attacks_left=1
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            level=5
+        [/modify_unit]
+
+        #adjacent to alice but not to bob
+        [unit]
+            id="teacher"
+            type="Test Melee Quintain"
+            level=10
+            x,y=3,3
+            side=1
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_ability
+                        [abilities]
+                            [damage]
+                                affect_allies=yes
+                                # self=teacher, student=alice, other=bob, so 10 - 5 + 1 = 6
+                                value="(level - student.level + other.level)"
+                                apply_to=opponent
+                                [affect_adjacent]
+                                    adjacent=n,ne,se,s,sw,nw
+                                [/affect_adjacent]
+                            [/damage]
+                        [/abilities]
+                    [/effect]
+                [/object]
+            [/modifications]
+        [/unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=alice
+        [/store_unit]
+
+        # 100 - 6 = 94
+        {ASSERT ({VARIABLE_CONDITIONAL alice.hitpoints equals 94})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -338,6 +338,7 @@
 0 opponent_weapon_has_special
 0 plague_without_priority
 0 student_teacher_are_same
+0 teacher_damage_formula
 # Math operations in ability or specials tags
 0 special_calculation_add
 0 special_calculation_add2_add3_cumulative


### PR DESCRIPTION
Originally by gfgtdf, this was cherry-picked from gfgtdf's PR #7589, with modifications.

COMMON_KEEP_A_B_UNIT_TEST gains support for optional args SIDE1_LEADER and SIDE2_LEADER.