### PR TITLE
Fix parts of #7810

### DIFF
--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -815,6 +815,11 @@ void context_manager::save_all_maps(bool auto_save_windows)
 			if(name.empty() || filesystem::is_directory(name)) {
 				std::ostringstream s;
 				s << default_dir_ << "/" << "window_" << i + 1;
+				if(!get_map_context().is_embedded() && !get_map_context().is_pure_map()) {
+					s << ".cfg";
+				} else {
+					s << ".map";
+				}
 				name = s.str();
 				get_map_context().set_filename(name);
 			}

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -221,7 +221,7 @@ map_context::map_context(const game_config_view& game_config, const std::string&
 
 			if(!map_data_loc.empty()) {
 				if(map_data_loc.find("\"{") == std::string::npos) {
-					// 2.0 Embedded map
+					// 2.0 Embedded pure map
 					LOG_ED << "Loading embedded map file";
 					embedded_ = true;
 					pure_map_ = true;

--- a/src/gui/dialogs/editor/choose_addon.cpp
+++ b/src/gui/dialogs/editor/choose_addon.cpp
@@ -83,7 +83,8 @@ void editor_choose_addon::populate_list(bool show_all)
 	}
 
 	for(const std::string& dir : dirs) {
-		if(show_all || filesystem::file_exists(filesystem::get_addons_dir() + "/" + dir + "/_server.pbl")) {
+		if((show_all || filesystem::file_exists(filesystem::get_addons_dir() + "/" + dir + "/_server.pbl"))
+			&& filesystem::file_exists(filesystem::get_addons_dir() + "/" + dir + "/_main.cfg")) {
 			const widget_data& entry{
 				{"existing_addon_id", widget_item{{"label", dir}}},
 			};


### PR DESCRIPTION
F5 causing the editor to crash - the editor saves temporary files out to disk which don't have an extension, so give them the proper extension
The add-on selection dialog showing non-add-on folders in the add-ons folder - only show files with a _main.cfg