### PR TITLE
1.18 - fix terrain graphics rule for elevation/ice/water transition

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -1260,13 +1260,14 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 # {NEW:TRANSITION            Aa,Ha,Ms,Ai,Rra          (W*,S*)             -505        frozen/ice-to-water    FLAG=submerged}
 # But there are ledges, so we need more rules
 # This might be made more concise, but the idea is to filter out ledges
+# The third/sixth rules have that extra filter to allow ice transitions where there are no ledges because everything is 'elevated'
 {NEW:TRANSITION            (!,*^Qh*,!,Aa,Ha,Ms,Ai,Rra)          (!,*^Qh*,!,W*,S*)             -485        frozen/ice             FLAG=non_submerged}
 {NEW:TRANSITION            Aa^Qhh*,Ha^Qhh*,Ms^Qhh*,Ai^Qhh*,Rra^Qhh*          (W*^Qhh*,S*^Qhh*)             -485        frozen/ice             FLAG=non_submerged}
-{NEW:TRANSITION            Aa^Qhu*,Ha^Qhu*,Ms^Qhu*,Ai^Qhu*,Rra^Qhu*          (W*^Qhu*,S*^Qhu*)             -485        frozen/ice             FLAG=non_submerged}
+{NEW:TRANSITION            (!,*^Qh*,!,Aa,Ha,Ms,Ai,Rra)          (W*^Qhu*,S*^Qhu*)             -485        frozen/ice             FLAG=non_submerged    FILTER_PRIMARY_FLAG=has_flag=elevated}
 # ---
 {NEW:TRANSITION            (!,*^Qh*,!,Aa,Ha,Ms,Ai,Rra)          (!,*^Qh*,!,W*,S*)             -505        frozen/ice-to-water             FLAG=submerged}
 {NEW:TRANSITION            Aa^Qhh*,Ha^Qhh*,Ms^Qhh*,Ai^Qhh*,Rra^Qhh*          (W*^Qhh*,S*^Qhh*)             -505        frozen/ice-to-water             FLAG=submerged}
-{NEW:TRANSITION            Aa^Qhu*,Ha^Qhu*,Ms^Qhu*,Ai^Qhu*,Rra^Qhu*          (W*^Qhu*,S*^Qhu*)             -505        frozen/ice-to-water             FLAG=submerged}
+{NEW:TRANSITION            (!,*^Qh*,!,Aa,Ha,Ms,Ai,Rra)          (W*^Qhu*,S*^Qhu*)             -505        frozen/ice-to-water             FLAG=submerged    FILTER_PRIMARY_FLAG=has_flag=elevated}
 
 # we just draw this again (invisible below the base layer) to set the transition flags
 {NEW:TRANSITION            Aa,Ha,Ms,Ai                        (W*,Ss)     -1001                     frozen/ice-to-water}

--- a/data/core/terrain-graphics/new-macros.cfg
+++ b/data/core/terrain-graphics/new-macros.cfg
@@ -1107,6 +1107,9 @@ transition#endarg
 #arg FILTER_FLAG
 #endarg
 
+#arg FILTER_PRIMARY_FLAG
+#endarg
+
 #arg IPF
 ~NOP()#endarg
 
@@ -1132,6 +1135,7 @@ transition#endarg
         [tile]
             pos=3
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
         [/tile]
         [tile]
             pos=2
@@ -1163,6 +1167,7 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-trim-@R3
         [/tile]
 
@@ -1191,6 +1196,7 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-trim-@R3
         [/tile]
 
@@ -1219,6 +1225,7 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-trim-@R3
         [/tile]
 
@@ -1244,31 +1251,37 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R3
         [/tile]
         [tile]
             pos=3
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R4
         [/tile]
         [tile]
             pos=4
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R5
         [/tile]
         [tile]
             pos=5
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R0
         [/tile]
         [tile]
             pos=6
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R1
         [/tile]
         [tile]
             pos=7
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R2
         [/tile]
 
@@ -1294,26 +1307,31 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R3
         [/tile]
         [tile]
             pos=3
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R4
         [/tile]
         [tile]
             pos=4
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R5
         [/tile]
         [tile]
             pos=5
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R0
         [/tile]
         [tile]
             pos=6
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R1
         [/tile]
 
@@ -1339,21 +1357,25 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R3
         [/tile]
         [tile]
             pos=3
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R4
         [/tile]
         [tile]
             pos=4
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R5
         [/tile]
         [tile]
             pos=5
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R0
         [/tile]
 
@@ -1379,16 +1401,19 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R3
         [/tile]
         [tile]
             pos=3
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R4
         [/tile]
         [tile]
             pos=4
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R5
         [/tile]
 
@@ -1414,11 +1439,13 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R3
         [/tile]
         [tile]
             pos=3
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R4
         [/tile]
 
@@ -1444,6 +1471,7 @@ transition#endarg
         [tile]
             pos=2
             type={TERRAINLIST}
+            {FILTER_PRIMARY_FLAG}
             set_no_flag={FLAG}-@R3
         [/tile]
 


### PR DESCRIPTION
Allows for more flag-based filtering, so that the ice transitions can be disabled in the little hole in the upper right, but still works for the same terrain inside the big gulch region.
![Screenshot_20240128_](https://github.com/wesnoth/wesnoth/assets/13510196/e0e45364-57fc-4ff0-9557-ad5461910f59)
