### PR TITLE
Balance for Knalgan Alliance 1.18

### DIFF
--- a/data/core/units/dwarves/Dragonguard.cfg
+++ b/data/core/units/dwarves/Dragonguard.cfg
@@ -14,7 +14,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=46
+    cost=61
     usage=archer
     description= _ "It is not clear why the Dragonguards are called what they are, a name given by their dwarven brethren. Some speculate that the name comes from their weapon of choice, these strange staves that belch fire and death. Others have surmised that it is because such weapons would be a threat against even a true Dragon, should such a thing be seen again in the known world. Whatever the case, it is for these weapons that the guardians of the great Dwarven citadels are both renowned and feared; weapons that have broken the mightiest of warriors with a single blow."
     die_sound={SOUND_LIST:DWARF_DIE}

--- a/data/core/units/dwarves/Fighter.cfg
+++ b/data/core/units/dwarves/Fighter.cfg
@@ -8,7 +8,7 @@
     hitpoints=38
     movement_type=dwarvishfoot
     movement=4
-    experience=41
+    experience=45
     level=1
     alignment=neutral
     advances_to=Dwarvish Steelclad

--- a/data/core/units/dwarves/Guardsman.cfg
+++ b/data/core/units/dwarves/Guardsman.cfg
@@ -8,7 +8,7 @@
     hitpoints=42
     movement_type=dwarvishfoot
     movement=4
-    experience=36
+    experience=40
     level=1
     alignment=neutral
     advances_to=Dwarvish Stalwart

--- a/data/core/units/dwarves/Guardsman.cfg
+++ b/data/core/units/dwarves/Guardsman.cfg
@@ -8,7 +8,7 @@
     hitpoints=42
     movement_type=dwarvishfoot
     movement=4
-    experience=47
+    experience=36
     level=1
     alignment=neutral
     advances_to=Dwarvish Stalwart
@@ -38,7 +38,7 @@
         icon=attacks/javelin-human.png
         type=pierce
         range=ranged
-        damage=5
+        damage=6
         number=1
     [/attack]
     {DEFENSE_ANIM "units/dwarves/guard-defend-2.png" "units/dwarves/guard-defend-1.png" {SOUND_LIST:DWARF_HIT} }

--- a/data/core/units/dwarves/Lord.cfg
+++ b/data/core/units/dwarves/Lord.cfg
@@ -13,7 +13,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=69
     usage=fighter
     description= _ "Clad in shining armor, these dwarves look like kings from under the mountains. They wield axe and hammer with masterful skill, and can hit a target with a thrown hand axe at several paces. Though slow on their feet, these dwarves are a testament to the prowess of their kin."
     die_sound={SOUND_LIST:DWARF_DIE}

--- a/data/core/units/dwarves/Sentinel.cfg
+++ b/data/core/units/dwarves/Sentinel.cfg
@@ -14,7 +14,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=44
+    cost=63
     usage=fighter
     description= _ "Champions among their fellow troops, the dwarven sentinels form the bulwark of their battle lines. Leading a direct assault against a line that they fortify, is often out of the question; it tends toward being suicidal, rather than merely ineffectual. Equipped with the strongest of Knalgan armor, these dwarves are masters of the melee and can hold a patch of earth with the single-minded tenacity of an oak."
     die_sound={SOUND_LIST:DWARF_DIE}

--- a/data/core/units/dwarves/Stalwart.cfg
+++ b/data/core/units/dwarves/Stalwart.cfg
@@ -6,10 +6,10 @@
     image="units/dwarves/stalwart.png"
     small_profile=portraits/dwarves/sentinel.webp~CROP(0,100,400,400)
     profile=portraits/dwarves/sentinel.webp
-    hitpoints=54
+    hitpoints=59
     movement_type=dwarvishfoot
     movement=4
-    experience=85
+    experience=78
     level=2
     alignment=neutral
     advances_to=Dwarvish Sentinel
@@ -43,7 +43,7 @@
         icon=attacks/javelin-human.png
         type=pierce
         range=ranged
-        damage=8
+        damage=9
         number=1
     [/attack]
     [standing_anim]

--- a/data/core/units/dwarves/Steelclad.cfg
+++ b/data/core/units/dwarves/Steelclad.cfg
@@ -9,7 +9,7 @@
     hitpoints=57
     movement_type=dwarvishfoot
     movement=4
-    experience=74
+    experience=88
     level=2
     alignment=neutral
     advances_to=Dwarvish Lord

--- a/data/core/units/dwarves/Thunderer.cfg
+++ b/data/core/units/dwarves/Thunderer.cfg
@@ -8,7 +8,7 @@
     hitpoints=34
     movement_type=dwarvishfoot
     movement=4
-    experience=40
+    experience=35
     level=1
     alignment=neutral
     advances_to=Dwarvish Thunderguard

--- a/data/core/units/dwarves/Thunderguard.cfg
+++ b/data/core/units/dwarves/Thunderguard.cfg
@@ -9,11 +9,11 @@
     hitpoints=47
     movement_type=dwarvishfoot
     movement=4
-    experience=95
+    experience=65
     level=2
     alignment=neutral
     advances_to=Dwarvish Dragonguard
-    cost=27
+    cost=24
     usage=mixed fighter
     description= _ "The Dwarven Thunderguards are famed for their curious weaponry, these strange staves of wood and iron that make a thunderous noise in their anger. The machinations behind this weaponry are a mystery, a secret taken to the grave by the dwarves of Knalga who wield them, and are assumed to have even forged them. The most that is known are reports of dwarves pouring a strange black dust into the mouth of their weapons, which some say is a food to fuel the beast imprisoned within.
 

--- a/data/core/units/gryphons/Gryphon_Master.cfg
+++ b/data/core/units/gryphons/Gryphon_Master.cfg
@@ -13,7 +13,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=38
+    cost=40
     usage=scout
     description= _ "Gryphon Masters have long experience flying the Gryphons, which have become an extension of themselves. This special relationship makes the heart of the earth-bound tremble, for these mighty birds of prey may strike from anywhere."
     die_sound={SOUND_LIST:GRYPHON_DIE}

--- a/data/core/units/gryphons/Gryphon_Rider.cfg
+++ b/data/core/units/gryphons/Gryphon_Rider.cfg
@@ -8,11 +8,11 @@
     hitpoints=34
     movement_type=fly
     movement=8
-    experience=38
+    experience=46
     level=1
     alignment=neutral
     advances_to=Gryphon Master
-    cost=24
+    cost=23
     usage=scout
     description= _ "Only a few are able to bond with the mighty Gryphons. Those who do may become Gryphon Riders, and discover the world of the skies upon the backs of these flying beasts."
     die_sound={SOUND_LIST:GRYPHON_DIE}

--- a/data/core/units/humans/Outlaw.cfg
+++ b/data/core/units/humans/Outlaw.cfg
@@ -6,14 +6,14 @@
     gender=male,female
     image="units/human-outlaws/outlaw.png"
     profile="portraits/humans/outlaw.webp"
-    hitpoints=42
+    hitpoints=47
     movement_type=elusivefoot
     movement=7
     level=2
     alignment=chaotic
-    experience=77
+    experience=71
     advances_to=Fugitive
-    cost=26
+    cost=24
     usage=mixed fighter
     description= _ "After some years of service, former ‘footpads’ rise up in the ranks of their fellow outlaws. Having proven themselves in combat, they are given more dangerous tasks, and a greater share of the spoils. Though many opponents would mock their choice of weaponry, the outlaws are well aware of its deadly capacity, and also of the ready availability of ammunition. Outlaws are somewhat ill at ease fighting during the day, preferring the cover of nightfall."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/humans/Outlaw_Assassin.cfg
+++ b/data/core/units/humans/Outlaw_Assassin.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=44
+    cost=46
     usage=fighter
     description= _ "The greatest of thieves are sometimes tasked to take far more than their victim’s belongings. Masters of knife-fighting and uncannily light on their feet, these menacing figures will employ any means to dispatch their victims, be it poisoned knives thrown from afar, or a dagger planted in the back. Deadly at night, assassins are less able fighting under the sun."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/humans/Outlaw_Footpad.cfg
+++ b/data/core/units/humans/Outlaw_Footpad.cfg
@@ -10,7 +10,7 @@
     hitpoints=30
     movement_type=elusivefoot
     movement=7
-    experience=36
+    experience=35
     level=1
     alignment=chaotic
     advances_to=Outlaw

--- a/data/core/units/humans/Outlaw_Fugitive.cfg
+++ b/data/core/units/humans/Outlaw_Fugitive.cfg
@@ -7,7 +7,7 @@
     gender=male,female
     image="units/human-outlaws/fugitive.png"
     profile="portraits/humans/outlaw.webp"
-    hitpoints=62
+    hitpoints=68
     movement_type=elusivefoot
     movement=7
     experience=150
@@ -15,7 +15,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=53
+    cost=55
     usage=mixed fighter
     description= _ "Veteran criminals become notorious for both their ruthlessness and ability to elude capture. They can be dangerous in their element, though no match for the sheer numbers that law-abiding soldiery can throw at them."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/humans/Outlaw_Rogue.cfg
+++ b/data/core/units/humans/Outlaw_Rogue.cfg
@@ -9,11 +9,11 @@
     hitpoints=40
     movement_type=elusivefoot
     movement=6
-    experience=70
+    experience=80
     level=2
     alignment=chaotic
     advances_to=Assassin
-    cost=24
+    cost=25
     usage=fighter
     description= _ "The ringleaders of any group of thieves earn their positions by skill. These rogues have spent many an unpleasant moment darting through crowds and dodging away from those who wish them ill, a set of skills which is very handy in a fight. Masters of knifework, they can also throw knives with reliable accuracy, and their long hours of prowling around at night leave them more comfortable fighting in the dark."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/humans/Outlaw_Thief.cfg
+++ b/data/core/units/humans/Outlaw_Thief.cfg
@@ -9,7 +9,7 @@
     hitpoints=24
     movement_type=elusivefoot
     movement=6
-    experience=28
+    experience=29
     level=1
     alignment=chaotic
     advances_to=Rogue

--- a/data/core/units/humans/Woodsman_Huntsman.cfg
+++ b/data/core/units/humans/Woodsman_Huntsman.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=43
     usage=archer
     description= _ "Hunting is a popular sport of noblemen, but it can also be a livelihood for commoners. Like any other craft, it has men of masterful skill in its practice. Huntsmen know all the tricks of their trade, and are skilled at navigating the wilderness, at tracking, and at the use of the bow. They are a fair shot at moving targets, and targets hiding under brush and cover; a skill wrought from years of practice at shooting game, and one which garrisoned bowmen often lack.
 

--- a/data/core/units/humans/Woodsman_Poacher.cfg
+++ b/data/core/units/humans/Woodsman_Poacher.cfg
@@ -8,7 +8,7 @@
     hitpoints=33
     movement_type=smallfoot
     movement=5
-    experience=29
+    experience=28
     level=1
     alignment=chaotic
     advances_to=Trapper

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=43
     usage=mixed fighter
     description= _ "Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. They have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
 

--- a/data/core/units/humans/Woodsman_Trapper.cfg
+++ b/data/core/units/humans/Woodsman_Trapper.cfg
@@ -5,12 +5,12 @@
     race=human
     image="units/human-outlaws/trapper.png"
     profile=portraits/humans/trapper.webp
-    hitpoints=45
+    hitpoints=49
     movement_type=smallfoot
     movement=5
     level=2
     alignment=chaotic
-    experience=65
+    experience=73
     advances_to=Huntsman, Ranger
     cost=21
     usage=archer
@@ -34,7 +34,7 @@ Their skill at hunting is very useful in combat, and also leaves them unusually 
         icon=attacks/dagger-human.png
         type=blade
         range=melee
-        damage=4
+        damage=5
         number=4
     [/attack]
     [attack]


### PR DESCRIPTION
Changes:

Level 1:
Fighter - xp changed from 41 to 45.
Thunderer - xp changed from 40 to 35.
Guardsman - ranged damage increased from 5 to 6, xp changed from 47 to 40.
Footpad - xp changed from 36 to 35.
Thief - xp changed from 28 to 29.
Poacher - xp changed from 29 to 28.
Gryphon Rider - cost changed from 24 to 23, xp changed from 38 to 46.

Level 2: 
Steelclad - xp changed from 74 to 88.
Thunderguard - cost changed from 27 to 24, xp changed from 95 to 65.
Stalwart - hp changed from54 to 59, ranged damage changed from 8 to 9, xp changed from 85 to 78.
Outlaw - cost changed from 26 to 24, hp changed from 42 to 47, xp changed from 77 to 71.
Rogue - xp changed from 70 to 80, cost changed from 24 to 25.
Trapper - hp changed from 45 to 49, melee damage changed from 4 to 5, xp changed from 65 to 73.
Gryphon Master - cost changed from 38 to 40. 

Level 3:
Lord - cost changed from 50 to 69. 
Sentinel - cost changed from 44 to 63. 
Dragonguard - cost changed from 46 to 61. 
Fugitive - hp changed from 62 to 68, cost changed from 53 to 55. 
Huntsman - cost changed from 50 to 43. 
Ranger - cost changed from 52 to 43. 
Assassin - cost changed from 44 to 46.
