### PR TITLE
Add range support for [micro_ai]side=

### DIFF
--- a/data/lua/wml/micro_ai.lua
+++ b/data/lua/wml/micro_ai.lua
@@ -19,9 +19,8 @@ function wesnoth.wml_actions.micro_ai(cfg)
     -- Check that the required common keys are all present and set correctly
     if (not cfg.ai_type) then wml.error("[micro_ai] is missing required ai_type= key") end
     if (not cfg.side) then wml.error("[micro_ai] is missing required side= key") end
-    if string.find(cfg.side, ',') then
-        local sides = stringx.split(cfg.side)
-        for _,side in ipairs(sides) do
+    if string.find(cfg.side, ',') or string.find(cfg.side, '-') then
+        for side in stringx.iter_ranges(cfg.side) do
             cfg.side = tonumber(side)
             wesnoth.wml_actions.micro_ai(cfg)
         end

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -1256,7 +1256,7 @@
 		max=infinite
 		{INSERT_TAG}
 		{REQUIRED_KEY ai_type string}
-		{REQUIRED_KEY side s_unsigned}
+		{REQUIRED_KEY side s_unsigned_range_list}
 		{REQUIRED_KEY action micro_ai_action}
 		{SIMPLE_KEY ca_id string}
 		[if]


### PR DESCRIPTION
~~It can take a list as of this commit: https://github.com/wesnoth/wesnoth/commit/0bd679b11c8a5bf6b2b2c0a38ee2250b9736de77~~

~~From @CelticMinstrel on IRC/Discord:~~

> It's likely another case of "we want to encourage the use of filters going forward" that didn't make it into the schema because it > was complicated to handle it correctly.
> Looking closer, I guess I was wrong. It doesn't actually support a filter for the sides.
> BTW, s_unsigned_range_list is incorrect. It doesn't support ranges, so it would have to be s_unsigned_list.
> Unless of course you want to make it support ranges, which is valid.
> I don't know how useful it is. There aren't so many sides in a normal scenario that I'd find ranges to be useful.
> Maybe it's s_uint_list actually.

~~Have to agree checking for a `s_uint_list` makes sense since sides are always represented by (natural) numbers.~~

EDIT: Now also adds range support for `[micro_ai]side=` in addition to updating the relevant schema.

I hope this PR can go through quickly since this is the one thing blocking https://github.com/wesnoth/wesnoth/pull/7792