### PR TITLE
repair detects non-existent default attribute value in numérical attribute

### DIFF
--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -14,7 +14,7 @@
 	{SIMPLE_KEY divide s_real_range_list}
 	{SIMPLE_KEY affect_adjacent s_bool}
 	{SIMPLE_KEY affect_self s_bool}
-	{SIMPLE_KEY affect_allies s_bool}
+	{SIMPLE_KEY affect_allies bool_or_empty}
 	{SIMPLE_KEY affect_enemies s_bool}
 	{FILTER_BOOLEAN_OPS abilities}
 [/tag]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -41,6 +41,14 @@
         value="none|one_side|both_sides"
     [/type]
     [type]
+        name="bool_or_empty"
+        [list]
+            [element]
+                value="true|false|yes|no|none"
+            [/element]
+        [/list]
+    [/type]
+    [type]
         name="addon_type"
         value="sp|mp|hybrid"
     [/type]
@@ -423,6 +431,7 @@
     {SUBST_TYPE anim_hits}
     {SUBST_TYPE f_int}
     {SUBST_TYPE alignment}
+	{SUBST_TYPE bool_or_empty}
     [type]
         name="global"
         value="global"

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -307,3 +307,140 @@
 )}
 
 #undef FILTER_ABILITY_TEST
+
+##
+# Common code for the tests in this file.
+##
+# Actions:
+# Give both Alice and Bob 100% chance to hit.
+# Give Alice a drains ability to value 50(defined in hardcoding by default).
+# During Alice's turn, move Alice next to Bob, and have Alice attack Bob.
+# During Bob's turn, have Bob attack Alice.
+##
+#define FILTER_ABILITY_TEST_WITHOUT_VALUE
+    [event]
+        name=start
+        # Make sure the attacks hit
+        {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 100 ()}
+        {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 100 ()}
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [drains]
+                    [/drains]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        {VARIABLE triggers 0}
+    [/event]
+
+    [event]
+        name=side 1 turn 1
+        [do_command]
+            [move]
+                x=7,13
+                y=3,4
+            [/move]
+            [attack]
+                [source]
+                    x,y=13,4
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [do_command]
+            [attack]
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=13,4
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: [event][filter][filter_ability]
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST_WITHOUT_VALUE.
+# Add an event with a filter matching Alice's drains ability who had no value specified.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST_WITHOUT_VALUE.
+##
+# Expected end state:
+# The filtered event is triggered exactly once.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_with_value_by_default (
+    {FILTER_ABILITY_TEST_WITHOUT_VALUE}
+    [event]
+        name=attack
+        first_time_only=no
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=50
+            [/filter_ability]
+        [/filter]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event][filter][filter_ability]
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST_WITHOUT_VALUE.
+# Add an event with a filter matching Alice's drains ability who had no value specified.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST_WITHOUT_VALUE.
+##
+# Expected end state:
+# The filtered event is never triggered.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_no_match_by_default (
+    {FILTER_ABILITY_TEST_WITHOUT_VALUE}
+    [event]
+        name=attack
+        first_time_only=no
+        [filter]
+            [filter_ability]
+                tag_name=drains
+                value=35
+            [/filter_ability]
+        [/filter]
+        {FAIL}
+    [/event]
+    [event]
+        name=turn 2
+        {SUCCEED}
+    [/event]
+)}
+
+#undef FILTER_ABILITY_TEST_WITHOUT_VALUE

--- a/src/tests/test_config_filters.cpp
+++ b/src/tests/test_config_filters.cpp
@@ -84,4 +84,14 @@ BOOST_AUTO_TEST_CASE(test_int_add_sub_filter)
 	BOOST_ASSERT(int_matches_if_present_or_negative(sub_2_to_4, add_minus_3, "sub", "add"));
 }
 
+BOOST_AUTO_TEST_CASE(test_without_attribute_filter)
+{
+	config add_3 {"add", 3};
+	config value_3 {"value", 3};
+
+	BOOST_ASSERT(!int_matches_if_present(value_3, add_3, "value"));
+	BOOST_ASSERT(int_matches_if_present(value_3, add_3, "value", 3));
+	BOOST_ASSERT(!int_matches_if_present_or_negative(add_3, value_3, "add", "sub"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1435,7 +1435,7 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 	if(!bool_matches_if_present(filter, cfg, "affect_self", true))
 		return false;
 
-	if(!bool_matches_if_present(filter, cfg, "affect_allies", true))
+	if(!bool_or_empty(filter, cfg, "affect_allies"))
 		return false;
 
 	if(!bool_matches_if_present(filter, cfg, "affect_enemies", false))
@@ -1460,8 +1460,28 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 	if(!string_matches_if_present(filter, cfg, "active_on", "both"))
 		return false;
 
-	if(!int_matches_if_present(filter, cfg, "value"))
-		return false;
+	if(!filter["value"].empty()){
+		bool has_other_key = (!cfg["add"].empty() || !cfg["sub"].empty() || !cfg["multiply"].empty() || !cfg["divide"].empty());
+		if(!has_other_key){
+			if(tag_name == "drains"){
+				if(!int_matches_if_present(filter, cfg, "value", 50)){
+					return false;
+				}
+			} else if(tag_name == "berserk"){
+				if(!int_matches_if_present(filter, cfg, "value", 1)){
+					return false;
+				}
+			} else if(tag_name == "heal_on_hit" || tag_name == "heals" || tag_name == "regenerate" || tag_name == "leadership"){
+				if(!int_matches_if_present(filter, cfg, "value" , 0)){
+					return false;
+				}
+			}
+		} else {
+			if(!int_matches_if_present(filter, cfg, "value")){
+				return false;
+			}
+		}
+	}
 
 	if(!int_matches_if_present_or_negative(filter, cfg, "add", "sub"))
 		return false;

--- a/src/utils/config_filters.hpp
+++ b/src/utils/config_filters.hpp
@@ -34,8 +34,14 @@ namespace utils::config_filters
  */
 bool bool_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, bool def);
 
-bool double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute);
-bool int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute);
+/**
+ * Checks whether the filter matches the value of @a cfg[@a attribute]. If @a cfg doesn't have that
+ * attribute, assume that an unset value is equivalent to @a def if exist, else value false is returned.
+ *
+ * Always returns true if the filter puts no restriction on the value of @a cfg[@a attribute].
+ */
+bool double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<double> def = NULL);
+bool int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<int> def = NULL);
 
 /**
  * Restricts filters to only looking for values that are zero or more.
@@ -50,15 +56,17 @@ bool unsigned_matches_if_present(const config& filter, const config& cfg, const 
  * `add=1` or `sub=-1`; this assumes that code elsewhere has already checked that cfg contains at most one of those
  * keys.
  *
- * This only checks for the presence of @a attribute in the filter, so the caller should call this function a second
- * time, with @a attribute and @a opposite reversed.
+ * This only checks for the presence of @a attribute and @a opposite in the filter, so the caller should call this function a second
+ * time, with @a attribute and @a opposite reversed and if none of these attribute is here value false is returned.
  *
  * The function is named "negative" in case we later want to add a "reciprocal" for the "multiply"/"divide" pair.
  */
 bool int_matches_if_present_or_negative(
-	const config& filter, const config& cfg, const std::string& attribute, const std::string& opposite);
+	const config& filter, const config& cfg, const std::string& attribute, const std::string& opposite, std::optional<int> def = NULL);
 
 bool string_matches_if_present(
 	const config& filter, const config& cfg, const std::string& attribute, const std::string& def);
+
+bool bool_or_empty(const config& filter, const config& cfg, const std::string& attribute);
 
 } // namespace utils::config_filters

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -149,6 +149,8 @@
 0 event_test_filter_ability_no_match_neg_prefix
 0 event_test_filter_ability_active
 0 event_test_filter_ability_active_inactive
+0 event_test_filter_ability_with_value_by_default
+0 event_test_filter_ability_no_match_by_default
 0 test_ability_id_active
 0 test_ability_id_not_active
 0 event_test_filter_attack


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/7923 .when we want to detect an ability with value=0-20 and an ability with add=15 is present, this is detected because the system assigns a value of 0 when 'value' is not present, and so the system matches abilities that do not use 'value' or even no numerical value at all. it is therefore necessary to decide that the absence of an attribute is a non-correspondence to the criteria.