### PR TITLE
Fix UI update when changing pixel scale in preferences

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -761,7 +761,7 @@ void raise_resize_event()
 	point size = video::window_size();
 	SDL_Event event;
 	event.window.type = SDL_WINDOWEVENT;
-	event.window.event = SDL_WINDOWEVENT_RESIZED;
+	event.window.event = SDL_WINDOWEVENT_SIZE_CHANGED;
 	event.window.windowID = 0; // We don't check this anyway... I think...
 	event.window.data1 = size.x;
 	event.window.data2 = size.y;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -291,6 +291,9 @@ bool update_framebuffer()
 			// Delete it and let it be recreated.
 			LOG_DP << "destroying old render texture";
 			render_texture_.reset();
+		} else {
+			// This isn't currently used, but ensure it's accurate anyway.
+			render_texture_.set_draw_size(lsize);
 		}
 	}
 	if (!render_texture_) {


### PR DESCRIPTION
This just brings the custom resize event that can be fired in line with the change made in ac96df07bebbfc5d494f7325b89aa42ad4e567a9 .

The only thing that uses this event is the pixel scale slider which fires it manually when changed, as the window size doesn't actually change but the UI still needs to be regenerated.

This fixes the display updating incorrectly when changing pixel scale in prefs. (which i haven't reported because i just fixed it in stead)