### PR TITLE
WC: fix #7921 Random training per scenario

### DIFF
--- a/data/campaigns/World_Conquest/lua/campaign/scenario.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/scenario.lua
@@ -70,14 +70,14 @@ on_event("wc2_start", function(cx)
 				side = side_num
 			}
 		end
-	end
-
-	if wml.variables.wc2_difficulty.extra_training then
-		for side_num = 1, wml.variables.wc2_player_count do
-			wesnoth.wml_actions.wc2_give_random_training {
-				among="2,3,4,5,6",
-				side = side_num,
-			}
+	
+		if wml.variables.wc2_difficulty.extra_training then
+			for side_num = 1, wml.variables.wc2_player_count do
+				wesnoth.wml_actions.wc2_give_random_training {
+					among="2,3,4,5,6",
+					side = side_num,
+				}
+			end
 		end
 	end
 

--- a/data/campaigns/World_Conquest/lua/campaign/scenario.lua
+++ b/data/campaigns/World_Conquest/lua/campaign/scenario.lua
@@ -70,7 +70,7 @@ on_event("wc2_start", function(cx)
 				side = side_num
 			}
 		end
-	
+
 		if wml.variables.wc2_difficulty.extra_training then
 			for side_num = 1, wml.variables.wc2_player_count do
 				wesnoth.wml_actions.wc2_give_random_training {


### PR DESCRIPTION
a free random training on easier difficulties should only be given in the first scenario. (Otherwise they'll accumulate to 5 free trainings at scenario 5.)