### PR TITLE
Show accuracy/parry as weapon specials in html, fixes #7895

### DIFF
--- a/data/tools/unit_tree/html_output.py
+++ b/data/tools/unit_tree/html_output.py
@@ -957,9 +957,15 @@ class HTMLOutput:
                                         sname = T(special, "name")
                                         if sname:
                                             s.append(sname)
+                                accuracy = attack.get_text_val("accuracy", default="0")
+                                parry = attack.get_text_val("parry", default="0")
+                                if accuracy != "0":
+                                    s.append(cleantext("accuracy "+accuracy+"%"))
+                                if parry != "0":
+                                    s.append(cleantext("parry "+parry+"%"))
+                                if s:
                                     s = ", ".join(s)
-                                    if s:
-                                        write(" (%s)" % cleantext(s, quote=False))
+                                    write(" (%s)" % cleantext(s, quote=False))
                             write('</div>')
 
                         write('</div>')
@@ -1235,12 +1241,12 @@ class HTMLOutput:
                         else:
                             error_message("Warning: Weapon special %s has no name for %s.\n" %
                                           (special.name.decode("utf8"), uid))
-                accuracy = attack.get_text_val("accuracy", default=0)
-                parry = attack.get_text_val("parry", default=0)
-                if accuracy != 0:
-                    s.append("accuracy "+str(accuracy)+"%")
-                if parry != 0:
-                    s.append("parry "+str(parry)+"%")
+                accuracy = attack.get_text_val("accuracy", default="0")
+                parry = attack.get_text_val("parry", default="0")
+                if accuracy != "0":
+                    s.append(cleantext("accuracy "+accuracy+"%"))
+                if parry != "0":
+                    s.append(cleantext("parry "+parry+"%"))
                 if s:
                     write('<td>(%s)</td>' % ', '.join(s))
                 write('</tr>')

--- a/data/tools/unit_tree/html_output.py
+++ b/data/tools/unit_tree/html_output.py
@@ -1235,6 +1235,12 @@ class HTMLOutput:
                         else:
                             error_message("Warning: Weapon special %s has no name for %s.\n" %
                                           (special.name.decode("utf8"), uid))
+                accuracy = attack.get_text_val("accuracy", default=0)
+                parry = attack.get_text_val("parry", default=0)
+                if accuracy != 0:
+                    s.append("accuracy "+str(accuracy)+"%")
+                if parry != 0:
+                    s.append("parry "+str(parry)+"%")
                 if s:
                     write('<td>(%s)</td>' % ', '.join(s))
                 write('</tr>')

--- a/data/tools/unit_tree/html_output.py
+++ b/data/tools/unit_tree/html_output.py
@@ -962,7 +962,7 @@ class HTMLOutput:
                                 if accuracy != "0":
                                     s.append("accuracy "+accuracy+"%")
                                 if parry != "0":
-                                    s.append(cleantext("parry "+parry+"%"))
+                                    s.append("parry "+parry+"%")
                                 if s:
                                     s = ", ".join(s)
                                     write(" (%s)" % cleantext(s, quote=False))

--- a/data/tools/unit_tree/html_output.py
+++ b/data/tools/unit_tree/html_output.py
@@ -960,7 +960,7 @@ class HTMLOutput:
                                 accuracy = attack.get_text_val("accuracy", default="0")
                                 parry = attack.get_text_val("parry", default="0")
                                 if accuracy != "0":
-                                    s.append(cleantext("accuracy "+accuracy+"%"))
+                                    s.append("accuracy "+accuracy+"%")
                                 if parry != "0":
                                     s.append(cleantext("parry "+parry+"%"))
                                 if s:


### PR DESCRIPTION
Not tested, and not planning to personally test until #3953

Given attack has accuracy=2 and parry=3, unit would show instead of current 
12 × 5 ranged (arcane) (pierce, skilled)
12 × 5 ranged (arcane) (pierce, skilled, accuracy 2%, parry 3%)