### PR TITLE
Add lua mouse button event handler

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -603,13 +603,7 @@ void mouse_handler::mouse_motion(int x, int y, const bool browse, bool update, m
 bool mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button,
 									   map_location loc, bool click)
 {
-	if (gui().view_locked() || button < SDL_BUTTON_LEFT || button > SDL_BUTTON_X2) {
-		return false;
-	} else if (event.state > SDL_PRESSED || !gui().get_map().on_board(loc)) {
-		return false;
-	}
-
-	static const std::string buttons[6] = {
+	static const std::array<const std::string, 6> buttons = {
 		"",
 		"left",		// SDL_BUTTON_LEFT
 		"middle",	// SDL_BUTTON_MIDDLE
@@ -617,14 +611,15 @@ bool mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_
 		"mouse4",	// SDL_BUTTON_X1
 		"mouse5"	// SDL_BUTTON_X2
 	};
-	static const std::string events[3] = {
-		"up",		// SDL_RELEASED
-		"down",		// SDL_PRESSED
-		"click"
-	};
+
+	if (gui().view_locked() || button < SDL_BUTTON_LEFT || button > buttons.size()) {
+		return false;
+	} else if (event.state > SDL_PRESSED || !gui().get_map().on_board(loc)) {
+		return false;
+	}
 
 	if(game_lua_kernel* lk = pc_.gamestate().lua_kernel_.get()) {
-		lk->mouse_button_callback(loc, buttons[button], events[event.state]);
+		lk->mouse_button_callback(loc, buttons[button], (event.state == SDL_RELEASED ? "up" : "down"));
 
 		// Are we being asked to send a click event?
 		if (click) {
@@ -633,7 +628,7 @@ bool mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_
 				return false;
 			}
 			// We allow this event to be consumed, but not up/down
-			return lk->mouse_button_callback(loc, buttons[button], events[2]);
+			return lk->mouse_button_callback(loc, buttons[button], "click");
 		}
 	}
 	return false;

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -599,7 +599,7 @@ void mouse_handler::mouse_motion(int x, int y, const bool browse, bool update, m
 
 // Hook for notifying lua game kernel of mouse button events. We pass button as
 // a serpaate argument than the original SDL event in order to manage touch
-// emulation (i.e., long touch = right click) and such.
+// emulation (e.g., long touch = right click) and such.
 bool mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button,
 									   map_location loc, bool click)
 {
@@ -610,17 +610,17 @@ bool mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_
 	}
 
 	static const std::string buttons[6] = {
-		[0]					= "",
-		[SDL_BUTTON_LEFT]	= "left",
-		[SDL_BUTTON_MIDDLE]	= "middle",
-		[SDL_BUTTON_RIGHT]	= "right",
-		[SDL_BUTTON_X1]		= "x1",
-		[SDL_BUTTON_X2]		= "x2",
+		"",
+		"left",		// SDL_BUTTON_LEFT
+		"middle",	// SDL_BUTTON_MIDDLE
+		"right",	// SDL_BUTTON_RIGHT
+		"mouse4",	// SDL_BUTTON_X1
+		"mouse5"	// SDL_BUTTON_X2
 	};
 	static const std::string events[3] = {
-		[SDL_RELEASED]		= "up",
-		[SDL_PRESSED]		= "down",
-		[2]					= "click",
+		"up",		// SDL_RELEASED
+		"down",		// SDL_PRESSED
+		"click"
 	};
 
 	if(game_lua_kernel* lk = pc_.gamestate().lua_kernel_.get()) {

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -597,6 +597,21 @@ void mouse_handler::mouse_motion(int x, int y, const bool browse, bool update, m
 	}
 }
 
+// Hook for notifying lua game kernel of mouse button events. We pass button as
+// a serpaate argument than the original SDL event in order to manage touch
+// emulation (i.e., long touch = right click) and such.
+void mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc)
+{
+	if (loc == map_location::null_location())
+		return;
+
+	if(game_lua_kernel* lk = pc_.gamestate().lua_kernel_.get()) {
+		// Ever any reason to allow lua functions to consume an event? If so,
+		// would have to make sure state stays correctly updated.
+		lk->mouse_button_callback(loc, button, event.state == SDL_PRESSED);
+	}
+}
+
 unit_map::iterator mouse_handler::selected_unit()
 {
 	unit_map::iterator res = find_unit(selected_hex_);

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -604,11 +604,22 @@ void mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_
 {
 	if (loc == map_location::null_location())
 		return;
+	if (button < SDL_BUTTON_LEFT || button > SDL_BUTTON_X2)
+		return;
+
+	static const std::string buttons[6] = {
+		[0]					= "",
+		[SDL_BUTTON_LEFT]	= "left",
+		[SDL_BUTTON_MIDDLE]	= "middle",
+		[SDL_BUTTON_RIGHT]	= "right",
+		[SDL_BUTTON_X1]		= "x1",
+		[SDL_BUTTON_X2]		= "x2",
+	};
 
 	if(game_lua_kernel* lk = pc_.gamestate().lua_kernel_.get()) {
 		// Ever any reason to allow lua functions to consume an event? If so,
 		// would have to make sure state stays correctly updated.
-		lk->mouse_button_callback(loc, button, event.state == SDL_PRESSED);
+		lk->mouse_button_callback(loc, buttons[button], event.state == SDL_PRESSED);
 	}
 }
 

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -600,12 +600,14 @@ void mouse_handler::mouse_motion(int x, int y, const bool browse, bool update, m
 // Hook for notifying lua game kernel of mouse button events. We pass button as
 // a serpaate argument than the original SDL event in order to manage touch
 // emulation (i.e., long touch = right click) and such.
-void mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc)
+bool mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button,
+									   map_location loc, bool click)
 {
-	if (loc == map_location::null_location())
-		return;
-	if (button < SDL_BUTTON_LEFT || button > SDL_BUTTON_X2)
-		return;
+	if (gui().view_locked() || button < SDL_BUTTON_LEFT || button > SDL_BUTTON_X2) {
+		return false;
+	} else if (event.state > SDL_PRESSED || !gui().get_map().on_board(loc)) {
+		return false;
+	}
 
 	static const std::string buttons[6] = {
 		[0]					= "",
@@ -615,12 +617,26 @@ void mouse_handler::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_
 		[SDL_BUTTON_X1]		= "x1",
 		[SDL_BUTTON_X2]		= "x2",
 	};
+	static const std::string events[3] = {
+		[SDL_RELEASED]		= "up",
+		[SDL_PRESSED]		= "down",
+		[2]					= "click",
+	};
 
 	if(game_lua_kernel* lk = pc_.gamestate().lua_kernel_.get()) {
-		// Ever any reason to allow lua functions to consume an event? If so,
-		// would have to make sure state stays correctly updated.
-		lk->mouse_button_callback(loc, buttons[button], event.state == SDL_PRESSED);
+		lk->mouse_button_callback(loc, buttons[button], events[event.state]);
+
+		// Are we being asked to send a click event?
+		if (click) {
+			// Was both the up and down on the same map tile?
+			if (loc != drag_from_hex_) {
+				return false;
+			}
+			// We allow this event to be consumed, but not up/down
+			return lk->mouse_button_callback(loc, buttons[button], events[2]);
+		}
 	}
+	return false;
 }
 
 unit_map::iterator mouse_handler::selected_unit()

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -119,7 +119,7 @@ protected:
 	 * Due to the way this class is constructed we can assume that the
 	 * display* gui_ member actually points to a game_display (derived class)
 	 */
-	game_display& gui() { return *gui_; }
+	game_display& gui() override { return *gui_; }
 	/** Const version */
 	const game_display& gui() const override { return *gui_; }
 

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -83,9 +83,9 @@ public:
 		const bool highlight = true,
 		const bool fire_event = true);
 
-	void move_action(bool browse);
+	void move_action(bool browse) override;
 
-	void touch_action(const map_location hex, bool browse);
+	void touch_action(const map_location hex, bool browse) override;
 
 	void select_or_action(bool browse);
 
@@ -121,19 +121,19 @@ protected:
 	 */
 	game_display& gui() { return *gui_; }
 	/** Const version */
-	const game_display& gui() const { return *gui_; }
+	const game_display& gui() const override { return *gui_; }
 
-	int drag_threshold() const;
+	int drag_threshold() const override;
 	/**
 	 * Use update to force an update of the mouse state.
 	 */
-	void mouse_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location());
+	void mouse_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location()) override;
 	bool mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc, bool click = false) override;
-	bool right_click_show_menu(int x, int y, const bool browse);
+	bool right_click_show_menu(int x, int y, const bool browse) override;
 //	bool left_click(int x, int y, const bool browse);
 	bool move_unit_along_current_route();
 
-	void touch_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location());
+	void touch_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location()) override;
 
 	void save_whiteboard_attack(const map_location& attacker_loc, const map_location& defender_loc, int weapon_choice);
 

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -128,6 +128,7 @@ protected:
 	 * Use update to force an update of the mouse state.
 	 */
 	void mouse_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location());
+	void mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc) override;
 	bool right_click_show_menu(int x, int y, const bool browse);
 //	bool left_click(int x, int y, const bool browse);
 	bool move_unit_along_current_route();

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -128,7 +128,7 @@ protected:
 	 * Use update to force an update of the mouse state.
 	 */
 	void mouse_motion(int x, int y, const bool browse, bool update=false, map_location loc = map_location::null_location());
-	void mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc) override;
+	bool mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc, bool click = false) override;
 	bool right_click_show_menu(int x, int y, const bool browse);
 //	bool left_click(int x, int y, const bool browse);
 	bool move_unit_along_current_route();

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -239,6 +239,7 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 		}
 	} else if(is_middle_click(event)) {
 		if(event.state == SDL_PRESSED) {
+			drag_from_hex_ = loc;
 			set_scroll_start(event.x, event.y);
 			scroll_started_ = true;
 
@@ -249,13 +250,14 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 				minimap_scrolling_ = true;
 				last_hex_ = minimap_loc;
 				gui().scroll_to_tile(minimap_loc, display::WARP, false);
+			} else if(mouse_button_event(event, SDL_BUTTON_MIDDLE, loc, true)) {
+				scroll_started_ = false;
+				simple_warp_ = false;
 			} else if(simple_warp_) {
 				// middle click not on minimap, check gamemap instead
 				if(loc.valid()) {
 					last_hex_ = loc;
-					if (!mouse_button_event(event, SDL_BUTTON_MIDDLE, loc, true)) {
-						gui().scroll_to_tile(loc, display::WARP, false);
-					}
+					gui().scroll_to_tile(loc, display::WARP, false);
 				}
 			} else {
 				// Deselect the current tile as we're scrolling
@@ -269,11 +271,10 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 			clear_drag_from_hex();
 		}
 	} else if(event.button == SDL_BUTTON_X1 || event.button == SDL_BUTTON_X2) {
-		bool dummy_flag = false;
 		if(event.state == SDL_PRESSED) {
 			cancel_dragging();
 			// record mouse-down hex in drag_from_hex_
-			init_dragging(dummy_flag);
+			drag_from_hex_ = loc;
 			mouse_button_event(event, event.button, loc);
 		} else {
 			mouse_button_event(event, event.button, loc, true);

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -158,6 +158,10 @@ bool mouse_handler_base::mouse_motion_default(int x, int y, bool /*update*/)
 	return false;
 }
 
+void mouse_handler_base::mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc)
+{
+}
+
 void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bool browse)
 {
 	if(is_middle_click(event) && !preferences::middle_click_scrolls()) {
@@ -171,6 +175,7 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 	static clock_t touch_timestamp = 0;
 
 	if(is_touch_click(event)) {
+		mouse_button_event(event, SDL_BUTTON_LEFT, loc);
 		if (event.state == SDL_PRESSED) {
 			cancel_dragging();
 			touch_timestamp = clock();
@@ -183,6 +188,7 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 				clock_t dt = clock() - touch_timestamp;
 				if (dt > CLOCKS_PER_SEC * 3 / 10) {
 					right_click(event.x, event.y, browse); // show_menu_ = true;
+					mouse_button_event(event, SDL_BUTTON_RIGHT, loc);
 				}
 			} else {
 				touch_timestamp = 0;
@@ -192,6 +198,7 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 			left_mouse_up(event.x, event.y, browse);
 		}
 	} else if(is_left_click(event)) {
+		mouse_button_event(event, SDL_BUTTON_LEFT, loc);
 		if(event.state == SDL_PRESSED) {
 			cancel_dragging();
 			init_dragging(dragging_left_);
@@ -202,6 +209,7 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 			left_mouse_up(event.x, event.y, browse);
 		}
 	} else if(is_right_click(event)) {
+		mouse_button_event(event, SDL_BUTTON_RIGHT, loc);
 		if(event.state == SDL_PRESSED) {
 			cancel_dragging();
 			init_dragging(dragging_right_);
@@ -212,6 +220,7 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 			right_mouse_up(event.x, event.y, browse);
 		}
 	} else if(is_middle_click(event)) {
+		mouse_button_event(event, SDL_BUTTON_MIDDLE, loc);
 		if(event.state == SDL_PRESSED) {
 			set_scroll_start(event.x, event.y);
 			scroll_started_ = true;
@@ -238,6 +247,8 @@ void mouse_handler_base::mouse_press(const SDL_MouseButtonEvent& event, const bo
 			simple_warp_ = false;
 			scroll_started_ = false;
 		}
+	} else if(event.button == SDL_BUTTON_X1 || event.button == SDL_BUTTON_X2) {
+		mouse_button_event(event, event.button, loc);
 	}
 	if(!dragging_left_ && !dragging_right_ && !dragging_touch_ && dragging_started_) {
 		dragging_started_ = false;

--- a/src/mouse_handler_base.hpp
+++ b/src/mouse_handler_base.hpp
@@ -96,6 +96,7 @@ public:
 			= 0;
 
 	virtual void mouse_press(const SDL_MouseButtonEvent& event, const bool browse);
+	virtual void mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc);
 	bool is_left_click(const SDL_MouseButtonEvent& event) const;
 	bool is_middle_click(const SDL_MouseButtonEvent& event) const;
 	bool is_right_click(const SDL_MouseButtonEvent& event) const;

--- a/src/mouse_handler_base.hpp
+++ b/src/mouse_handler_base.hpp
@@ -96,7 +96,7 @@ public:
 			= 0;
 
 	virtual void mouse_press(const SDL_MouseButtonEvent& event, const bool browse);
-	virtual void mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc);
+	virtual bool mouse_button_event(const SDL_MouseButtonEvent& event, uint8_t button, map_location loc, bool click = false);
 	bool is_left_click(const SDL_MouseButtonEvent& event) const;
 	bool is_middle_click(const SDL_MouseButtonEvent& event) const;
 	bool is_right_click(const SDL_MouseButtonEvent& event) const;
@@ -217,6 +217,7 @@ public:
 protected:
 	void cancel_dragging();
 	void clear_dragging(const SDL_MouseButtonEvent& event, bool browse);
+	void clear_drag_from_hex();
 	void init_dragging(bool& dragging_flag);
 
 	/** MMB click (on game map) state flag */
@@ -243,7 +244,7 @@ protected:
 	/** Drag start position y */
 	int drag_from_y_;
 
-	/** Drag start map location */
+	/** Drag start or mouse-down map location */
 	map_location drag_from_hex_;
 
 	/** last highlighted hex */

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -5952,20 +5952,23 @@ void game_lua_kernel::mouse_over_hex_callback(const map_location& loc)
 	return;
 }
 
-void game_lua_kernel::mouse_button_callback(const map_location& loc, const std::string &button, bool down)
+bool game_lua_kernel::mouse_button_callback(const map_location& loc, const std::string &button, const std::string &event)
 {
 	lua_State *L = mState;
 
 	if (!luaW_getglobal(L, "wesnoth", "game_events", "on_mouse_button")) {
-		return;
+		return false;
 	}
 
 	lua_push(L, loc.wml_x());
 	lua_push(L, loc.wml_y());
 	lua_push(L, button);
-	lua_push(L, down);
-	luaW_pcall(L, 4, 0, false);
-	return;
+	lua_push(L, event);
+
+	if (!luaW_pcall(L, 4, 1)) return false;
+	bool result = luaW_toboolean(L, -1);
+	lua_pop(L, 1);
+	return result;
 }
 
 void game_lua_kernel::select_hex_callback(const map_location& loc)

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -5952,13 +5952,14 @@ void game_lua_kernel::mouse_over_hex_callback(const map_location& loc)
 	return;
 }
 
-void game_lua_kernel::mouse_button_callback(const map_location& loc, unsigned int button, bool down)
+void game_lua_kernel::mouse_button_callback(const map_location& loc, const std::string &button, bool down)
 {
 	lua_State *L = mState;
 
 	if (!luaW_getglobal(L, "wesnoth", "game_events", "on_mouse_button")) {
 		return;
 	}
+
 	lua_push(L, loc.wml_x());
 	lua_push(L, loc.wml_y());
 	lua_push(L, button);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -5952,6 +5952,21 @@ void game_lua_kernel::mouse_over_hex_callback(const map_location& loc)
 	return;
 }
 
+void game_lua_kernel::mouse_button_callback(const map_location& loc, unsigned int button, bool down)
+{
+	lua_State *L = mState;
+
+	if (!luaW_getglobal(L, "wesnoth", "game_events", "on_mouse_button")) {
+		return;
+	}
+	lua_push(L, loc.wml_x());
+	lua_push(L, loc.wml_y());
+	lua_push(L, button);
+	lua_push(L, down);
+	luaW_pcall(L, 4, 0, false);
+	return;
+}
+
 void game_lua_kernel::select_hex_callback(const map_location& loc)
 {
 	lua_State *L = mState;

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -274,7 +274,7 @@ public:
 	ai::lua_ai_action_handler* create_lua_ai_action_handler(char const *code, ai::lua_ai_context &context);
 
 	void mouse_over_hex_callback(const map_location& loc);
-	void mouse_button_callback(const map_location& loc, unsigned int button, bool down);
+	void mouse_button_callback(const map_location& loc, const std::string &button, bool down);
 	void select_hex_callback(const map_location& loc);
 	void preload_finished() {has_preloaded_ = true;}
 };

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -274,7 +274,7 @@ public:
 	ai::lua_ai_action_handler* create_lua_ai_action_handler(char const *code, ai::lua_ai_context &context);
 
 	void mouse_over_hex_callback(const map_location& loc);
-	void mouse_button_callback(const map_location& loc, const std::string &button, bool down);
+	bool mouse_button_callback(const map_location& loc, const std::string &button, const std::string &event);
 	void select_hex_callback(const map_location& loc);
 	void preload_finished() {has_preloaded_ = true;}
 };

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -274,6 +274,7 @@ public:
 	ai::lua_ai_action_handler* create_lua_ai_action_handler(char const *code, ai::lua_ai_context &context);
 
 	void mouse_over_hex_callback(const map_location& loc);
+	void mouse_button_callback(const map_location& loc, unsigned int button, bool down);
 	void select_hex_callback(const map_location& loc);
 	void preload_finished() {has_preloaded_ = true;}
 };


### PR DESCRIPTION
This is a flexible event handler mechanism to allow for more advanced add-on features. It does not allow the add-on to consume the value however, so there's no mechanism for the add-on to requrest the default action not be executed.

We would normally deal separately with mouse down, up and click, with the later being an event where the mouse has gone both down and up on the same UI component. However, Wesnoth's code seems to allow a mouse up on many UI components to serve as a click, so this implementation follows that behavior.

This addresses issue #7949

I'm still in the process of testing, but would like to get this in before the freeze!