### PR TITLE
Update the copyright info for the Finnish help images

### DIFF
--- a/copyrights.csv
+++ b/copyrights.csv
@@ -1,5 +1,4 @@
 Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes,Needs Update,MD5
-2023/12/10,data/campaigns/Under_the_Burning_Suns/images/attacks/blowgun-elven.png,GNU GPL v2+,Lari Nieminen(zookeeper);Severin Glöckner(Shiki/Sevu);(doofus-01),,,30fe72f66318d9cdaf67e3014dd85bbf
 2013/06/09,attic/character-box.png,GNU GPL v2+,Jordà Polo(ettin),,,077f1c18956286b064986790287ed9e6
 2011/03/11,attic/clasher-attack-mace.png,GNU GPL v2+,unknown,,,5d80af2990022162b7e09bd2a6c2af31
 2008/02/11,attic/credit-map.jpg,GNU GPL v2+,unknown,,,64ee878b38eb7b46e9fc9449bc95ae64
@@ -2132,6 +2131,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/campaigns/Two_Brothers/images/story/Two_Brothers_M1P2.webp,GNU GPL v2+,(Stefan),,,8c35affd986a1b2eca1700b64ccd35d4
 2022/04/13,data/campaigns/Two_Brothers/images/story/Two_Brothers_M2P1.webp,GNU GPL v2+,(Stefan),,,4269c985d5bd7c29e3dfdceb252cfaa8
 2022/04/13,data/campaigns/Two_Brothers/images/story/Two_Brothers_M4P1_the_end.webp,GNU GPL v2+,(Stefan),,,4e07375b8358fda46583ef394cdbf8df
+2023/12/10,data/campaigns/Under_the_Burning_Suns/images/attacks/blowgun-elven.png,GNU GPL v2+,Lari Nieminen(zookeeper);Severin Glöckner(Shiki/Sevu);(doofus-01),,,30fe72f66318d9cdaf67e3014dd85bbf
 2017/05/13,data/campaigns/Under_the_Burning_Suns/images/attacks/claws-crab.png,GNU GPL v2+,Lari Nieminen(zookeeper);Severin Glöckner(Shiki/Sevu),,,2b399df2166cd61046f48af8117d81b8
 2017/01/09,data/campaigns/Under_the_Burning_Suns/images/attacks/energyray.png,GNU GPL v2+,Lari Nieminen(zookeeper),,,2f1f51c0321f18e9b38aaa1d059baa44
 2019/10/11,data/campaigns/Under_the_Burning_Suns/images/attacks/faerie-fire-sun.png,CC BY-SA 4.0,Nemaara Lang(nemaara),,,d7ee0a052f606873cac7bacbe4a647bd
@@ -3064,6 +3064,9 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2015/02/20,data/core/images/help/l10n/es/hpxp.png,GNU GPL v2+,unknown,,,e8dbef425934eff5c9f734aabe960214
 2015/02/20,data/core/images/help/l10n/es/recruit.png,GNU GPL v2+,unknown,,,d7f9b5862bc9465c4e1bc2513a00263f
 2015/02/20,data/core/images/help/l10n/es/tooltip.png,GNU GPL v2+,unknown,,,f3721f44c30dfdb6f9c6086be30835c5
+2023/12/16,data/core/images/help/l10n/fi/hpxp.png,CC BY-SA 4.0,Jaakko Saarikko (Styxnix),screenshot,,bab0586e45fcad729ee1b2b76cb5177c,bab0586e45fcad729ee1b2b76cb5177c
+2023/12/16,data/core/images/help/l10n/fi/recruit.png,CC BY-SA 4.0,Jaakko Saarikko (Styxnix),screenshot,,1b4e518b8a1829ecbd867ab71e6c54fb,1b4e518b8a1829ecbd867ab71e6c54fb
+2023/12/16,data/core/images/help/l10n/fi/tooltip.png,CC BY-SA 4.0,Jaakko Saarikko (Styxnix),screenshot,,5c7299de7c5f8cb200a921b521f2cc1b,5c7299de7c5f8cb200a921b521f2cc1b
 2015/02/20,data/core/images/help/l10n/fr/hpxp.png,GNU GPL v2+,unknown,,,3a123d59308bbedb3d6ee617ff77f8d1
 2015/02/20,data/core/images/help/l10n/fr/recruit.png,GNU GPL v2+,unknown,,,137b03b4cd2569e00d9f7e70d87d6be5
 2015/02/20,data/core/images/help/l10n/fr/tooltip.png,GNU GPL v2+,unknown,,,0dd5ff8f1536ce9dee90c6a7f26a0862
@@ -3282,6 +3285,8 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2021/05/30,data/core/images/items/torch.png,CC BY-SA 4.0,(blarumyrran),,,549e5ea5bbe60ea1ea1aff98bf6fb4f3
 2011/03/11,data/core/images/lobby/group-expanded.png,GNU GPL v2+,Guangcong Luo(Zarel),,,9aa456b3188962914935c0e71cf211a4
 2011/03/11,data/core/images/lobby/group-folded.png,GNU GPL v2+,Guangcong Luo(Zarel),,,f55dec41cb1bfe71c465c6e5ac2ebded
+2023/12/16,data/core/images/lobby/l10n/fi/sort-az-off.png,GNU GPL v2+,(Zarael);Jaakko Saarikko (Styxnix),,,5a68c89fc38b0c864a426f6a9c2b5269
+2023/12/16,data/core/images/lobby/l10n/fi/sort-az.png,GNU GPL v2+,(Zarael);Jaakko Saarikko (Styxnix),,,a5d7c9990b23184436e197246522b953
 2014/12/21,data/core/images/lobby/l10n/sr/sort-az-off.png,GNU GPL v2+,Chusslove Illich(caslav.ilic),,,559d69f527079db29b7a24100cd69c46
 2014/12/21,data/core/images/lobby/l10n/sr/sort-az.png,GNU GPL v2+,Chusslove Illich(caslav.ilic),,,0ededf0352cdf7ac4558b333b81a5847
 2014/12/21,data/core/images/lobby/sort-az-off.png,GNU GPL v2+,(Zarael),,,89ce53a0dbc82ada087de1f8b7bc3729
@@ -18213,7 +18218,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2019/01/01,images/misc/map.png,GNU GPL v2+,Charles Dang(vultraz),,,afc05fa4297f7b475378b9def337ae97
 2011/03/11,images/misc/missing-image.png,GNU GPL v2+,Ali El Gariani(alink),,,a2f1498e0b2116e010c52f1c8c8752f9
 2011/03/11,images/misc/no_observer.png,GNU GPL v2+,(uso),,,19e0191bb40637ab522a0ae87676e430
-2021/01/12,images/misc/orb-two-color.png,CC BY-SA 4.0,unknown;Steve Cotton(octalot),,,379fad15afff70ca547ead3ea8726f33
+2021/01/12,images/misc/orb-two-color.png,GNU GPL v2+,Emilien Rotival(LordBob);Steve Cotton(octalot),,,379fad15afff70ca547ead3ea8726f33
 2014/03/02,images/misc/orb.png,GNU GPL v2+,Emilien Rotival(LordBob),,,3dab3f94bd36bda49ea7750e2efdaeba
 2014/03/02,images/misc/orb@2x.png,GNU GPL v2+,Emilien Rotival(LordBob),,,85903aa2cdf599b19647f23a67d59b59
 2011/03/11,images/misc/petrified.png,GNU GPL v2+,Hogne Håskjold(frame/freim),,,3af072c7dd72897f7056e9e6fb224249


### PR DESCRIPTION
This assumes Styxnix is the right attribution, currently waiting for confirmation in IRC (in the Finnish language channel). I'm going AFK for the afternoon, so anyone please merge once it's confirmed.

Move the previous addition of the UtBS blowgun into sort-by-filename order.

Correct copyright of orb-two-color.png, as it was based on orb.png.