### PR TITLE
Fix some multiline po: comments

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/03_Stirring_in_the_Night.cfg
@@ -659,10 +659,10 @@
             speaker=Garak
             # po: Garak dies in this scenario, and the important part of this conversation is to tell the player that.
             #
-            # This is said at LONGDARK4, with the moon on the schedule picture as if the next turn will be dawn. Garak
-            # has had the dream tonight while they were camped here, he hasn't had premonitions beforehand; that's
-            # probably just because of the nearby undead, not some prophetic vision. Neither Garak nor a first-time
-            # player know that the scenario will extend the night indefinitely until the enemies are defeated.
+            # po: This is said at LONGDARK4, with the moon on the schedule picture as if the next turn will be dawn. Garak
+            # po: has had the dream tonight while they were camped here, he hasn't had premonitions beforehand; that's
+            # po: probably just because of the nearby undead, not some prophetic vision. Neither Garak nor a first-time
+            # po: player know that the scenario will extend the night indefinitely until the enemies are defeated.
             message=_"I had a dream this night Kaleh, full of gloom and darkness. My journey will end here one way or another."
         [/message]
         [message]

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/09_Blood_is_Thicker_Than_Water.cfg
@@ -1610,11 +1610,11 @@
         [message]
             speaker=Nym
             # po: Nym is talking about Hekuba, the male necromancer who is the final enemy leader in
-            # the last part of this scenario. This line is at the end of the rescuing-merfolk part,
-            # so far Hekuba has either watched silently (if Darius is still alive), or has said
-            # versions of Darius' lines about the sacrifice.
+            # po: the last part of this scenario. This line is at the end of the rescuing-merfolk part,
+            # po: so far Hekuba has either watched silently (if Darius is still alive), or has said
+            # po: versions of Darius' lines about the sacrifice.
             #
-            # Either way, he just walked into the shrouded area in the north-west.
+            # po: Either way, he just walked into the shrouded area in the north-west.
             message= _ "Who was that?"
         [/message]
         [message]

--- a/data/core/macros/special-notes.cfg
+++ b/data/core/macros/special-notes.cfg
@@ -118,7 +118,7 @@ _"This unit has a defense cap on certain terrain types — it cannot achieve a h
 
 "+
         # po: User-visible string, but only shown in the help pages of UMC units that haven't yet been updated to the 1.16 special notes format.
-        # Don't use markup in this, because it's shown by both Pango (in the sidebar's tooltips) and the GUI1 help browser (for unit descriptions).
+        # po: Don't use markup in this, because it's shown by both Pango (in the sidebar's tooltips) and the GUI1 help browser (for unit descriptions).
         _"Special Notes (1.14-style, please update to the new list format to avoid duplicates):"#enddef
 # wmlindent: stop ignoring
 


### PR DESCRIPTION
Multiline comments need the `po:` prefix on each line, otherwise that line is ignored. This fixes all occurances of this.

Any lines which have nothing after the `po:` are still ignored, so I haven't added it to the paragraph-break lines. The resulting .pot file doesn't have paragraphs.

Planning to just do a CI check overnight and merge in the morning.