### PR TITLE
HttT S14 Use "id=" to remove Gryphon units

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/14_Plunging_Into_the_Darkness.cfg
@@ -482,6 +482,7 @@
 
                 [unit]
                     type=Gryphon
+                    id=Gryphon-A
                     side=1
                     x,y=13,23
                 [/unit]
@@ -522,8 +523,7 @@
 
                 # This kills the gryphon unit so it can travel some more
                 [kill]
-                    type=Gryphon
-                    x,y=13,23
+                    id=Gryphon-A
                 [/kill]
 
                 [move_unit_fake]
@@ -535,6 +535,7 @@
 
                 [unit]
                     type=Gryphon
+                    id=Gryphon-B
                     side=1
                     x,y=15,19
                 [/unit]
@@ -598,8 +599,7 @@
 
                 # This gets rid of the gryphon
                 [kill]
-                    type=Gryphon
-                    x,y=15,19
+                    id=Gryphon-B
                 [/kill]
 
                 [unit]
@@ -627,8 +627,7 @@
 
                 # This gets rid of the gryphon rider
                 [kill]
-                    type=Gryphon Rider
-                    x,y=15,19
+                    id=Mounted Dwarf
                 [/kill]
 
                 [move_unit_fake]


### PR DESCRIPTION
Usually, when (14, 23) is unoccupied by any unit,
(14, 23) = Kalenz
(13, 23) = Gryphon
(12, 22) = irrelevant
, and then the Gryphon is killed by the current code.

However, when (14, 23) is occupied either by an ally or enemy unit (picture below),
(14, 23) = occupied
(13, 23) = Kalenz
(12, 22) = Gryphon
, and then the Gryphon stays there and joins the recall list.

(15, 19) is almost always unoccupied, but the same problem can occur.

Therefore, this fix uses "id=" instead of positions to make sure that Gryphons are removed no matter where they are on the map, just like how Gryphon Tender (Elvish Shaman) is removed by the current code.

Relevant forum posts: [Feedback by Orek (me)](https://forums.wesnoth.org/viewtopic.php?p=681283#p681283), [Feedback by JL42](https://forums.wesnoth.org/viewtopic.php?p=685757#p685757)

![HttT-14-Gryphon-xy](https://github.com/wesnoth/wesnoth/assets/155947547/fe1ae86e-03b4-4305-baf9-8b00c1f5612b)