### PR TITLE
GUI2/Game Load: refactor filter implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,6 +249,7 @@ if(ENABLE_GAME)
 		SDL2::SDL2
 		SDL2::SDL2main
 		CURL::libcurl
+		fmt
 	)
 	if(MSVC)
 		target_link_libraries(wesnoth SDL2_image::SDL2_image)

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -86,8 +86,6 @@ private:
 
 	std::vector<savegame::save_info> games_;
 	const game_config_view& cache_config_;
-
-	std::vector<std::string> last_words_;
 };
 } // namespace dialogs
 } // namespace gui2

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -136,6 +136,18 @@ void listbox::set_row_active(const unsigned row, const bool active)
 	generator_->item(row).set_active(active);
 }
 
+void listbox::set_rows_shown_by(std::function<bool(std::size_t)> func)
+{
+	boost::dynamic_bitset<> mask{};
+	mask.resize(get_item_count(), true);
+
+	for(std::size_t i = 0; i < mask.size(); ++i) {
+		mask[i] = std::invoke(func, i);
+	}
+
+	set_row_shown(mask);
+}
+
 void listbox::set_row_shown(const unsigned row, const bool shown)
 {
 	assert(generator_);

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -143,6 +143,8 @@ public:
 	 */
 	void set_row_shown(const boost::dynamic_bitset<>& shown);
 
+	void set_rows_shown_by(std::function<bool(std::size_t)> func);
+
 	/**
 	 * Returns a list of visible rows
 	 *

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -43,6 +43,7 @@
     "boost-spirit",
     "boost-test",
     "boost-process",
+    "fmt",
     {
       "name": "curl",
       "features": [ "openssl" ]


### PR DESCRIPTION
Opening this for feedback. This replaces the old filter code with a new regex-based method, and adds a new function to filter listboxes based on a predicate instead of providing a mask directly.

In terms of performance, it's extremely fast on my machine (often under 1ms). It pulls in the `fmt` library as a substitute for `<format>` (there's a flag I can set for header-only mode), which could be further deployed elsewhere in preparation for the standard library version once we can use C++20.