### PR TITLE
Solution to #7768. Added a way for players to change an existing label to an empty label. 

### DIFF
--- a/src/map/label.cpp
+++ b/src/map/label.cpp
@@ -168,13 +168,19 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 	{
 		// Found old checking if need to erase it
 		if(text.str().empty()) {
+
+			current_label->second.update_info(
+				text, creator, tooltip, team_name, color, visible_in_fog, visible_in_shroud, immutable, category);
+
+			res = &current_label->second;
+
 			// Erase the old label.
 			current_label_map->second.erase(current_label);
 
 			// Restore the global label in the same spot, if any.
 			if(terrain_label* global_label = get_label_private(loc, "")) {
-				global_label->recalculate();
-			}
+			 	global_label->recalculate();
+			 }
 		} else {
 			current_label->second.update_info(
 				text, creator, tooltip, team_name, color, visible_in_fog, visible_in_shroud, immutable, category);
@@ -194,7 +200,7 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 			global_label->recalculate();
 		}
 	}
-
+	
 	categories_dirty = true;
 	return res;
 }

--- a/src/map/label.cpp
+++ b/src/map/label.cpp
@@ -172,9 +172,8 @@ const terrain_label* map_labels::set_label(const map_location& loc,
 			current_label->second.update_info(
 				text, creator, tooltip, team_name, color, visible_in_fog, visible_in_shroud, immutable, category);
 
-			res = &current_label->second;
+			res = add_label(*this, text, creator, team_name, loc, color, visible_in_fog, visible_in_shroud, immutable, category, tooltip);
 
-			// Erase the old label.
 			current_label_map->second.erase(current_label);
 
 			// Restore the global label in the same spot, if any.

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -830,10 +830,6 @@ void menu_handler::label_terrain(mouse_handler& mousehandler, bool team_only)
 			color = team::get_side_color(gui_->viewing_side());
 		}
 
-		if(old_label != NULL && label == "") {
-			label = " ";
-		}
-
 		const terrain_label* res = gui_->labels().set_label(loc, label, gui_->viewing_team(), team_name, color);
 		if(res) {
 			resources::recorder->add_label(res);

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -829,6 +829,11 @@ void menu_handler::label_terrain(mouse_handler& mousehandler, bool team_only)
 		} else {
 			color = team::get_side_color(gui_->viewing_side());
 		}
+
+		if(old_label != NULL && label == "") {
+			label = " ";
+		}
+
 		const terrain_label* res = gui_->labels().set_label(loc, label, gui_->viewing_team(), team_name, color);
 		if(res) {
 			resources::recorder->add_label(res);


### PR DESCRIPTION
Hello! 
This is my solution to #7768.

I made a statement that checks if the player wants to change the name of an existing map label to an empty label. And then creates a label that is visually empty but won't be deleted and thereby will still be recorded.

I tested my solution by running two instances of the game, entered multiplayer and logged in with two different accounts. Then I created a game and tried all the different permutations that one can create a label and change it to an empty text.

This is my first time contributing to Westnoth and would really appreciate the feedback!