### PR TITLE
Rebalance utbs amla

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -17,6 +17,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
     always_display=yes
     [effect]
         apply_to=hitpoints
+        increase_total = 3
         heal_full=yes
     [/effect]
     [effect]
@@ -105,6 +106,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Strong Strikes"
         image = icons/crossed_sword_and_hammer.png
         require_amla = swordsmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -122,6 +129,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Swordsman"
         image = icons/crossed_sword_and_hammer.png
         require_amla = strong_strikes
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -144,6 +154,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Taunt"
         image = attacks/fangs-horse.png
         require_amla = swordsmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = max_attacks
@@ -177,6 +193,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Run By (Taunting strike)"
         image = attacks/foot-boot.png
         require_amla = taunt, skirmisher
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -219,6 +238,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Strong Shots"
         image = attacks/bow-elven.png
         require_amla = bowmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -231,6 +256,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Bowman"
         image = attacks/bow-elven.png
         require_amla = strong_shots
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -248,6 +276,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Piercing Shot"
         image = attacks/bow-elven.png
         require_amla = bowmanship_training, strength_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = new_attack
@@ -275,6 +309,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         image = attacks/bow-elven.png
         require_amla = piercing_shot
         exclude_amla = overwhelming_power
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -288,6 +325,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         image = attacks/bow-elven.png
         require_amla = piercing_shot
         exclude_amla = stronger_grip
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -347,6 +387,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Skirmisher"
         image = icons/sandals.png
         require_amla = stamina_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = new_ability
@@ -386,6 +432,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Slow"
         image = attacks/bolas.png
         require_amla = training_with_bolas
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -406,6 +458,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Opportunist"
         image = attacks/bolas.png
         require_amla = slow, skirmisher
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = new_ability
@@ -457,6 +512,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Accurate Strikes"
         image = attacks/sword-elven.png
         require_amla = swordsmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -474,6 +535,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Faster Strikes"
         image = attacks/sword-elven.png
         require_amla = swordsmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -486,6 +553,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Sword Dance"
         image = attacks/sword-elven.png
         require_amla = faster_strikes, accurate_strikes, footwork
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -522,6 +592,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Quickdraw"
         image = attacks/bow-elven.png
         require_amla = bowmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -534,6 +610,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Ranger"
         image = attacks/bow-elven.png
         require_amla = quickdraw, footwork
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -552,6 +631,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Rain of Arrows"
         image = attacks/bow-elven.png
         require_amla = bowmanship_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = new_attack
@@ -582,6 +667,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         image = attacks/bow-elven.png
         require_amla = rain_of_arrows, herbalism
         exclude_amla = twin_arrows
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -599,6 +687,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         image = icons/crossed_sword_and_hammer.png
         require_amla = rain_of_arrows
         exclude_amla = toxic_rain
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -627,6 +718,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Footwork"
         image = icons/sandals.png
         require_amla = stamina_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = defense
@@ -653,6 +750,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Skirmisher"
         image = icons/sandals.png
         require_amla = stamina_training
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = new_ability
@@ -696,6 +799,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Run By (Bolas)"
         image = attacks/foot-boot.png
         require_amla = training_with_bolas, skirmisher
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -708,6 +817,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Slow"
         image = attacks/bolas.png
         require_amla = training_with_bolas
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -728,6 +843,9 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Bolaship"
         image = attacks/bolas.png
         require_amla = slow, stamina_training
+        [filter]
+            level=3
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack
@@ -759,6 +877,12 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         description = _"Run By (Sword and Bow)"
         image = attacks/foot-boot.png
         require_amla = sword_dance, ranger, skirmisher
+        [filter]
+            level=2
+            [or]
+                level=3
+            [/or]
+        [/filter]
         {COMMON_AMLA_EFFECTS}
         [effect]
             apply_to = attack


### PR DESCRIPTION
So that the player can navigate all the improvement choices, I decided to ensure that the secondary options are only available from level 2 and the tertiary options (requiring two amlas to be available) at level 3.

In addition, I modified the experiences required for level changes in order to force the player to take 3 primary amlas to reach level 2 as well as an increase in max_hipoints by 3 to maintain consistency.