### PR TITLE
Deprecate abilites

### DIFF
--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -250,6 +250,9 @@ variant unit_callable::get_value(const std::string& key) const
 
 		return variant(std::move(res));
 	} else if(key == "abilities") {
+		deprecated_message("unit.abilities", DEP_LEVEL::FOR_REMOVAL, version_info("1.21"), "Use unit.ability_ids instead.");
+		return formula_callable::convert_vector(u_.get_ability_id_list());
+	} else if(key == "ability_ids") {
 		return formula_callable::convert_vector(u_.get_ability_id_list());
 	} else if(key == "hitpoints") {
 		return variant(u_.hitpoints());
@@ -381,6 +384,7 @@ void unit_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "objects_count");
 	add_input(inputs, "attacks");
 	add_input(inputs, "abilities");
+	add_input(inputs, "ability_ids");
 	add_input(inputs, "hitpoints");
 	add_input(inputs, "max_hitpoints");
 	add_input(inputs, "experience");
@@ -440,6 +444,9 @@ variant unit_type_callable::get_value(const std::string& key) const
 	} else if(key == "race") {
 		return variant(u_.race_id());
 	} else if(key == "abilities") {
+		deprecated_message("unittype.abilities", DEP_LEVEL::FOR_REMOVAL, version_info("1.21"), "Use unittype.ability_ids instead.");
+		return formula_callable::convert_vector(u_.get_ability_id_list());
+	} else if(key == "ability_ids") {
 		return formula_callable::convert_vector(u_.get_ability_id_list());
 	} else if(key == "traits") {
 		std::vector<variant> res;
@@ -493,6 +500,7 @@ void unit_type_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "race");
 	add_input(inputs, "alignment");
 	add_input(inputs, "abilities");
+	add_input(inputs, "ability_ids");
 	add_input(inputs, "traits");
 	add_input(inputs, "attacks");
 	add_input(inputs, "hitpoints");

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -624,6 +624,11 @@ UNIT_GETTER("traits", std::vector<std::string>) {
 }
 
 UNIT_GETTER("abilities", std::vector<std::string>) {
+	deprecated_message("unit.abilities", DEP_LEVEL::FOR_REMOVAL, version_info("1.21"), "Use unit.ability_ids instead.");
+	return u.get_ability_id_list();
+}
+
+UNIT_GETTER("ability_ids", std::vector<std::string>) {
 	return u.get_ability_id_list();
 }
 

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -16,6 +16,8 @@
 #include "scripting/lua_unit_type.hpp"
 
 #include "scripting/lua_attributes.hpp"
+#include "deprecation.hpp"
+#include "game_version.hpp"
 #include "scripting/lua_common.hpp"
 #include "scripting/lua_unit_attacks.hpp"
 #include "scripting/push_check.hpp"
@@ -122,9 +124,13 @@ UNIT_TYPE_GETTER("traits", traits_map) {
 }
 
 UNIT_TYPE_GETTER("abilities", std::vector<std::string>) {
+	deprecated_message("unit_type.abilities", DEP_LEVEL::FOR_REMOVAL, version_info("1.21"), "Use unit_type.ability_ids instead.");
 	return ut.get_ability_id_list();
 }
 
+UNIT_TYPE_GETTER("ability_ids", std::vector<std::string>) {
+	return ut.get_ability_id_list();
+}
 UNIT_TYPE_GETTER("attacks", lua_index_raw) {
 	(void)ut;
 	push_unit_attacks_table(L, 1);


### PR DESCRIPTION
the deprecated the `u.abilities` properties in formula and lua which returns a list of ability ids, and renames them to "ability_ids", the idea is that by doing this now we can eventually make `u.abilities` return a userdata that gives more information than just the ids.