### PR TITLE
wesnoth-lib review

### DIFF
--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -652,7 +652,7 @@ The installation status for each add-on is shown below each entry. For add-ons t
 
 To search for add-ons by keywords, type any relevant terms in any order in the search box, separated by spaces. You can also sort the add-on list by clicking the column headers. It is also possible to choose to only display add-ons of specific categories by clicking on the <bold>text='Type'</bold> dropdown.
 
-To install an add-on, select it from the list and click the <bold>text='+'</bold> icon, or simply double-click on the add-on’s title. If the window is too small to show them inline, the <bold>text='Addon Details'</bold> button provides you with additional details about the add-on, such as its full description, installation status, and available translations."
+To install an add-on, select it from the list and click the <bold>text='+'</bold> icon, or simply double-click on the add-on’s title. If the window is too small to show them inline, the <bold>text='Add-on Details'</bold> button provides you with additional details about the add-on, such as its full description, installation status, and available translations."
     [/topic]
     # wmllint: markcheck on
 

--- a/data/gui/window/addon_manager.cfg
+++ b/data/gui/window/addon_manager.cfg
@@ -947,7 +947,7 @@
 
 [window]
 	id = "addon_manager"
-	description = "Addon selection dialog."
+	description = "Add-on selection dialog."
 
 	[resolution]
 		window_width=800

--- a/data/gui/window/editor_edit_pbl.cfg
+++ b/data/gui/window/editor_edit_pbl.cfg
@@ -192,7 +192,7 @@
 											[text_box]
 												id = icon
 												definition = "default"
-												tooltip = _"The path to the icon image to display to display in the add-ons manager. Must be an image from mainline."
+												tooltip = _"The path to the icon image to display in the add-ons manager. Must be an image from mainline."
 											[/text_box]
 										[/column]
 
@@ -205,7 +205,7 @@
 						[/row]
 						{ROW text_box _"Author:" "author" _"The author of this add-on. If forum authentication is used, this is your forum username."}
 						{ROW text_box _"Version:" "version" _"The add-on’s current version. This should be of the form X.Y.Z."}
-						{ROW multimenu_button _"Dependencies:" "dependencies" _"A comma delimited list of the IDs of any other add-ons that this add-on depends on. The add-on ID is the folder name in your operating system’s file explorer, not the add-on’s name."}
+						{ROW multimenu_button _"Dependencies:" "dependencies" _"A comma delimited list of the IDs of any other add-ons that this add-on depends on. The add-on ID is the folder name in your operating system’s file manager, not the add-on’s name."}
 						{ROW multimenu_button _"Tags:" "tags" ""}
 						{ROW menu_button _"Type:" "type" ""}
 						{ROW text_box _"Forum thread:" "forum_thread" _"The numeric topic ID of a thread on the Wesnoth forums where players can post feedback."}

--- a/data/gui/window/editor_edit_pbl_translation.cfg
+++ b/data/gui/window/editor_edit_pbl_translation.cfg
@@ -94,7 +94,7 @@
 
 					[grid]
 
-						{ROW text_box _"* Language:" "language" _"The IETF language code of the translation, such as sv (Swedish) or zh_CN (Simplified Chinese)."}
+						{ROW text_box _"* Language:" "language" _"The POSIX locale code of the translation, such as sv (Swedish) or zh_CN (Simplified Chinese)."}
 						{ROW text_box _"* Title:" "lang_title" _"The translation of the add-on’s title."}
 						{ROW text_box _"Description:" "description" _"The translation of the add-on’s description."}
 

--- a/data/gui/window/editor_edit_pbl_translation.cfg
+++ b/data/gui/window/editor_edit_pbl_translation.cfg
@@ -94,7 +94,7 @@
 
 					[grid]
 
-						{ROW text_box _"* Language:" "language" _"The POSIX locale code of the translation, such as sv (Swedish) or zh_CN (Simplified Chinese)."}
+						{ROW text_box _"* Language:" "language" _"The POSIX locale name of the translation, such as sv (Swedish) or zh_CN (Simplified Chinese)."}
 						{ROW text_box _"* Title:" "lang_title" _"The translation of the add-on’s title."}
 						{ROW text_box _"Description:" "description" _"The translation of the add-on’s description."}
 

--- a/data/gui/window/editor_edit_pbl_translation.cfg
+++ b/data/gui/window/editor_edit_pbl_translation.cfg
@@ -94,9 +94,9 @@
 
 					[grid]
 
-						{ROW text_box _"* Language:" "language" _"The language code of the translation, such as sv (Swedish) or zh_CN (Simplified Chinese)."}
-						{ROW text_box _"* Title:" "lang_title" _"The translation of the addon’s title."}
-						{ROW text_box _"Description:" "description" _"The translation of the addon’s description."}
+						{ROW text_box _"* Language:" "language" _"The IETF language code of the translation, such as sv (Swedish) or zh_CN (Simplified Chinese)."}
+						{ROW text_box _"* Title:" "lang_title" _"The translation of the add-on’s title."}
+						{ROW text_box _"Description:" "description" _"The translation of the add-on’s description."}
 
 					[/grid]
 


### PR DESCRIPTION
* Removed duplicated  'to display' text
* Favour generic term 'file manager' over Microsoft terminology.
* Clarify language code use - though I'm not actually sure what language code convention Wesnoth follows. Please correct as necessary.
* Replace inconsistent spelling of 'add-on'. It looks like older instances use the single-word form 'addon' (which I don't think is right) and that 'add-on' is currently the intended spelling in Wesnoth's context. I verified this by checking the `en_US` language option.
  * There are a couple of lingering instances I left alone because the line they were in had been disabled-via-comment (and should probably just be deleted).