### PR TITLE
Multipass rendering

### DIFF
--- a/src/draw_manager.hpp
+++ b/src/draw_manager.hpp
@@ -93,6 +93,17 @@ void invalidate_region(const rect& region);
 void invalidate_all();
 
 /**
+ * Request an extra render pass.
+ *
+ * This is used for blur effects, which need to first render what's
+ * underneath so that it can be blurred.
+ *
+ * There is not currently any limit to the number of extra render passes,
+ * but do try to keep it finite.
+ */
+void request_extra_render_pass();
+
+/**
  * Ensure that everything which needs to be drawn is drawn.
  *
  * This includes making sure window sizes and locations are up to date,

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -24,6 +24,7 @@
 #include "gui/core/canvas_private.hpp"
 
 #include "draw.hpp"
+#include "draw_manager.hpp"
 #include "font/text.hpp"
 #include "formatter.hpp"
 #include "gettext.hpp"
@@ -526,23 +527,19 @@ bool canvas::update_blur(const rect& screen_region, bool force)
 	// We could use the previous render frame, but there could well have been
 	// another element there last frame such as a popup window which we
 	// don't want to be part of the blur.
-	// The only stable solution is to render in multiple passes.
-	// For now, we defer rendering of translucent elements to the next frame,
-	// so one frame is rendered without the element, then the element captures
-	// the result from that frame and renders itself on the next frame.
-	// Ultimately even with hardware acceleration of the blur effect
-	// a similar solution will need to be retained. The difference with a
-	// better future implementation would be that the multiple rendering
-	// passes can be managed at a higher level, and that they can be done
-	// within a single frame.
+	// The stable solution is to render in multiple passes,
+	// so that is what we shall do.
 
+	// For the first pass, this element and its children are not rendered.
 	if(!deferred_) {
 		DBG_GUI_D << "Deferring blur at " << screen_region;
 		deferred_ = true;
+		draw_manager::request_extra_render_pass();
 		return false;
 	}
 
-	// Read and blur pixels from the previous render frame.
+	// For the second pass we read the result of the first pass at
+	// this widget's location, and blur it.
 	DBG_GUI_D << "Blurring " << screen_region << " depth " << blur_depth_;
 	rect read_region = screen_region;
 	auto setter = draw::set_render_target({});

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -550,6 +550,11 @@ bool canvas::update_blur(const rect& screen_region, bool force)
 	return true;
 }
 
+void canvas::queue_reblur()
+{
+	blur_texture_.reset();
+}
+
 void canvas::draw()
 {
 	// This early-return has to come before the `validate(rect.w <= w_)` check, as during the boost_unit_tests execution

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -101,6 +101,9 @@ public:
 	 */
 	bool update_blur(const rect& screen_region, const bool force = false);
 
+	/** Clear the cached blur texture, forcing it to regenerate. */
+	void queue_reblur();
+
 	/**
 	 * Draw the canvas' shapes onto the screen.
 	 *

--- a/src/gui/dialogs/story_viewer.cpp
+++ b/src/gui/dialogs/story_viewer.cpp
@@ -307,6 +307,9 @@ void story_viewer::display_part()
 	text_label.set_text_alpha(0);
 	text_label.set_label(part_text);
 
+	// Regenerate any background blur texture
+	panel_canvas.queue_reblur();
+
 	begin_fade_draw(true);
 	// if the previous page was skipped, it is possible that we already have a timer running.
 	clear_image_timer();


### PR DESCRIPTION
I didn't like that the blur effect required two frames to render, so i implemented basic multipass rendering. That is, while rendering, anything can request that another rendering pass is performed before flipping to the screen. This means the blur can render the thing behind it, blur that, then render itself, all in the same frame.

Theoretically this would also work for multiple layered blurs, rendering in three or more passes. But try not to do that as it's expensive, and will probably drop frames on weak hardware.

I also noticed while testing that the story screen text panels now have blur, and it wasn't updating, so i forced it to regenerate the blur at each step. Without the multipass rendering, this causes a one-frame flicker which was pretty much unacceptable. It looks pretty good now.