### PR TITLE
AToTB: Remove the instant-communication amulets

### DIFF
--- a/changelog_entries/atotb_amulets.md
+++ b/changelog_entries/atotb_amulets.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * A Tale of Two Brothers
+     * Remove the magic communication amulets from the story.

--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -47,32 +47,38 @@
     [story]
         [part]
             music=revelation.ogg
-            story=_ "The remote freehold of Maghre in the western reaches of the Kingdom of Wesnoth was once a peaceful place, its inhabitants largely unaware of the comings and goings of the wider world. Wars and the rumor of wars touched them not, until the day a dark mage settled in the region and began seeking sacrifices for his evil summonings."
-            background=story/Two_Brothers_M1P1.webp
+            # po: This text is shown with the journey map, showing the village in the foothills along the route between Aldril and Dan’Tonk.
+            # po: I'm assuming the beacons either use smoke signals or basic fire signals, with a few agreed ones to request goods or indicate that surplus is for sale.
+            story=_ "The remote freehold of Maghre in the western reaches of the Kingdom of Wesnoth was once a peaceful place, its inhabitants largely unaware of the comings and goings of the wider world. Wars and the rumor of wars touched them not. Even merchants were rarely seen, although caravans between Aldril and Dan’Tonk might send a wagon when called by the beacon tower."
+            {TB_BIGMAP}
+            {JOURNEY_REST_BEFORE_STAGE1}
         [/part]
         [part]
-            story=_ "Skeletons and zombies killed cattle and fired fields. <i>“Fear and obey Mordak the Mage!”</i> they cried in fell voices as they did their foul deeds. People vanished from isolated farmsteads. Men and women began to fear the night, and their children even the bright day. But the nearest lord was more than a day’s ride distant, and messengers sent to seek his help did not return."
+            story=_ "Then came the day that a dark mage settled in the region and began seeking sacrifices for his summonings.
+
+Skeletons and zombies killed cattle and fired fields. <i>“Fear and obey Mordak the Mage!”</i> they cried in fell voices as they did their foul deeds. People vanished from isolated farmsteads. Men and women began to fear the night, and their children even the bright day. But the nearest lord was more than a day’s ride distant, and messengers sent to seek his help did not return."
             background=story/Two_Brothers_M1P1.webp
         [/part]
         [part]
             story=_ "There was a man named Baran who had shown talent as a mage when he was young, gone to the great Academy on the Isle of Alduin, and returned to work his magic in the land where he was born. The people looked to him for help and leadership. He found weapons half-forgotten from the times of their sires and grandsires hanging in many houses, and bade the villagers to take them down and clean and oil them. He set the smiths of Maghre to making spearheads and ax-blades for the rest."
-            background=story/Two_Brothers_M1P1.webp
+            # Although I'd prefer to have less image changes during the story, this text fits neither the previous image of a necromancer, nor the next one which shows Arvith.
+            background=portraits/baran.webp
         [/part]
         [part]
-            story=_ "Now Baran had a brother named Arvith who had also left Maghre to seek his fortune, and had become the leader of a small band of horsemen who hired out as guards to merchant caravans. Fortunate it was for all that when Baran was but an apprentice mage, he had made a pair of amulets for himself and his brother, with which they might call to each other when in dire need. Baran sent out that call."
+            story=_ "Now Baran had a brother named Arvith who had also left Maghre to seek his fortune, and had become the leader of a small band of horsemen who hired out as guards to merchant caravans. Fortunate it was for all that, in better times, the brothers had talked of using trade beacons for other signals when in dire need. Baran sent out that call."
             background=story/Two_Brothers_M1P2.webp
         [/part]
         [part]
             story=_ "12 V, 363 YW
 Excerpt from the journal of Baran of Maghre
 
-If I could but face this ‘Mordak’! I think my magic might prove stronger than his. But he bides in the hills, well-guarded by his servants, and I muster frightened peasants to fight his minions with blades and sticks. I need my brother; he always had a better head for battle than I.
+If I could but face this ‘Mordak’! I think my magic might prove stronger than his. But he bides in the hills, well-guarded by his servants, and I muster frightened peasants to fight his minions with blades and sticks.
 
-Will he heed the call? I do not know if he has kept the amulet; we have not spoken since that evil day at Toen Caric. If he will not come for me, perhaps he will return to aid our village in its hour of desperate need."
+I need my brother; he always had a better head for battle than I. Yet we have not spoken since that evil day at Toen Caric. If he will not come for me, perhaps he will return to aid our village in its hour of desperate need."
             background=story/Two_Brothers_M1P2.webp
         [/part]
         [part]
-            story=_ "Heeding the call of his amulet, Arvith gathered such men as he could and hurried to Maghre to help Baran."
+            story=_ "Heeding the call, Arvith gathered such men as he could and hurried to Maghre to help Baran."
             show_title=yes
             {TB_BIGMAP}
             {JOURNEY_STAGE1}

--- a/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
@@ -362,7 +362,8 @@ But I am still troubled. I wonder... is this sense of foreboding I feel merely a
 
         [message]
             speaker=Arvith
-            message= _ "I must go back to earning my living. But we have our amulets, little brother. If you are beset again, I will come."
+            # po: "you have my word" is a idiom for promising to do something
+            message= _ "I must go back to earning my living. But you have my word, little brother; if you are beset again, I will come."
         [/message]
 
         [endlevel]

--- a/data/campaigns/Two_Brothers/utils/bigmap.cfg
+++ b/data/campaigns/Two_Brothers/utils/bigmap.cfg
@@ -27,6 +27,10 @@
     [/story]
 #enddef
 
+#define JOURNEY_REST_BEFORE_STAGE1
+    {NEW_REST 722 662}
+#enddef
+
 # trackplacer: tracks begin
 #
 # Hand-hack this section strictly at your own risk.


### PR DESCRIPTION
Having these in canon felt like a plot hole in other campaigns. If an apprentice mage could make these amulets circa 350 YW then every village and border-fort should have them, but Wesnoth's storylines work better if a messenger on horseback is the usual method of long-distance communication. For example, TSG is about a commander sent to discipline a lazy outpost, only to find that they should have brought reinforcements. When it's the enemy trying to communicate, DM S21 and UtBS S08 both involve stopping the messengers.

This changes the intro to have a beacons for communicating with the trade caravans, I'm leaving it ambiguous whether it's a smoke signal or a fire signal. Fire beacons might make more sense if the village sees the caravan's campfires at night and, in normal usage, light the beacon to trade.

While this adds beacons to canon, they're an ancient technology with a limited range and very limited bandwidth. There are easy plot reasons not to set beacons up, such as the costs of having people watch for and maintain them, there are easy plot reasons why they don't work on a given day, such as weather, and there are easy plot reasons for attempted communication to be ignored by assuming that it's a fire for a different purpose.

Previously suggested in https://r.wesnoth.org/p669889 .