### PR TITLE
Add a 'special_id_active' attribute to [overwrite] in case the 'experimental_filter_specials' filter is not accepted(postpone 1.19)

### DIFF
--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -58,6 +58,7 @@
 	[tag]
 		name="overwrite"
 		{FILTER_TAG "experimental_filter_specials" abilities ()}
+		{SIMPLE_KEY special_id_active string_list}
 		{SIMPLE_KEY priority real}
 	[/tag]
 [/tag]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/test_overwrite_specials_filter.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/test_overwrite_specials_filter.cfg
@@ -1,15 +1,12 @@
-#####
-# API(s) being tested: [damage]overwrite_specials,[overwrite][experimental_filter_specials]
-##
-# Actions:
-# Three [damage] abilities are added, one with value=5, other with add=11 and the last with multiply=2.
-# The one with multiply=2 have overwrite_specials=both_sides and [overwrite][experimental_filter_specials] for overwrite [damage] with add=11 but not value=5.
-# Have alice attack bob.
-##
-# Expected end state:
-# Alice has 100 - (5*2)=90 hitpoints because add=11 overwrited but not value=5 who replace 9 pt of damage of bob.
-#####
-{GENERIC_UNIT_TEST "test_overwrite_specials_filter" (
+#macros used for test below
+
+#define FILTER_SPECIALS
+    [experimental_filter_specials]
+        add=1-14
+    [/experimental_filter_specials]
+#enddef
+
+#define TEST_OVERWRITE FILTER
     [event]
         name=start
         [modify_unit]
@@ -41,9 +38,7 @@
                         multiply=2
                         overwrite_specials=both_sides
                         [overwrite]
-                            [experimental_filter_specials]
-                                add=1-14
-                            [/experimental_filter_specials]
+                            {FILTER}
                         [/overwrite]
                     [/damage]
                     [chance_to_hit]
@@ -101,4 +96,34 @@
         {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 90})}
         {SUCCEED}
     [/event]
+#enddef
+
+#####
+# API(s) being tested: [damage]overwrite_specials,[overwrite][experimental_filter_specials]
+##
+# Actions:
+# Three [damage] abilities are added, one with value=5, other with add=11 and the last with multiply=2.
+# The one with multiply=2 have overwrite_specials=both_sides and [overwrite][experimental_filter_specials] for overwrite [damage] with add=11 but not value=5.
+# Have alice attack bob.
+##
+# Expected end state:
+# Alice has 100 - (5*2)=90 hitpoints because add=11 overwrited but not value=5 who replace 9 pt of damage of bob.
+#####
+{GENERIC_UNIT_TEST "test_overwrite_specials_filter" (
+    {TEST_OVERWRITE {FILTER_SPECIALS}}
+)}
+
+#####
+# API(s) being tested: [damage]overwrite_specials,[overwrite]special_id_active
+##
+# Actions:
+# Three [damage] abilities are added, one with value=5, other with add=11 and the last with multiply=2.
+# The one with multiply=2 have overwrite_specials=both_sides and [overwrite][experimental_filter_specials] for overwrite [damage] with add=11 but not value=5.
+# Have alice attack bob.
+##
+# Expected end state:
+# Alice has 100 - (5*2)=90 hitpoints because add=11 overwrited but not value=5 who replace 9 pt of damage of bob.
+#####
+{GENERIC_UNIT_TEST "test_overwrite_special_id_active" (
+    {TEST_OVERWRITE (special_id_active=test_overwrite)}
 )}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -363,6 +363,7 @@
 0 trait_requirement_test
 0 test_remove_ability_by_filter
 0 test_overwrite_specials_filter
+0 test_overwrite_special_id_active
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test


### PR DESCRIPTION

Because of this risk I duplicate special_id_active in overwrite to be sure to maintain a way to remain selective on the abilities/specials to overwrite.