### PR TITLE
automatically generate "load_addon_<addon_id>" [resource]

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -562,6 +562,7 @@ void game_config_manager::load_addons_cfg()
 			config umc_cfg;
 			cache_.get_config(main_cfg, umc_cfg, validator.get());
 
+			umc_cfg.add_child("resource", config{"id", "load_addon_" + addon_id});
 			static const std::set<std::string> tags_with_addon_id {
 				"era",
 				"modification",


### PR DESCRIPTION
It is a common problem that when an addon1 that wants to  make use of another addon2s assets (units etc) it doesn't really have a good way to do so unless addon2 provides a [resource] that addon1 can load via [load_resource]. In particular it seems to be a not so uncommon practice to include other addons data via macro inclusion, however this is a very bad things to do since

* It parses the addons basicially twice (or even more times), resulting in much longer loading times.
* It evades the addon versions checks in mp (when the version of the included addon had changed for one player), leading to possible OOS erros during the game.
* It will can lead to events being exceuted twice when multiple addons include the same code that way.

To make it easier for addon1 to load addon2 without having to ask the author of addon2 to add a [resource] he can load, the game now automatically generates a [resource] for each addon.