### PR TITLE
Arcane Resistances Rework

### DIFF
--- a/changelog_entries/ArcaneResistancesRework.md
+++ b/changelog_entries/ArcaneResistancesRework.md
@@ -1,0 +1,13 @@
+ ### Units
+   * Movement type changes:
+     * Smallfoot, armoredfoot, elusivefoot, mounted, fly, smallfly, lightfly, deepsea, mountainfoot, gurefoot, rodentfoot, lizard, dunefoot, duneelusivefoot, dunearmoredfoot, dunehorse, dunearmoredhorse - arcane resistance changed from 20% to 10%.
+     * Treefolk - arcane resistance changed from -30% to -20%.
+     * Undeadfoot - arcane resistance changed from -50% to -20%.
+     * Undeadfly - arcane resistance changed from -40% to -20%.
+     * Drakefly, drakeglide, drakeglide2, drakefoot - arcane resistance changed from -30% to -10%.
+   * Loyalists:
+     * Paladin - arcane resistance changed from 60% to 30%.
+     * White mage - arcane resistance changed from 40% to 30%.
+     * Mage of Light - arcane resistance changed from 60% to 50%.
+   * Undead:
+     * Lich - arcane resistance changed from -40% to -20%.

--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -62,7 +62,7 @@
         impact=120
         fire=100
         cold=100
-        arcane=80
+        arcane=90
     [/resistance]
 #enddef
 
@@ -133,6 +133,6 @@
         impact=80
         fire=50
         cold=150
-        arcane=130
+        arcane=110
     [/resistance]
 #enddef

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -458,7 +458,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -588,7 +588,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=90
             fire=110
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -632,7 +632,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=120
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -674,7 +674,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=70
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
         [special_note]
             note={INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}
@@ -796,7 +796,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=60
             fire=150
             cold=100
-            arcane=130
+            arcane=120
         [/resistance]
     [/movetype]
 
@@ -854,7 +854,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -898,7 +898,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=70
             fire=100
             cold=40
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1029,7 +1029,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1087,7 +1087,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=90
             cold=60
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1133,7 +1133,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=120
             cold=40
-            arcane=150
+            arcane=120
         [/resistance]
     [/movetype]
 
@@ -1156,7 +1156,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=120
             cold=40
-            arcane=140
+            arcane=120
         [/resistance]
     [/movetype]
 
@@ -1277,7 +1277,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=120
             cold=120
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1376,7 +1376,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=90
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1480,7 +1480,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=70
             fire=50
             cold=150
-            arcane=130
+            arcane=110
         [/resistance]
     [/movetype]
 
@@ -1522,7 +1522,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1564,7 +1564,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1606,7 +1606,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1648,7 +1648,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=90
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
     [/movetype]
 
@@ -1690,7 +1690,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=80
             fire=100
             cold=100
-            arcane=80
+            arcane=90
         [/resistance]
         [special_note]
             note={INTERNAL:SPECIAL_NOTES_DEFENSE_CAP}

--- a/data/core/units/humans/Horse_Paladin.cfg
+++ b/data/core/units/humans/Horse_Paladin.cfg
@@ -22,7 +22,7 @@
 Full paladins are generally not quite as fearsome as the ‘Grand Knights’ that champion most armies, but they are first-class fighters nonetheless. Additionally, their wisdom and piety grants these warrior monks certain curious abilities; a paladin is very powerful in fighting magical or unnatural things, and most have some skill at medicine and healing."
     die_sound=horse-die.ogg
     [resistance]
-        arcane=40
+        arcane=70
     [/resistance]
     [abilities]
         {ABILITY_HEALS}

--- a/data/core/units/humans/Mage_White.cfg
+++ b/data/core/units/humans/Mage_White.cfg
@@ -27,7 +27,7 @@ Though not trained for combat, they are a potent ally against magical or unnatur
         {ABILITY_CURES}
     [/abilities]
     [resistance]
-        arcane=60
+        arcane=70
     [/resistance]
     [healing_anim]
         start_time=-525

--- a/data/core/units/humans/Mage_of_Light.cfg
+++ b/data/core/units/humans/Mage_of_Light.cfg
@@ -30,7 +30,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         {ABILITY_CURES}
     [/abilities]
     [resistance]
-        arcane=40
+        arcane=50
     [/resistance]
     [healing_anim]
         start_time=-525

--- a/data/core/units/undead/Necro_Lich.cfg
+++ b/data/core/units/undead/Necro_Lich.cfg
@@ -8,9 +8,6 @@
     profile="portraits/undead/lich.webp"
     hitpoints=60
     movement_type=undeadfoot
-    [resistance]
-        arcane=140
-    [/resistance]
     movement=6
     experience=150
     level=3


### PR DESCRIPTION
Smallfoot, armoredfoot, elusivefoot, mounted,  fly, smallfly, lightfly, deepsea, mountainfoot, gurefoot, rodentfoot, lizard, dunefoot, duneelusivefoot, dunearmoredfoot, dunehorse, dunearmoredhorse - arcane resistance changed from 20% to 10%. 
Treefolk - arcane resistance changed from -30% to -20%.
Undeadfoot - arcane resistance changed from -50% to -20%.
Undeadfly - arcane resistance changed from -40% to -20%.
Drakefly, drakeglide, drakeglide2, drakefoot - arcane resistance changed from -30% to -10%.

Float ???

Paladin - arcane resistance changed from 60% to 30%.
White mage - arcane resistance changed from 40% to 30%.
Mage of Light - arcane resistance changed from 60% to 50%.
Lich - arcane resistance changed from -40% to -20%.

@nemaara kinda lore changes, paladin no longer is on a level of MoL with arcane resistance and Lich doesnt have arcane resistane lower than ancient lich. I also dont know exactly know what to do with ghoul from lore perspective should they have higher arcane resistance or should it go down by 10%, Im leaning towards 10% but we will see. 