### PR TITLE
Add (and use) a drawing function to clear the current render target

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -38,6 +38,16 @@ static SDL_Renderer* renderer()
 /* basic drawing and pixel primatives */
 /**************************************/
 
+void draw::clear()
+{
+	DBG_D << "clear";
+	SDL_BlendMode b;
+	SDL_GetRenderDrawBlendMode(renderer(), &b);
+	SDL_SetRenderDrawBlendMode(renderer(), SDL_BLENDMODE_NONE);
+	fill(0, 0, 0, 0);
+	SDL_SetRenderDrawBlendMode(renderer(), b);
+}
+
 void draw::fill(
 	const SDL_Rect& area,
 	uint8_t r, uint8_t g, uint8_t b, uint8_t a)

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -46,11 +46,22 @@ namespace draw
 /* basic drawing and pixel primatives */
 /**************************************/
 
+/**
+ * Clear the current render target.
+ *
+ * Sets all pixel values in the current render target to (0, 0, 0, 0),
+ * that is both black and fully transparent.
+ *
+ * To clear to a fully opaque colour in stead, use fill().
+ */
+void clear();
 
 /**
  * Fill an area with the given colour.
  *
  * If the alpha component is not specified, it defaults to fully opaque.
+ * If not fully opaque, the fill colour will apply according to the current
+ * blend mode, by default SDL_BLENDMODE_BLEND.
  *
  * If a fill area is not specified, it will fill the entire render target.
  *

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -682,7 +682,7 @@ void window::update_render_textures()
 	// Clear the entire texture.
 	{
 		auto setter = draw::set_render_target(render_buffer_);
-		draw::fill(0,0,0,0);
+		draw::clear();
 	}
 
 	// Rerender everything.

--- a/src/minimap.cpp
+++ b/src/minimap.cpp
@@ -361,9 +361,7 @@ void render_minimap(unsigned dst_w,
 		const draw::render_target_setter target_setter{minimap};
 
 		// Clear the minimap texture, as some of it can be left transparent.
-		draw::set_blend_mode(SDL_BLENDMODE_NONE);
-		draw::fill(0, 0, 0, 0);
-		draw::set_blend_mode(SDL_BLENDMODE_BLEND);
+		draw::clear();
 
 		//
 		// Terrain


### PR DESCRIPTION
This might fix #8061 ... in any case `fill(0,0,0,0)` wasn't doing what it was supposed to.

I added a `draw::clear()` function to clear the current render target / fill it with transparency, as semi-transparent fills are being used in a few places and i don't want to change how they work.