### PR TITLE
Dragons! (Postponed 1.19)

### DIFF
--- a/data/core/units/monsters/Fire_Dragon.cfg
+++ b/data/core/units/monsters/Fire_Dragon.cfg
@@ -7,18 +7,15 @@
     image_icon="units/monsters/fire-dragon.png~CROP(0,0,160,160)"
     profile="portraits/monsters/fire-dragon.webp"
     {DEFENSE_ANIM_RANGE "units/monsters/fire-dragon.png" "units/monsters/fire-dragon.png" {SOUND_LIST:DRAKE_HIT} melee}
-    [abilities]
-        {ABILITY_LEADERSHIP}
-    [/abilities]
-    hitpoints=101
+    hitpoints=500
     movement_type=drakefly
     movement=8
-    experience=250
+    experience=500
     level=5
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=100
+    cost=1297
     undead_variation=drake
     usage=archer
     description= _ "A dragon is a legendary creature, normally seen only in fantastic tales. They are very rare, and were it not for the historical events, the singlehanded destruction of cities and towns that these creatures have wrought, they might be dismissed as mere myth. Legends are very specific about the ravages of dragons; noting their great strength, speed, their preternatural cunning, and above all else, the great fire that burns inside of them.
@@ -27,6 +24,7 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
     die_sound=drake-die.ogg
     [resistance]
         fire=0
+        cold=90
     [/resistance]
     [attack]
         name=bite
@@ -35,7 +33,7 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
         type=blade
         range=melee
         damage=21
-        number=2
+        number=4
     [/attack]
     [attack]
         name=tail
@@ -44,7 +42,7 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
         type=impact
         range=melee
         damage=24
-        number=1
+        number=3
     [/attack]
     [attack]
         name=fire breath
@@ -56,7 +54,7 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
         [/specials]
         range=ranged
         damage=14
-        number=4
+        number=6
     [/attack]
 
     [attack_anim]

--- a/data/core/units/monsters/Fire_Dragon.cfg
+++ b/data/core/units/monsters/Fire_Dragon.cfg
@@ -24,7 +24,7 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
     die_sound=drake-die.ogg
     [resistance]
         fire=0
-        cold=90
+        cold=110
     [/resistance]
     [attack]
         name=bite
@@ -53,8 +53,8 @@ Battling a dragon is said to be the pinnacle of danger itself, fit only for fool
             {WEAPON_SPECIAL_MARKSMAN}
         [/specials]
         range=ranged
-        damage=14
-        number=6
+        damage=21
+        number=4
     [/attack]
 
     [attack_anim]

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -6,7 +6,7 @@
     race=undead
     image="units/monsters/skeletal-dragon/skeletal-dragon.png"
     image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(0,0,160,160)"
-    hitpoints=86
+    hitpoints=171
     movement_type=undeadfly
     movement=5
     experience=200
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=100
+    cost=297
     usage=fighter
     [resistance]
         blade=60
@@ -35,7 +35,7 @@
         [specials]
             {WEAPON_SPECIAL_DRAIN}
         [/specials]
-        damage=10
+        damage=17
         number=4
     [/attack]
     [attack]
@@ -43,8 +43,8 @@
         description= _"claws"
         type=blade
         range=melee
-        damage=25
-        number=2
+        damage=24
+        number=3
     [/attack]
     {DEFENSE_ANIM "units/monsters/skeletal-dragon/skeletal-dragon.png" "units/monsters/skeletal-dragon/skeletal-dragon.png" {SOUND_LIST:SKELETON_BIG_HIT} }
     [attack_anim]

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -20,9 +20,9 @@
         blade=60
         pierce=40
         impact=120
-        fire=100
+        fire=120
         #you have many arcane units by now, probably, and he shouldn't die all that easily.
-        arcane=100
+        arcane=120
     [/resistance]
     description= _ "Long ago one of the mightiest living creatures, the feared Dragon has become only bones and dark sinew. Long after its death, it was raised through the dark powers of necromancy, which it now serves. The Skeletal Dragon may look like nothing more than a pile of bones, but few people who thought that way lived long enough to change their minds."
     die_sound=skeleton-big-die.ogg


### PR DESCRIPTION
As we all know dragons are weak. 

These changes are here to help with that a bit. 

Fire Dragon - hp changed form 101 to 500, cold resistance changed from -50% to 10%, 14-4 fire breath changed to 14-6, bite changed from 21-2 to 21-4, tail changed from 24-1 to 24-3, xp changed from 250 to 500, cost changed form 100 to 1297g, leadership removed. (Dont approach without at least 7 ancient liches. It bites.)
Skeletal dragon - hp changed from 86 to 171, jaw changed from 10-4 to 17-4, claws changed from 25-2 to 24-3, cost changed from 100 to 297. 

This is a separate issue from monsters balance pass because Draconic weakness is a long standing issue that sparks discussion (im knida counting on that) (also I didnt finish monsters and felt like this PR). 