### PR TITLE
UtBS: Units with tailwind have green orbs and rest-heal

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -587,6 +587,29 @@ Any units adjacent to this unit will fight as if it were dusk when it is night, 
                     find_in=utbs_tailwind2_sources
                 [/filter_adjacent]
             [/filter]
+            # Temporarily increase the max moves correspondingly, so the unit gets a green orb and
+            # can rest heal next turn, because units only rest heal if their moves and max moves are
+            # exactly equal at the start of the next turn.
+            #
+            # Without this object units only rest heal if the player moves them to reduce their
+            # movement down to match the maximum.
+            #
+            # Using `duration=turn` means that the wrong max moves will show during the AI turn.
+            # Rest healing mechanics work as normal - units rest heal if (and only if) they aren't
+            # moved the previous turn.
+            #
+            # Using `duration=turn end` allows the unit to move 1 or 2 hexes and still rest heal.
+            # When the object is removed at turn end, the moves remaining will be capped to the max,
+            # so rest healing works.
+            #
+            # Remember to change the tailwind+1 object to match this one.
+            [object]
+                duration=turn end
+                [effect]
+                    apply_to=movement
+                    increase=2
+                [/effect]
+            [/object]
             moves="$($this_unit.moves + 2)"
         [/modify_unit]
         [modify_unit]
@@ -601,6 +624,13 @@ Any units adjacent to this unit will fight as if it were dusk when it is night, 
                     [/filter_adjacent]
                 [/not]
             [/filter]
+            [object]
+                duration=turn end
+                [effect]
+                    apply_to=movement
+                    increase=1
+                [/effect]
+            [/object]
             moves="$($this_unit.moves + 1)"
         [/modify_unit]
 


### PR DESCRIPTION
Fixes #7966

In UtBS, at the start of the player's turn any units that are next to a Quenoth Shaman get +1 move (or +2 for some of the L2/L3 shamans).

Without this fix, the buffed units have an orange orb instead of the green unmoved orb, and don't rest-heal next turn. This makes things look correct during the player's turn, at the expense of showing the unit's max_moves as the buffed amount, even if the unit won't get the buff next turn.