### PR TITLE
Replace idiom 'by hand' with its actual meaning

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -412,9 +412,9 @@ Loading a .cfg file has different results depending on the contents of the .cfg 
 [topic]
     id=editor_separate_events_file
     title= _ "Using a separate file for WML events"
-    text= _ <<When loading a .cfg file, the scenario editor understands files created by the scenario editor, but is likely to have difficulty with files that have been edited by hand.
+    text= _ <<When loading a .cfg file, the scenario editor understands files created by the scenario editor, but is likely to have difficulty with files that have been edited manually.
 
-One option is to create a separate WML file, also with the .cfg extension, which uses the WML preprocessor to include the editor-created file. This separate file contains both the [scenario] tag and any hand-edited WML such as events. With this workflow, the add-on’s file structure could look like this:
+One option is to create a separate WML file, also with the .cfg extension, which uses the WML preprocessor to include the editor-created file. This separate file contains both the [scenario] tag and any manually-edited WML such as events. With this workflow, the add-on’s file structure could look like this:
 
 <header>text='Example'</header>
 If your add-on will only be used on 1.18 and later, it is instead recommended to use the new include_file attribute to load a .cfg file containing additional WML into the scenario.
@@ -503,7 +503,7 @@ If you are editing the map and not using the Scenario Mode support, then it’s 
 
 " + _ <<<header>text='Files created by the Scenario Editor'</header>
 
-In scenario mode, the editor saves the scenario data as a .cfg file and the map data as a separate .map file. The scenario then references the .map file via map_file. When loading a .cfg file, the scenario editor understands files created by the scenario editor itself, but is likely to have difficulty with files that have been edited by hand; problems can be avoided by <ref>dst='editor_separate_events_file' text='using a separate .cfg file'</ref> for the hand-edited parts.>>
+In scenario mode, the editor saves the scenario data as a .cfg file and the map data as a separate .map file. The scenario then references the .map file via map_file. When loading a .cfg file, the scenario editor understands files created by the scenario editor itself, but is likely to have difficulty with files that have been edited manually; problems can be avoided by <ref>dst='editor_separate_events_file' text='using a separate .cfg file'</ref> for the manually-edited parts.>>
 [/topic]
 # wmlscope: stop ignoring
 # wmlindent: stop ignoring

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -790,7 +790,7 @@ bool map_context::save_scenario()
 		wml_stream
 			<< "# This file was generated using the scenario editor.\n"
 			<< "#\n"
-			<< "# If you edit this file by hand, then do not use macros.\n"
+			<< "# If you edit this file manually, then do not use macros.\n"
 			<< "# The editor doesn't support macros, and so using them will result in only being able to edit the map.\n"
 			<< "# Additionally, the contents of all [side] and [time] tags as well as any events that have an id starting with 'editor_event-' are replaced entirely.\n"
 			<< "# Any manual changes made to those will be lost.\n"


### PR DESCRIPTION
While native Anglophones should know what 'by hand' means in these contexts, I think it's clearer for non-native readers and translators to use its meaning of non-automatic, non-machine -> manual processes.