### PR TITLE
Use 'neg' like prefix for negative value in parse_range

### DIFF
--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -83,25 +83,25 @@
     # definition of range_list and s_range_list, before macros are expanded
     {LIST_TYPE_COMPLEX range (
         [element]
-            value="\d+"
+            value="(neg)?\d+"
         [/element]
         [element]
-            value="\d+-\d+"
+            value="(neg)?\d+-(neg)?\d+"
         [/element]
         [element]
-            value="\d+-infinity"
+            value="(neg)?\d+-infinity"
         [/element]
     )}
     # definition of real_range_list and s_real_range_list, before macros are expanded
     {LIST_TYPE_COMPLEX real_range (
         [element]
-            value="\d+(\.\d+)?"
+            value="(neg)?\d+(\.\d+)?"
         [/element]
         [element]
-            value="\d+(\.\d+)?-\d+(\.\d+)?"
+            value="(neg)?\d+(\.\d+)?-(neg)?\d+(\.\d+)?"
         [/element]
         [element]
-            value="\d+(\.\d+)?-infinity"
+            value="(neg)?\d+(\.\d+)?-infinity"
         [/element]
     )}
     [type]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -9,7 +9,7 @@
 # During Alice's turn, move Alice next to Bob, and have Alice attack Bob.
 # During Bob's turn, have Bob attack Alice.
 ##
-#define FILTER_ABILITY_TEST
+#define FILTER_ABILITY_TEST DRAINS_VALUE
     [event]
         name=start
         # Make sure the attacks hit
@@ -29,7 +29,7 @@
                 apply_to=new_ability
                 [abilities]
                     [drains]
-                        value=25
+                        value={DRAINS_VALUE}
                         [filter]
                             [filter_location]
                                 time_of_day=neutral
@@ -92,13 +92,42 @@
 # The filtered event is triggered exactly once.
 #####
 {GENERIC_UNIT_TEST event_test_filter_ability (
-    {FILTER_ABILITY_TEST}
+    {FILTER_ABILITY_TEST 25}
     [event]
         name=attack
         [filter]
             [filter_ability]
                 tag_name=drains
                 value=25
+            [/filter_ability]
+        [/filter]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
+    [/event]
+)}
+
+# API(s) being tested: [event][filter][filter_ability]
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST.
+# Add an event with a filter matching Alice's drains ability.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST.
+##
+# Expected end state:
+# The filtered event is triggered exactly once.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_neg_value (
+    {FILTER_ABILITY_TEST -25}
+    [event]
+        name=attack
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=neg25
             [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
@@ -122,13 +151,42 @@
 # The filtered event is never triggered.
 #####
 {GENERIC_UNIT_TEST event_test_filter_ability_no_match (
-    {FILTER_ABILITY_TEST}
+    {FILTER_ABILITY_TEST 25}
     [event]
         name=attack
         [filter]
             [filter_ability]
                 tag_name=drains
                 value=45
+            [/filter_ability]
+        [/filter]
+        {FAIL}
+    [/event]
+    [event]
+        name=turn 2
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event][filter][filter_ability]
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST.
+# Add an event with a filter for a drains ability, but a different value to Alice's ability.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST.
+##
+# Expected end state:
+# The filtered event is never triggered.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_no_match_neg_prefix (
+    {FILTER_ABILITY_TEST 25}
+    [event]
+        name=attack
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=neg45
             [/filter_ability]
         [/filter]
         {FAIL}
@@ -151,7 +209,7 @@
 # The filtered event is triggered exactly once.
 #####
 {GENERIC_UNIT_TEST event_test_filter_ability_active (
-    {FILTER_ABILITY_TEST}
+    {FILTER_ABILITY_TEST 25}
     [event]
         name=attack
         [filter]
@@ -182,7 +240,7 @@
 # The filtered event is never triggered.
 #####
 {GENERIC_UNIT_TEST event_test_filter_ability_active_inactive (
-    {FILTER_ABILITY_TEST}
+    {FILTER_ABILITY_TEST 25}
     [event]
         name=start
         [object]

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -825,8 +825,19 @@ std::vector<std::string> quoted_split(const std::string& val, char c, int flags,
 std::pair<int, int> parse_range(const std::string& str)
 {
 	const std::string::const_iterator dash = std::find(str.begin(), str.end(), '-');
-	const std::string a(str.begin(), dash);
-	const std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
+	const std::string& neg_prefix = "neg";
+	std::string a(str.begin(), dash);
+	std::size_t pos = a.find(neg_prefix);
+	if (pos != std::string::npos){
+		a.replace(pos, neg_prefix.length(), "-");
+	}
+	std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
+	if (b !=a){
+		pos = b.find(neg_prefix);
+		if (pos != std::string::npos){
+		b.replace(pos, neg_prefix.length(), "-");
+		}
+	}
 	std::pair<int,int> res {0,0};
 	try {
 		if (b == "infinity") {
@@ -848,8 +859,19 @@ std::pair<int, int> parse_range(const std::string& str)
 std::pair<double, double> parse_range_real(const std::string& str)
 {
 	const std::string::const_iterator dash = std::find(str.begin(), str.end(), '-');
-	const std::string a(str.begin(), dash);
-	const std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
+	const std::string& neg_prefix = "neg";
+	std::string a(str.begin(), dash);
+	std::size_t pos = a.find(neg_prefix);
+	if (pos != std::string::npos){
+		a.replace(pos, neg_prefix.length(), "-");
+	}
+	std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
+	if (b !=a){
+		pos = b.find(neg_prefix);
+		if (pos != std::string::npos){
+		b.replace(pos, neg_prefix.length(), "-");
+		}
+	}
 	std::pair<double,double> res {0,0};
 	try {
 		if(b == "infinity") {

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -832,10 +832,10 @@ std::pair<int, int> parse_range(const std::string& str)
 		a.replace(pos, neg_prefix.length(), "-");
 	}
 	std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
-	if (b !=a){
+	if (b != a){
 		pos = b.find(neg_prefix);
 		if (pos != std::string::npos){
-		b.replace(pos, neg_prefix.length(), "-");
+			b.replace(pos, neg_prefix.length(), "-");
 		}
 	}
 	std::pair<int,int> res {0,0};
@@ -850,7 +850,7 @@ std::pair<int, int> parse_range(const std::string& str)
 			res.second = res.first;
 		}
 	} catch(const std::invalid_argument&) {
-	    ERR_GENERAL << "Invalid range: "<< str;
+		ERR_GENERAL << "Invalid range: "<< str;
 	}
 
 	return res;
@@ -866,10 +866,10 @@ std::pair<double, double> parse_range_real(const std::string& str)
 		a.replace(pos, neg_prefix.length(), "-");
 	}
 	std::string b = dash != str.end() ? std::string(dash + 1, str.end()) : a;
-	if (b !=a){
+	if (b != a){
 		pos = b.find(neg_prefix);
 		if (pos != std::string::npos){
-		b.replace(pos, neg_prefix.length(), "-");
+			b.replace(pos, neg_prefix.length(), "-");
 		}
 	}
 	std::pair<double,double> res {0,0};

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -143,7 +143,9 @@
 0 event_test_filter_side
 0 event_test_filter_unit
 0 event_test_filter_ability
+0 event_test_filter_ability_neg_value
 0 event_test_filter_ability_no_match
+0 event_test_filter_ability_no_match_neg_prefix
 0 event_test_filter_ability_active
 0 event_test_filter_ability_active_inactive
 0 test_ability_id_active


### PR DESCRIPTION
Since '-' is usually used to define a range of numbers but the same sign is used to define a negative number, it is impossible to filter a negative number [filter_abiliti] and similar filter hence the idea of using 'neg' instead for define negative value in parse_range