### PR TITLE
Refactor the sides list to use 1-indexing everywhere

### DIFF
--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1636,7 +1636,7 @@ int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, b
 bool backstab_check(const map_location& attacker_loc,
 		const map_location& defender_loc,
 		const unit_map& units,
-		const std::vector<team>& teams)
+		const team_list& teams)
 {
 	const unit_map::const_iterator defender = units.find(defender_loc);
 	if(defender == units.end()) {

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -26,8 +26,7 @@
 #include "attack_prediction.hpp"
 #include "units/ptr.hpp"
 #include "units/unit_alignments.hpp"
-
-#include <vector>
+#include "utils/ordinal_list.hpp"
 
 struct map_location;
 class team;
@@ -36,6 +35,7 @@ class unit_type;
 class unit;
 class unit_map;
 class gamemap;
+using team_list = utils::ordinal_list<team>;
 
 /** Calculates the number of blows resulting from swarm. */
 inline unsigned swarm_blows(unsigned min_blows, unsigned max_blows, unsigned hp, unsigned max_hp)
@@ -310,4 +310,4 @@ int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, b
 bool backstab_check(const map_location& attacker_loc,
 		const map_location& defender_loc,
 		const unit_map& units,
-		const std::vector<team>& teams);
+		const team_list& teams);

--- a/src/actions/heal.cpp
+++ b/src/actions/heal.cpp
@@ -84,7 +84,7 @@ namespace {
 	POISON_STATUS poison_progress(int side, const unit & patient,
 	                              std::vector<unit *> & healers)
 	{
-		const std::vector<team> &teams = resources::gameboard->teams();
+		const auto& teams = resources::gameboard->teams();
 		unit_map &units = resources::gameboard->units();
 
 		POISON_STATUS curing = POISON_NORMAL;
@@ -125,7 +125,7 @@ namespace {
 			// Healers on the current side can cure poison (for any side).
 			// Allies of the current side can slow poison (for the current side).
 			// Enemies of the current side can do nothing.
-			if ( teams[cure_side-1].is_enemy(side) )
+			if ( teams[cure_side].is_enemy(side) )
 				continue;
 
 			// Allied healers can only slow poison, not cure it.

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -139,7 +139,7 @@ void move_unit_spectator::set_unit(const unit_map::const_iterator &u)
 
 game_events::pump_result_t get_village(const map_location& loc, int side, bool *action_timebonus, bool fire_event)
 {
-	std::vector<team> &teams = resources::gameboard->teams();
+	auto& teams = resources::gameboard->teams();
 	team *t = static_cast<unsigned>(side - 1) < teams.size() ? &teams[side - 1] : nullptr;
 	if (t && t->owns_village(loc)) {
 		return game_events::pump_result_t();
@@ -152,7 +152,7 @@ game_events::pump_result_t get_village(const map_location& loc, int side, bool *
 	int old_owner_side = 0;
 	// We strip the village off all other sides, unless it is held by an ally
 	// and our side is already defeated (and thus we can't occupy it)
-	for(std::vector<team>::iterator i = teams.begin(); i != teams.end(); ++i) {
+	for(auto i = teams.begin(); i != teams.end(); ++i) {
 		int i_side = std::distance(teams.begin(), i) + 1;
 		if (!t || not_defeated || t->is_enemy(i_side)) {
 			if(i->owns_village(loc)) {
@@ -353,7 +353,7 @@ namespace { // Private helpers for move_unit()
 		: spectator_(move_spectator)
 		, skip_sighting_(skip_sightings)
 		, skip_ally_sighting_(skip_ally_sightings)
-		, playing_team_is_viewing_(display::get_singleton()->playing_team() == display::get_singleton()->viewing_team() || display::get_singleton()->show_everything())
+		, playing_team_is_viewing_(display::get_singleton()->playing_side() == display::get_singleton()->viewing_side() || display::get_singleton()->show_everything())
 		, route_(route)
 		, begin_(route.begin())
 		, full_end_(route.end())

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -147,7 +147,7 @@ void aspect_attacks_base::do_attack_analysis(const map_location& loc,
 
 	const gamemap& map_ = resources::gameboard->map();
 	unit_map& units_ = resources::gameboard->units();
-	const std::vector<team>& teams_ = resources::gameboard->teams();
+	const auto& teams_ = resources::gameboard->teams();
 
 	const std::size_t max_positions = 1000;
 	if(result.size() > max_positions && !cur_analysis.movements.empty()) {

--- a/src/ai/default/ca.cpp
+++ b/src/ai/default/ca.cpp
@@ -673,7 +673,7 @@ void get_villages_phase::find_villages(
 
 	std::size_t min_distance = 100000;
 	const gamemap &map_ = resources::gameboard->map();
-	std::vector<team> &teams_ = resources::gameboard->teams();
+	auto& teams_ = resources::gameboard->teams();
 
 	// When a unit is dispatched we need to make sure we don't
 	// dispatch this unit a second time, so store them here.
@@ -702,9 +702,9 @@ void get_villages_phase::find_villages(
 		}
 
 		bool want_village = true, owned = false;
-		for(std::size_t n = 0; n != teams_.size(); ++n) {
+		for(std::size_t n = 1; n <= teams_.size(); ++n) {
 			owned = teams_[n].owns_village(current_loc);
-			if(owned && !current_team().is_enemy(n+1)) {
+			if(owned && !current_team().is_enemy(n)) {
 				want_village = false;
 			}
 

--- a/src/ai/default/contexts.cpp
+++ b/src/ai/default/contexts.cpp
@@ -129,7 +129,7 @@ std::vector<target> default_ai_context_impl::find_targets(const move_map& enemy_
 	unit_map &units_ = resources::gameboard->units();
 	unit_map::iterator leader = units_.find_leader(get_side());
 	const gamemap &map_ = resources::gameboard->map();
-	std::vector<team> teams_ = resources::gameboard->teams();
+	auto& teams_ = resources::gameboard->teams();
 	const bool has_leader = leader != units_.end();
 
 	std::vector<target> targets;
@@ -177,9 +177,9 @@ std::vector<target> default_ai_context_impl::find_targets(const move_map& enemy_
 
 			assert(map_.on_board(*t));
 			bool ally_village = false;
-			for (std::size_t i = 0; i != teams_.size(); ++i)
+			for(std::size_t i = 1; i <= teams_.size(); ++i)
 			{
-				if (!current_team().is_enemy(i + 1) && teams_[i].owns_village(*t)) {
+				if (!current_team().is_enemy(i) && teams_[i].owns_village(*t)) {
 					ally_village = true;
 					break;
 				}

--- a/src/ai/formula/ai.cpp
+++ b/src/ai/formula/ai.cpp
@@ -399,7 +399,7 @@ variant formula_ai::get_value(const std::string& key) const
 	} else if(key == "teams")
 	{
 		std::vector<variant> vars;
-		for(std::vector<team>::const_iterator i = resources::gameboard->teams().begin(); i != resources::gameboard->teams().end(); ++i) {
+		for(auto i = resources::gameboard->teams().begin(); i != resources::gameboard->teams().end(); ++i) {
 			vars.emplace_back(std::make_shared<team_callable>(*i));
 		}
 		return variant(vars);

--- a/src/ai/simulated_actions.cpp
+++ b/src/ai/simulated_actions.cpp
@@ -182,7 +182,7 @@ bool simulated_synced_command(){
 
 // Helper functions.
 void helper_check_village(const map_location& loc, int side){
-	std::vector<team> &teams = resources::gameboard->teams();
+	auto& teams = resources::gameboard->teams();
 	team *t = static_cast<unsigned>(side - 1) < teams.size() ? &teams[side - 1] : nullptr;
 	if(t && t->owns_village(loc)){
 		return;
@@ -192,7 +192,7 @@ void helper_check_village(const map_location& loc, int side){
 
 	// Strip the village off all other sides.
 	int old_owner_side = 0;
-	for(std::vector<team>::iterator i = teams.begin(); i != teams.end(); ++i){
+	for(auto i = teams.begin(); i != teams.end(); ++i){
 		int i_side = std::distance(teams.begin(), i) + 1;
 		if(!t || has_leader || t->is_enemy(i_side)){
 			if(i->owns_village(loc)){

--- a/src/ai/testing.cpp
+++ b/src/ai/testing.cpp
@@ -90,7 +90,7 @@ void ai_testing::log_victory(std::set<unsigned int> winners)
 
 void ai_testing::log_game_start()
 {
-	for (std::vector<team>::const_iterator tm = resources::gameboard->teams().begin(); tm != resources::gameboard->teams().end(); ++tm) {
+	for(auto tm = resources::gameboard->teams().begin(); tm != resources::gameboard->teams().end(); ++tm) {
 		int side = tm-resources::gameboard->teams().begin()+1;
 		LOG_AI_TESTING << "AI_IDENTIFIER " << side << ": " << ai::manager::get_singleton().get_active_ai_identifier_for_side(side);
 		LOG_AI_TESTING << "TEAM " << side << ": " << tm->side();
@@ -105,7 +105,7 @@ void ai_testing::log_game_end()
 	LOG_AI_TESTING << "GAME_END_TURN: "<< resources::tod_manager->turn();
 	resources::recorder->add_log_data("ai_log","end_turn",
 		std::to_string(resources::tod_manager->turn()));
-	for (std::vector<team>::const_iterator tm = resources::gameboard->teams().begin(); tm != resources::gameboard->teams().end(); ++tm) {
+	for(auto tm = resources::gameboard->teams().begin(); tm != resources::gameboard->teams().end(); ++tm) {
 		int side = tm-resources::gameboard->teams().begin()+1;
 		resources::recorder->add_log_data("ai_log","end_gold"+std::to_string(side),std::to_string(tm->gold()));
 		resources::recorder->add_log_data("ai_log","end_units"+std::to_string(side),std::to_string(resources::gameboard->side_units(side)));

--- a/src/carryover_show_gold.cpp
+++ b/src/carryover_show_gold.cpp
@@ -40,7 +40,7 @@ void carryover_show_gold(game_state& state, bool hidden, bool is_observer, bool 
 	const end_level_data& end_level = *state.end_level_data_;
 	const bool is_victory = end_level.is_victory;
 	// We need to write the carryover amount to the team that's why we need non const
-	std::vector<team>& teams = board.teams();
+	auto& teams = board.teams();
 
 	// maybe this can be the case for scenario that only contain a story and end during the prestart event ?
 	if(teams.size() < 1) {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -156,7 +156,7 @@ display::display(const display_context* dc,
 	, halo_man_()
 	, wb_(wb)
 	, exclusive_unit_draw_requests_()
-	, currentTeam_(0)
+	, currentTeam_(1)
 	, dont_show_all_(false)
 	, xpos_(0)
 	, ypos_(0)
@@ -194,7 +194,7 @@ display::display(const display_context* dc,
 	, animate_map_(true)
 	, animate_water_(true)
 	, flags_()
-	, activeTeam_(0)
+	, activeTeam_(1)
 	, drawing_buffer_()
 	, map_screenshot_(false)
 	, reach_map_()
@@ -358,7 +358,7 @@ texture display::get_flag(const map_location& loc)
 
 void display::set_team(std::size_t teamindex, bool show_everything)
 {
-	assert(teamindex < dc_->teams().size());
+	assert(dc_->teams().has_index(teamindex));
 	currentTeam_ = teamindex;
 	if(!show_everything) {
 		labels().set_team(&dc_->teams()[teamindex]);
@@ -375,7 +375,7 @@ void display::set_team(std::size_t teamindex, bool show_everything)
 
 void display::set_playing_team(std::size_t teamindex)
 {
-	assert(teamindex < dc_->teams().size());
+	assert(dc_->teams().has_index(teamindex));
 	activeTeam_ = teamindex;
 	invalidate_game_status();
 }
@@ -1758,7 +1758,7 @@ void display::draw_minimap_units()
 			auto status = orb_status::allied;
 			if(dc_->teams()[currentTeam_].is_enemy(side)) {
 				status = orb_status::enemy;
-			} else if(currentTeam_ + 1 == static_cast<unsigned>(side)) {
+			} else if(currentTeam_ == static_cast<unsigned>(side)) {
 				status = dc_->unit_orb_status(u);
 			} else {
 				// no-op, status is already set to orb_status::allied;
@@ -2738,7 +2738,7 @@ void display::draw_hex(const map_location& loc)
 					bool item_visible_for_team = true;
 					if(dont_show_all_ && !ov.team_name.empty()) {
 						// dont_show_all_ imples that viewing_team() is a valid index to get_teams()
-						const std::string& current_team_name = get_teams()[viewing_team()].team_name();
+						const std::string& current_team_name = get_teams()[viewing_side()].team_name();
 						const std::vector<std::string>& current_team_names = utils::split(current_team_name);
 						const std::vector<std::string>& team_names = utils::split(ov.team_name);
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -103,10 +103,10 @@ public:
 
 	const gamemap& get_map() const { return dc_->map(); }
 
-	const std::vector<team>& get_teams() const {return dc_->teams();}
+	const team_list& get_teams() const {return dc_->teams();}
 
 	/** The playing team is the team whose turn it is. */
-	std::size_t playing_team() const { return activeTeam_; }
+	std::size_t playing_side() const { return activeTeam_; }
 
 	bool team_valid() const;
 
@@ -116,15 +116,7 @@ public:
 	 *
 	 * For players, it will be their side (or one of them, if they control multiple sides).
 	 *
-	 * The value returned is a 0-based index into the vector returned by get_teams().
-	 */
-	std::size_t viewing_team() const { return currentTeam_; }
-	/**
-	 * The 1-based equivalent of the 0-based viewing_team() function. This is the side-number that
-	 * WML uses.
-	 *
-	 * TODO: provide a better interface in a better place (consistent base numbers, and not in a GUI
-	 * class).
+	 * This is the side-number that WML uses.
 	 */
 	int viewing_side() const { return static_cast<int>(currentTeam_ + 1); }
 
@@ -215,7 +207,7 @@ public:
 
 	/** Virtual functions shadowed in game_display. These are needed to generate reports easily, without dynamic casting. Hope to factor out eventually. */
 	virtual const map_location & displayed_unit_hex() const { return map_location::null_location(); }
-	virtual int playing_side() const { return -100; } //In this case give an obviously wrong answer to fail fast, since this could actually cause a big bug. */
+//	virtual int playing_side() const { return -100; } //In this case give an obviously wrong answer to fail fast, since this could actually cause a big bug. */
 	virtual const std::set<std::string>& observers() const { static const std::set<std::string> fake_obs = std::set<std::string> (); return fake_obs; }
 
 	/**

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -23,7 +23,12 @@
 
 const team& display_context::get_team(int side) const
 {
-	return teams().at(side - 1);
+	return teams().at(side);
+}
+
+bool display_context::has_team(int side) const
+{
+	return teams().has_index(side);
 }
 
 bool display_context::would_be_discovered(const map_location & loc, int side_num, bool see_all)
@@ -118,10 +123,10 @@ orb_status display_context::unit_orb_status(const unit& u) const
 
 int display_context::village_owner(const map_location& loc) const
 {
-	const std::vector<team> & t = teams();
-	for(std::size_t i = 0; i != t.size(); ++i) {
+	const auto& t = teams();
+	for(std::size_t i = 1; i <= t.size(); ++i) {
 		if(t[i].owns_village(loc))
-			return i + 1;
+			return i;
 	}
 	return 0;
 }

--- a/src/display_context.hpp
+++ b/src/display_context.hpp
@@ -18,9 +18,13 @@
 #include "units/orb_status.hpp"
 #include "units/ptr.hpp"
 #include <string>
+#include <type_traits>
 #include <vector>
+#include "boost/range.hpp"
+#include "utils/ordinal_list.hpp"
 
 class team;
+using team_list = utils::ordinal_list<team>;
 class gamemap;
 class unit_map;
 
@@ -34,21 +38,16 @@ struct map_location;
 class display_context
 {
 public:
-	virtual const std::vector<team> & teams() const = 0;
+	virtual const team_list& teams() const = 0;
 	virtual const gamemap & map() const = 0;
 	virtual const unit_map & units() const = 0;
 	virtual const std::vector<std::string> & hidden_label_categories() const = 0;
 	virtual std::vector<std::string> & hidden_label_categories() = 0;
-
-	/** This getter takes a 1-based side number, not a 0-based team number. */
+	
+	[[deprecated("Use teams() instead")]]
 	const team& get_team(int side) const;
-
-	// this one is only a template function to prevent compilation erros when class team is an incomplete type.
-	template<typename T = void>
-	bool has_team(int side) const
-	{
-		return side > 0 && side <= static_cast<int>(teams().size());
-	}
+	[[deprecated("Use teams().has_index instead")]]
+	bool has_team(int side) const;
 
 	// Helper for is_visible_to_team
 

--- a/src/editor/action/action_village.cpp
+++ b/src/editor/action/action_village.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<editor_action> editor_action_village::perform(map_context& mc) c
 		return nullptr;
 	}
 
-	std::vector<team>& teams = mc.teams();
+	auto& teams = mc.teams();
 
 	try {
 		if(teams.at(side_number_).owns_village(loc_)) {
@@ -58,7 +58,7 @@ std::unique_ptr<editor_action> editor_action_village::perform(map_context& mc) c
 
 void editor_action_village::perform_without_undo(map_context& mc) const
 {
-	std::vector<team>& teams = mc.teams();
+	auto& teams = mc.teams();
 
 	for(team& t : teams) {
 		if(t.owns_village(loc_)) {

--- a/src/editor/action/mouse/mouse_action_village.cpp
+++ b/src/editor/action/mouse/mouse_action_village.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<editor_action> mouse_action_village::up_left(editor_display& dis
 	if (!disp.get_map().on_board(hex))   return nullptr;
 	if (!disp.get_map().is_village(hex)) return nullptr;
 
-	return std::make_unique<editor_action_village>(hex, disp.playing_team());
+	return std::make_unique<editor_action_village>(hex, disp.playing_side());
 }
 
 std::unique_ptr<editor_action> mouse_action_village::up_right(editor_display& disp, int x, int y)

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -614,7 +614,7 @@ hotkey::ACTION_STATE editor_controller::get_action_state(const hotkey::ui_comman
 		case editor::ADDON:
 			return ACTION_STATELESS;
 		case editor::SIDE:
-			return static_cast<std::size_t>(index) == gui_->playing_team()
+			return static_cast<std::size_t>(index + 1) == gui_->playing_side()
 					? ACTION_SELECTED : ACTION_DESELECTED;
 		case editor::TIME:
 			return index ==	get_current_map_context().get_time_manager()->get_current_time()
@@ -1042,7 +1042,7 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 			get_current_map_context().remove_side();
 			return true;
 		case HOTKEY_EDITOR_SIDE_EDIT:
-			context_manager_->edit_side_dialog(gui_->viewing_team());
+			context_manager_->edit_side_dialog(gui_->viewing_side());
 			return true;
 
 		// Transitions

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -122,7 +122,6 @@ public:
 
 	// Import symbols from base class.
 	using display_context::units;
-	using display_context::teams;
 	using display_context::map;
 
 	/** Const units accessor. */
@@ -138,13 +137,13 @@ public:
 	}
 
 	/** Const teams accessor. */
-	virtual const std::vector<team>& teams() const override
+	virtual const team_list& teams() const override
 	{
 		return teams_;
 	}
 
 	/** Local non-const overload of @ref teams */
-	std::vector<team>& teams()
+	team_list& teams()
 	{
 		return teams_;
 	}
@@ -508,7 +507,7 @@ private:
 
 	map_labels labels_;
 	unit_map units_;
-	std::vector<team> teams_;
+	team_list teams_;
 	std::vector<std::string> lbl_categories_;
 	std::unique_ptr<tod_manager> tod_manager_;
 	mp_game_settings mp_settings_;

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -381,7 +381,7 @@ void game_board::write_config(config& cfg) const
 {
 	cfg["next_underlying_unit_id"] = unit_id_manager_.get_save_id();
 
-	for(std::vector<team>::const_iterator t = teams_.begin(); t != teams_.end(); ++t) {
+	for(auto t = teams_.begin(); t != teams_.end(); ++t) {
 		int side_num = std::distance(teams_.begin(), t) + 1;
 
 		config& side = cfg.add_child("side");

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -51,7 +51,7 @@ namespace events {
  **/
 class game_board : public display_context
 {
-	std::vector<team> teams_;
+	team_list teams_;
 	std::vector<std::string> labels_;
 
 	std::unique_ptr<gamemap> map_;
@@ -83,12 +83,12 @@ public:
 	game_board(const config& level);
 	virtual ~game_board();
 
-	virtual const std::vector<team>& teams() const override
+	virtual const team_list& teams() const override
 	{
 		return teams_;
 	}
 
-	std::vector<team>& teams()
+	team_list& teams()
 	{
 		return teams_;
 	}
@@ -97,7 +97,7 @@ public:
 
 	team& get_team(int i)
 	{
-		return teams_.at(i - 1);
+		return teams_.at(i);
 	}
 
 	virtual const gamemap& map() const override

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -124,12 +124,12 @@ void game_display::highlight_hex(map_location hex)
 {
 	wb::future_map_if future(!synced_context::is_synced()); /**< Lasts for whole method. */
 
-	const unit *u = resources::gameboard->get_visible_unit(hex, dc_->teams()[viewing_team()], !dont_show_all_);
+	const unit *u = resources::gameboard->get_visible_unit(hex, dc_->teams()[viewing_side()], !dont_show_all_);
 	if (u) {
 		displayedUnitHex_ = hex;
 		invalidate_unit();
 	} else {
-		u = resources::gameboard->get_visible_unit(mouseoverHex_, dc_->teams()[viewing_team()], !dont_show_all_);
+		u = resources::gameboard->get_visible_unit(mouseoverHex_, dc_->teams()[viewing_side()], !dont_show_all_);
 		if (u) {
 			// mouse moved from unit hex to non-unit hex
 			if (dc_->units().count(selectedHex_)) {
@@ -151,7 +151,7 @@ void game_display::display_unit_hex(map_location hex)
 
 	wb::future_map_if future(!synced_context::is_synced()); /**< Lasts for whole method. */
 
-	const unit *u = resources::gameboard->get_visible_unit(hex, dc_->teams()[viewing_team()], !dont_show_all_);
+	const unit *u = resources::gameboard->get_visible_unit(hex, dc_->teams()[viewing_side()], !dont_show_all_);
 	if (u) {
 		displayedUnitHex_ = hex;
 		invalidate_unit();
@@ -246,7 +246,7 @@ void game_display::draw_hex(const map_location& loc)
 
 	if(on_map && loc == mouseoverHex_ && !map_screenshot_) {
 		drawing_layer hex_top_layer = LAYER_MOUSEOVER_BOTTOM;
-		const unit* u = resources::gameboard->get_visible_unit(loc, dc_->teams()[viewing_team()]);
+		const unit* u = resources::gameboard->get_visible_unit(loc, dc_->teams()[viewing_side()]);
 		if(u != nullptr) {
 			hex_top_layer = LAYER_MOUSEOVER_TOP;
 		}

--- a/src/game_display.hpp
+++ b/src/game_display.hpp
@@ -197,9 +197,6 @@ public:
 	static int& debug_highlight(const map_location& loc);
 	static void clear_debug_highlights() { debugHighlights_.clear(); }
 
-	/** The playing team is the team whose turn it is. */
-	virtual int playing_side() const override { return static_cast<int>(activeTeam_) + 1; }
-
 	std::string current_team_name() const;
 
 	display_chat_manager & get_chat_manager() { return *chat_man_; }

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -208,18 +208,14 @@ void manager::execute_on_events(const std::string& event_id, manager::event_func
 {
 	const std::string standardized_event_id = event_handlers::standardize_name(event_id);
 	const game_data* gd = resources::gamedata;
-	auto& active_handlers = event_handlers_->get_active();
-
-	// Save the end outside the loop so the end point remains constant,
-	// even if new events are added to the queue.
-	const unsigned saved_end = active_handlers.size();
-
+	// Copy the list so that new events added during processing are not executed.
+	auto active_handlers = event_handlers_->get_active();
 
 	{
 		// Ensure that event handlers won't be cleaned up while we're iterating them.
 		event_handler_list_lock lock;
 
-		for (unsigned i = 0; i < saved_end; ++i) {
+		for (unsigned i = 0; i < active_handlers.size(); ++i) {
 			handler_ptr handler = nullptr;
 
 			try {

--- a/src/gui/dialogs/multiplayer/mp_change_control.cpp
+++ b/src/gui/dialogs/multiplayer/mp_change_control.cpp
@@ -152,7 +152,7 @@ void mp_change_control::highlight_side_nick()
 	for(const std::string& nick : nicks_) {
 		std::string label_str = "";
 
-		if(selected_side_ <= static_cast<unsigned int>(teams.size()) && teams.at(selected_side_).current_player() == nick) {
+		if(teams.has_index(selected_side_) && teams.at(selected_side_).current_player() == nick) {
 			label_str = formatter() << "<b>" << nick << "</b>";
 		} else {
 			label_str = nick;

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -405,7 +405,7 @@ void command_executor::surrender_game() {
 	if(gui2::show_message(_("Surrender"), _("Do you really want to surrender the game?"), gui2::dialogs::message::yes_no_buttons) != gui2::retval::CANCEL) {
 		playmp_controller* pmc = dynamic_cast<playmp_controller*>(resources::controller);
 		if(pmc && !pmc->is_linger_mode() && !pmc->is_observer()) {
-			pmc->surrender(display::get_singleton()->viewing_team());
+			pmc->surrender(display::get_singleton()->viewing_side());
 		}
 	}
 }

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -77,15 +77,15 @@ const game_state & play_controller::hotkey_handler::gamestate() const {
 bool play_controller::hotkey_handler::browse() const { return play_controller_.is_browsing(); }
 bool play_controller::hotkey_handler::linger() const { return play_controller_.is_linger_mode(); }
 
-const team & play_controller::hotkey_handler::viewing_team() const { return play_controller_.get_teams()[gui()->viewing_team()]; }
-bool play_controller::hotkey_handler::viewing_team_is_playing() const { return gui()->viewing_team() == gui()->playing_team(); }
+const team & play_controller::hotkey_handler::viewing_team() const { return play_controller_.get_teams()[gui()->viewing_side()]; }
+bool play_controller::hotkey_handler::viewing_team_is_playing() const { return gui()->viewing_side() == gui()->playing_side(); }
 
 void play_controller::hotkey_handler::objectives(){
 	menu_handler_.objectives();
 }
 
 void play_controller::hotkey_handler::show_statistics(){
-	menu_handler_.show_statistics(gui()->viewing_team()+1);
+	menu_handler_.show_statistics(gui()->viewing_side());
 }
 
 void play_controller::hotkey_handler::unit_list(){

--- a/src/hotkey/hotkey_handler_sp.cpp
+++ b/src/hotkey/hotkey_handler_sp.cpp
@@ -71,11 +71,11 @@ void playsingle_controller::hotkey_handler::recall(){
 }
 
 void playsingle_controller::hotkey_handler::toggle_shroud_updates(){
-	menu_handler_.toggle_shroud_updates(gui()->viewing_team()+1);
+	menu_handler_.toggle_shroud_updates(gui()->viewing_side());
 }
 
 void playsingle_controller::hotkey_handler::update_shroud_now(){
-	menu_handler_.update_shroud_now(gui()->viewing_team()+1);
+	menu_handler_.update_shroud_now(gui()->viewing_side());
 }
 
 void playsingle_controller::hotkey_handler::end_turn(){

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -151,7 +151,7 @@ void menu_handler::status_table()
 {
 	int selected_side;
 
-	if(gui2::dialogs::game_stats::execute(board(), gui_->viewing_team(), selected_side)) {
+	if(gui2::dialogs::game_stats::execute(board(), gui_->viewing_side(), selected_side)) {
 		gui_->scroll_to_leader(selected_side);
 	}
 }
@@ -231,8 +231,8 @@ bool menu_handler::has_friends() const
 		return !gui_->observers().empty();
 	}
 
-	for(std::size_t n = 0; n != pc_.get_teams().size(); ++n) {
-		if(n != gui_->viewing_team() && pc_.get_teams()[gui_->viewing_team()].team_name() == pc_.get_teams()[n].team_name()
+	for(std::size_t n = 1; n <= pc_.get_teams().size(); ++n) {
+		if(n != gui_->viewing_side() && pc_.get_teams()[gui_->viewing_side()].team_name() == pc_.get_teams()[n].team_name()
 				&& pc_.get_teams()[n].is_network()) {
 			return true;
 		}
@@ -480,7 +480,7 @@ void menu_handler::show_enemy_moves(bool ignore_units, int side_num)
 				&& !invisible) {
 			const unit_movement_resetter move_reset(u);
 			const pathfind::paths& path
-					= pathfind::paths(u, false, true, pc_.get_teams()[gui_->viewing_team()], 0, false, ignore_units);
+					= pathfind::paths(u, false, true, pc_.get_teams()[gui_->viewing_side()], 0, false, ignore_units);
 
 			gui_->highlight_another_reach(path, hex_under_mouse);
 		}
@@ -678,12 +678,12 @@ unit_map::iterator menu_handler::current_unit()
 	const mouse_handler& mousehandler = pc_.get_mouse_handler_base();
 	const bool see_all = gui_->show_everything() || (pc_.is_replay() && pc_.get_replay_controller()->see_all());
 
-	unit_map::iterator res = board().find_visible_unit(mousehandler.get_last_hex(), pc_.get_teams()[gui_->viewing_team()], see_all);
+	unit_map::iterator res = board().find_visible_unit(mousehandler.get_last_hex(), pc_.get_teams()[gui_->viewing_side()], see_all);
 	if(res != pc_.get_units().end()) {
 		return res;
 	}
 
-	return board().find_visible_unit(mousehandler.get_selected_hex(), pc_.get_teams()[gui_->viewing_team()], see_all);
+	return board().find_visible_unit(mousehandler.get_selected_hex(), pc_.get_teams()[gui_->viewing_side()], see_all);
 }
 
 // Helpers for create_unit()
@@ -829,7 +829,7 @@ void menu_handler::label_terrain(mouse_handler& mousehandler, bool team_only)
 		} else {
 			color = team::get_side_color(gui_->viewing_side());
 		}
-		const terrain_label* res = gui_->labels().set_label(loc, label, gui_->viewing_team(), team_name, color);
+		const terrain_label* res = gui_->labels().set_label(loc, label, gui_->viewing_side(), team_name, color);
 		if(res) {
 			resources::recorder->add_label(res);
 		}
@@ -1349,7 +1349,7 @@ void menu_handler::send_chat_message(const std::string& message, bool allies_onl
 		if(board().is_observer()) {
 			cfg["to_sides"] = game_config::observer_team_name;
 		} else {
-			cfg["to_sides"] = pc_.get_teams()[gui_->viewing_team()].allied_human_teams();
+			cfg["to_sides"] = pc_.get_teams()[gui_->viewing_side()].allied_human_teams();
 		}
 	}
 
@@ -1412,7 +1412,7 @@ void menu_handler::do_search(const std::string& new_search)
 				if(std::search(
 						   name.begin(), name.end(), last_search_.begin(), last_search_.end(), utils::chars_equal_insensitive)
 						!= name.end()) {
-					if(!pc_.get_teams()[gui_->viewing_team()].is_enemy(ui->side())
+					if(!pc_.get_teams()[gui_->viewing_side()].is_enemy(ui->side())
 							|| !ui->invisible(ui->get_location())) {
 						found = true;
 					}

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -1474,7 +1474,7 @@ bool mouse_handler::unit_in_cycle(unit_map::const_iterator it)
 		return false;
 	}
 
-	if(current_team().is_enemy(static_cast<int>(gui().viewing_team() + 1)) && it->invisible(it->get_location())) {
+	if(current_team().is_enemy(static_cast<int>(gui().viewing_side())) && it->invisible(it->get_location())) {
 		return false;
 	}
 
@@ -1538,12 +1538,12 @@ void mouse_handler::set_current_paths(const pathfind::paths& new_paths)
 
 team& mouse_handler::viewing_team()
 {
-	return pc_.get_teams()[gui().viewing_team()];
+	return pc_.get_teams()[gui().viewing_side()];
 }
 
 const team& mouse_handler::viewing_team() const
 {
-	return pc_.get_teams()[gui().viewing_team()];
+	return pc_.get_teams()[gui().viewing_side()];
 }
 
 team& mouse_handler::current_team()

--- a/src/pathfind/pathfind.cpp
+++ b/src/pathfind/pathfind.cpp
@@ -681,7 +681,7 @@ marked_route mark_route(const plain_route &rt, bool update_move_cost)
 		assert(last_step || resources::gameboard->map().on_board(*(i+1)));
 		const int move_cost = last_step ? 0 : u.movement_cost(static_cast<const game_board*>(resources::gameboard)->map()[*(i+1)]);
 
-		const team& viewing_team = resources::gameboard->teams()[display::get_singleton()->viewing_team()];
+		const team& viewing_team = resources::gameboard->teams()[display::get_singleton()->viewing_side()];
 
 		if (last_step || zoc || move_cost > movement) {
 			// check if we stop an a village and so maybe capture it
@@ -730,7 +730,7 @@ marked_route mark_route(const plain_route &rt, bool update_move_cost)
 }
 
 shortest_path_calculator::shortest_path_calculator(const unit& u, const team& t,
-		const std::vector<team>& teams, const gamemap& map,
+		const team_list& teams, const gamemap& map,
 		bool ignore_unit, bool ignore_defense, bool see_all)
 	: unit_(u), viewing_team_(t), teams_(teams), map_(map),
 	  movement_left_(unit_.movement_left()),

--- a/src/pathfind/pathfind.hpp
+++ b/src/pathfind/pathfind.hpp
@@ -20,17 +20,20 @@
 
 #pragma once
 
+#include "map/location.hpp"
+#include "movetype.hpp"
+#include "utils/ordinal_list.hpp"
+
+#include <vector>
+#include <map>
+#include <set>
+
 class gamemap;
 class team;
 class unit;
 class unit_type;
 class game_board;
-#include "map/location.hpp"
-#include "movetype.hpp"
-
-#include <vector>
-#include <map>
-#include <set>
+using team_list = utils::ordinal_list<team>;
 
 namespace pathfind {
 
@@ -204,7 +207,7 @@ marked_route mark_route(const plain_route &rt, bool update_move_cost = false);
 struct shortest_path_calculator : cost_calculator
 {
 	shortest_path_calculator(const unit& u, const team& t,
-		const std::vector<team> &teams, const gamemap &map,
+		const team_list &teams, const gamemap &map,
 		bool ignore_unit = false, bool ignore_defense_ = false,
 		bool see_all = false);
 	virtual double cost(const map_location& loc, const double so_far) const;
@@ -212,7 +215,7 @@ struct shortest_path_calculator : cost_calculator
 private:
 	const unit& unit_;
 	const team& viewing_team_;
-	const std::vector<team>& teams_;
+	const team_list& teams_;
 	const gamemap& map_;
 	const int movement_left_;
 	const int total_movement_;

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -78,14 +78,14 @@ public:
 	}
 	const unit_map & units() const override { return *um_; }
 	const gamemap & map() const override { return *gm_; }
-	const std::vector<team> & teams() const override { return *tm_; }
+	const team_list& teams() const override { return *tm_; }
 	const std::vector<std::string> & hidden_label_categories() const override { return *lbls_; }
 	std::vector<std::string>& hidden_label_categories() override { throw "Writable hidden label categories not supported in this context"; }
 
 private:
 	const unit_map * um_;
 	const gamemap * gm_;
-	const std::vector<team> * tm_;
+	const team_list* tm_;
 	const std::vector<std::string> * lbls_;
 };
 

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -705,7 +705,7 @@ void play_controller::tab()
 	case gui::TEXTBOX_SEARCH: {
 		for(const unit& u : get_units()) {
 			const map_location& loc = u.get_location();
-			if(!gui_->fogged(loc) && !(get_teams()[gui_->viewing_team()].is_enemy(u.side()) && u.invisible(loc)))
+			if(!gui_->fogged(loc) && !(get_teams()[gui_->viewing_side()].is_enemy(u.side()) && u.invisible(loc)))
 				dictionary.insert(u.name());
 		}
 		// TODO List map labels
@@ -866,7 +866,7 @@ void play_controller::process_keyup_event(const SDL_Event& event)
 				unit_movement_resetter move_reset(*u, u->side() != current_side());
 
 				mouse_handler_.set_current_paths(pathfind::paths(
-					*u, false, true, get_teams()[gui_->viewing_team()], mouse_handler_.get_path_turns()));
+					*u, false, true, get_teams()[gui_->viewing_side()], mouse_handler_.get_path_turns()));
 
 				gui_->highlight_reach(mouse_handler_.current_paths());
 			} else {
@@ -1259,8 +1259,8 @@ void play_controller::check_next_scenario_is_known() {
 
 bool play_controller::can_use_synced_wml_menu() const
 {
-	const team& viewing_team = get_teams()[gui_->viewing_team()];
-	return gui_->viewing_team() == gui_->playing_team() && !events::commands_disabled && viewing_team.is_local_human()
+	const team& viewing_team = get_teams()[gui_->viewing_side()];
+	return gui_->viewing_side() == gui_->playing_side() && !events::commands_disabled && viewing_team.is_local_human()
 		&& !is_browsing();
 }
 
@@ -1352,7 +1352,7 @@ play_controller::scoped_savegame_snapshot::~scoped_savegame_snapshot()
 
 void play_controller::show_objectives() const
 {
-	const team& t = get_teams()[gui_->viewing_team()];
+	const team& t = get_teams()[gui_->viewing_side()];
 	static const std::string no_objectives(_("No objectives available"));
 	std::string objectives = utils::interpolate_variables_into_string(t.objectives(), *gamestate_->get_game_data());
 	gui2::show_transient_message(get_scenario_name(), (objectives.empty() ? no_objectives : objectives), "", true);

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -151,12 +151,12 @@ public:
 		return *gamestate().end_level_data_;
 	}
 
-	std::vector<team>& get_teams()
+	team_list& get_teams()
 	{
 		return gamestate().board_.teams();
 	}
 
-	const std::vector<team>& get_teams() const
+	const team_list& get_teams() const
 	{
 		return gamestate().board_.teams();
 	}

--- a/src/playmp_controller.cpp
+++ b/src/playmp_controller.cpp
@@ -226,7 +226,7 @@ void playmp_controller::linger()
 	if(get_end_level_data().transient.reveal_map) {
 		// Change the view of all players and observers
 		// to see the whole map regardless of shroud and fog.
-		update_gui_to_player(gui_->viewing_team(), true);
+		update_gui_to_player(gui_->viewing_side(), true);
 	}
 
 	bool quit;

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -735,7 +735,7 @@ void playsingle_controller::require_end_turn()
 void playsingle_controller::check_objectives()
 {
 	if(!get_teams().empty()) {
-		const team& t = get_teams()[gui_->viewing_team()];
+		const team& t = get_teams()[gui_->viewing_side()];
 
 		if(!is_regular_game_end() && !is_browsing() && t.objectives_changed()) {
 			show_objectives();

--- a/src/playturn.cpp
+++ b/src/playturn.cpp
@@ -196,7 +196,7 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 
 		// TODO: can we replace this with just a call to play_controller::update_viewing_player() ?
 		auto disp_set_team = [](int side_index) {
-			const bool side_changed = static_cast<int>(display::get_singleton()->viewing_team()) != side_index;
+			const bool side_changed = static_cast<int>(display::get_singleton()->viewing_side()) != side_index;
 			display::get_singleton()->set_team(side_index);
 
 			if(side_changed) {
@@ -204,10 +204,10 @@ turn_info::PROCESS_DATA_RESULT turn_info::process_network_data(const config& cfg
 			}
 		};
 
-		if (resources::gameboard->is_observer() || (resources::gameboard->teams())[display::get_singleton()->playing_team()].is_local_human()) {
-			disp_set_team(display::get_singleton()->playing_team());
+		if (resources::gameboard->is_observer() || (resources::gameboard->teams())[display::get_singleton()->playing_side()].is_local_human()) {
+			disp_set_team(display::get_singleton()->playing_side());
 		} else if (tm.is_local_human()) {
-			disp_set_team(side - 1);
+			disp_set_team(side);
 		}
 
 		resources::whiteboard->on_change_controller(side,tm);

--- a/src/preferences/game.cpp
+++ b/src/preferences/game.cpp
@@ -962,7 +962,7 @@ bool confirm_no_moves()
 	return confirmation == "no_moves" || confirmation.empty();
 }
 
-void encounter_recruitable_units(const std::vector<team>& teams)
+void encounter_recruitable_units(const team_list& teams)
 {
 	for(const team& help_team : teams) {
 		help_team.log_recruitable();
@@ -977,7 +977,7 @@ void encounter_start_units(const unit_map& units)
 	}
 }
 
-static void encounter_recallable_units(const std::vector<team>& teams)
+void encounter_recallable_units(const team_list& teams)
 {
 	for(const team& t : teams) {
 		for(const unit_const_ptr u : t.recall_list()) {

--- a/src/preferences/game.hpp
+++ b/src/preferences/game.hpp
@@ -18,6 +18,7 @@
 #include "game_config.hpp"
 #include "preferences/general.hpp"
 #include "serialization/compression.hpp"
+#include "utils/ordinal_list.hpp"
 
 #include <set>
 #include <vector>
@@ -26,6 +27,7 @@ class game_board;
 class gamemap;
 class team;
 class unit_map;
+using team_list = utils::ordinal_list<team>;
 
 namespace preferences
 {
@@ -247,7 +249,7 @@ bool confirm_no_moves();
 
 // Add all recruitable units as encountered so that information
 // about them are displayed to the user in the help system.
-void encounter_recruitable_units(const std::vector<team>& teams);
+void encounter_recruitable_units(const team_list& teams);
 
 // Add all units that exist at the start to the encountered units so
 // that information about them are displayed to the user in the help
@@ -255,7 +257,7 @@ void encounter_recruitable_units(const std::vector<team>& teams);
 void encounter_start_units(const unit_map& units);
 
 // Add all units that are recallable as encountered units.
-void encounter_recallable_units(std::vector<team>& teams);
+void encounter_recallable_units(const team_list& teams);
 
 // Add all terrains on the map as encountered terrains.
 void encounter_map_terrain(const gamemap& map);

--- a/src/quit_confirmation.cpp
+++ b/src/quit_confirmation.cpp
@@ -75,7 +75,7 @@ bool quit_confirmation::default_prompt()
 		int retval = sq.get_retval();
 		if(retval == 1)
 		{
-			pmc->surrender(display::get_singleton()->viewing_team());
+			pmc->surrender(display::get_singleton()->viewing_side());
 			return true;
 		}
 		else if(retval == 2)

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -99,7 +99,7 @@ static std::string flush(std::ostringstream &s)
 
 static const time_of_day get_visible_time_of_day_at(const reports::context& rc, const map_location & hex)
 {
-	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+	const team &viewing_team = rc.teams()[rc.screen().viewing_side()];
 	if (viewing_team.shrouded(hex)) {
 		// Don't show time on shrouded tiles.
 		return rc.tod().get_time_of_day();
@@ -132,21 +132,21 @@ static char const *naps = "</span>";
 static const unit *get_visible_unit(const reports::context& rc)
 {
 	return rc.dc().get_visible_unit(rc.screen().displayed_unit_hex(),
-		rc.teams()[rc.screen().viewing_team()],
+		rc.teams()[rc.screen().viewing_side()],
 		rc.screen().show_everything());
 }
 
 static const unit *get_selected_unit(const reports::context& rc)
 {
 	return rc.dc().get_visible_unit(rc.screen().selected_hex(),
-		rc.teams()[rc.screen().viewing_team()],
+		rc.teams()[rc.screen().viewing_side()],
 		rc.screen().show_everything());
 }
 
 static unit_const_ptr get_selected_unit_ptr(const reports::context& rc)
 {
 	return rc.dc().get_visible_unit_shared_ptr(rc.screen().selected_hex(),
-		rc.teams()[rc.screen().viewing_team()],
+		rc.teams()[rc.screen().viewing_side()],
 		rc.screen().show_everything());
 }
 
@@ -452,7 +452,7 @@ static config unit_abilities(const unit* u, const map_location& loc)
 REPORT_GENERATOR(unit_abilities, rc)
 {
 	const unit *u = get_visible_unit(rc);
-	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+	const team &viewing_team = rc.teams()[rc.screen().viewing_side()];
 	const map_location& mouseover_hex = rc.screen().mouseover_hex();
 	const map_location& displayed_unit_hex = rc.screen().displayed_unit_hex();
 	const map_location& hex = (mouseover_hex.valid() && !viewing_team.shrouded(mouseover_hex)) ? mouseover_hex : displayed_unit_hex;
@@ -465,7 +465,7 @@ REPORT_GENERATOR(selected_unit_abilities, rc)
 
 	const map_location& mouseover_hex = rc.screen().mouseover_hex();
 	const unit *visible_unit = get_visible_unit(rc);
-	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+	const team &viewing_team = rc.teams()[rc.screen().viewing_side()];
 
 	if (visible_unit && u && visible_unit->id() != u->id() && mouseover_hex.valid() && !viewing_team.shrouded(mouseover_hex))
 		return unit_abilities(u, mouseover_hex);
@@ -619,7 +619,7 @@ static config unit_defense(const reports::context& rc, const unit* u, const map_
 REPORT_GENERATOR(unit_defense,rc)
 {
 	const unit *u = get_visible_unit(rc);
-	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+	const team &viewing_team = rc.teams()[rc.screen().viewing_side()];
 	const map_location& mouseover_hex = rc.screen().mouseover_hex();
 	const map_location& displayed_unit_hex = rc.screen().displayed_unit_hex();
 	const map_location& hex = (mouseover_hex.valid() && !viewing_team.shrouded(mouseover_hex)) ? mouseover_hex : displayed_unit_hex;
@@ -906,7 +906,7 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		std::map<int, std::set<std::string>, std::greater<int>> resistances;
 		std::set<std::string> seen_types;
 		const team &unit_team = rc.dc().get_team(u.side());
-		const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+		const team &viewing_team = rc.teams()[rc.screen().viewing_side()];
 		for (const unit &enemy : rc.units())
 		{
 			if (enemy.incapacitated()) //we can't attack statues so don't display them in this tooltip
@@ -1692,7 +1692,7 @@ REPORT_GENERATOR(position, rc)
 	str << mouseover_hex;
 
 	const unit *u = get_visible_unit(rc);
-	const team &viewing_team = rc.teams()[rc.screen().viewing_team()];
+	const team &viewing_team = rc.teams()[rc.screen().viewing_side()];
 	if (!u ||
 	    (displayed_unit_hex != mouseover_hex &&
 	     displayed_unit_hex != rc.screen().selected_hex()) ||
@@ -1713,7 +1713,7 @@ REPORT_GENERATOR(position, rc)
 
 REPORT_GENERATOR(side_playing, rc)
 {
-	const team &active_team = rc.teams()[rc.screen().playing_team()];
+	const team &active_team = rc.teams()[rc.screen().playing_side()];
 	std::string flag_icon = active_team.flag_icon();
 	std::string old_rgb = game_config::flag_rgb;
 	std::string new_rgb = team::get_side_color_id(rc.screen().playing_side());

--- a/src/reports.hpp
+++ b/src/reports.hpp
@@ -48,7 +48,7 @@ public:
 	public:
 		context(const display_context & dc, const display & disp, const tod_manager & tod, std::shared_ptr<wb::manager> wb, utils::optional_reference<events::mouse_handler> mhb) : dc_(dc), disp_(disp), tod_(tod), wb_(wb), mhb_(mhb) {}
 
-		const std::vector<team> & teams() const { return dc_.teams(); }
+		const team_list& teams() const { return dc_.teams(); }
 		const unit_map & units() const { return dc_.units(); }
 		const gamemap & map() const { return dc_.map(); }
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -470,7 +470,7 @@ int game_lua_kernel::intf_get_displayed_unit(lua_State *L)
 
 	unit_map::const_iterator ui = board().find_visible_unit(
 		game_display_->displayed_unit_hex(),
-		teams()[game_display_->viewing_team()],
+		teams()[game_display_->viewing_side()],
 		game_display_->show_everything());
 	if (!ui.valid()) return 0;
 
@@ -4914,7 +4914,7 @@ unit_map & game_lua_kernel::units() {
 	return game_state_.board_.units();
 }
 
-std::vector<team> & game_lua_kernel::teams() {
+team_list& game_lua_kernel::teams() {
 	return game_state_.board_.teams();
 }
 

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -18,6 +18,7 @@
 #include "scripting/lua_kernel_base.hpp" // for lua_kernel_base
 
 #include "game_events/action_wml.hpp"   // for wml_action, etc
+#include "utils/ordinal_list.hpp"
 
 #include <stack>
 #include <string>                       // for string
@@ -41,6 +42,7 @@ class game_data;
 class tod_manager;
 class play_controller;
 class reports;
+using team_list = utils::ordinal_list<team>;
 
 struct map_location;
 typedef int (*lua_CFunction) (lua_State *L);
@@ -197,7 +199,7 @@ class game_lua_kernel : public lua_kernel_base
 
 public:
 	game_board & board();
-	std::vector<team> & teams();
+	team_list& teams();
 	const gamemap & map() const;
 	game_display * get_display() const { return game_display_; }
 	/**

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -20,6 +20,7 @@
 #include "server/wesnothd/player_connection.hpp"
 #include "server/common/simple_wml.hpp"
 #include "side_controller.hpp"
+#include "utils/ordinal_list.hpp"
 
 #include <map>
 #include <optional>
@@ -30,7 +31,7 @@
 namespace wesnothd
 {
 typedef std::vector<player_iterator> user_vector;
-typedef std::vector<std::optional<player_iterator>> side_vector;
+typedef utils::ordinal_list<std::optional<player_iterator>> side_vector;
 class server;
 
 class game

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -675,7 +675,7 @@ bool team::fogged(const map_location& loc) const
 	return fog_.shared_value(ally_fog(resources::gameboard->teams()), loc.wml_x(), loc.wml_y());
 }
 
-const std::vector<const shroud_map*>& team::ally_shroud(const std::vector<team>& teams) const
+const std::vector<const shroud_map*>& team::ally_shroud(const team_list& teams) const
 {
 	if(ally_shroud_.empty()) {
 		for(std::size_t i = 0; i < teams.size(); ++i) {
@@ -688,7 +688,7 @@ const std::vector<const shroud_map*>& team::ally_shroud(const std::vector<team>&
 	return ally_shroud_;
 }
 
-const std::vector<const shroud_map*>& team::ally_fog(const std::vector<team>& teams) const
+const std::vector<const shroud_map*>& team::ally_fog(const team_list& teams) const
 {
 	if(ally_fog_.empty()) {
 		for(std::size_t i = 0; i < teams.size(); ++i) {

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -26,6 +26,7 @@
 #include "side_proxy_controller.hpp"
 #include "team_shared_vision.hpp"
 #include "units/ptr.hpp"
+#include "utils/ordinal_list.hpp"
 
 #include <set>
 
@@ -35,7 +36,7 @@
 class game_data;
 class gamemap;
 struct color_t;
-
+using team_list = utils::ordinal_list<class team>;
 
 namespace wb {
 	class side_actions;
@@ -401,8 +402,8 @@ public:
 
 private:
 
-	const std::vector<const shroud_map*>& ally_shroud(const std::vector<team>& teams) const;
-	const std::vector<const shroud_map*>& ally_fog(const std::vector<team>& teams) const;
+	const std::vector<const shroud_map*>& ally_shroud(const team_list& teams) const;
+	const std::vector<const shroud_map*>& ally_fog(const team_list& teams) const;
 
 	int gold_;
 	std::set<map_location> villages_;

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -142,10 +142,10 @@ unit_drawer::unit_drawer(display& thedisp)
 	, map(dc.map())
 	, teams(dc.teams())
 	, halo_man(thedisp.get_halo_manager())
-	, viewing_team(disp.viewing_team())
-	, playing_team(disp.playing_team())
-	, viewing_team_ref(teams[viewing_team])
-	, playing_team_ref(teams[playing_team])
+	, viewing_team(disp.viewing_side())
+	, playing_team(disp.playing_side())
+	, viewing_team_ref(teams.at(viewing_team))
+	, playing_team_ref(teams.at(playing_team))
 	, is_blindfolded(disp.is_blindfolded())
 	, show_everything(disp.show_everything())
 	, sel_hex(disp.selected_hex())
@@ -352,15 +352,15 @@ void unit_drawer::redraw_unit(const unit& u) const
 		if(viewing_team_ref.is_enemy(side)) {
 			if(!u.incapacitated())
 				orb_img = get_orb_image(orb_status::enemy);
-		} else if(static_cast<std::size_t>(side) != playing_team + 1) {
+		} else if(static_cast<std::size_t>(side) != playing_team) {
 			// We're looking at either the player's own unit or an ally's unit, but either way it
 			// doesn't belong to the playing_team and isn't expected to move until after its next
 			// turn refresh.
 			auto os = orb_status::moved;
-			if(static_cast<std::size_t>(side) != viewing_team + 1)
+			if(static_cast<std::size_t>(side) != viewing_team)
 				os = orb_status::allied;
 			orb_img = get_orb_image(os);
-		} else if(static_cast<std::size_t>(side) != viewing_team + 1) {
+		} else if(static_cast<std::size_t>(side) != viewing_team) {
 			// We're looking at an ally's unit, during that ally's turn.
 			auto os = dc.unit_orb_status(u);
 			orb_img = get_playing_ally_orb_image(os);

--- a/src/units/drawer.hpp
+++ b/src/units/drawer.hpp
@@ -27,6 +27,7 @@
 #include "map/location.hpp"
 #include "sdl/rect.hpp"
 #include "utils/math.hpp"
+#include "utils/ordinal_list.hpp"
 
 #include <map>
 #include <vector>
@@ -36,6 +37,7 @@ class display_context;
 class gamemap;
 namespace halo { class manager; }
 class team;
+using team_list = utils::ordinal_list<team>;
 class unit;
 
 struct color_t;
@@ -52,7 +54,7 @@ private:
 	display & disp;
 	const display_context & dc;
 	const gamemap & map;
-	const std::vector<team> & teams;
+	const team_list& teams;
 	halo::manager & halo_man;
 	std::size_t viewing_team;
 	std::size_t playing_team;

--- a/src/utils/ordinal_list.hpp
+++ b/src/utils/ordinal_list.hpp
@@ -1,0 +1,63 @@
+/*
+	Copyright (C) 2003 - 2024
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include <deque>
+
+namespace utils {
+
+/**
+ * A list that's indexed from 1..size() instead of 0..(size()-1).
+ * Other than that detail, it's almost identical to the underlying container type.
+ * Only random-access underlying containers are supported.
+ */
+template<typename T, typename Container = std::deque<T>>
+class ordinal_list {
+	Container elems_;
+public:
+	using iterator = typename Container::iterator;
+	using const_iterator = typename Container::const_iterator;
+	using value_type = typename Container::value_type;
+	using reference = typename Container::reference;
+	using const_reference = typename Container::const_reference;
+	ordinal_list() {}
+	ordinal_list(size_t sz, value_type fill = value_type()) {}
+	iterator begin() { return elems_.begin(); }
+	const_iterator begin() const { return elems_.begin(); }
+	const_iterator cbegin() const { return elems_.cbegin(); }
+	iterator end() { return elems_.end(); }
+	const_iterator end() const { return elems_.end(); }
+	const_iterator cend() const { return elems_.cend(); }
+	reference at(size_t i) { return elems_.at(i - 1); }
+	const_reference at(size_t i) const { return elems_.at(i - 1); }
+	reference operator[](size_t i) { return elems_.at(i - 1); }
+	const_reference operator[](size_t i) const { return elems_.at(i - 1); }
+	size_t size() const { return elems_.size(); }
+	bool has_index(size_t i) const;
+	void push_back(const_reference& item);
+	void pop_back();
+	reference front();
+	const_reference front() const;
+	reference back();
+	const_reference back() const;
+	void clear() {}
+	void resize(size_t sz) {}
+	bool empty() const;
+	
+	template<typename... Args>
+	void emplace_back(Args&&... args) {}
+};
+
+}

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -567,9 +567,9 @@ void scoped_recall_unit::activate()
 {
 	assert(resources::gameboard);
 
-	const std::vector<team>& teams = resources::gameboard->teams();
+	const auto& teams = resources::gameboard->teams();
 
-	std::vector<team>::const_iterator team_it = std::find_if(teams.begin(), teams.end(), [&](const team& t) { return t.save_id_or_number() == player_; });
+	auto team_it = std::find_if(teams.begin(), teams.end(), [&](const team& t) { return t.save_id_or_number() == player_; });
 
 	if(team_it != teams.end()) {
 		if(team_it->recall_list().size() > recall_index_) {

--- a/src/whiteboard/utility.cpp
+++ b/src/whiteboard/utility.cpp
@@ -40,7 +40,7 @@ namespace wb {
 
 std::size_t viewer_team()
 {
-	return display::get_singleton()->viewing_team();
+	return display::get_singleton()->viewing_side();
 }
 
 int viewer_side()
@@ -51,7 +51,7 @@ int viewer_side()
 side_actions_ptr viewer_actions()
 {
 	side_actions_ptr side_actions =
-			resources::gameboard->teams()[display::get_singleton()->viewing_team()].get_side_actions();
+			resources::gameboard->teams()[display::get_singleton()->viewing_side()].get_side_actions();
 	return side_actions;
 }
 
@@ -115,7 +115,7 @@ unit* future_visible_unit(map_location hex, int viewer_side)
 		return nullptr;
 	}
 	//use global method get_visible_unit
-	return resources::gameboard->get_visible_unit(hex, resources::gameboard->get_team(viewer_side), false);
+	return resources::gameboard->get_visible_unit(hex, resources::gameboard->teams().at(viewer_side), false);
 }
 
 unit* future_visible_unit(int on_side, map_location hex, int viewer_side)
@@ -132,7 +132,7 @@ int path_cost(const std::vector<map_location>& path, const unit& u)
 	if(path.size() < 2)
 		return 0;
 
-	const team& u_team = resources::gameboard->get_team(u.side());
+	const team& u_team = resources::gameboard->teams().at(u.side());
 	const map_location& dest = path.back();
 	if ( (resources::gameboard->map().is_village(dest) && !u_team.owns_village(dest))
 	     || pathfind::enemy_zoc(u_team, dest, u_team) )
@@ -226,7 +226,7 @@ action_ptr find_action_at(map_location hex, team_filter team_filter)
 
 std::deque<action_ptr> find_actions_of(const unit& target)
 {
-	return resources::gameboard->get_team(target.side()).get_side_actions()->actions_of(target);
+	return resources::gameboard->teams().at(target.side()).get_side_actions()->actions_of(target);
 }
 
 } //end namespace wb


### PR DESCRIPTION
The intent behind this was to fix #6230 by changing the underlying container type from `vector` to `deque`, but that turned out to be a pretty intrusive change due to the `vector` type being baked into the interface and spiralling out to several other classes as well.

So I decided to normalize the side indexing system at the same time so that the sides list is always indexed from 1 instead of 0. 

With this refactor it should also be relatively easy to switch out `deque` for something else later on if we wanted to, such as `boost::stable_vector`.

It's not done and doesn't even build yet – there are link errors because I haven't finished implementing `ordinal_list`, and I reduced my initial workload by deprecating some functions which I still need to go through and replace. However, I thought it would be better to have other eyes on it sooner rather than later. I still need to comb through the source for all references to sides, looking for places that add or subtract 1 from a side index, or loops that iterate from `0` to `size() - 1` instead of `1` to `size()`, or places that use the side number to index other lists. If anyone happens to spot any such locations, please point them out to me. Code style comments and the like are welcome too.

Ignore the event handler commit for now. I'll rebase it away later.