### PR TITLE
Make a copy of the active event handler list before executing them.

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_priority_in_same_name.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_priority_in_same_name.cfg
@@ -1,0 +1,40 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [event]priority=
+##
+# Actions:
+# In a normal-priority start event, add a high priority start event.
+# Check that the normal-priority start event only ran once.
+##
+# Expected end state:
+# The test passes when the normal priority start event is only run once.
+#####
+{GENERIC_UNIT_TEST "events_test_priority_in_same_name" (
+    [event]
+        name = prestart
+        {VARIABLE X 1}
+    [/event]
+
+    [event]
+        name = start
+        first_time_only = no
+        {ASSERT ({VARIABLE_CONDITIONAL X equals 1})}
+        {VARIABLE X 2}
+
+        # Add a high-priority event with the same name as the event that's
+        # being triggered, which in 1.17.24 caused the events list to be
+        # reordered, and the current event (the normal priority one) to trigger
+        # again.
+        [event]
+            name = start
+            priority = 1
+            {VARIABLE X 2}
+        [/event]
+    [/event]
+
+    [event]
+        name = side turn
+        {SUCCEED}
+    [/event]
+)}

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -208,18 +208,14 @@ void manager::execute_on_events(const std::string& event_id, manager::event_func
 {
 	const std::string standardized_event_id = event_handlers::standardize_name(event_id);
 	const game_data* gd = resources::gamedata;
-	auto& active_handlers = event_handlers_->get_active();
-
-	// Save the end outside the loop so the end point remains constant,
-	// even if new events are added to the queue.
-	const unsigned saved_end = active_handlers.size();
-
+	// Copy the list so that new events added during processing are not executed.
+	auto active_handlers = event_handlers_->get_active();
 
 	{
 		// Ensure that event handlers won't be cleaned up while we're iterating them.
 		event_handler_list_lock lock;
 
-		for (unsigned i = 0; i < saved_end; ++i) {
+		for (unsigned i = 0; i < active_handlers.size(); ++i) {
 			handler_ptr handler = nullptr;
 
 			try {

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -464,6 +464,7 @@
 0 order_of_variable_events3
 0 premature_end_turn1
 2 premature_end_turn2
+0 events_test_priority_in_same_name
 0 events_test_priority_vs_origin
 0 events_test_same_priority
 0 events_test_multi_int


### PR DESCRIPTION
This avoids issues if the events being executed add new handlers, since adding a new handler needs to sort the list according to the event priority.

Fixes #8157