### PR TITLE
fix self-detecting unit issue in abilities [affect_adjacent] and [fiter_adjacent]

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -378,6 +378,8 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 				return false;
 			if (!ufilt(*unit, *this))
 				return false;
+			if((*this).id() == (*unit).id())
+				return false;
 			if (i.has_attribute("is_enemy")) {
 				const display_context& dc = resources::filter_con->get_disp_context();
 				if (i["is_enemy"].to_bool() != dc.get_team(unit->side()).is_enemy(side_)) {
@@ -435,6 +437,9 @@ bool unit::ability_affects_adjacent(const std::string& ability, const config& cf
 			if (std::find(dirs.begin(), dirs.end(), direction) == dirs.end()) {
 				continue;
 			}
+		}
+		if((*this).id() == from.id()){
+			return false;
 		}
 		auto filter = i.optional_child("filter");
 		if (!filter || //filter tag given


### PR DESCRIPTION
…

when selecting a unit with an active ability only when adjacent to another, it marks active when the cursor is placed next to it

and with https://github.com/wesnoth/wesnoth/pull/7805 it's the problem of displaying the halo with an ability that only affects adjacent units, in this case the owner briefly displays the halo when he moves to side of a unit meeting the conditions