### PR TITLE
EI S04b: Fix Hahid's name having a trailing comma

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg
@@ -391,7 +391,7 @@
         [unit]
             side=4
             x,y=19,21
-            name= _ "Hahid al-Ali",
+            name= _ "Hahid al-Ali"
             id="Hahid al-Ali"
             type=Dune Apothecary
             facing=se


### PR DESCRIPTION
This doesn't change a translatable string, it removes a comma that was immediately after the translatable string.

Fixes #8372.