### PR TITLE
EI: fix macros in translatable strings, improve po hints

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
  ### Campaigns
    * Eastern Invasion
      * Fix S04b’s time limit, which extends by 10 turns if a bonus objective is completed.
+     * Fix macros in translatable strings, because they prevent translation. (issue #8225)
  ### Editor
  ### Multiplayer
  ### Lua API

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -125,6 +125,7 @@
         [/modifications]
         controller=ai
         team_name=orc
+        #po: Whitefang Orcs, the same clan that attacked Tath at the start of Descent into Darkness
         user_team_name= _ "Clan Whitefang"
         recruit=Orcish Grunt,Orcish Archer,Orcish Assassin,Wolf Rider
         {GOLD 70 140 210} # reduced scaling, since enemies spend most of their gold fighting each other
@@ -372,7 +373,8 @@
         [/message]
         [message]
             speaker=Prok-Bak
-            message= _ "That’s Whitefang territory you’re squatting in, snake! Show some respect for the Chief!" # whitefangs from DiD, in roughly the same area
+            #po: Whitefang Orcs, the same clan that attacked Tath at the start of Descent into Darkness
+            message= _ "That’s Whitefang territory you’re squatting in, snake! Show some respect for the Chief!"
         [/message]
         [message]
             speaker=Bagork
@@ -603,9 +605,9 @@
     [/event]
 
     # some gold guarded by each of the factions
-#define GOLD_PICKUP X Y PICTURE AMOUNT RACE
+#define GOLD_PICKUP X Y PICTURE AMOUNT LABEL_TEXT MESSAGE
     {PLACE_IMAGE {PICTURE} {X} {Y}}
-    {SET_LABEL {X} {Y} _"{AMOUNT} gold"}
+    {SET_LABEL {X} {Y} {LABEL_TEXT}}
     [event]
         name=moveto
         [filter]
@@ -614,7 +616,7 @@
         [/filter]
         [message]
             speaker=unit
-            message= _ "These {RACE} have a pile of {AMOUNT} gold pieces!"
+            message={MESSAGE}
             sound=gold.ogg
         [/message]
         [gold]
@@ -625,9 +627,9 @@
         {REMOVE_LABEL $unit.x $unit.y}
     [/event]
 #enddef
-    {GOLD_PICKUP 11 4  items/gold-coins-small.png 10 dwarves}
-    {GOLD_PICKUP 37 26 items/gold-coins-small.png 20 serpents}
-    {GOLD_PICKUP 38 10 items/gold-coins-small.png 20 orcs}
+    {GOLD_PICKUP 11 4  items/gold-coins-small.png 10 (_"10 gold") (_"These dwarves have a pile of 10 gold pieces!")}
+    {GOLD_PICKUP 37 26 items/gold-coins-small.png 20 (_"20 gold") (_"These nagas have a pile of 20 gold pieces!")}
+    {GOLD_PICKUP 38 10 items/gold-coins-small.png 20 (_"20 gold") (_"These orcs have a pile of 20 gold pieces!")}
     {PLACE_ITEM_SHIELD_OF_THE_SENTINEL 9 4}
     [item]
         x,y=9,4
@@ -653,6 +655,7 @@
         [/filter]
         [message]
             speaker=second_unit
+            #po: The unit who killed Bagork responds to Bagork's last breath, which was "I will kill all of you!"
             message= _ "Not likely."
         [/message]
     [/event]
@@ -722,6 +725,7 @@
             [then]
                 [message]
                     speaker=Dacyn
+                    #po: $gold is at least 300
                     message= _ "We are doing well. Our forces have already gathered $gold gold — plenty for the winter, and there is enough time remaining to gather even more."
                 [/message]
             [/then]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -363,17 +363,6 @@
         [/then]
     [/if]
 #enddef
-#define FROSTBITE_NOTE AMOUNT
-    [note]
-        description= _ "Living units take {AMOUNT} cold damage every turn. Damage increases every 10 turns."
-        [show_if]
-            [variable]
-                name=frostbite_amount
-                equals={AMOUNT}
-            [/variable]
-        [/show_if]
-    [/note]
-#enddef
     [event]
         name=prestart
 
@@ -464,21 +453,17 @@
             [note]
                 description= _ "It is winter, daytime is shorter"
             [/note]
-            {FROSTBITE_NOTE 1}
-            {FROSTBITE_NOTE 2}
-            {FROSTBITE_NOTE 3}
-            {FROSTBITE_NOTE 4}
-            {FROSTBITE_NOTE 5}
-            {FROSTBITE_NOTE 6}
-            {FROSTBITE_NOTE 7}
-            {FROSTBITE_NOTE 8}
-            {FROSTBITE_NOTE 9}
-            {FROSTBITE_NOTE 10}
-            {FROSTBITE_NOTE 11}
-            {FROSTBITE_NOTE 12}
-            {FROSTBITE_NOTE 13}
-            {FROSTBITE_NOTE 14}
-            {FROSTBITE_NOTE 15}
+            [note]
+                #po: The amount is likely between 2 and 10 per turn.
+                #po: With the current balancing it’s the same for every difficulty, starting at 2/turn and rising by 1 every 10 turns.
+                description= _ "Living units take $|frostbite_amount cold damage every turn. Damage increases every 10 turns."
+                [show_if]
+                    [variable]
+                        name=frostbite_amount
+                        greater_than=0
+                    [/variable]
+                [/show_if]
+            [/note]
         [/objectives]
     [/event]
 
@@ -1012,6 +997,7 @@ As tribute to the orcs."
         [/message]
         [message]
             speaker=Verash
+            #po: "Aspirant" is a drake military rank
             message= _ "Aspirant Mortic,
 As you command."
         [/message]
@@ -1126,9 +1112,10 @@ No further tribute can be paid."
             id=Mortic
         [/filter]
 
-        # letting us know that they're just a small and relatively weak Drake Flight but it sets us up to meet some strong ones later
         [message]
             speaker=Mortic
+            #po: letting us know that they're just a small and relatively weak Drake Flight but it sets us up to meet some strong ones later
+            #po: "aspirant" is a drake military rank
             message= _ "I am Aspirant.
 Yet in these northlands, even prey bares its fangs,
 And threatens to vanquish us.
@@ -1367,6 +1354,7 @@ I shall not fall here."
         {VARIABLE gold 25}
         [message]
             speaker=unit
+            #po: circa 25 gold pieces
             message= _ "This shipwreck was carrying chests of gold! Most of them are buried under the ice, but I can still reach $gold pieces."
             sound=gold.ogg
         [/message]
@@ -1390,6 +1378,7 @@ I shall not fall here."
         {VARIABLE gold 30}
         [message]
             speaker=unit
+            #po: circa 30 gold pieces
             message= _ "This ruined town still has some valuables! I count enough to be worth $gold gold pieces."
             sound=gold.ogg
         [/message]
@@ -1413,6 +1402,7 @@ I shall not fall here."
         {VARIABLE gold 15}
         [message]
             speaker=unit
+            #po: circa 15 gold pieces
             message= _ "This drake only had $gold gold pieces in his camp. Not much of a dragon hoard..."
             sound=gold.ogg
         [/message]

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -339,6 +339,9 @@
         {NOTRAIT_UNIT 1 "Bowman" 24 5}
         [+unit]
             role="escapee sidekick 2"
+            # Fixing the gender makes translation easier, as it avoids the need for text variants.
+            # Our heroes are all male, so let's have the very non-heroic unit be male too.
+            gender=male
             [modifications]
                 {TRAIT_DESERTER}
                 {TRAIT_QUICK}
@@ -655,11 +658,15 @@
         [/message]
         [message]
             role=escapee sidekick 2
+            #po: Speaker is the male deserter, however the other units don't know their backstory yet
             message= _ "I’m sure your commanders will come and save us!"
         [/message]
         [message]
             role=escapee sidekick 0
+            #po: Male speaker talking to male deserter, also the huge enemies changed in 1.17 from trolls to orcs
             message= _ "What? Didn’t you see those huge orcs drag them away? It’s hopeless!"
+            #po: Female speaker talking to male deserter, also the huge enemies changed in 1.17 from trolls to orcs
+            message= _ "female^What? Didn’t you see those huge orcs drag them away? It’s hopeless!"
         [/message]
         [message]
             role=escapee leader
@@ -743,7 +750,10 @@
             {STORE_UNIT_VAR (role=escapee sidekick 2) name deserter_name}
             [message]
                 role=escapee sidekick 1
+                #po: The speaker is male. The deserter, "escapee sidekick 2", will always be male. The other escapees are random units from the player's recall list
                 message= _ "$deserter_name, I don’t recognize you, and you look like you’ve been locked up longer than the rest of us. How did you get here?"
+                #po: The speaker is female. The deserter, "escapee sidekick 2", will always be male. The other escapees are random units from the player's recall list
+                female_message= _ "female^$deserter_name, I don’t recognize you, and you look like you’ve been locked up longer than the rest of us. How did you get here?"
             [/message]
             {CLEAR_VARIABLE deserter_name}
             [message]
@@ -752,10 +762,14 @@
             [/message]
             [message]
                 role=escapee leader
+                #po: The speaker is male
                 message= _ "(scowling) A deserter. We should lock you back in your cell."
+                #po: The speaker is female
+                message= _ "female^(scowling) A deserter. We should lock you back in your cell."
             [/message]
             [message]
                 role=escapee sidekick 2
+                #po: "you" being an audience of three units
                 message= _ "No, please, you don’t understand! The undead are everywhere! I didn’t want to die like all my friends..."
             [/message]
         [/event]
@@ -1304,11 +1318,13 @@ I serve his will."
         # east cell
         [message]
             speaker=Ga'all
+            #po: Ga'all and Verash are drakes from S10
             message= _ "I am free!
 Never again shall I be prisoner!"
         [/message]
         [message]
             speaker=Verash
+            #po: Ga'all and Verash are drakes from S10
             message= _ "You disobey the Aspirant.
 For your treachery,
 Your punishment is death."
@@ -1532,6 +1548,7 @@ Your punishment is death."
         name=remove disguise
         [message]
             speaker=Chief Dra-Nak
+            #po: Boja is the name of the cave bear
             message= _ "Hey, who are you? Boja, sic ’em!"
         [/message]
         [message]
@@ -1569,9 +1586,9 @@ Your punishment is death."
     [/event]
 
     # orcish treasury gold, so even if you didn't save anything, you may still be able to start S12 with a little bit
-#define TREASURY_GOLD X Y IMAGE AMOUNT
+#define TREASURY_GOLD X Y IMAGE AMOUNT LABEL_TEXT MESSAGE
     {PLACE_IMAGE {IMAGE} {X} {Y}}
-    {SET_LABEL {X} {Y} _"{AMOUNT} gold"}
+    {SET_LABEL {X} {Y} {LABEL_TEXT}}
     [event]
         name=moveto
 
@@ -1586,7 +1603,7 @@ Your punishment is death."
             speaker=narrator
             image=wesnoth-icon.png
             sound=gold.ogg
-            message= _ "You’ve pillaged {AMOUNT} orcish gold pieces!"
+            message={MESSAGE}
         [/message]
         [gold]
             side=1
@@ -1594,8 +1611,8 @@ Your punishment is death."
         [/gold]
     [/event]
 #enddef
-    {TREASURY_GOLD 34 10 "items/gold-coins-small.png"  70}
-    {TREASURY_GOLD 35 11 "items/gold-coins-medium.png" 115}
+    {TREASURY_GOLD 34 10 "items/gold-coins-small.png" 70 (_"70 gold") (_"You’ve pillaged 70 orcish gold pieces!")}
+    {TREASURY_GOLD 35 11 "items/gold-coins-medium.png" 115 (_"115 gold") (_"You’ve pillaged 115 orcish gold pieces!")}
 
     #---------------------------
     # RING OF INVISIBILITY
@@ -1671,6 +1688,7 @@ Your punishment is death."
         [/message]
         [message]
             side=3
+            #po: The player didn’t open all the cells before moving a hero to the exit and triggering the victory event
             message= _ "Wait, you can’t leave us behind!"
         [/message]
 

--- a/data/campaigns/Eastern_Invasion/utils/traits.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/traits.cfg
@@ -20,7 +20,7 @@
         male_name= _ "deserter"
         female_name= _ "female^deserter"
         description= _ "When this unit drops below half health, it will flee the battle and reappear on your recall list."
-        # NOTE - implmentation is handled using [event]s in _main.cfg
+        # NOTE - implementation is handled using the events below, the macros are instantiated in _main.cfg
     [/trait]
 #enddef
 
@@ -38,42 +38,14 @@
         [/have_unit]        # also prevents this from triggering in S20, when the deserters are AI-controlled
     [/filter_condition]
 
-    {RANDOM (1,2,3)}
-    [switch]
-        variable=random
-        [case]
-            value=1
-            [message]
-                speaker=${UNIT}.id
-                message=_ "Forget this!"
-            [/message]
-        [/case]
-        [case]
-            value=2
-            [message]
-                speaker=${UNIT}.id
-                message=_"Run for your lives!"
-            [/message]
-        [/case]
-        [case]
-            value=3
-            [message]
-                speaker=${UNIT}.id
-                message=_"Get me out of here!"
-            [/message]
-        [/case]
-    [/switch]
-    {CLEAR_VARIABLE random}
-    [put_to_recall_list]
-        id=${UNIT}.id
-        heal=yes
-    [/put_to_recall_list]
-    [message]
-        speaker=narrator
-        message= _ "The ‘deserter’ trait has caused ${UNIT}.name to flee back to your recall list."
-        image=wesnoth-icon.png
-    [/message]
+    [fire_event]
+        name=deserter deserts
+        [primary_unit]
+            id=${UNIT}.id
+        [/primary_unit]
+    [/fire_event]
 #enddef
+
 #define GLOBAL__TRAIT_DESERTER
     [event]
         name=attacker hits
@@ -82,6 +54,68 @@
     [event]
         name=defender hits
         {DESERTER_EVENT filter unit}
+    [/event]
+
+    [event]
+        # This event is triggered from "attacker hits" or "defender hits", it's a separate event
+        # so that the primary/secondary unit in combat can be treated as $unit in this code.
+        name=deserter deserts
+        first_time_only=no
+        {RANDOM (1,2,3)}
+        [switch]
+            variable=random
+            [case]
+                value=1
+                [message]
+                    speaker=$unit.id
+                    #po: The unit is about to desert
+                    message=_ "Forget this!"
+                [/message]
+            [/case]
+            [case]
+                value=2
+                [message]
+                    speaker=$unit.id
+                    message=_"Run for your lives!"
+                [/message]
+            [/case]
+            [case]
+                value=3
+                [message]
+                    speaker=$unit.id
+                    #po: the speaker is male
+                    message=_"Get me out of here!"
+                    female_message=_"female^Get me out of here!"
+                [/message]
+            [/case]
+        [/switch]
+        {CLEAR_VARIABLE random}
+        [put_to_recall_list]
+            id=$unit.id
+            heal=yes
+        [/put_to_recall_list]
+        [if]
+            [have_unit]
+                id=$unit.id
+                gender=male
+                search_recall_list=yes
+            [/have_unit]
+            [then]
+                [message]
+                    speaker=narrator
+                    #po: unit is male
+                    message= _ "The ‘deserter’ trait has caused $unit.name to flee back to your recall list."
+                    image=wesnoth-icon.png
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker=narrator
+                    message= _ "female^The ‘deserter’ trait has caused $unit.name to flee back to your recall list."
+                    image=wesnoth-icon.png
+                [/message]
+            [/else]
+        [/if]
     [/event]
 #enddef
 


### PR DESCRIPTION
In S11, make the first deserter always male so the translations don't need to worry about gender variants.

Fixes #8225. Most the new strings are ones that had to be added to replace the strings that contained macros. The deserter mechanism included strings that had to change, so a few of the deserter-related strings in S11 have also been split for male/female speakers; I think that's a bug-fix, and those strings are currently only translated in `en_GB` and `sk` (plus any translation that's not yet reached @ivanovic ).