### PR TITLE
Fix deprecation warning when setting [endlevel]end_credits=

### DIFF
--- a/data/lua/wml/endlevel.lua
+++ b/data/lua/wml/endlevel.lua
@@ -24,7 +24,7 @@ function wesnoth.wml_actions.endlevel(cfg)
 
 	local end_credits = cfg.end_credits
 	if end_credits ~= nil then
-		wesnoth.set_end_campaign_credits(end_credits)
+		wesnoth.scenario.show_credits = end_credits
 	end
 
 	local side_results = {}

--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -3388,6 +3388,7 @@ For game purposes, the races group into factions; for example, orcs often cooper
         [/filter]
         {VARIABLE endlevel_test.result "victory"}
         {VARIABLE endlevel_test.bonus "yes"}
+        {VARIABLE endlevel_test.end_credits "no"}
         [insert_tag]
             name=endlevel
             variable=endlevel_test

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -135,8 +135,6 @@ class game_lua_kernel : public lua_kernel_base
 	int intf_extract_unit(lua_State *L);
 	int intf_find_vacant_tile(lua_State *L);
 	int intf_float_label(lua_State *L);
-	int intf_set_end_campaign_credits(lua_State *L);
-	int intf_set_end_campaign_text(lua_State *L);
 	int intf_clear_menu_item(lua_State *L);
 	int intf_create_side(lua_State *L);
 	int intf_set_menu_item(lua_State *L);


### PR DESCRIPTION
Change the Lua implementation to directly call the non-deprecated function, this is related to 9daa10a9f2.

Clean up the C++ header files by removing the declarations of functions that were removed in 3c8de46771.

Use [endlevel]end_credits=no in the test scenario (trigger it by moving to hex 9,3). If you debug with :next_level without triggering the moveto, "The End" will show; trigger the moveto first, and it won't show the credits.