### PR TITLE
Nr: Add names of people who helped with rewrite to the credits

### DIFF
--- a/data/campaigns/Northern_Rebirth/_main.cfg
+++ b/data/campaigns/Northern_Rebirth/_main.cfg
@@ -66,6 +66,12 @@
             name = "Charles Dang (vultraz)"
         [/entry]
     [/about]
+    [about]
+        title = _ "2023 Dialog Rewrite"
+        [entry]
+            name = "Nathanel K. Stottlemyer (ShadowOfHassen)"
+        [/entry]
+    [/about]
 [/campaign]
 
 #ifdef CAMPAIGN_NORTHERN_REBIRTH


### PR DESCRIPTION
This PR is just supposed to add my name and the names of those who helped me with the dialog rewrite/edit/ touchup to the credits. I had been planning to do this after the last tweak I wanted to add, that is issue #7684. However seeing that no one has gotten back to me, I decided that that change isn't that important and to just go ahead with this.

The other people who helped (and I don't know how they want put in or added were @nemaara @stevecotton @Wedge009. If they want they can put their names with mine in the credits listing I made. (Assuming I did it right and the entire thing doesn't need redone)

If people think the rewrite/edit/touchup shouldn't be in the credits that's OK, but at the very least seeing that I put a lot fo work in it I should at least be somewhere so people can find me if they have questions.
