### PR TITLE
reverse change to filter_ability ->experimental_filter_ability

### DIFF
--- a/changelog_entries/filter_ability_experimental.md
+++ b/changelog_entries/filter_ability_experimental.md
@@ -1,0 +1,2 @@
+ ### WML Engine
+   * [filter_ability(_active)] and [filter_specials] are experimental.

--- a/data/schema/filters/unit.cfg
+++ b/data/schema/filters/unit.cfg
@@ -47,8 +47,8 @@
 	{FILTER_TAG "filter_adjacent" adjacent ()}
 	{FILTER_TAG "filter_location" location ()}
 	{FILTER_TAG "filter_side" side ()}
-	{FILTER_TAG "experimental_filter_ability" abilities ()}
-	{FILTER_TAG "experimental_filter_ability_active" abilities ()}
+	{FILTER_TAG "filter_ability" abilities ()}
+	{FILTER_TAG "filter_ability_active" abilities ()}
 	{FILTER_BOOLEAN_OPS unit}
 [/tag]
 

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -146,7 +146,7 @@
 			[case]
 				value=remove_ability
 				{LINK_TAG "units/unit_type/abilities"}
-				{FILTER_TAG "experimental_filter_ability" abilities ()}
+				{FILTER_TAG "filter_ability" abilities ()}
 			[/case]
 			[case]
 				value=new_animation

--- a/data/test/scenarios/wml_tests/ScenarioWML/EffectWML/test_remove_ability_by_filter.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EffectWML/test_remove_ability_by_filter.cfg
@@ -1,5 +1,5 @@
 #####
-# API(s) being tested: [effect]apply_to=remove_ability[experimental_filter_ability]
+# API(s) being tested: [effect]apply_to=remove_ability[filter_ability]
 ##
 # Actions:
 # Two [chance_to_hit] abilities are added, setting the chance to 0 and 100 respectively.
@@ -64,10 +64,10 @@
             silent=yes
             [effect]
                 apply_to=remove_ability
-                [experimental_filter_ability]
+                [filter_ability]
                     id=test_cth
                     tag_name=chance_to_hit
-                [/experimental_filter_ability]
+                [/filter_ability]
             [/effect]
         [/object]
         [object]
@@ -77,10 +77,10 @@
             silent=yes
             [effect]
                 apply_to=remove_ability
-                [experimental_filter_ability]
+                [filter_ability]
                     id=test_cth
                     tag_name=chance_to_hit
-                [/experimental_filter_ability]
+                [/filter_ability]
             [/effect]
         [/object]
         [store_unit]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -83,7 +83,7 @@
 #enddef
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability]
+# API(s) being tested: [event][filter][filter_ability]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -99,10 +99,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=25
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
@@ -120,10 +120,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=10-30
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
@@ -135,7 +135,7 @@
     [/event]
 )}
 
-# API(s) being tested: [event][filter][experimental_filter_ability]
+# API(s) being tested: [event][filter][filter_ability]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -151,10 +151,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=-25--10
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
@@ -167,7 +167,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability]
+# API(s) being tested: [event][filter][filter_ability]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -183,10 +183,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=45
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {FAIL}
     [/event]
@@ -197,7 +197,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability]
+# API(s) being tested: [event][filter][filter_ability]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -213,10 +213,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=-45-10
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {FAIL}
     [/event]
@@ -227,7 +227,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability_active]
+# API(s) being tested: [event][filter][filter_ability_active]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -243,10 +243,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability_active]
+            [filter_ability_active]
                 tag_name=drains
                 value=25
-            [/experimental_filter_ability_active]
+            [/filter_ability_active]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
@@ -259,7 +259,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability_active]
+# API(s) being tested: [event][filter][filter_ability_active]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -292,10 +292,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability_active]
+            [filter_ability_active]
                 tag_name=drains
                 value=25
-            [/experimental_filter_ability_active]
+            [/filter_ability_active]
         [/filter]
         {FAIL}
     [/event]
@@ -383,7 +383,7 @@
 #enddef
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability]
+# API(s) being tested: [event][filter][filter_ability]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST_WITHOUT_VALUE.
@@ -399,10 +399,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=50
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {VARIABLE_OP triggers add 1}
@@ -414,7 +414,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability]
+# API(s) being tested: [event][filter][filter_ability]
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST_WITHOUT_VALUE.
@@ -430,10 +430,10 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability]
+            [filter_ability]
                 tag_name=drains
                 value=35
-            [/experimental_filter_ability]
+            [/filter_ability]
         [/filter]
         {FAIL}
     [/event]

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -806,7 +806,7 @@ void unit_filter_compound::fill(vconfig cfg)
 					return side_filter(c, args.fc).match(args.u.side());
 				});
 			}
-			else if (child.first == "experimental_filter_ability") {
+			else if (child.first == "filter_ability") {
 				create_child(child.second, [](const vconfig& c, const unit_filter_args& args) {
 					for(const config::any_child ab : args.u.abilities().all_children_range()) {
 						if(args.u.ability_matches_filter(ab.cfg, ab.key, c.get_parsed_config())) {
@@ -816,7 +816,7 @@ void unit_filter_compound::fill(vconfig cfg)
 					return false;
 				});
 			}
-			else if (child.first == "experimental_filter_ability_active") {
+			else if (child.first == "filter_ability_active") {
 				create_child(child.second, [](const vconfig& c, const unit_filter_args& args) {
 					if(!display::get_singleton()){
 						return false;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2255,7 +2255,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 				remove_ability_by_id(ab.cfg["id"]);
 			}
 		}
-		if(auto fab_effect = effect.optional_child("experimental_filter_ability")) {
+		if(auto fab_effect = effect.optional_child("filter_ability")) {
 			remove_ability_by_attribute(*fab_effect);
 		}
 	} else if(apply_to == "image_mod") {


### PR DESCRIPTION
By changing the names of filter_ability to experimental_filter_ability, I think I'm making a mistake. By doing this, we will force the authors who use these filters to change the names when we exit the "experimental" phase and I don't like that, it would be better to just indicate it in the changelog and the wiki.