### PR TITLE
wmlxgettext: treat gender as a po hint

### DIFF
--- a/changelog_entries/gettext_gender.md
+++ b/changelog_entries/gettext_gender.md
@@ -1,0 +1,2 @@
+ ### Translations
+   * When WML specifies a unit or unit type’s gender, it’s automatically included as a po hint

--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -66,7 +66,7 @@ _pending_cinfo = {
 # type of pending wmlinfo:
 # it can be None or it can have an actual value.
 # Possible actual values are: 'speaker', 'id', 'role', 'description',
-#                             'condition', 'type', or 'race'
+#                             'condition', 'type', 'race' or 'gender'
 _pending_winfotype = None
 
 # ----------

--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -207,7 +207,7 @@ class WmlTagState:
 
 class WmlGetinfState:
     def __init__(self):
-        rx = ( r'\s*(speaker|id|role|description|condition|type|race)' +
+        rx = ( r'\s*(speaker|id|role|description|condition|type|race|gender)' +
                r'\s*=\s*(.*)' )
         self.regex = re.compile(rx, re.I)
         self.iffail = 'wml_str01'


### PR DESCRIPTION
This will automatically record the gender (if specified) of each `[unit]`, `[unit_type]` and `[side]` (leader).

The hint `gender=male,female` is often applied to `[unit_type]name=`, although that's usually the male name. I believe that's the only downside of this change.

Resolves #8382.