### PR TITLE
Use '_' instead of '-' as separator in filter_abilites filters

### DIFF
--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -7,11 +7,11 @@
 	{SIMPLE_KEY overwrite_specials string_list}
 	{SIMPLE_KEY apply_to string_list}
 	{SIMPLE_KEY active_on string_list}
-	{SIMPLE_KEY value s_range_list}
-	{SIMPLE_KEY add s_range_list}
-	{SIMPLE_KEY sub s_range_list}
-	{SIMPLE_KEY multiply s_real_range_list}
-	{SIMPLE_KEY divide s_real_range_list}
+	{SIMPLE_KEY value s_range_spe_list}
+	{SIMPLE_KEY add s_range_spe_list}
+	{SIMPLE_KEY sub s_range_spe_list}
+	{SIMPLE_KEY multiply s_real_range_spe_list}
+	{SIMPLE_KEY divide s_real_range_spe_list}
 	{SIMPLE_KEY affect_adjacent s_bool}
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies s_bool}

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -7,11 +7,11 @@
 	{SIMPLE_KEY overwrite_specials string_list}
 	{SIMPLE_KEY apply_to string_list}
 	{SIMPLE_KEY active_on string_list}
-	{SIMPLE_KEY value s_range_spe_list}
-	{SIMPLE_KEY add s_range_spe_list}
-	{SIMPLE_KEY sub s_range_spe_list}
-	{SIMPLE_KEY multiply s_real_range_spe_list}
-	{SIMPLE_KEY divide s_real_range_spe_list}
+	{SIMPLE_KEY value s_range_tilde_list}
+	{SIMPLE_KEY add s_range_tilde_list}
+	{SIMPLE_KEY sub s_range_tilde_list}
+	{SIMPLE_KEY multiply s_real_range_tilde_list}
+	{SIMPLE_KEY divide s_real_range_tilde_list}
 	{SIMPLE_KEY affect_adjacent s_bool}
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies s_bool}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -110,10 +110,10 @@
             value="\d+"
         [/element]
         [element]
-            value="\d+_\d+"
+            value="\d+~\d+"
         [/element]
         [element]
-            value="\d+_infinity"
+            value="\d+~infinity"
         [/element]
     )}
     # definition of real_range_spe_list and s_real_range_spe_list, before macros are expanded
@@ -122,10 +122,10 @@
             value="\d+(\.\d+)?"
         [/element]
         [element]
-            value="\d+(\.\d+)?_\d+(\.\d+)?"
+            value="\d+(\.\d+)?~\d+(\.\d+)?"
         [/element]
         [element]
-            value="\d+(\.\d+)?_infinity"
+            value="\d+(\.\d+)?~infinity"
         [/element]
     )}
     [type]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -104,28 +104,40 @@
             value="\d+(\.\d+)?-infinity"
         [/element]
     )}
-    # definition of range_spe_list and s_range_spe_list, before macros are expanded
-    {LIST_TYPE_COMPLEX range_spe (
+    # definition of range_tilde_list and s_range_tilde_list, before macros are expanded
+    {LIST_TYPE_COMPLEX range_tilde (
         [element]
-            value="\d+"
+            value="-?\d+"
         [/element]
         [element]
-            value="\d+~\d+"
+            value="-?\d+~-?\d+"
         [/element]
         [element]
-            value="\d+~infinity"
+            value="-?\d+~infinity"
+        [/element]
+        [element]
+            value="-infinity~-?\d+"
+        [/element]
+        [element]
+            value="-infinity~infinity"
         [/element]
     )}
-    # definition of real_range_spe_list and s_real_range_spe_list, before macros are expanded
-    {LIST_TYPE_COMPLEX real_range_spe (
+    # definition of real_range_tilde_list and s_real_range_tilde_list, before macros are expanded
+    {LIST_TYPE_COMPLEX real_range_tilde (
         [element]
-            value="\d+(\.\d+)?"
+            value="-?\d+(\.\d+)?"
         [/element]
         [element]
-            value="\d+(\.\d+)?~\d+(\.\d+)?"
+            value="-?\d+(\.\d+)?~-?\d+(\.\d+)?"
         [/element]
         [element]
-            value="\d+(\.\d+)?~infinity"
+            value="-?\d+(\.\d+)?~infinity"
+        [/element]
+        [element]
+            value="-infinity~-?\d+(\.\d+)?"
+        [/element]
+        [element]
+            value="-infinity~infinity"
         [/element]
     )}
     [type]
@@ -416,8 +428,8 @@
     {SUBST_TYPE coordinates}
     {SUBST_TYPE range_list}
     {SUBST_TYPE real_range_list}
-    {SUBST_TYPE range_spe_list}
-    {SUBST_TYPE real_range_spe_list}
+    {SUBST_TYPE range_tilde_list}
+    {SUBST_TYPE real_range_tilde_list}
     {SUBST_TYPE terrain_code}
     {SUBST_TYPE terrain_list}
     {SUBST_TYPE dir}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -104,6 +104,30 @@
             value="\d+(\.\d+)?-infinity"
         [/element]
     )}
+    # definition of range_spe_list and s_range_spe_list, before macros are expanded
+    {LIST_TYPE_COMPLEX range_spe (
+        [element]
+            value="\d+"
+        [/element]
+        [element]
+            value="\d+_\d+"
+        [/element]
+        [element]
+            value="\d+_infinity"
+        [/element]
+    )}
+    # definition of real_range_spe_list and s_real_range_spe_list, before macros are expanded
+    {LIST_TYPE_COMPLEX real_range_spe (
+        [element]
+            value="\d+(\.\d+)?"
+        [/element]
+        [element]
+            value="\d+(\.\d+)?_\d+(\.\d+)?"
+        [/element]
+        [element]
+            value="\d+(\.\d+)?_infinity"
+        [/element]
+    )}
     [type]
         name=alignment
         value="lawful|neutral|chaotic|liminal"
@@ -392,6 +416,8 @@
     {SUBST_TYPE coordinates}
     {SUBST_TYPE range_list}
     {SUBST_TYPE real_range_list}
+    {SUBST_TYPE range_spe_list}
+    {SUBST_TYPE real_range_spe_list}
     {SUBST_TYPE terrain_code}
     {SUBST_TYPE terrain_list}
     {SUBST_TYPE dir}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -118,9 +118,6 @@
         [element]
             value="-infinity~-?\d+"
         [/element]
-        [element]
-            value="-infinity~infinity"
-        [/element]
     )}
     # definition of real_range_tilde_list and s_real_range_tilde_list, before macros are expanded
     {LIST_TYPE_COMPLEX real_range_tilde (
@@ -135,9 +132,6 @@
         [/element]
         [element]
             value="-infinity~-?\d+(\.\d+)?"
-        [/element]
-        [element]
-            value="-infinity~infinity"
         [/element]
     )}
     [type]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -10,6 +10,8 @@
 # During Bob's turn, have Bob attack Alice.
 ##
 #define FILTER_ABILITY_TEST
+#arg DRAINS_VALUE
+25#endarg
     [event]
         name=start
         # Make sure the attacks hit
@@ -29,7 +31,7 @@
                 apply_to=new_ability
                 [abilities]
                     [drains]
-                        value=25
+                        value={DRAINS_VALUE}
                         [filter]
                             [filter_location]
                                 time_of_day=neutral
@@ -110,6 +112,56 @@
     [/event]
 )}
 
+{GENERIC_UNIT_TEST event_test_filter_ability_interval_number (
+    {FILTER_ABILITY_TEST}
+    [event]
+        name=attack
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=10~30
+            [/filter_ability]
+        [/filter]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
+    [/event]
+)}
+
+# API(s) being tested: [event][filter][filter_ability]
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST.
+# Add an event with a filter matching Alice's drains ability.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST.
+##
+# Expected end state:
+# The filtered event is triggered exactly once.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_neg_value (
+    {FILTER_ABILITY_TEST -25}
+    [event]
+        name=attack
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=-25~-10
+            [/filter_ability]
+        [/filter]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
+    [/event]
+)}
+
+
+
 #####
 # API(s) being tested: [event][filter][filter_ability]
 ##
@@ -138,6 +190,37 @@
         {SUCCEED}
     [/event]
 )}
+
+#####
+# API(s) being tested: [event][filter][filter_ability]
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST.
+# Add an event with a filter for a drains ability, but a different value to Alice's ability.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST.
+##
+# Expected end state:
+# The filtered event is never triggered.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_no_match_neg_prefix (
+    {FILTER_ABILITY_TEST}
+    [event]
+        name=attack
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=-45~10
+            [/filter_ability]
+        [/filter]
+        {FAIL}
+    [/event]
+    [event]
+        name=turn 2
+        {SUCCEED}
+    [/event]
+)}
+
+
 
 #####
 # API(s) being tested: [event][filter][filter_ability_active]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -142,7 +142,7 @@
 # The filtered event is triggered exactly once.
 #####
 {GENERIC_UNIT_TEST event_test_filter_ability_neg_value (
-    {FILTER_ABILITY_TEST -25}
+    {FILTER_ABILITY_TEST DRAINS_VALUE=-25}
     [event]
         name=attack
         [filter]

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -822,9 +822,9 @@ std::vector<std::string> quoted_split(const std::string& val, char c, int flags,
 	return res;
 }
 
-std::pair<int, int> parse_range(const std::string& str)
+std::pair<int, int> parse_range(const std::string& str, bool alter_sep)
 {
-	const std::string::const_iterator dash = std::find(str.begin(), str.end(), '-');
+	const std::string::const_iterator dash = alter_sep ? std::find(str.begin(), str.end(), '_') : std::find(str.begin(), str.end(), '-');
 	const std::string a(str.begin(), dash);
 	const std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
 	std::pair<int,int> res {0,0};
@@ -845,9 +845,9 @@ std::pair<int, int> parse_range(const std::string& str)
 	return res;
 }
 
-std::pair<double, double> parse_range_real(const std::string& str)
+std::pair<double, double> parse_range_real(const std::string& str, bool alter_sep)
 {
-	const std::string::const_iterator dash = std::find(str.begin(), str.end(), '-');
+	const std::string::const_iterator dash = alter_sep ? std::find(str.begin(), str.end(), '_') : std::find(str.begin(), str.end(), '-');
 	const std::string a(str.begin(), dash);
 	const std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
 	std::pair<double,double> res {0,0};
@@ -868,21 +868,21 @@ std::pair<double, double> parse_range_real(const std::string& str)
 	return res;
 }
 
-std::vector<std::pair<int, int>> parse_ranges(const std::string& str)
+std::vector<std::pair<int, int>> parse_ranges(const std::string& str, bool alter_sep)
 {
 	std::vector<std::pair<int, int>> to_return;
 	for(const std::string& r : utils::split(str)) {
-		to_return.push_back(parse_range(r));
+		to_return.push_back(parse_range(r, alter_sep));
 	}
 
 	return to_return;
 }
 
-std::vector<std::pair<double, double>> parse_ranges_real(const std::string& str)
+std::vector<std::pair<double, double>> parse_ranges_real(const std::string& str, bool alter_sep)
 {
 	std::vector<std::pair<double, double>> to_return;
 	for(const std::string& r : utils::split(str)) {
-		to_return.push_back(parse_range_real(r));
+		to_return.push_back(parse_range_real(r, alter_sep));
 	}
 
 	return to_return;

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -824,7 +824,7 @@ std::vector<std::string> quoted_split(const std::string& val, char c, int flags,
 
 std::pair<int, int> parse_range(const std::string& str, bool alter_sep)
 {
-	const std::string::const_iterator dash = alter_sep ? std::find(str.begin(), str.end(), '_') : std::find(str.begin(), str.end(), '-');
+	const std::string::const_iterator dash = alter_sep ? std::find(str.begin(), str.end(), '~') : std::find(str.begin(), str.end(), '-');
 	const std::string a(str.begin(), dash);
 	const std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
 	std::pair<int,int> res {0,0};
@@ -847,7 +847,7 @@ std::pair<int, int> parse_range(const std::string& str, bool alter_sep)
 
 std::pair<double, double> parse_range_real(const std::string& str, bool alter_sep)
 {
-	const std::string::const_iterator dash = alter_sep ? std::find(str.begin(), str.end(), '_') : std::find(str.begin(), str.end(), '-');
+	const std::string::const_iterator dash = alter_sep ? std::find(str.begin(), str.end(), '~') : std::find(str.begin(), str.end(), '-');
 	const std::string a(str.begin(), dash);
 	const std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
 	std::pair<double,double> res {0,0};

--- a/src/serialization/string_utils.hpp
+++ b/src/serialization/string_utils.hpp
@@ -282,13 +282,13 @@ std::string bullet_list(const T& v, std::size_t indent = 4, const std::string& b
  */
 std::string indent(const std::string& string, std::size_t indent_size = 4);
 
-std::pair<int, int> parse_range(const std::string& str);
+std::pair<int, int> parse_range(const std::string& str, bool alter_sep = false);
 
-std::vector<std::pair<int, int>> parse_ranges(const std::string& str);
+std::vector<std::pair<int, int>> parse_ranges(const std::string& str, bool alter_sep = false);
 
-std::pair<double, double> parse_range_real(const std::string& str);
+std::pair<double, double> parse_range_real(const std::string& str, bool alter_sep = false);
 
-std::vector<std::pair<double, double>> parse_ranges_real(const std::string& str);
+std::vector<std::pair<double, double>> parse_ranges_real(const std::string& str, bool alter_sep = false);
 
 int apply_modifier(const int number, const std::string &amount, const int minimum = 0);
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1454,7 +1454,7 @@ static bool int_matches_if_present(const config& filter, const config& cfg, cons
 			return false;
 		}
 	}
-	return in_ranges<int>(cfg[attribute].to_int(0), utils::parse_ranges(filter[attribute].str()));
+	return in_ranges<int>(cfg[attribute].to_int(0), utils::parse_ranges(filter[attribute].str(), true));
 }
 
 static bool double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute)
@@ -1463,7 +1463,7 @@ static bool double_matches_if_present(const config& filter, const config& cfg, c
 		return true;
 	}
 
-	return in_ranges<double>(cfg[attribute].to_double(1), utils::parse_ranges_real(filter[attribute].str()));
+	return in_ranges<double>(cfg[attribute].to_double(1), utils::parse_ranges_real(filter[attribute].str(), true));
 }
 
 static bool type_value_if_present(const config& filter, const config& cfg)

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -143,7 +143,10 @@
 0 event_test_filter_side
 0 event_test_filter_unit
 0 event_test_filter_ability
+0 event_test_filter_ability_interval_number
+0 event_test_filter_ability_neg_value
 0 event_test_filter_ability_no_match
+0 event_test_filter_ability_no_match_neg_prefix
 0 event_test_filter_ability_active
 0 event_test_filter_ability_active_inactive
 0 test_ability_id_active


### PR DESCRIPTION
Since '-' is usually used to define a range of numbers but the same sign is used to define a negative number, it is impossible to filter a negative number [filter_abiliti] and similar filter hence the idea of using ' _' instead in this specific case to remedy the problem.