### PR TITLE
Allow filter also apply_to in [resistance]

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1451,8 +1451,12 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 	if(!string_matches_if_present(filter, cfg, "id", ""))
 		return false;
 
-	if(!string_matches_if_present(filter, cfg, "apply_to", "self"))
-		return false;
+	if(filter.has_attribute("apply_to")){
+		const std::string& default_apply = (tag_name != "resistance") ? "self" : "";
+		if(!string_matches_if_present(filter, cfg, "apply_to", default_apply)){
+			return false;
+		}
+	}
 
 	if(!string_matches_if_present(filter, cfg, "overwrite_specials", "none"))
 		return false;


### PR DESCRIPTION
In engine [resistance] is the only ability that also uses the apply_to attribute, but in a different way than for special weapons so I propose that in this case the filter applpy_to does not have a default value.

It seems unlikely to me that anyone will use this attribute in a custom ability (dummy, tailwind etc.) but if it is considered possible then I will abandon the idea