### PR TITLE
Fix Kaleh sword parry

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -169,7 +169,7 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         [effect]
             apply_to = attack
             name = sword
-            parry = 10
+            increase_parry = 10
         [/effect]
         [effect]
             apply_to = hitpoints


### PR DESCRIPTION
Nym's 2 parry adjustments function as expected. Kaleh's does not as it uses improper WML. It should use increase_parry instead of parry.