### PR TITLE
[1.16] Revert "systemd: drop _ prefix from username"

### DIFF
--- a/changelog_entries/systemd_nobody.md
+++ b/changelog_entries/systemd_nobody.md
@@ -1,2 +1,2 @@
  ### Security Fixes
-   * Run wesnothd server as `wesnoth:wesnoth` instead of `nobody:users`, improving safety and fixing a warning message in systemd 246+
+   * Run wesnothd server as `_wesnoth:_wesnoth` instead of `nobody:users`, improving safety and fixing a warning message in systemd 246+

--- a/packaging/systemd/wesnothd.service.in
+++ b/packaging/systemd/wesnothd.service.in
@@ -23,7 +23,8 @@ ExecStopPost=/bin/rm -f @FIFO_DIR@/socket
 
 SyslogIdentifier=Wesnothd@BINARY_SUFFIX@
 WorkingDirectory=@FIFO_DIR@
-User=wesnoth
+User=_wesnoth
+Group=_wesnoth
 
 # Additional security-related features
 # (when using the -c option, do not use ProtectHome)

--- a/packaging/systemd/wesnothd.service.scons.in
+++ b/packaging/systemd/wesnothd.service.scons.in
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 ExecStart=%bindir/wesnothd
-User=wesnoth
+User=_wesnoth
+Group=_wesnoth
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/systemd/wesnothd.sysusers.conf.in
+++ b/packaging/systemd/wesnothd.sysusers.conf.in
@@ -1,1 +1,2 @@
-u wesnoth - "Wesnoth multiplayer server"
+u _wesnoth -
+g _wesnoth -

--- a/packaging/systemd/wesnothd.tmpfiles.conf.in
+++ b/packaging/systemd/wesnothd.tmpfiles.conf.in
@@ -1,1 +1,1 @@
-d @FIFO_DIR@ 0700 wesnoth wesnoth -
+d @FIFO_DIR@ 0700 _wesnoth _wesnoth -


### PR DESCRIPTION
Prefixing all system and group names with the underscore is recommended by the systemd developers.

This reverts commit 8b6ef6aeeb80273a5826e2a25fffe5a2ca26a529.

(cherry picked from commit 91bd96b319ffa4b33fcfb33dce03c529aa480509)

1.17.25 was released using `_wesnoth:_wesnoth`.  So should be the upcoming 1.16.12.

Some discussion in https://github.com/wesnoth/wesnoth/pull/8168#issuecomment-1898040835.

Ping @stevecotton