### PR TITLE
add `"pkgconf"` to `vcpkg.json`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,9 +75,7 @@ See [here](https://github.com/wesnoth/wesnoth/blob/master/projectfiles/Xcode/REA
 ### Windows
 Wesnoth uses CMake for project configuration and vcpkg for installing dependencies. See [here](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio) for information on using Visual Studio with cmake. The first time it's run, vcpkg will build all the required dependencies which may take over an hour, however it will only need to be done once.
 
-NOTE 1: You will need a Windows implementation of pkg-config present in your PATH, such as [pkg-config-lite](https://sourceforge.net/projects/pkgconfiglite/).
-
-NOTE 2: You will need to run `vcpkg integrate install` on the command line to make Visual Studio aware of vcpkg. If Visual Studio is open when this is executed, then you will need to close and re-open Visual Studio.
+NOTE 1: You will need to run `vcpkg integrate install` on the command line to make Visual Studio aware of vcpkg. If Visual Studio is open when this is executed, then you will need to close and re-open Visual Studio.
 
 ## SCons Build
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -46,6 +46,10 @@
     {
       "name": "curl",
       "features": [ "openssl" ]
+    },
+    {
+      "name": "pkgconf",
+      "platform": "windows"
     }
   ]
 }


### PR DESCRIPTION
When I was compiling on Windows, I got an error:

```text
[cmake] CMake Error at D:/program/cmake/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
[cmake]   Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
```

PkgConfig installation is quite troublesome in Windows, but vcpkg provides it for us, so we only need to add the following line in `vcpkg.json` to automatically add Pkgconfig during Windows build:

```json
    {
      "name": "pkgconf",
      "platform": "windows"
    }
```