### PR TITLE
EI - Sentinel Shield Bugfix

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -417,7 +417,7 @@ sentinel #enddef
     # block all damage
     [modify_unit]
         [filter]
-            id=${ATTACKER}
+            id=${ATTACKER}.id
         [/filter]
 
         [object]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -471,7 +471,7 @@ sentinel #enddef
             {VARIABLE_OP drain_amount divide 2}
             [heal_unit]
                 [filter]
-                    id=${ATTACKER}
+                    id=${ATTACKER}.id
                 [/filter]
 
                 amount=$drain_amount
@@ -484,7 +484,7 @@ sentinel #enddef
             {VARIABLE_OP drain_amount divide 1}
             [heal_unit]
                 [filter]
-                    id=${ATTACKER}
+                    id=${ATTACKER}.id
                 [/filter]
 
                 amount=$drain_amount


### PR DESCRIPTION
During the transition from add-on to mainline, EI's Sentinel Shield item's behavior got broken. This fixes it.