### PR TITLE
EI: fix Terraent standing animation, and update stats to match mainline

### DIFF
--- a/data/campaigns/Eastern_Invasion/units/Human_Terraent_Paladin.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Terraent_Paladin.cfg
@@ -1,9 +1,32 @@
 #textdomain wesnoth-ei
 [unit_type]
     id=Terraent
-    [base_unit]
-        id=Paladin
-    [/base_unit]
+    race=human
+    profile="portraits/humans/paladin.webp"
+    hitpoints=77
+    movement_type=mounted
+    movement=8
+    experience=150
+    level=3
+    alignment=lawful
+    advances_to=null
+    {AMLA_DEFAULT}
+    undead_variation=mounted
+    cost=82
+    usage=fighter
+    #textdomain wesnoth-units
+    name= _ "Paladin"
+    description= _ "Knights of the highest virtue, Paladins have sworn their strength not to king and crown, but to ideals themselves; of chivalry, and the stewardship of everything that is good. They may serve in the armies of the world, but their first loyalties often lie with groups of their own making; secret, monastic orders that cross political and cultural boundaries. Rulers are sometimes wary of them, for the paladins’ loyalty is only as strong as the liege’s apparent virtue. This has led the more darkly ambitious to either attempt to defame and disperse these groups, or more rarely, to conjure elaborate deceptions to keep these otherwise staunchly loyal troops in service.
+
+Full paladins are generally not quite as fearsome as the ‘Grand Knights’ that champion most armies, but they are first-class fighters nonetheless. Additionally, their wisdom and piety grants these warrior monks certain curious abilities; a paladin is very powerful in fighting magical or unnatural things, and most have some skill at medicine and healing."
+    #textdomain wesnoth-ei
+    die_sound=horse-die.ogg
+    [resistance]
+        arcane=70
+    [/resistance]
+    [abilities]
+        {ABILITY_HEALS}
+    [/abilities]
 
     image="units/terraent/terraent.png"
     image_icon="units/terraent/terraent.png~CROP(8,10,72,72)"
@@ -17,7 +40,7 @@
         icon=attacks/sword-holy.png
         type=arcane
         range=melee
-        damage=8
+        damage=9
         number=5
     [/attack]
     [attack]
@@ -28,7 +51,7 @@
             {WEAPON_SPECIAL_CHARGE}
         [/specials]
         range=melee
-        damage=15
+        damage=16
         number=2
     [/attack]
 
@@ -38,12 +61,6 @@
             halo=units/terraent/terraent-halo[1~12].png:150
         [/frame]
     [/standing_anim]
-    [movement_anim]
-        [frame]
-            image="units/terraent/terraent[1~4,2,5].png:[200,300*3,200*2]"
-            halo=units/terraent/terraent-halo[1~12].png:150
-        [/frame]
-    [/movement_anim]
     [healing_anim]
         start_time=-300
         [frame]


### PR DESCRIPTION
When Terraent was created, the mainline paladin had no standing anim. When that was added, it conflicted with Terraent's. This fixes that issue.

This also updates Terraent's other stats to match the mainline paladin's rebalanced stats.

#8371 

(is this an acceptable way to fix the issue?)