### PR TITLE
Revert "Check for correct openssl version."

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # forbid defaulting to gnu++NN instead of c++NN
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(OpenSSL 3.0 REQUIRED)
+find_package(OpenSSL 1.0 REQUIRED)
 
 if(APPLE)
 	find_library(APPKIT_LIBRARY AppKit REQUIRED)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ order to build Wesnoth:
  * Vorbisfile aka libvorbis
  * libbz2
  * libz
- * libssl                      >= 3.0
+ * libssl
  * libcrypto (from OpenSSL)
  * libcurl4 (OpenSSL version)
 


### PR DESCRIPTION
This reverts commits 7ce1bf9f7da and c6a2dc93175.

OpenSSL >= 3.0 was required (but only when building with CMake) so that `src/preferences/credentials.cpp` could use `EVP_EncryptInit_ex2()` (commit a880f01a315), but that change was reverted (commit 83ab05532a9), all within three hours.

Tested locally by building with OpenSSL version 1.1.1w, logging into the lobby with "Save password locally (encrypted)" checked, quitting, and logging in again without having to enter a password.

@Pentarctagon