### PR TITLE
Avoid enabling deprecation logging after disabling

### DIFF
--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -21,11 +21,7 @@
 #include "game_version.hpp"
 
 // Set the default severity with the second parameter.
-// -1 means the default is to never log on this domain.
-// 0 would mean log errors only.
-// 1 would mean log errors and warnings.
-// and so on and so on.
-static lg::log_domain log_deprecate("deprecation", 0);
+static lg::log_domain log_deprecate("deprecation", default_deprecation_severity);
 
 std::string deprecated_message(
 		const std::string& elem_name, DEP_LEVEL level, const version_info& version, const std::string& detail)

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -20,6 +20,12 @@
 /** See https://wiki.wesnoth.org/CompatibilityStandards for more info. */
 enum class DEP_LEVEL : uint8_t { INDEFINITE = 1, PREEMPTIVE, FOR_REMOVAL, REMOVED };
 
+// -1 means the default is to never log on this domain.
+// 0 would mean log errors only.
+// 1 would mean log errors and warnings.
+// and so on and so on.
+const static int default_deprecation_severity = 0;
+
 /**
  * Prints a message to the deprecation log domain informing players that a given feature
  * has been deprecated.

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -91,18 +91,28 @@ bool
 const bool& debug = debug_impl;
 
 void set_debug(bool new_debug) {
+    int severity;
+    lg::get_log_domain_severity("deprecation", severity);
+    int delta_severity; // change in severity
+    switch(severity) {
+        case -1: // LG_DISABLED, hence don't change
+            delta_severity = 0;
+            break;
+        case 0: // LG_ERROR
+        case 1: // LG_WARN
+        case 2: // LG_INFO
+        case 3: // LG_DEBUG
+            delta_severity = 2;
+            break;
+        default: // undefined case, hence don't change
+            delta_severity = 0;
+    }
 	if(debug_impl && !new_debug) {
 		// Turning debug mode off; decrease deprecation severity
-		int severity;
-		if(lg::get_log_domain_severity("deprecation", severity)) {
-			lg::set_log_domain_severity("deprecation", severity - 2);
-		}
+        lg::set_log_domain_severity("deprecation", severity - delta_severity);
 	} else if(!debug_impl && new_debug) {
 		// Turning debug mode on; increase deprecation severity
-		int severity;
-		if(lg::get_log_domain_severity("deprecation", severity)) {
-			lg::set_log_domain_severity("deprecation", severity + 2);
-		}
+        lg::set_log_domain_severity("deprecation", severity + delta_severity);
 	}
 	debug_impl = new_debug;
 }

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -23,6 +23,7 @@
 #include "game_version.hpp"
 #include "wesconfig.h"
 #include "serialization/string_utils.hpp"
+#include "deprecation.hpp"
 
 static lg::log_domain log_engine("engine");
 #define LOG_NG LOG_STREAM(info, log_engine)
@@ -93,28 +94,16 @@ const bool& debug = debug_impl;
 void set_debug(bool new_debug) {
     int severity;
     lg::get_log_domain_severity("deprecation", severity);
-    int delta_severity; // change in severity
-    switch(severity) {
-        case -1: // LG_DISABLED, hence don't change
-            delta_severity = 0;
-            break;
-        case 0: // LG_ERROR
-        case 1: // LG_WARN
-        case 2: // LG_INFO
-        case 3: // LG_DEBUG
-            delta_severity = 2;
-            break;
-        default: // undefined case, hence don't change
-            delta_severity = 0;
+    if(severity != -1){ // if deprecation logging not disabled
+        if(debug_impl && !new_debug) {
+            // Turning debug mode off; reset to default deprecation severity
+            lg::set_log_domain_severity("deprecation", default_deprecation_severity);
+        } else if(!debug_impl && new_debug) {
+            // Turning debug mode on; increase deprecation severity
+            lg::set_log_domain_severity("deprecation", default_deprecation_severity + 2);
+        }
+        debug_impl = new_debug;
     }
-	if(debug_impl && !new_debug) {
-		// Turning debug mode off; decrease deprecation severity
-        lg::set_log_domain_severity("deprecation", severity - delta_severity);
-	} else if(!debug_impl && new_debug) {
-		// Turning debug mode on; increase deprecation severity
-        lg::set_log_domain_severity("deprecation", severity + delta_severity);
-	}
-	debug_impl = new_debug;
 }
 
 //

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -74,6 +74,7 @@ const unsigned max_logs = 8;
 
 enum severity
 {
+    LG_DISABLED=-1,
 	LG_ERROR=0,
 	LG_WARN=1,
 	LG_INFO=2,


### PR DESCRIPTION
Fixes issue #7894

Setting "log-none deprecation" causes the deprecation severity to be set to -1 (disabled). The problem was that debug mode being enabled changed the deprecation severity afterwards hence
enabling deprecation messages.
