### PR TITLE
Handling RTL in the left pane of the help browser

### DIFF
--- a/changelog_entries/rtl_help_menu.md
+++ b/changelog_entries/rtl_help_menu.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * Fix the left pane of the help browser’s layout for right-to-left languages (Arabic and Hebrew) (issue #8205)

--- a/src/help/help_menu.cpp
+++ b/src/help/help_menu.cpp
@@ -29,7 +29,7 @@
 namespace help {
 
 help_menu::help_menu(const section& toplevel, int max_height) :
-	gui::menu(empty_string_vector, true, max_height, -1, nullptr, &gui::menu::bluebg_style),
+	gui::menu(empty_string_vector, true, max_height, -1, &gui::menu::bluebg_style),
 	visible_items_(),
 	toplevel_(toplevel),
 	expanded_(),

--- a/src/help/help_menu.cpp
+++ b/src/help/help_menu.cpp
@@ -29,12 +29,12 @@
 namespace help {
 
 help_menu::help_menu(const section& toplevel, int max_height) :
-	gui::menu(empty_string_vector, true, max_height, -1, &gui::menu::bluebg_style),
+	gui::menu(true, max_height, -1, &gui::menu::bluebg_style),
 	visible_items_(),
 	toplevel_(toplevel),
 	expanded_(),
 	chosen_topic_(nullptr),
-	selected_item_(&toplevel, "", 0)
+	selected_item_(&toplevel, 0)
 {
 	silent_ = true; //silence the default menu sounds
 	update_visible_items(toplevel_);
@@ -43,7 +43,7 @@ help_menu::help_menu(const section& toplevel, int max_height) :
 		selected_item_ = visible_items_.front();
 }
 
-bool help_menu::expanded(const section &sec)
+bool help_menu::expanded(const section &sec) const
 {
 	return expanded_.find(&sec) != expanded_.end();
 }
@@ -70,8 +70,7 @@ void help_menu::update_visible_items(const section &sec, unsigned level)
 	}
 	for (const auto &s : sec.sections) {
 		if (is_visible_id(s.id)) {
-			const std::string vis_string = get_string_to_show(s, level + 1);
-			visible_items_.emplace_back(&s, vis_string, level + 1);
+			visible_items_.emplace_back(&s, level + 1);
 			if (expanded(s)) {
 				update_visible_items(s, level + 1);
 			}
@@ -79,36 +78,9 @@ void help_menu::update_visible_items(const section &sec, unsigned level)
 	}
 	for (const auto &t : sec.topics) {
 		if (is_visible_id(t.id)) {
-			const std::string vis_string = get_string_to_show(t, level + 1);
-			visible_items_.emplace_back(&t, vis_string, level + 1);
+			visible_items_.emplace_back(&t, level + 1);
 		}
 	}
-}
-
-std::string help_menu::indent_list(const std::string& icon, const unsigned level) {
-	std::stringstream to_show;
-	for (unsigned i = 1; i < level; ++i) {
-		to_show << "    "; // Indent 4 spaces
-	}
-
-	to_show << IMG_TEXT_SEPARATOR << IMAGE_PREFIX << icon;
-	return to_show.str();
-}
-
-std::string help_menu::get_string_to_show(const section &sec, const unsigned level)
-{
-	std::stringstream to_show;
-	to_show << indent_list(expanded(sec) ? open_section_img : closed_section_img, level)
-		 << IMG_TEXT_SEPARATOR << sec.title;
-	return to_show.str();
-}
-
-std::string help_menu::get_string_to_show(const topic &topic, const unsigned level)
-{
-	std::stringstream to_show;
-	to_show <<  indent_list(topic_img, level)
-		<< IMG_TEXT_SEPARATOR << topic.title;
-	return to_show.str();
 }
 
 bool help_menu::select_topic_internal(const topic &t, const section &sec)
@@ -167,21 +139,13 @@ int help_menu::process()
 			// * user single-clicks on the icon (or to the left of it): expand or collapse the tree view
 			// * user double-clicks anywhere: expand or collapse the tree view
 			// * note: the first click of the double-click has the single-click effect too
-			int x = mousex - menu::location().x;
-
-			const std::string icon_img = expanded(*sec) ? open_section_img : closed_section_img;
-			// the "thickness" is the width of the left border
-			int text_start = style_->item_size(indent_list(icon_img, selected_item_.level)).w - style_->get_thickness();
-
-			// NOTE: if you want to forbid click to the left of the icon
-			// also check x >= text_start-image_width(icon_img)
-			if (menu::double_clicked() || x < text_start) {
+			if (menu::double_clicked() || hit_on_indent_or_icon(static_cast<std::size_t>(res), mousex)) {
 				// Open or close a section if we double-click on it
 				// or do simple click on the icon.
 				expanded(*sec) ? contract(*sec) : expand(*sec);
 				update_visible_items(toplevel_);
 				display_visible_items();
-			} else if (x >= text_start){
+			} else {
 				// click on title open the topic associated to this section
 				chosen_topic_ = find_topic(default_toplevel, ".."+sec->id );
 			}
@@ -202,22 +166,33 @@ const topic *help_menu::chosen_topic()
 
 void help_menu::display_visible_items()
 {
-	std::vector<std::string> menu_items;
+	std::vector<gui::indented_menu_item> menu_items;
+	std::optional<std::size_t> selected;
 	for(std::vector<visible_item>::const_iterator items_it = visible_items_.begin(),
 		 end = visible_items_.end(); items_it != end; ++items_it) {
-		std::string to_show = items_it->visible_string;
 		if (selected_item_ == *items_it)
-			to_show = std::string("*") + to_show;
-		menu_items.push_back(to_show);
+			selected = menu_items.size();
+		menu_items.push_back(items_it->get_menu_item(*this));
 	}
-	set_items(menu_items, false, true);
+	set_items(menu_items, selected);
 }
 
-help_menu::visible_item::visible_item(const section *_sec, const std::string &vis_string, int lev) :
-	t(nullptr), sec(_sec), visible_string(vis_string), level(lev) {}
+help_menu::visible_item::visible_item(const section *_sec, int lev) :
+	t(nullptr), sec(_sec), level(lev) {}
 
-help_menu::visible_item::visible_item(const topic *_t, const std::string &vis_string, int lev) :
-	t(_t), sec(nullptr), visible_string(vis_string), level(lev) {}
+help_menu::visible_item::visible_item(const topic *_t, int lev) :
+	t(_t), sec(nullptr), level(lev) {}
+
+gui::indented_menu_item help_menu::visible_item::get_menu_item(const help_menu& parent) const
+{
+	if(sec) {
+		const auto& img = parent.expanded(*sec) ? open_section_img : closed_section_img;
+		return {level, img, sec->title};
+	}
+
+	// As sec was a nullptr, this must have a non-null topic
+	return {level, topic_img, t->title};
+}
 
 bool help_menu::visible_item::operator==(const section &_sec) const
 {

--- a/src/help/help_menu.hpp
+++ b/src/help/help_menu.hpp
@@ -51,15 +51,16 @@ public:
 private:
 	/** Information about an item that is visible in the menu. */
 	struct visible_item {
-		visible_item(const section *_sec, const std::string &visible_string, int level);
-		visible_item(const topic *_t, const std::string &visible_string, int level);
+		visible_item(const section *_sec, int level);
+		visible_item(const topic *_t, int level);
 		// Invariant, one if these should be nullptr. The constructors
 		// enforce it.
 		const topic *t;
 		const section *sec;
-		std::string visible_string;
+		gui::indented_menu_item get_menu_item(const help_menu& parent) const;
+		/** Indentation level, always one more than the parent section. */
 		int level;
-		bool operator==(const visible_item &vis_item) const;
+		bool operator==(const visible_item &sec) const;
 		bool operator==(const section &sec) const;
 		bool operator==(const topic &t) const;
 	};
@@ -68,7 +69,7 @@ private:
 	void update_visible_items(const section &top_level, unsigned starting_level=0);
 
 	/** Return true if the section is expanded. */
-	bool expanded(const section &sec);
+	bool expanded(const section &sec) const;
 
 	/** Mark a section as expanded. Do not update the visible items or anything. */
 	void expand(const section &sec);
@@ -84,10 +85,10 @@ private:
 	 * menu-string at the specified level.
 	 */
 	std::string indent_list(const std::string &icon, const unsigned level);
-	/** Return the string to use as the menu-string for sections at the specified level. */
-	std::string get_string_to_show(const section &sec, const unsigned level);
-	/** Return the string to use as the menu-string for topics at the specified level. */
-	std::string get_string_to_show(const topic &topic, const unsigned level);
+	/** Return the data to use with the superclass's set_items() for sections at the specified level. */
+	gui::indented_menu_item get_item_to_show(const section &sec, const unsigned level);
+	/** Return the data to use with the superclass's set_items() for topics at the specified level. */
+	gui::indented_menu_item get_item_to_show(const topic &topic, const unsigned level);
 
 	/** Draw the currently visible items. */
 	void display_visible_items();

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -32,7 +32,7 @@ class menu : public scrollarea
 {
 public:
 
-	enum ROW_TYPE { NORMAL_ROW, SELECTED_ROW, HEADING_ROW };
+	enum ROW_TYPE { NORMAL_ROW, SELECTED_ROW };
 	//basic menu style
 	class style
 	{
@@ -44,8 +44,6 @@ public:
 		virtual SDL_Rect item_size(const std::string& item) const;
 		virtual void draw_row_bg(menu& menu_ref, const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE type);
 		virtual void draw_row(menu& menu_ref, const std::size_t row_index, const SDL_Rect& rect, ROW_TYPE type);
-		void scale_images(int max_width, int max_height);
-		void adjust_image_bounds(int& w, int& h) const;
 		std::size_t get_font_size() const;
 		std::size_t get_cell_padding() const;
 		std::size_t get_thickness() const;
@@ -55,9 +53,8 @@ public:
 		std::size_t cell_padding_;
 		std::size_t thickness_;  //additional cell padding for style use only
 
-		int normal_rgb_, selected_rgb_, heading_rgb_;
-		double normal_alpha_, selected_alpha_, heading_alpha_;
-		int max_img_w_, max_img_h_;
+		int normal_rgb_, selected_rgb_;
+		double normal_alpha_, selected_alpha_;
 	};
 
 	//image-border selection style
@@ -65,8 +62,8 @@ public:
 	{
 	public:
 		imgsel_style(const std::string &img_base, bool has_bg,
-								 int normal_rgb, int selected_rgb, int heading_rgb,
-								 double normal_alpha, double selected_alpha, double heading_alpha);
+								 int normal_rgb, int selected_rgb,
+								 double normal_alpha, double selected_alpha);
 		virtual ~imgsel_style();
 
 		virtual SDL_Rect item_size(const std::string& item) const;
@@ -86,8 +83,8 @@ public:
 		bool has_background_;
 		bool initialized_;
 		bool load_failed_;
-		int normal_rgb2_, selected_rgb2_, heading_rgb2_;
-		double normal_alpha2_, selected_alpha2_, heading_alpha2_;
+		int normal_rgb2_, selected_rgb2_;
+		double normal_alpha2_, selected_alpha2_;
 	};
 
 	friend class style;
@@ -120,8 +117,6 @@ public:
 	void move_selection(std::size_t id);
 	void move_selection_keeping_viewport(std::size_t id);
 	void reset_selection();
-
-	void set_heading(const std::vector<std::string>& heading);
 
 	/**
 	 * Set new items to show and redraw/recalculate everything. If
@@ -171,16 +166,11 @@ protected:
 
 	int hit_column(int x) const;
 
-	int hit_heading(int x, int y) const;
-
 	void invalidate_row(std::size_t id);
 	void invalidate_row_pos(std::size_t pos);
-	void invalidate_heading();
 
 private:
 	std::size_t max_items_onscreen() const;
-
-	std::size_t heading_height() const;
 
 	int max_height_, max_width_;
 	mutable int max_items_, item_height_;
@@ -190,9 +180,6 @@ private:
 
 	std::vector<item> items_;
 	std::vector<std::size_t> item_pos_;
-
-	std::vector<std::string> heading_;
-	mutable int heading_height_;
 
 	mutable std::vector<int> column_widths_;
 
@@ -237,8 +224,6 @@ private:
 
 	//ellipsis calculation is slightly off, so default to false
 	bool use_ellipsis_;
-
-	int highlight_heading_;
 
 	/**
 	 * Set new items to show. If strip_spaces is false, spaces will

--- a/src/widgets/menu.hpp
+++ b/src/widgets/menu.hpp
@@ -108,38 +108,9 @@ public:
 		std::size_t id;
 	};
 
-	class sorter
-	{
-	public:
-		virtual ~sorter() {}
-		virtual bool column_sortable(int column) const = 0;
-		virtual bool less(int column, const item& row1, const item& row2) const = 0;
-	};
-
-	class basic_sorter : public sorter
-	{
-	public:
-		basic_sorter();
-		virtual ~basic_sorter() {}
-
-		basic_sorter& set_alpha_sort(int column);
-		basic_sorter& set_numeric_sort(int column);
-		basic_sorter& set_id_sort(int column);
-		basic_sorter& set_redirect_sort(int column, int to);
-		basic_sorter& set_position_sort(int column, const std::vector<int>& pos);
-	protected:
-		virtual bool column_sortable(int column) const;
-		virtual bool less(int column, const item& row1, const item& row2) const;
-
-	private:
-		std::set<int> alpha_sort_, numeric_sort_, id_sort_;
-		std::map<int,int> redirect_sort_;
-		std::map<int,std::vector<int>> pos_sort_;
-	};
-
 	menu(const std::vector<std::string>& items,
 	     bool click_selects=false, int max_height=-1, int max_width=-1,
-		 const sorter* sorter_obj=nullptr, style *menu_style=nullptr, const bool auto_join=true);
+		 style *menu_style=nullptr, const bool auto_join=true);
 
 	/** Default implementation, but defined out-of-line for efficiency reasons. */
 	~menu();
@@ -149,11 +120,6 @@ public:
 	void move_selection(std::size_t id);
 	void move_selection_keeping_viewport(std::size_t id);
 	void reset_selection();
-
-	// allows user to change_item while running (dangerous)
-	void change_item(int pos1,int pos2,const std::string& str);
-
-	virtual void erase_item(std::size_t index);
 
 	void set_heading(const std::vector<std::string>& heading);
 
@@ -188,13 +154,6 @@ public:
 
 	// scrollarea override
 	void scroll(unsigned int pos) override;
-
-	//currently, menus do not manage the memory of their sorter
-	//this should be changed to a more object-oriented approach
-	void set_sorter(sorter *s);
-	void sort_by(int column);
-	int get_sort_by() const {return sortby_;}
-	bool get_sort_reversed() const {return sortreversed_;}
 
 protected:
 	bool item_ends_with_image(const std::string& item) const;
@@ -279,9 +238,6 @@ private:
 	//ellipsis calculation is slightly off, so default to false
 	bool use_ellipsis_;
 
-	const sorter* sorter_;
-	int sortby_;
-	bool sortreversed_;
 	int highlight_heading_;
 
 	/**
@@ -289,10 +245,6 @@ private:
 	 * remain at the item edges.
 	 */
 	void fill_items(const std::vector<std::string>& items, bool strip_spaces);
-
-	void do_sort();
-	void recalculate_pos();
-	void assert_pos();
 
 	void update_size();
 	enum SELECTION_MOVE_VIEWPORT { MOVE_VIEWPORT, NO_MOVE_VIEWPORT };

--- a/src/widgets/menu_style.cpp
+++ b/src/widgets/menu_style.cpp
@@ -212,9 +212,9 @@ void menu::imgsel_style::draw_row(menu& menu_ref, const std::size_t row_index, c
 	}
 }
 
-SDL_Rect menu::imgsel_style::item_size(const std::string& item) const
+SDL_Rect menu::imgsel_style::item_size(const indented_menu_item& imi) const
 {
-	SDL_Rect bounds = style::item_size(item);
+	SDL_Rect bounds = style::item_size(imi);
 
 	bounds.w += 2 * thickness_;
 	bounds.h += 2 * thickness_ + 4;

--- a/src/widgets/menu_style.cpp
+++ b/src/widgets/menu_style.cpp
@@ -28,27 +28,26 @@ namespace gui {
 
 	//static initializations
 menu::imgsel_style menu::bluebg_style("dialogs/selection", true,
-										   0x000000, 0x000000, 0x333333,
-										   0.35, 0.0, 0.3);
+										   0x000000, 0x000000,
+										   0.35, 0.0);
 
 menu::style &menu::default_style = menu::bluebg_style;
 
 	//constructors
 menu::style::style() : font_size_(font::SIZE_NORMAL),
 		cell_padding_(font::SIZE_NORMAL * 3/5), thickness_(0),
-		normal_rgb_(0x000000), selected_rgb_(0x000099), heading_rgb_(0x333333),
-		normal_alpha_(0.2),  selected_alpha_(0.6), heading_alpha_(0.3),
-		max_img_w_(-1), max_img_h_(-1)
+		normal_rgb_(0x000000), selected_rgb_(0x000099),
+		normal_alpha_(0.2),  selected_alpha_(0.6)
 {}
 
 menu::style::~style()
 {}
 menu::imgsel_style::imgsel_style(const std::string &img_base, bool has_bg,
-								 int normal_rgb, int selected_rgb, int heading_rgb,
-								 double normal_alpha, double selected_alpha, double heading_alpha)
+								 int normal_rgb, int selected_rgb,
+								 double normal_alpha, double selected_alpha)
 								 : img_base_(img_base), has_background_(has_bg),  initialized_(false), load_failed_(false),
-								 normal_rgb2_(normal_rgb), selected_rgb2_(selected_rgb), heading_rgb2_(heading_rgb),
-								 normal_alpha2_(normal_alpha), selected_alpha2_(selected_alpha), heading_alpha2_(heading_alpha)
+								 normal_rgb2_(normal_rgb), selected_rgb2_(selected_rgb),
+								 normal_alpha2_(normal_alpha), selected_alpha2_(selected_alpha)
 {}
 menu::imgsel_style::~imgsel_style()
 {}
@@ -56,28 +55,6 @@ menu::imgsel_style::~imgsel_style()
 std::size_t menu::style::get_font_size() const { return font_size_; }
 std::size_t menu::style::get_cell_padding() const { return cell_padding_; }
 std::size_t menu::style::get_thickness() const { return thickness_; }
-
-void menu::style::scale_images(int max_width, int max_height)
-{
-	max_img_w_ = max_width;
-	max_img_h_ = max_height;
-}
-
-void menu::style::adjust_image_bounds(int& w, int& h) const
-{
-	int scale = 100;
-	if(max_img_w_ > 0 && w > max_img_w_) {
-		scale = (max_img_w_ * 100) / w;
-	}
-	if(max_img_h_ > 0 && h > max_img_h_) {
-		scale = std::min<int>(scale, ((max_img_h_ * 100) / h));
-	}
-	if(scale != 100)
-	{
-		w = (scale * w)/100;
-		h = (scale * h)/100;
-	}
-}
 
 bool menu::imgsel_style::load_image(const std::string &img_sub)
 {
@@ -116,8 +93,6 @@ bool menu::imgsel_style::load_images()
 				normal_alpha_ = normal_alpha2_;
 				selected_rgb_ = selected_rgb2_;
 				selected_alpha_ = selected_alpha2_;
-				heading_rgb_ = heading_rgb2_;
-				heading_alpha_ = heading_alpha2_;
 
 				load_failed_ = false;
 			}


### PR DESCRIPTION
Fixes #8205

This addresses #5600 and #8205. As #8205 is specifically about the names I'm marking it as fixing that one, and leaving #5600 for the issues that you can see on the right-hand pane in that issue's first screenshot, where the yellow text should be to the left of the corresponding white header text.

The GUI1 menu code is only used to support one UI feature, which is the help browser. The RTL support displayed incorrectly, and the code in menu::draw_row was complex, because it supported multiple columns and multiple things in each column; to do so it did a lot of string parsing. The help browser itself wanted to know whether clicks are on the icon or the text, but that wasn't provided by the existing code (it's all in the same column), so was already reimplemented in help_menu.cpp's subclass.

This rips out a lot of features, so that each row has only an indent, an optional icon, and optional text. It's a 3 commit PR, where
* the first commit removes some constructor arguments, but otherwise only touches dead code
* the second deletes lines from active code
* the third changes the menu's data format

In LTR languages, this looks almost identical.

In RTL languages, the book icons now appear in the right place, and the text placement is reasonable.

![image](https://github.com/wesnoth/wesnoth/assets/101462/35792960-32e3-4980-94d3-d6c8758a3b8a)