### PR TITLE
IPF: improve memory safety when constructing mod queue

### DIFF
--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -45,14 +45,14 @@ public:
 	}
 
 	bool empty() const  { return priorities_.empty(); }
-	void push(modification * mod);
+	void push(std::unique_ptr<modification> mod);
 	void pop();
 	std::size_t size() const;
 	modification * top() const;
 
 private:
 	/** Map from a mod's priority() to the mods having that priority. */
-	typedef std::map<int, std::vector<std::shared_ptr<modification>>, std::greater<int>> map_type;
+	typedef std::map<int, std::vector<std::unique_ptr<modification>>, std::greater<int>> map_type;
 	/** Map from a mod's priority() to the mods having that priority. */
 	map_type priorities_;
 };

--- a/src/tests/test_image_modifications.cpp
+++ b/src/tests/test_image_modifications.cpp
@@ -122,31 +122,38 @@ BOOST_AUTO_TEST_CASE(test_modificaiton_queue_order)
 	environment_setup env_setup;
 
 	modification_queue queue;
-	modification* low_priority_mod = new fl_modification();
-	modification* high_priority_mod = new rc_modification();
 
-	queue.push(low_priority_mod);
-	queue.push(high_priority_mod);
+	auto low_priority_mod = std::make_unique<fl_modification>();
+	auto high_priority_mod = std::make_unique<rc_modification>();
+
+	modification* lptr = low_priority_mod.get();
+	modification* hptr = high_priority_mod.get();
+
+	queue.push(std::move(low_priority_mod));
+	queue.push(std::move(high_priority_mod));
 
 	BOOST_REQUIRE_EQUAL(queue.size(), 2);
 
-	BOOST_CHECK_EQUAL(queue.top(), high_priority_mod);
+	BOOST_CHECK_EQUAL(queue.top(), hptr);
 	queue.pop();
-	BOOST_CHECK_EQUAL(queue.top(), low_priority_mod);
+	BOOST_CHECK_EQUAL(queue.top(), lptr);
 	queue.pop();
 
-	low_priority_mod = new fl_modification();
-	high_priority_mod = new rc_modification();
+	low_priority_mod = std::make_unique<fl_modification>();
+	high_priority_mod = std::make_unique<rc_modification>();
+
+	lptr = low_priority_mod.get();
+	hptr = high_priority_mod.get();
 
 	// reverse insertion order now
-	queue.push(high_priority_mod);
-	queue.push(low_priority_mod);
+	queue.push(std::move(high_priority_mod));
+	queue.push(std::move(low_priority_mod));
 
 	BOOST_REQUIRE_EQUAL(queue.size(), 2);
 
-	BOOST_CHECK_EQUAL(queue.top(), high_priority_mod);
+	BOOST_CHECK_EQUAL(queue.top(), hptr);
 	queue.pop();
-	BOOST_CHECK_EQUAL(queue.top(), low_priority_mod);
+	BOOST_CHECK_EQUAL(queue.top(), lptr);
 	queue.pop();
 }
 


### PR DESCRIPTION
Previously, the mod parser returned a raw to-heap pointer. Once added to a mod queue, it would then be owned by a shared_ptr (overkill). This makes it so the mod executors are managed by unique_ptrs for their entire lifetime.