### PR TITLE
HttT S17 Map always has 6 castle hexes around Konrad

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -10,7 +10,7 @@
         create_map = << return wesnoth.require("cave_map_generator").generate_map(...) >>
 
         map_width=50
-        map_height=70
+        map_height=75
         village_density=20
         terrain_wall = "Xu"
         terrain_clear = "Uu"
@@ -471,76 +471,6 @@
         [/foreach]
 
         {CLEAR_VARIABLE adjacent_to_starting_loc}
-
-        # making sure that there are 6 castle hexes when Konrad is at (odd,68)
-        [store_locations]
-            [and]
-                [filter]
-                    id=Konrad
-                [/filter]
-
-                radius=0
-
-                x=1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47
-
-                [not]
-                    y=1-67
-                [/not]
-            [/and]
-
-            variable=starting_loc_odd
-        [/store_locations]
-
-        [foreach]
-            array=starting_loc_odd
-            [do]
-                [terrain]
-                    x,y=$this_item.x,"$($this_item.y - 2)"
-                    terrain=Cud
-                [/terrain]
-            [/do]
-        [/foreach]
-
-        {CLEAR_VARIABLE starting_loc_odd}
-
-        # making sure that there are 6 castle hexes when Konrad is at (even,68)
-        [store_locations]
-            [and]
-                [filter]
-                    id=Konrad
-                [/filter]
-
-                radius=0
-
-                x=2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48
-
-                [not]
-                    y=1-67
-                [/not]
-            [/and]
-
-            variable=starting_loc_even
-        [/store_locations]
-
-        [foreach]
-            array=starting_loc_even
-            [do]
-                [terrain]
-                    x,y=$this_item.x,"$($this_item.y - 2)"
-                    terrain=Cud
-                [/terrain]
-                [terrain]
-                    x,y="$($this_item.x - 1)","$($this_item.y - 1)"
-                    terrain=Cud
-                [/terrain]
-                [terrain]
-                    x,y="$($this_item.x + 1)","$($this_item.y - 1)"
-                    terrain=Cud
-                [/terrain]
-            [/do]
-        [/foreach]
-
-        {CLEAR_VARIABLE starting_loc_even}
     [/event]
 
     [event]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -471,6 +471,76 @@
         [/foreach]
 
         {CLEAR_VARIABLE adjacent_to_starting_loc}
+
+        # making sure that there are 6 castle hexes when Konrad is at (odd,68)
+        [store_locations]
+            [and]
+                [filter]
+                    id=Konrad
+                [/filter]
+
+                radius=0
+
+                x=1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47
+
+                [not]
+                    y=1-67
+                [/not]
+            [/and]
+
+            variable=starting_loc_odd
+        [/store_locations]
+
+        [foreach]
+            array=starting_loc_odd
+            [do]
+                [terrain]
+                    x,y=$this_item.x,"$($this_item.y - 2)"
+                    terrain=Cud
+                [/terrain]
+            [/do]
+        [/foreach]
+
+        {CLEAR_VARIABLE starting_loc_odd}
+
+        # making sure that there are 6 castle hexes when Konrad is at (even,68)
+        [store_locations]
+            [and]
+                [filter]
+                    id=Konrad
+                [/filter]
+
+                radius=0
+
+                x=2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48
+
+                [not]
+                    y=1-67
+                [/not]
+            [/and]
+
+            variable=starting_loc_even
+        [/store_locations]
+
+        [foreach]
+            array=starting_loc_even
+            [do]
+                [terrain]
+                    x,y=$this_item.x,"$($this_item.y - 2)"
+                    terrain=Cud
+                [/terrain]
+                [terrain]
+                    x,y="$($this_item.x - 1)","$($this_item.y - 1)"
+                    terrain=Cud
+                [/terrain]
+                [terrain]
+                    x,y="$($this_item.x + 1)","$($this_item.y - 1)"
+                    terrain=Cud
+                [/terrain]
+            [/do]
+        [/foreach]
+
+        {CLEAR_VARIABLE starting_loc_even}
     [/event]
 
     [event]


### PR DESCRIPTION
Relevant forum post: [https://forums.wesnoth.org/viewtopic.php?p=683820#p683820](https://forums.wesnoth.org/viewtopic.php?p=683820#p683820)

Most of the time, Konrad can recruit/recall 6 units per turn. However, when he spawns at the very bottom of the map, some hexes are outside the map boundary, and therefore, only 5 or 3 units can be recruited/recalled. To fix this problem, 1 castle hex is added when he is at (odd, 68), and 3 castle hexes are added when he is at (even, 68).

![HttT-17-CastlesAddedSmall](https://github.com/wesnoth/wesnoth/assets/155947547/fee4b977-fe73-492d-b050-e9a83fc33708)

These added codes are made based on the codes immediately above (line 445~473). If more experienced people can come up with better and more concise codes to achieve the same outcome, I am all for it.