### PR TITLE
Add tests for [harm_unit]

### DIFF
--- a/data/test/macros/wml_unit_test_macros.cfg
+++ b/data/test/macros/wml_unit_test_macros.cfg
@@ -136,3 +136,20 @@ bob#endarg
     {CLEAR_VARIABLE {ID1}}
     {CLEAR_VARIABLE {ID2}}
 #enddef
+
+# Takes a unit id, and checks that its hitpoints and experience are the expected values.
+# Clobbers the variable "temp".
+#define ASSERT_UNIT_HP_XP ID EXPECTED_HP EXPECTED_XP
+    [store_unit]
+        [filter]
+            id={ID}
+        [/filter]
+        variable=temp
+    [/store_unit]
+
+    {ASSERT ({VARIABLE_CONDITIONAL temp.length numerical_equals 1})}
+    {ASSERT ({VARIABLE_CONDITIONAL temp.hitpoints numerical_equals {EXPECTED_HP}})}
+    {ASSERT ({VARIABLE_CONDITIONAL temp.experience numerical_equals {EXPECTED_XP}})}
+
+    {CLEAR_VARIABLE temp}
+#enddef

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_no_experience_no.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_no_experience_no.cfg
@@ -1,0 +1,63 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set all units to a known number of hitpoints.
+# Both of these have Alice as the harmer.
+# Use [harm_unit] with Bob as the victim, and a fatal amount of damage but with kill=no.
+# Use [harm_unit] with Charlie and Dave as victims, and a fatal amount of damage but with kill=no.
+##
+# Expected end state:
+# The victims get reduced to 1 hp, but survive.
+# Nobody gets any experience.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_kill_no_experience_no" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,bob,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=no
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT_UNIT_HP_XP "bob" 1 0}
+        {ASSERT_UNIT_HP_XP "charlie" 10 0}
+        {ASSERT_UNIT_HP_XP "dave" 10 0}
+
+        [harm_unit]
+            [filter]
+                id=charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=no
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT_UNIT_HP_XP "bob" 1 0}
+        {ASSERT_UNIT_HP_XP "charlie" 1 0}
+        {ASSERT_UNIT_HP_XP "dave" 1 0}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_no_experience_yes.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_no_experience_yes.cfg
@@ -1,0 +1,63 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set all units to a known number of hitpoints.
+# Both of these have Alice as the harmer.
+# Use [harm_unit] with Bob as the victim, and a fatal amount of damage but with kill=no.
+# Use [harm_unit] with Charlie and Dave as victims, and a fatal amount of damage but with kill=no.
+##
+# Expected end state:
+# The victims get reduced to 1 hp, but survive.
+# Alice and Bob get 1 experience point each for the first fight.
+# Alice gets 2 experience points for the second fight, Charlie and Dave get 1 each.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_kill_no_experience_yes" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,bob,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=no
+            # experience=yes is the default, so this test leaves it unset
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 1}
+        {ASSERT_UNIT_HP_XP "bob" 1 1}
+        {ASSERT_UNIT_HP_XP "charlie" 10 0}
+        {ASSERT_UNIT_HP_XP "dave" 10 0}
+
+        [harm_unit]
+            [filter]
+                id=charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 3}
+        {ASSERT_UNIT_HP_XP "bob" 1 1}
+        {ASSERT_UNIT_HP_XP "charlie" 1 1}
+        {ASSERT_UNIT_HP_XP "dave" 1 1}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_split_experience_no.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_split_experience_no.cfg
@@ -1,0 +1,61 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set Alice, Charlie and Dave to a known number of hitpoints.
+# Set Bob to a known but higher number of hitpoints.
+# Use [harm_unit] with Alice as harmer, the others as victims, and damage equal to Charlie's hitpoints.
+##
+# Expected end state:
+# Charlie and Dave die.
+# Nobody gets any experience.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_kill_split_experience_no" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=15
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob,charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=yes
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT_UNIT_HP_XP "bob" 5 0}
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=charlie,dave
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_split_experience_yes.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_split_experience_yes.cfg
@@ -1,0 +1,60 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set Alice, Charlie and Dave to a known number of hitpoints.
+# Set Bob to a known but higher number of hitpoints.
+# Use [harm_unit] with Alice as harmer, the others as victims, and damage equal to Charlie's hitpoints.
+##
+# Expected end state:
+# Alice gets 17 experience points, Bob gets 1, Charlie and Dave die.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_kill_split_experience_yes" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=15
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob,charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=yes
+            # experience=yes is the default, so this test leaves it unset
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 17}
+        {ASSERT_UNIT_HP_XP "bob" 5 1}
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=charlie,dave
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_yes_experience_no.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_yes_experience_no.cfg
@@ -1,0 +1,73 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set all units to a known number of hitpoints.
+# Both of these have Alice as the harmer.
+# Use [harm_unit] with Bob as the victim, and a fatal amount of damage.
+# Use [harm_unit] with Charlie and Dave as victims, and a fatal amount of damage.
+##
+# Expected end state:
+# Bob, Charlie and Dave die.
+# Nobody gets any experience.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_kill_yes_experience_no" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,bob,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=yes
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=bob
+                [/have_unit]
+            [/not]
+        )}
+        {ASSERT_UNIT_HP_XP "charlie" 10 0}
+        {ASSERT_UNIT_HP_XP "dave" 10 0}
+
+        [harm_unit]
+            [filter]
+                id=charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=yes
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=bob,charlie,dave
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_yes_experience_yes.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_kill_yes_experience_yes.cfg
@@ -1,0 +1,72 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set all units to a known number of hitpoints.
+# Both of these have Alice as the harmer.
+# Use [harm_unit] with Bob as the victim, and a fatal amount of damage.
+# Use [harm_unit] with Charlie and Dave as victims, and a fatal amount of damage.
+##
+# Expected end state:
+# Alice gets 8 experience points for the first fight, Bob dies.
+# Alice gets 16 experience points for the second fight, Charlie and Dave die.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_kill_yes_experience_yes" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,bob,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=yes
+            # experience=yes is the default, so this test leaves it unset
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 8}
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=bob
+                [/have_unit]
+            [/not]
+        )}
+        {ASSERT_UNIT_HP_XP "charlie" 10 0}
+        {ASSERT_UNIT_HP_XP "dave" 10 0}
+
+        [harm_unit]
+            [filter]
+                id=charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=10
+            kill=yes
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 24}
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=bob,charlie,dave
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_survivable_experience_no.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_survivable_experience_no.cfg
@@ -1,0 +1,61 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set all units to a known number of hitpoints.
+# Both of these have Alice as the harmer.
+# Use [harm_unit] with Bob as the victim, and a non-fatal amount of damage.
+# Use [harm_unit] with Charlie and Dave as victims, and a non-fatal amount of damage.
+##
+# Expected end state:
+# The victims take the expected amount of damage.
+# Nobody gets any experience.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_survivable_experience_no" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,bob,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=5
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT_UNIT_HP_XP "bob" 5 0}
+        {ASSERT_UNIT_HP_XP "charlie" 10 0}
+        {ASSERT_UNIT_HP_XP "dave" 10 0}
+
+        [harm_unit]
+            [filter]
+                id=charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=5
+            experience=no
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 0}
+        {ASSERT_UNIT_HP_XP "bob" 5 0}
+        {ASSERT_UNIT_HP_XP "charlie" 5 0}
+        {ASSERT_UNIT_HP_XP "dave" 5 0}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_survivable_experience_yes.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/harm_unit_survivable_experience_yes.cfg
@@ -1,0 +1,61 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [harm_unit]
+##
+# Actions:
+# Set all units to a known number of hitpoints.
+# Both of these have Alice as the harmer.
+# Use [harm_unit] with Bob as the victim, and a non-fatal amount of damage.
+# Use [harm_unit] with Charlie and Dave as victims, and a non-fatal amount of damage.
+##
+# Expected end state:
+# The victims take the expected amount of damage.
+# Alice and Bob get 1 experience point each for the first fight.
+# Alice gets 2 experience points for the second fight, Charlie and Dave get 1 each.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "harm_unit_survivable_experience_yes" (
+    [event]
+        name=side 1 turn
+        [modify_unit]
+            [filter]
+                id=alice,bob,charlie,dave
+            [/filter]
+            [effect]
+                apply_to=hitpoints
+                set=10
+            [/effect]
+        [/modify_unit]
+
+        [harm_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=5
+            # experience=yes is the default, so this test leaves it unset
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 1}
+        {ASSERT_UNIT_HP_XP "bob" 5 1}
+        {ASSERT_UNIT_HP_XP "charlie" 10 0}
+        {ASSERT_UNIT_HP_XP "dave" 10 0}
+
+        [harm_unit]
+            [filter]
+                id=charlie,dave
+            [/filter]
+            [filter_second]
+                id=alice
+            [/filter_second]
+            amount=5
+        [/harm_unit]
+        {ASSERT_UNIT_HP_XP "alice" 10 3}
+        {ASSERT_UNIT_HP_XP "bob" 5 1}
+        {ASSERT_UNIT_HP_XP "charlie" 5 1}
+        {ASSERT_UNIT_HP_XP "dave" 5 1}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -222,6 +222,14 @@
 0 test_attacks_used
 0 no_duplicate_advancements
 0 add_advancement
+0 harm_unit_survivable_experience_no
+0 harm_unit_survivable_experience_yes
+0 harm_unit_kill_no_experience_no
+0 harm_unit_kill_no_experience_yes
+0 harm_unit_kill_split_experience_no
+0 harm_unit_kill_split_experience_yes
+0 harm_unit_kill_yes_experience_no
+0 harm_unit_kill_yes_experience_yes
 # Terrain mask tests
 0 test_terrain_mask_simple_nop
 0 test_terrain_mask_simple_set


### PR DESCRIPTION
This is testing experience=yes and experience=no, with the expectation that some new values for that attribute will be added afterwards.

Adds a new generic macro ASSERT_UNIT_HP_XP. Looking thorugh the ability tests, ASSERT_UNIT_HP (without the XP) could be a heavily-used macro, but it wouldn't be used by this particular commit, so I'm not adding it in this commit.