### PR TITLE
SoF S02: Alanin has planned (unshrouded) his escape route

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/2_Closing_the_Gates.cfg
@@ -261,18 +261,28 @@
                 [/item]
             [/do]
         [/foreach]
+
+        # Still able to see outside, and next to Rugnur's shortest path to the keep.
+        [recall]
+            id=Alanin
+            x,y=18,11
+        [/recall]
+        # Alanin has ridden into the fort, and planned his escape route.
+        # This conveniently clears the shroud for the moves during the start event.
+        [remove_shroud]
+            side=1
+            x=29-32
+            y=7-14
+            # Road because Alanin, villages because they're owned by side 1 and it looks odd otherwise.
+            terrain=Rr,*^V*
+            radius=2
+        [/remove_shroud]
     [/event]
 
     [event]
         name=start
-        {MOVE_UNIT id=Rugnur 22 12}
+        {MOVE_UNIT id=Rugnur 17 12}
         {MODIFY_UNIT id=Glildur facing ne}
-        [recall]
-            id=Alanin
-        [/recall]
-        [redraw]
-            side=1
-        [/redraw]
         [message]
             speaker=Rugnur
             message= _ "These elves are right behind me! We have to go warn the council of this attack...!"
@@ -293,6 +303,7 @@
             variable=changealanin
             kill=yes
         [/store_unit]
+        {MOVE_UNIT id=Rugnur 22 12}
         [message]
             speaker=Glildur
             message= _ "I see you have sent a messenger to the city. Good idea, but will it really help? We have more troops and more provisions, and we are going to enter those caves and kill you!"


### PR DESCRIPTION
The intro to this map shows Rugnur running into the stronghold, with the elves not far behind. Those moves were running into shroud, which generated "could not find move_unit_fake route" warnings because the animation prefers routes that moving side can already see.

Also, have the conversation between Alanin and Rugnur take place with Alanin on a road hex, because if he starts on the keep then he takes a long route to avoid cave terrain.

Fixes #8350.