### PR TITLE
fix (most parts of) 7780 make unit_placed events nonundoable by default

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -658,7 +658,7 @@ place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_locat
 	recruit_checksums(*u, wml_triggered);
 	resources::whiteboard->on_gamestate_change();
 
-	resources::game_events->pump().fire("unit_placed", current_loc);
+	std::get<0>(res) |= std::get<0>(resources::game_events->pump().fire("unit_placed", current_loc));
 	if(!new_unit_itor.valid()) {
 		return place_recruit_result { true, 0, false };
 	}


### PR DESCRIPTION
There are still other places in the code that call unit_placed so there might be some cases left where unit_placed don't prevent undoing, but most of them are nonundoable anyways.