### PR TITLE
Modify shema validation for more consistency

### DIFF
--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -47,12 +47,7 @@
 [tag]
 	name="heals"
 	max=infinite
-	super="units/unit_type/abilities/~generic~"
-	{SIMPLE_KEY value f_int}
-	{SIMPLE_KEY add f_int}
-	{SIMPLE_KEY sub f_int}
-	{SIMPLE_KEY multiply f_int}
-	{SIMPLE_KEY divide f_int}
+	super="units/unit_type/abilities/~value~"
 	{SIMPLE_KEY poison string} # TODO: Enum
 [/tag]
 [tag]
@@ -66,13 +61,10 @@
 	max=0
 	super="units/unit_type/abilities/~generic~"
 	{SIMPLE_KEY value f_int}
-	{SIMPLE_KEY max_value f_int}
 	{SIMPLE_KEY add f_int}
 	{SIMPLE_KEY sub f_int}
 	{SIMPLE_KEY multiply f_int}
 	{SIMPLE_KEY divide f_int}
-	{SIMPLE_KEY apply_to string}
-	{SIMPLE_KEY active_on ability_context}
 [/tag]
 # Defense not currently supported though.
 # May never be? Not sure
@@ -85,26 +77,23 @@
 	name="resistance"
 	max=infinite
 	super="units/unit_type/abilities/~value~"
+	{SIMPLE_KEY apply_to string}
+	{SIMPLE_KEY active_on ability_context}
+	{SIMPLE_KEY max_value f_int}
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
 [tag]
 	name="leadership"
 	max=infinite
-	super="units/unit_type/abilities/~generic~"
-	{SIMPLE_KEY value f_int}
-	{SIMPLE_KEY add f_int}
-	{SIMPLE_KEY sub f_int}
-	{SIMPLE_KEY multiply f_int}
-	{SIMPLE_KEY divide f_int}
+	super="units/unit_type/abilities/~value~"
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]
 [tag]
 	name="illuminates"
 	max=infinite
-	super="units/unit_type/abilities/~generic~"
-	{SIMPLE_KEY value f_int}
+	super="units/unit_type/abilities/~value~"
 	{SIMPLE_KEY max_value f_int}
 	{SIMPLE_KEY min_value f_int}
 [/tag]


### PR DESCRIPTION
In the validation schema abilities-value in abilities.cfg contains not only the numerical attributes but also active_on and apply_to, while these two deniers are only used by [resistance], and the abilities used as weapons are validated by the schema validation of special weapons, and the abilities [leadership], [heals], [regenerate] and [illuminates] also use all numerical attributes.