### PR TITLE
Add game logic to Forest of Fear

### DIFF
--- a/data/multiplayer/maps/5p_Forest_of_Fear.map
+++ b/data/multiplayer/maps/5p_Forest_of_Fear.map
@@ -12,7 +12,7 @@ Gs^Fp, Gs^Fp, Re, Ww, Gs^Fms, Mm, Hh, Rp, Gs^Fp, Rd, Rd, Rd, Gg, Rd, Rp, Rp, Hh,
 Ss, Ss, Gg, Re, Gg, Re^Tf, Hh, Rp, Gg, Gg, Gs^Fds, Hh, Hh, Gg, Rp, Gg^Vh, Gs^Fms, Mm, Gg, Wwf, Ww, Mm, Gs^Fp, Re, Gg^Ve, Gs^Fp, Mm, Gg, Rp, Gs^Fp, Hh, Hh
 Ss, Ss, Mm, Re, Gg, Gg, Gs^Fp, Rp, Gg, Gs^Fms, Gs^Fp, Mm, Ss, Gs^Fp, Ww^Bw|, Hh, Ww, Hh, Wwf, Ww^Vm, Ww, Gs^Fms, Re, Re, Hh, Hh, Gs^Fms, Gs^Fms, Rp, Hh, Gs^Fp, Gs^Fp
 Ss, Ss, Hh, Re, Re, Gg, Rp, Rp, Re, Gg, Ss^Vhs, Hh, Ss, Ss, Chs, Ss, Chw, Ww, Ww, Wwf, Gg, Gs^Fds, Re, Gg, Gs^Fp, Re^Tf, Hh, Gs^Fds, Rp, Gg, Hh, Hh
-Gs^Fp, Gs^Fp, Gs^Fms, Gg^Vh, Gg, Rp, Gs^Fp, Hh, Hh, Re, Gs^Fms, Ss, Ww, Gg, Gg, Chr, Khw, Chw, Ww, Ww, Hh, Re, Mm, Mm, Mm, Hh, Rd, Rd, Gg^Vh, Rp, Gs^Fp, Gs^Fp
+Gs^Fp, Gs^Fp, Gs^Fms, Gg^Vh, Gg, Rp, Gs^Fp, Hh, Hh, Re, Gs^Fms, Ss, Ww, Gg, Gg, Chr, 6 Khw, Chw, Ww, Ww, Hh, Re, Mm, Mm, Mm, Hh, Rd, Rd, Gg^Vh, Rp, Gs^Fp, Gs^Fp
 Gs^Fp, Re^Tf, Hh, Gg, Gs^Fp, Rp, Rp, Gg, Mm, Re, Re, Hh, Mm, Wwf, Hh, Chr, Ww, Ww^Bw\, Gs^Fp, Gs^Fp, Hh^Vhh, Re, Gs^Fp, Mm, Gs^Fds, Rd, Gg, Gs^Fp, Hh, Rp, Gg, Gg
 Hh, Hh, Gg, Gg, Ch, Ch, Ch, Rp, Gg, Gg, Ww^Bw|, Gs^Fp, Ww, Wwf, Wwf, Gs^Fp, Ww, Ww, Ww, Hh, Gs^Fds, Re, Re, Gs^Fms, Rd, Rd, Ss, Gg, Rp, Rp, Gg, Gg
 Gs^Fp, Gs^Fp, Hh, Ch, Ch, 2 Kh, Ww, Rp, Ww, Ww, Ww^Bw|, Ww, Ww, Wwf, Gg, Wwf, Gg, Ww, Ww, Ww, Gs^Fp, Re^Tf, Hh, Re, Gs^Fp, Hh, Ss, Hh, Rp, Gg, Gs^Fms, Gs^Fp

--- a/data/multiplayer/scenarios/5p_Forest_of_Fear.cfg
+++ b/data/multiplayer/scenarios/5p_Forest_of_Fear.cfg
@@ -1,67 +1,368 @@
 #textdomain wesnoth-multiplayer
 
+#define SPAWNER_SIDE SIDE TYPE TERRAIN
+    [side]
+        side={SIDE}
+        defeat_condition=always
+        controller=ai
+        allow_player=no
+        no_leader=yes
+        hidden=yes
+        color=brown
+        [ai]
+            village_value=0
+            [avoid]
+                terrain=*^V*
+            [/avoid]
+        [/ai]
+    [/side]
+    [event]
+        name=turn end
+        first_time_only=no
+        [store_unit_type]
+            type={TYPE}
+        [/store_unit_type]
+        # Only spawn another if population cap is not yet met.
+        [if]
+            [have_unit]
+                type={TYPE}
+                count=0-$($spawn_cap * 12 / $unit_type.cost)
+            [/have_unit]
+            [then]
+                [if]
+                    [lua]
+                        # Spawn chance per turn divided by monster unit cost.
+                        code=<< local t = ...; return ( mathx.random() < (wml.variables["spawn_rate"] / wesnoth.unit_types[t.type].cost) ) >>
+                        [args]
+                            type={TYPE}
+                        [/args]
+                    [/lua]
+                    [then]
+                        # Spawn a new creature along a map edge, as if it wandered in from outside the map.
+                        {SCATTER_UNITS 1 {TYPE} 0
+                        (
+                            terrain={TERRAIN}
+                            [not]
+                                x=2-29
+                                y=2-29
+                            [/not]
+                        )
+                        (
+                            side={SIDE}
+                            animate=yes
+                        )
+                        }
+                    [/then]
+                [/if]
+            [/then]
+        [/if]
+    [/event]
+#enddef
+
+#define SPAWN_HEIR SIDE PLACEMENT
+    [store_side]
+        side={SIDE}
+    [/store_side]
+    # Get the faction leader list of the side.
+    [lua]
+        code=<<
+            local t = ...
+            for faction in wml.child_range(wesnoth.scenario.era, "multiplayer_side") do
+                if faction.id == t.faction then
+                    wml.variables.random = faction.leader
+                    return
+                end
+            end
+            >>
+        [args]
+            faction=$side.faction
+        [/args]
+    [/lua]
+    # Pick a random leader from the list.
+    {RANDOM $random}
+    [store_unit_type]
+        type=$random
+    [/store_unit_type]
+    # Give this leader whichever role is unfilled.
+    [if]
+        [have_unit]
+            side=$side.side
+            role=heir
+        [/have_unit]
+        [then]
+            {VARIABLE role reclaimer}
+        [/then]
+        [else]
+            {VARIABLE role heir}
+        [/else]
+    [/if]
+    # Spawn it.
+    [unit]
+        side=$side.side
+        type=$random
+        canrecruit=yes
+        role=$role
+        recall_cost=$unit_type.cost
+        placement={PLACEMENT}
+    [/unit]
+#enddef
+
 [multiplayer]
     id=multiplayer_Forest_of_Fear
     name= _ "5p — Forest of Fear"
     map_file=multiplayer/maps/5p_Forest_of_Fear.map
-    description= _ "In this mixed landscape, five armies battle for supremacy."
+    description= _ "Five bands of fools enter the forbidden forest seeking their fortunes. Fill they their pockets with fine faerie treasures? Or fill they the bellies of furry four-legged fiends? Find out what fate awaits thee in this foggy forest… of fear!"
 
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}
 
     [side]
-        [ai]
-            villages_per_scout=20
-        [/ai]
         side=1
         canrecruit=yes
         controller=human
-        team_name=north
-        user_team_name= _ "teamname^North"
-        fog=yes
-    [/side]
-    [side]
+        user_team_name= _ "North"
         [ai]
             villages_per_scout=20
         [/ai]
+    [/side]
+    [side]
         side=2
         canrecruit=yes
         controller=human
-        team_name=west
-        user_team_name= _ "teamname^West"
-        fog=yes
-    [/side]
-    [side]
+        user_team_name= _ "West"
         [ai]
             villages_per_scout=20
         [/ai]
+    [/side]
+    [side]
         side=3
         canrecruit=yes
         controller=human
-        team_name=south-east
-        user_team_name= _ "teamname^Southeast"
-        fog=yes
-    [/side]
-    [side]
+        user_team_name= _ "Southeast"
         [ai]
             villages_per_scout=20
         [/ai]
+    [/side]
+    [side]
         side=4
         canrecruit=yes
         controller=human
-        team_name=north-east
-        user_team_name= _ "teamname^Northeast"
-        fog=yes
-    [/side]
-    [side]
+        user_team_name= _ "Northeast"
         [ai]
             villages_per_scout=20
         [/ai]
+    [/side]
+    [side]
         side=5
         canrecruit=yes
         controller=human
-        team_name=south
-        user_team_name= _ "teamname^South"
-        fog=yes
+        user_team_name= _ "South"
+        [ai]
+            villages_per_scout=20
+        [/ai]
     [/side]
+    [side]
+        side=6
+        controller=ai
+        controller_lock=yes
+        team_name=7,8,9,10,11,12,13,14,15,16,17,18,19
+        team_lock=yes
+        user_team_name= _ "Forest Wardens"
+        color=gold
+        color_lock=yes
+        faction=Rebels
+        village_gold=6
+        village_support=3
+        gold=300
+        [ai]
+            villages_per_scout=20
+        [/ai]
+    [/side]
+
+    {SPAWNER_SIDE 7  "Wose Shaman"      *^F*        }
+    {SPAWNER_SIDE 8  "Great Wolf"       H*,*^F*,G*  }
+    {SPAWNER_SIDE 9  "Cave Bear"        M*,H*,U*    }
+    {SPAWNER_SIDE 10 "Gryphon"          M*,H*,G*    }
+    {SPAWNER_SIDE 11 "Cuttle Fish"      W*,S*       }
+    {SPAWNER_SIDE 12 "Water Serpent"    W*,S*       }
+    {SPAWNER_SIDE 13 "Woodland Boar"    *^F*,G*     }
+    {SPAWNER_SIDE 14 "White Horse"      *^F*,G*,R*  }
+    {SPAWNER_SIDE 15 "Caribe"           W*,S*       }
+    {SPAWNER_SIDE 16 "Dragonfly"        W*,S*,G*    }
+    {SPAWNER_SIDE 17 "Soldier Ant"      M*,H*,G*,U* }
+    {SPAWNER_SIDE 18 "Fire Guardian"    *^F*,S*,U*  }
+    {SPAWNER_SIDE 19 "Giant Mudcrawler" H*,R*,S*    }
+
+    [options]
+        [slider]
+            id="spawn_rate"
+            default=9
+            min=0
+            max=100
+            name= _ "Monster Spawn Rate"
+            description= _ "Rate divided by monster cost."
+        [/slider]
+        [slider]
+            id="spawn_cap"
+            default=6
+            min=0
+            max=100
+            name= _ "Monster Spawn Cap"
+            description= _ "Dozens divided by monster cost."
+        [/slider]
+        [slider]
+            id="chest_gold"
+            default=75
+            min=25
+            max=500
+            step=25
+            name= _ "Treasure Chest Gold"
+            description= _ "The amount of gold stashed inside the treasure chest on the faerie keep."
+        [/slider]
+    [/options]
+
+    [event]
+        name=prestart
+        [objectives]
+            [objective]
+                description= _ "Defeat enemy leaders"
+                condition=win
+            [/objective]
+            [note]
+                description= _ "The treasure chest on the faerie keep can only be unlocked by a leader, for a bonus of $chest_gold gold."
+            [/note]
+            [note]
+                description= _ "Forest creatures will ally with any side whose leader holds the faerie keep yet attack all other sides."
+            [/note]
+            [note]
+                description= _ "Forest creatures appear along map edges at the end of each turn. They avoid capturing villages."
+            [/note]
+            [note]
+                description= _ "Each side gets two leaders. Whenever a leader is lost then another appears on the recall list at its full cost."
+            [/note]
+        [/objectives]
+        # Heirs of computer players try to take the faerie keep.
+        [micro_ai]
+            side=1,2,3,4,5
+            ai_type=goto
+            action=add
+            release_unit_at_goal=yes
+            [filter]
+                role=heir
+            [/filter]
+            [filter_location]
+                location_id=6
+            [/filter_location]
+        [/micro_ai]
+        # Reclaimers of computer players try to (re)take a home keep.
+        [micro_ai]
+            side=1,2,3,4,5
+            ai_type=goto
+            action=add
+            release_unit_at_goal=yes
+            [filter]
+                role=reclaimer
+            [/filter]
+            [filter_location]
+                location_id=1,2,3,4,5
+            [/filter_location]
+        [/micro_ai]
+    [/event]
+
+    # Give each side an heir (a second leader).
+    [event]
+        name=turn 1 refresh
+        [store_side]
+            variable=sides
+        [/store_side]
+        [foreach]
+            array=sides
+            [do]
+                [if]
+                    [have_unit]
+                        side=$this_item.side
+                    [/have_unit]
+                    [then]
+                        {SPAWN_HEIR $this_item.side leader}
+                    [/then]
+                [/if]
+            [/do]
+        [/foreach]
+    [/event]
+
+    # If a side loses a leader then put a new heir on its recall list.
+    [event]
+        name=die
+        first_time_only=no
+        [filter]
+            canrecruit=yes
+        [/filter]
+        {SPAWN_HEIR $unit.side map}
+    [/event]
+
+    # Forest creatures ally with a side when its leader reaches the faerie keep.
+    [event]
+        name=enter_hex
+        first_time_only=no
+        [filter]
+            [filter_location]
+                location_id=6
+            [/filter_location]
+            canrecruit=yes
+            side=1,2,3,4,5
+        [/filter]
+        [modify_side]
+            side=$unit.side
+            team_name=$unit.side,7,8,9,10,11,12,13,14,15,16,17,18,19
+        [/modify_side]
+        [floating_text]
+            x,y=$x1,$y1
+            text= _ "<span color='yellow'>May the forest be with you!</span>"
+        [/floating_text]
+    [/event]
+
+    # Forest creatures break their alliance with a side when it loses the faerie keep, either by abdication or assassination of its leader there.
+    [event]
+        name=exit_hex,die
+        first_time_only=no
+        [filter]
+            [filter_location]
+                location_id=6
+            [/filter_location]
+            canrecruit=yes
+            side=1,2,3,4,5
+        [/filter]
+        [modify_side]
+            side=$unit.side
+            team_name=$unit.side
+        [/modify_side]
+    [/event]
+
+    # A leader unlocks the hill treasure chest and takes its gold.
+    {PLACE_IMAGE items/chest.png 16 14}
+    [event]
+        name=moveto
+        [filter]
+            [filter_location]
+                location_id=6
+            [/filter_location]
+            canrecruit=yes
+            side=1,2,3,4,5
+        [/filter]
+        [gold]
+            amount=$chest_gold
+            side=$unit.side
+        [/gold]
+        [remove_item]
+            x,y=$x1,$y
+            image=items/chest.png
+        [/remove_item]
+        [floating_text]
+            x,y=$x1,$y1
+            text= _ "<span color='gold'>+$chest_gold gold</span>"
+        [/floating_text]
+    [/event]
 [/multiplayer]
+
+#undef SPAWNER_SIDE
+#undef SPAWN_HEIR


### PR DESCRIPTION
Similarly to #7792 this adds game logic to Forest of Fear rewarding taking and holding the central castle. Each turn, dangerous forest wildlife and magical creatures enter from the edges of the map to attack players and each other (while ignoring villages). Yet these creatures will ally with whichever player occupies the faerie keep using their leader, and for as long as they do. Which means both relief from their relentless attacks and the ability to see through their eyes (`share_vision`) by the magic of the faerie throne.

As with King of the Hill, each side gets two leaders and whenever one dies another replacement leader is always available from the recall list at its full recruiting cost. And a treasure chest of gold (which only a leader can unlock) awaits the first player to claim the center.