### PR TITLE
Update title screen widget blur when resizing the game window

### DIFF
--- a/data/gui/window/title_screen.cfg
+++ b/data/gui/window/title_screen.cfg
@@ -94,6 +94,7 @@ where
 
 #define _GUI_TIP_SECTION
 	[panel]
+		id = "tip_panel"
 		definition = "box_display"
 
 		[grid]
@@ -247,6 +248,7 @@ where
 
 #define _GUI_MENU_SECTION
 	[panel]
+		id = "menu_panel"
 		definition = "box_display"
 
 		[grid]

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -483,6 +483,7 @@ void text_shape::draw(wfl::map_formula_callable& variables)
 canvas::canvas()
 	: shapes_()
 	, blur_depth_(0)
+	, blur_region_(sdl::empty_rect)
 	, deferred_(false)
 	, w_(0)
 	, h_(0)
@@ -494,6 +495,7 @@ canvas::canvas()
 canvas::canvas(canvas&& c) noexcept
 	: shapes_(std::move(c.shapes_))
 	, blur_depth_(c.blur_depth_)
+	, blur_region_(c.blur_region_)
 	, deferred_(c.deferred_)
 	, w_(c.w_)
 	, h_(c.h_)
@@ -510,6 +512,15 @@ bool canvas::update_blur(const rect& screen_region, bool force)
 		// No blurring needed.
 		return true;
 	}
+
+	if(screen_region != blur_region_) {
+		DBG_GUI_D << "blur region changed from " << blur_region_
+			<< " to " << screen_region;
+		// something has changed. regenerate the texture.
+		blur_texture_.reset();
+		blur_region_ = screen_region;
+	}
+
 	if(blur_texture_ && !force) {
 		// We already made the blur. It's expensive, so don't do it again.
 		return true;

--- a/src/gui/core/canvas.hpp
+++ b/src/gui/core/canvas.hpp
@@ -173,6 +173,9 @@ private:
 	/** Blurred background texture. */
 	texture blur_texture_;
 
+	/** The region of the screen we have blurred (if any). */
+	rect blur_region_;
+
 	/** Whether we have deferred rendering so we can capture for blur. */
 	bool deferred_;
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -315,8 +315,24 @@ void title_screen::init_callbacks()
 	//
 	// Preferences
 	//
-	register_button(*this, "preferences", hotkey::HOTKEY_PREFERENCES, []() {
+	register_button(*this, "preferences", hotkey::HOTKEY_PREFERENCES, [this]() {
 		gui2::dialogs::preferences_dialog::display();
+
+		// Currently blurred windows don't capture well if there is something
+		// on top of them at the time of blur. Resizing the game window in
+		// preferences will cause the title screen tip and menu panels to
+		// capture the prefs dialog in their blur. This workaround simply
+		// forces them to re-capture the blur after the dialog closes.
+		panel* tip_panel = find_widget<panel>(this, "tip_panel", false, false);
+		if(tip_panel != nullptr) {
+			tip_panel->get_canvas(tip_panel->get_state()).queue_reblur();
+			tip_panel->queue_redraw();
+		}
+		panel* menu_panel = find_widget<panel>(this, "menu_panel", false, false);
+		if(menu_panel != nullptr) {
+			menu_panel->get_canvas(menu_panel->get_state()).queue_reblur();
+			menu_panel->queue_redraw();
+		}
 	});
 
 	//


### PR DESCRIPTION
This adds a check to regenerate blur whenever the screen region of the blur changes. This should catch most cases of moved and resized widgets.

It also explicitly regenerates the title screen blurs when the prefs dialog is closed. Otherwise the regenerated blurs will include the prefs dialog that's sitting on top.

Fixes #8023 