### PR TITLE
Fix a crash in :inspect when switching from page 2 to a different item

### DIFF
--- a/changelog_entries/crash_inspect_page.md
+++ b/changelog_entries/crash_inspect_page.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Fix a crash in the `:inspect` window when pagination is used (issue #7851).

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -92,6 +92,7 @@ public:
 	void clear_data()
 	{
 		data.clear();
+		pages.clear();
 	}
 
 	void set_data(const std::string& new_data)


### PR DESCRIPTION
Switching to a different item cleared the data, but didn't clear the cache of where the page breaks are located. The subsequent call to `get_data_paged(int which_page)` has a bounds check for the page number, so it's sufficient to just clear the page breaks, which is already ok as it resets the object to the same state as a newly-created instance.

Forward-ported to fix #7851, but currently untestable in master, as the page-selection buttons are only shown when there's a large amount of text, which triggers the known regression (the credits-crash bug).

(cherry picked from commit 7cb5f09bcf0de4b5a2cc26a593cffa2d5cfbcd14)