### PR TITLE
Force the UI to update fully when changing addon filters

### DIFF
--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -199,7 +199,7 @@ void listbox::set_row_shown(const boost::dynamic_bitset<>& shown)
 		point best_size = generator_->calculate_best_size();
 		generator_->place(generator_->get_origin(), {std::max(best_size.x, content_visible_area().w), best_size.y});
 
-		resize_needed = !content_resize_request();
+		resize_needed = !content_resize_request(true);
 	}
 
 	if(resize_needed) {


### PR DESCRIPTION
content_resize_request() doesn't appear to return the correct result in this case, even when the number of rows to display has increased.

Fix #7270