### PR TITLE
Balance for Drakes 1.18

### DIFF
--- a/data/core/units/drakes/Arbiter.cfg
+++ b/data/core/units/drakes/Arbiter.cfg
@@ -4,10 +4,10 @@
     name= _ "Drake Arbiter"
     race=drake
     image="units/drakes/arbiter.png"
-    hitpoints=62
+    hitpoints=63
     movement_type=drakefoot
     movement=5
-    experience=105
+    experience=81
     level=2
     alignment=lawful
     advances_to=Drake Warden

--- a/data/core/units/drakes/Armageddon.cfg
+++ b/data/core/units/drakes/Armageddon.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=85
+    cost=118
     usage=archer
     # wmllint: local spelling Armageddon
     description= _ "Were it not for the armor they wear, certain drakes might be indistinguishable from true dragons, at least to the lesser races for whom dragons are but legend. The creatures known as ‘Armageddon Drakes’ are towering things, both immune to and possessed of a tremendous fire."

--- a/data/core/units/drakes/Blademaster.cfg
+++ b/data/core/units/drakes/Blademaster.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=47
+    cost=62
     usage=fighter
     #wmllint: local spelling Blademasters
     description= _ "Black armor marks the elite order of the Fighter caste: the Blademasters. Only a few manage to gain the skill and power necessary to be admitted to this highest rank without perishing in battle. Though other drakes may disparage the Fighter caste, they always check twice to be sure none are around; Blademasters fiercely protect their fellows’ honor, and no-one would dispute their right to do so."

--- a/data/core/units/drakes/Clasher.cfg
+++ b/data/core/units/drakes/Clasher.cfg
@@ -7,7 +7,7 @@
     hitpoints=43
     movement_type=drakefoot
     movement=5
-    experience=45
+    experience=41
     level=1
     alignment=lawful
     advances_to=Drake Thrasher,Drake Arbiter

--- a/data/core/units/drakes/Enforcer.cfg
+++ b/data/core/units/drakes/Enforcer.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=44
+    cost=58
     usage=fighter
     profile=portraits/drakes/enforcer.webp
     description= _ "Not for Enforcers are the tactics of maneuver and deception; rather, they charge in wherever the melee is the fiercest. At close range, it matters little that their armor prevents them from spouting flame; all that matters is the power they’ve learned to focus in each strike. Drake leaders are careful not to besmirch the honor of the Enforcers, and generally call upon them to combat only the most pernicious of enemies."

--- a/data/core/units/drakes/Fighter.cfg
+++ b/data/core/units/drakes/Fighter.cfg
@@ -8,7 +8,7 @@
     hitpoints=39
     movement_type=drakefly
     movement=6
-    experience=42
+    experience=41
     level=1
     alignment=lawful
     advances_to=Drake Warrior

--- a/data/core/units/drakes/Fire.cfg
+++ b/data/core/units/drakes/Fire.cfg
@@ -8,7 +8,7 @@
     hitpoints=63
     movement_type=drakefly
     movement=5
-    experience=80
+    experience=84
     level=2
     alignment=lawful
     advances_to=Inferno Drake

--- a/data/core/units/drakes/Flameheart.cfg
+++ b/data/core/units/drakes/Flameheart.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=51
+    cost=66
     usage=mixed fighter
     description= _ "Flamehearts lack the strength to defeat other high-ranking drakes in single combat, but prefer in any case to avoid confrontation within the tribe. Experience has taught any drake of this stature the extent of his authority: where he can push those he leads and when it is best to leave them to their own devices. Only occasionally will a Flameheart challenge his tribe’s leader for supremacy, and only if he is sure of the support of his fellow drakes."
     die_sound=drake-die.ogg

--- a/data/core/units/drakes/Flare.cfg
+++ b/data/core/units/drakes/Flare.cfg
@@ -8,7 +8,7 @@
     hitpoints=55
     movement_type=drakefly
     movement=5
-    experience=80
+    experience=86
     level=2
     alignment=lawful
     advances_to=Drake Flameheart

--- a/data/core/units/drakes/Glider.cfg
+++ b/data/core/units/drakes/Glider.cfg
@@ -8,7 +8,7 @@
     hitpoints=32
     movement_type=drakeglide
     movement=8
-    experience=35
+    experience=39
     level=1
     alignment=lawful
     advances_to=Sky Drake

--- a/data/core/units/drakes/Hurricane.cfg
+++ b/data/core/units/drakes/Hurricane.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=59
     usage=scout
     description= _ "Hurricane Drakes have moved above the menial hunting and gathering to which the lower members of their caste are relegated. They are an integral part of the drakes’ military, scouting ahead of the main forces, carrying messages across the battlefield, and falling upon the enemy where it’s least expected. Being allowed—grudgingly—to train with the newcomers from other castes has increased their skill in combat, but their greatest strength still lies in their speed and flight."
     die_sound=drake-die.ogg

--- a/data/core/units/drakes/Inferno.cfg
+++ b/data/core/units/drakes/Inferno.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=51
+    cost=64
     usage=archer
     #wmllint: local spelling draconic
     description= _ "Inferno Drakes are masters of the fire they breathe, respected and feared in their tribes nearly as much as the draconic ancestors themselves. They can prowl unharmed through a firestorm of their own creation, scales tinged red from extensive use of their inner flame, their sculpted red-gold armor enhancing the illusion that they are, in fact, dragons."

--- a/data/core/units/drakes/Sky.cfg
+++ b/data/core/units/drakes/Sky.cfg
@@ -8,11 +8,11 @@
     hitpoints=45
     movement_type=drakeglide2
     movement=9
-    experience=80
+    experience=76
     level=2
     alignment=lawful
     advances_to=Hurricane Drake
-    cost=28
+    cost=32
     usage=scout
     description= _ "The lightweight ceramic armor that the Sky Drakes wear is a symbol of their rank, glazed silver to honor their connection to the air. As leaders of the hunt, they are often away from their homes for long periods of time. Each tries to bring as much game home as possible, competing to gain the respect of their tribe."
     die_sound=drake-die.ogg

--- a/data/core/units/drakes/Thrasher.cfg
+++ b/data/core/units/drakes/Thrasher.cfg
@@ -9,7 +9,7 @@
     hitpoints=66
     movement_type=drakefoot
     movement=5
-    experience=95
+    experience=77
     level=2
     alignment=lawful
     advances_to=Drake Enforcer

--- a/data/core/units/drakes/Warden.cfg
+++ b/data/core/units/drakes/Warden.cfg
@@ -12,7 +12,7 @@
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=46
+    cost=62
     usage=fighter
     profile=portraits/drakes/warden.webp
     description= _ "Wardens are set apart from the rest of the Clasher caste by two things: their ornate helms, modeled after their dragon ancestors, and the care with which they drape their armored wings in brightly colored cloth before reporting for duty. Though this mode of dress stems from the pride they feel for their role in drake society, it is far from ceremonial. Their cumbersome bronze plate is the strongest work from the Drake forges, and their halberds can cleave a human in half."

--- a/data/core/units/drakes/Warrior.cfg
+++ b/data/core/units/drakes/Warrior.cfg
@@ -8,11 +8,11 @@
     hitpoints=60
     movement_type=drakefly
     movement=6
-    experience=70
+    experience=81
     level=2
     alignment=lawful
     advances_to=Drake Blademaster
-    cost=32
+    cost=31
     usage=fighter
     description= _ "Drakes of the Fighter caste, like the Warrior, are the foundation of any tribe’s army. No special abilities or skills set them apart; only their natural brute strength and military training help them carve their way through enemy forces. They fight as they have for centuries, clad in ceramic-plated leather with the traditional war blade mounted on the back of each hand."
     die_sound=drake-die.ogg

--- a/data/core/units/saurians/Ambusher.cfg
+++ b/data/core/units/saurians/Ambusher.cfg
@@ -6,14 +6,14 @@
     gender=female
     image="units/saurians/ambusher/ambusher.png"
     profile="portraits/saurians/skirmisher.webp"
-    hitpoints=36
+    hitpoints=38
     movement_type=lizard
     movement=7
     experience=55
     level=2
     alignment=chaotic
     advances_to=Saurian Flanker
-    cost=24
+    cost=22
     usage=scout
     description= _ "Saurians are light on their feet, and able at navigating terrain that often confounds their enemies. When this natural mobility is combined with experience, strength, and proper equipment, their warriors can become particularly threatening in battle — if only because they are so much more difficult to confine than other foes. Even in armor, saurian warriors can take advantage of the smallest gap in an enemy line, and have the prowess to make the enemy regret tactical mistakes."
     die_sound=hiss-die.wav

--- a/data/core/units/saurians/Flanker.cfg
+++ b/data/core/units/saurians/Flanker.cfg
@@ -6,7 +6,7 @@
     gender=female
     image="units/saurians/flanker/flanker.png"
     profile="portraits/saurians/skirmisher.webp"
-    hitpoints=47
+    hitpoints=54
     movement_type=lizard
     movement=7
     experience=150
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=46
+    cost=42
     usage=scout
     description= _ "Saurian warriors are generally weaker in frame than their elven or human counterparts. This is of course a relative term, and they can still become considerably powerful, whilst losing none of their natural mobility. This is very dangerous in combat, as a careless enemy can soon find their support troops flanked by these creatures."
     die_sound=hiss-die.wav

--- a/data/core/units/saurians/Javelineer.cfg
+++ b/data/core/units/saurians/Javelineer.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=42
     usage=archer
     description= _ "After years of combat practice, saurians warriors that are the most talented in the skill of spear throwing might advance to the ranks of the javelineers. With better equipment and exceptional aim, saurian javelineers are not to be underestimated."
     die_sound=hiss-die.wav
@@ -33,7 +33,7 @@
         range=ranged
         type=pierce
         damage=9
-        number=5
+        number=4
         icon=attacks/spear-thrown.png
     [/attack]
 

--- a/data/core/units/saurians/Soothsayer.cfg
+++ b/data/core/units/saurians/Soothsayer.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=25
+    cost=29
     usage=healer
     description= _ "Saurians are known to have some strange skills, arts bordering on the magical and mysterious. It is clear that some of them are particularly skilled at a sort of medicine, which is of great benefit whenever battle is brought against them."
     die_sound=hiss-die.wav
@@ -27,7 +27,7 @@
         type=impact
         range=melee
         damage=5
-        number=2
+        number=3
     [/attack]
     [attack]
         name=curse

--- a/data/core/units/saurians/Spearthrower.cfg
+++ b/data/core/units/saurians/Spearthrower.cfg
@@ -22,7 +22,7 @@
         description=_"spear"
         range=melee
         type=pierce
-        damage=6
+        damage=5
         number=3
         icon=attacks/spear.png
     [/attack]


### PR DESCRIPTION
Changes: 
Level 1:
Fighter - xp changed from 42 to 41.
Clasher - xp changed from 43 to 41.
Glider - xp changed from 35 to 39.

Level 2: 
Warrior - xp changed from 70 to 81, cost changed from 32 to 31. 
Arbiter - hp changed from 62 to 63, xp changed from 105 to 81.
Thrasher - xp changed from 95 to 77.
Flare  - xp changed from 80 to 86.
Fire - xp changed from 80 to 84.
Sky - xp changed from 80 to 76, cost changed from 28 to 32. 
Ambusher - hp changed from 36 to 38, cost changed from 24 to 22. 
Soothsayer - melee attack strikes changed from 2 to 3, mp changed from 6 to 7, cost changed from 25 to 28.
Spearthrower - melee damage changed from 6 to 5.

Level 3:
Blademaster - cost changed from 47 to 62.
Warden - cost changed from 46 to 62.
Enforcer - cost changed from 44 to 58.
Flameheart - cost changed from 51 to 66.
Inferno - cost changed from 51 to 64.
Hurricane - cost changed from 43 to 59.
Flanker - hp changed from 47 to 52, cost changed from 46 to 42.
Javelineer - ranged attack strikes changed from 5 to 4, cost changed from 52 to 42.

Armageddon drake - cost changed from 85 to 118.

Importantly - added Arma drake, Spearthrower and Javelineer. MP changes not included. 