### PR TITLE
Update SDL render hints

### DIFF
--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -40,11 +40,17 @@ window::window(const std::string& title,
 		throw exception("Failed to create a SDL_Window object.", true);
 	}
 
-	if(sdl::runtime_at_least(2,0,10)) {
-		// Rendering in batches (for efficiency) is enabled by default from SDL 2.0.10
-		// The way Wesnoth uses SDL as of September 2019 does not work well with this rendering mode (eg story-only scenarios)
-		SDL_SetHint(SDL_HINT_RENDER_BATCHING, "0");
-	}
+#ifdef _WIN32
+	// SDL uses Direct3D v9 by default on Windows systems. However, returning
+	// from the Windows lock screen causes issues with rendering. Resolution
+	// is either to rebuild render textures on the SDL_RENDER_TARGETS_RESET
+	// event or use an alternative renderer that does not have this issue.
+	// Suitable options are Direct3D v11+ or OpenGL.
+	// See https://github.com/wesnoth/wesnoth/issues/8038 for details.
+	// Note that SDL_HINT_RENDER_DRIVER implies SDL_HINT_RENDER_BATCHING is
+	// disabled, according to https://discourse.libsdl.org/t/a-couple-of-questions-regarding-batching-in-sdl-2-0-10/26453/2.
+	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "direct3d11");
+#endif
 
 	if(!SDL_CreateRenderer(window_, -1, render_flags)) {
 		throw exception("Failed to create a SDL_Renderer object.", true);


### PR DESCRIPTION
Resolves #8038 by requesting Direct3D v11 over the default Direct3D v9 on Windows platforms.

According to https://discourse.libsdl.org/t/a-couple-of-questions-regarding-batching-in-sdl-2-0-10/26453/2, `SDL_HINT_RENDER_DRIVER` implies `SDL_HINT_RENDER_BATCHING=0`. I tested `SDL_HINT_RENDER_BATCHING=1` on Windows and Linux and was not able to replicate #4237 nor #4245 (I was never able to replicate the related #4309). Given the rendering work I think disabling batched renders is no longer necessary.

I suppose we could force `SDL_HINT_RENDER_BATCHING=1` on Windows as well just for consistency but Wesnoth isn't exactly a demanding application in terms of rendering. If someone with sufficiently low-end hardware can demonstrate a significant difference between batched and non-batched renders, then we can consider enforcing it for Windows too.