### PR TITLE
Log instead of assert for incorrect [teleport] tags in ActionWML

### DIFF
--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -525,6 +525,19 @@
 		{INSERT_TAG}
 		{SIMPLE_KEY id string}
 		{DEFAULT_KEY remove s_bool no}
+		[if]
+			[not]
+				# As it allows s_bool, this can't test for every possible "yes" value,
+				# but if there's no remove= then it's definitely adding a tunnel.
+				glob_on_remove=*
+			[/not]
+			[then]
+				# These are also max=1, but max defaults to 1 anyway
+				{FILTER_TAG "filter" unit min=1}
+				{FILTER_TAG "source" location min=1}
+				{FILTER_TAG "target" location min=1}
+			[/then]
+		[/if]
 	[/tag]
 	[tag]
 		name="do_command"

--- a/src/game_events/action_wml.cpp
+++ b/src/game_events/action_wml.cpp
@@ -848,6 +848,11 @@ WML_HANDLER_FUNCTION(tunnel,, cfg)
 		cfg.get_children("filter").empty()) {
 		ERR_WML << "[tunnel] is missing a mandatory tag:\n"
 		        << cfg.get_config().debug();
+	} else if (cfg.get_children("source").size() > 1 ||
+		cfg.get_children("target").size() > 1 ||
+		cfg.get_children("filter").size() > 1) {
+		ERR_WML << "[tunnel] should have exactly one of each mandatory tag:\n"
+		        << cfg.get_config().debug();
 	} else {
 		pathfind::teleport_group tunnel(delay ? cfg : vconfig(cfg.get_parsed_config()), false);
 		resources::tunnels->add(tunnel);


### PR DESCRIPTION
Each [teleport] tag should have exactly one each of [source], [target] and [filter]. Missing any of those is caught immediately above the new conditional block, so this makes having two or more of any of them be treated the same.

The log should maybe be made more visible, but it's a case that can already be detected by schema validation, so validate it there instead.

The code in teleport.cpp uses assert() in the cases that the newly-added code in this commit catches. That's bug #8175, and it's probably still reachable for units with teleport abilities, so this doesn't close that bug. The change in #8223 should still be added as well.