### PR TITLE
1.18 - N/S bridge and sprite layering

### DIFF
--- a/data/core/terrain-graphics/enduring-bridge.cfg
+++ b/data/core/terrain-graphics/enduring-bridge.cfg
@@ -146,7 +146,7 @@
         [/tile]
         [image]
             center=90,108
-            base=90,108
+            base=90,72
             layer={LAYER}
             name={IMAGE}.png
         [/image]


### PR DESCRIPTION
adjust layering to keep units from sinking into N/S bridge image, fixes #8111 (and hopefully doesn't create any new issues)

I also see the NW, N, NE bridge to castle transition needs help, but that needs new images so I will postpone.