### PR TITLE
 remove checking for the presence of add, sub etc. attributes when check value.

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1472,20 +1472,17 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 		return false;
 
 	if(!filter["value"].empty()){
-		bool has_other_key = (!cfg["add"].empty() || !cfg["sub"].empty() || !cfg["multiply"].empty() || !cfg["divide"].empty());
-		if(!has_other_key){
-			if(tag_name == "drains"){
-				if(!int_matches_if_present(filter, cfg, "value", 50)){
-					return false;
-				}
-			} else if(tag_name == "berserk"){
-				if(!int_matches_if_present(filter, cfg, "value", 1)){
-					return false;
-				}
-			} else if(tag_name == "heal_on_hit" || tag_name == "heals" || tag_name == "regenerate" || tag_name == "leadership"){
-				if(!int_matches_if_present(filter, cfg, "value" , 0)){
-					return false;
-				}
+		if(tag_name == "drains"){
+			if(!int_matches_if_present(filter, cfg, "value", 50)){
+				return false;
+			}
+		} else if(tag_name == "berserk"){
+			if(!int_matches_if_present(filter, cfg, "value", 1)){
+				return false;
+			}
+		} else if(tag_name == "heal_on_hit" || tag_name == "heals" || tag_name == "regenerate" || tag_name == "leadership"){
+			if(!int_matches_if_present(filter, cfg, "value" , 0)){
+				return false;
 			}
 		} else {
 			if(!int_matches_if_present(filter, cfg, "value")){


### PR DESCRIPTION
For me (and this is not the opinion of @soliton-) when we check the value of the value attribute,
 we seek to verify that the value encoded in ability (or possibly the default) corresponds,
 the value by default means that the value attribute is encoded with this default value, that's it.
 Apparently @soliton- understood that it was the returned value that was checked and
 I let myself get into this error which I am now correcting.

currently absence of default value is only detected when other numeric attributes are used, this commit is here to repair this rather unfortunate oversight.