### PR TITLE
Store core ID into save

### DIFF
--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -17,6 +17,7 @@
 
 #include "config.hpp"
 #include "log.hpp"
+#include "preferences/general.hpp"
 #include "serialization/string_utils.hpp"
 #include "game_version.hpp"
 #include "game_config_manager.hpp"
@@ -77,6 +78,7 @@ config game_classification::to_config() const
 	cfg["difficulty"] = difficulty;
 	cfg["random_mode"] = random_mode;
 	cfg["oos_debug"] = oos_debug;
+	cfg["core"] = preferences::core_id();
 
 	return cfg;
 }


### PR DESCRIPTION
As the core is potentially changing the behavior of the game, the core should be stored into the save in order to have the full setting of the game in the save.

The behavior of the engine when loading a save with a core (different from default) can be left open, but the saves should include the core id to leave options open.