### PR TITLE
Update vcpkg baseline to include glib's build fix

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -282,7 +282,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vcpkg_installed  # vcpkg generates this dir next to vcpkg.json
-          key: win-cache-master-${{ matrix.cfg }}-0002
+          key: win-cache-master-${{ matrix.cfg }}-0003
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1.3
@@ -292,7 +292,7 @@ jobs:
       - name: Build vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg
-          git -C vcpkg checkout 5b081066f0740e54bdcbe4d0772d85dbb1d8e266
+          git -C vcpkg checkout fc59c2a30a99536e8fb6e085c228e9f724dd87d0
           vcpkg/bootstrap-vcpkg.bat
 
       - name: Setup cmake


### PR DESCRIPTION
Using the version from 2 days ago, as that avoids an update to CMake, and I want to look at one issue at a time.