### PR TITLE
1.18 - remove LAYER argument from main Cud wall rule

### DIFF
--- a/data/core/terrain-graphics.cfg
+++ b/data/core/terrain-graphics.cfg
@@ -941,7 +941,7 @@ C*,K*,X*,Q*,W*,Ai,M*,*^Qh*,*^V*,*^B*,_off^_usr#enddef
 {NEW:WALL2            (Cud*,Kud*)      Ql*                  (!,Cud*,Kud*,Ql*)      unwalkable/dcastle-lava FLAG=castlewall}
 {NEW:WALL2            (Cud*,Kud*)      Qx*                  (!,Cud*,Kud*,Qx*)      unwalkable/dcastle-chasm FLAG=castlewall LAYER=-1}
 
-{NEW:WALL             (Cud*,Kud*)      (!,Cud*,Kud*,X*)                            castle/dwarven-castle LAYER=-1}
+{NEW:WALL             (Cud*,Kud*)      (!,Cud*,Kud*,X*)                            castle/dwarven-castle}
 
 {NEW:WALL             Xue            (Qx*,Ql*)                                 cave/earthy-wall-rough-chasm}
 {NEW:WALL             Xue            (!,Xu*,Xo*)                                   cave/earthy-wall-rough}


### PR DESCRIPTION
fixes #8333 
removes something added in b4471f3 that might have been ghost of an abandoned plan that crept in, because I'm not seeing the reason for it now.