### PR TITLE
Invalid [resistance] who don't have max_value attribute

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance_value.cfg
@@ -1,0 +1,142 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [resistance]abilitie witout max_value specified
+##
+# Actions:
+# Give both Alice and Bob 100% chance to hit.
+# Give Bob and Alice [resistance] multiply=2 without max_value attribute and give damage=12
+# Move Alice next to Bob, and have Alice attack Bob.
+##
+# Expected end state:
+# Alice and Bob fight with damage 12 because [resistance] can't work without max_value.
+#####
+
+{GENERIC_UNIT_TEST "resistance_without_value_test" (
+    [event]
+        name=start
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [resistance]
+                        id=steadfast1
+                        multiply=2
+                        affect_self=yes
+                    [/resistance]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=1
+                    [/attacks]
+                    [damage]
+                        value=12
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [resistance]
+                        id=steadfast1
+                        multiply=2
+                        affect_self=yes
+                    [/resistance]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=1
+                    [/attacks]
+                    [damage]
+                        value=12
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+            kill=yes
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$a.x,$a.y
+                [/source]
+                [destination]
+                    x,y=$b.x,$b.y
+                [/destination]
+            [/attack]
+        [/do_command]
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+        #damage are 12, if test fail hitpoints !=88
+        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 88})}
+        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 88})}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1792,7 +1792,7 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 
 	unit_ability_list resistance_abilities = get_abilities_weapons("resistance",loc, weapon, opp_weapon);
 	utils::erase_if(resistance_abilities, [&](const unit_ability& i) {
-		return !resistance_filter_matches(*i.ability_cfg, attacker, damage_name, 100-res);
+		return ((*i.ability_cfg)["max_value"].empty() || !resistance_filter_matches(*i.ability_cfg, attacker, damage_name, 100-res));
 	});
 
 	if(!resistance_abilities.empty()) {

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -340,6 +340,7 @@
 0 damage_secondary_type_test
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
+0 resistance_without_value_test
 0 filter_special_id_active
 0 filter_ability_special_id_active
 0 filter_special_id_not_exists


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/8092 issue.

If [resistance] ability don't contain "max_value" attribute, it will be removed of the list because invalid