### PR TITLE
HttT S11 Make the objective clearer

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/maps/11_The_Ford_of_Abez.map
+++ b/data/campaigns/Heir_To_The_Throne/maps/11_The_Ford_of_Abez.map
@@ -7,8 +7,8 @@ Hh, Hh, Hh, Hh, Gs, Gs, Gs, Gs, Gs, Gs, Gll^Fp, Gs, Gll^Fp, Rb, Co, 3 Ko, Co, Co
 Gs, Gs, Gs, Gs, Gs, Gs, Gg, Gs, Gll^Fmf, Gll^Fp, Gll^Fdf, Gll^Fmf, Gll^Fp, Rb, Rb^Es, Co, Rb, Rb^Es, Gd, Re, Gd, Gs, Gs, Gs, Gs, Gs, Gs^Vc, Gs, Gs, Gs, Gd, Re, Re, Re, Gd, Gd, Gs, Gg, Gg, Gg, Gs, Gg, Gs, Gs^Em, Gs, Gs
 Gs, Gs, Gs, Gs, Gs^Vl, Gg, Gs, Gs, Gll^Fmf, Gll^Fmf, Gll^Fdf, Gll^Fdf, Gll, Re, Gd, Rb, Gd, Re, Gd, Gs^Es, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Rd, Re, Rd, Rd, Gs^Vc, Gs, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg^Em, Gg
 Gg, Gg, Gg, Gg, Gg, Gs, Gg, Gs, Gs, Gs^Fmf, Gs, Gs, Gs, Gd, Gs, Gd, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Gs, Rd, Rd, Rd, Gs, Gg, Gs, Gg, Gg, Gg, Gg, Gg, Gg, Ds, Gg, Gg, Gg
-Gg, Gg, Ds, Gg, Gg, Gg, Gg, Gs, Gg, Gs, Gs, Gs, Ds, Gs, Gs, Gs^Es, Gs, Gs, Ds, Gs, Gs, Gs, Ds, Ds, Ds, Ds, Ds, Gs, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Gg, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds
-Ds, Ds, Ww, Ds, Ds, Ds, Ds, Gg, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ww, Ww, Ww, Ww, Ww, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww
+Gg, Gg, Ds, Gg, Gg, Gg, Gg, Gs, Gg, Gs, Gs, Gs, Ds, Gs, Gs, Gs^Es, Gs, Gs, Ds, Gs, Gs, Gs, Ds, Ds, Ds, Ds, Ds, Gs, Gs, Gs, Ds, Ds, Ds, Ds, Ds, Gg, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds
+Ds, Ds, Ww, Ds, Ds, Ds, Ds, Gg, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ds, Ww, Ww, Ww, Ww, Ww, Ds, Ds, Ds, Ww, Ww, Ww, Ww, Ww, Ds, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww
 Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ds, Ww, Ww, Ww, Ds, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Ww, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Ww, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Wo
 Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo
 Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Ww, Ww, Ww, Ww, Ww, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Wo, Ww, Wo, Wo, Wo

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -22,7 +22,7 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Move Konrad to the north side of the river"
+                description= _ "Move Konrad to the north side of the river past the sandy shores"
                 condition=win
             [/objective]
             [objective]
@@ -461,8 +461,8 @@
         name=moveto
         [filter]
             id=Konrad
-            x=1-44
-            y=1-8
+            x=1,2,3-6,7,8-11,12,13-17,18,19-21,22-26,27,28-34,35,36-41,42,43-44
+            y=1-9,1-8,1-9,1-10,1-9,1-8,1-9,1-8,1-9,1-8,1-9,1-8,1-9,1-8,1-7,1-8
         [/filter]
 
         [message]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -22,7 +22,7 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Move Konrad to the north side of the river and off the beach"
+                description= _ "Move Konrad to the north side of the river"
                 condition=win
             [/objective]
             [objective]
@@ -462,10 +462,10 @@
         [filter]
             id=Konrad
             x=1-44
-            y=1-10
+            y=1-11
             [filter_location]
                 [not]
-                    terrain=Ds,Ww
+                    terrain=Ww
                 [/not]
             [/filter_location]
         [/filter]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -22,7 +22,7 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Move Konrad to the north side of the river"
+                description= _ "Move Konrad to the north side of the river and off the beach"
                 condition=win
             [/objective]
             [objective]
@@ -462,10 +462,10 @@
         [filter]
             id=Konrad
             x=1-44
-            y=1-11
+            y=1-10
             [filter_location]
                 [not]
-                    terrain=Ww
+                    terrain=Ds,Ww
                 [/not]
             [/filter_location]
         [/filter]

--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -22,7 +22,7 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Move Konrad to the north side of the river past the sandy shores"
+                description= _ "Move Konrad to the north side of the river"
                 condition=win
             [/objective]
             [objective]
@@ -461,8 +461,13 @@
         name=moveto
         [filter]
             id=Konrad
-            x=1,2,3-6,7,8-11,12,13-17,18,19-21,22-26,27,28-34,35,36-41,42,43-44
-            y=1-9,1-8,1-9,1-10,1-9,1-8,1-9,1-8,1-9,1-8,1-9,1-8,1-9,1-8,1-7,1-8
+            x=1-44
+            y=1-11
+            [filter_location]
+                [not]
+                    terrain=Ww
+                [/not]
+            [/filter_location]
         [/filter]
 
         [message]


### PR DESCRIPTION
For almost 20 years, "Move Konrad to the north side of the river" has been criticized for being misleading and unclear objective because “the north side” does not include sand hexes. There are dozens of posts pointing this out in [the campaign feedback thread](https://forums.wesnoth.org/viewtopic.php?t=8716).

Therefore, “past the sandy shores” is added to the objective sentence. I’m not sure if this is a correct, natural, and clear English expression, so I don’t mind seeing it replaced by better wording.

Also, currently, only y=1~8 hexes trigger the scenario end event, but some grass hexes are y=9 (picture). Therefore, all the non-sand hexes in the north are specified in the fixed version.

![HttT-11-xy](https://github.com/wesnoth/wesnoth/assets/155947547/5c8bf1c3-a573-4668-87d9-ddac3000fe74)

