### PR TITLE
Check that copyrights.csv is sorted by filename

### DIFF
--- a/copyrights.csv
+++ b/copyrights.csv
@@ -1,24 +1,4 @@
 Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes,Needs Update,MD5
-2023/12/23,data/core/images/scenery/windmill-derelict.png,CC BY-SA 4.0,(doofus-01),,,03bc2cebab792e4a2e3c53e59d92e6c3
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-01.png,CC BY-SA 4.0,(doofus-01),,,ee0237fb4e1f9cac999e5ebf58c68924
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-02.png,CC BY-SA 4.0,(doofus-01),,,61095f1747246cf09070784c89be26b7
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-03.png,CC BY-SA 4.0,(doofus-01),,,cb11075c45b777be9f07a6c433c55059
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-04.png,CC BY-SA 4.0,(doofus-01),,,fb0ecefcf3a5ca0d96bcfb4e3c69138a
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-05.png,CC BY-SA 4.0,(doofus-01),,,2f606218b820da9ea548ae295d0bce45
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-06.png,CC BY-SA 4.0,(doofus-01),,,ec51b360b523d74754951c92c9402df0
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-07.png,CC BY-SA 4.0,(doofus-01),,,cd320dae86781af3d10f91917a8373bb
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-08.png,CC BY-SA 4.0,(doofus-01),,,5a94938d51d3c18975d198d919bc22fd
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-09.png,CC BY-SA 4.0,(doofus-01),,,a52b7a3885d678c3070dac7de2a97a62
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-10.png,CC BY-SA 4.0,(doofus-01),,,d5afefa1ebea20fbaa3e00e57c5ef64e
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-11.png,CC BY-SA 4.0,(doofus-01),,,921093b3ad57c1199ec9539673c6a442
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-12.png,CC BY-SA 4.0,(doofus-01),,,dcb34bfacae4a9d72459f52b167a698c
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-13.png,CC BY-SA 4.0,(doofus-01),,,e0c1caf8d4803a0f3977b6a74b25b7c5
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-14.png,CC BY-SA 4.0,(doofus-01),,,720913580ceb1df8976ab21e10e41af0
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-15.png,CC BY-SA 4.0,(doofus-01),,,86213e5b2a4231a37daa819e57c81315
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-16.png,CC BY-SA 4.0,(doofus-01),,,723ab42ea4846e18cd17799fe6ed6cad
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-17.png,CC BY-SA 4.0,(doofus-01),,,113085558364c12601c38529dd543779
-2023/12/23,data/core/images/terrain/misc/decorative/windmill-18.png,CC BY-SA 4.0,(doofus-01),,,cf8dddd17a94d365df469c53038d536d
-2023/12/23,data/core/images/terrain/misc/windmill-embellishment-tile.png,CC BY-SA 4.0,(doofus-01),,,bd4933eeddbcfdd4dfe4218bda6cfb74
 2013/06/09,attic/character-box.png,GNU GPL v2+,Jordà Polo(ettin),,,077f1c18956286b064986790287ed9e6
 2011/03/11,attic/clasher-attack-mace.png,GNU GPL v2+,unknown,,,5d80af2990022162b7e09bd2a6c2af31
 2008/02/11,attic/credit-map.jpg,GNU GPL v2+,unknown,,,64ee878b38eb7b46e9fc9449bc95ae64
@@ -4012,6 +3992,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/core/images/scenery/windmill-16.png,GNU GPL v2+,(musketsquid);J.W. Bjerk(eleazar),,,0e56c6bf9f31f7d31f0d049974f9b219
 2011/03/11,data/core/images/scenery/windmill-17.png,GNU GPL v2+,(musketsquid);J.W. Bjerk(eleazar),,,1fffb56bf730ad2bd0715ddd0f231a2c
 2011/03/11,data/core/images/scenery/windmill-18.png,GNU GPL v2+,(musketsquid);J.W. Bjerk(eleazar),,,8bbe12ddcf031d1772bea98efa048d64
+2023/12/23,data/core/images/scenery/windmill-derelict.png,CC BY-SA 4.0,(doofus-01),,,03bc2cebab792e4a2e3c53e59d92e6c3
 2017/07/29,data/core/images/scenery/wreck-2.png,CC BY-SA 4.0,(doofus-01),,,ccf4446a97faa4cda0cd598dbd20a557
 2017/07/29,data/core/images/scenery/wreck-3.png,CC BY-SA 4.0,(doofus-01),,,da37de6bfc9db13a13dfd141e532049d
 2017/07/29,data/core/images/scenery/wreck.png,CC BY-SA 4.0,(doofus-01),,,a6030fc8675da1ce6560dc7c1c6757c9
@@ -7547,6 +7528,24 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2015/01/22,data/core/images/terrain/misc/brazier-A07.png,GNU GPL v2+,unknown,,,684e2136aaa9e313ac12c0a2fee0d2df
 2015/01/22,data/core/images/terrain/misc/brazier-A08.png,GNU GPL v2+,unknown,,,d1661c666b8c52f1490bad18c59f92ff
 2015/01/22,data/core/images/terrain/misc/brazier-embellishment.png,GNU GPL v2+,unknown,,,f60c00dfc06e63fb7ec1ede5ff5a5f58
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-01.png,CC BY-SA 4.0,(doofus-01),,,ee0237fb4e1f9cac999e5ebf58c68924
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-02.png,CC BY-SA 4.0,(doofus-01),,,61095f1747246cf09070784c89be26b7
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-03.png,CC BY-SA 4.0,(doofus-01),,,cb11075c45b777be9f07a6c433c55059
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-04.png,CC BY-SA 4.0,(doofus-01),,,fb0ecefcf3a5ca0d96bcfb4e3c69138a
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-05.png,CC BY-SA 4.0,(doofus-01),,,2f606218b820da9ea548ae295d0bce45
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-06.png,CC BY-SA 4.0,(doofus-01),,,ec51b360b523d74754951c92c9402df0
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-07.png,CC BY-SA 4.0,(doofus-01),,,cd320dae86781af3d10f91917a8373bb
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-08.png,CC BY-SA 4.0,(doofus-01),,,5a94938d51d3c18975d198d919bc22fd
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-09.png,CC BY-SA 4.0,(doofus-01),,,a52b7a3885d678c3070dac7de2a97a62
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-10.png,CC BY-SA 4.0,(doofus-01),,,d5afefa1ebea20fbaa3e00e57c5ef64e
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-11.png,CC BY-SA 4.0,(doofus-01),,,921093b3ad57c1199ec9539673c6a442
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-12.png,CC BY-SA 4.0,(doofus-01),,,dcb34bfacae4a9d72459f52b167a698c
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-13.png,CC BY-SA 4.0,(doofus-01),,,e0c1caf8d4803a0f3977b6a74b25b7c5
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-14.png,CC BY-SA 4.0,(doofus-01),,,720913580ceb1df8976ab21e10e41af0
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-15.png,CC BY-SA 4.0,(doofus-01),,,86213e5b2a4231a37daa819e57c81315
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-16.png,CC BY-SA 4.0,(doofus-01),,,723ab42ea4846e18cd17799fe6ed6cad
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-17.png,CC BY-SA 4.0,(doofus-01),,,113085558364c12601c38529dd543779
+2023/12/23,data/core/images/terrain/misc/decorative/windmill-18.png,CC BY-SA 4.0,(doofus-01),,,cf8dddd17a94d365df469c53038d536d
 2014/12/21,data/core/images/terrain/misc/detritus/detritusA-1.png,GNU GPL v2+,(doofus-01),,,161ad499fe3a530767759ec0c18d4e53
 2014/12/21,data/core/images/terrain/misc/detritus/detritusA-2.png,GNU GPL v2+,(doofus-01),,,d48c77a00cd638b07fb550ed9562b506
 2014/12/21,data/core/images/terrain/misc/detritus/detritusA-3.png,GNU GPL v2+,(doofus-01),,,ffcee9b8bc50c08ea32eee3645798513
@@ -7687,6 +7686,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2011/03/11,data/core/images/terrain/misc/windmill-A16.png,GNU GPL v2+,(musketaquid),,,69cbe2770a94b2d062d013bd5a0b39a3
 2011/03/11,data/core/images/terrain/misc/windmill-A17.png,GNU GPL v2+,(musketaquid),,,9e43ea634ade5c7172f1559b5b1f2298
 2011/03/11,data/core/images/terrain/misc/windmill-A18.png,GNU GPL v2+,(musketaquid),,,0cec0d94324adc2e986336bc03da60b2
+2023/12/23,data/core/images/terrain/misc/windmill-embellishment-tile.png,CC BY-SA 4.0,(doofus-01),,,bd4933eeddbcfdd4dfe4218bda6cfb74
 2014/12/21,data/core/images/terrain/misc/windmill-tile.png,GNU GPL v2+,(musketaquid),,,bc1f55db951c03517c4dd9eeceb5ee05
 2016/03/18,data/core/images/terrain/mountains/basic-castle-n-ne.png,GNU GPL v2+,Hogne Håskjold(freim),,,b9efbdf9dca893b227b8af7e4e12efc7
 2016/03/18,data/core/images/terrain/mountains/basic-castle-n.png,GNU GPL v2+,Hogne Håskjold(freim),,,20325075325e86a689e502cba6052c3c

--- a/update_copyrights
+++ b/update_copyrights
@@ -58,14 +58,20 @@ added = []
 changed = []
 unchanged = []
 removed = []
+# Sanity-check that the input is in the same order as the output would be
+csvfile_needs_sorting = False
 
 with open(options.input) as csvfile:
     reader = csv.reader(csvfile)
+    previous_file = ""
     for row in reader:
         if row[0] == "Date":
             continue
 
         file = row[1]
+        if file < previous_file:
+            csvfile_needs_sorting = True
+        previous_file = file
 
         if not os.path.exists(file):
             removed.append(file)
@@ -104,10 +110,20 @@ else:
     for row in final_output:
         print(",".join(row))
 
+any_check_failed = False
 if len(removed) > 0:
+    any_check_failed = True
     print("There are "+str(len(removed))+" removed images")
 
 if len(added) > 0 or len(changed) > 0:
+    any_check_failed = True
     print("There are "+str(len(added))+" new images")
     print("There are "+str(len(changed))+" changed images")
+
+if csvfile_needs_sorting:
+    any_check_failed = True
+    print("The input file isn’t sorted by filename")
+    print("    Changed or newly added lines are put at the top for easy editing,\n    but you should run the tool again after editing to sort the file.")
+
+if any_check_failed:
     sys.exit(1)


### PR DESCRIPTION
When the tool finds new or changed files, it puts them at the top of the output .csv file for easy editing. However, this means that those lines move when update_copyrights is run again. It also means that any two PRs touching images are likely to have merge conflicts, as they'll change line 2 of copyrights.csv.

Make the CI fail unless the file has been sorted again after editing.