### PR TITLE
Work around #7543 for 1.16

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -44,5 +44,11 @@
     "boost-ptr-container",
     "boost-spirit",
     "boost-test"
+  ],
+  "overrides": [
+    {
+      "name": "pango",
+      "version": "1.50.11"
+    }
   ]
 }


### PR DESCRIPTION
Works around #7543 for MSVC developers but does not resolve it as the official Wesnoth Windows builds do not use MSVC or vcpkg.

Only necessary for 1.16 because 1.17+ uses fontconfig.