### PR TITLE
make `wml_tag::iterator` copy assignable

### DIFF
--- a/src/serialization/schema/tag.hpp
+++ b/src/serialization/schema/tag.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -59,7 +60,7 @@ private:
 	{
 		std::queue<const wml_tag*> condition_queue;
 		typename Map::const_iterator current;
-		const config& match;
+		std::reference_wrapper<const config> match;
 	public:
 		// Construct a begin iterator
 		iterator(const wml_tag& base_tag, const config& match) : match(match)
@@ -81,7 +82,7 @@ private:
 		}
 		void push_new_tag_conditions(const wml_tag& tag)
 		{
-			wml_tag::push_new_tag_conditions(condition_queue, match, tag);
+			wml_tag::push_new_tag_conditions(condition_queue, match.get(), tag);
 		}
 		bool equal(const iterator<T, Map>& other) const
 		{


### PR DESCRIPTION
For more context:
https://github.com/wesnoth/wesnoth/pull/8136#issuecomment-1872243927

This makes iterators based on `wml_tag::iterator` to meet LegacyInputIterator requirements.