### PR TITLE
1.18 SoF S1 - Victory Conditions

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -218,9 +218,9 @@
             side=1
             [objective]
 #ifdef HARD
-                description= _ "Transport 5 caravans full of silver back to the dwarvish castle"
+                description= _ "Transport 5 caravans full of silver to the dwarvish stronghold in the northeast corner"
 #else
-                description= _ "Transport 4 caravans full of silver back to the dwarvish castle"
+                description= _ "Transport 4 caravans full of silver to the dwarvish stronghold in the northeast corner"
 #endif
                 condition=win
                 [show_if]
@@ -228,7 +228,7 @@
                 [/show_if]
             [/objective]
             [objective]
-                description= _ "Bring Alanin, who has the Ruby of Fire, to the dwarvish castle"
+                description= _ "Bring Alanin, who has the Ruby of Fire, to the dwarvish stronghold in the northeast corner"
                 condition=win
                 [show_if]
                     {VARIABLE_CONDITIONAL havestone boolean_not_equals yes}

--- a/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/1_A_Bargain_is_Struck.cfg
@@ -677,8 +677,8 @@
     [/event]
 
 #define SOF1_HOME_AREA
-    x=23-25
-    y=1-3 #enddef
+    x=23-27,28-29
+    y=1-3,1-2 #enddef
 
     # Alanin reaches the dwarvish citadel
 


### PR DESCRIPTION
This is to fix #8083 
1. Clarify the objectives of where the caravans and rider are supposed to go
2. make the target area a little bigger (could have also made it `enter_hex` instead of `moveto`, but I think this should do - it wasn't the main complaint anyway)

EDIT:  I'm really not a fan of this copyrights.csv CI, it gives me grief even when I don't touch images.
EDIT2: Never mind, I see it has nothing to do with this, it was failing after the recent translations update