### PR TITLE
fix #7821: all cases of the calculation should be cached

### DIFF
--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -933,11 +933,11 @@ double recruitment::compare_unit_types(const std::string& a, const std::string& 
 		double value_of_b = damage_to_a / (a_max_hp * b_cost);
 
 		if (value_of_a > value_of_b) {
-			return value_of_a / value_of_b;
+			retval = value_of_a / value_of_b;
 		} else if (value_of_a < value_of_b) {
-			return -value_of_b / value_of_a;
+			retval = -value_of_b / value_of_a;
 		} else {
-			return 0.;
+			retval = 0.;
 		}
 	}
 


### PR DESCRIPTION
in the previous logic some cases return from the function and others would set a return variable that would be set later.

this commit, changes all the cases into all returns so that other cases added in the future should not avoid caching.

right now there are no ways to avoid the caching which should be the expected behaviour (unless explicitly added the case where cache is unwanted)