### PR TITLE
Fix [resistance] without max_value bug

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance_value.cfg
@@ -1,0 +1,144 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [resistance]abilitie witout max_value specified
+##
+# Actions:
+# Give both Alice and Bob 100% chance to hit.
+# Give Bob and Alice [resistance]add=20 without max_value attribute and give damage=10
+# Move Alice next to Bob, and have Alice attack Bob.
+##
+# Expected end state:
+# Alice and Bob fight with damage 10-(10*20/100)=8.
+#####
+
+{GENERIC_UNIT_TEST "resistance_value_test" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [resistance]
+                        id=steadfast1
+                        add=20
+                        affect_self=yes
+                        #max_value=90
+                    [/resistance]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=1
+                    [/attacks]
+                    [damage]
+                        value=10
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [resistance]
+                        id=steadfast1
+                        add=20
+                        affect_self=yes
+                        #max_value=90
+                    [/resistance]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=1
+                    [/attacks]
+                    [damage]
+                        value=10
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+            kill=yes
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$a.x,$a.y
+                [/source]
+                [destination]
+                    x,y=$b.x,$b.y
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        #damage without modification are 10 and 8 with resistance added to 20%, if test fail hitpoints !=92
+        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 92})}
+        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 92})}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1798,10 +1798,18 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 	if(!resistance_abilities.empty()) {
 		unit_abilities::effect resist_effect(resistance_abilities, 100-res);
 
-		res = 100 - std::min<int>(
-			resist_effect.get_composite_value(),
-			resistance_abilities.highest("max_value").first
-		);
+		unit_ability_list resistance_max_value;
+		resistance_max_value.append_if(resistance_abilities, [&](const unit_ability& i) {
+			return (*i.ability_cfg).has_attribute("max_value");
+		});
+		if(!resistance_max_value.empty()){
+			res = 100 - std::min<int>(
+				resist_effect.get_composite_value(),
+				resistance_max_value.highest("max_value").first
+			);
+		} else {
+			res = 100 - resist_effect.get_composite_value();
+		}
 	}
 
 	return res;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -340,6 +340,7 @@
 0 damage_secondary_type_test
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
+0 resistance_value_test
 0 filter_special_id_active
 0 filter_ability_special_id_active
 0 filter_special_id_not_exists


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/8092 issue.

If none [resistance] ability of the list contain max_avlue, on default value of 100 is used instead.