### PR TITLE
Remove warning 'Weapon special x has no name for', fixes #8298

### DIFF
--- a/data/tools/unit_tree/html_output.py
+++ b/data/tools/unit_tree/html_output.py
@@ -1238,9 +1238,6 @@ class HTMLOutput:
                         sname = T(special, "name")
                         if sname:
                             s.append(cleantext(sname, quote=False))
-                        else:
-                            error_message("Warning: Weapon special %s has no name for %s.\n" %
-                                          (special.name.decode("utf8"), uid))
                 accuracy = attack.get_text_val("accuracy", default="0")
                 parry = attack.get_text_val("parry", default="0")
                 if accuracy != "0":


### PR DESCRIPTION
fixes #8298