### PR TITLE
Show an error when mainline campaigns are missing.

### DIFF
--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -360,7 +360,9 @@ void campaign_selection::pre_show(window& window)
 		widget_data data;
 		widget_item item;
 
-		item["label"] = _("Most mainline campaigns are missing. If you’re on Linux, then this most likely means the incorrect package was installed. To get the rest of the campaigns you will need to either: correctly install the wesnoth metapackage, install each campaign’s package one by one, or install Wesnoth via Steam or Flatpak.");
+		// TRANSLATORS: "more than 15" gives a little leeway to add or remove one without changing the translatable text.
+		// It's already ambiguous, 1.18 has 19 campaigns, if you include the tutorial and multiplayer-only World Conquest.
+		item["label"] = _("Wesnoth normally includes more than 15 mainline campaigns, even before installing any from the add-ons server. If you’ve installed the game via a package manager, there’s probably a separate package to install the complete game data.");
 		data.emplace("description", item);
 
 		pages.add_page(data);

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -57,6 +57,12 @@ void campaign_selection::campaign_selected()
 	if(!tree.selected_item()->id().empty()) {
 		auto iter = std::find(page_ids_.begin(), page_ids_.end(), tree.selected_item()->id());
 
+		if(tree.selected_item()->id() == missing_campaign_) {
+			find_widget<button>(this, "ok", false).set_active(false);
+		} else {
+			find_widget<button>(this, "ok", false).set_active(true);
+		}
+
 		const int choice = std::distance(page_ids_.begin(), iter);
 		if(iter == page_ids_.end()) {
 			return;
@@ -347,7 +353,7 @@ void campaign_selection::pre_show(window& window)
 		missing["icon"] = "units/unknown-unit.png";
 		missing["name"] = _("Missing Campaigns");
 		missing["completed"] = false;
-		missing["id"] = "missing-campaign";
+		missing["id"] = missing_campaign_;
 
 		add_campaign_to_tree(missing);
 
@@ -358,7 +364,7 @@ void campaign_selection::pre_show(window& window)
 		data.emplace("description", item);
 
 		pages.add_page(data);
-		page_ids_.push_back("missing-campaign");
+		page_ids_.push_back(missing_campaign_);
 	}
 
 	//

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -17,9 +17,10 @@
 
 #include "gui/dialogs/campaign_selection.hpp"
 
+#include "filesystem.hpp"
 #include "font/text_formatting.hpp"
-#include "gui/dialogs/campaign_difficulty.hpp"
 #include "gui/auxiliary/find_widget.hpp"
+#include "gui/dialogs/campaign_difficulty.hpp"
 #include "gui/widgets/button.hpp"
 #include "gui/widgets/image.hpp"
 #include "gui/widgets/listbox.hpp"
@@ -337,6 +338,27 @@ void campaign_selection::pre_show(window& window)
 
 		pages.add_page(data);
 		page_ids_.push_back(campaign["id"]);
+	}
+
+	std::vector<std::string> dirs;
+	filesystem::get_files_in_dir(game_config::path + "/data/campaigns", nullptr, &dirs);
+	if(dirs.size() <= 1) {
+		config missing;
+		missing["icon"] = "units/unknown-unit.png";
+		missing["name"] = _("Missing Campaigns");
+		missing["completed"] = false;
+		missing["id"] = "missing-campaign";
+
+		add_campaign_to_tree(missing);
+
+		widget_data data;
+		widget_item item;
+
+		item["label"] = _("Most mainline campaigns are missing. If you’re on Linux, then this most likely means the incorrect package was installed. To get the rest of the campaigns you will need to either: correctly install the wesnoth metapackage, install each campaign’s package one by one, or install Wesnoth via Steam or Flatpak.");
+		data.emplace("description", item);
+
+		pages.add_page(data);
+		page_ids_.push_back("missing-campaign");
 	}
 
 	//

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -131,6 +131,8 @@ private:
 	bool currently_sorted_asc_;
 
 	std::vector<std::string> last_search_words_;
+
+	inline const static std::string missing_campaign_ = "missing-campaign";
 };
 
 } // namespace dialogs

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -132,7 +132,7 @@ private:
 
 	std::vector<std::string> last_search_words_;
 
-	inline const static std::string missing_campaign_ = "missing-campaign";
+	inline const static std::string missing_campaign_ = "////missing-campaign////";
 };
 
 } // namespace dialogs


### PR DESCRIPTION
A Linux packaging issue has, for apparently multiple years now, resulted in Wesnoth getting installed with only the tutorial campaign available. So, check for that and alert the player that there's an issue so they don't think Wesnoth actually only has a tutorial available.

Fixes #7875