### PR TITLE
EI - 04b_Ill_Humors.cfg "time over" bugfix

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg
@@ -1,15 +1,12 @@
 #textdomain wesnoth-ei
 
-#define SCENARIO_TURN_LIMIT
-22 #enddef
-
 #wmllint: local spelling alswdan
 
 [scenario]
     id=04b_Ill_Humors
     name= _ "Ill Humours"
     map_file=04b_Ill_Humors.map
-    turns={SCENARIO_TURN_LIMIT}
+    turns=22
     next_scenario=05_Northern_Outpost
 
     {DEFAULT_SCHEDULE_AFTERNOON}
@@ -994,12 +991,6 @@
     [/event]
 
     [event]
-        name=side 1 turn {SCENARIO_TURN_LIMIT} end
-        [fire_event]
-            name=time over
-        [/fire_event]
-    [/event]
-    [event]
         name=time over
         [message]
             speaker=Gweddry
@@ -1044,5 +1035,4 @@
     {HERODEATH_DACYN}
 [/scenario]
 
-#undef SCENARIO_TURN_LIMIT
 #undef SPAWN_ON_TURN


### PR DESCRIPTION
04b's "time over" event triggers on turn 22, even after the turn limit gets extended (thanks for the bug report 'Emperor').  This is a quick fix for the issue.