### PR TITLE
Balance for Dunefolk 1.18

### DIFF
--- a/data/core/units/dunefolk/Apothecary.cfg
+++ b/data/core/units/dunefolk/Apothecary.cfg
@@ -16,11 +16,11 @@ units/dunefolk/herbalist/#enddef
         {ABILITY_SELF_HEAL}
     [/abilities]
     movement=5
-    experience=65
+    experience=50
     level=2
     alignment=liminal
     advances_to=Dune Luminary
-    cost=27
+    cost=23
     usage=healer
     description= _ "Even in the absence of battle, infection and injury are common plights in the harsh desert sands. Dunefolk healers, in particular, require vast knowledge of herbs and medicine in comparison with healers of other races. Their lack of magic combined with the meager plantlife in the desert results in great difficulty in treating the plethora of ailments and poisons that plague the dune peoples. Apothecaries are typically more knowledgeable and well-traveled compared to their less experienced brethren, but their real skill lies in the complex task of tending to valuable medicinal plants. The Dunefolk have no means of healing without the necessary materials, and thus these men possess a special role in supporting the remedial arts of their kind."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/dunefolk/Blademaster.cfg
+++ b/data/core/units/dunefolk/Blademaster.cfg
@@ -8,7 +8,7 @@ units/dunefolk/soldier/#enddef
     name= _ "Dune Blademaster"
     race=dunefolk
     image="{PATH_TEMP}blademaster.png"
-    hitpoints=69
+    hitpoints=76
     movement_type=dunearmoredfoot
     movement=5
     level=3

--- a/data/core/units/dunefolk/Burner.cfg
+++ b/data/core/units/dunefolk/Burner.cfg
@@ -9,10 +9,10 @@ units/dunefolk/burner/#enddef
     race=dunefolk
     gender=male,female
     image="{PATH_TEMP}burner.png"
-    hitpoints=34
+    hitpoints=35
     movement_type=dunefoot
     movement=5
-    experience=40
+    experience=37
     level=1
     alignment=lawful
     advances_to=Dune Scorcher

--- a/data/core/units/dunefolk/Captain.cfg
+++ b/data/core/units/dunefolk/Captain.cfg
@@ -11,11 +11,11 @@ units/dunefolk/soldier/#enddef
     hitpoints=48
     movement_type=dunearmoredfoot
     movement=5
-    experience=75
+    experience=74
     level=2
     alignment=lawful
     advances_to=Dune Warmaster
-    cost=30
+    cost=29
     usage=fighter
     [abilities]
         {ABILITY_LEADERSHIP}

--- a/data/core/units/dunefolk/Cataphract.cfg
+++ b/data/core/units/dunefolk/Cataphract.cfg
@@ -17,7 +17,7 @@ units/dunefolk/rider/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=62
+    cost=69
     usage=fighter
     undead_variation=mounted
     description= _ "Cataphracts are eminent horsemen, riders of mounts that are possessed less of speed or endurance but tremendous power instead. Bearing a lance along with their signature maces, these warriors are most often the secondary strike force after a primary assault. After enemy forces are already occupied and weakened by a flank of swordsmen, a terrifying sight is a group of cataphracts lining up, lances pitched at the ready. A gap is made amongst the Dunefolk ranks, and in a single charge, these mighty horsemen pierce straight through enemy formations, dealing a lethal blow in a single stroke. Those who try to flee swiftly discover that neither sand nor hills deter these riders in the slightest, and the displaced air of a descending mace is the last sound they hear."
@@ -43,7 +43,7 @@ units/dunefolk/rider/#enddef
         description= _ "mace"
         type=impact
         range=melee
-        damage=14
+        damage=15
         number=3
         icon=attacks/mace.png
     [/attack]
@@ -52,7 +52,7 @@ units/dunefolk/rider/#enddef
         description=_"lance"
         type=pierce
         range=melee
-        damage=13
+        damage=14
         number=2
         icon=attacks/lance.png
         [specials]

--- a/data/core/units/dunefolk/Explorer.cfg
+++ b/data/core/units/dunefolk/Explorer.cfg
@@ -12,7 +12,7 @@ units/dunefolk/rover/#enddef
     hitpoints=46
     movement_type=dunefoot
     movement=6
-    experience=80
+    experience=73
     level=2
     alignment=liminal
     advances_to=Dune Wayfarer

--- a/data/core/units/dunefolk/Falconer.cfg
+++ b/data/core/units/dunefolk/Falconer.cfg
@@ -30,11 +30,11 @@ units/dunefolk/skirmisher/#enddef
         sand=1
         deep_water=1
     [/vision_costs]
-    experience=78
+    experience=70
     level=2
     alignment=lawful
     advances_to=Dune Sky Hunter
-    cost=23
+    cost=29
     usage=mixed fighter
     description= _ "While well respected among the dunefolk, the art of falconry is relatively rare due to the time and skill required to properly train birds of prey. Falconers most typically use their craft for sport or hunting, especially for scouting game and water out in the open dunes. The same intelligence can be useful when applied to warfare, if the falconer can be convinced to risk their prized pets for combative purposes.
 

--- a/data/core/units/dunefolk/Harrier.cfg
+++ b/data/core/units/dunefolk/Harrier.cfg
@@ -17,7 +17,7 @@ units/dunefolk/skirmisher/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=47
+    cost=50
     usage=mixed fighter
     [abilities]
         {ABILITY_SKIRMISHER}

--- a/data/core/units/dunefolk/Herbalist.cfg
+++ b/data/core/units/dunefolk/Herbalist.cfg
@@ -16,11 +16,11 @@ units/dunefolk/herbalist/#enddef
         {ABILITY_HEALS}
     [/abilities]
     movement=5
-    experience=39
+    experience=36
     level=1
     alignment=liminal
     advances_to=Dune Apothecary,Dune Alchemist
-    cost=14
+    cost=13
     usage=healer
     description= _ "As those responsible for caring for the ill and wounded among the Dunefolk, herbalists possess both the medicinal skills to heal a variety of afflictions and the skill to seek and gather restorative herbs. Their motivations are many; some look to it as an adventure or as a steady source of pay while others feel it to be a duty to their society. No matter the reason, these healers are an invaluable part of Dunefolk society and are especially useful for their ability to administer quick treatments in the midst of battle or while traveling in the desert.
 

--- a/data/core/units/dunefolk/Horse_Archer.cfg
+++ b/data/core/units/dunefolk/Horse_Archer.cfg
@@ -11,7 +11,7 @@ units/dunefolk/rider/#enddef
     hitpoints=44
     movement_type=dunehorse
     movement=8
-    experience=65
+    experience=62
     level=2
     alignment=liminal
     advances_to=Dune Windbolt

--- a/data/core/units/dunefolk/Raider.cfg
+++ b/data/core/units/dunefolk/Raider.cfg
@@ -20,11 +20,11 @@ units/dunefolk/rider/#enddef
     hitpoints=45
     movement_type=dunehorse
     movement=9
-    experience=70
+    experience=77
     level=2
     alignment=chaotic
     advances_to=Dune Marauder
-    cost=34
+    cost=35
     usage=scout
     undead_variation=mounted
     description= _ "Though rarely found in organized armies, raiders are a staple among the nomadic Dunefolk, who regularly ambush rival caravans and camps at night. In these scenarios, raw power is of little concern. The greatest importance is placed on speed — striking quickly and spreading as much chaos as possible in the shortest time possible allows these riders to get in and out of the blitz without fear of counterattack. Raiders are the fastest of the Dunefolk, capable of outpacing nearly anything they might encounter in the sandy deserts."

--- a/data/core/units/dunefolk/Rider.cfg
+++ b/data/core/units/dunefolk/Rider.cfg
@@ -8,10 +8,10 @@ units/dunefolk/rider/#enddef
     name= _ "Dune Rider"
     race=dunefolk
     image="{PATH_TEMP}rider.png"
-    hitpoints=34
+    hitpoints=33
     movement_type=dunehorse
     movement=8
-    experience=47
+    experience=49
     level=1
     alignment=liminal
     advances_to=Dune Raider,Dune Horse Archer,Dune Sunderer

--- a/data/core/units/dunefolk/Rover.cfg
+++ b/data/core/units/dunefolk/Rover.cfg
@@ -9,10 +9,10 @@ units/dunefolk/rover/#enddef
     race=dunefolk
     image="{PATH_TEMP}rover.png"
     profile="portraits/dunefolk/rover.webp"
-    hitpoints=32
+    hitpoints=33
     movement_type=dunefoot
     movement=5
-    experience=43
+    experience=40
     level=1
     alignment=liminal
     advances_to=Dune Explorer

--- a/data/core/units/dunefolk/Scorcher.cfg
+++ b/data/core/units/dunefolk/Scorcher.cfg
@@ -13,11 +13,11 @@ units/dunefolk/burner/#enddef
     hitpoints=47
     movement_type=dunefoot
     movement=5
-    experience=70
+    experience=60
     level=2
     alignment=lawful
     advances_to=Dune Firetrooper
-    cost=25
+    cost=23
     usage=archer
     description= _ "The scorcher’s moniker is derived not from the destruction they wreak on adversarial formations, but on their own singed appearances. By experimenting endlessly with their equipment, most scorchers inevitably overstep their bounds at some point and are seared by the highly volatile Sanbaar sap that soaks their weapons. Bearing their burns as a mark of pride in their work, these archers relish igniting great swaths of flame on the battlefield, though this sometimes also results in unintended friendly fire."
     die_sound={SOUND_LIST:HUMAN_DIE}
@@ -42,7 +42,7 @@ units/dunefolk/burner/#enddef
         description= _ "flamethrower"
         type=fire
         range=ranged
-        damage=9
+        damage=10
         number=3
         icon=attacks/fire-blast.png
     [/attack]

--- a/data/core/units/dunefolk/Skirmisher.cfg
+++ b/data/core/units/dunefolk/Skirmisher.cfg
@@ -12,7 +12,7 @@ units/dunefolk/skirmisher/#enddef
     hitpoints=29
     movement_type=duneelusivefoot
     movement=6
-    experience=34
+    experience=36
     level=1
     alignment=lawful
     advances_to=Dune Strider, Dune Falconer

--- a/data/core/units/dunefolk/Sky_Hunter.cfg
+++ b/data/core/units/dunefolk/Sky_Hunter.cfg
@@ -34,7 +34,7 @@ units/dunefolk/skirmisher/#enddef
     alignment=lawful
     advances_to=null
     {AMLA_DEFAULT}
-    cost=51
+    cost=54
     usage=mixed fighter
     description= _ "Often mistaken for young Rocs, desert eagles are large, majestic birds of prey who are notoriously aggressive and nearly impossible to tame. In the wild, the eagles feed on larger prey such as wolves, small horses, and, it is said, naughty young children. The power of these creatures makes them tremendously difficult to engage, with only the most skilled of falconers even daring to approach them. In the event that the bird tamer is actually successful, the relationship between bird and hunter becomes less of master and pet, and more a mutual bond between two equals. Serving not only as tools for combat, the eagles can live for up to a few decades and are often precious companions to their dunefolk partners."
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}

--- a/data/core/units/dunefolk/Soldier.cfg
+++ b/data/core/units/dunefolk/Soldier.cfg
@@ -11,11 +11,11 @@ units/dunefolk/soldier/#enddef
     hitpoints=41
     movement_type=dunearmoredfoot
     movement=5
-    experience=43
+    experience=39
     level=1
     alignment=lawful
     advances_to=Dune Swordsman,Dune Captain,Dune Spearguard
-    cost=18
+    cost=17
     usage=fighter
     description= _ "While most Dunefolk castes serve an additional practical purpose beyond only direct warfare, cities and caravans usually train a group of soldiers completely dedicated to military purposes. By practicing intensely to hone their skills in swordplay, these warriors learn to navigate tricky fights in close quarters, mastering their enemies through melee combat. A typical Dunefolk formation makes use of this adeptness by placing soldiers in a spaced pattern, allowing them to assault and overwhelm clustered enemy lines by engaging them in quasi-single combat."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/dunefolk/Spearguard.cfg
+++ b/data/core/units/dunefolk/Spearguard.cfg
@@ -11,11 +11,11 @@ units/dunefolk/soldier/#enddef
     hitpoints=53
     movement_type=dunearmoredfoot
     movement=5
-    experience=75
+    experience=74
     level=2
     alignment=lawful
     advances_to=Dune Spearmaster
-    cost=30
+    cost=29
     usage=fighter
     description= _ "The push and pull of any battle requires varying degrees of offense and defense. The Dunefolk no doubt value offense as the greater of the two and typically focus most of their efforts on training skilled swordsmen. However, in any band of warriors, a small number of soldiers opt to trade in their swords and instead fulfill the vital role of defenders. Guarding crucial supply lines and vantage points, spearguards are most often positioned slightly behind the main line and used as a supporting force or a deterrent to flanking attacks. Though these fighters tend to see less direct combat than their sword-wielding brethren, they are highly skilled with spear and shield and more than capable of repelling most advances."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/dunefolk/Spearmaster.cfg
+++ b/data/core/units/dunefolk/Spearmaster.cfg
@@ -8,7 +8,7 @@ units/dunefolk/soldier/#enddef
     name= _ "Dune Spearmaster"
     race=dunefolk
     image="{PATH_TEMP}spearmaster.png"
-    hitpoints=67
+    hitpoints=68
     movement_type=dunearmoredfoot
     movement=5
     experience=150

--- a/data/core/units/dunefolk/Strider.cfg
+++ b/data/core/units/dunefolk/Strider.cfg
@@ -9,14 +9,14 @@ units/dunefolk/skirmisher/#enddef
     race=dunefolk
     gender=female
     image="{PATH_TEMP}strider.png"
-    hitpoints=39
+    hitpoints=42
     movement_type=duneelusivefoot
     movement=6
-    experience=74
+    experience=64
     level=2
     alignment=lawful
     advances_to=Dune Harrier
-    cost=23
+    cost=29
     usage=mixed fighter
     description= _ "The power of any Dunefolk assault is inhibited by one major drawback: organized Dunefolk forces tend to be rather slow. Because of this, enemy forces often have the ability to regroup and call upon reinforcements, in which case a second assault becomes much more difficult. To combat this, striders exchange their rudimentary slings with heavy bolas, allowing them to slow retreating lines from the side and prevent a clean escape. The same tactic can be applied in the opposite scenario of a Dunefolk retreat; an advancing army can be hampered, allowing injured Dunefolk warriors time to recuperate. The danger of such a tactic is that despite their elusiveness, striders are fairly fragile in direct combat and are easily taken down if left exposed."
     die_sound={SOUND_LIST:HUMAN_FEMALE_DIE}

--- a/data/core/units/dunefolk/Sunderer.cfg
+++ b/data/core/units/dunefolk/Sunderer.cfg
@@ -11,7 +11,7 @@ units/dunefolk/rider/#enddef
     hitpoints=55
     movement_type=dunearmoredhorse
     movement=7
-    experience=76
+    experience=85
     level=2
     alignment=lawful
     advances_to=Dune Cataphract

--- a/data/core/units/dunefolk/Swordsman.cfg
+++ b/data/core/units/dunefolk/Swordsman.cfg
@@ -11,11 +11,11 @@ units/dunefolk/soldier/#enddef
     hitpoints=56
     movement_type=dunearmoredfoot
     movement=5
-    experience=75
+    experience=68
     level=2
     alignment=lawful
     advances_to=Dune Blademaster
-    cost=30
+    cost=28
     usage=fighter
     description= _ "In a direct clash of large armies, the Dunefolk commonly encounter either densely packed ‘shield walls’ or heavily fortified enemy positions. Striking against these highly organized fronts can be quite challenging — an enemy formation might leave only small, brief gaps between shields and armor while threatening a counterstrike with a thrust of spears and projectiles. Dunefolk swordplay thus places a heavy emphasis on power and more importantly, precision. A warrior might find only one chance to strike at an enemy, but an experienced swordsman is more than likely to seize the opportunity and make his strike count. Honing in with almost unnatural accuracy, a contingent of of swordsmen is enough to crack even the sternest of defenses."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/nagas/Ophidian.cfg
+++ b/data/core/units/nagas/Ophidian.cfg
@@ -6,14 +6,14 @@
     gender=male,female
     image="units/nagas/mixed/ophidian.png"
     profile="portraits/nagas/naga-ophidian.webp"
-    hitpoints=43
+    hitpoints=44
     movement_type=naga
     movement=7
-    experience=76
+    experience=62
     level=2
     alignment=neutral
     advances_to=Naga Sicarius
-    cost=22
+    cost=24
     usage=fighter
     description= _ "Experienced warriors of the Southern Naga often find work as mercenaries, usually hired by neighboring Dunefolk to control key waterways near the coastline. Due to their constant confrontations with enemy horsemen, Ophidians have retired the ringed blades of their youth and picked up the piercing jarid, a type of small javelin that the nagas have made more deadly by adding lead harvested from sunken ship ballasts. Though generally amicable with their wealthy employers, this friendliness should not be mistaken for loyalty, for the Ophidian are known for readily switching between rival city-state factions at the start of each shipping season, when demand for water-based protection is the highest. As a group, these nagas encourage a healthy amount of competition among the surface factions, ensuring their services are valued by one tribe or another."
     die_sound=naga-die.ogg

--- a/data/core/units/nagas/Ringcaster.cfg
+++ b/data/core/units/nagas/Ringcaster.cfg
@@ -6,14 +6,14 @@
     gender=male,female
     image="units/nagas/mixed/ringcaster.png"
     profile="portraits/nagas/naga-ringcaster.webp"
-    hitpoints=40
+    hitpoints=41
     movement_type=naga
     movement=7
-    experience=70
+    experience=62
     level=2
     alignment=neutral
     advances_to=Naga Zephyr
-    cost=22
+    cost=24
     usage=mixed fighter
     description= _ "The chakram, a greater blade ring than the chakri, is the signature weapon of the southern Naga and their renowned Ringcasters. Well balanced chakrams are useful for throwing, but the rejected blades make a good fist-load weapon, similar to a sharp-bladed tekko or knuckleduster."
     die_sound=naga-die.ogg
@@ -43,7 +43,7 @@
         description= _"chakram"
         type=blade
         range=ranged
-        damage=7
+        damage=8
         number=3
         icon=attacks/chakram.png
     [/attack]


### PR DESCRIPTION
Changes:

Level 1:
Burner - hp changed from 34 to 35, xp changed from 40 to 37.
Herbalist - cost changed from 14 to 13, xp changed for 39 to 36.
Rider - hp changed from 34 to 33, xp changed from 47 to 49.
Rover - hp changed from 32 to 33, xp changed from 43 to 40. 
Soldier - cost changed from 18 to 17, xp changed from 43 to 39. 
Skirmisher - xp changed from 34 to 39. 

Level 2:
Explorer - xp changed from 80 to 73.
Swordsman - cost changed from 30 to 28, xp changed from 75 to 68.
Capitan - cost changed from 30 to 29, xp changed from 75 to 74.
Spearguard - cost changed from 30 to 29, xp changed from 75 to 74.
Scorcher - ranged damage changed from 9 to 10, cost changed from 25 to 23, xp changed from 70 to 60.
Raider - cost changed from 34 to 35, xp changed from 70 to 77.
Swiftrider - xp changed from 65 to 62.
Sunderer - xp changed from 76 to 85. 
Apothecary - cost changed from 27 to 23, xp changed from 65 to 50.
Falconer - hp changed from 38 to 39, cost changed from 23 to 29, xp changed from 78 to 70. 
Strider - hp changed from 39 to 42, cost changed from 23 to 29, xp changed from 74 to 64. 
Ophidian - hp changed from 43 to 44, cost changed from 22 to 24, xp changed from 76 to 62.
Ringcaster - hp changed from 40 to 41, cost changed from 22 to 24, ranged damage changed from 7 to 8, xp changed from 70 to 62.

Level 3:
Blademaster - hp changed from 69 to 76.
Spearmaster - hp changed from 67 to 68.
Cataphract - mace melee attack damage changed from 14 to 15, lance damage changed from 13 to 14, cost changed from 62 to 65 cost changed from 62 to 69.
Harrier - cost changed from 47 to 50.
Sky Hunter - cost changed from 50 to 54.
