### PR TITLE
[1.16] systemd: Run as _wesnoth:_wesnoth using sysusers.d

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -767,7 +767,8 @@ if not access(fifodir, F_OK):
     env.Alias("install-wesnothd", fifodir)
 if env["systemd"]:
     env.InstallData("prefix", "wesnothd", "#packaging/systemd/wesnothd.service", "lib/systemd/system")
-    env.InstallData("prefix", "wesnothd", "#packaging/systemd/wesnothd.conf", "lib/tmpfiles.d")
+    env.InstallData("prefix", "wesnothd", "#packaging/systemd/wesnothd/tmpfiles.conf", "lib/tmpfiles.d")
+    env.InstallData("prefix", "wesnothd", "#packaging/systemd/wesnothd/sysusers.conf", "lib/sysusers.d")
 
 # Wesnoth campaign server
 env.InstallBinary(campaignd)

--- a/changelog_entries/systemd_nobody.md
+++ b/changelog_entries/systemd_nobody.md
@@ -1,0 +1,2 @@
+ ### Security Fixes
+   * Run wesnothd server as `_wesnoth:_wesnoth` instead of `nobody:users`, improving safety and fixing a warning message in systemd 246+

--- a/packaging/systemd/SConscript
+++ b/packaging/systemd/SConscript
@@ -1,4 +1,5 @@
 Import("env")
 
 env.ScanReplace("wesnothd.service", "wesnothd.service.scons.in")
-env.ScanReplace("wesnothd.conf", "wesnothd.tmpfiles.conf.in")
+env.ScanReplace("wesnothd.tmpfiles.conf", "wesnothd.tmpfiles.conf.in")
+env.ScanReplace("wesnothd.sysusers.conf", "wesnothd.sysusers.conf.in")

--- a/packaging/systemd/wesnothd.service.in
+++ b/packaging/systemd/wesnothd.service.in
@@ -23,8 +23,8 @@ ExecStopPost=/bin/rm -f @FIFO_DIR@/socket
 
 SyslogIdentifier=Wesnothd@BINARY_SUFFIX@
 WorkingDirectory=@FIFO_DIR@
-User=nobody
-Group=users
+User=_wesnoth
+Group=_wesnoth
 
 # Additional security-related features
 # (when using the -c option, do not use ProtectHome)

--- a/packaging/systemd/wesnothd.service.scons.in
+++ b/packaging/systemd/wesnothd.service.scons.in
@@ -4,6 +4,8 @@ After=network.target
 
 [Service]
 ExecStart=%bindir/wesnothd
+User=_wesnoth
+Group=_wesnoth
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/wesnothd.sysusers.conf.in
+++ b/packaging/systemd/wesnothd.sysusers.conf.in
@@ -1,0 +1,2 @@
+u _wesnoth -
+g _wesnoth -

--- a/packaging/systemd/wesnothd.tmpfiles.conf.in
+++ b/packaging/systemd/wesnothd.tmpfiles.conf.in
@@ -1,1 +1,1 @@
-d @FIFO_DIR@ 0700 nobody users -
+d @FIFO_DIR@ 0700 _wesnoth _wesnoth -


### PR DESCRIPTION
[systemd 246+ logs a warning message](https://github.com/systemd/systemd/blob/v246/NEWS#L106-L113), because running as "nobody" is unsafe.

This should be reviewed and tested by someone who knows and uses systemd, as I do not.  Is this worth escalating in the changelog to `### Security Fixes`?

See also #8168 for master.