### PR TITLE
Fix overlapping fog texture at some zoom levels

### DIFF
--- a/data/game_config.cfg
+++ b/data/game_config.cfg
@@ -33,8 +33,10 @@
     hp_bar_scaling=0.6
     xp_bar_scaling=0.5
 
-    # zoom factors must be a sorted list of ascending multipliers
-    zoom_levels = 0.25, 0.33333333333333333, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0
+    # zoom_levels must be an ascending list of hex sizes in pixels.
+    # hex sizes must be divisible by 4 to prevent graphical glitches.
+    # sizes are in draw space, so standard 1x zoom is always 72.
+    zoom_levels = 16, 24, 36, 52, 72, 100, 144, 216, 288
 
     flag_rgb=flag_green
     unit_rgb=magenta

--- a/data/game_config.cfg
+++ b/data/game_config.cfg
@@ -34,8 +34,11 @@
     xp_bar_scaling=0.5
 
     # zoom_levels must be an ascending list of hex sizes in pixels.
-    # hex sizes must be divisible by 4 to prevent graphical glitches.
-    # sizes are in draw space, so standard 1x zoom is always 72.
+    # Hex sizes must be divisible by 4 to prevent graphical glitches.
+    # 1x zoom is always 72, as defined by tile_size in game_config.cpp.
+    # Sizes are in draw-space, so will be scaled for high-dpi automatically.
+    # As given here these correspond as closely as possible to zoom factors of:
+    #   1/4, 1/3, 1/2, 1/sqrt(2), 1, sqrt(2), 2, 3, 4
     zoom_levels = 16, 24, 36, 52, 72, 100, 144, 216, 288
 
     flag_rgb=flag_green

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1917,6 +1917,12 @@ bool display::set_zoom(unsigned int amount, const bool validate_value_and_set_in
 		new_zoom = zoom_levels[zoom_index_];
 	}
 
+	if((new_zoom / 4) * 4 != new_zoom) {
+		WRN_DP << "set_zoom forcing zoom " << new_zoom
+			<< " which is not a multiple of 4."
+			<< " This will likely cause graphical glitches.";
+	}
+
 	const SDL_Rect& outside_area = map_outside_area();
 	const SDL_Rect& area = map_area();
 

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -274,7 +274,12 @@ void load_config(const config &v)
 	if(!zoom_levels_str.empty()) {
 		zoom_levels.clear();
 		std::transform(zoom_levels_str.begin(), zoom_levels_str.end(), std::back_inserter(zoom_levels), [](const std::string zoom) {
-			return static_cast<int>(std::stold(zoom) * tile_size);
+			int z = std::stoi(zoom);
+			if((z / 4) * 4 != z) {
+				ERR_NG << "zoom level " << z << " is not divisible by 4."
+					<< " This will cause graphical glitches!";
+			}
+			return z;
 		});
 	}
 


### PR DESCRIPTION
Zoom scales, which are described in draw-space pixels, were always required to be multiples of 4. This was violated at some point, resulting in graphical glitches when drawing fog at some zoom levels.

This both checks that zoom scales are divisible by four, and changes the zoom level specification to integers rather than multiplication factors so that they can be specified accurately.

This *also* fixes an auxiliary problem that the 1/3x zoom level specified as "0.33333333333333333" was incorrectly rounding to 23 in stead of 24, resulting in more graphical glitches.

This is related to #6959 but won't fix it entirely as that's a separate problem. The 1/3x zoom level is likely improved however.

These are the types of glitches fixed by this change. They are only obvious in fog, as that applies twice when hexes overlap:
![fog_glitches](https://github.com/wesnoth/wesnoth/assets/243646/b4b9e328-bfb4-44b4-8aca-dca0455413ba)
