### PR TITLE
08_Clearwater_Port.map

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/maps/08_Clearwater_Port.map
+++ b/data/campaigns/The_Rise_Of_Wesnoth/maps/08_Clearwater_Port.map
@@ -4,7 +4,7 @@ Ms, Ms, Ms, Ms^Xm, Ms^Xm, Ms^Xm, Ms, Ms, Ms, Ms, Ha, Ha, Ha, Aa, Aa^Fda, Aa^Fda,
 Ha, Ha, Ha, Ms, Ha, Ha, Ha, Ms, Ms, Ms, Ha, Ha^Fda, Aa^Fda, Ha^Vhha, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Ha, Ha, Ms, Ha, Ha, Ha, Ha, Ha, Ha, Ha^Fda, Ha, Ha, Ha, Ha, Gd, Gd, Aa^Fda, Gd, Aa, Aa, Ai, Ww, Wo, Wo
 Aa, Aa, Ha^Vhha, Ms, Ha, Aa, Ha^Fda, Ha, Ha^Fda, Ha, Ha^Fda, Ha^Fda, Aa^Fda, Aa, Aa, Aa, Aa, Aa, Ha, Ha, Ms, Ms, Ha, Ha^Fda, Ha^Fda, Ha, Ha, Ha, Ha, Ha, Ha, Ha, Gd, Aa^Fda, Aa^Fda, Aa^Fda, Aa, Aa, Ai, Ww, Wo, Wo
 Aa, Aa, Ms, Ms, Aa, Aa^Vha, Ha, Aa^Fda, Aa^Fda, Ha, Ha, Aa^Fda, Aa^Fda, Aa, Cha, Cha, Chr, Aa, Ha, Ha, Ha, Ha^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Re, Gd^Vh, Re, Re, Re, Gd, Ha, Ha^Fda, Aa^Fda, Aa^Fda, Aa, Aa^Vha, Ai, Ww, Wo, Wo
-Aa, Aa, Aa, Aa, Aa, Ha, Ha, Aa^Fda, Gd, Ha, Re, Re, Re, Aa, Chr, 5 Kha, Cha, Aa^Fda, Aa^Fda, Ha, Ha, Ha^Fda, Aa^Fda, Aa^Fda, Aa, Aa, Re, Re, Aa, Aa, Aa, Re, Re, Gd, Gd, Aa, Ai, Ai, Ww, Ww, Wo, Wo
+Aa, Aa, Aa, Aa, Aa, Ha, Ha, Aa^Fda, Gd, Ha, Re, Re, Re, Aa, Chr, 6 Kha, Cha, Aa^Fda, Aa^Fda, Ha, Ha, Ha^Fda, Aa^Fda, Aa^Fda, Aa, Aa, Re, Re, Aa, Aa, Aa, Re, Re, Gd, Gd, Aa, Ai, Ai, Ww, Ww, Wo, Wo
 Gd, Gd, Re, Aa, Gd, Aa^Vha, Re, Gd, Re, Re, Re, Ha, Ha, Re, Aa, Ch, Aa^Fda, Aa^Fda, Aa, Ha, Aa^Vha, Aa^Fda, Re, Aa, Re, Re, Aa, Aa, Ai, Aa, Aa, Aa, Aa, Re, Re, Aa, Ai, Ai, Ww, Wo, Wo, Wo
 Re, Re, Re, Re, Re, Re, Re, Re, Re, Re, Ha, Ha, Ha, Re, Re, Aa^Fda, Re, Re, Re, Aa, Aa, Re, Re, Re, Aa, Aa, Aa, Ai, Ww, Ww, Ww, Ai, Ai, Gd, Gd, Gd, Ai, Ww, Ww, Wo, Wo, Wo
 Re, Re, Aa^Vha, Re, Re, Re, Re, Re, Aa^Fda, Aa^Fda, Ha^Fda, Ai, Ha, Aa, Aa, Re, Aa^Fda, Aa^Fda, Re, Re, Re, Re, Gd, Gd^Vh, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo
@@ -18,7 +18,7 @@ Ww, Ww, Aa^Vha, Ai, Gd, Ww, Ww, Gd, Ww, Ww, Ww^Bw\, Ww, Gd^Vh, Ww, Gd, Ai, Aa, A
 Aa, Aa, Aa, Aa, Aa, Gd, Aa^Vha, Ww^Bw|, Aa, Ww, Aa, Gd, Aa, Rd, Rd, Aa, Aa^Fda, Aa, Aa^Fda, Rd, Aa, Aa, Aa, Aa, Cha, Ai, Re, Ds, Ds, Ds, Aa^Vhca, Ds, Aa, Aa, Rr, Aa^Vhca, Rr, Ha, Aa, Ai, Ww, Ww
 Aa, Aa, Aa, Aa, Aa^Fda, Aa, Re, Rd, Re, Aa^Vha, Aa, Aa, Aa, Aa, Aa, Aa^Fda, Aa^Fda, Aa^Vha, Re, Aa^Fda, Aa^Fda, Re, Re, Gd, Re, Cha, Cha, Gd^Vhc, Rr, Aa, Aa^Vhca, Aa, Cha, Cha, Ch, Rr, Rr, Ha, Ha, Ai, Ww, Ww
 Aa, Aa, Aa, Aa^Fda, Aa^Fda, Re, Cea, Rd, Ce, Re, Re, Gd, Gd, Aa, Re, Aa^Fda, Rd, Rd, Rd, Gd^Fdw, Rd, Re, Chr, Re, Re, Re, Rr, Rr, Cha, Rr, Rr, Rr, Ch, 1 Kha, Ch, Rr, Ha, Ha, Aa^Vha, Ai, Ww, Ww
-Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Re, Re, Cea, 4 Ke, Ce, Rd, Rd, Rd, Rd, Rd, Rd, Rd, Aa, Gd^Fdw, Gd^Fdw, Rd, Re, Rd, Rr, Re, Rr, Rr, Re, Aa, Aa, Cha, 2 Kha, Rr, Rr, Cha, Rr, Rr, Ha, Ha, Ai, Ai, Ww, Ww
+Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Re, Re, Cea, 5 Ke, Ce, Rd, Rd, Rd, Rd, Rd, Rd, Rd, Aa, Gd^Fdw, Gd^Fdw, Rd, Re, Rd, Rr, Re, Rr, Rr, Re, Aa, Aa, Cha, 2 Kha, Rr, Rr, Cha, Rr, Rr, Ha, Ha, Ai, Ai, Ww, Ww
 Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Re, Aa, Cea, Re, Re, Rd, Re, Re, Re, Aa, Re, Ha^Fda, Aa^Fda, Ha^Fda, Aa^Fda, Gd, Re, Chr, Rr, Aa^Vha, Re, Re, Aa, Re, Cha, Aa, Aa, Aa, Rr, Ha, Rr, Aa^Vhca, Aa, Ai, Ww, Ww, Ww
 Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Re^Vh, Re, Aa^Fda, Aa, Aa, Re, Rd, Gd^Vh, Ha, Ha, Ha, Ha, Ha, Ha, Ha, Ha, Re, Re, Re, Rr, Aa, Aa, Aa, Aa, Ai, Cha, Aa^Vhca, Ha, Gd, Aa^Vhca, Aa, Ha, Aa, Ai, Ww, Ww, Wo, Wo
 Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa, Ha, Gd, Rd, Ha, Ms, Ms, Ha, Ha, Ha^Fda, Ha, Aa^Fda, Ha^Fda, Ha, Ha, Rr, Rr, Re, Aa, Re, Ai, Ai, Ai, Ai, Aa, Ww, Ai, Ww, Gd, Ww, Ww, Wo, Wo, Wo, Wo
@@ -29,7 +29,7 @@ Ha, Ha, Ha, Ha, Ms, Ms, Ms, Ha, Ha, Gd, Re, Rd, Rd, Rd, Aa, Aa, Ai, Aa, Ai, Ai, 
 Ms, Ms, Ms^Xm, Ms^Xm, Ms^Xm, Ms, Ha, Ha, Gd, Re, Re, Re, Rd, Aa^Vha, Aa, Ai, Ai, Ai, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wwr, Wwr, Wo, Wwr, Ww, Ww, Wwr, Wwr, Ww, Wo, Wo, Wo, Wo, Wo, Wo
 Ms, Ms, Ms, Ms, Ms, Ms, Ha^Vhha, Ha^Fda, Aa^Fda, Gd^Fdw, Gd^Fdw, Re, Rd, Aa, Aa, Aa, Ai, Ai, Ww, Ww, Wo, Ww, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Wwr, Ai, Ai, Ww, Ww, Wwr, Wo, Wo, Wo, Wo, Wo, Wo, Wo
 Ms, Ms, Ha^Fda, Ha, Ha^Fda, Ha, Ha^Fda, Ha, Aa^Fda, Aa^Fda, Gd, Re, Gd^Fdw, Rd, Rd, Re, Re, Ai, Wwr, Wwr, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Gd, Gd^Vh, Ai, Ai, Wwr, Wo, Wo, Wo, Wo, Wo, Wo, Wo
-Ha^Fda, Ha^Fda, Aa^Fda, Ha^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Gd, Aa, Gd, Aa, Gd^Fdw, Aa^Fda, Cea, 3 Ke, Ce, Gd, Ww, Ww, Ww, Wwr, Wo, Wo, Wo, Wo, Ww, Ai, Ai, Aa^Fda, Ai, Aa^Vha, Ha, Ai, Wwr, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
+Ha^Fda, Ha^Fda, Aa^Fda, Ha^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Gd, Aa, Gd, Aa, Gd^Fdw, Aa^Fda, Cea, 4 Ke, Ce, Gd, Ww, Ww, Ww, Wwr, Wo, Wo, Wo, Wo, Ww, Ai, Ai, Aa^Fda, Ai, Aa^Vha, Ha, Ai, Wwr, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
 Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa^Fda, Aa, Aa, Aa, Gd, Gd, Aa^Fda, Aa^Fda, Cea, Cea, Cea, Ww, Ww, Ai, Ww, Ww, Wwr, Wwr, Wwr, Ww, Ww, Ww^Bw\, Aa^Fda, Gd, Aa, Ha, Ha^Fda, Ai, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
 Ha, Ha, Ha, Aa^Fda, Aa, Aa, Aa, Aa, Aa, Gd, Gd^Vh, Ai, Ai, Ai, Ww, Ai, Ww, Ai, Ww, Ww, Wo, Wwr, Wwr, Ww, Wwr, Ww, Ai, Gd^Vh, Aa^Fda, Ha, Ha^Fda, Ai, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
 Ha, Ha, Aa^Vha, Aa, Aa, Aa, Aa^Vha, Gd, Ai, Ai, Ai, Ai, Ai, Ww, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ai, Ai, Ai, Ai, Ai, Ai, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo


### PR DESCRIPTION
Fixed starting location (bug)

In 1.17, the author has changed the enemy side numbers in the scenario file. However, it seems that the map file starting locations where not updated accordingly. This file updates the starting location. However, there is a chance the author did alter the map as whole, and in that case, we should wait for his upload for the new file.

Tldr: changed these locations:
3 into 4
4 into 5
5 into 6 (originally there was no 6th starting location)