### PR TITLE
Save horizontal scrolling inversion check in static variable

### DIFF
--- a/changelog_entries/horizontal_scrolling.md
+++ b/changelog_entries/horizontal_scrolling.md
@@ -1,2 +1,2 @@
  ### Miscellaneous and Bug Fixes
-   * Fix a regression from 1.13.11 that inverted horizontal scrolling with SDL versions 2.0.18+ on X11 and versions 2.0.20+ on Wayland (issue #7404, PR #8137)
+   * Fix a regression from 1.13.11 that inverted horizontal scrolling with SDL versions 2.0.18+ on X11 and versions 2.0.20+ on Wayland (issues #3362 and #7404, PR #8137)

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -232,28 +232,31 @@ void controller_base::handle_event(const SDL_Event& event)
 		break;
 
 	case SDL_MOUSEWHEEL:
-		// Down and right are positive in Wesnoth's map.
-		// Up and right are positive in SDL_MouseWheelEvent on all
-		// platforms:
+		// Right and down are positive in Wesnoth's map.
+		// Right and up are positive in SDL_MouseWheelEvent on all platforms:
 		//     https://wiki.libsdl.org/SDL2/SDL_MouseWheelEvent
 		// Except right is wrongly negative on X11 in SDL < 2.0.18:
 		//     https://github.com/libsdl-org/SDL/pull/4700
 		//     https://github.com/libsdl-org/SDL/commit/515b7e9
 		// and on Wayland in SDL < 2.0.20:
 		//     https://github.com/libsdl-org/SDL/commit/3e1b3bc
-		// Fixes issue #7404, which is a regression caused by pull #2481
-		// that fixed issue #2218.
+		// Fixes issues #3362 and #7404, which are a regression caused by pull #2481 that fixed issue #2218.
 		{
-			int xmul = 1;
-#if !defined(_WIN32) && !defined(__APPLE__)
-			const char* video_driver = SDL_GetCurrentVideoDriver();
-			SDL_version ver;
-			SDL_GetVersion(&ver);
-			if(video_driver != nullptr && ver.major <= 2 && ver.minor <= 0) {
-				if(std::strcmp(video_driver, "x11") == 0 && ver.patch < 18) {
-					xmul = -1;
-				} else if(std::strcmp(video_driver, "wayland") == 0 && ver.patch < 20) {
-					xmul = -1;
+			static int xmul = 0;
+#if defined(_WIN32) || defined(__APPLE__)
+			xmul = 1;
+#else
+			if(xmul == 0) {
+				xmul = 1;
+				const char* video_driver = SDL_GetCurrentVideoDriver();
+				SDL_version ver;
+				SDL_GetVersion(&ver);
+				if(video_driver != nullptr && ver.major <= 2 && ver.minor <= 0) {
+					if(std::strcmp(video_driver, "x11") == 0 && ver.patch < 18) {
+						xmul = -1;
+					} else if(std::strcmp(video_driver, "wayland") == 0 && ver.patch < 20) {
+						xmul = -1;
+					}
 				}
 			}
 #endif


### PR DESCRIPTION
Avoids two to four function calls on each SDL_MouseWheelEvent.

Also update code comment and changelog entry based on @vgaming's report of issue #3362 being fixed.

Slightly improves commit ab4001d.  Tested again with SDL 2.0.14 and 2.28.5.

Slight (unnoticeable) performance improvement inspired by @vgaming's review of pull #8158.

See also #8186 for 1.16.