### PR TITLE
Balance for Undead 1.18

### DIFF
--- a/data/core/units/bats/Bat_Blood.cfg
+++ b/data/core/units/bats/Bat_Blood.cfg
@@ -10,11 +10,11 @@
     hitpoints=27
     movement_type=smallfly
     movement=9
-    experience=70
+    experience=37
     level=1
     alignment=chaotic
     advances_to=Dread Bat
-    cost=22
+    cost=23
     usage=scout
     description= _ "Blood Bats are so named because of their ruddy hue, which some mark as a symbol of their preferred diet. These creatures are fast and can drain the blood of those they attack, thereby gaining some of the health lost by their victims."
     die_sound=bat-flapping.wav

--- a/data/core/units/bats/Bat_Dread.cfg
+++ b/data/core/units/bats/Bat_Dread.cfg
@@ -15,7 +15,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=34
+    cost=32
     usage=scout
     description= _ "The most vicious, predatory, and successful of the Blood Bats become Dread Bats, gaining the ability to drain not merely the blood but the very life energy of their victims."
     die_sound=bat-flapping.wav

--- a/data/core/units/undead/Corpse_Ghast.cfg
+++ b/data/core/units/undead/Corpse_Ghast.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=50
     usage=fighter
     description= _ "The ghast is a creature taken from humankind’s most primal nightmares. Unlike their lesser cousins, ghouls and necrophages, ghasts are not patient enough to wait for their victim to die from poison before consuming the body. They attack directly with their enormous mouths, trying to rip the flesh straight from their foes. Once their enemy is defeated, they eat the rest of the body, gaining strength in the process."
     die_sound=ghoul-hit.wav
@@ -28,7 +28,7 @@
         icon=attacks/fangs.png
         type=blade
         range=melee
-        damage=10
+        damage=12
         number=3
         [specials]
             {WEAPON_SPECIAL_POISON}

--- a/data/core/units/undead/Corpse_Ghoul.cfg
+++ b/data/core/units/undead/Corpse_Ghoul.cfg
@@ -9,7 +9,7 @@
     hitpoints=33
     movement_type=gruefoot
     movement=5
-    experience=35
+    experience=30
     level=1
     alignment=chaotic
     advances_to=Necrophage

--- a/data/core/units/undead/Corpse_Necrophage.cfg
+++ b/data/core/units/undead/Corpse_Necrophage.cfg
@@ -9,11 +9,11 @@
     hitpoints=47
     movement_type=gruefoot
     movement=5
-    experience=120
+    experience=61
     level=2
     alignment=chaotic
     advances_to=Ghast
-    cost=27
+    cost=23
     usage=fighter
     description= _ "The necrophage, or ‘devourer of the dead’, is a monstrous, corpulent thing, which bears only a crude resemblance to a man. They appear to be quite rotten in spite of their ability to move; they are rife with disease and poisons of the blood, and have a stench to match. But the most revolting fact about these creatures, apparent only to those who can perceive the traces of foul magic on them, is that they were somehow made from living men — a process about which almost nothing is known, but which can be nothing but nightmarish."
     die_sound=ghoul-hit.wav
@@ -27,7 +27,7 @@
         icon=attacks/claws-undead.png
         type=blade
         range=melee
-        damage=7
+        damage=9
         number=3
         [specials]
             {WEAPON_SPECIAL_POISON}

--- a/data/core/units/undead/Necro_Ancient_Lich.cfg
+++ b/data/core/units/undead/Necro_Ancient_Lich.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=100
+    cost=214
     usage=mixed fighter
     description= _ "A lich that accrues enough power over its newfound immortal lifespan becomes one who can stain souls with despair and sow ruin across the world. Invariably in command of a nigh-limitless horde of risen warriors and undead monsters, a lich of this order has a mastery of dark sorcery that can bring dread to the most storied magi of human and elven kind. Such a figure usually marks a dark and bloody chapter in history, and in those times of need, it is only through the tireless efforts of the most valiant heroes that the rise of an Ancient Lich has not led to the shadows ruling the world for the rest of time."
     die_sound=lich-die.ogg

--- a/data/core/units/undead/Necro_Dark_Sorcerer.cfg
+++ b/data/core/units/undead/Necro_Dark_Sorcerer.cfg
@@ -9,11 +9,11 @@
     hitpoints=48
     movement_type=smallfoot
     movement=5
-    experience=90
+    experience=110
     level=2
     alignment=chaotic
     advances_to=Lich,Necromancer
-    cost=33
+    cost=34
     usage=mixed fighter
     description= _ "The dread inspired by black magic is enhanced by the secrecy and fell rumors which surround it. Dark sorcerers have begun to unlock the secrets of life and death, the latter of which is all too easy to inflict. This labor gives the first glimmerings of the connection between the soul and inert matter, and the first successful experiments in manipulating this bond. The terrible unknown that lurks beyond death is glimpsed, and will inevitably be fathomed.
 

--- a/data/core/units/undead/Necro_Lich.cfg
+++ b/data/core/units/undead/Necro_Lich.cfg
@@ -17,7 +17,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=90
     usage=fighter
     description= _ "A lich is the physical embodiment of black magic’s first goal: the quest to achieve immortality. Though a great deal is sacrificed in the rebirth, in becoming a lich one cheats death of that which truly gives it terror. For it is the mind that is retained, and the spirit which follows, though the body may wither away.
 

--- a/data/core/units/undead/Necromancer.cfg
+++ b/data/core/units/undead/Necromancer.cfg
@@ -6,15 +6,18 @@
     race=human
     image="units/undead-necromancers/necromancer.png"
     profile="portraits/humans/necromancer.webp"
-    hitpoints=70
+    hitpoints=76
     movement_type=smallfoot
+    [resistance]
+        impact=90
+    [/resistance]
     movement=5
     experience=150
     level=3
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=50
+    cost=90
     usage=mixed fighter
     description= _ "One of the pinnacles of what is considered ‘black magic’ is the art of necromancy, the terrible ability to awaken the dead with false life. This discovery alone caused humanity’s condemnation of black magic, for the nightmarish things it has made real have given fear a vast new arsenal.
 
@@ -41,7 +44,7 @@ This ability, in all aspects, is the first step towards cheating death of its ul
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
         range=ranged
-        damage=17
+        damage=19
         number=2
         icon=attacks/iceball.png
     [/attack]
@@ -53,7 +56,7 @@ This ability, in all aspects, is the first step towards cheating death of its ul
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
         range=ranged
-        damage=12
+        damage=16
         number=2
         icon=attacks/dark-missile.png
     [/attack]

--- a/data/core/units/undead/Skele_Banebow.cfg
+++ b/data/core/units/undead/Skele_Banebow.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=41
+    cost=52
     description= _ "The most powerful of the undead archers invariably end up being those who were themselves archers in their previous life. They wander the fields of battle, guided by the fading memory of their former skill, neither knowing, nor caring what their purpose or foes might be. They are driven only by a malice born of their empty and tortured existence."
     usage=archer
     die_sound=skeleton-big-die.ogg

--- a/data/core/units/undead/Skele_Bone_Shooter.cfg
+++ b/data/core/units/undead/Skele_Bone_Shooter.cfg
@@ -8,11 +8,11 @@
     hitpoints=42
     movement_type=undeadfoot
     movement=5
-    experience=80
+    experience=60
     level=2
     alignment=chaotic
     advances_to=Banebow
-    cost=26
+    cost=24
     description= _ "Of a dark sorcerer’s creations, some take more strongly to the false life given them. The potency of their unlife is given equipment to match; archers, in particular, are often outfitted with a truly vile arsenal. Their quivers are filled with shafts made not of wood, but of the bones of their victims. It follows that they are dubbed simply ‘Bone-Shooters’ by their unfortunate enemies."
     usage=archer
     die_sound=skeleton-big-die.ogg

--- a/data/core/units/undead/Skele_Draug.cfg
+++ b/data/core/units/undead/Skele_Draug.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=47
+    cost=70
     usage=fighter
     description= _ "There is little left, in these towering ruins, of the men they once were. Warriors at heart, they are now lost in the dream of unlife; wandering through the battles of their memory and fighting desperately for release, for a peace bought only by strength of arms. And so they struggle; both unthinking, and unrelenting."
     die_sound=skeleton-big-die.ogg

--- a/data/core/units/undead/Skele_Revenant.cfg
+++ b/data/core/units/undead/Skele_Revenant.cfg
@@ -9,11 +9,11 @@
     hitpoints=47
     movement_type=undeadfoot
     movement=5
-    experience=85
+    experience=78
     level=2
     alignment=chaotic
     advances_to=Draug
-    cost=31
+    cost=28
     usage=fighter
     description= _ "Given false life to do battle once more, the creatures known as Revenants were clearly great warriors in their time, though the memory of that time is almost wholly lost to their undead selves. Even the sorcerers who raised them can only speculate on their past. Such questions aside, a Revenant is a powerful tool in combat: a fearless warrior that feels no pain and will fight to the bitter end."
     die_sound=skeleton-big-die.ogg

--- a/data/core/units/undead/Skeleton.cfg
+++ b/data/core/units/undead/Skeleton.cfg
@@ -8,7 +8,7 @@
     hitpoints=34
     movement_type=undeadfoot
     movement=5
-    experience=35
+    experience=39
     level=1
     alignment=chaotic
     advances_to=Revenant,Deathblade

--- a/data/core/units/undead/Spirit_Nightgaunt.cfg
+++ b/data/core/units/undead/Spirit_Nightgaunt.cfg
@@ -13,7 +13,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=71
     usage=scout
     description= _ "The purpose of the masks that these creatures wear is unknown, as is the countenance that they obscure. These terrible forms are rarely seen by the living, and those who live to speak of them had no leisure to study their foe."
     die_sound=wail-long.wav

--- a/data/core/units/undead/Spirit_Shadow.cfg
+++ b/data/core/units/undead/Spirit_Shadow.cfg
@@ -8,11 +8,11 @@
     hitpoints=24
     movement_type=undeadspirit
     movement=7
-    experience=100
+    experience=77
     level=2
     alignment=chaotic
     advances_to=Nightgaunt
-    cost=38
+    cost=44
     usage=scout
     description= _ "When light came into the world and gave form to the unknown, fear was forced to retreat into darkness. Since that day, the shadows of the world have held terror for humanity, though it knows not why.
 

--- a/data/core/units/undead/Spirit_Spectre.cfg
+++ b/data/core/units/undead/Spirit_Spectre.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=52
+    cost=78
     usage=scout
     description= _ "Sometimes called the ‘hollow men’, spectres form the right arm of their masters’ powers. They are an unholy terror to the living, for they are quite as deadly as their appearance suggests.
 

--- a/data/core/units/undead/Spirit_Wraith.cfg
+++ b/data/core/units/undead/Spirit_Wraith.cfg
@@ -8,7 +8,7 @@
     hitpoints=25
     movement_type=undeadspirit
     movement=7
-    experience=100
+    experience=90
     level=2
     alignment=chaotic
     advances_to=Spectre


### PR DESCRIPTION
Changes:
Level1:
Skeleton - xp changed from 35 to 39. 
Ghoul - xp changed from 35 to 30. 
Blood Bat - cost changed from 22 to 23, xp changed from 70 to 37. 

Level 2:
Revenant - cost changed from 31 to 28, xp changed from 85 to 78.
Dark Sorcerer - cost changed from 33 to 34, xp changed from 90 to 110.
Shadow - cost changed from 38 to 44, xp changed from 100 to 77.
Wraith - xp changed from 100 to 90.
Necrophage - melee damage changed from 7 to 9, cost changed from 27 to 23, xp changed from 120 to 61.
Bone Shooter - cost changed from 26 to 24, xp changed from 80 to 60.
Dread Bat - cost changed from 34 to 32.

Level 3:
Draug - cost changed from 47 to 70.
Lich - cost changed from 50 to 90. 
Necromancer - ranged cold damage changed from 17 to 19, ranged arcane damage changed from 12 to 16, hp changed to 76, impact resistance changed to 10%, cost changed from 50 to 90.
Nightgaunt - cost changed from 52 to 71. 
Specter - cost changed from 52 to 78.
Ghast  - melee damage changed from 10 to 12, cost changed from 43 to 50. 
Banebow - cost changed from 41 to 52. 

Level 4:
Ancient lich cost changed from 100 to  214.

Some bigger changes were made, Now you cant get 5 shadow opening and you cant get 4 shadow 2 blood bat opening. Necro got more hp and impact resistance. 
