### PR TITLE
copyrights.csv: Fix and check "License" and "Needs Updated" fields

### DIFF
--- a/copyrights.csv
+++ b/copyrights.csv
@@ -3473,28 +3473,28 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/core/images/portraits/humans/assassin+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,4ecedf135bc611849785fb3a1590b778
 2022/04/13,data/core/images/portraits/humans/assassin.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,6306d4b89b7f4841c5cfd3c306e024c3
 2022/04/13,data/core/images/portraits/humans/bandit.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,50335db1b9ca24472c72d5d8f600a081
-2022/04/13,data/core/images/portraits/humans/bowman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,ad79ea2bf82099d722ee561e62757ae7
-2022/04/13,data/core/images/portraits/humans/cavalier.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,cae97edf99c1931485a45f7a44290ca1
-2022/04/13,data/core/images/portraits/humans/cavalryman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,ecee0112f1cdf3757ac16caabcacd5a8
+2022/04/13,data/core/images/portraits/humans/bowman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,ad79ea2bf82099d722ee561e62757ae7
+2022/04/13,data/core/images/portraits/humans/cavalier.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,cae97edf99c1931485a45f7a44290ca1
+2022/04/13,data/core/images/portraits/humans/cavalryman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,ecee0112f1cdf3757ac16caabcacd5a8
 2022/04/13,data/core/images/portraits/humans/dark-adept+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,7513b4d187b5f15cba10940f6d7d00fa
 2022/04/13,data/core/images/portraits/humans/dark-adept.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,05d10d186fa3288a1df5c54cb483a25d
-2022/04/13,data/core/images/portraits/humans/duelist.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,4d946796a11ee95186746e350b30d3ee
-2022/04/13,data/core/images/portraits/humans/fencer.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,f65e7c2a07f3a2c22688ffdf3a34595b
+2022/04/13,data/core/images/portraits/humans/duelist.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,4d946796a11ee95186746e350b30d3ee
+2022/04/13,data/core/images/portraits/humans/fencer.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,f65e7c2a07f3a2c22688ffdf3a34595b
 2022/04/13,data/core/images/portraits/humans/footpad+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,3604bbbd536a39d9b8f90d6e6eb47ff3
 2022/04/13,data/core/images/portraits/humans/footpad.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,449865b589e88aacb3b0d709312b3fa8
-2022/04/13,data/core/images/portraits/humans/general.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,4fef2c26f1493ba81bf67338cfbafd9a
+2022/04/13,data/core/images/portraits/humans/general.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,4fef2c26f1493ba81bf67338cfbafd9a
 2022/04/13,data/core/images/portraits/humans/grand-knight-2.webp,GNU GPL v2+,Jason Lutes,,,540778642dfd45c02c2fbcc925774163
 2022/04/13,data/core/images/portraits/humans/grand-knight.webp,GNU GPL v2+,Jason Lutes,,,eebf659b2ebf083cb2acaeb994339e85
-2022/04/13,data/core/images/portraits/humans/halberdier.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,8063013bf4753352ce8ef31b8428b79d
+2022/04/13,data/core/images/portraits/humans/halberdier.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,8063013bf4753352ce8ef31b8428b79d
 2022/04/13,data/core/images/portraits/humans/heavy-infantry.webp,GNU GPL v2+,Emilien Rotival(LordBob);Alexander van Gessel(AI/AI0867),,,2942cc56aca7d1f9d90c5fea81ab3d73
-2022/04/13,data/core/images/portraits/humans/horseman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,95478b11397d4dcdb52781b202c58421
+2022/04/13,data/core/images/portraits/humans/horseman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,95478b11397d4dcdb52781b202c58421
 2022/04/13,data/core/images/portraits/humans/huntsman.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,fa06c53b8e10ffc737912a3328808ae5
-2022/04/13,data/core/images/portraits/humans/iron-mauler.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,482becdcc1da362e88cce145a8d6657d
-2022/04/13,data/core/images/portraits/humans/javelineer.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,63adb05b511e10e0d31ed38e8a9883c6
-2022/04/13,data/core/images/portraits/humans/knight.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,c2e3908adc6de7ed2ac744def504dbd6
-2022/04/13,data/core/images/portraits/humans/lancer.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,f069f98da46ba10930d62f76874a508e
-2022/04/13,data/core/images/portraits/humans/lieutenant.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,d7a07b0d5abca4c2d8cc10afee34488e
-2022/04/13,data/core/images/portraits/humans/longbowman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,e078b309f901e7b8d1195014fa3050fd
+2022/04/13,data/core/images/portraits/humans/iron-mauler.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,482becdcc1da362e88cce145a8d6657d
+2022/04/13,data/core/images/portraits/humans/javelineer.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,63adb05b511e10e0d31ed38e8a9883c6
+2022/04/13,data/core/images/portraits/humans/knight.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,c2e3908adc6de7ed2ac744def504dbd6
+2022/04/13,data/core/images/portraits/humans/lancer.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,f069f98da46ba10930d62f76874a508e
+2022/04/13,data/core/images/portraits/humans/lieutenant.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,d7a07b0d5abca4c2d8cc10afee34488e
+2022/04/13,data/core/images/portraits/humans/longbowman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,e078b309f901e7b8d1195014fa3050fd
 2022/04/13,data/core/images/portraits/humans/mage+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,ef6538c504fa88014ef87a689370e2d5
 2022/04/13,data/core/images/portraits/humans/mage-arch+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,ae203559d864f96ff0d665bf92e2bbda
 2022/04/13,data/core/images/portraits/humans/mage-arch.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,9ac31c91062aac8b95bc7d13be40965f
@@ -3507,32 +3507,32 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/core/images/portraits/humans/mage-white+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,3b152ea0072d309de685ec0299be4e61
 2022/04/13,data/core/images/portraits/humans/mage-white.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,bd3bf01f0a0277335788bf174dda98d8
 2022/04/13,data/core/images/portraits/humans/mage.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,4d8beecb716f95d29d82e88bf852a842
-2022/04/13,data/core/images/portraits/humans/marshal-2.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,86b2aa3108f976b22261476226e91942
-2022/04/13,data/core/images/portraits/humans/marshal.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,8671e949d67b73267277812ecea8df46
-2022/04/13,data/core/images/portraits/humans/master-at-arms.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,df8f34aaa7d2add9d92fb890ddb842b9
-2022/04/13,data/core/images/portraits/humans/master-bowman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,593926a47a39c0f1f91b6c5ef81f243d
+2022/04/13,data/core/images/portraits/humans/marshal-2.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,86b2aa3108f976b22261476226e91942
+2022/04/13,data/core/images/portraits/humans/marshal.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,8671e949d67b73267277812ecea8df46
+2022/04/13,data/core/images/portraits/humans/master-at-arms.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,df8f34aaa7d2add9d92fb890ddb842b9
+2022/04/13,data/core/images/portraits/humans/master-bowman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,593926a47a39c0f1f91b6c5ef81f243d
 2022/04/13,data/core/images/portraits/humans/necromancer+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,93eb5c0e51192ad3e775931068354df6
 2022/04/13,data/core/images/portraits/humans/necromancer.webp,GNU GPL v2+,EEL(EELuminatus);Kathrin Polikeit(Kitty),,,51ffdd85d9743d1b583b4bcd17f3b56d
 2022/04/13,data/core/images/portraits/humans/outlaw+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,43f9619ada30d3239a75b2c958548bec
 2022/04/13,data/core/images/portraits/humans/outlaw.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,9dccc4adb70eebb974ff6885b36a4b60
-2022/04/13,data/core/images/portraits/humans/paladin.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,87f2f90020ecca890f8c4765bac7c209
-2022/04/13,data/core/images/portraits/humans/peasant.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,2112dccdadfa170499ab8b31ad84deba
-2022/04/13,data/core/images/portraits/humans/pikeman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,a27fff8764ba7eac9e09347825997940
+2022/04/13,data/core/images/portraits/humans/paladin.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,87f2f90020ecca890f8c4765bac7c209
+2022/04/13,data/core/images/portraits/humans/peasant.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,2112dccdadfa170499ab8b31ad84deba
+2022/04/13,data/core/images/portraits/humans/pikeman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,a27fff8764ba7eac9e09347825997940
 2022/04/13,data/core/images/portraits/humans/ranger.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,f6960dd2e707f0e70b2acc8842baf5ce
-2022/04/13,data/core/images/portraits/humans/royal-guard.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,b10f9be65b945fc76f5d665b51618184
+2022/04/13,data/core/images/portraits/humans/royal-guard.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,b10f9be65b945fc76f5d665b51618184
 2022/04/13,data/core/images/portraits/humans/royal-warrior.webp,CC BY-SA 4.0,Emilien Rotival(LordBob),,,17ba198f897cb465d2362cd7945f330f
 2022/04/13,data/core/images/portraits/humans/ruffian.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,959f1c0f73baed2166039d6f6c5eb31f
-2022/04/13,data/core/images/portraits/humans/sergeant.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,c6e4923290252949d35179d7a5dcba8a
-2022/04/13,data/core/images/portraits/humans/spearman-2.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,40b6ce45306d445eae91dca695b4578b
-2022/04/13,data/core/images/portraits/humans/spearman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,243bb1fadde883cec24e82c80f667747
+2022/04/13,data/core/images/portraits/humans/sergeant.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,c6e4923290252949d35179d7a5dcba8a
+2022/04/13,data/core/images/portraits/humans/spearman-2.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,40b6ce45306d445eae91dca695b4578b
+2022/04/13,data/core/images/portraits/humans/spearman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,243bb1fadde883cec24e82c80f667747
 2022/04/13,data/core/images/portraits/humans/swordsman-2.webp,GNU GPL v2+,Santiago Iborra(Quellion),,,5f4a9dfd43d343a65aba841d917bd831
-2022/04/13,data/core/images/portraits/humans/swordsman-3.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,fef1d6b19a5488ecc5969bf59f337d22
+2022/04/13,data/core/images/portraits/humans/swordsman-3.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,fef1d6b19a5488ecc5969bf59f337d22
 2022/04/13,data/core/images/portraits/humans/swordsman.webp,GNU GPL v2+,Santiago Iborra(Quellion),,,d3a3c9078ffe2b6007baf4f7e0be519a
 2022/04/13,data/core/images/portraits/humans/thief+female.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,fe53967df8d92de984ade0e81ed13f6c
 2022/04/13,data/core/images/portraits/humans/thief.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,2219ed857ea83967b04cb10910594cbb
 2022/04/13,data/core/images/portraits/humans/thug.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,9381d98b5307d2192390b1a1ea85e928
 2022/04/13,data/core/images/portraits/humans/trapper.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,2803c193528f820b038508d4ebed155c
-2022/04/13,data/core/images/portraits/humans/woodsman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,f3f9e6dbf753aacc09886eb5c8847866
+2022/04/13,data/core/images/portraits/humans/woodsman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,f3f9e6dbf753aacc09886eb5c8847866
 2023/01/26,data/core/images/portraits/merfolk/brawler.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,9ecb48e85e1f18147c312548edbe7eac
 2022/04/13,data/core/images/portraits/merfolk/enchantress.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,17a063013a3af3059091f8af36e20d4a
 2022/04/13,data/core/images/portraits/merfolk/fighter.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,a1bb70b5358c3894a949397f97fd2604
@@ -3567,9 +3567,9 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2023/09/10,data/core/images/portraits/monsters/dragonfly.webp,CC BY-SA 4.0,(doofus-01),,,bfe76b7f84bfa2774670fbd65439dfcb
 2023/12/28,data/core/images/portraits/monsters/falcon-elder.webp,CC BY-SA 4.0,(doofus-01),,,ce75909cccbad74862ad9d6170ac08e6
 2022/04/13,data/core/images/portraits/monsters/falcon.webp,CC BY-SA 4.0,(doofus-01),,,feed667049223da049df178dc88cae00
-2022/04/13,data/core/images/portraits/monsters/fire-dragon.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,9cbe9adcd4f2e1e7e5e750061ec9f519
-2022/04/13,data/core/images/portraits/monsters/fire_guardian.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,7a328e7a7ace87143c774b6ee57deb67
-2022/04/13,data/core/images/portraits/monsters/fire_wraith_A.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,b748face8ca7b8660d12b1353900af06
+2022/04/13,data/core/images/portraits/monsters/fire-dragon.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,9cbe9adcd4f2e1e7e5e750061ec9f519
+2022/04/13,data/core/images/portraits/monsters/fire_guardian.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,7a328e7a7ace87143c774b6ee57deb67
+2022/04/13,data/core/images/portraits/monsters/fire_wraith_A.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,b748face8ca7b8660d12b1353900af06
 2022/04/13,data/core/images/portraits/monsters/giant-mudcrawler.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,b3c04ca822d49f0dc585ae612212d36a
 2022/04/13,data/core/images/portraits/monsters/giant-rat.webp,GNU GPL v2+,(ZygoUgo),,,d85f3599f10ae584f8c81b7f7e41a1fc
 2022/04/13,data/core/images/portraits/monsters/giant-spider.webp,CC0,unknown,https://commons.wikimedia.org/wiki/File:Spider_on_the_yellow_pond-lily_leaf.JPG,,55e1252e43db22ebdf819034ec5705e8
@@ -3602,8 +3602,8 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/core/images/portraits/monsters/water-serpent.webp,CC BY-SA 4.0,unknown,,,642f348775c94a6b5396cb906c78985e
 2022/11/06,data/core/images/portraits/monsters/white-horse.webp,CC BY-SA 4.0,(doofus-01),,,f3958665146c27add94f7612bebf185b
 2022/04/13,data/core/images/portraits/monsters/woodland_boar.webp,CC BY-SA 4.0,(doofus-01),,,4008a3adb1b29d1d4d08ac427da28a5f
-2022/04/13,data/core/images/portraits/monsters/yeti.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,58a386feb8e11f97c280f66bf59281d5
-2022/04/13,data/core/images/portraits/monsters/young-ogre.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,75fbb5cb1ee2704e0243759cadd0b789
+2022/04/13,data/core/images/portraits/monsters/yeti.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,58a386feb8e11f97c280f66bf59281d5
+2022/04/13,data/core/images/portraits/monsters/young-ogre.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,75fbb5cb1ee2704e0243759cadd0b789
 2022/04/13,data/core/images/portraits/nagas/dirkfang.webp,CC BY-SA 4.0,(doofus-01),,,7af840c8dc9de442fba3de4aeec51453
 2022/04/13,data/core/images/portraits/nagas/fighter.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,13c91211569dcf3bd43bda2fcf828905
 2022/04/13,data/core/images/portraits/nagas/myrmidon.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,0f97a5a5eb5357772a5d69c99cb2b4e8
@@ -3612,36 +3612,36 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/core/images/portraits/nagas/naga-mace_warrior3.webp,CC BY-SA 4.0,(doofus-01),,,85fc5f2da86afd6294e432a40cf2b5be
 2022/04/13,data/core/images/portraits/nagas/naga-ophidian.webp,CC BY-SA 4.0,Emilien Rotival(LordBob),,,2dc69b2849f466eafe08718b27643137
 2022/04/13,data/core/images/portraits/nagas/naga-ringcaster.webp,CC BY-SA 4.0,Emilien Rotival(LordBob),,,85b539ad6262d4a8311a250e91fcdb50
-2022/04/13,data/core/images/portraits/orcs/archer.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,ab8dab6b36fa601efdafcdc2dfef1fcb
-2022/04/13,data/core/images/portraits/orcs/assassin.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,f104961afe062cf959b8225ec113c9fa
-2022/04/13,data/core/images/portraits/orcs/crossbowman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,8bc977cbe8cd9d65ecfcd7c8324e996b
-2022/04/13,data/core/images/portraits/orcs/grunt-2.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,7abb195fee411590b0f29f133a857fb9
-2022/04/13,data/core/images/portraits/orcs/grunt-3.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,aab9808e2a902b0ecf9072f34b1a985b
-2022/04/13,data/core/images/portraits/orcs/grunt-4.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,80d59019e068fcf72a50c455dc9abdff
-2022/04/13,data/core/images/portraits/orcs/grunt-5.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,3db8649613bb1285e9ebad5f7e64e0e0
-2022/04/13,data/core/images/portraits/orcs/grunt-6.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,e345ec7ac7fbbeaab423d5b559a2be40
-2022/04/13,data/core/images/portraits/orcs/grunt.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,5c4edf807d9b2ff87d5a4780ce1e4213
+2022/04/13,data/core/images/portraits/orcs/archer.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,ab8dab6b36fa601efdafcdc2dfef1fcb
+2022/04/13,data/core/images/portraits/orcs/assassin.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,f104961afe062cf959b8225ec113c9fa
+2022/04/13,data/core/images/portraits/orcs/crossbowman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,8bc977cbe8cd9d65ecfcd7c8324e996b
+2022/04/13,data/core/images/portraits/orcs/grunt-2.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,7abb195fee411590b0f29f133a857fb9
+2022/04/13,data/core/images/portraits/orcs/grunt-3.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,aab9808e2a902b0ecf9072f34b1a985b
+2022/04/13,data/core/images/portraits/orcs/grunt-4.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,80d59019e068fcf72a50c455dc9abdff
+2022/04/13,data/core/images/portraits/orcs/grunt-5.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,3db8649613bb1285e9ebad5f7e64e0e0
+2022/04/13,data/core/images/portraits/orcs/grunt-6.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,e345ec7ac7fbbeaab423d5b559a2be40
+2022/04/13,data/core/images/portraits/orcs/grunt.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,5c4edf807d9b2ff87d5a4780ce1e4213
 2022/04/13,data/core/images/portraits/orcs/ruler-2.webp,GNU GPL v2+,unknown,,,800752e38462bc10911e002d95e3c0d8
 2022/04/13,data/core/images/portraits/orcs/ruler.webp,GNU GPL v2+,unknown,,,d5ee7e5308c4dd2cb0269a6eebec4077
-2022/04/13,data/core/images/portraits/orcs/slayer.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,e1681df5d6ba26ca8297a4c607198223
-2022/04/13,data/core/images/portraits/orcs/slurbow.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,f2603f87a47281dd4462b45e1cd9fb1b
-2022/04/13,data/core/images/portraits/orcs/sovereign.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,a25c26e608a47fff88964e9987f63b67
-2022/04/13,data/core/images/portraits/orcs/warlord.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,2ce532c56e9e9fa94bb319a9f527befe
-2022/04/13,data/core/images/portraits/orcs/warrior.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,2f67525b7c2274c4f2bf07e3c9caf1a0
+2022/04/13,data/core/images/portraits/orcs/slayer.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,e1681df5d6ba26ca8297a4c607198223
+2022/04/13,data/core/images/portraits/orcs/slurbow.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,f2603f87a47281dd4462b45e1cd9fb1b
+2022/04/13,data/core/images/portraits/orcs/sovereign.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,a25c26e608a47fff88964e9987f63b67
+2022/04/13,data/core/images/portraits/orcs/warlord.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,2ce532c56e9e9fa94bb319a9f527befe
+2022/04/13,data/core/images/portraits/orcs/warrior.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,2f67525b7c2274c4f2bf07e3c9caf1a0
 2022/04/13,data/core/images/portraits/saurians/augur.webp,GNU GPL v2+,Phil Barber(thespaceinvader),,,02de4318b0b921d6362cdc2f1ef18aed
 2022/04/13,data/core/images/portraits/saurians/skirmisher.webp,GNU GPL v2+,Phil Barber(thespaceinvader),,,17b85d8afdb5eb34fb77450bf28bddd1
-2022/04/13,data/core/images/portraits/trolls/troll-hero-alt.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,b94ffed4fc4654ceb472905403f78c67
-2022/04/13,data/core/images/portraits/trolls/troll-hero.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,13a30afa24e20b77bd182346792a497b
-2022/04/13,data/core/images/portraits/trolls/troll-rocklobber.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,a05931d4c2708b982b7b68bc9f3d5cf0
-2022/04/13,data/core/images/portraits/trolls/troll-shaman.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,48c22c8d1d33b936bb38f8b67266a4d6
-2022/04/13,data/core/images/portraits/trolls/troll-warrior.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,b706a9eb8268a69c2fe98e5f20a1a962
-2016/03/21,data/core/images/portraits/trolls/troll.png,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,811651c5526a9c675cbaf9dc4f949a09
-2022/04/13,data/core/images/portraits/trolls/whelp.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,03457fc340fa318cabcc987684f350cf
-2022/04/13,data/core/images/portraits/undead/ancient-lich.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,609635f43c4d1279f7c4329a86d29f76
+2022/04/13,data/core/images/portraits/trolls/troll-hero-alt.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,b94ffed4fc4654ceb472905403f78c67
+2022/04/13,data/core/images/portraits/trolls/troll-hero.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,13a30afa24e20b77bd182346792a497b
+2022/04/13,data/core/images/portraits/trolls/troll-rocklobber.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,a05931d4c2708b982b7b68bc9f3d5cf0
+2022/04/13,data/core/images/portraits/trolls/troll-shaman.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,48c22c8d1d33b936bb38f8b67266a4d6
+2022/04/13,data/core/images/portraits/trolls/troll-warrior.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,b706a9eb8268a69c2fe98e5f20a1a962
+2016/03/21,data/core/images/portraits/trolls/troll.png,GNU GPL v2+,Emilien Rotival(LordBob),,,811651c5526a9c675cbaf9dc4f949a09
+2022/04/13,data/core/images/portraits/trolls/whelp.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,03457fc340fa318cabcc987684f350cf
+2022/04/13,data/core/images/portraits/undead/ancient-lich.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,609635f43c4d1279f7c4329a86d29f76
 2022/04/13,data/core/images/portraits/undead/archer.webp,GNU GPL v2+,Chris Wilson(Valkier),,,04c45e93830d86b2db294f21c316110e
 2022/04/13,data/core/images/portraits/undead/banebow.webp,GNU GPL v2+,Chris Wilson(Valkier),,,d9a2afc24ba457b54ae35dbdf953b12d
 2022/04/13,data/core/images/portraits/undead/bone-shooter.webp,GNU GPL v2+,Chris Wilson(Valkier),,,44dd3a02024bf2eef169093976a74b50
-2022/04/13,data/core/images/portraits/undead/brown-lich.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,5e026d9b2311ffb3ccb87f3ad315793d
+2022/04/13,data/core/images/portraits/undead/brown-lich.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,5e026d9b2311ffb3ccb87f3ad315793d
 2022/04/13,data/core/images/portraits/undead/death-knight.webp,GNU GPL v2+,Phil Barber(thespaceinvader);Christian Sirviö(Girgistian),,,1d0cbad788dfb3d2c0353596c75446bc
 2022/04/13,data/core/images/portraits/undead/deathblade.webp,GNU GPL v2+,Chris Wilson(Valkier),,,b365a05feccca00a227577498e8eb4c7
 2022/04/13,data/core/images/portraits/undead/draug-2.webp,GNU GPL v2+,Chris Wilson(Valkier),,,9c3d0008ecc4ec1877fb98b2384a6977
@@ -3656,7 +3656,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/core/images/portraits/undead/soulless.webp,GNU GPL v2+,(doofus-01),,,fcf58f0ac2d8a1117b307e171a5de867
 2022/04/13,data/core/images/portraits/undead/spectre.webp,GNU GPL v2+,Kathrin Polikeit(Kitty),,,879d56c47e9d6ee70a079d12f180d7bc
 2022/04/13,data/core/images/portraits/undead/walking-corpse.webp,GNU GPL v2+,(doofus-01),,,3061b54eb8f6fbe0fc58b1ba7eb16555
-2022/04/13,data/core/images/portraits/undead/wraith.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,c6f09bb47ee41d5d4d93a98825f1a045
+2022/04/13,data/core/images/portraits/undead/wraith.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,c6f09bb47ee41d5d4d93a98825f1a045
 2023/09/10,data/core/images/portraits/undead/zombie-ant.webp,CC BY-SA 4.0,(doofus-01),,,6735f6840f3fc671174e76997e51a46a
 2022/04/13,data/core/images/portraits/undead/zombie-bat.webp,GNU GPL v2+,(doofus-01),,,7a80f317be585b2645370e87b662b176
 2022/04/13,data/core/images/portraits/undead/zombie-beastrider.webp,CC BY-SA 4.0,(doofus-01),,,e2a8b187aa50879088741626ba1d659b
@@ -3683,8 +3683,8 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2022/04/13,data/core/images/portraits/wolves/wolf-dark.webp,CC BY-SA 4.0,(doofus-01),,,1d6f491b0dd5616c05f2c4503008e371
 2024/01/06,data/core/images/portraits/wolves/wolf-great.webp,CC BY-SA 4.0,(doofus-01),,,5e0692aaa756e017e2387a2114c5c269
 2024/01/06,data/core/images/portraits/wolves/wolf-red.webp,CC BY-SA 4.0,(doofus-01),,,ec99a9f920214fcac744174d7adf8e93
-2016/03/21,data/core/images/portraits/woses/ancient-wose.png,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,04f1aad0f752a74540da3cae4b724de7
-2022/04/13,data/core/images/portraits/woses/wose.webp,GNU GPL v2+;CC BY-SA 4.0,Emilien Rotival(LordBob),,,208d96cf188f54f1cb89aeb246251bd1
+2016/03/21,data/core/images/portraits/woses/ancient-wose.png,GNU GPL v2+,Emilien Rotival(LordBob),,,04f1aad0f752a74540da3cae4b724de7
+2022/04/13,data/core/images/portraits/woses/wose.webp,GNU GPL v2+,Emilien Rotival(LordBob),,,208d96cf188f54f1cb89aeb246251bd1
 2011/03/11,data/core/images/projectiles/bolas-n.png,GNU GPL v2+,unknown,,,ff2965b6039cd11dc86ee5d34ab4d253
 2011/03/11,data/core/images/projectiles/bolas-ne.png,GNU GPL v2+,unknown,,,72c187b9dd8f6c51890e6293f3a7bcaa
 2014/12/21,data/core/images/projectiles/bone-n.png,GNU GPL v2+,Richard Kettering(Jetrel),,,9e9c2ce1aa92f61da758f345d9d1845d

--- a/copyrights.csv
+++ b/copyrights.csv
@@ -2659,7 +2659,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2021/12/11,data/core/images/attacks/spear-simple.png,CC BY-SA 4.0,(doofus-01),,,3937d8fa5898709a27a57dcc2506fb91
 2021/12/11,data/core/images/attacks/spear-thrown.png,CC BY-SA 4.0,(doofus-01),,,51d906b9882266c02f20215c30fa9209
 2014/12/21,data/core/images/attacks/spear.png,GNU GPL v2+,unknown,,,76f57435763c2cd4256720fbfb595b93
-2011/06/15,data/core/images/attacks/staff-elven-star.png,GNU GPL v2+,(blarumyrran),based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both,edc6ccdf77e4088475585c1ea45340a3
+2011/06/15,data/core/images/attacks/staff-elven-star.png,GNU GPL v2+,(blarumyrran),"based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both",,edc6ccdf77e4088475585c1ea45340a3
 2014/12/21,data/core/images/attacks/staff-elven.png,GNU GPL v2+,Pekka Aikio(pekka),,,7de227ebbf43ece0aaae4787aed241b0
 2014/12/21,data/core/images/attacks/staff-green.png,GNU GPL v2+,(blarumyrran),,,cce959131378b48d56a0c5796271fd42
 2014/12/21,data/core/images/attacks/staff-magic.png,GNU GPL v2+,Richard Kettering(Jetrel),,,38d947ae558431777d35dbed76bea200
@@ -3147,17 +3147,17 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2015/08/24,data/core/images/icons/rusty_targ.png,GNU GPL v2+,(doofus-01),,,dffe2367db193621befe95f5f84e5ba5
 2014/12/21,data/core/images/icons/sandals.png,GNU GPL v2+,unknown,,,3fe9cbdb4c6c475f101aa96248b9c988
 2014/12/21,data/core/images/icons/scroll_red.png,GNU GPL v2+,unknown,,,e8f31032b14077369f2fed45252b4e8a
-2011/06/15,data/core/images/icons/shield_polished.png,GNU GPL v2+,(blarumyrran),based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both,85aa5b6f37ad83a376ffc3aa1a54796a
+2011/06/15,data/core/images/icons/shield_polished.png,GNU GPL v2+,(blarumyrran),"based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both",,85aa5b6f37ad83a376ffc3aa1a54796a
 2014/12/21,data/core/images/icons/shield_steel.png,GNU GPL v2+,(blarumyrran),,,28f8e7e3d578b89a225e6dc6ab964229
 2014/12/21,data/core/images/icons/shield_tower.png,GNU GPL v2+,unknown,,,251cc8dacdc88c33219936d73f4c020f
 2014/12/21,data/core/images/icons/shield_tower_merfolk.png,GNU GPL v2+,unknown,,,4a740a231005ee9a2b8d13beee7edc8a
 2014/12/21,data/core/images/icons/shield_wooden.png,GNU GPL v2+,unknown,,,4f7e73f6e3f68e460bf5418021e0d175
 2015/08/24,data/core/images/icons/silver_buckler.png,GNU GPL v2+,(doofus-01),,,4733396e3f76c3c4d78b9ea487005ff1
 2015/08/24,data/core/images/icons/skull_ring.png,GNU GPL v2+,(doofus-01),,,893378713b51cdf32a359a0ad0fc9074
-2011/06/15,data/core/images/icons/steel_armor.png,GNU GPL v2+,(blarumyrran),based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both,6a24f4906b39b594ab7d2b96941cfcf1
+2011/06/15,data/core/images/icons/steel_armor.png,GNU GPL v2+,(blarumyrran),"based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both",,6a24f4906b39b594ab7d2b96941cfcf1
 2014/12/21,data/core/images/icons/stone_ring.png,GNU GPL v2+,unknown,,,4d0c660d1eae3f4c98bf9602bdcdacb8
 2014/12/21,data/core/images/icons/tunic_elven.png,GNU GPL v2+,(blarumyrran),,,f5da398e33be35d5004123a93c787ab2
-2011/03/11,data/core/images/items/altar-evil.png,GNU GPL v2+,(blarumyrran),based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both,cb68e6c82abff232355002e63ced4f67
+2011/03/11,data/core/images/items/altar-evil.png,GNU GPL v2+,(blarumyrran),"based on 3d model by Clint Bellanger, but licensed to CC0 on the agreement of both",,cb68e6c82abff232355002e63ced4f67
 2021/05/30,data/core/images/items/altar.png,GNU GPL v2+,(blarumyrran),,,dc71efb574d58a48dd715224a1341dbd
 2021/05/30,data/core/images/items/ankh-necklace.png,GNU GPL v2+,(blarumyrran),,,c133ed6282ea82a6892e7ee39de5c352
 2021/05/30,data/core/images/items/ankh-necklace2.png,CC BY-SA 4.0,(blarumyrran),,,9350e4c88b43fef3bf5f742ab2d55f33
@@ -13569,7 +13569,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2023/09/30,data/core/images/units/monsters/raven/harbinger-hit2.png,CC BY-SA 4.0,(doofus-01),,,01efee79256d7a4afa06c60716cb8577
 2023/09/30,data/core/images/units/monsters/raven/harbinger-ne.png,CC BY-SA 4.0,(doofus-01),,,c923c6a0cc0962deb28b641aec443ce9
 2024/01/01,data/core/images/units/monsters/raven/harbinger-soar.png,CC BY-SA 4.0,(doofus-01),,,cc43e4f780ea5117abf5c0e3452d1333
-2024/01/01,data/core/images/units/monsters/raven/harbinger.png,CC BY-SA 4.0,(doofus-01),,2024/01/01,66db7d1db16e54e4504792979647d07b
+2024/01/01,data/core/images/units/monsters/raven/harbinger.png,CC BY-SA 4.0,(doofus-01),,,66db7d1db16e54e4504792979647d07b
 2023/09/30,data/core/images/units/monsters/raven/herald-hit1.png,CC BY-SA 4.0,(doofus-01),,,d5ea89ea03d1cb65cb4d9bd604c33383
 2023/09/30,data/core/images/units/monsters/raven/herald-hit2.png,CC BY-SA 4.0,(doofus-01),,,4f58601de4c920edaf8172979fc0cce8
 2023/09/30,data/core/images/units/monsters/raven/herald-ne.png,CC BY-SA 4.0,(doofus-01),,,987b88f02b56f26dc7485debeef0b2b1

--- a/update_copyrights
+++ b/update_copyrights
@@ -58,6 +58,8 @@ added = []
 changed = []
 # Already mentioned in the CSV file, but lacking something in either the license or author fields
 incomplete = []
+# Already mentioned in the CSV file, but have something in the needs update field
+update = []
 unchanged = []
 removed = []
 # Sanity-check that the input is in the same order as the output would be
@@ -90,6 +92,8 @@ for root, _, files in os.walk(options.repo):
 
             if not file in csv_data:
                 added.append(["", file, "", "", "", do_git(file), hash])
+            elif csv_data[file][5] != "":
+                update.append(csv_data[file])
             elif csv_data[file][6] != hash:
                 csv_data[file][5] = do_git(file)
                 csv_data[file][6] = hash
@@ -102,9 +106,10 @@ for root, _, files in os.walk(options.repo):
 added.sort(key=itemgetter(1))
 changed.sort(key=itemgetter(1))
 incomplete.sort(key=itemgetter(1))
+update.sort(key=itemgetter(1))
 unchanged.sort(key=itemgetter(1))
 
-final_output = added + changed + incomplete + unchanged
+final_output = added + changed + incomplete + update + unchanged
 
 if options.output != "":
     with open(options.output, 'w') as f:
@@ -120,11 +125,12 @@ if len(removed) > 0:
     any_check_failed = True
     print("There are "+str(len(removed))+" removed images")
 
-if len(added) > 0 or len(changed) > 0 or len(incomplete) > 0:
+if len(added) > 0 or len(changed) > 0 or len(incomplete) > 0 or len(update) > 0:
     any_check_failed = True
     print("There are "+str(len(added))+" new images")
     print("There are "+str(len(changed))+" changed images")
     print("There are "+str(len(incomplete))+" images that lack license or author information")
+    print("There are "+str(len(update))+" images that need updated information")
     if options.output != "":
         print("These are at the top of the output for easy editing, run the tool again after editing to sort the file")
 

--- a/update_copyrights
+++ b/update_copyrights
@@ -26,6 +26,18 @@ import sys
 # [6] = current md5 hash
 ##
 
+##
+# Add new licenses to this list:
+# Avoid things like "GNU GPL v2+;CC BY-SA 4.0", unless you mean to dual license
+# under either GNU GPL v2+ or CC BY-SA 4.0.  GNU GPL v2+ and CC BY-SA 4.0 (e.g.
+# a GNU GPL v2+ file with CC BY-SA 4.0 modifications) isn't legally possible.
+##
+known_licenses = (
+        "CC BY-SA 4.0",
+        "CC0",
+        "GNU GPL v2+",
+        )
+
 def do_git(file):
     return str(check_output(["git", "log", "-1", "--format=%ad", "--date=format:%Y/%m/%d", file]), 'UTF-8').rstrip('\n')
 
@@ -64,6 +76,8 @@ unchanged = []
 removed = []
 # Sanity-check that the input is in the same order as the output would be
 csvfile_needs_sorting = False
+# Sanity-check for known licenses
+unknown_licenses = []
 
 with open(options.input) as csvfile:
     reader = csv.reader(csvfile)
@@ -99,6 +113,9 @@ for root, _, files in os.walk(options.repo):
                 csv_data[file][6] = hash
                 changed.append(csv_data[file])
             elif csv_data[file][2].strip() == "" or csv_data[file][3].strip() == "":
+                incomplete.append(csv_data[file])
+            elif not csv_data[file][2] in known_licenses:
+                unknown_licenses.append(csv_data[file][2])
                 incomplete.append(csv_data[file])
             else:
                 unchanged.append(csv_data[file])
@@ -140,6 +157,11 @@ if csvfile_needs_sorting:
 
     if options.output != "" and final_output == unchanged:
         print("The new output file is correctly sorted")
+
+if len(unknown_licenses) > 0:
+    any_check_failed = True
+    print("Unknown licenses:")
+    print("    " + "\n    ".join(unknown_licenses))
 
 if any_check_failed:
     sys.exit(1)


### PR DESCRIPTION
Commit 97c8feb8ca3b (pull #7903) included a comma in the "Notes" field of four files, which instead of being enclosed in quotes, overflowed into the "Needs Update" field.  So if those files are updated, update_copyrights would clobber part of the notes.

The same commit specified for 58 of LordBob's portraits a license of "GNU GPL v2+;CC BY-SA 4.0".  I don't know if the semicolon is supposed to mean "and" or "or".

"And" isn't legally possible, because the GPL doesn't allow others to relicense under CC BY-SA.  "Or" appears incorrect, because LordBob [licensed][1] his portraits under "the GNU GPL" and I can't find any evidence of him also licensing them under CC BY-SA 4.0.

@Pentarctagon, is this license fix correct, or did LordBob relicense some (but not all) of his portraits somewhere I can't find?

Commit 1ecd4f4d599c (pull #8195) updated the "Date" field but didn't clear "Needs Update" after update_copyrights set "Needs Update" and "MD5" for data/core/images/units/monsters/raven/harbinger.png.

@doofus-01, is the row for data/core/images/units/monsters/raven/harbinger.png otherwise up-to-date?

Make update_copyrights check for and warn about "Needs Update" instead of clobbering it.  This should trigger CI failures if someone forgets to update a row or accidentally puts into the "Needs Update" field important information that shouldn't be clobbered on future updates.

And make it check for and warn about possibly invalid licenses like "GNU GPL v2+;CC BY-SA 4.0".

[1]: https://forums.wesnoth.org/viewtopic.php?p=329342#p329342