### PR TITLE
Solution to #7768 (No Label removing for other players in multiplayer)

### DIFF
--- a/src/map/label.cpp
+++ b/src/map/label.cpp
@@ -223,6 +223,21 @@ void map_labels::clear(const std::string& team_name, bool force)
 	categories_dirty = true;
 }
 
+void map_labels::clear_label(const terrain_label* label)
+{
+	if (label == nullptr)
+	{
+		return;
+	}
+	team_label_map::iterator i = labels_.find(label->team_name());
+
+	label_map& p = i->second;
+
+	p.erase(label->location());
+
+
+}
+
 void map_labels::clear_map(label_map& m, bool force)
 {
 	label_map::iterator i = m.begin();

--- a/src/map/label.hpp
+++ b/src/map/label.hpp
@@ -71,6 +71,7 @@ public:
 	void enable(bool is_enabled);
 
 	void clear(const std::string&, bool force);
+	void clear_label(const terrain_label* label);
 
 	void recalculate_labels();
 	void recalculate_shroud();
@@ -89,6 +90,7 @@ private:
 	terrain_label* add_label(T&&... args);
 
 	void clear_map(label_map&, bool);
+
 
 	terrain_label* get_label_private(const map_location& loc, const std::string& team_name);
 	// Note: this is not an overload of get_label() so that we do not block

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -840,11 +840,6 @@ void menu_handler::label_terrain(mouse_handler& mousehandler, bool team_only)
 	}
 }
 
-void menu_handler::clear_label()
-{
-	// TODO: Implement
-}
-
 void menu_handler::clear_labels()
 {
 	if(gui_->team_valid() && !board().is_observer()) {

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -833,7 +833,16 @@ void menu_handler::label_terrain(mouse_handler& mousehandler, bool team_only)
 		if(res) {
 			resources::recorder->add_label(res);
 		}
+		else
+		{
+			resources::recorder->clear_label(loc.x, loc.y);
+		}
 	}
+}
+
+void menu_handler::clear_label()
+{
+
 }
 
 void menu_handler::clear_labels()

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -842,7 +842,7 @@ void menu_handler::label_terrain(mouse_handler& mousehandler, bool team_only)
 
 void menu_handler::clear_label()
 {
-
+	// TODO: Implement
 }
 
 void menu_handler::clear_labels()

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -83,8 +83,6 @@ public:
 	void change_side(mouse_handler& mousehandler);
 	void kill_unit(mouse_handler& mousehandler);
 	void label_terrain(mouse_handler& mousehandler, bool team_only);
-	// clear_label is NYI
-	void clear_label();
 	void clear_labels();
 	void label_settings();
 	void continue_move(mouse_handler& mousehandler, int side_num);

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -83,6 +83,7 @@ public:
 	void change_side(mouse_handler& mousehandler);
 	void kill_unit(mouse_handler& mousehandler);
 	void label_terrain(mouse_handler& mousehandler, bool team_only);
+	// clear_label is NYI
 	void clear_label();
 	void clear_labels();
 	void label_settings();

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -83,6 +83,7 @@ public:
 	void change_side(mouse_handler& mousehandler);
 	void kill_unit(mouse_handler& mousehandler);
 	void label_terrain(mouse_handler& mousehandler, bool team_only);
+	void clear_label();
 	void clear_labels();
 	void label_settings();
 	void continue_move(mouse_handler& mousehandler, int side_num);

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -281,6 +281,17 @@ void replay::add_label(const terrain_label* label)
 	cmd.add_child("label",val);
 }
 
+void replay::clear_label(int x, int y)
+{
+	config& cmd = add_nonundoable_command();
+	config val;
+
+	val["x"] = x;
+	val["y"] = y;
+
+	cmd.add_child("clear_label", std::move(val));
+}
+
 void replay::clear_labels(const std::string& team_name, bool force)
 {
 	config& cmd = add_nonundoable_command();
@@ -763,6 +774,16 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 						label.creator(),
 						label.team_name(),
 						label.color());
+		} 
+		else if(auto clear_label = cfg->optional_child("clear_label")) 
+		{
+			
+			int x = stoi(std::string(clear_label["x"]));
+			int y = stoi(std::string(clear_label["y"]));
+			map_location loc(x, y);
+			const terrain_label* label = display::get_singleton()->labels().get_label(loc);
+			display::get_singleton()->labels().clear_label(label);
+
 		}
 		else if (auto clear_labels = cfg->optional_child("clear_labels"))
 		{

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -774,7 +774,7 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 						label.team_name(),
 						label.color());
 		}
-		else if(auto clear_label = cfg->optional_child("clear_label")) 
+		else if(auto clear_label = cfg->optional_child("clear_label"))
 		{
 			int x = stoi(std::string(clear_label["x"]));
 			int y = stoi(std::string(clear_label["y"]));

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -285,7 +285,6 @@ void replay::clear_label(int x, int y)
 {
 	config& cmd = add_nonundoable_command();
 	config val;
-
 	val["x"] = x;
 	val["y"] = y;
 

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -773,16 +773,14 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 						label.creator(),
 						label.team_name(),
 						label.color());
-		} 
+		}
 		else if(auto clear_label = cfg->optional_child("clear_label")) 
 		{
-			
 			int x = stoi(std::string(clear_label["x"]));
 			int y = stoi(std::string(clear_label["y"]));
 			map_location loc(x, y);
 			const terrain_label* label = display::get_singleton()->labels().get_label(loc);
 			display::get_singleton()->labels().clear_label(label);
-
 		}
 		else if (auto clear_labels = cfg->optional_child("clear_labels"))
 		{

--- a/src/replay.hpp
+++ b/src/replay.hpp
@@ -72,6 +72,7 @@ public:
 	*/
 	void user_input(const std::string &name, const config &input, int from_side);
 	void add_label(const terrain_label*);
+	//@param x and y used to create a map loc reference, (i.e a tile) and refer to the label found there
 	void clear_label(int x, int y);
 	void clear_labels(const std::string&, bool);
 	void add_rename(const std::string& name, const map_location& loc);

--- a/src/replay.hpp
+++ b/src/replay.hpp
@@ -72,6 +72,7 @@ public:
 	*/
 	void user_input(const std::string &name, const config &input, int from_side);
 	void add_label(const terrain_label*);
+	void clear_label(int x, int y);
 	void clear_labels(const std::string&, bool);
 	void add_rename(const std::string& name, const map_location& loc);
 	void end_turn(int next_player_number);

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -942,7 +942,8 @@ bool game::is_legal_command(const simple_wml::node& command, player_iterator use
 	}
 
 	if((is_player || is_host) && (
-		command.child("label") ||
+		command.child("label") || 
+		command.child("clear_label") ||
 		command.child("clear_labels") ||
 		command.child("rename") ||
 		command.child("countdown_update")

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -942,7 +942,7 @@ bool game::is_legal_command(const simple_wml::node& command, player_iterator use
 	}
 
 	if((is_player || is_host) && (
-		command.child("label") || 
+		command.child("label") ||
 		command.child("clear_label") ||
 		command.child("clear_labels") ||
 		command.child("rename") ||


### PR DESCRIPTION
In issue #7768 we see an issue where if you delete a label by emptying its contents, it is deleted for you, but not other players in multiplayer. I attempted to remedy this issue this way:

I first examined the issue and discovered that the game currently has no way of deleting a single label - which, can be considered a separate issue per se. I resolved to then try to kill two birds with one stone - but first only resolving the first issue, and starting to carve the path for the second (An option to simply remove a single label)

First, I learned how the game maintains these things - a config file is created and maintained by the multiplayer server being run, and can accept commands to manipulate the file for the scenario maintaining the labels for everyone. 

I started first with labels themselves - their own ability to delete and find labels innately. 

I then looked at the recorder - the thing responsible for recording things that happen in the game, and told it how to record and send the command to the server, and implemented it into menu events

I taught the server to recognize "clear_label" (a single label) as a command. 

I tested this by running the boost test suite, and I used two computers with a locally built server, created labels, modified them without deletion to test whether or not that still works, cleared all labels to test whether or not that still works, and I emptied labels to see if the other player would still see it, and voila, the other player no longer sees the other label. 

Please feel free to ask any questions, comments, or if I need to change anything else, also feel free to let me know. If you folks would like a video of the aforementioned test, I can do it when I get home today from work. Thank you. 

