### PR TITLE
Re-enable Windows CI jobs

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -255,13 +255,70 @@ jobs:
       - name: Run unit tests
         run: ./run_boost_tests --path=projectfiles/Xcode/build/"$CFG" --executable=unit_tests
 
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg: [Debug, Release]
+    env:
+      CFG: ${{ matrix.cfg }}
+    defaults:
+      run:
+        shell: cmd
+    runs-on: windows-2019
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Cache object files
+        id: windows-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            D:/a/wesnoth/vcpkg
+            D:/a/wesnoth/wesnoth/vcpkg_installed
+          key: win-cache-master-${{ matrix.cfg }}-0001
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1.3
+
+      - name: Build vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git D:/a/wesnoth/vcpkg
+          cd D:/a/wesnoth/vcpkg
+          git checkout 4c1734ba2a969b1e6daa0ac79bc46ead7324df90
+          D:/a/wesnoth/vcpkg/bootstrap-vcpkg.bat
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.13
+        with:
+          cmake-version: '3.20.6'
+
+      - name: Run cmake
+        run: |
+          cmake -DCMAKE_BUILD_TYPE=%CFG% -DENABLE_GAME=true -DENABLE_SERVER=true -DENABLE_CAMPAIGN_SERVER=true -DENABLE_TESTS=true -DENABLE_MYSQL=false -DENABLE_NLS=false -DVCPKG_TARGET_TRIPLET=x64-windows -DCMAKE_TOOLCHAIN_FILE=D:/a/wesnoth/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_GENERATOR_PLATFORM=x64 -G "Visual Studio 16 2019" .
+
+# delete buildtrees directory to free up space after cmake invokes vcpkg to build the dependencies
+# otherwise the job was failing when trying to write a .obj file
+# building vcpkg on the more spacious C drive didn't work since for some reason vcpkg decides to not create the pango/cairo pkgconfig files there
+      - name: Build wesnoth, wesnothd, campaignd and unit tests
+        run: |
+          rmdir /s /q D:\a\wesnoth\vcpkg\buildtrees
+          MSBuild.exe wesnoth.sln -p:Configuration=%CFG%
+
+      - name: Run WML unit tests
+        if: matrix.cfg == 'Release'
+        run: python run_wml_tests -v -g -c -t 20 -p D:/a/wesnoth/wesnoth/%CFG%/wesnoth.exe
+
 # run after all other jobs have completed to check overall build status
   discord-notification:
     runs-on: ubuntu-latest
 
     name: Discord Notification
 
-    needs: [checks, ubuntu, steam-runtime, mingw, flatpak, translations, macos-intel]
+    needs: [checks, ubuntu, steam-runtime, mingw, flatpak, translations, macos-intel, windows]
     if: always()
 
     steps:

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -260,7 +260,7 @@ map_context::map_context(const game_config_view& game_config, const std::string&
 						throw editor_map_load_exception(filename, _("Found the characters '<<' indicating inline lua is present - aborting"));
 					}
 					load_scenario();
-				} catch(const std::exception& e) {
+				} catch(const std::exception&) {
 					// 5.2 The file can't be loaded by the editor as a scenario, so try to just load the map
 					gui2::show_message(_("Error"), _("Failed to load the scenario, attempting to load only the map."), gui2::dialogs::message::auto_close);
 


### PR DESCRIPTION
Based on some feedback, doing a `git checkout` may help with the frequent cache misses of the vcpkg dependencies.