### PR TITLE
Avoid linebreak in title text of help pages

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1029,7 +1029,7 @@ void generate_unit_sections(const config* /*help_cfg*/, section& sec, int /*leve
 		for (const std::string &variation_id : type.variations()) {
 			// TODO: Do we apply encountered stuff to variations?
 			const unit_type &var_type = type.get_variation(variation_id);
-			const std::string topic_name = var_type.type_name() + "\n" + var_type.variation_name();
+			const std::string topic_name = var_type.variation_name();
 			const std::string var_ref = hidden_symbol(var_type.hide_help()) + variation_prefix + var_type.id() + "_" + variation_id;
 
 			topic var_topic(topic_name, var_ref, "");


### PR DESCRIPTION
Displaying variations in the help has some rough edges. This is a patch from the liked PR which, while it can be further improved, is still good enough to improve the situation. Changes:

* Doesn't clutter unit help tree when a unit variation is displayed (that's the main problem. Doofus posted a before/after image is in the issue.)

* When displaying a unit variation in the help, it displays the links below the unit image at the same line as when displaying the base unit (That's a side effect)

Room for further improvement improvement:
Change the code so that not the same text is used in both places. Sidebar should stay as with this change, but help page couls show the Type Name with the variation in parentheses in the same line, instead of with the line break as before, or not at all with this change. But as we don't have that currently, I'm proposing to add this patch from #6011