### PR TITLE
Allow effects applied in [modifications] to be reported by [advancement], [object] or [trait]

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -47,15 +47,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
     [effect]
         [filter]
             level=1
-#ifdef EASY
-            formula="max_experience > 24"
-#endif
-#ifdef NORMAL
-            formula="max_experience > 28"
-#endif
-#ifdef HARD
-            formula="max_experience > 33"
-#endif
+            formula="advancements_applied >= 1"
         [/filter]
         apply_to=level
         set=2
@@ -63,15 +55,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
     [effect]
         [filter]
             level=2
-#ifdef EASY
-            formula="max_experience > 41"
-#endif
-#ifdef NORMAL
-            formula="max_experience > 46"
-#endif
-#ifdef HARD
-            formula="max_experience > 54"
-#endif
+            formula="advancements_applied >= 3"
         [/filter]
         apply_to=level
         set=3
@@ -894,11 +878,6 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
     movement_type=quenoth_foot
     movement=6
     hitpoints=32
-    # The evolution of this unit is carried out only with AMLAs so that it takes two amlas
-    # to reach level two then two more for level 3.
-    # As the unit variables do not include the number of amla achieved,
-    # the maximum experience is the only one that can be directly used in advancement without resorting to an external lua type function.
-    # Do not modify this value without also modifying the max_experience checks in the custom AMLAs
     experience=16
     level=1
     profile=portraits/kaleh.webp

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -246,6 +246,12 @@ variant unit_callable::get_value(const std::string& key) const
 	} else if(key == "level" || key == "full") {
 		// This allows writing "upkeep == full"
 		return variant(u_.level());
+	} else if(key == "advancements_applied") {
+		return variant(u_.check_number_advancement());
+	} else if(key == "traits_applied") {
+		return variant(u_.check_number_trait());
+	} else if(key == "objects_applied") {
+		return variant(u_.check_number_object());
 	} else if(key == "total_movement" || key == "max_moves") {
 		return variant(u_.total_movement());
 	} else if(key == "movement_left" || key == "moves") {
@@ -360,6 +366,9 @@ void unit_callable::get_inputs(formula_input_vector& inputs) const
 	add_input(inputs, "experience");
 	add_input(inputs, "max_experience");
 	add_input(inputs, "level");
+	add_input(inputs, "advancements_applied");
+	add_input(inputs, "traits_applied");
+	add_input(inputs, "objects_applied");
 	add_input(inputs, "moves");
 	add_input(inputs, "max_moves");
 	add_input(inputs, "attacks_left");

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -240,6 +240,9 @@ unit::unit(const unit& o)
 	, experience_(o.experience_)
 	, max_experience_(o.max_experience_)
 	, level_(o.level_)
+	, check_number_advancement_(o.check_number_advancement_)
+	, check_number_trait_(o.check_number_trait_)
+	, check_number_object_(o.check_number_object_)
 	, recall_cost_(o.recall_cost_)
 	, canrecruit_(o.canrecruit_)
 	, recruit_list_(o.recruit_list_)
@@ -321,6 +324,9 @@ unit::unit(unit_ctor_t)
 	, experience_(0)
 	, max_experience_(1)
 	, level_(0)
+	, check_number_advancement_(0)
+	, check_number_trait_(0)
+	, check_number_object_(0)
 	, recall_cost_(-1)
 	, canrecruit_(false)
 	, recruit_list_()
@@ -1241,6 +1247,15 @@ void unit::expire_modifications(const std::string& duration)
 				}
 
 				modifications_.remove_child(mod_name, j);
+				if(mod_name == "advance" || mod_name == "advancement"){
+					--check_number_advancement_;
+				}
+				if(mod_name == "trait"){
+					--check_number_trait_;
+				}
+				if(mod_name == "object"){
+					--check_number_object_;
+				}
 			}
 		}
 	}
@@ -2564,6 +2579,16 @@ void unit::add_modification(const std::string& mod_type, const config& mod, bool
 		add_trait_description(mod, description);
 	}
 
+	if(mod_type == "advance" || mod_type == "advancement"){
+		++check_number_advancement_;
+	}
+	if(mod_type == "trait"){
+		++check_number_trait_;
+	}
+	if(mod_type == "object"){
+		++check_number_object_;
+	}
+
 	//NOTE: if not a trait, description is currently not used
 }
 
@@ -2595,6 +2620,9 @@ void unit::apply_modifications()
 	log_scope("apply mods");
 
 	variables_.clear_children("mods");
+	check_number_advancement_ = 0;
+	check_number_trait_= 0;
+	check_number_object_ = 0;
 	if(modifications_.has_child("advance")) {
 		deprecated_message("[advance]", DEP_LEVEL::PREEMPTIVE, {1, 15, 0}, "Use [advancement] instead.");
 	}

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -570,6 +570,20 @@ public:
 		level_ = level;
 	}
 
+	/** The number of modification aplied to unitby advancement, trait or object */
+	std::size_t check_number_advancement() const
+	{
+		return check_number_advancement_;
+	}
+	std::size_t check_number_trait() const
+	{
+		return check_number_trait_;
+	}
+	std::size_t check_number_object() const
+	{
+		return check_number_object_;
+	}
+
 	/** The ID of the variation of this unit's type. */
 	const std::string& variation() const
 	{
@@ -1902,6 +1916,10 @@ private:
 	int max_experience_;
 
 	int level_;
+
+	std::size_t check_number_advancement_;
+	std::size_t check_number_trait_;
+	std::size_t check_number_object_;
 
 	int recall_cost_;
 	bool canrecruit_;


### PR DESCRIPTION

Can resolve https://github.com/wesnoth/wesnoth/issues/8179

This approach consists of using three different variables to perform the counting before making them accessible in the formulas, but not in the wml variables because they must remain read-only to avoid any modifications making their values incorrect.