### PR TITLE
wc: fix lua error at victory (#7823)

### DIFF
--- a/data/campaigns/World_Conquest/resources/resources.cfg
+++ b/data/campaigns/World_Conquest/resources/resources.cfg
@@ -61,7 +61,9 @@
                     for side_num = 1, wml.variables.wc2_player_count do
                         leaders = wesnoth.units.find_on_map{ side = side_num, canrecruit = true }
                         if #leaders == 1 then
+                            leaders[1]:extract()
                             leaders[1].id = "wc2_leader" .. side_num
+                            leaders[1]:to_map()
                         end
                     end
                 end)


### PR DESCRIPTION
It seems like id can only be set when the unit is not on the map.