### PR TITLE
verify what ''add'' 'sub' etc.. modify value by default in filter_ability checks 'value'(postpone1.19)

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1421,6 +1421,27 @@ void unit::remove_ability_by_id(const std::string& ability)
 	}
 }
 
+ /**
+ * Returns true if any of "add", "sub", "multiply" or "divide" are present and have a value
+ * other than their respective no-op value.
+ */
+static bool has_value_changing_modifier(const config& cfg)
+{
+	if(cfg.has_attribute("add") && cfg["add"].to_int(0) != 0){
+		return true;
+	}
+	if(cfg.has_attribute("sub") && cfg["sub"].to_int(0) != 0){
+		return true;
+	}
+	if(cfg.has_attribute("multiply") && cfg["multiply"].to_double(1) != 1){
+		return true;
+	}
+	if(cfg.has_attribute("divide") && cfg["divide"].to_double(1) != 1){
+		return true;
+	}
+	return false;
+}
+
 static bool matches_ability_filter(const config & cfg, const std::string& tag_name, const config & filter)
 {
 	using namespace utils::config_filters;
@@ -1472,8 +1493,7 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 		return false;
 
 	if(!filter["value"].empty()){
-		bool has_other_key = (!cfg["add"].empty() || !cfg["sub"].empty() || !cfg["multiply"].empty() || !cfg["divide"].empty());
-		if(!has_other_key){
+		if(!has_value_changing_modifier(cfg)){
 			if(tag_name == "drains"){
 				if(!int_matches_if_present(filter, cfg, "value", 50)){
 					return false;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1493,7 +1493,12 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 		return false;
 
 	if(!filter["value"].empty()){
-		if(!has_value_changing_modifier(cfg)){
+		if(has_value_changing_modifier(cfg)){
+			//if true, then default value modified, and can't be checked.
+			if(!int_matches_if_present(filter, cfg, "value")){
+				return false;
+			}
+		} else {
 			if(tag_name == "drains"){
 				if(!int_matches_if_present(filter, cfg, "value", 50)){
 					return false;
@@ -1506,10 +1511,11 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 				if(!int_matches_if_present(filter, cfg, "value" , 0)){
 					return false;
 				}
-			}
-		} else {
-			if(!int_matches_if_present(filter, cfg, "value")){
-				return false;
+				//if other tags, then ability can't have default value
+			} else {
+				if(!int_matches_if_present(filter, cfg, "value")){
+					return false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
As @soliton- in https://github.com/wesnoth/wesnoth/issues/7992#issuecomment-1795270245 noticed the presence of 'add' 'sub' etc.. is not enough to determine if the default value of an ability is changed (add=0, multiply=1); hence this repair to refine it to ensure the value is not changed.