### PR TITLE
Make event_test_filter_condition check when the filters run

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -10,58 +10,70 @@
 # The third moveto event's condition is enabled by the second moveto event.
 ##
 # Expected end state:
-# All three moveto events each trigger once.
+# All three moveto events each trigger once when the first move happens.
+# A second move (without resetting the condition) triggers the third moveto again.
 #####
 {GENERIC_UNIT_TEST event_test_filter_condition (
     [event]
         name=start
         {VARIABLE var 1}
-        {VARIABLE triggers 0}
+        {VARIABLE triggers_first 0}
+        {VARIABLE triggers_second 0}
+        {VARIABLE triggers_third 0}
+
+        # A single move triggers all three events, because the filter for the second
+        # event is tested after the first event has already run.
         [do_command]
             [move]
                 x=7,8
                 y=3,3
             [/move]
         [/do_command]
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_first equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_second equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_third equals 1})}
+
+        # At this point var equals 3, so only the third event triggers.
         [do_command]
             [move]
                 x=8,9
                 y=3,4
             [/move]
         [/do_command]
-        [do_command]
-            [move]
-                x=9,8
-                y=4,4
-            [/move]
-        [/do_command]
-        {RETURN ({VARIABLE_CONDITIONAL triggers equals 3})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_first equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_second equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_third equals 2})}
+
+        {SUCCEED}
     [/event]
     [event]
         name=moveto
+        first_time_only=no
         [filter_condition]
             {VARIABLE_CONDITIONAL var equals 1}
         [/filter_condition]
         {ASSERT ({VARIABLE_CONDITIONAL var equals 1})}
         {VARIABLE var 2}
-        {VARIABLE_OP triggers add 1}
+        {VARIABLE_OP triggers_first add 1}
     [/event]
     [event]
         name=moveto
+        first_time_only=no
         [filter_condition]
             {VARIABLE_CONDITIONAL var equals 2}
         [/filter_condition]
         {ASSERT ({VARIABLE_CONDITIONAL var equals 2})}
         {VARIABLE var 3}
-        {VARIABLE_OP triggers add 1}
+        {VARIABLE_OP triggers_second add 1}
     [/event]
     [event]
         name=moveto
+        first_time_only=no
         [filter_condition]
             {VARIABLE_CONDITIONAL var equals 3}
         [/filter_condition]
         {ASSERT ({VARIABLE_CONDITIONAL var equals 3})}
-        {VARIABLE_OP triggers add 1}
+        {VARIABLE_OP triggers_third add 1}
     [/event]
 )}
 


### PR DESCRIPTION
This passes both with and without #8245, it tests to prevent an unintentional API change in case someone looks at that copy and prematurely optimises the list copying.

It also adds the missing first_time_only=no, which is why the three [moveto] events didn't trigger the third event three times.