### PR TITLE
EI: "survivor" trait no longer grants "terror" immunity

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/abilities.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/abilities.cfg
@@ -281,7 +281,7 @@ Any units adjacent to this unit will fight as if it were dusk when it is day, an
     [dummy]
         id=terror
         name= _ "terror"
-        description= _ "This unit can frighten enemies in a 2 hex radius, making them fight worse. Units with the fearless or survivor traits are unaffected.
+        description= _ "This unit can frighten enemies in a 2 hex radius, making them fight worse. Units with the fearless trait are unaffected.
 
 When an enemy unit of lower level within a 2 hex radius engages in combat, its attacks do 25% less damage times the difference in their levels."
     [/dummy]
@@ -293,7 +293,7 @@ When an enemy unit of lower level within a 2 hex radius engages in combat, its a
             {FILT}
 
             [not]
-                trait=fearless,arrogant,survivor
+                trait=fearless,arrogant
             [/not]
         [/filter]
         apply_to=new_ability

--- a/data/campaigns/Eastern_Invasion/utils/abilities.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/abilities.cfg
@@ -293,7 +293,7 @@ When an enemy unit of lower level within a 2 hex radius engages in combat, its a
             {FILT}
 
             [not]
-                trait=fearless,arrogant
+                trait=fearless,audacious
             [/not]
         [/filter]
         apply_to=new_ability


### PR DESCRIPTION
Minor tweak to EI.

Mal-Ravanal and Khrakrahs have the "terror" ability, reducing the damage of nearby enemies.  The custom "survivor" trait (found on a number of scripted units) grants immunity, but these units are numerous and I feel this devalues the "terror" ability.  This PR removes survivors' terror immunity.