### PR TITLE
LoW: Replace lingering instances of ‘old’ style gold carry over

### DIFF
--- a/changelog_entries/low_gold_carry_over.md
+++ b/changelog_entries/low_gold_carry_over.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * Legend of Wesmere
+     * Replace lingering instances of ‘old’ style gold carry over for S9, S11 and S14 (issue #7862)

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/09_Bounty_Hunters.cfg
@@ -430,6 +430,7 @@ Chapter Three"
 #else
                 bonus=yes
 #endif
+                {NEW_GOLD_CARRYOVER 40}
             [/endlevel]
         [/command]
     [/event]

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter3/11_Battle_of_the_Book.cfg
@@ -284,7 +284,7 @@
 #else
             bonus=yes
 #endif
-            carryover_percentage=40
+            {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
     [/event]
 

--- a/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
+++ b/data/campaigns/Legend_of_Wesmere/scenarios/chapter4/14_Human_Alliance.cfg
@@ -586,7 +586,7 @@ Chapter Four"
             result=victory
             bonus=no
             save=no
-            carryover_percentage=40
+            {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
     [/event]
 


### PR DESCRIPTION
So it looks like when I made #7248 I wasn't aware of - or had forgotten about - the distinction between 'old' and 'new' style gold carry-over. Like that PR, this potentially disrupts the gold balancing again, but this time in the player's favour. My assumption was the changes that led to both #7230 and #7862 being reported were intended to change the entire campaign to the 'new' style carry over at the standard 40% rate. If that assumption is incorrect, then some other means of sorting out the gold carry-over inconsistency needs to be decided upon.

Otherwise resolves #7862.