### PR TITLE
require_modification/campaign now defaults to yes

### DIFF
--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -205,7 +205,7 @@ game_info::game_info(const config& game, const std::vector<std::string>& install
 		mod_info.emplace_back(cfg["name"].str(), true);
 		info_stream << ' ' << mod_info.back().first;
 
-		if(cfg["require_modification"].to_bool(false)) {
+		if(cfg["require_modification"].to_bool(true)) {
 			if(auto mod = game_config.find_child("modification", "id", cfg["id"])) {
 				addon_req result = check_addon_version_compatibility(*mod, game);
 				addons_outcome = std::max(addons_outcome, result); // Elevate to most severe error level encountered so far

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -343,7 +343,7 @@ void saved_game::load_non_scenario(const std::string& type, const std::string& i
 		non_scenario["name"] = cfg["addon_title"].str("mainline");
 		non_scenario["version"] = cfg["addon_version"].str(version_default);
 		non_scenario["min_version"] = cfg["addon_min_version"];
-		non_scenario["required"] = cfg[require_attr].to_bool(true);
+		non_scenario["required"] = cfg[require_attr].to_bool(!cfg["addon_id"].empty());
 		config& content = non_scenario.add_child("content");
 		content["id"] = id;
 		content["name"] = cfg["addon_title"].str(cfg["name"].str(""));

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -322,6 +322,7 @@ void saved_game::check_require_scenario()
 	config& content = scenario.add_child("content");
 	content["id"] = starting_point_["id"];
 	content["name"] = starting_point_["name"];
+	// TODO: would it be better if this ued the actual tagname ([multiplayer]/[scenario]) instead of always using [scenario] 
 	content["type"] = "scenario";
 
 	mp_settings_.update_addon_requirements(scenario);

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -335,7 +335,6 @@ void saved_game::load_non_scenario(const std::string& type, const std::string& i
 		// Note the addon_id if this mod is required to play the game in mp.
 		std::string require_attr = "require_" + type;
 
-		// By default, eras have "require_era = true", and mods have "require_modification = false".
 		// anything with no addon_id is from mainline, and therefore isn't required in the sense that all players already have it
 		const std::string version_default = cfg["addon_id"].empty() ? game_config::wesnoth_version.str() : "";
 		config non_scenario;

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -231,9 +231,9 @@ void saved_game::set_defaults()
 	};
 
 	if(auto campaign = game_config.find_child("campaign", "id", classification_.campaign)) {
-		// FIXME: The mp code could use `require_scenario` to check wheterh we ahve the addon in question installed.
-		//        But since [scenario]s are usually hidden behind `#ifdef CAMPAIGN_DEFINE ` it would be able to find them.
-		//        Investiage how this shoudl actually work.
+		// FIXME: The mp code could use `require_scenario` to check whether we have the addon in question installed.
+		//        But since [scenario]s are usually hidden behind `#ifdef CAMPAIGN_DEFINE` it would not be able to find them.
+		//        Investigate how this should actually work.
 		bool require_campaign = campaign["require_campaign"].to_bool(true);
 		starting_point_["require_scenario"] = require_campaign;
 	}

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -231,6 +231,9 @@ void saved_game::set_defaults()
 	};
 
 	if(auto campaign = game_config.find_child("campaign", "id", classification_.campaign)) {
+		// FIXME: The mp code could use `require_scenario` to check wheterh we ahve the addon in question installed.
+		//        But since [scenario]s are usually hidden behind `#ifdef CAMPAIGN_DEFINE ` it would be able to find them.
+		//        Investiage how this shoudl actually work.
 		bool require_campaign = campaign["require_campaign"].to_bool(true);
 		starting_point_["require_scenario"] = require_campaign;
 	}
@@ -333,7 +336,6 @@ void saved_game::load_non_scenario(const std::string& type, const std::string& i
 
 		// By default, eras have "require_era = true", and mods have "require_modification = false".
 		// anything with no addon_id is from mainline, and therefore isn't required in the sense that all players already have it
-		const bool require_default = cfg["addon_id"].empty() ? false : type == "era";
 		const std::string version_default = cfg["addon_id"].empty() ? game_config::wesnoth_version.str() : "";
 		config non_scenario;
 		// if there's no addon_id, then this isn't an add-on
@@ -341,7 +343,7 @@ void saved_game::load_non_scenario(const std::string& type, const std::string& i
 		non_scenario["name"] = cfg["addon_title"].str("mainline");
 		non_scenario["version"] = cfg["addon_version"].str(version_default);
 		non_scenario["min_version"] = cfg["addon_min_version"];
-		non_scenario["required"] = cfg[require_attr].to_bool(require_default);
+		non_scenario["required"] = cfg[require_attr].to_bool(true);
 		config& content = non_scenario.add_child("content");
 		content["id"] = id;
 		content["name"] = cfg["addon_title"].str(cfg["name"].str(""));


### PR DESCRIPTION
It's better to be defensive with those default values, especially now that the mp lobby code can automatically download addons, having require_modification set to true isn't inconvenient for the users either.

(The issue that the added comment is abotu isn't something that was added in this commit)