### PR TITLE
UtBS: Mention the campaign mechanics in the campaign description

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -19,6 +19,8 @@
 
     description= _ "In the distant future a small band of elves struggles to survive amidst the ruins of fallen empires. Lead your people out of the desert on an epic journey to find a new home.
 
+" + _ "Note: This campaign changes some standard mechanics, such as the day/night cycle, recall costs and general approach to the difficulty levels. The Quenoth elves include units that can attack several times per turn, and others that can move after attacking." + "
+
 " + _"(Expert level, 10 scenarios.)"
 
     # Old difficulty levels are not selectable anymore, but for now loading saves using them should still work.


### PR DESCRIPTION
Let players see what to expect when looking through the campaign menu, instead of only giving players this information after they start the campaign and have no clear or quick way to return to the main or campaign selection menus.

The cherry-picks text from both the commits and the review comments of #8027, and fixes part (but not all) of #8009.

The preceding translatable string includes trailing newlines, but is the same as 1.16. So I've left that as-is, while using a separate non-translatable string for the new string's newlines.