### PR TITLE
SoF S02: Don't [allow_undo] when activating the runes

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -674,9 +674,6 @@
                     speaker=unit
                     message= _ "My glyph is on."
                 [/message]
-
-                [allow_undo]
-                [/allow_undo]
             [/else]
         [/if]
     [/event]


### PR DESCRIPTION
Standing on the runes changes some hexes to impassable, so it's a change to the game state. It isn't a random event, so it would be possible to add an [on_undo], but that seems unnecessary, and would need to handle multiple runes.

Fixes #8343 (assuming that @alberic89 confirms that it's only happened in this scenario).