### PR TITLE
Generalize the use of max_value and add the min_value attribute

### DIFF
--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -61,6 +61,8 @@
 	max=0
 	super="units/unit_type/abilities/~generic~"
 	{SIMPLE_KEY value f_int}
+	{SIMPLE_KEY max_value f_int}
+	{SIMPLE_KEY min_value f_int}
 	{SIMPLE_KEY add f_int}
 	{SIMPLE_KEY sub f_int}
 	{SIMPLE_KEY multiply f_int}
@@ -79,8 +81,6 @@
 	super="units/unit_type/abilities/~value~"
 	{SIMPLE_KEY apply_to string}
 	{SIMPLE_KEY active_on ability_context}
-	{SIMPLE_KEY max_value f_int}
-	{SIMPLE_KEY min_value f_int}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
@@ -95,12 +95,6 @@
 	name="illuminates"
 	max=infinite
 	super="units/unit_type/abilities/~value~"
-	{SIMPLE_KEY max_value f_int}
-	{SIMPLE_KEY min_value f_int}
-	{SIMPLE_KEY add f_int}
-	{SIMPLE_KEY sub f_int}
-	{SIMPLE_KEY multiply f_int}
-	{SIMPLE_KEY divide f_int}
 [/tag]
 [tag]
 	name="hides"

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -51,6 +51,8 @@
 	{SIMPLE_KEY sub f_int}
 	{SIMPLE_KEY multiply f_real}
 	{SIMPLE_KEY divide f_real}
+	{SIMPLE_KEY max_value s_f_int}
+	{SIMPLE_KEY min_value s_f_int}
 	{SIMPLE_KEY cumulative bool}
 	{DEPRECATED_KEY backstab bool}
 	{FILTER_TAG "filter_base_value" base_value ()}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_max_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_max_value.cfg
@@ -8,10 +8,9 @@
 # Have the side 1 leader attack the side 2 leader with both its weapons
 ##
 # Expected end state:
-# max_value does nothing.
-# The side 1 leader has 2 weapons both of which have 3 strikes
+# max_value works.
+# The side 1 leader has 2 weapons both of which have 1 strikes
 #####
-#ifndef SCHEMA_VALIDATION
 {COMMON_KEEP_A_B_UNIT_TEST "attacks_max_value" (
     [event]
         name = start
@@ -28,6 +27,5 @@
         [/modify_unit]
     [/event]
 
-    {CHECK_STRIKES "3,3" ({SUCCEED})}
+    {CHECK_STRIKES "1,1" ({SUCCEED})}
 )}
-#endif

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heals_max_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals/heals_max_value.cfg
@@ -10,10 +10,9 @@
 # Wait a turn for healing to take place.
 ##
 # Expected end state:
-# max_value does nothing.
-# The Mage has 6 hp: 1 + 2 (rest healing) + 3 ([heals])
+# max_value works.
+# The Mage has 4 hp: 1 + 2 (rest healing) + 1 ([heals])
 #####
-#ifndef SCHEMA_VALIDATION
 {GENERIC_UNIT_TEST "heal_max_value" (
     [event]
         name = start
@@ -55,8 +54,7 @@
             [/filter]
             variable = temp
         [/store_unit]
-        {ASSERT {VARIABLE_CONDITIONAL temp.hitpoints numerical_equals 6}}
+        {ASSERT {VARIABLE_CONDITIONAL temp.hitpoints numerical_equals 4}}
         {SUCCEED}
     [/event]
 )}
-#endif

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_max_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_max_value.cfg
@@ -8,10 +8,9 @@
 # Attack each other
 ##
 # Expected end state:
-# max_value does nothing
-# The damage from the attack is increased by 50%
+# max_value works
+# The damage from the attack is increased by 10%
 #####
-#ifndef SCHEMA_VALIDATION
 {COMMON_KEEP_A_B_UNIT_TEST "leadership_max_value" (
     [event]
         name = start
@@ -27,8 +26,7 @@
             [/effect]
         [/modify_unit]
 
-        {ATTACK_AND_VALIDATE 150}
+        {ATTACK_AND_VALIDATE 110}
         {SUCCEED}
     [/event]
 )}
-#endif

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/regenerate/regenerate_max_value.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/regenerate/regenerate_max_value.cfg
@@ -9,10 +9,9 @@
 # Wait a turn for regenerating to take place.
 ##
 # Expected end state:
-# max_value does nothing.
-# The Mage has 6 hp: 1 + 2 (rest healing) + 3 ([regenerate])
+# max_value works.
+# The Mage has 4 hp: 1 + 2 (rest healing) + 1 ([regenerate])
 #####
-#ifndef SCHEMA_VALIDATION
 {GENERIC_UNIT_TEST "regenerate_max_value" (
     [event]
         name = start
@@ -52,8 +51,7 @@
             [/filter]
             variable = temp
         [/store_unit]
-        {ASSERT {VARIABLE_CONDITIONAL temp.hitpoints numerical_equals 6}}
+        {ASSERT {VARIABLE_CONDITIONAL temp.hitpoints numerical_equals 4}}
         {SUCCEED}
     [/event]
 )}
-#endif

--- a/src/tod_manager.cpp
+++ b/src/tod_manager.cpp
@@ -241,7 +241,7 @@ const time_of_day tod_manager::get_illuminated_time_of_day(
 			if(itor != units.end() && !itor->incapacitated()) {
 				unit_ability_list illum = itor->get_abilities("illuminates");
 				if(!illum.empty()) {
-					unit_abilities::effect illum_effect(illum, terrain_light);
+					unit_abilities::effect illum_effect(illum, terrain_light, nullptr, unit_abilities::EFFECT_WITHOUT_CLAMP_MIN_MAX);
 					const int unit_mod = illum_effect.get_composite_value();
 
 					// Record this value.

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -2031,7 +2031,7 @@ effect::effect(const unit_ability_list& list, int def, const_attack_ptr att, EFF
 			}
 		}
 
-		if(wham == EFFECT_CLAMP_MIN_MAX){
+		if(wham == EFFECT_DEFAULT || wham == EFFECT_CUMULABLE){
 			if(cfg.has_attribute("max_value")){
 				max_value = max_value ? std::min(*max_value, cfg["max_value"].to_int()) : cfg["max_value"].to_int();
 			}

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -25,7 +25,7 @@ bool filter_base_matches(const config& cfg, int def);
 
 enum value_modifier {NOT_USED,SET,ADD,MUL,DIV};
 
-enum EFFECTS { EFFECT_DEFAULT=1, EFFECT_CUMULABLE=2, EFFECT_CLAMP_MIN_MAX=3 };
+enum EFFECTS { EFFECT_DEFAULT=1, EFFECT_CUMULABLE=2, EFFECT_WITHOUT_CLAMP_MIN_MAX=3 };
 
 struct individual_effect
 {

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1828,7 +1828,7 @@ int unit::resistance_value(unit_ability_list resistance_list, const std::string&
 	});
 
 	if(!resistance_list.empty()) {
-		unit_abilities::effect resist_effect(resistance_list, 100-res, nullptr, unit_abilities::EFFECT_CLAMP_MIN_MAX);
+		unit_abilities::effect resist_effect(resistance_list, 100-res);
 
 		res = 100 - resist_effect.get_composite_value();
 	}


### PR DESCRIPTION

In the case of [leadership], the fact that the values of each ability can be added when cumulative=yes can justify the addition of limit values not to be exceeded, but this can also apply to heals and [regenerates] with the use of 'add' or 'multiply'.

As for [resistance], it already uses max_value, but if cumulative=yes, then all max_values can add up which could be problematic.