### PR TITLE
add some logging to game history query

### DIFF
--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -232,20 +232,20 @@ std::unique_ptr<simple_wml::document> dbconn::get_game_history(int player_id, in
 "limit 11 offset ? ";
 		params.emplace_back(offset);
 
-		LOG_SQL << "before getting connection for game history query for player " << player_id;
+		DBG_SQL << "before getting connection for game history query for player " << player_id;
 
 		mariadb::connection_ref connection = create_connection();
 
-		LOG_SQL << "game history query text for player " << player_id << ": " << game_history_query;
+		DBG_SQL << "game history query text for player " << player_id << ": " << game_history_query;
 
 		game_history gh;
 		get_complex_results(connection, gh, game_history_query, params);
 
-		LOG_SQL << "after game history query for player " << player_id;
+		DBG_SQL << "after game history query for player " << player_id;
 
 		auto doc = gh.to_doc();
 
-		LOG_SQL << "after parsing results of game history query for player " << player_id;
+		DBG_SQL << "after parsing results of game history query for player " << player_id;
 
 		return doc;
 	}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -232,9 +232,22 @@ std::unique_ptr<simple_wml::document> dbconn::get_game_history(int player_id, in
 "limit 11 offset ? ";
 		params.emplace_back(offset);
 
+		LOG_SQL << "before getting connection for game history query for player " << player_id;
+
+		mariadb::connection_ref connection = create_connection();
+
+		LOG_SQL << "game history query text for player " << player_id << ": " << game_history_query;
+
 		game_history gh;
-		get_complex_results(create_connection(), gh, game_history_query, params);
-		return gh.to_doc();
+		get_complex_results(connection, gh, game_history_query, params);
+
+		LOG_SQL << "after game history query for player " << player_id;
+
+		auto doc = gh.to_doc();
+
+		LOG_SQL << "after parsing results of game history query for player " << player_id;
+
+		return doc;
 	}
 	catch(const mariadb::exception::base& e)
 	{


### PR DESCRIPTION
---

Not sure if this makes sense to keep after the performance issue is resolved or not, but the goal is:
* log the actual SQL statement being run, to make sure it matches what I think it should.
* log between the individual steps so it's clear which is taking up too much time.