### PR TITLE
Use -Wno-dangling-reference when building with GCC-13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,18 @@ if(NOT MSVC)
 		set(COMPILER_FLAGS "${COMPILER_FLAGS} -Qunused-arguments -Wno-unknown-warning-option -Wmismatched-tags -Wno-conditional-uninitialized -Wno-unused-lambda-capture")
 	endif()
 
+	if(CMAKE_CXX_COMPILER_ID MATCHES "GNU"
+			AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13
+			AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 14)
+		# GCC-13 added this new warning, and included it in -Wextra,
+		# however in GCC-13 it has a lot of false positives.
+		#
+		# It's likely to generate false postives with GCC-14 too, but
+		# I'm using a narrow version check as GCC-14 is still in dev.
+		# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110075
+		set(COMPILER_FLAGS "${COMPILER_FLAGS} -Wno-dangling-reference")
+	endif()
+
 ### Set strict compiler flags.
 
 	if(ENABLE_STRICT_COMPILATION)

--- a/SConstruct
+++ b/SConstruct
@@ -330,6 +330,15 @@ if "gcc" in env["TOOLS"]:
     env.AppendUnique(CCFLAGS = Split("-Wall -Wextra"))
     env.AppendUnique(CXXFLAGS = Split("-Werror=non-virtual-dtor -std=c++" + env["cxx_std"]))
 
+    # GCC-13 added this new warning, and included it in -Wextra,
+    # however in GCC-13 it has a lot of false positives.
+    #
+    # It's likely to generate false postives with GCC-14 too, but
+    # I'm using a narrow version check as GCC-14 is still in dev.
+    # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110075
+    if "CXXVERSION" in env and env["CXXVERSION"].startswith("13."):
+      env.AppendUnique(CXXFLAGS = "-Wno-dangling-reference")
+
 if env["prereqs"]:
     conf = env.Configure(**configure_args)
 


### PR DESCRIPTION
Version 13 of GCC added the -Wdangling-reference option, however due to false positives it had to be moved from -Wall to -Wextra. Discussion about its status in GCC-14 is in
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110075

The docs don't explain exactly what triggers the warning, but here's the explanation from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106393#c1
> The warning works by checking if a reference is initialized with a function
> that returns a reference, and at least one parameter of the function is a
> reference that is bound to a temporary. It assumes that such a function
> actually returns one of its arguments! ... suppress the warning when we've
> seen the definition of the function and we can say that it can return a
> variable with static storage duration.

Consistent with that, we're getting warnings on functions of the form find(container, const std::string&). All of the things triggering it seem to be false positives:

* Calls to find_widget<...>.
* Calls to theme::get_theme_config.
* Calls to race::gender_value.
* In src/actions/attack.cpp, any `attacker->attacks()[i]`. Although there's an iterator in there, the eventual reference is to a member of the array, not the iterator.
* In src/gui/dialogs/unit_advance.cpp, `cfg.child_range("...").back()` That returns an object indirectly owned by cfg.

We'd like the other warnings of -Wextra, so turn off -Wdangling-reference.

Fixes #8334 in a least-changes way. Alternatively, there's a new `#pragma` that could be used to mark `find_widget` etc as not returning a pointer into the temporary argument.