### PR TITLE
Offscreen window rendering

### DIFF
--- a/data/gui/widget/panel_story_viewer.cfg
+++ b/data/gui/widget/panel_story_viewer.cfg
@@ -20,10 +20,7 @@
 
 			[draw]
 
-				# This works fine for normal messages. However, messages with options behave
-				# strangely, and messages with scrollbars perform badly.
-				# Uncomment once this has been fixed.
-				#{DEFAULT_BLUR}
+				{DEFAULT_BLUR}
 
 				[image]
 					x = 0

--- a/data/gui/widget/panel_wml_message.cfg
+++ b/data/gui/widget/panel_wml_message.cfg
@@ -20,10 +20,7 @@
 
 			[draw]
 
-				# This works fine for normal messages. However, messages with options behave
-				# strangely, and messages with scrollbars perform badly.
-				# Uncomment once this has been fixed.
-				#{DEFAULT_BLUR}
+				{DEFAULT_BLUR}
 
 				[image]
 					x = 0

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -577,7 +577,7 @@ draw::render_target_setter::render_target_setter(const texture& t)
 	, viewport_()
 {
 	// Validate we can render to this texture.
-	assert(t.get_access() == SDL_TEXTUREACCESS_TARGET);
+	assert(!t || t.get_access() == SDL_TEXTUREACCESS_TARGET);
 
 	if (!renderer()) {
 		WRN_D << "can't set render target with null renderer";
@@ -587,7 +587,11 @@ draw::render_target_setter::render_target_setter(const texture& t)
 	target_ = video::get_render_target();
 	SDL_RenderGetViewport(renderer(), &viewport_);
 
-	video::force_render_target(t);
+	if (t) {
+		video::force_render_target(t);
+	} else {
+		video::reset_render_target();
+	}
 }
 
 draw::render_target_setter::~render_target_setter()
@@ -602,7 +606,11 @@ draw::render_target_setter::~render_target_setter()
 
 draw::render_target_setter draw::set_render_target(const texture& t)
 {
-	DBG_D << "setting render target to "
-	      << t.w() << 'x' << t.h() << " texture";
+	if (t) {
+		DBG_D << "setting render target to "
+		      << t.w() << 'x' << t.h() << " texture";
+	} else {
+		DBG_D << "setting render target to main render buffer";
+	}
 	return draw::render_target_setter(t);
 }

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -446,7 +446,9 @@ private:
  * SDL_TEXTUREACCESS_TARGET access mode.
  *
  * @param t     The new render target. This must be a texture created
- *              with SDL_TEXTUREACCESS_TARGET.
+ *              with SDL_TEXTUREACCESS_TARGET, or an empty texture.
+ *              If empty, it will set the render target to Wesnoth's
+ *              primary render buffer.
  * @returns     A render_target_setter object. When this object is
  *              destroyed the render target will be restored to
  *              whatever it was before this call.

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -482,6 +482,7 @@ void text_shape::draw(wfl::map_formula_callable& variables)
 canvas::canvas()
 	: shapes_()
 	, blur_depth_(0)
+	, deferred_(false)
 	, w_(0)
 	, h_(0)
 	, variables_()
@@ -492,11 +493,64 @@ canvas::canvas()
 canvas::canvas(canvas&& c) noexcept
 	: shapes_(std::move(c.shapes_))
 	, blur_depth_(c.blur_depth_)
+	, deferred_(c.deferred_)
 	, w_(c.w_)
 	, h_(c.h_)
 	, variables_(c.variables_)
 	, functions_(c.functions_)
 {
+}
+
+// It would be better if the blur effect was managed at a higher level.
+// But for now this works and should be both general and robust.
+bool canvas::update_blur(const rect& screen_region, bool force)
+{
+	if(!blur_depth_) {
+		// No blurring needed.
+		return true;
+	}
+	if(blur_texture_ && !force) {
+		// We already made the blur. It's expensive, so don't do it again.
+		return true;
+	}
+
+	// To blur what is underneath us, it must already be rendered somewhere.
+	// This is okay for sub-elements of an opaque window (panels on the main
+	// title screen for example) as the window will already have rendered
+	// its background to the render buffer before we get here.
+	// If however we are blurring elements behind the window, such as if
+	// the window itself is translucent (objectives popup), or it is
+	// transparent with a translucent element (character dialogue),
+	// then we need to render what will be behind it before capturing that
+	// and rendering a blur.
+	// We could use the previous render frame, but there could well have been
+	// another element there last frame such as a popup window which we
+	// don't want to be part of the blur.
+	// The only stable solution is to render in multiple passes.
+	// For now, we defer rendering of translucent elements to the next frame,
+	// so one frame is rendered without the element, then the element captures
+	// the result from that frame and renders itself on the next frame.
+	// Ultimately even with hardware acceleration of the blur effect
+	// a similar solution will need to be retained. The difference with a
+	// better future implementation would be that the multiple rendering
+	// passes can be managed at a higher level, and that they can be done
+	// within a single frame.
+
+	if(!deferred_) {
+		DBG_GUI_D << "Deferring blur at " << screen_region;
+		deferred_ = true;
+		return false;
+	}
+
+	// Read and blur pixels from the previous render frame.
+	DBG_GUI_D << "Blurring " << screen_region << " depth " << blur_depth_;
+	rect read_region = screen_region;
+	auto setter = draw::set_render_target({});
+	surface s = video::read_pixels_low_res(&read_region);
+	s = blur_surface(s, blur_depth_);
+	blur_texture_ = texture(s);
+	deferred_ = false;
+	return true;
 }
 
 void canvas::draw()
@@ -508,18 +562,15 @@ void canvas::draw()
 		return;
 	}
 
-	// Note: this doesn't update if whatever is underneath changes.
-	if(blur_depth_ && !blur_texture_) {
-		// Cache a blurred image of whatever is underneath.
-		SDL_Rect rect = draw::get_viewport();
-		surface s = video::read_pixels_low_res(&rect);
-		s = blur_surface(s, blur_depth_);
-		blur_texture_ = texture(s);
+	if(deferred_) {
+		// We will draw next frame.
+		return;
 	}
 
 	// Draw blurred background.
 	// TODO: hwaccel - this should be able to be removed at some point with shaders
 	if(blur_depth_ && blur_texture_) {
+		DBG_GUI_D << "blitting blur size " << blur_texture_.draw_size();
 		draw::blit(blur_texture_);
 	}
 

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -25,6 +25,7 @@
 #include "formula/callable.hpp"
 #include "formula/function.hpp"
 #include "sdl/texture.hpp"
+#include "sdl/rect.hpp"
 
 namespace wfl { class variant; }
 struct point;
@@ -86,6 +87,19 @@ public:
 	canvas(const canvas&) = delete;
 	canvas& operator=(const canvas&) = delete;
 	canvas(canvas&& c) noexcept;
+
+	/**
+	 * Update the background blur texture, if relevant and necessary.
+	 *
+	 * This should be called sometime before draw().
+	 * Updating it later is less important as it's quite expensive.
+	 *
+	 * @param screen_region     The area of the screen underneath the canvas.
+	 * @param force             Regenerate the blur even if we already did it.
+	 *
+	 * @returns                 True if draw should continue, false otherwise.
+	 */
+	bool update_blur(const rect& screen_region, const bool force = false);
 
 	/**
 	 * Draw the canvas' shapes onto the screen.
@@ -155,6 +169,9 @@ private:
 
 	/** Blurred background texture. */
 	texture blur_texture_;
+
+	/** Whether we have deferred rendering so we can capture for blur. */
+	bool deferred_;
 
 	/** The full width of the canvas. */
 	unsigned w_;

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -1008,9 +1008,18 @@ void grid::impl_draw_children()
 			continue;
 		}
 
-		widget->draw_background();
+		// We may need to defer drawing to next frame for blur processing.
+		if(!widget->draw_background()) {
+			get_window()->defer_region(widget->get_rectangle());
+			continue;
+		}
+
 		widget->draw_children();
-		widget->draw_foreground();
+
+		if(!widget->draw_foreground()) {
+			get_window()->defer_region(widget->get_rectangle());
+			continue;
+		}
 	}
 }
 

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -93,11 +93,12 @@ void minimap::set_map_data(const std::string& map_data)
 	}
 }
 
-void minimap::impl_draw_background()
+bool minimap::impl_draw_background()
 {
 	if(map_) {
 		image::render_minimap(get_width(), get_height(), *map_, nullptr, nullptr, nullptr, true);
 	}
+	return true;
 }
 
 // }---------- DEFINITION ---------{

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -83,7 +83,7 @@ private:
 	std::unique_ptr<gamemap> map_;
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background() override;
+	virtual bool impl_draw_background() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/multi_page.cpp
+++ b/src/gui/widgets/multi_page.cpp
@@ -149,9 +149,10 @@ void multi_page::finalize(std::unique_ptr<generator_base> generator, const std::
 	swap_grid(nullptr, &get_grid(), std::move(generator), "_content_grid");
 }
 
-void multi_page::impl_draw_background()
+bool multi_page::impl_draw_background()
 {
 	/* DO NOTHING */
+	return true;
 }
 
 void multi_page::set_self_active(const bool /*active*/)

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -217,7 +217,7 @@ private:
 	builder_grid_map page_builders_;
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background() override;
+	virtual bool impl_draw_background() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -65,16 +65,24 @@ unsigned panel::get_state() const
 	return 0;
 }
 
-void panel::impl_draw_background()
+bool panel::impl_draw_background()
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".";
+	if(!get_canvas(0).update_blur(get_rectangle())) {
+		return false;
+	}
 	get_canvas(0).draw();
+	return true;
 }
 
-void panel::impl_draw_foreground()
+bool panel::impl_draw_foreground()
 {
 	DBG_GUI_D << LOG_HEADER << " size " << get_rectangle() << ".";
+	if(!get_canvas(1).update_blur(get_rectangle())) {
+		return false;
+	}
 	get_canvas(1).draw();
+	return true;
 }
 
 point panel::border_space() const

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -74,10 +74,10 @@ public:
 
 private:
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background() override;
+	virtual bool impl_draw_background() override;
 
 	/** See @ref widget::impl_draw_foreground. */
-	virtual void impl_draw_foreground() override;
+	virtual bool impl_draw_foreground() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -97,9 +97,10 @@ bool spacer::disable_click_dismiss() const
 	return false;
 }
 
-void spacer::impl_draw_background()
+bool spacer::impl_draw_background()
 {
 	/* DO NOTHING */
+	return true;
 }
 
 // }---------- DEFINITION ---------{

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -87,7 +87,7 @@ private:
 	bool fills_available_space();
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background() override;
+	virtual bool impl_draw_background() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -431,17 +431,22 @@ int styled_widget::get_text_maximum_height() const
 	return get_height() - config_->text_extra_height;
 }
 
-void styled_widget::impl_draw_background()
+bool styled_widget::impl_draw_background()
 {
 	DBG_GUI_D << LOG_HEADER << " label '" << debug_truncate(label_.str()) << "' size "
 			  << get_rectangle() << ".";
 
+	if(!get_canvas(get_state()).update_blur(get_rectangle())) {
+		return false;
+	}
 	get_canvas(get_state()).draw();
+	return true;
 }
 
-void styled_widget::impl_draw_foreground()
+bool styled_widget::impl_draw_foreground()
 {
 	/* DO NOTHING */
+	return true;
 }
 
 point styled_widget::get_best_text_size(point minimum_size, point maximum_size) const

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -459,10 +459,10 @@ public:
 
 protected:
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background() override;
+	virtual bool impl_draw_background() override;
 
 	/** See @ref widget::impl_draw_foreground. */
-	virtual void impl_draw_foreground() override;
+	virtual bool impl_draw_foreground() override;
 
 	/** Exposes font::pango_text::get_token, for the text label of this styled_widget */
 	std::string get_label_token(const point & position, const char * delimiters = " \n\r\t") const;

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -193,18 +193,18 @@ void toggle_panel::set_state(const state_t state)
 	assert(conf);
 }
 
-void toggle_panel::impl_draw_background()
+bool toggle_panel::impl_draw_background()
 {
 	// We don't have a fore and background and need to draw depending on
 	// our state, like a styled_widget. So we use the styled_widget's drawing method.
-	styled_widget::impl_draw_background();
+	return styled_widget::impl_draw_background();
 }
 
-void toggle_panel::impl_draw_foreground()
+bool toggle_panel::impl_draw_foreground()
 {
 	// We don't have a fore and background and need to draw depending on
 	// our state, like a styled_widget. So we use the styled_widget's drawing method.
-	styled_widget::impl_draw_foreground();
+	return styled_widget::impl_draw_foreground();
 }
 
 void toggle_panel::signal_handler_mouse_enter(const event::ui_event event,

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -175,10 +175,10 @@ private:
 	std::function<void(widget&)> callback_mouse_left_double_click_;
 
 	/** See @ref widget::impl_draw_background. */
-	virtual void impl_draw_background() override;
+	virtual bool impl_draw_background() override;
 
 	/** See @ref widget::impl_draw_foreground. */
-	virtual void impl_draw_foreground() override;
+	virtual bool impl_draw_foreground() override;
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -370,12 +370,12 @@ SDL_Rect widget::calculate_clipping_rectangle() const
 	}
 }
 
-void widget::draw_background()
+bool widget::draw_background()
 {
 	assert(visible_ == visibility::visible);
 
 	if(get_drawing_action() == redraw_action::none) {
-		return;
+		return true;
 	}
 
 	// Set viewport and clip so we can draw in local coordinates.
@@ -389,7 +389,7 @@ void widget::draw_background()
 	auto clip_setter = draw::reduce_clip(clip);
 
 	draw_debug_border();
-	impl_draw_background();
+	return impl_draw_background();
 }
 
 void widget::draw_children()
@@ -413,12 +413,12 @@ void widget::draw_children()
 	impl_draw_children();
 }
 
-void widget::draw_foreground()
+bool widget::draw_foreground()
 {
 	assert(visible_ == visibility::visible);
 
 	if(get_drawing_action() == redraw_action::none) {
-		return;
+		return true;
 	}
 
 	// Set viewport and clip so we can draw in local coordinates.
@@ -431,7 +431,7 @@ void widget::draw_foreground()
 	clip.shift(-get_origin());
 	auto clip_setter = draw::reduce_clip(clip);
 
-	impl_draw_foreground();
+	return impl_draw_foreground();
 }
 
 SDL_Rect widget::get_dirty_rectangle() const

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -378,10 +378,14 @@ void widget::draw_background()
 		return;
 	}
 
-	SDL_Rect dest = calculate_blitting_rectangle();
-	SDL_Rect clip = calculate_clipping_rectangle();
-	clip.x -= dest.x; clip.y -= dest.y;
+	// Set viewport and clip so we can draw in local coordinates.
+	rect dest = calculate_blitting_rectangle();
+	rect clip = calculate_clipping_rectangle();
+	// Presumably we are drawing to our window's render buffer.
+	point window_origin = get_window()->get_origin();
+	dest.shift(-window_origin);
 	auto view_setter = draw::set_viewport(dest);
+	clip.shift(-get_origin());
 	auto clip_setter = draw::reduce_clip(clip);
 
 	draw_debug_border();
@@ -396,10 +400,14 @@ void widget::draw_children()
 		return;
 	}
 
-	SDL_Rect dest = calculate_blitting_rectangle();
-	SDL_Rect clip = calculate_clipping_rectangle();
-	clip.x -= dest.x; clip.y -= dest.y;
+	// Set viewport and clip so we can draw in local coordinates.
+	rect dest = calculate_blitting_rectangle();
+	rect clip = calculate_clipping_rectangle();
+	// Presumably we are drawing to our window's render buffer.
+	point window_origin = get_window()->get_origin();
+	dest.shift(-window_origin);
 	auto view_setter = draw::set_viewport(dest);
+	clip.shift(-get_origin());
 	auto clip_setter = draw::reduce_clip(clip);
 
 	impl_draw_children();
@@ -413,10 +421,14 @@ void widget::draw_foreground()
 		return;
 	}
 
-	SDL_Rect dest = calculate_blitting_rectangle();
-	SDL_Rect clip = calculate_clipping_rectangle();
-	clip.x -= dest.x; clip.y -= dest.y;
+	// Set viewport and clip so we can draw in local coordinates.
+	rect dest = calculate_blitting_rectangle();
+	rect clip = calculate_clipping_rectangle();
+	// Presumably we are drawing to our window's render buffer.
+	point window_origin = get_window()->get_origin();
+	dest.shift(-window_origin);
 	auto view_setter = draw::set_viewport(dest);
+	clip.shift(-get_origin());
 	auto clip_setter = draw::reduce_clip(clip);
 
 	impl_draw_foreground();
@@ -452,6 +464,7 @@ void widget::queue_redraw()
 
 void widget::queue_redraw(const rect& region)
 {
+	get_window()->queue_rerender(region);
 	draw_manager::invalidate_region(region);
 }
 

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -538,8 +538,10 @@ public:
 	 *
 	 * Derived should override @ref impl_draw_background instead of changing
 	 * this function.
+	 *
+	 * @returns                   False if drawing should be deferred.
 	 */
-	void draw_background();
+	bool draw_background();
 
 	/**
 	 * Draws the children of a widget.
@@ -559,13 +561,16 @@ public:
 	 *
 	 * Derived should override @ref impl_draw_foreground instead of changing
 	 * this function.
+	 *
+	 * @returns                   False if drawing should be deferred.
 	 */
-	void draw_foreground();
+	bool draw_foreground();
 
 private:
 	/** See @ref draw_background. */
-	virtual void impl_draw_background()
+	virtual bool impl_draw_background()
 	{
+		return true;
 	}
 
 	/** See @ref draw_children. */
@@ -574,8 +579,9 @@ private:
 	}
 
 	/** See @ref draw_foreground. */
-	virtual void impl_draw_foreground()
+	virtual bool impl_draw_foreground()
 	{
+		return true;
 	}
 
 public:

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -173,6 +173,9 @@ private:
 	/** The part of the window (if any) currently marked for rerender. */
 	rect awaiting_rerender_;
 
+	/** Parts of the window (if any) with rendering deferred to next frame */
+	std::vector<rect> deferred_regions_;
+
 	/** Ensure render textures are valid and correct. */
 	void update_render_textures();
 
@@ -196,6 +199,16 @@ public:
 	 */
 	void queue_rerender(const rect& region);
 	void queue_rerender();
+
+	/**
+	 * Defer rendering of a particular region to next frame.
+	 *
+	 * This is used for blur, which must render the region underneath once
+	 * before rendering the blur.
+	 *
+	 * @param region    The region to defer in screen coordinates.
+	 */
+	void defer_region(const rect& region);
 
 	/** The status of the window. */
 	enum class status {

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -159,11 +159,43 @@ public:
 	 */
 	virtual void layout() override;
 
-	/** Called by draw_manager when it believes a redraw is necessary. */
+	/** Ensure the window's internal render buffer is up-to-date.
+	 *
+	 * This renders the window to an off-screen texture, which is then
+	 * copied to the screen during expose().
+	 */
+	virtual void render() override;
+
+private:
+	/** The internal render buffer used by render() and expose(). */
+	texture render_buffer_ = {};
+
+	/** The part of the window (if any) currently marked for rerender. */
+	rect awaiting_rerender_;
+
+	/** Ensure render textures are valid and correct. */
+	void update_render_textures();
+
+public:
+	/**
+	 * Called by draw_manager when it believes a redraw is necessary.
+	 * Can be called multiple times per vsync.
+	 */
 	virtual bool expose(const rect& region) override;
 
 	/** The current draw location of the window, on the screen. */
 	virtual rect screen_location() override;
+
+	/**
+	 * Queue a rerender of the internal render buffer.
+	 *
+	 * This does not request a repaint. Ordinarily use queue_redraw()
+	 * on a widget, which will call this automatically.
+	 *
+	 * @param region    The region to rerender in screen coordinates.
+	 */
+	void queue_rerender(const rect& region);
+	void queue_rerender();
 
 	/** The status of the window. */
 	enum class status {

--- a/src/sdl/point.hpp
+++ b/src/sdl/point.hpp
@@ -62,6 +62,11 @@ struct point : SDL_Point
 		return *this;
 	}
 
+	constexpr point operator-() const
+	{
+		return {-x, -y};
+	}
+
 	constexpr point operator-(const point& point) const
 	{
 		return {x - point.x, y - point.y};

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -519,6 +519,11 @@ void clear_render_target()
 	force_render_target({});
 }
 
+void reset_render_target()
+{
+	force_render_target(render_texture_);
+}
+
 texture get_render_target()
 {
 	// This should always be up-to-date, but assert for sanity.
@@ -561,7 +566,7 @@ void render_screen()
 	SDL_RenderPresent(*window);
 
 	// Reset the render target to the render texture.
-	force_render_target(render_texture_);
+	reset_render_target();
 }
 
 surface read_pixels(SDL_Rect* r)

--- a/src/video.hpp
+++ b/src/video.hpp
@@ -290,6 +290,9 @@ void force_render_target(const texture& t);
 /** Reset the render target to the main window / screen. */
 void clear_render_target();
 
+/** Reset the render target to the primary render buffer. */
+void reset_render_target();
+
 /** Get the current render target.
  *
  * Will return an empty texture if the render target is the underlying


### PR DESCRIPTION
I haven't done much (or any, really) testing on this, but it should solve #7615 

I verified that it does reduce CPU usage when opening the Load Game screen while in the tutorial.

I'm not sure if there might be rendering bugs in other areas. But the basic system is straightforward. It just renders windows to offscreen render textures when they change, and doesn't do any more work unless it needs to. When the window needs to be redrawn, it just blits from this texture without actually redrawing anything.

Renders should be minimal, and it's using all the same draw code so actually very little has changed.