### PR TITLE
Restore 'screen shake' animations

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/macros.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/macros.cfg
@@ -78,12 +78,21 @@
     [scroll]
         x=20
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=-20
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=20
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=-20
     [/scroll]

--- a/data/core/macros/interface-utils.cfg
+++ b/data/core/macros/interface-utils.cfg
@@ -152,18 +152,30 @@
         x=5
         y=0
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=-10
         y=0
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=5
         y=5
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=0
         y=-10
     [/scroll]
+    [delay]
+        time=25
+    [/delay]
     [scroll]
         x=0
         y=5
@@ -183,10 +195,22 @@
         name=lightning.ogg
     [/sound]
     {SCROLL 2 1}
+    [delay]
+        time=25
+    [/delay]
     {SCROLL -1 -3}
+    [delay]
+        time=25
+    [/delay]
     {SCROLL -3 1}
     {ACTION_WML}
+    [delay]
+        time=25
+    [/delay]
     {SCROLL 1 3}
+    [delay]
+        time=25
+    [/delay]
     {SCROLL 1 -2}
 #enddef
 


### PR DESCRIPTION
Resolves #8276.

With the new draw manager introduced in 1.17.6 it appears the `[scroll]` animations are playing too fast to be noticeable, so introduce a `[delay]` similar to other macros (eg `MEMOIRS_TREMOR`).

As mentioned in #8276, I have left the `[scroll]`s in UtBS S12 alone because they don't appear to do anything, even in 1.16.