### PR TITLE
Start game with theme buttons hidden.

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -925,6 +925,11 @@ void display::create_buttons()
 		action_buttons_.push_back(std::move(b));
 	}
 
+	if (prevent_draw_) {
+		// buttons start hidden in this case
+		hide_buttons();
+	}
+
 	layout_buttons();
 	DBG_DP << "buttons created";
 }
@@ -949,6 +954,26 @@ void display::draw_buttons()
 	//		btn->draw();
 	//	}
 	//}
+}
+
+void display::hide_buttons()
+{
+	for (auto& button : menu_buttons_) {
+		button->hide();
+	}
+	for (auto& button : action_buttons_) {
+		button->hide();
+	}
+}
+
+void display::unhide_buttons()
+{
+	for (auto& button : menu_buttons_) {
+		button->hide(false);
+	}
+	for (auto& button : action_buttons_) {
+		button->hide(false);
+	}
 }
 
 std::vector<texture> display::get_fog_shroud_images(const map_location& loc, image::TYPE image_type)
@@ -2210,6 +2235,21 @@ double display::turbo_speed() const
 	else
 		return 1.0;
 }
+
+void display::set_prevent_draw(bool pd)
+{
+	prevent_draw_ = pd;
+	if (!pd) {
+		// ensure buttons are visible
+		unhide_buttons();
+	}
+}
+
+bool display::get_prevent_draw()
+{
+	return prevent_draw_;
+}
+
 
 void display::fade_tod_mask(
 	const std::string& old_mask,

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -405,6 +405,11 @@ public:
 
 	void draw_buttons();
 
+	/** Hide theme buttons so they don't draw. */
+	void hide_buttons();
+	/** Unhide theme buttons so they draw again. */
+	void unhide_buttons();
+
 	/** Update the given report. Actual drawing is done in draw_report(). */
 	void refresh_report(const std::string& report_name, const config * new_cfg=nullptr);
 
@@ -545,8 +550,8 @@ public:
 
 	/** Prevent the game display from drawing.
 	  * Used while story screen is showing to prevent flicker. */
-	void set_prevent_draw(bool pd) { prevent_draw_ = pd; }
-	bool get_prevent_draw() { return prevent_draw_; }
+	void set_prevent_draw(bool pd = true);
+	bool get_prevent_draw();
 
 private:
 	bool prevent_draw_ = false;


### PR DESCRIPTION
Fixes #6922

Just hides the buttons until the game has started. There was already a function to cause the game map not to draw while the story screen was showing, so i just used that as the cue for unhiding the buttons.

There is some weirdness with the buttons under the minimap appearing at different times. But that seems to be a separate issue, and unrelated.