### PR TITLE
Give kraken submerge ability

### DIFF
--- a/data/core/units/monsters/Kraken.cfg
+++ b/data/core/units/monsters/Kraken.cfg
@@ -15,11 +15,14 @@
     advances_to=null
     attacks=1
     {AMLA_DEFAULT}
-    cost=62
+    cost=64
     undead_variation=swimmer
     usage=fighter
     description= _ "Krakens are gigantic creatures of the seas. They can grab their opponents with strong tentacles, or spit a poisonous black ink from a distance. The best way to survive an encounter with these monsters is to remain ashore."
     die_sound=water-blast.wav
+    [abilities]
+        {ABILITY_SUBMERGE}
+    [/abilities]
     {DEFENSE_ANIM "units/monsters/kraken/kraken-defend2.png" "units/monsters/kraken/kraken-defend1.png" squishy-hit.wav}
     [attack]
         name=tentacle


### PR DESCRIPTION
Scenario designers can finally have access to a sea creature unit with the submerge ability.

The kraken is based on the [giant squid](https://en.wikipedia.org/wiki/Giant_squid) and [colossal squid](https://en.wikipedia.org/wiki/Colossal_squid) which live in the deepest zones of the ocean (they are products of [deep sea gigantism](https://en.wikipedia.org/wiki/Deep-sea_gigantism)) and have chromatophores for some additional camouflage ability. Also the kraken's eerie green sprite lurks low in the water giving it a stealthy appearance:
![sneaky_kraken](https://github.com/wesnoth/wesnoth/assets/80054769/54eae225-34d5-4b1c-9b94-41ded0a422df)

No balance changes will be needed to DW (where the kraken serves as an advancement for the player's single cuttlefish unit) or WoF (which has already been tested with this). Since it has only recently been added to core, the kraken does not yet appear anywhere else in the game (or UMC) so right now is the perfect time to for this change.