### PR TITLE
Allow wesnoth --preprocess to work on files without the .cfg extension

### DIFF
--- a/changelog_entries/preprocess_non_cfg.md
+++ b/changelog_entries/preprocess_non_cfg.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * The command line `--preprocess` utility now accepts any filename, not just those ending .cfg.

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1770,14 +1770,11 @@ void preprocess_resource(const std::string& res_name,
 
 		// Files in current directory
 		for(const std::string& file : files) {
-			preprocess_resource(file, defines_map, write_cfg, write_plain_cfg, parent_directory);
+			if(filesystem::ends_with(file, ".cfg")) {
+				preprocess_resource(file, defines_map, write_cfg, write_plain_cfg, parent_directory);
+			}
 		}
 
-		return;
-	}
-
-	// process only config files.
-	if(!filesystem::ends_with(res_name, ".cfg")) {
 		return;
 	}
 


### PR DESCRIPTION
The changed function is only called when using --preprocess, but calls itself recursively. This moves the filename filter to be around the recursive call, thus skipping the check for the top-level call.

Fixes #7654.

Ping @ProditorMagnus 