### PR TITLE
deleted unnecessary check

### DIFF
--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -614,8 +614,7 @@ public:
 			const std::string& name = *(pos_++);
 			unsigned sz = name.size();
 
-			// Use reverse iterator to optimize testing
-			if(sz < 5 || !std::equal(name.rbegin(), name.rbegin() + 4, "gfc.")) {
+			if(sz == 0) {
 				continue;
 			}
 


### PR DESCRIPTION
The problem in #7654 was that the preprocessor ignored files with an extension other than .cfg. Now it will preprocess all files