### PR TITLE
Add clangd cache directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ config.h
 callgrind.out.*
 data/dist
 clean.sh
+
+# clangd cache
+.cache/clangd


### PR DESCRIPTION
I've written my previous PR using VSCode with the Clangd extension after generating a compile_commands.json file. This environment creates the .cache/clangd [index](https://clangd.llvm.org/design/indexing) directories.

I've decided to request this change as well to help future users and to reduce the need of editing .gitignore locally when contributing more in the future.