### PR TITLE
UtBS S6a: Avoid Dust Devil speaking

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/06a_In_the_Tunnels_of_Trolls.cfg
@@ -1577,10 +1577,14 @@
             [/have_unit]
         [/filter_condition]
 
+        {CHECK_EXPLORER}
+
         [message]
-            speaker=unit
+            speaker=$explorer.id
             message= _ "Look, a crumbling skeleton. I think this might be the body of the dwarven ghost. It shouldn’t take long to dig a shallow grave."
         [/message]
+
+        {CLEAR_VARIABLE explorer}
 
         [redraw]
         [/redraw]
@@ -1589,10 +1593,14 @@
             time=1000
         [/delay]
 
+        {CHECK_EXPLORER}
+
         [message]
-            speaker=unit
+            speaker=$explorer.id
             message= _ "May Eloh, or whatever god you worship, grant you peace and safe passage to the afterlife. We will avenge your death."
         [/message]
+
+        {CLEAR_VARIABLE explorer}
 
         # kills dwarf ghost blocking passage
         [kill]


### PR DESCRIPTION
Resolves #8192.

I grant this still doesn't make much sense, because arguably the Dust Devil shouldn't be able to bury the bones, but it's perhaps less jarring than a mute Dust Devil having dialogue.