### PR TITLE
[Campaigns][Eastern Invasion] fix editor group icon

### DIFF
--- a/data/campaigns/Eastern_Invasion/_main.cfg
+++ b/data/campaigns/Eastern_Invasion/_main.cfg
@@ -35,7 +35,7 @@
 [editor_group]
     id=eastern_invasion
     name= _ "Eastern Invasion"
-    icon="group_custom"
+    icon="group_mainline"
 [/editor_group]
 {campaigns/Eastern_Invasion/terrain.cfg}
 {campaigns/Eastern_Invasion/terrain-graphics.cfg}


### PR DESCRIPTION
## Summary
Changes Editor terrain Group Icon from "UMC" to "Mainline".

### Why?
Well, a mainline campaign should not have the UMC terrain group icon. Just looks odd in the terrain group listings.

