### PR TITLE
EI Shadow Mage, Shadow Lord Balance

### DIFF
--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
@@ -50,7 +50,7 @@
         icon=attacks/blast-wave.png
         type=impact
         range=ranged
-        damage=17 # same stats as the necromancer, but impact/arcane instead of cold/arcane
+        damage=15
         number=2
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
@@ -62,8 +62,8 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=12
-        number=2
+        damage=9
+        number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]

--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
@@ -50,7 +50,7 @@
         icon=attacks/blast-wave.png
         type=impact
         range=ranged
-        damage=17
+        damage=14
         number=2
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
@@ -62,7 +62,7 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=10
+        damage=8
         number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
@@ -62,7 +62,7 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=9
+        damage=8
         number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Lord.cfg
@@ -50,7 +50,7 @@
         icon=attacks/blast-wave.png
         type=impact
         range=ranged
-        damage=15
+        damage=17
         number=2
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
@@ -62,7 +62,7 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=8
+        damage=10
         number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Mage.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Mage.cfg
@@ -48,7 +48,7 @@
         icon=attacks/blast-wave.png
         type=impact
         range=ranged
-        damage=11
+        damage=12
         number=2
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
@@ -60,7 +60,7 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=6
+        damage=7
         number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Mage.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Mage.cfg
@@ -48,7 +48,7 @@
         icon=attacks/blast-wave.png
         type=impact
         range=ranged
-        damage=12
+        damage=11
         number=2
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
@@ -60,7 +60,7 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=7
+        damage=6
         number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}

--- a/data/campaigns/Eastern_Invasion/units/Human_Shadow_Mage.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Shadow_Mage.cfg
@@ -48,7 +48,7 @@
         icon=attacks/blast-wave.png
         type=impact
         range=ranged
-        damage=13 # same stats as the dark sorcerer, but impact/arcane instead of cold/arcane
+        damage=11
         number=2
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
@@ -60,8 +60,8 @@
         icon=attacks/dark-missile.png
         type=arcane
         range=ranged
-        damage=9
-        number=2
+        damage=6
+        number=3
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]


### PR DESCRIPTION
Original Shadow Mage/Lord stats were based on undead's 50% arcane vulnerability.  With the arcane rebalance, the Mage/Lord's arcane weapon is no longer worth using.

This PR adjusts the Lord/Mage's arcane weapon to be stronger, and impact weapon to be weaker.