### PR TITLE
1.18 - bridge-end layering relative to castle walls

### DIFF
--- a/data/core/terrain-graphics/enduring-bridge.cfg
+++ b/data/core/terrain-graphics/enduring-bridge.cfg
@@ -79,7 +79,7 @@
         [/tile]
         [image]
             center=63,126
-            base=108,118
+            base=108,108
             layer={LAYER}
             name={IMAGE}.png
         [/image]
@@ -113,7 +113,7 @@
         [/tile]
         [image]
             center=63,90
-            base=108,88
+            base=108,68
             layer={LAYER}
             name={IMAGE}.png
         [/image]


### PR DESCRIPTION
This adjusts layering of bridges vs castles to put castle walls above.  The image below is a hybrid: 
1. NW-SE (new)
2. NE-SW (current)
![Screenshot_20231216_bridges](https://github.com/wesnoth/wesnoth/assets/13510196/b9694255-ef71-4e8a-8296-078b98438efd)
My comment in #8121 on this issue may be wrong, I don't think new images are needed after all if "castles on top" are the desired outcome.  If "bridges on top" are desired, then lots of new images likely are needed to avoid weirdness like this:
![Screenshot_20231216_bridge-glitches](https://github.com/wesnoth/wesnoth/assets/13510196/b05d169a-da01-4334-ab9a-24672b263a18)
(the jaggy shadow on the dwarf castle NW and the strange cut-off on the elf castle NW)