### PR TITLE
Adaptive drag threshold

### DIFF
--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -93,8 +93,12 @@ void mouse_handler::set_side(int side_number)
 
 int mouse_handler::drag_threshold() const
 {
-	// TODO: Use physical screen size.
-	return 14;
+    // Function uses window resolution as an estimate of users perception of distance
+    // Tune this variable if necessary:
+    const unsigned threshold_1080p = 14; // threshold number of pixels for 1080p
+    double screen_diagonal = std::hypot(gui2::settings::screen_width,gui2::settings::screen_height);
+    const double scale_factor = threshold_1080p / std::hypot(1080,1920);
+    return static_cast<int>(screen_diagonal * scale_factor);
 }
 
 void mouse_handler::touch_motion(int x, int y, const bool browse, bool update, map_location new_hex)


### PR DESCRIPTION
Implemented TODO* in `mouse_handler::drag_threshold()`

Changes the drag threshold from 14 to be based on window resolution. Scaling is performed so that a 1080p window has the original threshold of 14 (since 1080p is currently the most popular monitor size and I assume people are mostly playing Wesnoth in full screen mode). 

*Note that I haven't used the physical screen size because I imagine that it would be impractical to maintain cross-platform, and probably it isn't a good measure of user perceived drag distance anyway (eg. you hold a phone much closer to your face than a laptop). 

The main use case for this is ensuring that on very high resolution displays the drag distance is still reasonable. 

Tangentially related to issue #7955
Closely related to issue #8071