### PR TITLE
Add game logic to King of the Hill scenario

### DIFF
--- a/data/multiplayer/maps/4p_King_of_the_Hill.map
+++ b/data/multiplayer/maps/4p_King_of_the_Hill.map
@@ -1,38 +1,38 @@
 Ms, Ms, Aa, Ha, Aa, Ai, Ai, Aa^Fpa, Ha, Ha, Ai, Ha, Aa^Fpa, Ha, Ms, Ha, Ms, Ms, Ha, Ha, Ha, Ha, Aa^Fpa, Ha, Ha, Ha, Ha, Ha, Ai, Ha, Ha, Ha, Ha, Ms, Ms, Ms, Ha, Ms
-Ms, Ms, Aa, Ha, Aa, Ai, Ai, Aa^Fpa, Ms, Ms^Xm, Ms, Ai, Ms, Aa^Fpa, Ha, Ai, Aa^Fpa, Ha, Ms, Ai, Ms, Ms, Aa^Fpa, Ha, Ha^Vhha, Ha, Ha, Ha, Ms, Ai, Ms, Ha, Ha, Ms, Ai, Ms, Ms, Ha
-Aa^Fpa, Aa^Fpa, Aa^Fpa, Aa, Ch, Aa, Aa, Ww, Aa, Ms, Rd, Ha, Aa, Ms, Aa^Fpa, Ms, Ms, Ha, Ms, Ms, Ha, Ms, Ms, Aa^Fpa, Rd, Ai, Ai, Ai, Ai, Ai, Ha, Ch, Ch, Aa^Fpa, Ha, Ha, Ms, Ha
-Gs^Fp, Gs^Fp, Gg, 4 Kh, Ch, Ch, Gg, Ww, Ww^Bw/, Ww^Bw/, Aa, Rd, Rd, Ha, Ha, Ha, Aa^Fpa, Ha, Ha, Ms, Aa^Fpa, Ms, Ha, Rd, Aa, Aa^Fpa, Ai, Ai, Ai, Ai, Ha, Ch, Rr, 3 Kh, Ch, Aa^Fpa, Aa^Fpa, Aa^Fpa
-Gs^Fp, Gs^Fp, Gg, Ch, Ch, Ch, Rr, Rr, Hh, Ww, Ww, Aa^Fpa, Aa^Fpa, Rd, Rd, Aa^Fpa, Rd, Aa, Rd, Aa, Rd, Aa^Fpa, Rd, Rd, Rd, Aa, Aa, Ww, Ww, Ww, Aa, Aa, Rr, Rr, Ch, Ch, Ha, Ha
-Gg, Gg, Gs^Fp, Gg, Gg, Gg, Rr, Mm, Gg, Ww, Ww, Ha, Ms, Aa, Aa^Vea, Rd, Aa, Rd, Aa^Fpa, Rd, Aa, Rd, Aa^Vha, Aa, Aa^Fpa, Rd, Ww^Bw\, Ww, Aa, Aa^Fpa, Aa^Vha, Rr, Ha, Aa, Aa^Fpa, Ha, Ha^Vhha, Ha
-Gs^Fp, Gs^Fp, Gg, Gg, Rd, Rd, Gs^Fp, Rr, Rr, Gs^Fp, Gs^Fp, Ww, Ww, Ww, Wwf, Rd, Wwf, Aa, Ww, Ha, Wwf, Wwf, Wwf, Ww, Ww, Aa, Ww, Ww^Bw\, Rd, Ha, Rr, Rr, Rd, Rd, Rd, Rd, Aa^Fpa, Aa^Fpa
-Gg^Tf, Gg, Gs^Fp, Rd, Gg, Gg, Hh, Gg, Gg, Rr, Rr, Hh, Hh, Ha, Aa, Wwf, Aa, Ww, Aa^Fpa, Ww, Aa, Rd, Aa, Ha, Ms, Ww, Ww, Aa, Ha, Rr, Aa^Fpa, Ms, Rd, Aa^Fpa, Aa, Aa, Ai, Ai
-Hh, Hh, Hh^Vhh, Rd, Gs^Fp, Hh, Mm, Mm, Gg, Gg, Rr, Gs^Fp, Gg^Vh, Gg, Rd, Rd, Rd, Ha, Rd, Aa^Fpa, Rd, Rd, Gg, Ha, Wwf, Ww, Ww, Aa^Fpa, Ms, Rr, Rd, Aa^Fpa, Rd, Aa, Ww, Ai, Ha, Ha
-Hh, Hh, Gs^Fp, Rd, Gg, Hh, Gg, Gg^Tf, Re, Re, Gg, Rr, Rr, Rd, Gg^Tf, Gg, Gs^Fp, Rd, Gg^Ve, Rd, Gg, Gg, Gg, Wwf, Wwf, Wwf, Aa, Aa, Rr, Rr, Aa, Rd, Aa, Ww^Bw\, Gg, Aa, Ha, Ha
-Gs^Fp, Gs^Fp, Gg^Tf, Rd, Rd, Gg, Re, Re, Gg, Gg, Hh, Gs^Fp, Rr, Gg, Hh, Mm, Ww, Hh, Gs^Fp, Hh, Ww, Ww, Ww, Wwf, Wwf, Ha, Aa, Rr, Aa^Vea, Ha, Aa, Aa^Fpa, Ha, Ww, Gg^Ve, Re, Aa, Aa
-Mm^Xm, Mm^Xm, Mm^Xm, Hh, Gs^Fp, Re, Gg^Vh, Gs^Fp, Gg^Tf, Gg, Mm, Gs^Fp, Rr, Gg, Ww, Ww, Wo, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Mm, Hh, Rr, Rr, Rd, Aa^Fpa, Aa, Aa^Fpa, Ww, Ww, Gg, Re, Gg, Gg
-Mm^Xm, Mm^Xm, Mm, Mm, Gg, Re, Hh, Gs^Fp, Hh, Gs^Fp, Ss, Gg, Rr, Gg, Ww, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Gg, Gs^Fp, Rr, Rr, Gg^Tf, Hh, Mm, Rd, Gg, Ha, Wwf, Gg, Re, Re, Gs^Fp, Gs^Fp
-Mm, Mm, Hh, Gg, Rd, Re, Re, Mm, Gs^Fp, Ss, Ww, Ww, Ww^Bw|, Ww, Ww, Ww, Gg^Vh, Gs^Fp, Gg, Gg, Hh, Gg, Rr, Rr, Gg, Gg, Gg, Hh, Rd, Rd, Gg, Gg, Wwf, Gg, Re, Gs^Fp, Mm, Mm
-Hh, Hh, Gs^Fp, Rd, Hh, Gs^Fp, Gg, Re, Gg, Ww, Ww, Ww, Rr, Ww, Gg, Hh, Gs^Fp, Rd, Rd^Tf, Rd, Rr, Rr, Gg, Gg, Gs^Fp, Mm, Ww, Gg, Rd, Gs^Fp, Gg, Gg, Ww, Hh, Re, Gg, Hh, Hh
-Ww, Ww, Ww, Ww^Vm, Hh, Gs^Fp, Gg, Re, Gg, Ww, Ww, Gg, Rr, Gg, Rr, Gg, Rr, Hh, Mm, Gs^Fp, Rr, Gg, Gg, Hh, Hh, Ww, Ww, Gg, Gg, Rd, Hh, Mm, Ww, Gg, Gg, Re, Gs^Fp, Gs^Fp
-Ww, Ww, Ww, Ww, Ww, Ww, Ww, Re, Ww, Ww, Ww, Gs^Fp, Hh^Vhh, Rr, Gg, Rr, Gg^Ve, Rr, Rr, Rr, Gs^Fp, Rr, Rr, Gs^Fp, Hh^Vhh, Gs^Fp, Mm, Gs^Fp, Hh^Vhh, Rd, Gs^Fp, Hh, Gg, Ww, Gg, Re, Gg, Gg^Tf
-Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww^Bw|, Ww, Ww, Ss, Ss, Hh, Hh, Hh, Rr, Hh, Gs^Fp, Cud, Mm, Hh, Gg^Ve, Rr, Gg, Rd, Hh, Mm, Hh, Rd, Rd, Gg, Gs^Fp, Gg, Wwf, Wwf, Re, Gg, Gg
-Wo, Wo, Wo, Wo, Ww, Ww, Gg, Re, Gg, Ss, Gg, Gs^Fp, Hh, Mm, Rr, Rr, Hh, Cud, Kud, Cud, Mm, Rr, Gg, Rd, Hh, Gs^Fp, Gg^Tf, Gg, Rd, Gs^Fp, Gg^Tf, Gg, Re, Re, Wwf, Gg, Hh, Hh
-Wo, Wo, Ww, Ww, Ww, Ss, Gs^Fp, Re, Gg, Gg, Gs^Fp, Gg^Tf, Gs^Fp, Rr, Mm, Gg^Tf, Gs^Fp, Cud, Cud, Cud, Hh, Rr, Gg, Hh, Mm, Mm, Mm, Gg, Rd, Hh, Gg, Gg, Re, Gg^Vh, Gs^Fp, Ww, Mm^Xm, Mm^Xm
-Wo, Wo, Ww, Ww, Ss, Ss^Vhs, Re, Re, Re, Gs^Fp, Re, Hh, Rr, Rr, Rr, Gs^Fp, Gg^Ve, Hh, Rr, Gs^Fp, Gg^Ve, Rr, Gg, Gs^Fp, Gg^Tf, Mm, Hh, Gs^Fp, Hh, Rd, Mm, Gs^Fp, Re, Hh, Mm, Ss, Mm^Xm, Mm^Xm
-Ww, Ww, Ww, Ss, Gs, Hh, Re, Gg, Mm, Re, Gs, Rr, Gg^Vh, Hh, Gg, Rr, Rr, Rr, Hh, Rr, Rr, Rr, Rr, Re, Re, Re, Re, Gs^Fp, Gg, Rd, Hh, Hh, Re, Gg, Ss, Ss, Hh, Hh
-Ww, Ww, Ss, Mm, Re, Re, Gs^Ft, Hh, Gs, Gs, Gs^Ft, Rr, Rr, Gs^Fp, Gg, Gg, Gg, Hh, Mm, Gs^Fp, Gg, Hh, Rr, Gg^Vh, Gg, Gs^Fp, Hh, Re, Re, Re, Re, Re, Gg, Ww^Bw\, Re, Gg, Gg^Tf, Gg
-Ss, Ss, Ss, Gs^Tf, Re, Gs^Ft, Ss, Ss, Gs, Ss, Hh, Gs, Rr, Gg, Gg, Gs^Fp, Hh, Gs^Fp, Ww, Hh, Gg^Tf, Gg, Gg, Rr, Md, Md, Hd, Gs^Tf, Rd, Gs^Fp, Hh, Gs^Fp, Ww, Ss, Gg, Re, Gs^Fp, Gs^Fp
-Ss, Ss, Ss^Vhs, Hh, Re, Gs, Ss, Gs, Ss, Ss, Gs^Tf, Rd, Gs, Rr, Rr, Hh, Gs^Fp, Ww, Ww^Vm, Ww, Gs^Fp, Gg, Gs, Rr, Rr, Hd, Dd, Dd, Rd, Hh, Mm, Ww, Ss, Gg, Re, Re, Tb^Tf, Hh
-Ss, Ss, Gs^Ft, Re, Gs, Gs^Ft, Ss, Gs, Ss, Gs^Ft, Rd, Rd, Gs, Gs, Rr, Mm, Gs^Fp, Ww, Ww, Ww, Hh, Gg, Hh, Dd, Rr, Dd, Hd, Rd, Dd^Vdt, Dd, Hh, Ww, Ww, Gg, Re, Gs^Fp, Mm, Mm
-Ss, Ss, Gs^Ft, Re, Gs, Mm, Gs^Ft, Gs, Ss^Vhs, Gs^Ft, Rd, Gs, Gs^Ft, Gs^Ft, Rr, Hh, Hh, Mm, Ww, Mm, Hh, Gs^Fp, Hh, Dd, Rr, Dd, Md, Rd, Dd, Dd, Gs, Mm, Ww, Gg, Re, Hh, Gs^Fp, Hh
-Ss, Ss, Gs^Tf, Re, Re, Gs, Ss, Ss, Hh, Rd, Gs, Hh, Hh, Gs^Vht, Rr, Gs, Gs, Gs, Wwf, Hh, Hh, Mm, Gg, Gs, Dd, Rr, Rr, Rd, Dd^Tf, Gs, Ww, Ww, Ww, Gs^Fp, Gg^Ve, Re, Gg, Gg
-Mm^Xm, Mm^Xm, Mm, Gs, Re, Gs^Ft, Gs^Ft, Ss, Gs, Rd, Gs, Mm, Gs^Ft, Rr, Gs, Hh, Gs^Ft, Gs, Ds, Wwf, Gg, Gg, Gg, Gs, Hh, Dd, Rr, Dd, Hd, Hh, Hh, Ww, Ww, Ww, Hh, Re, Gg, Gg^Tf
-Hh, Hh, Gs^Ft, Gs, Re, Gs, Mm, Gs, Rd, Rd, Hh, Gs, Rr, Rr, Hh, Mm, Gs, Gs, Ds, Wwf, Mm, Gs^Fp, Gs^Fp, Gg, Gs, Hd, Rr, Dd, Hd, Mm, Gs^Fp, Hh, Ww, Ww, Gg, Re, Gg, Gg
-Hh, Hh, Gs, Re, Gs^Ft, Gs^Tf, Mm, Hh, Rd, Gs^Ft, Gs, Gs^Ft, Rr, Gs, Gs^Vht, Gs^Ft, Re, Re, Wwf, Wwf, Gg^Tf, Gs^Fp, Hh, Gg, Gg, Gs, Rr, Dd, Dd, Mm, Ww, Ww, Ww, Ww, Gs^Fp, Re, Gg, Gg
-Gs, Gs, Gs, Re, Gs^Vht, Hh, Hh, Gs, Rr, Gs^Ft, Rr, Rr, Gs, Re, Re, Re, Gs^Ft, Gs, Wwf, Re, Re, Hh^Vhh, Re, Gg, Gg, Gs, Rr, Dd^Vda, Dd, Hh, Ww, Ww, Ww, Gg, Re, Re, Gs^Fp, Gs^Fp
-Gs^Ft, Gs^Ft, Ch, Rr, Rr, Gs, Rr, Rr, Ds, Rr, Mm, Mm, Gs^Tf, Gs^Ft, Mm, Mm, Mm, Hh, Ww, Ds, Gs, Re, Gs^Ft, Re, Re, Re, Dd, Rr, Rr, Hh, Gs, Ww, Gs, Gg, Rr, Hh^Vhh, Hh, Hh
-Gs^Ft, Gs^Ft, Ch, Ch, Rr, Rr, Gs, Ds, Ww, Mm, Gs^Ft, Hh, Gs^Ft, Gs^Ft, Hh, Mm, Ds, Ww, Ww, Ds, Gs^Tf, Gs^Ft, Ss, Gs, Gs^Ft, Gs, Hh, Dd, Dd, Rr, Gs, Gs^Ft, Rr, Rr, Ch, Hh, Mm, Mm
-Hh, Hh, Tb^Tf, 1 Kh, Ch, Rr, Gs, Hh, Ww, Ww, Ww, Hh, Hh, Ds, Mm, Hh, Ww, Ww, Ww, Gs^Ft, Hh, Hh, Ww, Ss, Hh, Gs, Mm, Hh, Rd, Rr, Rr, Rr, Ch, Ch, Ch, Gs^Ft, Gs^Ft, Gs^Ft
-Gs^Ft, Gs^Ft, Gs^Ft, Ch, Ch, Rr, Gs, Ww, Ww, Ww^Vm, Ww, Mm, Ww, Ww, Ww, Hh, Ww, Ww, Ww, Ww, Ww, Mm, Ww, Gs^Ft, Mm, Gs^Tf, Gs^Ft, Rd, Gs^Ft, Gs^Tf, Gs^Ft, Ch, Ch, 2 Kh, Hh, Gs^Tf, Mm^Xm, Mm^Xm
-Mm^Xm, Mm^Xm, Mm^Xm, Gs^Ft, Hh, Gs^Ft, Hh, Ds, Ww, Ww, Wo, Ww, Ww, Wo, Wo, Ww, Wo, Wo, Ww, Ww^Vm, Ww, Ww, Wo, Ww, Ww, Ss, Ss, Ss^Vhs, Ss, Hh, Ss, Gs^Ft, Gs^Ft, Mm, Mm, Mm, Mm^Xm, Mm^Xm
-Mm^Xm, Mm^Xm, Mm^Xm, Gs^Ft, Hh, Gs^Ft, Hh, Ds, Ds, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Wo, Ww, Ss, Ss, Ss, Ss, Hh, Ss, Gs^Ft, Gs^Ft, Mm, Mm, Mm, Mm^Xm, Mm^Xm
+Ms, Ms, Aa, Ha, Aa, Ai, Ai, Aa^Fpa, Ms, Ms^Xm, Ms, Ai, Ms, Aa^Fpa, Ha, Ai, Aa^Fpa, Ha, Ms, Ai, Ms, Ms, Aa^Fpa, Ha, Aa^Vka, Ha, Ha, Ha, Ms, Ai, Ms, Ha, Ha, Ms, Ai, Ms, Ms, Ha
+Aa^Fpa, Aa^Fpa, Aa^Fpa, Aa, Ch, Aa, Aa, Ww, Aa, Ms, Rb^Esa, Ha, Gg^Esa, Ms, Aa^Fpa, Ms, Ms, Ha, Ms, Ms, Ha, Ms, Aa, Aa^Fpa, Ww, Ww, Ww, Ai, Ai, Ai, Ha, Cha^Esa, Cha^Esa, Aa^Fpa, Ha, Ha, Ms, Ha
+Gg^Fp, Gg^Fp, Gg, 4 Kh, Ch, Ch, Gg, Ww, Ww^Bw/, Ww^Bw/, Wwf, Wwf, Wwf, Ha, Gg^Esa, Ha, Aa^Fpa, Ai, Ai, Ms, Aa^Fpa, Ms, Ha, Rb^Esa, Gg^Esa, Aa^Fp, Ww, Ai, Wo, Ww, Ai, Cha^Esa, Rr, 3 Kha, Cha^Esa, Aa^Fpa, Aa^Fpa, Aa^Fpa
+Gg^Fp, Gg^Fp, Gg, Ch, Ch, Ch, Rr, Rb, Hh, Ww, Ww, Aa^Fp, Gg^Fp, Wwf, Wwf, Hh^Esa, Wwf, Aa^Fpa, Wwf, Aa, Wwf, Gg^Fp, Wwf, Rb^Esa, Rb, Gg^Esa, Gg^Em, Ww, Ww, Ww, Gg^Esa, Gg^Esa, Rr, Rr, Cha^Esa, Cha^Esa, Ha, Ha
+Gg, Gg, Gg^Fp, Gg, Wwf, Gg, Rr, Mm, Gg, Ww^Vm, Ww, Hh^Esa, Mm, Gg, Gg^Ve, Wwf, Gg, Wwf, Aa^Fp, Wwf, Gg, Wwf, Gg^Ve, Gg, Gg^Fp, Rb, Ww^Bw\, Ww, Wwf, Aa^Fp, Gg^Vea, Rr, Hh, Gg^Esa, Aa^Fpa, Aa, Ha^Vea, Ha
+Gg^Fp, Gg^Fp, Gg, Gg, Rb, Gg, Gg, Rr, Rr, Gg^Fp, Gg^Fp, Ww, Ww, Ww, Ww, Wwf, Ww, Gg^Esa, Ww, Hh^Esa, Ww, Wwf, Ww, Ww, Ww, Gg, Ww, Ww^Bw\, Rb, Hh^Esa, Rr, Rr, Wwf, Wwf, Wwf, Wwf, Aa^Fpa, Aa^Fpa
+Ww, Gg, Gg^Ve, Rb, Gg, Gg, Hh, Gg^Fp, Gg, Rr, Rr, Hh, Hh, Hh, Wwf, Rb, Gg, Ww, Gg^Fp, Ww, Gg, Rb, Gg, Hh, Mm, Ww, Ww, Wwf, Hh, Rr, Gg^Fp, Mm, Wwf, Aa^Fp, Gg^Esa, Wwf, Ai, Ai
+Ww, Ww, Ww, Wwf, Gg, Hh, Mm, Mm, Gg, Gg, Rr, Gg^Fp, Gg^Vh, Gg, Rb, Rb, Rb, Hh, Rb, Gg^Fp, Rb, Rb, Gg, Hh, Wwf, Ww, Ww, Gg^Fp, Mm, Rr, Wwf, Gg^Fp, Wwf, Gg, Ww, Ww, Ha, Ha
+Gg^Fp, Gg^Fp, Ww, Wwf, Gg, Gg^Fp, Gg^Efm, Gg^Tf, Gg, Gg, Gg, Rr, Rr, Rb, Gg^Tf, Gg^Em, Gg^Fp, Rb, Mm, Rb, Gg, Gg, Gg, Wwf, Wwf, Wwf, Gg, Gg, Rr, Rr, Gg, Wwf, Gg, Wwf, Rb^Esa, Aa, Ha, Ha
+Gg^Fp, Gg^Fp, Gg^Tf, Wwf, Wwf, Gg, Gg, Gg, Gg, Gg^Efm, Hh, Gg^Fp, Rr, Gg^Em, Hh, Ss, Ww, Hh, Gg^Fp, Hh, Ww, Ww, Ww, Wwf, Wwf, Hh, Gg, Rr, Gg^Ve, Hh, Gg, Gg^Fp, Hh, Ww, Gg^Ve, Rb^Esa, Aa, Aa
+Mm^Xm, Mm^Xm, Mm, Hh, Wwf, Gg, Gg^Vh, Gg^Fp, Gg^Tf, Gg, Mm, Gg^Fp, Rr, Gg, Ww, Ww, Wo, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Mm, Hh, Rr, Rr, Gg, Gg^Fp, Gg, Gg^Fp, Ww, Ww, Gg, Rb^Esa, Gg^Esa, Gg^Esa
+Mm^Xm, Mm^Xm, Mm, Gg^Fp, Wwf, Gg, Hh, Gg^Fp, Hh, Gg^Fp, Ss, Gg, Rr, Gg, Ww, Wo, Ww, Ww, Ww^Vm, Ww, Ww, Ww, Gg, Gg^Fp, Rr, Rr, Gg^Tf, Hh, Mm, Gg^Efm, Gg, Hh, Wwf, Gg, Rb, Rb, Gg^Fp, Gg^Fp
+Mm, Mm, Hh, Ss, Gg, Rb, Rb, Mm, Gg^Fp, Ss, Ww, Ww, Ww^Bw|, Ww, Ww, Ww, Ss, Gg^Fp, Gg, Gg, Hh, Gg, Rr, Rr, Gg, Gg, Gg, Hh, Gg, Gg, Gg^Efm, Gg, Wwf, Gg, Rb, Gg^Fp, Mm, Mm
+Hh, Hh, Gg^Fp, Ss, Hh, Gg^Fp, Gg, Rb, Rb, Ww, Ww, Ww, Rr, Ww, Gg, Hh, Gg^Fp, Gg, Gg^Tf, Gg, Gg, Rr, Gg, Gg, Gg^Fp, Mm, Ww^Ewf, Gg, Wwf, Gg^Fp, Gg, Gg, Ww, Hh, Rb, Gg, Hh, Hh
+Ww, Ww, Ww, Ww^Vm, Hh, Gg^Fp, Gg, Rb, Gg, Wwf, Wwf, Gg, Rr, Gg, Rr, Gg, Rr, Hh, Mm, Gg^Fp, Rr, Rr, Gg, Hh, Hh, Ww, Ww, Ww, Ww^Ewl, Wwf, Hh, Mm, Ww, Gg, Gg, Rb, Gg^Fp, Gg^Fp
+Ww, Ww, Ww, Ww, Ww, Ww, Ww, Rb, Ww, Ww, Ww, Gg^Fp, Hh^Vhh, Rr, Gg, Rr, Gg^Ve, Rr, Rr, Rr, Gg^Fp, Rr, Rr, Gg^Fp, Hh^Vd, Gg^Fp, Mm, Gg^Fp, Hh^Vd, Wwf, Gg^Fp, Hh, Gg, Ww, Gg, Rb, Gg, Gg^Tf
+Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww^Bw|, Ww, Ww, Ss, Ss, Hh, Hh, Hh, Rr, Hh, Gg^Fp, Cf, Mm, Hh, Gg^Ve, Rr, Gg, Ww, Hh, Mm, Hh, Wwf, Wwf, Gg, Gg^Fp, Gg, Ww, Wwf, Rb, Gg, Gg
+Wo, Wo, Wo, Wo, Ww, Ww, Gg, Re, Gg, Ss, Gg, Gg^Fp, Hh, Mm, Rr, Rr, Hh, Cf, 5 Kf, Cf, Mm, Rr, Gg, Ww, Hh, Gg^Fp, Gg^Tf, Gg, Gg, Gg^Fp, Gg^Tf, Gg, Wwf, Wwf, Ww, Gg, Hh, Hh
+Wo, Wo, Ww, Ww, Ww, Ss, Gg^Fp, Re, Gg, Gg, Gg^Fp, Gg^Tf, Gg^Fp, Rr, Mm, Gg^Tf, Gg^Fp, Cf, Cf, Cf, Hh, Rr, Gg, Hh, Mm, Mm, Mm, Gg, Gg, Hh, Gg, Gg, Wwf, Gg^Vh, Gg^Fp, Ww, Mm^Xm, Mm^Xm
+Wo, Wo, Ww, Ww, Ss, Ss^Vhs, Re, Re, Re, Gg^Fp, Re, Hh, Rr, Rr, Rr, Gg^Fp, Gg^Ve, Hh, Rr, Gg^Fp, Gg^Ve, Rr, Gg, Gg^Fp, Gg^Tf, Mm, Hh, Gg^Fp, Hh, Gg, Mm, Gg^Fp, Re, Hh, Mm, Ss, Mm^Xm, Mm^Xm
+Ww, Ww, Ww, Ss, Gs, Hh, Re, Gg, Mm, Re, Gs, Rr, Gg^Vh, Hh, Gg, Rr, Rr, Rr, Hh, Rr, Rr, Rr, Rr, Re, Re, Re, Re, Gg^Fp, Gg, Gg, Hh, Hh, Re, Gg, Ss, Ss, Hh, Hh
+Ww, Ww^Ewl, Ss, Mm, Re, Re, Gs^Ft, Hh, Gs, Gs, Gs^Ft, Rr, Rr, Gg^Fp, Gg, Gg, Gg, Hh, Mm, Gg^Fp, Gg, Hh, Rr, Gg^Vh, Gg, Gg^Fp, Hh, Re, Re, Re, Re, Re, Gg, Ww^Bw\, Re, Gg, Gg^Tf, Gg
+Ss, Ss, Ss, Gs^Tf, Re, Gs^Ft, Ss, Ss, Gs, Ss, Hh, Gs, Rr, Gg, Gg, Gg^Fp, Wwf, Wwf^Fp, Ww, Wwf, Wwf^Tf, Gg, Gg, Rr, Mdd, Mdd, Hd, Gs^Tf, Rd, Gg^Fp, Hh, Gg^Fp, Wwt^Ewf, Ss, Gg, Re, Gg^Fp, Gg^Fp
+Ss, Ss, Ss^Vhs, Hh, Re, Gs, Ss, Gs, Ss, Ss, Gs^Tf, Rr, Gs, Rd, Rd, Hh, Wwf^Fp, Ww, Ww^Vm, Ww, Wwf^Fp, Gg, Gs, Rr, Rr, Hd, Rd, Dd, Rd, Hh, Mdd, Wwt, Ss, Gg, Re, Re, Tb^Tf, Hh
+Ss, Ss, Gs^Ft, Re, Gs, Gs^Ft, Ss, Gs, Ss, Gs^Ft, Rr, Rr, Gs, Gs, Rd, Mm, Gg^Fp, Ww, Ww, Ww, Ss, Gg, Hh, Gs, Rr, Rd, Hd, Rd, Dd^Vdt, Dd, Hhd, Wwt, Wwt, Gg, Re, Gg^Fp, Mm, Mm
+Ss, Ss, Gs^Ft, Re, Gs, Mm, Gs^Ft, Gs, Ss^Vhs, Gs^Ft, Rr, Gs, Gs^Ft, Gs^Ft, Rd, Hh, Hh, Ss, Ss, Ww, Ss, Gg^Fp, Hh, Gd, Rr, Dd, Mdd, Rd, Rd, Dd, Gd^Fts, Wwt, Wwt, Gg, Re, Hh, Gg^Fp, Hh
+Ss, Ss, Gs^Tf, Re, Re, Gs, Ss, Ss, Hh, Rr, Gs, Hh, Hh, Gs^Vht, Rd, Gs, Gs, Gs, Wwf, Ww, Hh, Mm, Gg, Gs, Gd, Rr, Rr, Rd, Dd, Rd, Wwt, Wwt, Wwt, Gg^Fp, Gg^Ve, Re, Gg, Gg
+Wwt, Ss, Ss, Gs, Re, Gs^Ft, Gs^Ft, Ss, Gs, Rr, Gs, Mm, Gs^Ft, Rd, Gs, Hh, Gs^Ft, Ds, Wwt, Wwf, Gg, Gg, Gg, Gs, Hhd, Rd, Rr, Rd, Dd, Hd, Hd, Wwt, Wot, Wwt, Hh, Re, Gg, Gg^Tf
+Wwt, Ww^Ewl, Gs^Ft, Gs, Re, Gs, Mm, Gs, Rr, Rr, Hh, Gs, Rd, Rd, Hh, Mm, Gs, Ds, Wwt, Wwt, Mm, Gg^Fp, Gg^Fp, Gg, Gs, Hhd, Rr, Dd, Hd, Dd^Do, Dd, Wwt, Wot, Wwt, Gg, Re, Gg, Gg
+Ss, Ss, Gs, Re, Gs^Ft, Gs^Tf, Mm, Hh, Rr, Gs^Ft, Gs, Gs^Ft, Rd, Gs, Gs^Vht, Gs^Ft, Rd, Rd, Wwf, Wwf, Gg^Tf, Gg^Fp, Hh, Gg, Gg, Gd, Rr, Rd, Dd, Mdd, Wwt, Wwt, Wwt, Wwt, Gg^Fp, Re, Gg, Gg
+Ss, Ss, Gs, Re, Gs^Vht, Hh, Hh, Gs, Rr, Gs^Ft, Rd, Rd, Gs, Rd, Rd, Rd, Gs^Ft, Wwf, Wwt, Rd, Rd, Rr^Vd, Rd, Gs, Gs, Gs, Rr, Dd^Vda, Rd, Dd, Wwt, Wot, Wwt, Wwf, Re, Re, Gg^Fp, Gg^Fp
+Gs^Ft, Wwf^Ft, Ch, Re, Gs, Gs, Rr, Rr, Ds, Rd, Mm, Mm, Gs^Tf, Gs^Ft, Mm, Mm, Mm, Hh, Wwt, Ds, Gs, Rd, Gs^Ft, Rd, Rd, Rd, Gs, Rr, Rr, Rd, Gs, Wwt, Wwf, Gg, Re, Hh^Vd, Hh, Hh
+Gs^Ft, Gs^Ft, Ch, Ch, Rr, Rr, Gs, Ds, Wwt, Mm, Gs^Ft, Hh, Gs^Ft, Gs^Ft, Hh, Mm, Ds, Wwt, Wwt, Ds, Gs^Tf, Gs^Ft, Ss, Gs, Gs^Ft, Gs, Hh, Gd, Gd, Rr, Gd, Gs^Ft, Gs, Gg, Ch, Hh, Mm, Mm
+Hh, Hh, Tb^Tf, 1 Kh, Ch, Gs, Wwf, Hh, Wwt, Wwt, Wwt, Hh, Hh, Ds, Mm, Hh, Wwt, Wwt, Wwt, Gs^Ft, Hh, Hh, Wwt, Ss, Hh, Gs, Mm, Hh, Gs, Rr, Rr, Gs, Ch, Ch, Ch, Gs^Ft, Gs^Ft, Gs^Ft
+Gs^Ft, Gs^Ft, Gs^Ft, Ch, Ch, Gs, Ds, Wwt, Wwt, Ww^Vm, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Wwt, Gs^Ft, Mm, Gs^Tf, Gs^Ft, Gs, Gs^Ft, Gs^Tf, Gs^Ft, Ch, Ch, 2 Kh, Hh, Gs^Tf, Mm^Xm, Mm^Xm
+Mm^Xm, Mm^Xm, Mm^Xm, Gs^Ft, Hh, Gs^Ft, Hh, Ds, Wwt, Wwt, Wot, Wwt, Wwt, Wot, Wot, Wwt, Wot, Wot, Wwt, Ww^Vm, Wwt, Wwt, Wot, Wwt, Wwt, Ss, Ss, Ss^Vhs, Ss, Ss, Ss, Gs^Ft, Gs^Ft, Mm, Mm, Mm, Mv, Mm^Xm
+Mm^Xm, Mm^Xm, Mm^Xm, Gs^Ft, Hh, Gs^Ft, Hh, Ds, Ds, Wwt, Wot, Wot, Wot, Wot, Wot, Wot, Wot, Wot, Wot, Wwt, Wot, Wot, Wot, Wot, Wwt, Ss, Ss, Ss, Ss, Ss, Ss, Gs^Ft, Gs^Ft, Mm, Mm, Mm, Mm^Xm, Mm^Xm

--- a/data/multiplayer/scenarios/4p_King_of_the_Hill.cfg
+++ b/data/multiplayer/scenarios/4p_King_of_the_Hill.cfg
@@ -1,62 +1,275 @@
 #textdomain wesnoth-multiplayer
 
-# original map by telex4, recreated by Becephalus 1/06, revised bex 05/06
+#define SPAWN_HEIR SIDE PLACEMENT
+    [store_side]
+        side={SIDE}
+    [/store_side]
+    # Get the faction leader list of the side.
+    [lua]
+        code=<<
+            local t = ...
+            for faction in wml.child_range(wesnoth.scenario.era, "multiplayer_side") do
+                if faction.id == t.faction then
+                    wml.variables.random = faction.leader
+                    return
+                end
+            end
+            >>
+        [args]
+            faction=$side.faction
+        [/args]
+    [/lua]
+    # Pick a random leader from the list.
+    {RANDOM $random}
+    [store_unit_type]
+        type=$random
+    [/store_unit_type]
+    # Give this leader whichever role is unfilled.
+    [if]
+        [have_unit]
+            side=$side.side
+            role=heir
+        [/have_unit]
+        [then]
+            {VARIABLE role reclaimer}
+        [/then]
+        [else]
+            {VARIABLE role heir}
+        [/else]
+    [/if]
+    # Spawn it.
+    [unit]
+        side=$side.side
+        type=$random
+        canrecruit=yes
+        role=$role
+        recall_cost=$unit_type.cost
+        placement={PLACEMENT}
+    [/unit]
+#enddef
 
 [multiplayer]
     id=multiplayer_King_of_the_Hill
     name= _ "4p — King of the Hill"
     map_file=multiplayer/maps/4p_King_of_the_Hill.map
-    description= _ "Controlling the area around the central keep is very lucrative in this 4 player FFA map. Works fine 2 vs. 2 as well. There are 36 villages." + _ " Recommended setting of 2 gold per village and 150 starting gold."
+    description= _ "The King is dead. Without an heir, his quarrelsome lords now vie for the hilltop throne and all the power and wealth it commands. Are you mighty enough to take this seat of power before your rivals do? Can you hold out against their many assassins? Is your arse truly great enough to fill the throne of a king? This free for all map has 38 villages and bonus income for the leader on the center keep." + _ " Recommended setting of 2 gold per village and 150 starting gold."
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}
 
     [side]
-        [ai]
-            villages_per_scout=16
-        [/ai]
         side=1
-        team_name=south-west
-        user_team_name= _ "teamname^Southwest"
-        canrecruit=yes
+        team_name=southwest
+        user_team_name= _ "Southwest"
         controller=human
         gold=150
-        fog=yes
-    [/side]
-    [side]
         [ai]
             villages_per_scout=16
         [/ai]
+    [/side]
+    [side]
         side=2
-        team_name=south-east
-        user_team_name= _ "teamname^Southeast"
-        canrecruit=yes
+        team_name=southeast
+        user_team_name= _ "Southeast"
         controller=human
         gold=150
-        fog=yes
-    [/side]
-    [side]
         [ai]
             villages_per_scout=16
         [/ai]
+    [/side]
+    [side]
         side=3
-        team_name=north-east
-        user_team_name= _ "teamname^Northeast"
-        canrecruit=yes
+        team_name=northeast
+        user_team_name= _ "Northeast"
         controller=human
         gold=150
-        fog=yes
-    [/side]
-    [side]
         [ai]
             villages_per_scout=16
         [/ai]
+    [/side]
+    [side]
         side=4
-        team_name=north-west
-        user_team_name= _ "teamname^Northwest"
-        canrecruit=yes
+        team_name=northwest
+        user_team_name= _ "Northwest"
         controller=human
         gold=150
-        fog=yes
+        [ai]
+            villages_per_scout=16
+        [/ai]
     [/side]
+    [side]
+        side=5
+        controller=ai
+        controller_lock=yes
+        team_name=guard
+        team_lock=yes
+        user_team_name= _ "High Guard"
+        color=gold
+        color_lock=yes
+        gold=150
+        [ai]
+            villages_per_scout=16
+        [/ai]
+    [/side]
+
+    [options]
+        [slider]
+            id="bonus_income"
+            default=15
+            min=5
+            max=40
+            name= _ "Hill Bonus Income"
+            description= _ "The amount of extra gold per turn granted to the leader who occupies the hill keep."
+        [/slider]
+        [slider]
+            id="chest_gold"
+            default=75
+            min=25
+            max=500
+            step=25
+            name= _ "Treasure Chest Gold"
+            description= _ "The amount of gold stashed inside the treasure chest on the hill."
+        [/slider]
+    [/options]
+
+    [event]
+        name=prestart
+        [objectives]
+            [objective]
+                description= _ "Defeat enemy leaders"
+                condition=win
+            [/objective]
+            [note]
+                description= _ "The treasure chest on the hill keep can only be unlocked by a leader, for a bonus of $chest_gold gold."
+            [/note]
+            [note]
+                description= _ "A side with a leader holding the hill keep gets +$bonus_income gold income each turn."
+            [/note]
+            [note]
+                description= _ "Each side gets two leaders. Whenever a leader is lost then another appears on the recall list at its full cost."
+            [/note]
+        [/objectives]
+        # The hill is always visible to all players.
+        [lift_fog]
+            location_id=5
+            radius=4
+            multiturn=yes
+        [/lift_fog]
+        [remove_shroud]
+            location_id=5
+            radius=4
+        [/remove_shroud]
+        # Heirs of computer players try to take the hill keep.
+        [micro_ai]
+            side=1,2,3,4
+            ai_type=goto
+            action=add
+            release_unit_at_goal=yes
+            [filter]
+                role=heir
+            [/filter]
+            [filter_location]
+                location_id=5
+            [/filter_location]
+        [/micro_ai]
+        # Reclaimers of computer players try to (re)take a home keep.
+        [micro_ai]
+            side=1,2,3,4
+            ai_type=goto
+            action=add
+            release_unit_at_goal=yes
+            [filter]
+                role=reclaimer
+            [/filter]
+            [filter_location]
+                location_id=1,2,3,4
+            [/filter_location]
+        [/micro_ai]
+    [/event]
+
+    # Give each side an heir (a second leader).
+    [event]
+        name=turn 1 refresh
+        [store_side]
+            variable=sides
+        [/store_side]
+        [foreach]
+            array=sides
+            [do]
+                [if]
+                    [have_unit]
+                        side=$this_item.side
+                    [/have_unit]
+                    [then]
+                        {SPAWN_HEIR $this_item.side leader}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
+    [/event]
+
+    # A leader on the hill keep gets a kingly tribute each turn.
+    [event]
+        name=turn refresh
+        first_time_only=no
+        [if]
+            [have_unit]
+                [filter_location]
+                    location_id=5
+                [/filter_location]
+                canrecruit=yes
+                side=$side_number
+            [/have_unit]
+            [then]
+                [gold]
+                    side=$side_number
+                    amount=$bonus_income
+                [/gold]
+                [scroll_to]
+                    location_id=5
+                [/scroll_to]
+                [floating_text]
+                    location_id=5
+                    text= _ "<span color='gold'>+$bonus_income gold</span>"
+                [/floating_text]
+            [/then]
+        [/if]
+    [/event]
+
+    # If a side loses a leader then put a new heir on its recall list.
+    [event]
+        name=die
+        first_time_only=no
+        [filter]
+            canrecruit=yes
+        [/filter]
+        {SPAWN_HEIR $unit.side map}
+    [/event]
+
+    # A leader unlocks the hill treasure chest and takes its gold.
+    {PLACE_IMAGE items/chest.png 18 18}
+    [event]
+        name=moveto
+        [filter]
+            [filter_location]
+                location_id=5
+            [/filter_location]
+            canrecruit=yes
+            side=1,2,3,4
+        [/filter]
+        [gold]
+            amount=$chest_gold
+            side=$unit.side
+        [/gold]
+        [remove_item]
+            x,y=$x1,$y
+            image=items/chest.png
+        [/remove_item]
+        [floating_text]
+            x,y=$x1,$y1
+            text= _ "<span color='gold'>+$chest_gold gold</span>"
+        [/floating_text]
+    [/event]
 [/multiplayer]
+
+#undef SPAWN_HEIR


### PR DESCRIPTION
The premise of this venerable mainline map was always for players to fight over the central hilltop castle. Yet its scenario gave no perks to combat the downsides of taking the hill:

- No recruiting while leader is traveling there.
- Leader vulnerable while traveling.
- Hill surrounded by enemies on multiple sides.

This update adds a powerful perk to hopefully make the hill worth fighting over.

~~When a leader sits on the hill keep, all other castles collapse into ruins so that no other side can recruit. Only if this leader (the king) is assassinated or abdicates his hilltop throne will the other castles be restored. To make the situation more clear, there is no fog or shroud on the hill, so that all players can see some of what goes on there at all times.~~

~~[Forum Development Thread](https://forums.wesnoth.org/viewtopic.php?t=56209)~~

UPDATE: Based on extensive feedback from @Hejnewar on discord, rewrote the scenario to be as follows:

A side with a leader holding the hill keep gets bonus gold and a bonus leader (who spawns on their original keep), A treasure chest which only a leader can unlock further rewards the first player to take the hill.

Also there are two tweaks to the King of the Hill map itself. One switches a handful of tiles to improve water access for the northern castles so that they are less disadvantaged when deploying water units. The other is a minor cosmetic touch up to help distinguish the cold and wet northern regions from dry and hot southern ones by switching to a slightly greener shade of grass under the pine forest tiles.