### PR TITLE
[1.16] Fix #7820 "Enable planning mode on start" Setting

### DIFF
--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -458,6 +458,7 @@ void play_controller::maybe_do_init_side()
 
 void play_controller::do_init_side()
 {
+	{
 	set_scontext_synced sync;
 	log_scope("player turn");
 	// In case we might end up calling sync:network during the side turn events,
@@ -525,9 +526,10 @@ void play_controller::do_init_side()
 	// Make sure vision is accurate.
 	actions::clear_shroud(current_side(), true);
 
-	init_side_end();
 	check_victory();
 	sync.do_final_checkup();
+	}
+	init_side_end();
 }
 
 void play_controller::init_side_end()


### PR DESCRIPTION
previously the code that tried to activate the whiteboard failed because it checks `can_modify_game_state` which checks for `!synced_context::is_unsynced`.

This moves init_side_end() further down to be called after check_victory and do_final_checkup for technical reasons. But this is safe to do since these functions only set unrelated variables and don't throw (except in case of  a gamebreaking error ofc)