### PR TITLE
Update COPYING.txt for jQuery and tablesorter

### DIFF
--- a/data/tools/addon_manager/COPYING.txt
+++ b/data/tools/addon_manager/COPYING.txt
@@ -1,11 +1,11 @@
 = jquery.js =
 
-http://jquery.com/
+https://jquery.com/
 
-Double licensed under MIT and GPL.
+Licensed under Expat (MIT).
 
 = tablesorter.js =
 
-http://tablesorter.com
+https://mottie.github.io/tablesorter/docs/
 
-Double licensed under MIT and GPL.
+Double licensed under Expat (MIT) and GPL 2.0.


### PR DESCRIPTION
Commit 81c31c40c53 updated jQuery to 3.7.0 and tablesorter to 2.31.3.

Update homepages, in particular for the tablesorter fork.

jQuery dropped the confusing and unnecessary dual licensing in 2012:
- https://blog.jquery.com/2012/09/10/jquery-licensing-changes/

Also specify the GPL version used by tablesorter and clarify the "MIT" license.  The license actually comes from Expat and is one of many licenses used by MIT (including the X11 license, which is also commonly called "the MIT license"):
- https://en.wikipedia.org/wiki/MIT_License#Ambiguity_and_variants
- https://www.gnu.org/licenses/license-list.html#Expat