### PR TITLE
Avoid extra square brackets in "missing key" error dialogs

### DIFF
--- a/src/gui/core/gui_definition.cpp
+++ b/src/gui/core/gui_definition.cpp
@@ -140,7 +140,7 @@ gui_definition::gui_definition(const config& cfg)
 
 	has_helptip_message_ = settings["has_helptip_message"];
 
-	VALIDATE(!has_helptip_message_.empty(), missing_mandatory_wml_key("[settings]", "has_helptip_message"));
+	VALIDATE(!has_helptip_message_.empty(), missing_mandatory_wml_key("settings", "has_helptip_message"));
 }
 
 void gui_definition::activate() const

--- a/src/wml_exception.cpp
+++ b/src/wml_exception.cpp
@@ -78,16 +78,7 @@ std::string missing_mandatory_wml_key(
 		, const std::string& primary_value)
 {
 	utils::string_map symbols;
-	if(!section.empty()) {
-		if(section[0] == '[') {
-			symbols["section"] = section;
-		} else {
-			WRN_NG << __func__
-					<< " parameter 'section' should contain brackets."
-					<< " Added them.";
-			symbols["section"] = "[" + section + "]";
-		}
-	}
+	symbols["section"] = section;
 	symbols["key"] = key;
 	if(!primary_key.empty()) {
 		assert(!primary_value.empty());

--- a/src/wml_exception.hpp
+++ b/src/wml_exception.hpp
@@ -131,11 +131,12 @@ private:
 /**
  * Returns a standard message for a missing wml key.
  *
- * @param section                 The section is which the key should appear
- *                                (this should include the section brackets).
- *                                It may contain parent sections to make it
- *                                easier to find the wanted sections. They are
- *                                listed like [parent][child][section].
+ * @param section                 The section in which the key should appear.
+ *                                Shouldn't include leading or trailing brackets,
+ *                                as they're already in the translatable string;
+ *                                but if it has to include brackets in the middle,
+ *                                for example "parent][child][section", then it
+ *                                seems reasonable include the outer ones too.
  * @param key                     The omitted key.
  * @param primary_key             The primary key of the section.
  * @param primary_value           The value of the primary key (mandatory if


### PR DESCRIPTION
This builds the standard text for errors such as
"In section '[styled_widget]' the mandatory key 'id' isn't set."

However, if passed "[styled_widget]" as the section argument, the message would say "[[styled_widget]]". If passed "styled_widget", the doubled "[[" and "]]" would still appear, along with an extra log message about the lack of square brackets.

Make calling it without square brackets the documentated way.

There are four calls to this that want to pass multiple tags, which I haven't changed. This means they'll still show doubled brackets, but as it's a message which should rarely be seen I feel that's better than having strings which look wrong in the source.

* gui/core/window_builder.cpp: "[window][resolution][" + tagname + "]"
* gui/widgets/listbox.cpp: "[list_data][row][column][widget]"
* theme.cpp: "[theme][partialresolution][remove]"
* theme.cpp: "[theme][partialresolution][change]"

Maybe we should revisit this for 1.19 (after the string freeze).

Fixes #8322

The changed behavior will be copied into a fix to #8175 - I'm planning to add a similar function with a standard message for having more than one instance of a mandatory key (when the max is 1).