### PR TITLE
Remove [filter_ability]type_value=

### DIFF
--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -16,6 +16,5 @@
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies s_bool}
 	{SIMPLE_KEY affect_enemies s_bool}
-	{DEFAULT_KEY type_value value_type empty}
 	{FILTER_BOOLEAN_OPS abilities}
 [/tag]

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -41,10 +41,6 @@
         value="none|one_side|both_sides"
     [/type]
     [type]
-        name="value_type"
-        value="|value|add|sub|multiply|divide"
-    [/type]
-    [type]
         name="addon_type"
         value="sp|mp|hybrid"
     [/type]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -97,6 +97,7 @@
     {FILTER_ABILITY_TEST}
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability]
                 tag_name=drains
@@ -104,6 +105,7 @@
             [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
         {VARIABLE_OP triggers add 1}
     [/event]
     [event]
@@ -116,6 +118,7 @@
     {FILTER_ABILITY_TEST}
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability]
                 tag_name=drains
@@ -123,6 +126,7 @@
             [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
         {VARIABLE_OP triggers add 1}
     [/event]
     [event]
@@ -145,6 +149,7 @@
     {FILTER_ABILITY_TEST DRAINS_VALUE=-25}
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability]
                 tag_name=drains
@@ -152,6 +157,7 @@
             [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
         {VARIABLE_OP triggers add 1}
     [/event]
     [event]
@@ -175,6 +181,7 @@
     {FILTER_ABILITY_TEST}
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability]
                 tag_name=drains
@@ -204,6 +211,7 @@
     {FILTER_ABILITY_TEST}
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability]
                 tag_name=drains
@@ -233,6 +241,7 @@
     {FILTER_ABILITY_TEST}
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability_active]
                 tag_name=drains
@@ -240,6 +249,7 @@
             [/filter_ability_active]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
         {VARIABLE_OP triggers add 1}
     [/event]
     [event]
@@ -280,6 +290,7 @@
 
     [event]
         name=attack
+        first_time_only=no
         [filter]
             [filter_ability_active]
                 tag_name=drains

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/test_overwrite_specials_filter.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/test_overwrite_specials_filter.cfg
@@ -42,9 +42,7 @@
                         overwrite_specials=both_sides
                         [overwrite]
                             [filter_specials]
-                                [not]
-                                    type_value=value
-                                [/not]
+                                add=1-14
                             [/filter_specials]
                         [/overwrite]
                     [/damage]

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1421,28 +1421,6 @@ void unit::remove_ability_by_id(const std::string& ability)
 	}
 }
 
-static bool type_value_if_present(const config& filter, const config& cfg)
-{
-	if(filter["type_value"].empty()) {
-		return true;
-	}
-
-	std::string cfg_type_value;
-	const std::vector<std::string> filter_attribute = utils::split(filter["type_value"]);
-	if(!cfg["value"].empty()){
-		cfg_type_value ="value";
-	} else if(!cfg["add"].empty()){
-		cfg_type_value ="add";
-	} else if(!cfg["sub"].empty()){
-		cfg_type_value ="sub";
-	} else if(!cfg["multiply"].empty()){
-		cfg_type_value ="multiply";
-	} else if(!cfg["divide"].empty()){
-		cfg_type_value ="divide";
-	}
-	return ( std::find(filter_attribute.begin(), filter_attribute.end(), cfg_type_value) != filter_attribute.end() );
-}
-
 static bool matches_ability_filter(const config & cfg, const std::string& tag_name, const config & filter)
 {
 	using namespace utils::config_filters;
@@ -1495,9 +1473,6 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 		return false;
 
 	if(!double_matches_if_present(filter, cfg, "divide"))
-		return false;
-
-	if(!type_value_if_present(filter, cfg))
 		return false;
 
 	// Passed all tests.


### PR DESCRIPTION
This addresses #7944 without addressing #7923. The code and schema changes are a subset of #7924, the test changes are a subset of those in #7924 with an extra assert added on top. I think #7924 should probably be merged, but there's a few changes still under discussion, and so it would be worth merging this and then rebasing to reduce the size of #7924.

There are questions about how `[filter_ability]type_value=` should treat empty values. The use cases that we can think of can be implemented in other ways, for example, if we want to look for big damage boosts, then we could filter for `add=5-infinity` `[or]` `multiply=2-infinity`. The simple answer seems to be to remove `type_value=` from the API before we freeze for 1.18.

Make the ability filter tests stricter. With the default first_time_only=yes then these events would be triggered at most once even if the filter would have passed multiple times.