### PR TITLE
[1.16] Fix a crash in :inspect when switching from page 2 to a different item

### DIFF
--- a/changelog_entries/crash_inspect_page.md
+++ b/changelog_entries/crash_inspect_page.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Fix a crash in the `:inspect` window when pagination is used (issue #7851).

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -91,6 +91,7 @@ public:
 	void clear_data()
 	{
 		data.clear();
+		pages.clear();
 	}
 
 	void set_data(const std::string& new_data)


### PR DESCRIPTION
Switching to a different item cleared the data, but didn't clear the cache of where the page breaks are located. The subsequent call to `get_data_paged(int which_page)` has a bounds check for the page number, so it's sufficient to just clear the page breaks, which is already ok as it resets the object to the same state as a newly-created instance.

Fixes (on 1.16) #7851. Will be forward-ported to master, as the bug will definitely exist on master too, however I'm unable to trigger the page-change buttons to appear on master (possibly a side-effect of #7565).