### PR TITLE
lg::severity Enum refactoring

### DIFF
--- a/src/chat_events.cpp
+++ b/src/chat_events.cpp
@@ -48,7 +48,7 @@ void chat_handler::change_logging(const std::string& data) {
 	if (j == data.end()) return;
 	const std::string level(data.begin(), j);
 	const std::string domain(j + 1, data.end());
-	int severity;
+	lg::severity severity;
 	if (level == "error") severity = lg::err().get_severity();
 	else if (level == "warning") severity = lg::warn().get_severity();
 	else if (level == "info") severity = lg::info().get_severity();

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -18,7 +18,6 @@
 #include "config.hpp"
 #include "formatter.hpp"
 #include "lexical_cast.hpp"
-#include "log.hpp"                      // for logger, set_strict_severity, etc
 #include "serialization/string_utils.hpp"  // for split
 
 #include <boost/any.hpp>                // for any
@@ -395,7 +394,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 	if(vm.count("log-debug"))
 		 parse_log_domains_(vm["log-debug"].as<std::string>(),lg::debug().get_severity());
 	if(vm.count("log-none"))
-		 parse_log_domains_(vm["log-none"].as<std::string>(),-1);
+		 parse_log_domains_(vm["log-none"].as<std::string>(),lg::severity::LG_NONE);
 	if(vm.count("logdomains"))
 		logdomains = vm["logdomains"].as<std::string>();
 	if(vm.count("log-precise"))
@@ -549,7 +548,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		translation_percent = std::clamp<unsigned int>(vm["translations-over"].as<unsigned int>(), 0, 100);
 }
 
-void commandline_options::parse_log_domains_(const std::string &domains_string, const int severity)
+void commandline_options::parse_log_domains_(const std::string &domains_string, const lg::severity severity)
 {
 	if(std::vector<std::string> domains = utils::split(domains_string, ','); !domains.empty()) {
 		if(!log) {
@@ -570,7 +569,7 @@ void commandline_options::parse_log_strictness (const std::string & severity) {
 		}
 	}
 	PLAIN_LOG << "Unrecognized argument to --log-strict : " << severity << " . \nDisabling strict mode logging.";
-	lg::set_strict_severity(-1);
+	lg::set_strict_severity(lg::severity::LG_NONE);
 }
 
 void commandline_options::parse_resolution_ (const std::string& resolution_string)

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "log.hpp"                      // for logger, set_strict_severity, etc
+
 #include <optional>
 
 #include <boost/program_options/options_description.hpp>
@@ -107,7 +109,7 @@ public:
 	 * Contains parsed arguments of --log-* (e.g. --log-debug).
 	 * Vector of pairs (severity, log domain).
 	 */
-	std::optional<std::vector<std::pair<int, std::string>>> log;
+	std::optional<std::vector<std::pair<lg::severity, std::string>>> log;
 	/** Non-empty if --log-strict was given */
 	std::optional<int> log_strict_level;
 	/** Non-empty if --load was given on the command line. Savegame specified to load after start. */
@@ -252,7 +254,7 @@ public:
 	/** Non-empty if --all-translations or --translations-over is given on the command line. */
 	std::optional<unsigned int> translation_percent;
 private:
-	void parse_log_domains_(const std::string &domains_string, const int severity);
+	void parse_log_domains_(const std::string &domains_string, const lg::severity severity);
 	void parse_log_strictness (const std::string &severity);
 	void parse_resolution_ (const std::string &resolution_string);
 	/** A helper function splitting vector of strings of format unsigned int:string to vector of tuples (unsigned int,string) */

--- a/src/deprecation.cpp
+++ b/src/deprecation.cpp
@@ -25,7 +25,7 @@
 // 0 would mean log errors only.
 // 1 would mean log errors and warnings.
 // and so on and so on.
-static lg::log_domain log_deprecate("deprecation", 0);
+static lg::log_domain log_deprecate("deprecation", lg::severity::LG_ERROR);
 
 std::string deprecated_message(
 		const std::string& elem_name, DEP_LEVEL level, const version_info& version, const std::string& detail)

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -91,17 +91,20 @@ bool
 const bool& debug = debug_impl;
 
 void set_debug(bool new_debug) {
+    // TODO: remove severity static casts and fix issue #7894
 	if(debug_impl && !new_debug) {
 		// Turning debug mode off; decrease deprecation severity
-		int severity;
+		lg::severity severity;
 		if(lg::get_log_domain_severity("deprecation", severity)) {
-			lg::set_log_domain_severity("deprecation", severity - 2);
+            int severityInt = static_cast<int>(severity);
+			lg::set_log_domain_severity("deprecation", static_cast<lg::severity>(severityInt - 2));
 		}
 	} else if(!debug_impl && new_debug) {
 		// Turning debug mode on; increase deprecation severity
-		int severity;
+        lg::severity severity;
 		if(lg::get_log_domain_severity("deprecation", severity)) {
-			lg::set_log_domain_severity("deprecation", severity + 2);
+            int severityInt = static_cast<int>(severity);
+			lg::set_log_domain_severity("deprecation", static_cast<lg::severity>(severityInt + 2));
 		}
 	}
 	debug_impl = new_debug;

--- a/src/gui/dialogs/log_settings.cpp
+++ b/src/gui/dialogs/log_settings.cpp
@@ -45,7 +45,7 @@ log_settings::log_settings()
 
 
 	//empty string is the filter (in other words, this grabs the whole list of domains)
-	std::string temp_string = lg::list_logdomains("");
+	std::string temp_string = lg::list_log_domains("");
 	//std::cout<<temp_string; //use to print the full log domain list
 	std::string one_domain;
 
@@ -79,10 +79,11 @@ void log_settings::pre_show(window& window)
 				group.add_member(button, this_id);
 			}
 		}
-		int current_sev, max_sev = widget_id_.size();
+		lg::severity current_sev;
+        lg::severity max_sev = lg::severity::LG_DEBUG;
 		if (lg::get_log_domain_severity(this_domain, current_sev)) {
 			if (current_sev <= max_sev) {
-				group.set_member_states(widget_id_[current_sev + 1]);
+				group.set_member_states(widget_id_[static_cast<int>(current_sev) + 1]);
 			}
 		}
 	}
@@ -150,7 +151,7 @@ void log_settings::set_logger(const std::string log_domain)
 	} else if(active_value == widget_id_[1]){ //level0: error
 		lg::set_log_domain_severity(log_domain, lg::err());
 	} else if(active_value == widget_id_[0]){ //level-1: disable
-		lg::set_log_domain_severity(log_domain, -1);
+		lg::set_log_domain_severity(log_domain, lg::severity::LG_NONE);
 	}
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -82,6 +82,12 @@ static std::string output_file_path_ = "";
 
 namespace lg {
 
+std::ostringstream& operator<<(std::ostringstream& oss, const lg::severity severity)
+{
+    oss << static_cast<int>(severity);
+    return oss;
+}
+
 /** Helper function for rotate_logs. */
 bool is_not_log_file(const std::string& fn)
 {
@@ -217,33 +223,33 @@ redirect_output_setter::~redirect_output_setter()
 	output_stream_ = old_stream_;
 }
 
-typedef std::map<std::string, int> domain_map;
+typedef std::map<std::string, severity> domain_map;
 static domain_map *domains;
-static int strict_level_ = -1;
+static severity strict_level_ = severity::LG_NONE;
 void timestamps(bool t) { timestamp = t; }
 void precise_timestamps(bool pt) { precise_timestamp = pt; }
 
 logger& err()
 {
-	static logger lg("error", 0);
+	static logger lg("error", severity::LG_ERROR);
 	return lg;
 }
 
 logger& warn()
 {
-	static logger lg("warning", 1);
+	static logger lg("warning", severity::LG_WARN);
 	return lg;
 }
 
 logger& info()
 {
-	static logger lg("info", 2);
+	static logger lg("info", severity::LG_INFO);
 	return lg;
 }
 
 logger& debug()
 {
-	static logger lg("debug", 3);
+	static logger lg("debug", severity::LG_DEBUG);
 	return lg;
 }
 
@@ -254,7 +260,7 @@ log_domain& general()
 	return dom;
 }
 
-log_domain::log_domain(char const *name, int severity)
+log_domain::log_domain(char const *name, severity severity)
 	: domain_(nullptr)
 {
 	// Indirection to prevent initialization depending on link order.
@@ -263,7 +269,7 @@ log_domain::log_domain(char const *name, int severity)
 	domain_->second = severity;
 }
 
-bool set_log_domain_severity(const std::string& name, int severity)
+bool set_log_domain_severity(const std::string& name, severity severity)
 {
 	std::string::size_type s = name.size();
 	if (name == "all") {
@@ -287,7 +293,7 @@ bool set_log_domain_severity(const std::string& name, const logger &lg) {
 	return set_log_domain_severity(name, lg.get_severity());
 }
 
-bool get_log_domain_severity(const std::string& name, int &severity)
+bool get_log_domain_severity(const std::string& name, severity &severity)
 {
 	domain_map::iterator it = domains->find(name);
 	if (it == domains->end())
@@ -296,7 +302,7 @@ bool get_log_domain_severity(const std::string& name, int &severity)
 	return true;
 }
 
-std::string list_logdomains(const std::string& filter)
+std::string list_log_domains(const std::string& filter)
 {
 	std::ostringstream res;
 	for(logd &l : *domains) {
@@ -306,7 +312,7 @@ std::string list_logdomains(const std::string& filter)
 	return res.str();
 }
 
-void set_strict_severity(int severity) {
+void set_strict_severity(severity severity) {
 	strict_level_ = severity;
 }
 

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -72,13 +72,15 @@ const std::string log_file_suffix = ".log";
 // Note that this count does not include the current log file!
 const unsigned max_logs = 8;
 
-enum severity
+enum class severity
 {
+    LG_NONE=-1,
 	LG_ERROR=0,
 	LG_WARN=1,
 	LG_INFO=2,
 	LG_DEBUG=3
 };
+std::ostringstream& operator<<(std::ostringstream& oss, lg::severity severity);
 
 /**
  * Helper class to redirect the output of the logger in a certain scope.
@@ -111,21 +113,21 @@ private:
 
 class logger;
 
-typedef std::pair<const std::string, int> logd;
+typedef std::pair<const std::string, severity> logd;
 
 class log_domain {
 	logd *domain_;
 public:
-	explicit log_domain(char const *name, int severity = 1);
+	explicit log_domain(char const *name, severity severity = severity::LG_WARN);
 	friend class logger;
 };
 
-bool set_log_domain_severity(const std::string& name, int severity);
+bool set_log_domain_severity(const std::string& name, severity severity);
 bool set_log_domain_severity(const std::string& name, const logger &lg);
-bool get_log_domain_severity(const std::string& name, int &severity);
-std::string list_logdomains(const std::string& filter);
+bool get_log_domain_severity(const std::string& name, severity &severity);
+std::string list_log_domains(const std::string& filter);
 
-void set_strict_severity(int severity);
+void set_strict_severity(severity severity);
 void set_strict_severity(const logger &lg);
 bool broke_strict();
 void set_log_to_file();
@@ -160,9 +162,9 @@ public:
 
 class logger {
 	char const *name_;
-	int severity_;
+    severity severity_;
 public:
-	logger(char const *name, int severity): name_(name), severity_(severity) {}
+	logger(char const *name, severity severity): name_(name), severity_(severity) {}
 	log_in_progress operator()(const log_domain& domain,
 		bool show_names = true, bool do_indent = false, bool show_timestamps = true, bool break_strict = true, bool auto_newline = true) const;
 
@@ -171,15 +173,7 @@ public:
 		return severity_ > domain.domain_->second;
 	}
 
-	/**
-	 * Returns following values depending on the logger:
-	 * error: 0
-	 * warn: 1
-	 * info: 2
-	 * debug: 3
-	 * See also the lg::severity enum.
-	 */
-	int get_severity() const
+	severity get_severity() const
 	{
 		return severity_;
 	}

--- a/src/server/campaignd/options.cpp
+++ b/src/server/campaignd/options.cpp
@@ -80,12 +80,12 @@ command_line::command_line(const std::vector<std::string>& args)
 	po::variables_map vm;
 	po::store(po::command_line_parser(args_).options(opts).style(style).run(), vm);
 
-	static const std::map<std::string, int> log_levels = {
+	static const std::map<std::string, lg::severity> log_levels = {
 		{ "error",   lg::err().get_severity() },
 		{ "warning", lg::warn().get_severity() },
 		{ "info",    lg::info().get_severity() },
 		{ "debug",   lg::debug().get_severity() },
-		{ "none",    -1 }
+		{ "none",    lg::severity::LG_NONE }
 	};
 
 	if(vm.count("help")) {

--- a/src/server/campaignd/options.hpp
+++ b/src/server/campaignd/options.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/program_options/options_description.hpp>
 #include <map>
+#include "log.hpp"
 
 namespace campaignd {
 
@@ -61,7 +62,7 @@ public:
 	/** True if --logdomains was passed. */
 	bool show_log_domains;
 	/** Log domain/severity configuration. */
-	std::map<std::string, int> log_domain_levels;
+	std::map<std::string, lg::severity> log_domain_levels;
 	/** Whether to use higher precision for log timestamps. */
 	bool log_precise_timestamps;
 	/** Whether to report timing information for server requests. */

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -663,12 +663,12 @@ void server::handle_read_from_fifo(const boost::system::error_code& error, std::
 			}
 		}
 	} else if(ctl == "log") {
-		static const std::map<std::string, int> log_levels = {
+		static const std::map<std::string, lg::severity> log_levels = {
 			{ "error",   lg::err().get_severity() },
 			{ "warning", lg::warn().get_severity() },
 			{ "info",    lg::info().get_severity() },
 			{ "debug",   lg::debug().get_severity() },
-			{ "none",    -1 }
+			{ "none",    lg::severity::LG_NONE }
 		};
 
 		if(ctl.args_count() != 2) {
@@ -1995,12 +1995,12 @@ static int run_campaignd(int argc, char** argv)
 	}
 
 	if(cmdline.show_log_domains) {
-		std::cout << lg::list_logdomains("");
+		std::cout << lg::list_log_domains("");
 		return 0;
 	}
 
 	for(const auto& ldl : cmdline.log_domain_levels) {
-		if(!lg::set_log_domain_severity(ldl.first, ldl.second)) {
+		if(!lg::set_log_domain_severity(ldl.first, static_cast<lg::severity>(ldl.second))) {
 			PLAIN_LOG << "Unknown log domain: " << ldl.first;
 			return 2;
 		}

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -3021,7 +3021,7 @@ int main(int argc, char** argv)
 			}
 
 			std::string s = val.substr(6, p - 6);
-			int severity;
+			lg::severity severity;
 
 			if(s == "error") {
 				severity = lg::err().get_severity();

--- a/src/tests/test_commandline_options.cpp
+++ b/src/tests/test_commandline_options.cpp
@@ -257,13 +257,14 @@ BOOST_AUTO_TEST_CASE (test_full_options)
 	BOOST_CHECK(co.load && *co.load == "loadfoo");
 	BOOST_CHECK(co.log);
 	BOOST_CHECK(co.log->size()==8);
-	BOOST_CHECK(co.log->at(0).first  == 0         && co.log->at(1).first  == 0);
+	BOOST_CHECK(co.log->at(0).first  == lg::severity::LG_ERROR && co.log->at(1).first == lg::severity::LG_ERROR);
 	BOOST_CHECK(co.log->at(0).second == "errfoo"  && co.log->at(1).second == "errbar/*");
-	BOOST_CHECK(co.log->at(2).first  == 1         && co.log->at(3).first == 1);
+	BOOST_CHECK(co.log->at(2).first  == lg::severity::LG_WARN && co.log->at(3).first == lg::severity::LG_WARN);
 	BOOST_CHECK(co.log->at(2).second == "warnfoo" && co.log->at(3).second == "warnfoo/bar");
-	BOOST_CHECK(co.log->at(4).first  == 2);
+	BOOST_CHECK(co.log->at(4).first  == lg::severity::LG_INFO);
 	BOOST_CHECK(co.log->at(4).second == "infofoo");
-	BOOST_CHECK(co.log->at(5).first  == 3         && co.log->at(6).first == 3        && co.log->at(7).first == 3);
+	BOOST_CHECK(co.log->at(5).first  == lg::severity::LG_DEBUG &&
+        co.log->at(6).first == lg::severity::LG_DEBUG && co.log->at(7).first == lg::severity::LG_DEBUG);
 	BOOST_CHECK(co.log->at(5).second == "dbgfoo"  && co.log->at(6).second == "dbgbar" && co.log->at(7).second == "dbg/foo/bar/baz");
 	BOOST_CHECK(co.logdomains && *co.logdomains == "filterfoo");
 	BOOST_CHECK(co.multiplayer);

--- a/src/tests/test_unit_map.cpp
+++ b/src/tests/test_unit_map.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE( test_1 ) {
 
 	//	unit * orc1p = new unit(orc1_side0_real);
 
-	lg::set_log_domain_severity("engine", lg::err().get_severity() - 1); // Don't log anything
+	lg::set_log_domain_severity("engine", lg::severity::LG_NONE); // Don't log anything
 	lg::set_log_domain_severity("unit", lg::err());
 	uresult1 = unit_map.add(map_location(1,1), *orc1_side0_real);
 	lg::set_log_domain_severity("unit", lg::warn());
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE( test_1 ) {
 	BOOST_CHECK_MESSAGE(uresult1.second == false, "Didn't Add at occupied location.");
 	BOOST_CHECK_MESSAGE(uresult1.first == unit_map.end(), "Didn't Add at occupied location.");
 
-	lg::set_log_domain_severity("engine", lg::err().get_severity() - 1); // Don't log anything
+	lg::set_log_domain_severity("engine", lg::severity::LG_NONE); // Don't log anything
 	// If the location is invalid, the unit never needs to be cloned, so no warning is emitted in the unit domain
 	uresult1 = unit_map.add(map_location(-1,1), *orc1_side0_real);
 	lg::set_log_domain_severity("engine", lg::info());
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE( test_1 ) {
 	// PLAIN_LOG<<"ID real ="<<orc1_side0_real.underlying_id();
 	// PLAIN_LOG<<"ID fake ="<<orc2_side0_fake.underlying_id();
 
-	lg::set_log_domain_severity("engine", lg::err().get_severity() - 1); // Don't log anything
+	lg::set_log_domain_severity("engine", lg::severity::LG_NONE); // Don't log anything
 	lg::set_log_domain_severity("unit", lg::err());
 	uresult1 = unit_map.add(map_location(1,2), *orc1_side0_real);
 	lg::set_log_domain_severity("unit", lg::warn());

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -352,7 +352,7 @@ static int handle_validate_command(const std::string& file, abstract_validator& 
 		defines_map.emplace(define, preproc_define(define));
 	}
 	PLAIN_LOG << "Validating " << file << " against schema " << validator.name_;
-	lg::set_strict_severity(0);
+	lg::set_strict_severity(lg::severity::LG_ERROR);
 	filesystem::scoped_istream stream = preprocess_file(file, &defines_map);
 	config result;
 	read(result, *stream, &validator);
@@ -372,7 +372,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	if(cmdline_opts.log) {
 		for(const auto& log_pair : *cmdline_opts.log) {
 			const std::string log_domain = log_pair.second;
-			const int severity = log_pair.first;
+			const lg::severity severity = log_pair.first;
 			if(!lg::set_log_domain_severity(log_domain, severity)) {
 				PLAIN_LOG << "unknown log domain: " << log_domain;
 				return 2;
@@ -491,7 +491,7 @@ static int process_command_args(const commandline_options& cmdline_opts)
 	}
 
 	if(cmdline_opts.logdomains) {
-		std::cout << lg::list_logdomains(*cmdline_opts.logdomains);
+		std::cout << lg::list_log_domains(*cmdline_opts.logdomains);
 		return 0;
 	}
 


### PR DESCRIPTION
Refactored all relevant code to use `lg::severity` Enum instead of `int` type. 
A nice-to-have prerequisite for issue #7894 (not technically required but would be nice).
