### PR TITLE
1.16: Use same vcpkg base-line as current master

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,17 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "wesnoth-dependencies",
   "version": "0.0.1",
-  "builtin-baseline": "877e3dc2323a4d4c3c75e7168c22a0c4e921d4db",
+  "builtin-baseline": "dafef74af53669ef1cc9015f55e0ce809ead62aa",
   "dependencies": [
     "sdl2",
     {
       "name": "sdl2-image",
       "features": [ "libjpeg-turbo" ]
     },
-    {
-      "name": "sdl2-mixer",
-      "features": [ "libvorbis" ]
-    },
+    "sdl2-mixer",
     "bzip2",
     "zlib",
     "pango",
@@ -45,6 +42,7 @@
     "boost-scope-exit",
     "boost-circular-buffer",
     "boost-ptr-container",
+    "boost-spirit",
     "boost-test"
   ]
 }


### PR DESCRIPTION
Uses the same base-line that @Vultraz updated in master recently, in b50a8012ea000b47955a1c92283be9d88fd929b2. This updates to pango 1.50.14 (from 1.50.12) which resolves #7217 (but also introduces #7543).

I had to make the other changes (back-ported from master) to compile. Tested and verified on VS2019 (Win7) and VS2022 (Win10).