### PR TITLE
Correct drag_distance calculation and adjust drag_threshold() to match

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -94,7 +94,7 @@ void mouse_handler::set_side(int side_number)
 int mouse_handler::drag_threshold() const
 {
 	// TODO: Use physical screen size.
-	return 14;
+	return 4;
 }
 
 void mouse_handler::touch_motion(int x, int y, const bool browse, bool update, map_location new_hex)

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -144,9 +144,9 @@ bool mouse_handler_base::mouse_motion_default(int x, int y, bool /*update*/)
 		if((dragging_left_  && (mouse_state & SDL_BUTTON(SDL_BUTTON_LEFT))  != 0) ||
 		   (dragging_right_ && (mouse_state & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0))
 		{
-			const double drag_distance =
+			const double drag_distance = std::sqrt(
 					std::pow(static_cast<double>(drag_from_x_- mx), 2) +
-					std::pow(static_cast<double>(drag_from_y_- my), 2);
+					std::pow(static_cast<double>(drag_from_y_- my), 2));
 
 			if(drag_distance > drag_threshold() * drag_threshold()) {
 				dragging_started_ = true;


### PR DESCRIPTION
If the user drags 13 pixels on the x or y axis, but none on the other, then it will not be considered a drag event. However, dragging just 3 pixels in both the x and y direction, a total distance of 4.25 pixels, will be counted as a drag. This patch calculates the correct length and triggers a drag if the total distance is at least 4 pixels in any direction.