### PR TITLE
changelog: add missing unit type ID prefix to clarify ambiguity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -270,7 +270,7 @@
      * Elvish Enchantress - cost changed from 55 to 70, ranged slow damage changed from 5 to 7, ranged magical damage changed from 9 to 13.
      * Ancient Wose - cost changed from 48 to 50.
      * Merman Entangler - cost changed from 46 to 42.
-     * Javelineer - cost changed from 48 to 55.
+     * Merman Javelineer - cost changed from 48 to 55.
      * Elvish Sylph - hp changed from 60 to 68, ranged slow damage changed from 6 to 7, ranged magical damage changed from 10 to 16, cost changed from 67 to 148.
    * Undead:
      * Skeleton - xp changed from 35 to 39.


### PR DESCRIPTION
Doing so since we have three Javelineers:

- Javelineer (Loyalist)
- Merman Javelineer (Rebels)
- Saurian Javelineer (core/pseudo-Drakes)

One can easily mistake the loyalist one for the merman one here.