### PR TITLE
HttT S12 Snow falls at a constant pace

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
@@ -224,7 +224,7 @@
                 allow_less=yes
 
                 [filter_location]
-                    terrain=Gs,Gd,Co,Ko,Re,Rb,Gll^Fp,Gll^Fmw,Gll^Fdw,Gd^Vo,Gd^Vc,Hhd^Vo ,Hhd^Vc
+                    terrain=Gs,Gd,Co,Ko,Gll^Fp,Gll^Fmw,Gll^Fdw,Gd^Vo,Gd^Vc,Hhd^Vo
                 [/filter_location]
 
                 [command]
@@ -253,18 +253,6 @@
                             value=Ko
 
                             {VARIABLE terrain Koa}
-                        [/case]
-
-                        [case]
-                            value=Coa
-
-                            {VARIABLE terrain Aa}
-                        [/case]
-
-                        [case]
-                            value=Hhd
-
-                            {VARIABLE terrain Ha}
                         [/case]
 
                         [case]
@@ -301,12 +289,6 @@
                             value=Hhd^Vo
 
                             {VARIABLE terrain Ha^Voa }
-                        [/case]
-
-                        [case]
-                            value=Hhd^Vc
-
-                            {VARIABLE terrain Ha^Vca }
                         [/case]
 
                         # just a fallback in case something goes wrong

--- a/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/12_Northern_Winter.cfg
@@ -290,21 +290,16 @@
 
                             {VARIABLE terrain Ha^Voa }
                         [/case]
-
-                        # just a fallback in case something goes wrong
-                        [else]
-                            {VARIABLE terrain $loc.terrain}
-                        [/else]
                     [/switch]
 
                     [terrain]
                         x,y=$loc.x,$loc.y
                         terrain=$terrain
                     [/terrain]
+
+                    {CLEAR_VARIABLE terrain}
                 [/command]
             [/random_placement]
-
-            {CLEAR_VARIABLE terrain}
         [/event]
     [/event]
 


### PR DESCRIPTION

Currently, snowfall is not at a constant pace as intended.
707 hexes of 10 terrain types (Gs,Gd,Co,Ko,Gll^Fp,Gll^Fmw,Gll^Fdw,Gd^Vo,Gd^Vc,Hhd^Vo) are converted to snowy terrains. Therefore, on challenging difficulty with 28 turn limit (=27 snowfall turns), it should be (26 hexes converted*22 turns) + (27 hexes converted*5 turns)=707 hexes. However, according to my experiments, 21~30 hexes are randomly converted. Removing Re and Rb from filtered locations should solve this problem.

Line 227 (original):
Re, Rb are dirt, and these hexes are not converted to snowy terrain. However, by having them within [filter_location], the snowfall pace fluctuates. Also, Hhd^Vc doesn't exist on this map.

Line 258~269 (original):
Coa and Hhd are not filtered.

Line306~311 (original)
Hhd^Vc doesn't exist on this map.

These changes make snow fall at a constant pace. Also, unnecessary codes are deleted.