### PR TITLE
add a "halo" and'overlay' abilities for add overlays so that the unit  benefits from a second halo or overlay when conditions are matched

### DIFF
--- a/changelog_entries/add_halo_overlay_abilities.md
+++ b/changelog_entries/add_halo_overlay_abilities.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * add a [halo] and an [overlay] ability to support halos or overlays illustrate the activity of other abilities like [illuminates] or others

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Sylph.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Sun_Sylph.cfg
@@ -7,6 +7,7 @@
     gender=female
     image=units/quenoth/sun_sylph/sun-sylph.png
     profile="portraits/quenoth/sun_sylph.webp"
+    halo=halo/elven/shyde-stationary-halo[1~6].png:150
     hitpoints=42
     movement_type=quenoth_float
     movement=6
@@ -19,6 +20,7 @@
     usage=healer
     [abilities]
         {UTBS_ABILITY_HEALS}
+        {ABILITY_SONG_VERSE_ILLUMINATES}
     [/abilities]
     description= _ "In times past, those who stepped beyond the boundary of the worlds of elf and faerie were called Sylphs, mystics with unparalleled knowledge of the secrets of the natural sphere. However, in the harsh new world, the path into the realm of the faerie became no longer a journey into the heart of nature, but a diverging path between light and darkness. Those elves who embrace the burning suns as the fulcrum of life and death learn also to harness their power, transforming into beings imbued with radiant fire. These Sun Sylphs very much embody the power that they wield: light that heals and protects, and flames that smolder with destruction."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -296,14 +296,14 @@ _ "third verse"#enddef
             id = song_$unit.underlying_id|_$turn_number
 
             [effect]
-                apply_to = new_ability
-                [abilities]
-                    {ABILITY_ILLUMINATES}
-                [/abilities]
-            [/effect]
-            [effect]
-                apply_to = halo
-                halo = halo/illuminates-aura.png~CS(50,20,-70)
+                apply_to=attack
+                name=sun incarnate
+                [set_specials]
+                    mode=append
+                    [dummy]
+                        id=sun_incarnate
+                    [/dummy]
+                [/set_specials]
             [/effect]
 
             duration = scenario
@@ -316,6 +316,29 @@ _ "third verse"#enddef
             [/remove_object]
         [/event]
     [/event]
+#enddef
+
+#define ABILITY_SONG_VERSE_ILLUMINATES
+    # Canned definition of the Illuminates ability to be included in an
+    # [abilities] clause.
+    [illuminates]
+        id=illumination_song_verse
+        value=25
+        max_value=25
+        cumulative=no
+        name= _ "third verse illuminates"
+        female_name= _ "female^third verse illuminates"
+        description= _ "When ability is active after sun incarnate attack, this unit illuminates the surrounding area, making lawful units fight better, and chaotic units fight worse.
+Any units adjacent to this unit will fight as if it were dusk when it is night, and as if it were day when it is dusk."
+        special_note={INTERNAL:SPECIAL_NOTES_ILLUMINATES}
+        affect_self=yes
+        [filter]
+            [has_attack]
+                special_id=sun_incarnate
+            [/has_attack]
+        [/filter]
+    [/illuminates]
+    {ADD_ABILITY_HALO illumination_song_verse "halo/illuminates-aura.png~CS(50,20,-70)"}
 #enddef
 
 #define WEAPON_SPECIAL_ONCE_PER_TURN ATTACK_NAME

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -387,3 +387,47 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
         special_note={INTERNAL:SPECIAL_NOTES_FEEDING}
     [/dummy]
 #enddef
+
+#define ADD_ABILITY_HALO ID HALO
+    # Show the image HALO above the unit when the ability with id ID is active
+    [halo]
+        id=halo_{ID}
+        halo_image={HALO}
+        [filter]
+            ability_id_active={ID}
+        [/filter]
+    [/halo]
+#enddef
+
+#define ADD_ABILITY_HALO_ADJACENT ID HALO
+    # Show the image HALO above the adjacent unit when the ability with id ID is active
+    [halo]
+        id=halo_{ID}
+        halo_image={HALO}
+        affect_self=no
+        affect_allies=yes
+        [filter]
+            ability={ID}
+        [/filter]
+        [affect_adjacent]
+            [filter]
+                ability_id_active={ID}
+            [/filter]
+        [/affect_adjacent]
+    [/halo]
+#enddef
+
+#define ICONS_ABILITIES ID ICON
+    [overlay]
+        id=icon_{ID}
+        overlay_image={ICON}
+        [filter]
+            ability_id_active={ID}
+        [/filter]
+    [/overlay]
+#enddef
+
+#define ABILITY_ILLUMINATES_AND_HALO HALO
+    {ABILITY_ILLUMINATES}
+    {ADD_ABILITY_HALO illumination {HALO}}
+#enddef

--- a/data/core/units/humans/Mage_of_Light.cfg
+++ b/data/core/units/humans/Mage_of_Light.cfg
@@ -6,7 +6,6 @@
     gender=male,female
     image="units/human-magi/white-cleric.png"
     profile="portraits/humans/mage-light.webp"
-    halo=halo/illuminates-aura.png
     hitpoints=47
     movement_type=smallfoot
     movement=5
@@ -26,7 +25,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
     {DEFENSE_ANIM "units/human-magi/white-cleric-defend.png" "units/human-magi/white-cleric.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [abilities]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_AND_HALO "halo/illuminates-aura.png"}
         {ABILITY_CURES}
     [/abilities]
     [resistance]

--- a/data/core/units/merfolk/Diviner.cfg
+++ b/data/core/units/merfolk/Diviner.cfg
@@ -6,7 +6,6 @@
     gender=female
     image="units/merfolk/diviner.png"
     profile=portraits/merfolk/priestess.webp
-    halo=halo/illuminates-aura.png
     hitpoints=45
     [resistance]
         arcane=60
@@ -24,7 +23,7 @@
     die_sound=mermaid-die.ogg
     {DEFENSE_ANIM "units/merfolk/diviner-defend2.png" "units/merfolk/diviner-defend1.png" mermaid-hit.ogg }
     [abilities]
-        {ABILITY_ILLUMINATES}
+        {ABILITY_ILLUMINATES_AND_HALO "halo/illuminates-aura.png"}
         {ABILITY_CURES}
     [/abilities]
     [healing_anim]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -42,6 +42,18 @@
 	{WML_MERGE_KEYS}
 [/tag]
 [tag]
+	name="halo"
+	max=infinite
+	super="units/unit_type/abilities/~generic~"
+	{SIMPLE_KEY halo_image string}
+[/tag]
+[tag]
+	name="overlay"
+	max=infinite
+	super="units/unit_type/abilities/~generic~"
+	{SIMPLE_KEY overlay_image string}
+[/tag]
+[tag]
 	name="heals"
 	max=infinite
 	super="units/unit_type/abilities/~generic~"

--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -219,7 +219,7 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             [/modifications]
             [abilities]
                 {ABILITY_SKIRMISHER}
-                {ABILITY_ILLUMINATES}
+                {ABILITY_ILLUMINATES_AND_HALO "halo/illuminates-aura.png"}
             [/abilities]
         [/unit]
 

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -62,6 +62,25 @@ void move_action::write(config & cfg) const
 }
 
 /**
+ * Reset halo of adjacent units when undo move.
+ */
+static void reset_adjacent(bool& halo_adjacent, unit_map& units, const map_location& loc)
+{
+	if(halo_adjacent){
+		unit_map::iterator u = units.find(loc);
+		const auto adjacent = get_adjacent_tiles(loc);
+		for(unsigned i = 0; i < adjacent.size(); ++i) {
+			const unit_map::const_iterator it = units.find(adjacent[i]);
+			if (it == units.end() || it->incapacitated())
+				continue;
+			if ( &*it == &*u )
+				continue;
+			it->anim_comp().set_standing();
+		}
+	}
+}
+
+/**
  * Undoes this action.
  * @return true on success; false on an error.
  */
@@ -91,8 +110,17 @@ bool move_action::undo(int)
 
 	// Move the unit.
 	unit_display::move_unit(rev_route, u.get_shared_ptr(), true, starting_dir);
+	bool halo_adjacent = false;
+	for (const config::any_child sp : u->abilities().all_children_range()){
+		if(!(sp.cfg)["halo_image"].empty() && (sp.cfg).has_child("affect_adjacent")){
+			halo_adjacent = true;
+			break;
+		}
+	}
+	reset_adjacent(halo_adjacent, units, rev_route.front());
 	units.move(u->get_location(), rev_route.back());
 	unit::clear_status_caches();
+	reset_adjacent(halo_adjacent, units, rev_route.back());
 
 	// Restore the unit's old state.
 	u = units.find(rev_route.back());

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -148,6 +148,8 @@ void unit_animation_component::refresh()
 void unit_animation_component::clear_haloes ()
 {
 	unit_halo_.reset();
+	abil_halos_.clear();
+	abil_halos_ref_.clear();
 	if(anim_ ) anim_->clear_haloes();
 }
 

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -44,7 +44,9 @@ public:
 		frame_begin_time_(0),
 		draw_bars_(false),
 		refreshing_(false),
-		unit_halo_() {}
+		unit_halo_(),
+		abil_halos_(),
+		abil_halos_ref_() {}
 
 	/** Copy construct a unit animation component, for use when copy constructing a unit. */
 	unit_animation_component(unit & my_unit, const unit_animation_component & o) :
@@ -56,7 +58,9 @@ public:
 		frame_begin_time_(o.frame_begin_time_),
 		draw_bars_(o.draw_bars_),
 		refreshing_(o.refreshing_),
-		unit_halo_() {}
+		unit_halo_(),
+		abil_halos_(),
+		abil_halos_ref_() {}
 
 	/** Chooses an appropriate animation from the list of known animations. */
 	const unit_animation* choose_animation(
@@ -134,4 +138,8 @@ private:
 
 	/** handle to the halo of this unit */
 	halo::handle unit_halo_;
+	/** handle to the abilities halos of this unit */
+	std::vector<halo::handle> abil_halos_;
+	/** vector used to check that halo_abilities vector isn't modified between each read */
+	std::vector<std::string> abil_halos_ref_;
 };

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -389,6 +389,13 @@ void unit_drawer::redraw_unit(const unit& u) const
 			}
 		};
 
+		const std::vector<std::string> overlays_abilities = u.overlays_abilities();
+		for(const std::string& ov : overlays_abilities) {
+			if(texture tex = image::get_texture(ov)) {
+				textures.push_back(std::move(tex));
+			}
+		};
+
 		disp.drawing_buffer_add(display::LAYER_UNIT_BAR, loc, [=,
 			textures      = std::move(textures),
 			adj_y         = adjusted_params.y,
@@ -461,6 +468,40 @@ void unit_drawer::redraw_unit(const unit& u) const
 	} else if(has_halo) {
 		halo_man.set_location(ac.unit_halo_, halo_x, halo_y);
 	}
+
+	const std::vector<std::string> halos_abilities = u.halo_abilities();
+	bool has_abil_halo = !ac.abil_halos_.empty() && ac.abil_halos_.front() && ac.abil_halos_.front()->valid();
+	if(!has_abil_halo && !halos_abilities.empty()) {
+		for(const std::string& halo_ab : halos_abilities){
+			ac.abil_halos_.push_back(halo_man.add(
+				halo_x, halo_y,
+				halo_ab + u.TC_image_mods(),
+				map_location(-1, -1)
+			));
+		}
+	}
+	if(has_abil_halo && (ac.abil_halos_ref_ != halos_abilities || halos_abilities.empty())){
+		for(halo::handle& abil_halo : ac.abil_halos_){
+			halo_man.remove(abil_halo);
+		}
+		ac.abil_halos_.clear();
+		if(!halos_abilities.empty()){
+			for(const std::string& halo_ab : halos_abilities){
+				ac.abil_halos_.push_back(halo_man.add(
+					halo_x, halo_y,
+					halo_ab + u.TC_image_mods(),
+					map_location(-1, -1)
+				));
+			}
+		}
+	}
+	else if(has_abil_halo){
+		for(halo::handle& abil_halo : ac.abil_halos_){
+			halo_man.set_location(abil_halo, halo_x, halo_y);
+		}
+	}
+
+	ac.abil_halos_ref_ = halos_abilities;
 
 	ac.anim_->redraw(params, halo_man);
 	ac.refreshing_ = false;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1559,6 +1559,18 @@ public:
 		return halo_.value_or("");
 	}
 
+	const std::vector<std::string> halo_or_icon_abilities(const std::string& tag_name, const map_location& loc) const;
+
+	const std::vector<std::string> halo_or_icon_abilities(const std::string& tag_name) const
+	{
+		return halo_or_icon_abilities(tag_name, loc_);
+	}
+	/** Get the [halo] abilities halo image(s). */
+	const std::vector<std::string> halo_abilities() const
+	{
+		return halo_or_icon_abilities("halo");
+	}
+
 	/** Set the unit's halo image. */
 	void set_image_halo(const std::string& halo);
 
@@ -1602,6 +1614,11 @@ public:
 		return overlays_;
 	}
 
+	/** Get the [overlay] ability overlay images. */
+	const std::vector<std::string> overlays_abilities() const
+	{
+		return halo_or_icon_abilities("overlay");
+	}
 	/**
 	 * Color for this unit's *current* hitpoints.
 	 *


### PR DESCRIPTION
One of the things that bothers me is the permanent character of the halos of the Mage of Light and other units with the "illuminates" ability, which forces them to program only a permanent illumination applied only to the possessor of the ability.

Adding the halo ability does not change anything about the behavior of the unit, but can be used in several cases:

1 allowing the use of ""illuminates" whose activity would be variable, in this case encoding the halo in halos ability and not in the unit_type allows to modulate the appearance of the halo under the same conditions

2. Applying illumination to adjacent units, I know it's pretty cheesy but a set developer might consider it easier if the hlo display follows the same logic.

3 The halo used to illustrate the possession in the unit of a special weapon used as leadership, the halo would be used to raise the possessor of the ability.

for overlay,same logic for illustrate possession of a special weapon used as leadership, or influence on student