### PR TITLE
Help Browser: only show one image if male and female are the same

### DIFF
--- a/changelog_entries/help_duplicate_images.md
+++ b/changelog_entries/help_duplicate_images.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * The help browser, when looking at a unit type which uses the same image for male and female units, now only shows one image instead of showing a duplicate.

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -302,8 +302,7 @@ std::string unit_topic_generator::operator()() const {
 	if (screen_width >= 1200) ss << "~XBRZ(2)";
 	ss << "' box='no'</img> ";
 
-
-	if (&female_type != &male_type) {
+	if (female_type.image() != male_type.image()) {
 		ss << "<img>src='" << female_type.image();
 		ss << "~RC(" << female_type.flag_rgb() << ">red)";
 		if (screen_width >= 1200) ss << "~XBRZ(2)";


### PR DESCRIPTION
If a unit type has male and female versions, then two images of the unit are displayed at the top-left of the help page. However, it did this even if the two images were the same, which made the duplication look like a bug.

The Naga Fighter is one of the affected unit types.

This was reported in the [WoF discussion about female drakes](https://r.wesnoth.org/p684546), and I was in the middle of logging a "good first issue" bug when I realised it was just a one-liner.

Screenshot **without** the fix:
![image](https://github.com/wesnoth/wesnoth/assets/101462/816f7fcf-712b-4519-b7d1-3bb9f67805ef)