### PR TITLE
Add female name strings for drake units

### DIFF
--- a/data/core/units/drakes/Arbiter.cfg
+++ b/data/core/units/drakes/Arbiter.cfg
@@ -169,4 +169,8 @@
             image="units/drakes/arbiter.png:100"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Arbiter"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Arbiter.cfg
+++ b/data/core/units/drakes/Arbiter.cfg
@@ -3,6 +3,7 @@
     id=Drake Arbiter
     name= _ "Drake Arbiter"
     race=drake
+    gender=male,female
     image="units/drakes/arbiter.png"
     hitpoints=63
     movement_type=drakefoot

--- a/data/core/units/drakes/Armageddon.cfg
+++ b/data/core/units/drakes/Armageddon.cfg
@@ -3,6 +3,7 @@
     id=Armageddon Drake
     name= _ "Armageddon Drake"
     race=drake
+    gender=male,female
     image="units/drakes/armageddon.png"
     profile="portraits/drakes/inferno.webp"
     hitpoints=98

--- a/data/core/units/drakes/Armageddon.cfg
+++ b/data/core/units/drakes/Armageddon.cfg
@@ -60,4 +60,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS claws.ogg {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Armageddon Drake"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Blademaster.cfg
+++ b/data/core/units/drakes/Blademaster.cfg
@@ -3,6 +3,7 @@
     id=Drake Blademaster
     name= _ "Drake Blademaster"
     race=drake
+    gender=male,female
     image="units/drakes/blademaster.png"
     profile="portraits/drakes/blademaster.webp"
     hitpoints=80

--- a/data/core/units/drakes/Blademaster.cfg
+++ b/data/core/units/drakes/Blademaster.cfg
@@ -56,4 +56,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Blademaster"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Burner.cfg
+++ b/data/core/units/drakes/Burner.cfg
@@ -62,4 +62,8 @@
             image="units/drakes/burner.png"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Burner"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Burner.cfg
+++ b/data/core/units/drakes/Burner.cfg
@@ -3,6 +3,7 @@
     id=Drake Burner
     name= _ "Drake Burner"
     race=drake
+    gender=male,female
     image="units/drakes/burner.png"
     profile="portraits/drakes/burner.webp"
     hitpoints=42

--- a/data/core/units/drakes/Clasher.cfg
+++ b/data/core/units/drakes/Clasher.cfg
@@ -3,6 +3,7 @@
     id=Drake Clasher
     name= _ "Drake Clasher"
     race=drake
+    gender=male,female
     image="units/drakes/clasher.png"
     hitpoints=43
     movement_type=drakefoot

--- a/data/core/units/drakes/Clasher.cfg
+++ b/data/core/units/drakes/Clasher.cfg
@@ -106,4 +106,8 @@ This is also the only caste that is allowed to break taboo and fight with spears
             image="units/drakes/clasher-blade.png:100"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Clasher"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Enforcer.cfg
+++ b/data/core/units/drakes/Enforcer.cfg
@@ -114,4 +114,8 @@
             image="units/drakes/enforcer-blade.png:100"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Enforcer"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Enforcer.cfg
+++ b/data/core/units/drakes/Enforcer.cfg
@@ -3,6 +3,7 @@
     id=Drake Enforcer
     name= _ "Drake Enforcer"
     race=drake
+    gender=male,female
     image="units/drakes/enforcer.png"
     #image_moving="units/drakes/enforcer-flying.png"
     hitpoints=85

--- a/data/core/units/drakes/Fighter.cfg
+++ b/data/core/units/drakes/Fighter.cfg
@@ -3,6 +3,7 @@
     id=Drake Fighter
     name= _ "Drake Fighter"
     race=drake
+    gender=male,female
     image="units/drakes/fighter.png"
     profile="portraits/drakes/fighter.webp"
     hitpoints=39

--- a/data/core/units/drakes/Fighter.cfg
+++ b/data/core/units/drakes/Fighter.cfg
@@ -59,4 +59,8 @@
             image="units/drakes/fighter.png"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Fighter"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Fire.cfg
+++ b/data/core/units/drakes/Fire.cfg
@@ -57,4 +57,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS claws.ogg {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Fire Drake"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Fire.cfg
+++ b/data/core/units/drakes/Fire.cfg
@@ -3,6 +3,7 @@
     id=Fire Drake
     name= _ "Fire Drake"
     race=drake
+    gender=male,female
     image="units/drakes/fire.png"
     profile="portraits/drakes/inferno.webp"
     hitpoints=63

--- a/data/core/units/drakes/Flameheart.cfg
+++ b/data/core/units/drakes/Flameheart.cfg
@@ -3,6 +3,7 @@
     id=Drake Flameheart
     name= _ "Drake Flameheart"
     race=drake
+    gender=male,female
     image="units/drakes/flameheart.png"
     profile="portraits/drakes/flameheart.webp"
     hitpoints=72

--- a/data/core/units/drakes/Flameheart.cfg
+++ b/data/core/units/drakes/Flameheart.cfg
@@ -61,4 +61,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS claws.ogg {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Flameheart"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Flare.cfg
+++ b/data/core/units/drakes/Flare.cfg
@@ -3,6 +3,7 @@
     id=Drake Flare
     name= _ "Drake Flare"
     race=drake
+    gender=male,female
     image="units/drakes/flare.png"
     profile="portraits/drakes/flameheart.webp"
     hitpoints=55

--- a/data/core/units/drakes/Flare.cfg
+++ b/data/core/units/drakes/Flare.cfg
@@ -60,4 +60,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS claws.ogg {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Flare"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Glider.cfg
+++ b/data/core/units/drakes/Glider.cfg
@@ -3,6 +3,7 @@
     id=Drake Glider
     name= _ "Drake Glider"
     race=drake
+    gender=male,female
     image="units/drakes/glider.png"
     profile="portraits/drakes/glider.webp"
     hitpoints=32

--- a/data/core/units/drakes/Glider.cfg
+++ b/data/core/units/drakes/Glider.cfg
@@ -61,4 +61,8 @@ Most often, Gliders hunt larger game like deer, swine, or dolphins; the drakesâ€
         [/frame]
         {SOUND:HIT_AND_MISS club.ogg {SOUND_LIST:MISS} -200}
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Glider"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Hurricane.cfg
+++ b/data/core/units/drakes/Hurricane.cfg
@@ -96,4 +96,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS club.ogg {SOUND_LIST:MISS} -200}
     [/attack_anim]
+    [female]
+        name= _ "female^Hurricane Drake"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Hurricane.cfg
+++ b/data/core/units/drakes/Hurricane.cfg
@@ -3,6 +3,7 @@
     id=Hurricane Drake
     name= _ "Hurricane Drake"
     race=drake
+    gender=male,female
     image="units/drakes/hurricane.png"
     profile="portraits/drakes/hurricane.webp"
     hitpoints=58

--- a/data/core/units/drakes/Inferno.cfg
+++ b/data/core/units/drakes/Inferno.cfg
@@ -59,4 +59,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS claws.ogg {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Inferno Drake"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Inferno.cfg
+++ b/data/core/units/drakes/Inferno.cfg
@@ -3,6 +3,7 @@
     id=Inferno Drake
     name= _ "Inferno Drake"
     race=drake
+    gender=male,female
     image="units/drakes/inferno.png"
     profile="portraits/drakes/inferno.webp"
     hitpoints=82

--- a/data/core/units/drakes/Sky.cfg
+++ b/data/core/units/drakes/Sky.cfg
@@ -3,6 +3,7 @@
     id=Sky Drake
     name= _ "Sky Drake"
     race=drake
+    gender=male,female
     image="units/drakes/sky.png"
     profile="portraits/drakes/hurricane.webp"
     hitpoints=45

--- a/data/core/units/drakes/Sky.cfg
+++ b/data/core/units/drakes/Sky.cfg
@@ -93,4 +93,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS club.ogg {SOUND_LIST:MISS} -200}
     [/attack_anim]
+    [female]
+        name= _ "female^Sky Drake"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Thrasher.cfg
+++ b/data/core/units/drakes/Thrasher.cfg
@@ -113,4 +113,8 @@
             image="units/drakes/thrasher-blade.png:100"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Thrasher"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Thrasher.cfg
+++ b/data/core/units/drakes/Thrasher.cfg
@@ -3,6 +3,7 @@
     id=Drake Thrasher
     name= _ "Drake Thrasher"
     race=drake
+    gender=male,female
     image="units/drakes/slasher.png"
     profile=portraits/drakes/enforcer.webp
     #image_moving="units/drakes/thrasher-flying.png"

--- a/data/core/units/drakes/Warden.cfg
+++ b/data/core/units/drakes/Warden.cfg
@@ -170,4 +170,8 @@
             image="units/drakes/warden.png:100"
         [/frame]
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Warden"
+        gender=female
+    [/female]
 [/unit_type]

--- a/data/core/units/drakes/Warden.cfg
+++ b/data/core/units/drakes/Warden.cfg
@@ -3,6 +3,7 @@
     id=Drake Warden
     name= _ "Drake Warden"
     race=drake
+    gender=male,female
     image="units/drakes/warden.png"
     hitpoints=82
     movement_type=drakefoot

--- a/data/core/units/drakes/Warrior.cfg
+++ b/data/core/units/drakes/Warrior.cfg
@@ -3,6 +3,7 @@
     id=Drake Warrior
     name= _ "Drake Warrior"
     race=drake
+    gender=male,female
     image="units/drakes/warrior.png"
     profile="portraits/drakes/fighter.webp"
     hitpoints=60

--- a/data/core/units/drakes/Warrior.cfg
+++ b/data/core/units/drakes/Warrior.cfg
@@ -53,4 +53,8 @@
         [/frame]
         {SOUND:HIT_AND_MISS {SOUND_LIST:SWORD_SWISH} {SOUND_LIST:MISS} -100}
     [/attack_anim]
+    [female]
+        name= _ "female^Drake Warrior"
+        gender=female
+    [/female]
 [/unit_type]


### PR DESCRIPTION
This (should) solve the issue raised by Antro of the Italiano translation team [on the forums](https://forums.wesnoth.org/viewtopic.php?p=684505#p684505). Basically, some languages have no neuter gender or cannot use it for unit names without sounding very awkward. So if any drake character is female, then its `unit_type` must also have a translatable string available for the female version of its name.

As with the naga race, there is no need for new sprites to be created for female variations of drake units. Since our real life audience is entirely made up of humans, they will not be able to tell the difference between male and female dragons anyway. :p

Additionally, this enables the long unused female drake name list and name generator to be used for recruited and randomly spawned units.