### PR TITLE
add priority= attribute to [lua]  tags

### DIFF
--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -418,6 +418,10 @@ void saved_game::expand_mp_events()
 				load_non_scenario("resource", id, pos);
 			}
 		}
+
+		auto lua_tags =  starting_point_.child_range("lua");
+		std::stable_sort(lua_tags.begin(), lua_tags.end(), [](const config& c1, const config& c2) { return c1["priority"].to_int() > c2["priority"].to_int(); });
+
 		starting_point_["has_mod_events"] = true;
 		starting_point_["loaded_resources"] = utils::join(loaded_resources);
 	}


### PR DESCRIPTION
When multiple [lua] tags from different [resource]s [era]s etc interact  with each other, the engine currently make no guarantee in which order they are executed, making it hard to reliably use (global) varialbes/functions in one [lua] tag that was defined in other [lua] tags