### PR TITLE
Fix horizontal scrolling regression (fixes #7404)

### DIFF
--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -232,8 +232,7 @@ void controller_base::handle_event(const SDL_Event& event)
 		break;
 
 	case SDL_MOUSEWHEEL:
-		// Down and right are positive in Wesnoth's map, but
-		// mouse_handler_base::mouse_wheel() inverts both axes.
+		// Down and right are positive in Wesnoth's map.
 		// Up and right are positive in SDL_MouseWheelEvent on all
 		// platforms:
 		//     https://wiki.libsdl.org/SDL2/SDL_MouseWheelEvent
@@ -245,20 +244,20 @@ void controller_base::handle_event(const SDL_Event& event)
 		// Fixes issue #7404, which is a regression caused by pull #2481
 		// that fixed issue #2218.
 		{
-			int xmul = -1;
+			int xmul = 1;
 #if !defined(_WIN32) && !defined(__APPLE__)
 			const char* video_driver = SDL_GetCurrentVideoDriver();
 			SDL_version ver;
 			SDL_GetVersion(&ver);
 			if(video_driver != nullptr && ver.major <= 2 && ver.minor <= 0) {
 				if(std::strcmp(video_driver, "x11") == 0 && ver.patch < 18) {
-					xmul = 1;
+					xmul = -1;
 				} else if(std::strcmp(video_driver, "wayland") == 0 && ver.patch < 20) {
-					xmul = 1;
+					xmul = -1;
 				}
 			}
 #endif
-			mh_base.mouse_wheel(xmul * event.wheel.x, event.wheel.y, is_browsing());
+			mh_base.mouse_wheel(xmul * event.wheel.x, -event.wheel.y, is_browsing());
 		}
 		break;
 

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -232,11 +232,32 @@ void controller_base::handle_event(const SDL_Event& event)
 		break;
 
 	case SDL_MOUSEWHEEL:
-#if defined(_WIN32) || defined(__APPLE__)
-		mh_base.mouse_wheel(-event.wheel.x, event.wheel.y, is_browsing());
-#else
-		mh_base.mouse_wheel(event.wheel.x, event.wheel.y, is_browsing());
+		// Up and right are positive in SDL_MouseWheelEvent on all
+		// platforms:
+		//     https://wiki.libsdl.org/SDL2/SDL_MouseWheelEvent
+		// Except right is wrongly negative on X11 in SDL < 2.0.18:
+		//     https://github.com/libsdl-org/SDL/pull/4700
+		//     https://github.com/libsdl-org/SDL/commit/515b7e9
+		// and on Wayland in SDL < 2.0.20:
+		//     https://github.com/libsdl-org/SDL/commit/3e1b3bc
+		// Fixes issue #7404, which is a regression caused by pull #2481
+		// that fixed issue #2218.
+		{
+			int xmul = -1;
+#if !defined(_WIN32) && !defined(__APPLE__)
+			const char* video_driver = SDL_GetCurrentVideoDriver();
+			SDL_version ver;
+			SDL_GetVersion(&ver);
+			if(video_driver != nullptr && ver.major <= 2 && ver.minor <= 0) {
+				if(std::strcmp(video_driver, "x11") == 0 && ver.patch < 18) {
+					xmul = 1;
+				} else if(std::strcmp(video_driver, "wayland") == 0 && ver.patch < 20) {
+					xmul = 1;
+				}
+			}
 #endif
+			mh_base.mouse_wheel(xmul * event.wheel.x, event.wheel.y, is_browsing());
+		}
 		break;
 
 	case TIMER_EVENT:

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -232,6 +232,8 @@ void controller_base::handle_event(const SDL_Event& event)
 		break;
 
 	case SDL_MOUSEWHEEL:
+		// Down and right are positive in Wesnoth's map, but
+		// mouse_handler_base::mouse_wheel() inverts both axes.
 		// Up and right are positive in SDL_MouseWheelEvent on all
 		// platforms:
 		//     https://wiki.libsdl.org/SDL2/SDL_MouseWheelEvent

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -371,9 +371,9 @@ void mouse_handler_base::mouse_wheel(int scrollx, int scrolly, bool browse)
 		CKey pressed;
 		// Alt + mousewheel do an 90° rotation on the scroll direction
 		if(pressed[SDLK_LALT] || pressed[SDLK_RALT]) {
-			gui().scroll(-movey, -movex);
+			gui().scroll(movey, movex);
 		} else {
-			gui().scroll(-movex, -movey);
+			gui().scroll(movex, movey);
 		}
 	}
 
@@ -384,9 +384,9 @@ void mouse_handler_base::mouse_wheel(int scrollx, int scrolly, bool browse)
 	}
 
 	if(scrolly < 0) {
-		mouse_wheel_down(x, y, browse);
-	} else if(scrolly > 0) {
 		mouse_wheel_up(x, y, browse);
+	} else if(scrolly > 0) {
+		mouse_wheel_down(x, y, browse);
 	}
 }
 


### PR DESCRIPTION
The old issue #2218 was actually a bug in SDL, fixed on X11 in version 2.0.18 and on Wayland in version 2.0.20.  The hardcoded workaround in pull #2481 (commit 4bc4373) caused a regression in fixed SDL versions.

This fix is similar to the workaround in widelands/widelands#5394 committed as widelands/widelands@67db32a.

Tested with SDL 2.0.14 and 2.28.5.