### PR TITLE
[🗺️ World Conquest⚔️] Renamed the Difficulty Levels to reflect their true Difficulties 

### DIFF
--- a/changelog_entries/world_conquest_difficulty_rename.md
+++ b/changelog_entries/world_conquest_difficulty_rename.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * World Conquest
+     * Renamed the difficulty levels to better reflect their true difficulty.

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -102,12 +102,12 @@ _ "World Conquest 4p" #enddef
         image = {IMAGE_ONE}
         type = mp
         abbrev = _ "WC" + {PLAYERS}\
-        {WC2_CAMPAIGN_DIFFICULTY VERY_EASY {WC2_HUMAN_DIFFICULTY human-peasants/peasant purple} _"Peasant" _"Beginner" 6 2 2 10 yes 0}
-        {WC2_CAMPAIGN_DIFFICULTY EASY {WC2_HUMAN_DIFFICULTY human-loyalists/sergeant black} _"Sergeant" _"Easy" 7 3 2 7 yes 5}
-        {WC2_CAMPAIGN_DIFFICULTY NORMAL {WC2_HUMAN_DIFFICULTY human-loyalists/lieutenant brown} _"Lieutenant" _"Medium" 8 4 2 5 yes 10} {DEFAULT_DIFFICULTY}
-        {WC2_CAMPAIGN_DIFFICULTY HARD {WC2_HUMAN_DIFFICULTY human-loyalists/general orange} _"General" _"Hard" 8 5 2 2 no 13}
-        {WC2_CAMPAIGN_DIFFICULTY VERY_HARD {WC2_HUMAN_DIFFICULTY human-loyalists/marshal white} _"Grand Marshal" _"Challenging" 9 6 2 1 no 17}
-        {WC2_CAMPAIGN_DIFFICULTY NIGHTMARE {WC2_NIGHTMARE_DIFFICULTY} _"Nightmare" _"Expert" 9 7 1 0 no 20}
+        {WC2_CAMPAIGN_DIFFICULTY VERY_EASY {WC2_HUMAN_DIFFICULTY human-peasants/peasant purple} _"Peasant" _"Normal" 6 2 2 10 yes 0}
+        {WC2_CAMPAIGN_DIFFICULTY EASY {WC2_HUMAN_DIFFICULTY human-loyalists/sergeant black} _"Sergeant" _"Challenging" 7 3 2 7 yes 5}
+        {WC2_CAMPAIGN_DIFFICULTY NORMAL {WC2_HUMAN_DIFFICULTY human-loyalists/lieutenant brown} _"Lieutenant" _"Difficult" 8 4 2 5 yes 10} {DEFAULT_DIFFICULTY}
+        {WC2_CAMPAIGN_DIFFICULTY HARD {WC2_HUMAN_DIFFICULTY human-loyalists/general orange} _"General" _"Fanatical" 8 5 2 2 no 13}
+        {WC2_CAMPAIGN_DIFFICULTY VERY_HARD {WC2_HUMAN_DIFFICULTY human-loyalists/marshal white} _"Grand Marshal" _"Torment" 9 6 2 1 no 17}
+        {WC2_CAMPAIGN_DIFFICULTY NIGHTMARE {WC2_NIGHTMARE_DIFFICULTY} _"Nightmare" _"Nightmare" 9 7 1 0 no 20}
 
         [about]
             title = _ "Campaign Design"


### PR DESCRIPTION
resolves #7661

Implements @knyghtmare 's latest suggestion from issue #7661

Field | 1 | 2 | 3 | 4 | 5 | 6
-- | -- | -- | -- | -- | -- | --
Old Name | Beginner | Easy | Medium | Hard | Challenging | Expert
New Implemented Name | Normal | Challenging | Difficult | Fanatical | Torment | Nightmare
Unit Image | Peasant | Sergeant | Lieutenant | General | Marshal | Dragon
