### PR TITLE
[1.16] Backport #8137: Fix horizontal scrolling regression (fixes #7404)

### DIFF
--- a/changelog_entries/horizontal_scrolling.md
+++ b/changelog_entries/horizontal_scrolling.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Fix a regression from 1.13.11 that inverted horizontal scrolling with SDL versions 2.0.18+ on X11 and versions 2.0.20+ on Wayland (issue #7404, PR #8158)

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -230,11 +230,33 @@ void controller_base::handle_event(const SDL_Event& event)
 		break;
 
 	case SDL_MOUSEWHEEL:
-#if defined(_WIN32) || defined(__APPLE__)
-		mh_base.mouse_wheel(-event.wheel.x, event.wheel.y, is_browsing());
-#else
-		mh_base.mouse_wheel(event.wheel.x, event.wheel.y, is_browsing());
+		// Down and right are positive in Wesnoth's map.
+		// Up and right are positive in SDL_MouseWheelEvent on all
+		// platforms:
+		//     https://wiki.libsdl.org/SDL2/SDL_MouseWheelEvent
+		// Except right is wrongly negative on X11 in SDL < 2.0.18:
+		//     https://github.com/libsdl-org/SDL/pull/4700
+		//     https://github.com/libsdl-org/SDL/commit/515b7e9
+		// and on Wayland in SDL < 2.0.20:
+		//     https://github.com/libsdl-org/SDL/commit/3e1b3bc
+		// Fixes issue #7404, which is a regression caused by pull #2481
+		// that fixed issue #2218.
+		{
+			int xmul = 1;
+#if !defined(_WIN32) && !defined(__APPLE__)
+			const char* video_driver = SDL_GetCurrentVideoDriver();
+			SDL_version ver;
+			SDL_GetVersion(&ver);
+			if(video_driver != nullptr && ver.major <= 2 && ver.minor <= 0) {
+				if(std::strcmp(video_driver, "x11") == 0 && ver.patch < 18) {
+					xmul = -1;
+				} else if(std::strcmp(video_driver, "wayland") == 0 && ver.patch < 20) {
+					xmul = -1;
+				}
+			}
 #endif
+			mh_base.mouse_wheel(xmul * event.wheel.x, -event.wheel.y, is_browsing());
+		}
 		break;
 
 	case TIMER_EVENT:

--- a/src/mouse_handler_base.cpp
+++ b/src/mouse_handler_base.cpp
@@ -325,9 +325,9 @@ void mouse_handler_base::mouse_wheel(int scrollx, int scrolly, bool browse)
 		CKey pressed;
 		// Alt + mousewheel do an 90° rotation on the scroll direction
 		if(pressed[SDLK_LALT] || pressed[SDLK_RALT]) {
-			gui().scroll(-movey, -movex);
+			gui().scroll(movey, movex);
 		} else {
-			gui().scroll(-movex, -movey);
+			gui().scroll(movex, movey);
 		}
 	}
 
@@ -338,9 +338,9 @@ void mouse_handler_base::mouse_wheel(int scrollx, int scrolly, bool browse)
 	}
 
 	if(scrolly < 0) {
-		mouse_wheel_down(x, y, browse);
-	} else if(scrolly > 0) {
 		mouse_wheel_up(x, y, browse);
+	} else if(scrolly > 0) {
+		mouse_wheel_down(x, y, browse);
 	}
 }
 


### PR DESCRIPTION
The old issue #2218 was actually a bug in SDL, fixed on X11 in version 2.0.18 and on Wayland in version 2.0.20.  The hardcoded workaround in pull #2481 (commit 4bc4373) caused a regression in fixed SDL versions.

This fix is similar to the workaround in widelands/widelands#5394 committed as widelands/widelands@67db32a.

Also make mouse handler use same coordinate signs as map and fix mouse_wheel_*() virtual method calls, which have been wrong in the X axis since commit dfe2f33 (and unused since commit c912f7e).

Tested with SDL 2.0.14 and 2.28.5.

Cherry picked from commit ab4001d (pull #8137) in the master branch (1.17).