### PR TITLE
Post-Freeze Corrections

### DIFF
--- a/data/campaigns/Eastern_Invasion/units/Undead_Horse_Barrow_Wight.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Undead_Horse_Barrow_Wight.cfg
@@ -15,7 +15,7 @@
     {AMLA_DEFAULT}
     cost=52
     usage=fighter
-    description= _ "Perpetually haunted by the fading memory of its former life, a Barrow Wight wanders aimlessly in a delerium of darkness and despair. Their chill essense is shrouded behind cloak and bone, shielding them from most magic."
+    description= _ "Perpetually haunted by the fading memory of its former life, a Barrow Wight wanders aimlessly in a delirium of darkness and despair. Their chill essence is shrouded behind cloak and bone, shielding them from most magic."
     die_sound=skeleton-big-die.ogg
 
     [standing_anim]

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -445,7 +445,7 @@ Any units adjacent to this unit will fight as if it were dusk when it is night, 
         name = _"nova"
         description= _ "This weapon, when used offensively, deals damage to all units adjacent to the caster when it hits." + "
 
-" + _ "This attack is the third verse of the Song of Sun Ascension. After using it, the first verse is availaibe in the next turn. Furthermore, invoking this attack will grant illumination for three turns."
+" + _ "This attack is the third verse of the Song of Sun Ascension. After using it, the first verse is available in the next turn. Furthermore, invoking this attack will grant illumination for three turns."
         special_note=_ "This unit has wide-area attacks centered on the caster."
         active_on = offense
     [/dummy]
@@ -1446,7 +1446,7 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
     [dummy]
         id = taunt
         name = _"taunt"
-        description= _ "Taunts the enemy making them try to attack Kaleh no matter what for a one turn."
+        description= _ "Taunts the enemy making them try to attack Kaleh, no matter what, for one turn."
     [/dummy]
 #enddef
 
@@ -1482,7 +1482,7 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
     [dummy]
         id = taunted
         name = _"taunted"
-        description= _ "This unit is taunted by Kaleh, it will try to attack him no matter what for one turn."
+        description= _ "This unit is taunted by Kaleh; it will try to attack him, no matter what, for one turn."
     [/dummy]
 #enddef
 

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -1446,7 +1446,7 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
     [dummy]
         id = taunt
         name = _"taunt"
-        description= _ "Taunts the enemy making them try to attack Kaleh, no matter what, for one turn."
+        description= _ "Taunts the enemy making them try to attack Kaleh for one turn."
     [/dummy]
 #enddef
 
@@ -1482,7 +1482,7 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
     [dummy]
         id = taunted
         name = _"taunted"
-        description= _ "This unit is taunted by Kaleh; it will try to attack him, no matter what, for one turn."
+        description= _ "This unit is taunted by Kaleh, it will try to attack him for one turn."
     [/dummy]
 #enddef
 

--- a/data/core/units/monsters/Roc.cfg
+++ b/data/core/units/monsters/Roc.cfg
@@ -17,7 +17,7 @@
     {AMLA_DEFAULT}
     cost=70
     usage=scout
-    description= _ "In remote desert mountains, far from any city or settlement, enormous raptors are rumoured to nest in the lofty crags.  Travellers and nomads claim to have witnessed livestock and grown men snatched into the sky without warning by these monsters.  While one should not place much faith in the accounts of the desert roamers, they are less fantastical than the drunken lies of sailors who claim to have witnessed full-rigged ships, attempting to navigate the narrow straights between the sheer cliffs where nothing can grow, sunk by giant eagles dropping large rocks.
+    description= _ "In remote desert mountains, far from any city or settlement, enormous raptors are rumoured to nest in the lofty crags.  Travellers and nomads claim to have witnessed livestock and grown men snatched into the sky without warning by these monsters.  While one should not place much faith in the accounts of the desert roamers, they are less fantastical than the drunken lies of sailors who claim to have witnessed full-rigged ships, attempting to navigate the narrow straits between the sheer cliffs where nothing can grow, sunk by giant eagles dropping large rocks.
 
 Whatever kernel of truth is in these tall tales, there is no denying that the desert is a dangerous place, and both traders and armies do sometimes disappear when trying to cross the harsh ranges.  If you must traverse the great deserts, keep an eye to the sky."
     die_sound={SOUND_LIST:GRYPHON_DIE}

--- a/data/core/units/monsters/Shadow_Jumping_Spider.cfg
+++ b/data/core/units/monsters/Shadow_Jumping_Spider.cfg
@@ -26,7 +26,7 @@
     cost=58
     usage=fighter
     undead_variation=spider
-    description= _ "Unlike the feared Giant Spider that uses poison and webs to catch prey, the Shadow Jumper relies on speed and the element of surprise.  These stealthy, keen-eyed hunters creep to within striking distance, then pounce with a piercing bite that is said to punch through steel.  Once they have pierced their victim's defenses, the spiders take what nourishment is available, feeding in a manner as fast and remorseless as befits their nature.
+    description= _ "Unlike the feared Giant Spider that uses poison and webs to catch prey, the Shadow Jumper relies on speed and the element of surprise.  These stealthy, keen-eyed hunters creep to within striking distance, then pounce with a bite that is said to punch through steel.  Once they have pierced their victim's defenses, the spiders take what nourishment is available, feeding in a manner as fast and remorseless as befits their nature.
 
 These giant jumping spiders often hunt in the same dark caverns as their web-weaving cousins, but they also prowl the forest canopy, ambushing hapless wanderers on the ground below.  While they prefer the shadows, they are perfectly capable of hunting in the broad daylight."
     die_sound=hiss-big.wav

--- a/data/core/units/monsters/Shadow_Jumping_Spider.cfg
+++ b/data/core/units/monsters/Shadow_Jumping_Spider.cfg
@@ -26,9 +26,9 @@
     cost=58
     usage=fighter
     undead_variation=spider
-    description= _ "Unlike the feared Giant Spider, that uses poison and webs to catch prey, the Shadow Jumper relies on speed and the element of surprise.  These stealthy, keen-eyed hunters creep to within striking distance, then pounce with a piercing bite that is said to punch through steel.  Once they have pierced their victim's defenses, the spiders take what nourishment is available, feeding in a manner as fast and remorseless as befits their nature.
+    description= _ "Unlike the feared Giant Spider that uses poison and webs to catch prey, the Shadow Jumper relies on speed and the element of surprise.  These stealthy, keen-eyed hunters creep to within striking distance, then pounce with a piercing bite that is said to punch through steel.  Once they have pierced their victim's defenses, the spiders take what nourishment is available, feeding in a manner as fast and remorseless as befits their nature.
 
-These giant jumping spiders often hunt in the same dark caverns as their web-weaving cousins, but they also prowl the forest canopy, ambushing happless wanderers on the ground below.  While they prefer the shadows, they are perfectly capable of hunting in the broad daylight."
+These giant jumping spiders often hunt in the same dark caverns as their web-weaving cousins, but they also prowl the forest canopy, ambushing hapless wanderers on the ground below.  While they prefer the shadows, they are perfectly capable of hunting in the broad daylight."
     die_sound=hiss-big.wav
     {DEFENSE_ANIM "units/monsters/jumping-spider-defend2.png" "units/monsters/jumping-spider-defend1.png" hiss.wav }
     [movement_anim]

--- a/data/gui/widget/minimap_default.cfg
+++ b/data/gui/widget/minimap_default.cfg
@@ -38,7 +38,7 @@
 
 [minimap_definition]
 	id = "no_size"
-	description = "a minimap without a size, this way it can be sized in it's container."
+	description = "a minimap without a size, this way it can be sized in its container."
 
 	{_GUI_RESOLUTION () 0}
 

--- a/data/gui/widget/slider_default.cfg
+++ b/data/gui/widget/slider_default.cfg
@@ -130,7 +130,7 @@
 
 [slider_definition]
 	id = "default"
-	description = "A slider with it's value on the right hand side."
+	description = "A slider with its value on the right hand side."
 
 	{_GUI_RESOLUTION () 150 250 22 16 50 ({GUI_FONT_SIZE_DEFAULT}) }
 
@@ -138,7 +138,7 @@
 
 [slider_definition]
 	id = "short"
-	description = "A slider with it's value on the right hand side."
+	description = "A slider with its value on the right hand side."
 
 	{_GUI_RESOLUTION () 50 150 22 16 50 ({GUI_FONT_SIZE_SMALL}) }
 


### PR DESCRIPTION
* Barrow Wight: discussed in #7958.
* UtBS abilities: looks like originally 'taunt' description had 'for a turn', then changed to 'for one turn' as per 'taunted' description. Also added punctuation for clarity.
* Roc: mentioned in #7902.
* Shadow Jumping Spider: spelling error.
* GUI descriptions: found these while looking for 'straight' apostrophes. I'm not sure if the user sees these, but the strings aren't marked for translation so I included them here.