### PR TITLE
New unit test for UtBS-style [heals] with a filter

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal.cfg
@@ -31,17 +31,10 @@
         variable=healer2
         kill=no
     [/store_unit]
-    [if]
-        [not]
-            {VARIABLE_CONDITIONAL leader1.hitpoints numerical_equals {leader1}}
-            {VARIABLE_CONDITIONAL leader2.hitpoints numerical_equals {leader2}}
-            {VARIABLE_CONDITIONAL healer1.hitpoints numerical_equals {healer1}}
-            {VARIABLE_CONDITIONAL healer2.hitpoints numerical_equals {healer2}}
-        [/not]
-        [then]
-            {FAIL}
-        [/then]
-    [/if]
+    {ASSERT {VARIABLE_CONDITIONAL leader1.hitpoints numerical_equals {leader1}}}
+    {ASSERT {VARIABLE_CONDITIONAL leader2.hitpoints numerical_equals {leader2}}}
+    {ASSERT {VARIABLE_CONDITIONAL healer1.hitpoints numerical_equals {healer1}}}
+    {ASSERT {VARIABLE_CONDITIONAL healer2.hitpoints numerical_equals {healer2}}}
 #enddef
 
 #####
@@ -162,3 +155,5 @@
         {SUCCEED}
     [/event]
 )}
+
+#undef EXPECT_HITPOINTS

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_with_filter.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_with_filter.cfg
@@ -1,0 +1,152 @@
+#textdomain wesnoth-test
+
+#define EXPECT_HITPOINTS a b c d
+    [store_unit]
+        [filter]
+            id=alice
+        [/filter]
+        variable=a
+        kill=no
+    [/store_unit]
+    [store_unit]
+        [filter]
+            id=bob
+        [/filter]
+        variable=b
+        kill=no
+    [/store_unit]
+    [store_unit]
+        [filter]
+            id=charlie
+        [/filter]
+        variable=c
+        kill=no
+    [/store_unit]
+    [store_unit]
+        [filter]
+            id=dave
+        [/filter]
+        variable=d
+        kill=no
+    [/store_unit]
+    {ASSERT {VARIABLE_CONDITIONAL a.hitpoints numerical_equals {a}}}
+    {ASSERT {VARIABLE_CONDITIONAL b.hitpoints numerical_equals {b}}}
+    {ASSERT {VARIABLE_CONDITIONAL c.hitpoints numerical_equals {c}}}
+    {ASSERT {VARIABLE_CONDITIONAL d.hitpoints numerical_equals {d}}}
+#enddef
+
+#####
+# API(s) being tested: [heals][affect_adjacent][filter]
+##
+# Actions:
+# Give Bob a healing ability with a filter.
+# Spawn two units next to Bob.
+# Give one of those units a no-healing debuff, corresponding to the healing filter.
+# Set all four units to 1 current hp and 999 max hp.
+# End turn and let healing be done.
+##
+# Expected end state:
+# Healing from the ability as well as rest healing are applied correctly.
+#####
+{GENERIC_UNIT_TEST "heal_with_filter" (
+    [event]
+        name = start
+
+        # Give Bob a copy of UTBS_ABILITY_HEALS
+        [object]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [heals]
+                        value=4
+                        id=healing
+                        affect_allies=yes
+                        name= _ "heals +4"
+                        description=  _ "Copy of UtBS’s ability, which interacts with a dehydration debuff."
+                        affect_self=no
+                        poison=slowed
+                        [affect_adjacent]
+                            [filter]
+                                [not]
+                                    status=dehydration_slowed_by_healer
+                                [/not]
+                            [/filter]
+                        [/affect_adjacent]
+                    [/heals]
+                [/abilities]
+            [/effect]
+        [/object]
+
+        # Create a unit adjacent to Bob
+        [unit]
+            location_id=2
+            type=Orcish Grunt
+            side=2
+            id=charlie
+            name=_"Charlie"
+        [/unit]
+
+        # Create another unit adjacent to Bob, but this one's wandering the desert of UtBS S02.
+        # The status is the equivalent of UtBS' APPLY_HYDRATION_EFFECT, when stood next to a healer.
+        [unit]
+            location_id=2
+            type=Orcish Grunt
+            side=2
+            id=dave
+            name=_"Dave"
+        [/unit]
+        [modify_unit]
+            [filter]
+                id=dave
+            [/filter]
+            [status]
+                dehydration_slowed_by_healer=yes
+            [/status]
+        [/modify_unit]
+
+        # Ensure we can heal as much as we may need to
+        [modify_unit]
+            [filter][/filter]
+            hitpoints=1
+            max_hitpoints=999
+        [/modify_unit]
+    [/event]
+
+    # Baseline: as defined in the scenario
+    [event]
+        name=side 1 turn 1 refresh
+        {EXPECT_HITPOINTS  1  1  1  1}
+        [end_turn][/end_turn]
+    [/event]
+
+    # side 2 gets healing but no rest healing
+    [event]
+        name=side 2 turn 1 refresh
+        {EXPECT_HITPOINTS  1  1  5  1}
+        [end_turn][/end_turn]
+    [/event]
+
+    # side 1 has no healers, but gets rest healing
+    [event]
+        name=side 1 turn 2 refresh
+        {EXPECT_HITPOINTS  3  1  5  1}
+        [end_turn][/end_turn]
+    [/event]
+
+    # side 2 gets healing and rest healing
+    [event]
+        name=side 2 turn 2 refresh
+        {EXPECT_HITPOINTS  3  3  11  3}
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=turn 3
+        {SUCCEED}
+    [/event]
+)}
+
+#undef EXPECT_HITPOINTS

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -465,6 +465,7 @@
 0 kill_fires_events
 # Game mechanics
 0 heal
+0 heal_with_filter
 0 zero_experience
 0 unit_no_advancements
 0 no_sides


### PR DESCRIPTION
The ability's code in UtBS hasn't changed since 1.16, but there's now bug #8037 about healing sometimes not working in UtBS S02. The new test was written to check for an engine bug when a healer has two units next to it, only one of which passes the filter. Although the test is passing, it seems reasonable to keep the test.

Also, use `{ASSERT ...}` for better logging in the old healing test.