### PR TITLE
Add optional tag name overrides to conditional tags in schema.cfg

### DIFF
--- a/data/schema/schema.cfg
+++ b/data/schema/schema.cfg
@@ -191,7 +191,6 @@
 					[tag]
 						name="elseif"
 						max=infinite
-						super="wml_schema/tag"
 						any_tag=yes
 						{ANY_KEY string}
 						[tag]

--- a/data/schema/schema.cfg
+++ b/data/schema/schema.cfg
@@ -56,6 +56,13 @@
 		name="bool"
 		value="yes|no|true|false"
 	[/type]
+    # Used to override a required key into an optional key with no allowed values.
+    # This should be used for the `name` key in certain tags where it is not allowed,
+    # as the schema can't override a supertag key with its absence.
+    [type]
+        name="disallowed"
+        value="]^"
+    [/type]
 	[tag]
 		name="root"
 		min=1
@@ -78,10 +85,8 @@
 								name="type"
 								max=infinite
 								super="wml_schema/type"
-								# Override the required name with an optional name
-								# Technically name is not really allowed here at all,
-								# but the schema can't override a supertag key with its absence.
-								{SIMPLE_KEY name string}
+                                # The `name` key should not exist in a union tag.
+								{SIMPLE_KEY name disallowed}
 							[/tag]
 						[/tag]
 					[/then]
@@ -96,10 +101,8 @@
 									name="type"
 									max=infinite
 									super="wml_schema/type"
-									# Override the required name with an optional name
-									# Technically name is not really allowed here at all,
-									# but the schema can't override a supertag key with its absence.
-									{SIMPLE_KEY name string}
+                                    # The `name` key should not exist in an intersection tag.
+									{SIMPLE_KEY name disallowed}
 								[/tag]
 							[/tag]
 						[/then]
@@ -118,10 +121,8 @@
 									name="element"
 									max=infinite
 									super="wml_schema/type"
-									# Override the required name with an optional name
-									# Technically name is not really allowed here at all,
-									# but the schema can't override a supertag key with its absence.
-									{SIMPLE_KEY name string}
+                                    # The `name` key should not exist in a list/element tag.
+									{SIMPLE_KEY name disallowed}
 								[/tag]
 							[/tag]
 						[/then]
@@ -173,10 +174,14 @@
 						super="wml_schema/tag"
 						{REQUIRED_KEY value string}
 						{DEFAULT_KEY trigger_if_missing bool no}
+                        # The `name` key should not exist in a switch/case tag.
+                        {SIMPLE_KEY name disallowed}
 					[/tag]
 					[tag]
 						name="else"
 						super="wml_schema/tag"
+                        # The `name` key should not exist in a switch/else tag.
+                        {SIMPLE_KEY name disallowed}
 					[/tag]
 				[/tag]
 				[tag]
@@ -187,6 +192,8 @@
 					[tag]
 						name="then"
 						super="wml_schema/tag"
+                        # The `name` key should not exist in an if/then tag.
+                        {SIMPLE_KEY name disallowed}
 					[/tag]
 					[tag]
 						name="elseif"
@@ -197,11 +204,15 @@
 							name="then"
 							min=1
 							super="wml_schema/tag"
+                            # The `name` key should not exist in an if/elseif/then tag.
+                            {SIMPLE_KEY name disallowed}
 						[/tag]
 					[/tag]
 					[tag]
 						name="else"
 						super="wml_schema/tag"
+                        # The `name` key should not exist in an if/else tag.
+                        {SIMPLE_KEY name disallowed}
 					[/tag]
 				[/tag]
 			[/tag]


### PR DESCRIPTION
Fixes schema.cfg validation errors after #8136.

I've followed the same pattern of the other tags in this schema to allow the conditional tags `case`, `else`, `then`, `elseif` and `else` to be defined without a name key.