### PR TITLE
Encapsulate side numbers in team queries

### DIFF
--- a/add_source_file
+++ b/add_source_file
@@ -90,18 +90,18 @@ def add_to_xcode(filename, targets):
         "The Battle for Wesnoth.xcodeproj",
         "project.pbxproj",
     )
-    
+
     project = pbxproj.XcodeProject.load(projectfile)
-    
+
     translated_targets = [item for t in targets for item in xcode_target_translations[t]]
     translated_targets = list(set(translated_targets))
     print(" xcode targets:", translated_targets)
-    
+
     for tname in translated_targets:
         if not project.get_target_by_name(tname):
             raise Exception(
                 f"Could not find target '{tname}' in Xcode project file")
-    
+
     # groups are organized by directory structure under "src"
     src_groups = project.get_groups_by_name("src")
     if len(src_groups) != 1:
@@ -114,7 +114,7 @@ def add_to_xcode(filename, targets):
             groupname = parent_group.get_name()
             raise Exception(f"problem finding '{d}' group in '{groupname}'")
         parent_group = found_groups[0]
-    
+
     # if the group already has an entry with the same filename, loudly skip.
     # note: this doesn't allow adding to targets one at a time.
     # a new file should be added to all targets at once...
@@ -123,7 +123,7 @@ def add_to_xcode(filename, targets):
     if project.get_files_by_name(filename.name, parent=parent_group):
         print("  '"+filename.name+"' already found in Xcode project '"+",".join(translated_targets)+"', skipping")
         return
-    
+
     # force is True here because otherwise a duplicate filename in
     # a different place will block addition of the new file.
     # the rest is just to match existing project file structure.
@@ -133,7 +133,7 @@ def add_to_xcode(filename, targets):
         parent=parent_group,
         target_name=translated_targets,
     )
-    
+
     # that's done, save the file
     project.save()
     return
@@ -146,7 +146,7 @@ def add_to_source_list(filename, source_list):
     source_list_file = rootdir.joinpath("source_lists", source_list)
     sl_lines = open(source_list_file).readlines()
     file_line = filename.as_posix() + '\n'
-    
+
     # we only need source files in the source_lists, not header files
     if filename.suffix != ".cpp":
         return
@@ -155,7 +155,7 @@ def add_to_source_list(filename, source_list):
     if file_line in sl_lines:
         print(f"  '{filename}' already found in '{source_list}', skipping")
         return
-    
+
     sl_lines.append(file_line)
     sl_lines.sort()
     open(source_list_file, 'w').writelines(sl_lines)
@@ -177,18 +177,18 @@ def add_to_code_blocks_target(filename, target):
         f"{target}.cbp",
     )
     cbp_lines = open(cbp_file).readlines()
-    
+
     filename_for_cbp = pathlib.PurePath(
         "..", "..", "src", filename
     ).as_posix()
-    
+
     elem = f"\t\t<Unit filename=\"{filename_for_cbp}\" />\n"
-    
+
     # if the target already has an entry with the same filename, loudly skip
     if elem in cbp_lines:
         print(f"  '{filename}' already found in '{target}.cbp', skipping")
         return
-    
+
     # find an appropriate line to add before/after
     index = 0
     for line in cbp_lines:
@@ -200,7 +200,7 @@ def add_to_code_blocks_target(filename, target):
             break
         index += 1
     cbp_lines.insert(index, elem)
-    
+
     open(cbp_file, 'w').writelines(cbp_lines)
 
 def add_to_code_blocks(filename, targets):
@@ -208,10 +208,62 @@ def add_to_code_blocks(filename, targets):
     print(" code::blocks targets:", translated_targets)
     for t in translated_targets:
         add_to_code_blocks_target(filename, t)
-        # if there's also an .hpp file, add that too
-        hpp = filename.with_suffix(".hpp")
-        if rootdir.joinpath("src", hpp).exists():
-            add_to_code_blocks_target(hpp, t)
+
+def sanity_check_existing_cpp_hpp(filenames):
+    """
+    If we're adding a .cpp file, check whether a .hpp should be added too, etc.
+    Only the files named on the command line are added, this exits if the check fails.
+    """
+    any_check_failed = False
+    for filename in filenames:
+        if filenames.count(filename) > 1:
+            print(f"ERROR: File '{filename}' given multiple times")
+            any_check_failed = True
+
+        if not rootdir.joinpath("src", filename).exists():
+            print(f"WARN: File '{filename}' does not exist")
+            any_check_failed = True
+
+        spouse = None
+        if filename.suffix == ".cpp":
+            spouse = filename.with_suffix(".hpp")
+        elif filename.suffix == ".hpp":
+            spouse = filename.with_suffix(".cpp")
+
+        if rootdir.joinpath("src", spouse).exists() and not filenames.count(spouse):
+            print(f"WARN: Requested to add '{filename}', should '{spouse}' be added too?")
+            any_check_failed = True
+
+        if any_check_failed:
+            break
+
+    if any_check_failed:
+        print("ERROR: Not making changes, as checks failed and --no-checks option was not used.")
+        exit(1)
+
+def canonicalise_filenames(original_filenames):
+    """
+    The script supports giving the filenames with or without the "src/" prefix.
+
+    Strip the "src/" if present, functions that need it will add it again later.
+    """
+    filenames = []
+
+    # If src/src/ exists, the filenames become ambiguous. No need to support that.
+    if rootdir.joinpath("src", "src").exists():
+        print("Please don't add a file or directory called src/src.")
+        exit(1)
+
+    for filename in options.filename:
+        filename = pathlib.PurePath(filename)
+        parts = filename.parts
+        if parts[0] == "src":
+            filename = pathlib.PurePath(*parts[1:])
+        else:
+            filename = pathlib.PurePath(*parts)
+        filenames.append(filename)
+
+    return filenames
 
 #======#
 # main #
@@ -225,27 +277,24 @@ if __name__ == "__main__":
     ap.add_argument("--target", action="store", nargs=1,
         default=["wesnoth"],
         help="which build targets to add the file to")
+    ap.add_argument("--no-checks", action="store_true",
+        help="do not check whether the files exist, etc")
     # By default, recognise --help too
     options = ap.parse_args()
 
     # Bail out if someone uses the old syntax of "add_source_file src/foo.cpp campaignd"
-    if len(options.filename) == 2 and not options.filename[1].count('.'):
-        print("The usage has changed, targets now need to be given using --target name")
-        exit(1)
+    if not options.no_checks:
+        if len(options.filename) == 2 and not options.filename[1].count('.'):
+            print("The usage has changed, targets now need to be given using --target name")
+            exit(1)
 
-    for filename in options.filename:
-        filename = pathlib.PurePath(filename)
+    # Convert the names to pathlib.PurePath objects without leading "src/"
+    filenames = canonicalise_filenames(options.filename)
 
-        # this only works on files in "src/".
-        # if it started with "src/", remove it.
-        parts = filename.parts
-        if parts[0] == "src":
-            filename = pathlib.PurePath(*parts[1:])
+    if not options.no_checks:
+        sanity_check_existing_cpp_hpp(filenames)
 
-        # note: this does not currently check whether or not the file exists,
-        # and does not currently work with file paths relative to elsewhere.
-        # it could be made to do that.
-
+    for filename in filenames:
         print(f"adding '{filename}' to targets: {options.target}")
         add_to_xcode(filename, options.target)
         add_to_source_lists(filename, options.target)

--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -1273,6 +1273,8 @@
 		<Unit filename="../../src/utils/reference_counter.hpp" />
 		<Unit filename="../../src/utils/scope_list.hpp" />
 		<Unit filename="../../src/utils/smart_list.hpp" />
+		<Unit filename="../../src/utils/team_query.cpp" />
+		<Unit filename="../../src/utils/team_query.hpp" />
 		<Unit filename="../../src/utils/type_trait_aliases.hpp" />
 		<Unit filename="../../src/utils/wesnoth_epoch.hpp" />
 		<Unit filename="../../src/variable.cpp" />

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		36D74F7F8D7655ACCABE562D /* edit_pbl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6FA542D78393E8FF067775DA /* edit_pbl.cpp */; };
 		3C254DF5B7DF196F2041955F /* mp_report.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 58C649488B3014E6F7254B62 /* mp_report.cpp */; };
 		3E9A4297B4A2828C569C8927 /* statistics_record.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27764FB68F02032F1C0B6748 /* statistics_record.cpp */; };
+		41844EADBABADE61EA27F0E5 /* team_query.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 87D84A82878D3A9A071A5A29 /* team_query.hpp */; };
 		4291489DA38012477DA3BA7C /* general.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84234C54BB84519421FD4136 /* general.cpp */; };
 		44CA4F8598147FDAE871B7CB /* prompt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D4594633BF3F8A06D6AE752F /* prompt.hpp */; };
 		46081FEE2B2F0F6A006ACAD7 /* libpcre2-8.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 46081FED2B2F0F6A006ACAD7 /* libpcre2-8.0.dylib */; };
@@ -657,8 +658,10 @@
 		62D24F2F1519982500350848 /* editor_toolkit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D24F2B1519982500350848 /* editor_toolkit.cpp */; };
 		62D24F321519987400350848 /* context_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D24F311519987400350848 /* context_manager.cpp */; };
 		62D24F351519995200350848 /* palette_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 62D24F341519995200350848 /* palette_manager.cpp */; };
+		6AA74531844344072924B5D8 /* team_query.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 87D84A82878D3A9A071A5A29 /* team_query.hpp */; };
 		6D574EACA3483ABEE72819F0 /* statistics_record.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27764FB68F02032F1C0B6748 /* statistics_record.cpp */; };
 		7BFC4DF5BFF8CF75855BA662 /* prompt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67044415B63F5888193BD7A6 /* prompt.cpp */; };
+		7D2E45719C73829B64041535 /* team_query.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71BD477D8FDB59E29376A73E /* team_query.cpp */; };
 		7FDF4E8D9C94E7DA8F41F7BB /* tod_new_schedule.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D46466DBCD81B13621C7342 /* tod_new_schedule.hpp */; };
 		867141839BDB89BFE876E310 /* carryover_show_gold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 09A440B1A671C45BE2924FB4 /* carryover_show_gold.cpp */; };
 		87744447951D17AA38BE5F48 /* mp_report.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 58C649488B3014E6F7254B62 /* mp_report.cpp */; };
@@ -1114,6 +1117,7 @@
 		95EB8A59287B139800B09F95 /* top_level_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */; };
 		97714C7A9FF444E29DCEF0BA /* carryover_show_gold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 09A440B1A671C45BE2924FB4 /* carryover_show_gold.cpp */; };
 		9B4B41D29C90B05F03DE21B0 /* edit_pbl_translation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C679447D91FD3623CC852FF8 /* edit_pbl_translation.hpp */; };
+		9C88485785D13CA30E42E2BC /* team_query.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 71BD477D8FDB59E29376A73E /* team_query.cpp */; };
 		B508D193100146E300B12852 /* engine_fai.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B508D191100146E300B12852 /* engine_fai.cpp */; };
 		B513B2290ED36BFB0006E551 /* libcairo.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B513B2270ED36BFB0006E551 /* libcairo.2.dylib */; };
 		B52EE8841213585300CFBDAB /* tod_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B52EE8821213585300CFBDAB /* tod_manager.cpp */; };
@@ -2183,7 +2187,9 @@
 		62D24F341519995200350848 /* palette_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = palette_manager.cpp; sourceTree = "<group>"; };
 		67044415B63F5888193BD7A6 /* prompt.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = prompt.cpp; sourceTree = "<group>"; };
 		6FA542D78393E8FF067775DA /* edit_pbl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = edit_pbl.cpp; sourceTree = "<group>"; };
+		71BD477D8FDB59E29376A73E /* team_query.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = team_query.cpp; path = team_query.cpp; sourceTree = "<group>"; };
 		84234C54BB84519421FD4136 /* general.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = general.cpp; sourceTree = "<group>"; };
+		87D84A82878D3A9A071A5A29 /* team_query.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = team_query.hpp; path = team_query.hpp; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* The Battle for Wesnoth.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "The Battle for Wesnoth.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		903F959B1ED5489500F1BDD3 /* credentials.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = credentials.cpp; path = preferences/credentials.cpp; sourceTree = "<group>"; };
@@ -4449,6 +4455,8 @@
 				469CA216253C52120045A0B3 /* shared_reference.hpp */,
 				9197972A26199FB5001E8133 /* variant.hpp */,
 				84234C54BB84519421FD4136 /* general.cpp */,
+				71BD477D8FDB59E29376A73E /* team_query.cpp */,
+				87D84A82878D3A9A071A5A29 /* team_query.hpp */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -5102,6 +5110,7 @@
 				9B4B41D29C90B05F03DE21B0 /* edit_pbl_translation.hpp in Headers */,
 				44CA4F8598147FDAE871B7CB /* prompt.hpp in Headers */,
 				FC66414CB2E3F0E8B0B747B6 /* tod_new_schedule.hpp in Headers */,
+				41844EADBABADE61EA27F0E5 /* team_query.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5114,6 +5123,7 @@
 				02A44BEAA567595C902031CF /* edit_pbl_translation.hpp in Headers */,
 				172E48A5BD149999CE64EDF8 /* prompt.hpp in Headers */,
 				7FDF4E8D9C94E7DA8F41F7BB /* tod_new_schedule.hpp in Headers */,
+				6AA74531844344072924B5D8 /* team_query.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5866,6 +5876,7 @@
 				0554467DB5FE99D85ABCDCA0 /* edit_pbl_translation.cpp in Sources */,
 				8C704B6F99C824A4073EEBEE /* prompt.cpp in Sources */,
 				DF974010BB46B844E83F7DDA /* tod_new_schedule.cpp in Sources */,
+				7D2E45719C73829B64041535 /* team_query.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6544,6 +6555,7 @@
 				7BFC4DF5BFF8CF75855BA662 /* prompt.cpp in Sources */,
 				C93048A9AE576B6AD016DFA4 /* tod_new_schedule.cpp in Sources */,
 				62714C2FBE84B66CF14E3722 /* test_sdl.cpp in Sources */,
+				9C88485785D13CA30E42E2BC /* team_query.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -400,6 +400,7 @@ utils/irdya_datetime.cpp
 utils/markov_generator.cpp
 utils/name_generator_factory.cpp
 utils/parse_network_address.cpp
+utils/team_query.cpp
 variable.cpp
 variable_info.cpp
 wesnothd_connection.cpp

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1636,7 +1636,7 @@ int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, b
 bool backstab_check(const map_location& attacker_loc,
 		const map_location& defender_loc,
 		const unit_map& units,
-		const std::vector<team>& teams)
+		const utils::team_query& teams)
 {
 	const unit_map::const_iterator defender = units.find(defender_loc);
 	if(defender == units.end()) {
@@ -1667,13 +1667,9 @@ bool backstab_check(const map_location& attacker_loc,
 		return false;
 	}
 
-	// If sides aren't valid teams, then they are enemies.
-	if(std::size_t(defender->side() - 1) >= teams.size() || std::size_t(opp->side() - 1) >= teams.size()) {
-		return true;
-	}
-
-	// Defender and opposite are enemies.
-	if(teams[defender->side() - 1].is_enemy(opp->side())) {
+	// Check whether defender and opposite are enemies.
+	const auto query = utils::team_query{teams};
+	if(query.is_enemy(*defender, *opp)) {
 		return true;
 	}
 

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -26,6 +26,7 @@
 #include "attack_prediction.hpp"
 #include "units/ptr.hpp"
 #include "units/unit_alignments.hpp"
+#include "utils/team_query.hpp"
 
 #include <vector>
 
@@ -310,4 +311,4 @@ int generic_combat_modifier(int lawful_bonus, unit_alignments::type alignment, b
 bool backstab_check(const map_location& attacker_loc,
 		const map_location& defender_loc,
 		const unit_map& units,
-		const std::vector<team>& teams);
+		const utils::team_query& teams);

--- a/src/ai/default/aspect_attacks.cpp
+++ b/src/ai/default/aspect_attacks.cpp
@@ -145,9 +145,10 @@ void aspect_attacks_base::do_attack_analysis(const map_location& loc,
 		return;
 	}
 
+	// FIXME: these are local variables, they shouldn't have underscores in their names
 	const gamemap& map_ = resources::gameboard->map();
 	unit_map& units_ = resources::gameboard->units();
-	const std::vector<team>& teams_ = resources::gameboard->teams();
+	const auto teams_ = utils::team_query{resources::gameboard->teams()};
 
 	const std::size_t max_positions = 1000;
 	if(result.size() > max_positions && !cur_analysis.movements.empty()) {

--- a/src/utils/team_query.cpp
+++ b/src/utils/team_query.cpp
@@ -1,0 +1,34 @@
+/*
+	Copyright (C) 2021 - 2024
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#include "utils/team_query.hpp"
+
+#include "units/unit.hpp"
+
+using namespace utils;
+
+bool team_query::is_enemy(const unit& a, const unit& b) const
+{
+	// If sides aren't valid teams, then they are enemies.
+	if(std::size_t(a.side() - 1) >= teams_.size() || std::size_t(b.side() - 1) >= teams_.size()) {
+		return true;
+	}
+
+	// Defender and opposite are enemies.
+	if(teams_[a.side() - 1].is_enemy(b.side())) {
+		return true;
+	}
+
+	return false;
+}

--- a/src/utils/team_query.hpp
+++ b/src/utils/team_query.hpp
@@ -1,0 +1,55 @@
+/*
+	Copyright (C) 2021 - 2024
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "team.hpp"
+
+#include <vector>
+
+namespace utils
+{
+/**
+ * A wrapper for the sides or teams array, answering questions such as "are these units on
+ * the same side".
+ *
+ * WML numbers sides starting from 1, C++ likes indicies to start from zero, and so dealing
+ * directly with a vector of sides requires handling the off-by-one numbering. This wrapper
+ * encapsulates that logic.
+ */
+class team_query
+{
+public:
+	/**
+	 * The lifetime of this object needs to be shorter than the teams vector, however the
+	 * code it replaces will already be relying on the lifetime of the global teams vector.
+	 */
+	team_query(const std::vector<team>& teams)
+		: teams_(teams)
+	{
+	}
+
+	/**
+	 * Returns true if the two units belong to opposing sides, false if they're
+	 * on allied sides or the same side. If either unit has an invalid side
+	 * number, it's an enemy of any unit except those with the identical
+	 * invalid number.
+	 */
+	bool is_enemy(const unit& a, const unit& b) const;
+
+private:
+	const std::vector<team>& teams_;
+};
+
+} // namespace utils


### PR DESCRIPTION
Draft, PR opened to test a new version of the add_source_files script on the CI.

WML numbers sides starting from 1, C++ likes indicies to start from zero, and so dealing directly with a vector of sides requires handling the off-by-one numbering.This wrapper encapsulates that logic.

This is a draft, looking at whether it would remove knowledge of the off-by-one quirk from a sufficient number of places in the source tree to be useful. It's a suggestion for reducing the number of files involved in PR #8271.

A wrapper for the sides or teams array, answering questions such as "are these units on the same side".
