### PR TITLE
use game_events.add in on_event.lua

### DIFF
--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -2,6 +2,20 @@
 -- so you have to call this function from a toplevel lua tag or from a preload event.
 -- It is also not possible to use this for first_time_only=yes events.
 
+-- This api used to be the default way to add events from lua (with its own implementation in lua
+-- based on game_events.on_event). Now its just calls game_evets.add, in particular because otherwise the
+-- priority parammter wouldn't work accord the differnt implmentaions..
+-- Still kept now for compatibility and because it has an easier to
+-- use interface meaning you can easily write in a lua file:
+--
+-- on_event("moveto", 10, function(ec)
+--   ...
+-- end)
+--
+-- which is imo more convenient than the interace wesnoth.game_events.add or wesnoth.game_events.add_repeating offers
+-- even though its at this point technicially equivalent to the later.
+
+
 return function(eventname, priority, fcn)
 	if type(priority) == "function" then
 		fcn = priority

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -7,7 +7,7 @@ return function(eventname, priority, fcn)
 		fcn = priority
 		priority = 0
 	end
-	
+
 	wesnoth.game_events.add{
 		name = eventname,
 		priority = priority,

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -4,7 +4,7 @@
 
 -- This api used to be the default way to add events from lua (with its own implementation in lua
 -- based on game_events.on_event). Now it just calls game_evets.add, because otherwise the
--- priority parammter wouldn't work across the differnt implmentaions.
+-- priority parameter wouldn't work across the different implementations.
 -- Still kept for compatibility and because it has an easier to
 -- use interface. Meaning you can easily write in a lua file:
 --
@@ -12,8 +12,8 @@
 --   ...
 -- end)
 --
--- which is imo more convenient than the interace wesnoth.game_events.add or wesnoth.game_events.add_repeating offers
--- even though its at this point technically equivalent to the later.
+-- which is imo more convenient than the interface wesnoth.game_events.add or wesnoth.game_events.add_repeating offers
+-- even though its at this point technically equivalent to the latter.
 
 
 return function(eventname, priority, fcn)

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -25,6 +25,7 @@ return function(eventname, priority, fcn)
 	wesnoth.game_events.add{
 		name = eventname,
 		priority = priority,
+		first_time_only = false,
 		action = function()
 			context = wesnoth.current.event_context
 			wesnoth.experimental.game_events.set_undoable(true)

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -13,7 +13,7 @@
 -- end)
 --
 -- which is imo more convenient than the interace wesnoth.game_events.add or wesnoth.game_events.add_repeating offers
--- even though its at this point technicially equivalent to the later.
+-- even though its at this point technically equivalent to the later.
 
 
 return function(eventname, priority, fcn)

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -2,54 +2,19 @@
 -- so you have to call this function from a toplevel lua tag or from a preload event.
 -- It is also not possible to use this for first_time_only=yes events.
 
-if rawget(_G, "core_on_event") then
-	return rawget(_G, "core_on_event")  -- prevent double execution
-end
-
-local event_handlers = {}
-
-local old_on_event = wesnoth.game_events.on_event or function(eventname) end
-wesnoth.game_events.on_event = function(eventname)
-	old_on_event(eventname)
-	local context = nil
-	for _, entry in pairs(event_handlers[eventname] or {}) do
-		if context == nil then
-			context = wesnoth.current.event_context
-		end
-		entry.h(context)
-	end
-end
-
-
----Register an event handler
----@param eventname string The event to handle; can be a comma-separated list
----@param priority? number Events execute in order of decreasing priority, and secondarily in order of adding
----@param fcn fun(ctx:event_context)
-local function on_event(eventname, priority, fcn)
-	if string.match(eventname, ",") then
-		for _,elem in ipairs((eventname or ""):split()) do
-			on_event(elem, priority, fcn)
-		end
-		return
-	end
-	local handler
+return function(eventname, priority, fcn)
 	if type(priority) == "function" then
-		handler = priority
+		fcn = priority
 		priority = 0
-	else
-		handler = fcn
 	end
-	eventname = string.gsub(eventname, " ", "_")
-	event_handlers[eventname] = event_handlers[eventname] or {}
-	local eh = event_handlers[eventname]
-	table.insert(eh, { h = handler, p = priority})
-	-- prioritize last entry
-	for i = #eh - 1, 1, -1 do
-		if eh[i].p < eh[i + 1].p then
-			eh[i], eh[i + 1] = eh[i + 1], eh[i]
+	
+	wesnoth.game_events.add{
+		name = eventname,
+		priority = priority,
+		action = function()
+			context = wesnoth.current.event_context
+			wesnoth.experimental.game_events.set_undoable(true)
+			fcn(context)
 		end
-	end
+	}
 end
-
-core_on_event = on_event
-return on_event

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -3,10 +3,10 @@
 -- It is also not possible to use this for first_time_only=yes events.
 
 -- This api used to be the default way to add events from lua (with its own implementation in lua
--- based on game_events.on_event). Now its just calls game_evets.add, in particular because otherwise the
--- priority parammter wouldn't work accord the differnt implmentaions..
--- Still kept now for compatibility and because it has an easier to
--- use interface meaning you can easily write in a lua file:
+-- based on game_events.on_event). Now it just calls game_evets.add, because otherwise the
+-- priority parammter wouldn't work across the differnt implmentaions.
+-- Still kept for compatibility and because it has an easier to
+-- use interface. Meaning you can easily write in a lua file:
 --
 -- on_event("moveto", 10, function(ec)
 --   ...

--- a/data/lua/on_event.lua
+++ b/data/lua/on_event.lua
@@ -19,7 +19,7 @@
 return function(eventname, priority, fcn)
 	if type(priority) == "function" then
 		fcn = priority
-		priority = 0
+		priority = 0.5
 	end
 
 	wesnoth.game_events.add{


### PR DESCRIPTION
previously on_event.lua and game_events.add had seperate priority lists, so that unrelated of the priority parameter (which both game_events.add and on_event.lua now support) on_event.lua events were always excuted first. 

The set_undoable(false) call is there for compatibility with the old on_event implementation.