### PR TITLE
wc: fix #6513  Bezoar artifact

### DIFF
--- a/data/campaigns/World_Conquest/resources/data/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/data/artifacts.cfg
@@ -82,9 +82,49 @@
         description=_ "fearless, undead, healthy, tenacity"
         info=_ "This shamanic totem protects from poison, drain, and plague. Bearers of the totem are immune to fear and their vulnerabilities are reduced."
         sound=heal.wav
-        {TRAIT_UNDEAD}
-        {TRAIT_FEARLESS}
-        {TRAIT_HEALTHY}
+        # Add dummy ability just for the text in the unit ui.
+        [effect]
+            apply_to=new_ability
+            [abilities]
+                [dummy]
+                    id="bezoar"
+                    name=_"Bezoar"
+                    # Using the same sing as above to prevent adding new strings.
+                    description=_"fearless, undead, healthy, tenacity"
+                [/dummy]
+            [/abilities]
+        [/effect]
+        # trait undead
+        [effect]
+            apply_to=status
+            add=unpoisonable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=undrainable
+        [/effect]
+        [effect]
+            apply_to=status
+            add=unplagueable
+        [/effect]
+        # fearless
+        [effect]
+            apply_to="fearless"
+        [/effect]
+        # healthy
+        [effect]
+            apply_to="healthy"
+        [/effect]
+        [effect]
+            apply_to=hitpoints
+            increase_total=1
+        [/effect]
+        [effect]
+            apply_to=hitpoints
+            times=per level
+            increase_total=1
+        [/effect]
+        # tenacity
         [effect]
             apply_to=new_ability
             [abilities]

--- a/data/campaigns/World_Conquest/resources/data/artifacts.cfg
+++ b/data/campaigns/World_Conquest/resources/data/artifacts.cfg
@@ -89,7 +89,7 @@
                 [dummy]
                     id="bezoar"
                     name=_"Bezoar"
-                    # Using the same sing as above to prevent adding new strings.
+                    # Using the same string as above to prevent adding new strings.
                     description=_"fearless, undead, healthy, tenacity"
                 [/dummy]
             [/abilities]


### PR DESCRIPTION
The item now applies the effects directly instead of using [trait]s,  The lua code that added traits in the wc lua files didn't work, but the main reason why i preferred  this solution instead of changing the lua files is that it makes it possible to simply remove the artifact via for example [remove_object] (which wouldn't work for artifacts using traits as those are separate modifications)

The code now also adds a dummy ability so that players know that this unit has the benefits of the healthy fearless and  undead  traits.