### PR TITLE
[WFL] deal with formula_callable inputs that currently don't do anything

### DIFF
--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -706,7 +706,6 @@ void team_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "village_gold");
 	add_input(inputs, "village_support");
 	add_input(inputs, "recall_cost");
-	add_input(inputs, "name");
 	add_input(inputs, "is_human");
 	add_input(inputs, "is_ai");
 	add_input(inputs, "is_network");

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -769,6 +769,10 @@ variant team_callable::get_value(const std::string& key) const
 		return variant(team_.flag_icon());
 	} else if(key == "team_name") {
 		return variant(team_.team_name());
+	} else if(key == "faction") {
+		return variant(team_.faction());
+	} else if(key == "faction_name") {
+		return variant(team_.faction_name());
 	} else if(key == "color") {
 		return variant(team_.color());
 	} else if(key == "share_vision") {

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -435,6 +435,8 @@ variant unit_type_callable::get_value(const std::string& key) const
 		return variant(u_.level());
 	} else if(key == "total_movement" || key == "max_moves" || key == "moves") {
 		return variant(u_.movement());
+	} else if(key == "undead") {
+		return variant(u_.musthave_status("unpoisonable") && u_.musthave_status("undrainable") && u_.musthave_status("unplagueable"));
 	} else if(key == "unpoisonable") {
 		return variant(u_.musthave_status("unpoisonable"));
 	} else if(key == "unslowable") {


### PR DESCRIPTION
The "undead" attribute for `unit_type_callable` was split in https://github.com/wesnoth/wesnoth/commit/d82762b87d8#diff-7842222d67a8d773accb3fa2e9b89c54e5342a648566c987c88004eb8998b1bc but the input remained and the split was not done for `unit_callable`.

For 1.18 I think it might be best to fix the input to have it work for unit and unit type. It can be removed for 1.20.