### PR TITLE
Balance for Northerners 1.18

### DIFF
--- a/data/core/units/goblins/Direwolf_Rider.cfg
+++ b/data/core/units/goblins/Direwolf_Rider.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=44
+    cost=52
     usage=scout
     description= _ "‘Dire wolves’ differ from the common variety only in size and color. They typically stand taller than a horse at the shoulder, and have an appetite to match. Only a madman would willingly encounter them; but goblins, at great cost to themselves, have managed to tame and ride them.
 

--- a/data/core/units/goblins/Pillager.cfg
+++ b/data/core/units/goblins/Pillager.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=28
+    cost=31
     usage=scout
     description= _ "Some Goblins train their wolves to overcome their fear of fire. In raids, these goblins take a supporting role; they will torch the homes and crops of their foes, and also carry nets to wreak havoc against those attempting to rally for defense or reprisal."
     die_sound={SOUND_LIST:WOLF_DIE}

--- a/data/core/units/goblins/Wolf_Rider.cfg
+++ b/data/core/units/goblins/Wolf_Rider.cfg
@@ -21,7 +21,7 @@
     hitpoints=32
     movement_type=orcishfoot
     movement=8
-    experience=36
+    experience=34
     level=1
     alignment=chaotic
     advances_to=Goblin Knight,Goblin Pillager

--- a/data/core/units/goblins/Wolf_Rider.cfg
+++ b/data/core/units/goblins/Wolf_Rider.cfg
@@ -21,7 +21,7 @@
     hitpoints=32
     movement_type=orcishfoot
     movement=8
-    experience=30
+    experience=36
     level=1
     alignment=chaotic
     advances_to=Goblin Knight,Goblin Pillager

--- a/data/core/units/nagas/Fighter.cfg
+++ b/data/core/units/nagas/Fighter.cfg
@@ -9,7 +9,7 @@
     hitpoints=33
     movement_type=naga
     movement=7
-    experience=32
+    experience=33
     level=1
     alignment=neutral
     advances_to=Naga Warrior

--- a/data/core/units/nagas/Myrmidon.cfg
+++ b/data/core/units/nagas/Myrmidon.cfg
@@ -14,7 +14,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=48
+    cost=47
     usage=fighter
     # wmllint: local spelling blademasters
     description= _ "The most practiced of the naga blademasters are initiated into the caste of the Myrmidon, masters of their twin-bladed art. They strike as fast as the snakes which they resemble, and dance away from attacks with grace. Not only are they potent enemies on any open terrain, but their ability to swim allows them deadly mobility in water."

--- a/data/core/units/nagas/Warrior.cfg
+++ b/data/core/units/nagas/Warrior.cfg
@@ -9,11 +9,11 @@
     hitpoints=43
     movement_type=naga
     movement=7
-    experience=66
+    experience=56
     level=2
     alignment=neutral
     advances_to=Naga Myrmidon
-    cost=24
+    cost=22
     usage=fighter
     description= _ "The young warriors of the naga aspire to the day when they merit their second blade. Their martial practice of using twin blades is wholly unlike that of the Orcs and other races, for they have begun to learn the art of using their serpentine form to best effect, twisting and turning to dodge from blows. This makes them potent on land, but the friction of water greatly impedes the technique."
     die_sound=naga-die.ogg

--- a/data/core/units/orcs/Archer.cfg
+++ b/data/core/units/orcs/Archer.cfg
@@ -8,7 +8,7 @@
     hitpoints=32
     movement_type=orcishfoot
     movement=5
-    experience=30
+    experience=32
     level=1
     alignment=chaotic
     advances_to=Orcish Crossbowman

--- a/data/core/units/orcs/Crossbowman.cfg
+++ b/data/core/units/orcs/Crossbowman.cfg
@@ -51,7 +51,7 @@
         icon=attacks/crossbow-orcish.png
         type=fire
         range=ranged
-        damage=12
+        damage=10
         number=2
     [/attack]
     [attack_anim]

--- a/data/core/units/orcs/Crossbowman.cfg
+++ b/data/core/units/orcs/Crossbowman.cfg
@@ -5,14 +5,14 @@
     race=orc
     image="units/orcs/xbowman.png"
     profile="portraits/orcs/crossbowman.webp"
-    hitpoints=43
+    hitpoints=46
     movement_type=orcishfoot
     movement=5
-    experience=80
+    experience=43
     level=2
     alignment=chaotic
     advances_to=Orcish Slurbow
-    cost=21
+    cost=22
     usage=archer
     description= _ "Despite the heavy importance placed on combat prowess by most orcs, very few tribes have any semblance of formal training in any of the warring arts. Because of this, orcish bowmen are rather ineffective at wielding longbows pilfered from human or elven archers, instead preferring to arm themselves with more easily handled crossbows. Simplistic but potent, these weapons can still be deadly even when handled roughly by inexperienced warriors."
     die_sound={SOUND_LIST:ORC_DIE}
@@ -33,7 +33,7 @@
         icon=attacks/sword-orcish.png
         type=blade
         range=melee
-        damage=4
+        damage=6
         number=3
     [/attack]
     [attack]
@@ -42,7 +42,7 @@
         icon=attacks/crossbow-orcish.png
         type=pierce
         range=ranged
-        damage=8
+        damage=9
         number=3
     [/attack]
     [attack]
@@ -51,7 +51,7 @@
         icon=attacks/crossbow-orcish.png
         type=fire
         range=ranged
-        damage=10
+        damage=12
         number=2
     [/attack]
     [attack_anim]

--- a/data/core/units/orcs/Nightblade.cfg
+++ b/data/core/units/orcs/Nightblade.cfg
@@ -16,7 +16,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=53
     usage=mixed fighter
     description= _ "The most seasoned orcish assassins usually operate as mercenaries specializing in “resolving internal conflicts” and rarely participate in larger scale battles. Startlingly skilled and battle-hardened by their work, these orcs seldom pledge their allegiance to any particular tribe, instead offering their services to whoever the highest bidder might be. When the agreement is made and the necessary supplies obtained, the assassin then strikes swiftly and silently at his target, eliminating them quietly under the cover of darkness. A contract with a nightblade is almost always a death sentence to the victim, making said expertise well worth its high price."
     die_sound={SOUND_LIST:ORC_DIE}

--- a/data/core/units/orcs/Slayer.cfg
+++ b/data/core/units/orcs/Slayer.cfg
@@ -11,11 +11,11 @@
         arcane=100
     [/resistance]
     movement=6
-    experience=64
+    experience=62
     level=2
     alignment=chaotic
     advances_to=Orcish Nightblade
-    cost=26
+    cost=21
     usage=mixed fighter
     description= _ "Skilled orcish assassins are surprisingly nimble covert troops who achieve great agility by forgoing the heavy armor of their brethren. Their weapon of choice, poison, is often criticized as a vicious tool unsuited for the established customs of typical warfare. Most orcs, however, recognize no such laws of combat and seek to attain victory by any means necessary. Defeat, no matter the reason, is usually treated as the greatest dishonor possible. The brutal nature of the total war that orcs engage in is precisely what gives rise to these ruthless soldiers, rightly dubbed ‘Slayers’ by their enemies."
     die_sound={SOUND_LIST:ORC_DIE}

--- a/data/core/units/orcs/Slurbow.cfg
+++ b/data/core/units/orcs/Slurbow.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=37
     usage=archer
     # wmllint: local spellings arbalest cranequin
     description= _ "The basic design of a crossbow gives rise to the arbalest or ‘slurbow’, a much more intricate device complete with a hand-turned cranequin to recock the weapon, and often with a multi-ply arc of laminate wood or bone, driving the projectile. Such a device is much easier to work with, and much more powerful than simpler crossbows; it is also beyond typical orcish manufacture.

--- a/data/core/units/orcs/Warlord.cfg
+++ b/data/core/units/orcs/Warlord.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=48
+    cost=52
     usage=fighter
     description= _ "While might is not the be-all end-all of supremacy in an orcish clan, it certainly is a prerequisite for earning the respect and obedience of other orcs. A warlord is most often the strongest fighter in his tribe, one who attains and holds his position by achieving victory time and time again over aspiring challengers. This might in combat permits such an orc to act as tribal chieftain, overseeing the day to day dealings of his clan as well as directing lesser warriors when the time comes for bloodshed. Though typically cunning and highly proficient at warfare, most warlords only earn admiration for their combative skills, lacking the knowledge or charisma to lead outside of battle. In time, this deficiency usually becomes the cause for a warlord’s downfall when his skills wane with age and another powerful warrior arises to take his place."
     die_sound={SOUND_LIST:ORC_DIE}

--- a/data/core/units/orcs/Warrior.cfg
+++ b/data/core/units/orcs/Warrior.cfg
@@ -8,11 +8,11 @@
     hitpoints=58
     movement_type=orcishfoot
     movement=5
-    experience=60
+    experience=67
     level=2
     alignment=chaotic
     advances_to=Orcish Warlord
-    cost=26
+    cost=23
     usage=fighter
     description= _ "Orcish swordplay focuses almost strictly on offense, making use of their natural stamina to outlast their opponents through sheer resilience. A more seasoned orcish warrior is thus commonly seen wielding two blades, choosing to forego a shield and instead trade hits with enemies in melee range. Though a rather brutish tactic, it is still quite effective for these fighters, who lack the training and finesse to act on more complex strategies."
     die_sound={SOUND_LIST:ORC_DIE}

--- a/data/core/units/trolls/Rocklobber.cfg
+++ b/data/core/units/trolls/Rocklobber.cfg
@@ -5,7 +5,7 @@
     race=troll
     image="units/trolls/lobber.png"
     profile=portraits/trolls/troll-rocklobber.webp
-    hitpoints=51
+    hitpoints=53
     movement_type=largefoot
     movement=5
     experience=100
@@ -34,7 +34,7 @@
         description=_"sling"
         type=impact
         range=ranged
-        damage=22
+        damage=19
         number=1
     [/attack]
     {DEFENSE_ANIM "units/trolls/lobber-defend2.png" "units/trolls/lobber-defend.png" {SOUND_LIST:TROLL_HIT} }

--- a/data/core/units/trolls/Rocklobber.cfg
+++ b/data/core/units/trolls/Rocklobber.cfg
@@ -34,7 +34,7 @@
         description=_"sling"
         type=impact
         range=ranged
-        damage=17
+        damage=22
         number=1
     [/attack]
     {DEFENSE_ANIM "units/trolls/lobber-defend2.png" "units/trolls/lobber-defend.png" {SOUND_LIST:TROLL_HIT} }

--- a/data/core/units/trolls/Troll.cfg
+++ b/data/core/units/trolls/Troll.cfg
@@ -8,11 +8,11 @@
     hitpoints=55
     movement_type=largefoot
     movement=5
-    experience=66
+    experience=58
     level=2
     alignment=chaotic
     advances_to=Troll Warrior
-    cost=27
+    cost=25
     description= _ "Trolls have long troubled the thoughts of humanity and dwarf-kind. Sages remain baffled at the origins of these creatures and the driving force behind their unnatural vitality and strength. A fully-grown troll towers above a man, and, even unarmed, would be a great threat in combat. The large clubs typically favored in fighting act as extensions of their arms, used for the same purpose of mauling their prey into submission."
     die_sound={SOUND_LIST:TROLL_DIE}
     usage=fighter

--- a/data/core/units/trolls/Warrior.cfg
+++ b/data/core/units/trolls/Warrior.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=44
+    cost=49
     usage=fighter
     description= _ "Trolls typically neither need nor prefer to use any proper armament in combat, as large ‘sticks and stones’ serve them all too well. However, trolls have been seen on numerous occasions clad in rough-shod armor and bearing metal hammers. It is speculated that orcish allies are the source and crafters of these; expeditions into several forcibly-vacated troll holes have shown little evidence of tool use, and certainly no metalworking of any kind. Given how dangerous a troll is with its bare hands, the thought of a troll with proper armament is entirely unsettling."
     die_sound={SOUND_LIST:TROLL_DIE}


### PR DESCRIPTION
Changes:
Level 1:
Archer - xp changed from 30 to 32.
Naga - xp changed from 32 to 33.
Wolf Rider - xp change from 30 to 34. 

Level 2:
Warrior - cost changed from 26 to 23, xp changed from 60 to 67.
Pillager - cost changed from 28 to 31. 
Troll - cost changed from 27 to 25, xp changed from 66 to 58. 
Rocklobber - ranged damage changed from 17 to 19, hp changed form 51 to 53. 
Naga Warrior - cost changed from 24 to 22, xp changed from 66 to 56.
Crossbowman - melee damage changed from 4 to 6, ranged pierce damage changed from 8 to 9, hp changed from 43 to 46, cost changed from 21 to 22, xp changed from 80 to 43.
Slayer - cost changed from 26 to 21, xp changed from 64 to 62.

Level 3:
Warlord - cost changed from 48 to 52.
Direwolf Rider - cost changed from 44 to 52. 
Troll Warrior - cost changed from 44 to 49.
Myrmidon - cost changed from 48 to 47.
Nightblade - cost changed from 43 to 53. 
Slurbow - cost changed from 43 to 37.
