### PR TITLE
[1.19] Combobox

### DIFF
--- a/data/gui/widget/combobox_default.cfg
+++ b/data/gui/widget/combobox_default.cfg
@@ -1,0 +1,278 @@
+#textdomain wesnoth-lib
+###
+### Definition of a combobox.
+### A widget with a text box and a list. Selecting an element from the list
+### set the value of the text box to that item of the list. The user can also
+### manually enter a value in the text box.
+###
+
+#define _GUI_DRAW_BACKGROUND COLOR
+	[rectangle]
+		x = 0
+		y = 0
+		w = "(width)"
+		h = "(height)"
+
+		fill_color = {COLOR}
+
+	[/rectangle]
+#enddef
+
+#define _GUI_TEXTBOX_BACKGROUND_ENABLED
+	{_GUI_DRAW_BACKGROUND ({GUI__BACKGROUND_COLOR_ENABLED})}
+#enddef
+
+#define _GUI_TEXTBOX_BACKGROUND_DISABLED
+	{_GUI_DRAW_BACKGROUND ({GUI__BACKGROUND_COLOR_DISABLED})}
+#enddef
+
+#define _GUI_DRAW_BORDER COLOR
+	[rectangle]
+		x = 0
+		y = 0
+		w = "(width)"
+		h = "(height)"
+
+		border_thickness = 1
+		border_color = {COLOR}
+
+	[/rectangle]
+#enddef
+
+#define _GUI_DRAW_TEXT SIZE COLOR
+#arg FONT_FAMILY
+#endarg
+	[rectangle]
+		x = "(text_x_offset + selection_offset)"
+		y = "(text_y_offset)"
+		w = "(selection_width)"
+		h = "(text_font_height)"
+
+		border_thickness = 0
+		fill_color = "21, 53, 80, 255"
+	[/rectangle]
+
+	[text]
+		x = "(text_x_offset)"
+		y = "(text_y_offset)"
+		w = "(text_width)"
+		h = "(text_height)"
+		maximum_width = "(text_maximum_width)"
+		font_size = {SIZE}
+		font_family = {FONT_FAMILY}
+		color = {COLOR}
+		text = "(text)"
+	[/text]
+#enddef
+
+#define __DISABLED_COLOR_PREPROCESSOR_WORKAROUND
+128, 128, 128, 255 #enddef
+
+#define _GUI_DRAW_TEXT_OR_HINT SIZE COLOR
+#arg FONT_FAMILY
+#endarg
+	[rectangle]
+		x = "(text_x_offset + selection_offset)"
+		y = "(text_y_offset)"
+		w = "(selection_width)"
+		h = "(text_font_height)"
+
+		border_thickness = 0
+		fill_color = "21, 53, 80, 255"
+	[/rectangle]
+
+	[text]
+		x = "(text_x_offset)"
+		y = "(text_y_offset)"
+		w = "(text_width)"
+		h = "(text_height)"
+		maximum_width = "(text_maximum_width)"
+
+		font_size = "(
+			if(text = '' and hint_text != '', hint_size, reg_size) where
+				hint_size = {GUI_FONT_SIZE_SMALL},
+				reg_size = {SIZE}
+			)"
+		font_family = {FONT_FAMILY}
+
+		color = "(
+			if(text = '' and hint_text != '', hint_color, reg_color) where
+				hint_color = [{__DISABLED_COLOR_PREPROCESSOR_WORKAROUND}],
+				reg_color = [{COLOR}]
+			)"
+
+		text = "(
+			if(text = '' and hint_text != '', hint_text, text))"
+	[/text]
+
+	[image]
+		x = "(width - image_width)"
+		y = "(max(0, height / 2 - image_height / 2))"
+		name = "(if(text = '' and hint_image != '', hint_image, ''))"
+	[/image]
+#enddef
+
+#define _GUI_DRAW_CURSOR X_OFFSET
+	[line]
+		x1 = "(cursor_offset + {X_OFFSET})"
+		y1 = "(text_y_offset + 2)"
+		x2 = "(cursor_offset + {X_OFFSET})"
+		y2 = "(text_y_offset + text_font_height - 2)"
+		color = "([255, 255, 255, cursor_alpha])"
+		thickness = 1
+	[/line]
+
+	[rectangle]
+		x = "(composition_offset + {X_OFFSET})"
+		y = "(text_y_offset + text_font_height - 2)"
+		w = "(composition_width)"
+		h = "2"
+		fill_color = "([140, 140, 0, if(composition_width > 0, 255, 0)])"
+		border_thickness = 0
+	[/rectangle]
+#enddef
+
+#define _GUI_RESOLUTION RESOLUTION MIN_WIDTH DEFAULT_WIDTH HEIGHT X_OFFSET EXTRA_WIDTH FONT_SIZE BACKGROUND_ENABLED BACKGROUND_DISABLED
+#arg FONT_FAMILY
+#endarg
+	[resolution]
+
+		{RESOLUTION}
+
+		min_width = {MIN_WIDTH}
+		min_height = {HEIGHT}
+
+		default_width = {DEFAULT_WIDTH}
+		default_height = {HEIGHT}
+
+		max_width = 0
+		max_height = {HEIGHT}
+
+		text_font_size = {FONT_SIZE}
+		text_font_family = {FONT_FAMILY}
+		text_x_offset = {X_OFFSET}
+		text_y_offset =	"(if(text_font_height <= height, (height - text_font_height) / 2, 0))"
+		text_extra_width = {EXTRA_WIDTH}
+
+		#functions = "(def show_hint_text() (text = '' and hint_text != '');)"
+
+		[state_enabled]
+
+			[draw]
+
+				{BACKGROUND_ENABLED}
+
+				{_GUI_DRAW_BORDER ({GUI__BORDER_COLOR_DARK}) }
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25.png~ROTATE(-90)"
+				[/image]
+
+			[/draw]
+
+		[/state_enabled]
+
+		[state_disabled]
+
+			[draw]
+
+				{BACKGROUND_DISABLED}
+
+				{_GUI_DRAW_BORDER ({GUI__FONT_COLOR_DISABLED_DARK__DEFAULT}) }
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25.png~ROTATE(-90)"
+				[/image]
+
+			[/draw]
+
+		[/state_disabled]
+
+		[state_focused]
+
+			[draw]
+
+				{BACKGROUND_ENABLED}
+
+				{_GUI_DRAW_BORDER ({GUI__BORDER_COLOR_BRIGHT}) }
+
+				# We never draw the hint text or image if focused
+				{_GUI_DRAW_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+				{_GUI_DRAW_CURSOR ({X_OFFSET}) }
+
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25-active.png~ROTATE(-90)"
+				[/image]
+
+			[/draw]
+
+		[/state_focused]
+
+		[state_hovered]
+
+			[draw]
+
+				{BACKGROUND_ENABLED}
+
+				{_GUI_DRAW_BORDER ({GUI__BORDER_COLOR}) }
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25-active.png~ROTATE(-90)"
+				[/image]
+
+			[/draw]
+
+		[/state_hovered]
+
+	[/resolution]
+
+#enddef
+
+[combobox_definition]
+	id = "default"
+	description = "Default text box"
+
+	{_GUI_RESOLUTION () 40 250 30 5 10 ({GUI_FONT_SIZE_DEFAULT}) ({_GUI_TEXTBOX_BACKGROUND_ENABLED}) ({_GUI_TEXTBOX_BACKGROUND_DISABLED})}
+
+[/combobox_definition]
+
+[combobox_definition]
+	id = "transparent"
+	description = "Background-less text box, used for WML messages"
+
+	{_GUI_RESOLUTION () 40 250 30 5 10 ({GUI_FONT_SIZE_DEFAULT}) () ()}
+
+[/combobox_definition]
+
+[combobox_definition]
+	id = "verbatim"
+	description = "Monospace text box for command inputs"
+
+	{_GUI_RESOLUTION () 40 250 30 5 10 ({GUI_FONT_SIZE_DEFAULT}) ({_GUI_TEXTBOX_BACKGROUND_ENABLED}) ({_GUI_TEXTBOX_BACKGROUND_DISABLED}) FONT_FAMILY=monospace}
+
+[/combobox_definition]
+
+#undef _GUI_RESOLUTION
+#undef _GUI_DRAW_CURSOR
+#undef _GUI_DRAW_TEXT
+#undef _GUI_DRAW_BORDER
+#undef _GUI_DRAW_BACKGROUND
+#undef _GUI_DRAW_TEXT_OR_HINT
+#undef _GUI_TEXTBOX_BACKGROUND_ENABLED
+#undef _GUI_TEXTBOX_BACKGROUND_DISABLED
+#undef __DISABLED_COLOR_PREPROCESSOR_WORKAROUND

--- a/data/gui/widget/text_box_default.cfg
+++ b/data/gui/widget/text_box_default.cfg
@@ -36,6 +36,16 @@
 	[/rectangle]
 #enddef
 
+#
+# The preprocessor can't process GUI__FONT_COLOR_DISABLED__DEFAULT as part of string
+# concatenation for some reason. Perhaps it's the optional argument. So I'm just copying
+# it here. Though the lack of quotes means I don't need to use concatenation anyway.
+#
+# -- vultraz, 2018-03-26
+#
+#define __DISABLED_COLOR_PREPROCESSOR_WORKAROUND
+128, 128, 128, 255 #enddef
+
 #define _GUI_DRAW_TEXT SIZE COLOR
 #arg FONT_FAMILY
 #endarg
@@ -57,20 +67,13 @@
 		maximum_width = "(text_maximum_width)"
 		font_size = {SIZE}
 		font_family = {FONT_FAMILY}
-		color = {COLOR}
+		color = "(if(editable=1, active_color, inactive_color) where
+			active_color = [{COLOR}],
+			inactive_color = [{__DISABLED_COLOR_PREPROCESSOR_WORKAROUND}]
+		)"
 		text = "(text)"
 	[/text]
 #enddef
-
-#
-# The preprocessor can't process GUI__FONT_COLOR_DISABLED__DEFAULT as part of string
-# concatenation for some reason. Perhaps it's the optional argument. So I'm just copying
-# it here. Though the lack of quotes means I don't need to use concatenation anyway.
-#
-# -- vultraz, 2018-03-26
-#
-#define __DISABLED_COLOR_PREPROCESSOR_WORKAROUND
-128, 128, 128, 255 #enddef
 
 #define _GUI_DRAW_TEXT_OR_HINT SIZE COLOR
 #arg FONT_FAMILY
@@ -100,7 +103,7 @@
 		font_family = {FONT_FAMILY}
 
 		color = "(
-			if(text = '' and hint_text != '', hint_color, reg_color) where
+			if((text = '' and hint_text != '') or editable = 0, hint_color, reg_color) where
 				hint_color = [{__DISABLED_COLOR_PREPROCESSOR_WORKAROUND}],
 				reg_color = [{COLOR}]
 			)"

--- a/data/schema/gui/widget_definitions.cfg
+++ b/data/schema/gui/widget_definitions.cfg
@@ -49,6 +49,44 @@
     [/tag]
 [/tag]
 [tag]
+    name="combobox_definition"
+    min="0"
+    max="infinite"
+    super="$generic/widget_definition"
+    [tag]
+        name="resolution"
+        min="0"
+        max="infinite"
+        super="$generic/widget_definition/resolution"
+        [tag]
+            name="state_disabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_enabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_hovered"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_focused"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        {DEFAULT_KEY "text_x_offset" f_unsigned ""}
+        {DEFAULT_KEY "text_y_offset" f_unsigned ""}
+    [/tag]
+[/tag]
+[tag]
     name="menu_button_definition"
     min="0"
     max="infinite"
@@ -260,6 +298,44 @@
     [/tag]
 [/tag]
 [tag]
+    name="multiline_text_definition"
+    min="0"
+    max="infinite"
+    super="$generic/widget_definition"
+    [tag]
+        name="resolution"
+        min="0"
+        max="infinite"
+        super="$generic/widget_definition/resolution"
+        [tag]
+            name="state_disabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_enabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_focused"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_hovered"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        {DEFAULT_KEY "text_x_offset" f_unsigned ""}
+        {DEFAULT_KEY "text_y_offset" f_unsigned ""}
+    [/tag]
+[/tag]
+[tag]
     name="multi_page_definition"
     min="0"
     max="infinite"
@@ -392,6 +468,31 @@
     [/tag]
 [/tag]
 [tag]
+    name="scroll_text_definition"
+    min="0"
+    max="infinite"
+    super="$generic/widget_definition"
+    [tag]
+        name="resolution"
+        min="0"
+        max="infinite"
+        super="$generic/widget_definition/resolution"
+        [tag]
+            name="state_disabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_enabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        {LINK_TAG "$cell/grid"}
+    [/tag]
+[/tag]
+[tag]
     name="scrollbar_panel_definition"
     min="0"
     max="infinite"
@@ -476,6 +577,31 @@
     min="0"
     max="infinite"
     super="$generic/widget_definition"
+[/tag]
+[tag]
+    name="spinner_definition"
+    min="0"
+    max="infinite"
+    super="$generic/widget_definition"
+    [tag]
+        name="resolution"
+        min="0"
+        max="infinite"
+        super="$generic/widget_definition/resolution"
+        [tag]
+            name="state_disabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        [tag]
+            name="state_enabled"
+            min="0"
+            max="1"
+            super="$generic/state"
+        [/tag]
+        {LINK_TAG "$cell/grid"}
+    [/tag]
 [/tag]
 [tag]
     name="stacked_widget_definition"

--- a/data/schema/gui/widget_instances.cfg
+++ b/data/schema/gui/widget_instances.cfg
@@ -44,6 +44,26 @@
         {DEFAULT_KEY "return_value_id" string ""}
     [/tag]
     [tag]
+        name="combobox"
+        min="0"
+        max="infinite"
+        super="$generic/widget_instance"
+        {DEFAULT_KEY "history" string ""}
+        {DEFAULT_KEY "max_input_length" int 0}
+        {DEFAULT_KEY "label" t_string ""}
+        {DEFAULT_KEY "hint_text" t_string ""}
+        {DEFAULT_KEY "hint_image" string ""}
+        [tag]
+            name = "option"
+            min="0"
+            max="infinite"
+            {DEFAULT_KEY "label" t_string ""}
+            {DEFAULT_KEY "tooltip" t_string ""}
+            {DEFAULT_KEY "icon" string ""}
+            {DEFAULT_KEY "details" t_string ""}
+        [/tag]
+    [/tag]
+    [tag]
         name="menu_button"
         min="0"
         max="infinite"
@@ -57,6 +77,19 @@
             {DEFAULT_KEY "icon" string ""}
             {DEFAULT_KEY "details" t_string ""}
         [/tag]
+    [/tag]
+    [tag]
+        name="multiline_text"
+        min="0"
+        max="infinite"
+        super="$generic/widget_instance"
+        {DEFAULT_KEY "history" string ""}
+        {DEFAULT_KEY "max_input_length" int 0}
+        {DEFAULT_KEY "label" t_string ""}
+        {DEFAULT_KEY "hint_text" t_string ""}
+        {DEFAULT_KEY "hint_image" string ""}
+        {DEFAULT_KEY "editable" bool true}
+        {DEFAULT_KEY "wrap" bool true}
     [/tag]
     [tag]
         name="multimenu_button"
@@ -358,6 +391,25 @@
         {DEFAULT_KEY "link_aware" bool false}
     [/tag]
     [tag]
+        name="spinner"
+        min="0"
+        max="infinite"
+        super="$generic/widget_instance"
+        {DEFAULT_KEY "wrap" bool true}
+    [/tag]
+    [tag]
+        name="scroll_text"
+        min="0"
+        max="infinite"
+        super="$generic/widget_instance"
+        {DEFAULT_KEY "horizontal_scrollbar_mode" scrollbar_mode initial_auto}
+        {DEFAULT_KEY "vertical_scrollbar_mode" scrollbar_mode initial_auto}
+        {DEFAULT_KEY "wrap" bool true}
+        {DEFAULT_KEY "text_alignment" f_h_align "left"}
+        {DEFAULT_KEY "link_aware" bool false}
+        {DEFAULT_KEY "editable" bool true}
+    [/tag]
+    [tag]
         name="scrollbar_panel"
         min="0"
         max="infinite"
@@ -428,6 +480,7 @@
         {DEFAULT_KEY "label" t_string ""}
         {DEFAULT_KEY "hint_text" t_string ""}
         {DEFAULT_KEY "hint_image" string ""}
+        {DEFAULT_KEY "editable" bool true}
     [/tag]
     [tag]
         name="toggle_button"

--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -771,6 +771,8 @@
 		<Unit filename="../../src/gui/widgets/chatbox.cpp" />
 		<Unit filename="../../src/gui/widgets/chatbox.hpp" />
 		<Unit filename="../../src/gui/widgets/clickable_item.hpp" />
+		<Unit filename="../../src/gui/widgets/combobox.cpp" />
+		<Unit filename="../../src/gui/widgets/combobox.hpp" />
 		<Unit filename="../../src/gui/widgets/container_base.cpp" />
 		<Unit filename="../../src/gui/widgets/container_base.hpp" />
 		<Unit filename="../../src/gui/widgets/debug.cpp" />

--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -664,6 +664,7 @@
 		8C704B6F99C824A4073EEBEE /* prompt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67044415B63F5888193BD7A6 /* prompt.cpp */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		900000000000000000000009 /* match_history.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4685A5F925B4501E006FD3A1 /* match_history.cpp */; };
+		9002415BA030D7C959EDA2E8 /* combobox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B0614CC785C0857883E43FF1 /* combobox.cpp */; };
 		903F959C1ED5489500F1BDD3 /* credentials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 903F959B1ED5489500F1BDD3 /* credentials.cpp */; };
 		903F959F1ED5496700F1BDD3 /* hash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B52EE8AD121359A600CFBDAB /* hash.cpp */; };
 		90606A2B1D5599BA00719B40 /* libpcre.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 90606A2A1D5599BA00719B40 /* libpcre.1.dylib */; };
@@ -1107,6 +1108,7 @@
 		91FAC70A1C7FBC3400DAB2C3 /* lua_formula_bridge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FAC7091C7FBC2C00DAB2C3 /* lua_formula_bridge.cpp */; };
 		91FBBAD81CB6BC3F00470BFE /* filesystem_sdl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FBBAD71CB6BC3F00470BFE /* filesystem_sdl.cpp */; };
 		91FBBADB1CB6D1B700470BFE /* markov_generator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91FBBAD91CB6D1B700470BFE /* markov_generator.cpp */; };
+		959D4992B2C0954057827AAC /* combobox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B0614CC785C0857883E43FF1 /* combobox.cpp */; };
 		95EB8A52287A02B900B09F95 /* draw_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A50287A02B800B09F95 /* draw_manager.cpp */; };
 		95EB8A55287A02EC00B09F95 /* top_level_drawable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */; };
 		95EB8A58287B138700B09F95 /* draw_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95EB8A50287A02B800B09F95 /* draw_manager.cpp */; };
@@ -2380,6 +2382,7 @@
 		95EB8A51287A02B800B09F95 /* draw_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = draw_manager.hpp; sourceTree = "<group>"; };
 		95EB8A53287A02EC00B09F95 /* top_level_drawable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = top_level_drawable.hpp; path = gui/core/top_level_drawable.hpp; sourceTree = "<group>"; };
 		95EB8A54287A02EC00B09F95 /* top_level_drawable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = top_level_drawable.cpp; path = gui/core/top_level_drawable.cpp; sourceTree = "<group>"; };
+		B0614CC785C0857883E43FF1 /* combobox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = combobox.cpp; path = combobox.cpp; sourceTree = "<group>"; };
 		B2CC45FEA71445AE817CAA6B /* edit_pbl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = edit_pbl.hpp; sourceTree = "<group>"; };
 		B508D191100146E300B12852 /* engine_fai.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = engine_fai.cpp; sourceTree = "<group>"; };
 		B508D192100146E300B12852 /* engine_fai.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = engine_fai.hpp; sourceTree = "<group>"; };
@@ -4062,6 +4065,7 @@
 				46F92D342174F6A300602C1C /* window_private.hpp */,
 				46F92D2E2174F6A300602C1C /* window.cpp */,
 				46F92D472174F6A300602C1C /* window.hpp */,
+				B0614CC785C0857883E43FF1 /* combobox.cpp */,
 			);
 			path = widgets;
 			sourceTree = "<group>";
@@ -5863,6 +5867,7 @@
 				0554467DB5FE99D85ABCDCA0 /* edit_pbl_translation.cpp in Sources */,
 				8C704B6F99C824A4073EEBEE /* prompt.cpp in Sources */,
 				DF974010BB46B844E83F7DDA /* tod_new_schedule.cpp in Sources */,
+				959D4992B2C0954057827AAC /* combobox.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6540,6 +6545,7 @@
 				EBB44A70837B84A928CB6424 /* edit_pbl_translation.cpp in Sources */,
 				7BFC4DF5BFF8CF75855BA662 /* prompt.cpp in Sources */,
 				C93048A9AE576B6AD016DFA4 /* tod_new_schedule.cpp in Sources */,
+				9002415BA030D7C959EDA2E8 /* combobox.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6643,15 +6649,15 @@
 					"$(PROJECT_DIR)/Headers/SDL2",
 					"$(PROJECT_DIR)/Headers/harfbuzz",
 				);
+				LD_CLASSIC_1000 = "";
+				LD_CLASSIC_1100 = "";
+				LD_CLASSIC_1200 = "";
+				LD_CLASSIC_1300 = "";
+				LD_CLASSIC_1400 = "";
+				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				"LD_CLASSIC_1000" = "";
-				"LD_CLASSIC_1100" = "";
-				"LD_CLASSIC_1200" = "";
-				"LD_CLASSIC_1300" = "";
-				"LD_CLASSIC_1400" = "";
-				"LD_CLASSIC_1500" = "-ld_classic";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -6717,16 +6723,16 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Applications;
+				LD_CLASSIC_1000 = "";
+				LD_CLASSIC_1100 = "";
+				LD_CLASSIC_1200 = "";
+				LD_CLASSIC_1300 = "";
+				LD_CLASSIC_1400 = "";
+				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LLVM_LTO = YES_THIN;
 				OTHER_CFLAGS = "-Wall";
 				OTHER_CPLUSPLUSFLAGS = "-Wall";
-				"LD_CLASSIC_1000" = "";
-				"LD_CLASSIC_1100" = "";
-				"LD_CLASSIC_1200" = "";
-				"LD_CLASSIC_1300" = "";
-				"LD_CLASSIC_1400" = "";
-				"LD_CLASSIC_1500" = "-ld_classic";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -7112,15 +7118,15 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Applications;
+				LD_CLASSIC_1000 = "";
+				LD_CLASSIC_1100 = "";
+				LD_CLASSIC_1200 = "";
+				LD_CLASSIC_1300 = "";
+				LD_CLASSIC_1400 = "";
+				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				OTHER_CFLAGS = "-Wall";
 				OTHER_CPLUSPLUSFLAGS = "-Wall";
-				"LD_CLASSIC_1000" = "";
-				"LD_CLASSIC_1100" = "";
-				"LD_CLASSIC_1200" = "";
-				"LD_CLASSIC_1300" = "";
-				"LD_CLASSIC_1400" = "";
-				"LD_CLASSIC_1500" = "-ld_classic";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -7178,16 +7184,16 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = /Applications;
+				LD_CLASSIC_1000 = "";
+				LD_CLASSIC_1100 = "";
+				LD_CLASSIC_1200 = "";
+				LD_CLASSIC_1300 = "";
+				LD_CLASSIC_1400 = "";
+				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LLVM_LTO = YES_THIN;
 				OTHER_CFLAGS = "-Wall";
 				OTHER_CPLUSPLUSFLAGS = "-Wall";
-				"LD_CLASSIC_1000" = "";
-				"LD_CLASSIC_1100" = "";
-				"LD_CLASSIC_1200" = "";
-				"LD_CLASSIC_1300" = "";
-				"LD_CLASSIC_1400" = "";
-				"LD_CLASSIC_1500" = "-ld_classic";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -7263,17 +7269,17 @@
 					"$(PROJECT_DIR)/Headers/SDL2",
 					"$(PROJECT_DIR)/Headers/harfbuzz",
 				);
+				LD_CLASSIC_1000 = "";
+				LD_CLASSIC_1100 = "";
+				LD_CLASSIC_1200 = "";
+				LD_CLASSIC_1300 = "";
+				LD_CLASSIC_1400 = "";
+				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-Wall";
-				"LD_CLASSIC_1000" = "";
-				"LD_CLASSIC_1100" = "";
-				"LD_CLASSIC_1200" = "";
-				"LD_CLASSIC_1300" = "";
-				"LD_CLASSIC_1400" = "";
-				"LD_CLASSIC_1500" = "-ld_classic";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -7318,15 +7324,15 @@
 					"$(PROJECT_DIR)/Headers/SDL2",
 					"$(PROJECT_DIR)/Headers/harfbuzz",
 				);
+				LD_CLASSIC_1000 = "";
+				LD_CLASSIC_1100 = "";
+				LD_CLASSIC_1200 = "";
+				LD_CLASSIC_1300 = "";
+				LD_CLASSIC_1400 = "";
+				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				"LD_CLASSIC_1000" = "";
-				"LD_CLASSIC_1100" = "";
-				"LD_CLASSIC_1200" = "";
-				"LD_CLASSIC_1300" = "";
-				"LD_CLASSIC_1400" = "";
-				"LD_CLASSIC_1500" = "-ld_classic";
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",

--- a/source_lists/libwesnoth_widgets
+++ b/source_lists/libwesnoth_widgets
@@ -1,5 +1,6 @@
 gui/widgets/addon_list.cpp
 gui/widgets/button.cpp
+gui/widgets/combobox.cpp
 gui/widgets/chatbox.cpp
 gui/widgets/drawing.cpp
 gui/widgets/horizontal_scrollbar.cpp

--- a/src/gui/widgets/combobox.cpp
+++ b/src/gui/widgets/combobox.cpp
@@ -1,0 +1,464 @@
+/*
+	Copyright (C) 2008 - 2024
+	by babaissarkar(Subhraman Sarkar) <suvrax@gmail.com>
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#define GETTEXT_DOMAIN "wesnoth-lib"
+
+#include "gui/widgets/combobox.hpp"
+
+#include "gui/core/log.hpp"
+#include "gui/core/register_widget.hpp"
+#include "gui/widgets/settings.hpp"
+#include "gui/widgets/window.hpp"
+#include "preferences/game.hpp"
+#include "serialization/unicode.hpp"
+#include <functional>
+#include "cursor.hpp"
+#include "wml_exception.hpp"
+#include "gettext.hpp"
+
+#define LOG_SCOPE_HEADER get_control_type() + " [" + id() + "] " + __func__
+#define LOG_HEADER LOG_SCOPE_HEADER + ':'
+
+
+namespace gui2
+{
+
+// ------------ WIDGET -----------{
+
+REGISTER_WIDGET(combobox)
+
+combobox::combobox(const implementation::builder_styled_widget& builder)
+	: text_box_base(builder, type())
+	, values_()
+	, selected_(0)
+	, max_input_length_(0)
+	, text_x_offset_(0)
+	, text_y_offset_(0)
+	, text_height_(0)
+	, dragging_(false)
+{
+	values_.emplace_back("label", this->get_label());
+
+	set_wants_mouse_left_double_click();
+
+	connect_signal<event::MOUSE_MOTION>(std::bind(
+			&combobox::signal_handler_mouse_motion, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_5));
+	connect_signal<event::LEFT_BUTTON_DOWN>(std::bind(
+			&combobox::signal_handler_left_button_down, this, std::placeholders::_2, std::placeholders::_3));
+	connect_signal<event::LEFT_BUTTON_UP>(std::bind(
+			&combobox::signal_handler_left_button_up, this, std::placeholders::_2, std::placeholders::_3));
+	connect_signal<event::LEFT_BUTTON_DOUBLE_CLICK>(std::bind(
+			&combobox::signal_handler_left_button_double_click, this, std::placeholders::_2, std::placeholders::_3));
+	connect_signal<event::MOUSE_ENTER>(
+			std::bind(&combobox::signal_handler_mouse_enter, this, std::placeholders::_2, std::placeholders::_3));
+
+	const auto conf = cast_config_to<combobox_definition>();
+	assert(conf);
+
+	set_font_size(get_text_font_size());
+	set_font_style(conf->text_font_style);
+
+	update_offsets();
+}
+
+void combobox::place(const point& origin, const point& size)
+{
+	// Inherited.
+	styled_widget::place(origin, size);
+
+	set_maximum_width(get_text_maximum_width()-ICON_SIZE);
+	set_maximum_height(get_text_maximum_height(), false);
+
+	set_maximum_length(max_input_length_);
+
+	update_offsets();
+}
+
+void combobox::update_canvas()
+{
+	/***** Gather the info *****/
+
+	// Set the cursor info.
+	const unsigned start = get_selection_start();
+	const int length = get_selection_length();
+
+	// Set the cursor info.
+	const unsigned edit_start = get_composition_start();
+	const int edit_length = get_composition_length();
+
+	set_maximum_length(max_input_length_);
+
+	PangoEllipsizeMode ellipse_mode = PANGO_ELLIPSIZE_NONE;
+	if(!can_wrap()) {
+		if((start + length) > (get_length() / 2)) {
+			ellipse_mode = PANGO_ELLIPSIZE_START;
+		} else {
+			ellipse_mode = PANGO_ELLIPSIZE_END;
+		}
+	}
+	set_ellipse_mode(ellipse_mode);
+
+	// Set the selection info
+	unsigned start_offset = 0;
+	unsigned end_offset = 0;
+	if(length == 0) {
+		// No nothing.
+	} else if(length > 0) {
+		start_offset = get_cursor_position(start).x;
+		end_offset = get_cursor_position(start + length).x;
+	} else {
+		start_offset = get_cursor_position(start + length).x;
+		end_offset = get_cursor_position(start).x;
+	}
+
+	// Set the composition info
+	unsigned comp_start_offset = 0;
+	unsigned comp_end_offset = 0;
+	if(edit_length == 0) {
+		// No nothing.
+	} else if(edit_length > 0) {
+		comp_start_offset = get_cursor_position(edit_start).x;
+		comp_end_offset = get_cursor_position(edit_start + edit_length).x;
+	} else {
+		comp_start_offset = get_cursor_position(edit_start + edit_length).x;
+		comp_end_offset = get_cursor_position(edit_start).x;
+	}
+
+	/***** Set in all canvases *****/
+
+	const int max_width = get_text_maximum_width() - ICON_SIZE;
+	const int max_height = get_text_maximum_height();
+
+	for(auto & tmp : get_canvases())
+	{
+
+		tmp.set_variable("text", wfl::variant(get_value()));
+		tmp.set_variable("text_x_offset", wfl::variant(text_x_offset_));
+		tmp.set_variable("text_y_offset", wfl::variant(text_y_offset_));
+		tmp.set_variable("text_maximum_width", wfl::variant(max_width));
+		tmp.set_variable("text_maximum_height", wfl::variant(max_height));
+
+		tmp.set_variable("cursor_offset",
+						 wfl::variant(get_cursor_position(start + length).x));
+
+		tmp.set_variable("selection_offset", wfl::variant(start_offset));
+		tmp.set_variable("selection_width", wfl::variant(end_offset - start_offset));
+		tmp.set_variable("text_wrap_mode", wfl::variant(ellipse_mode));
+
+		tmp.set_variable("composition_offset", wfl::variant(comp_start_offset));
+		tmp.set_variable("composition_width", wfl::variant(comp_end_offset - comp_start_offset));
+
+		tmp.set_variable("hint_text", wfl::variant(hint_text_));
+		tmp.set_variable("hint_image", wfl::variant(hint_image_));
+	}
+}
+
+void combobox::delete_char(const bool before_cursor)
+{
+	if(before_cursor) {
+		set_cursor(get_selection_start() - 1, false);
+	}
+
+	set_selection_length(1);
+
+	delete_selection();
+}
+
+void combobox::delete_selection()
+{
+	if(get_selection_length() == 0) {
+		return;
+	}
+
+	// If we have a negative range change it to a positive range.
+	// This makes the rest of the algorithms easier.
+	int len = get_selection_length();
+	unsigned start = get_selection_start();
+	if(len < 0) {
+		len = -len;
+		start -= len;
+	}
+
+	std::string tmp = get_value();
+	set_value(utf8::erase(tmp, start, len));
+	set_cursor(start, false);
+}
+
+void combobox::handle_mouse_selection(point mouse, const bool start_selection)
+{
+	mouse.x -= get_x();
+	mouse.y -= get_y();
+	// FIXME we don't test for overflow in width
+	if(mouse.x < static_cast<int>(text_x_offset_)
+	   || mouse.y < static_cast<int>(text_y_offset_)
+	   || mouse.y >= static_cast<int>(text_y_offset_ + text_height_)) {
+		return;
+	}
+
+	int offset = get_column_line(point(mouse.x - text_x_offset_, mouse.y - text_y_offset_)).x;
+
+	if(offset < 0) {
+		return;
+	}
+
+
+	set_cursor(offset, !start_selection);
+	update_canvas();
+	queue_redraw();
+	dragging_ |= start_selection;
+}
+
+void combobox::update_offsets()
+{
+	const auto conf = cast_config_to<combobox_definition>();
+	assert(conf);
+
+	text_height_ = font::get_max_height(get_text_font_size());
+
+	wfl::map_formula_callable variables;
+	variables.add("height", wfl::variant(get_height()));
+	variables.add("width", wfl::variant(get_width()));
+	variables.add("text_font_height", wfl::variant(text_height_));
+
+	text_x_offset_ = conf->text_x_offset(variables);
+	text_y_offset_ = conf->text_y_offset(variables);
+
+	// Since this variable doesn't change set it here instead of in
+	// update_canvas().
+	for(auto & tmp : get_canvases())
+	{
+		tmp.set_variable("text_font_height", wfl::variant(text_height_));
+	}
+
+	// Force an update of the canvas since now text_font_height is known.
+	update_canvas();
+}
+
+void combobox::handle_key_clear_line(SDL_Keymod /*modifier*/, bool& handled)
+{
+	handled = true;
+	set_value("");
+}
+
+void combobox::handle_key_up_arrow(SDL_Keymod /*modifier*/, bool& handled)
+{
+	DBG_GUI_E << LOG_SCOPE_HEADER;
+	handled = true;
+	if (selected_ > 1) {
+		set_selected(selected_ - 1, true);
+	}
+}
+
+void combobox::handle_key_down_arrow(SDL_Keymod /*modifier*/, bool& handled)
+{
+	DBG_GUI_E << LOG_SCOPE_HEADER;
+	handled = true;
+	if (selected_ < values_.size()-1) {
+		set_selected(selected_ + 1, true);
+	}
+}
+
+void combobox::set_values(const std::vector<::config>& values, unsigned selected)
+{
+	assert(selected < values.size());
+	assert(selected_ < values_.size());
+
+	if(values[selected]["label"] != values_[selected_]["label"]) {
+		queue_redraw();
+	}
+
+	values_ = values;
+	selected_ = selected;
+
+//	set_label(values_[selected_]["label"]);
+	text_box_base::set_value(values_[selected_]["label"]);
+}
+
+void combobox::set_selected(unsigned selected, bool fire_event)
+{
+	assert(selected < values_.size());
+	assert(selected_ < values_.size());
+
+	if(selected != selected_) {
+		queue_redraw();
+	}
+
+	selected_ = selected;
+
+//	set_label(values_[selected_]["label"]);
+	text_box_base::set_value(values_[selected_]["label"]);
+	if (fire_event) {
+		fire(event::NOTIFY_MODIFIED, *this, nullptr);
+	}
+}
+
+void combobox::update_mouse_cursor()
+{
+	unsigned x = get_x() + this->get_size().x;
+	unsigned mx = get_mouse_position().x;
+
+	if ((mx <= x) && (mx >= x-ICON_SIZE)) {
+		cursor::set(cursor::NORMAL);
+	} else {
+		cursor::set(cursor::IBEAM);
+	}
+}
+
+void combobox::signal_handler_mouse_enter(const event::ui_event /*event*/,
+											   bool& /*handled*/)
+{
+	update_mouse_cursor();
+}
+
+void combobox::signal_handler_mouse_motion(const event::ui_event event,
+											bool& handled,
+											const point& coordinate)
+{
+	DBG_GUI_E << get_control_type() << "[" << id() << "]: " << event << ".";
+
+	if(dragging_) {
+		handle_mouse_selection(coordinate, false);
+	} else {
+		update_mouse_cursor();
+	}
+
+	handled = true;
+}
+
+void combobox::signal_handler_left_button_down(const event::ui_event event,
+												bool& handled)
+{
+	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
+
+	/* get_x() is the left border
+	 * this->get_size().x is the size of this widget
+	 * so get_x() + this->get_size().x is the right border
+	 * ICON_SIZE is the size of the icon. */
+
+	unsigned x = get_x() + this->get_size().x;
+	unsigned mx = get_mouse_position().x;
+
+	if ((mx <= x) && (mx >= x-ICON_SIZE)) {
+		// If a button has a retval do the default handling.
+		dialogs::drop_down_menu droplist(this, values_, selected_, false);
+
+		if(droplist.show()) {
+			const int selected = droplist.selected_item();
+
+			// Safety check. If the user clicks a selection in the dropdown and moves their mouse away too
+			// quickly, selected_ could be set to -1. This returns in that case, preventing crashes.
+			if(selected < 0) {
+				return;
+			}
+
+			set_selected(selected, true);
+		}
+	} else {
+		/*
+		 * Copied from the base class see how we can do inheritance with the new
+		 * system...
+		 */
+		get_window()->keyboard_capture(this);
+		get_window()->mouse_capture();
+
+		handle_mouse_selection(get_mouse_position(), true);
+	}
+
+	handled = true;
+}
+
+void combobox::signal_handler_left_button_up(const event::ui_event event,
+											  bool& handled)
+{
+	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
+
+	dragging_ = false;
+	handled = true;
+}
+
+void
+combobox::signal_handler_left_button_double_click(const event::ui_event event,
+												   bool& handled)
+{
+	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
+
+	select_all();
+	handled = true;
+}
+
+// }---------- DEFINITION ---------{
+
+combobox_definition::combobox_definition(const config& cfg)
+	: styled_widget_definition(cfg)
+{
+	DBG_GUI_P << "Parsing combobox " << id;
+
+	load_resolutions<resolution>(cfg);
+}
+
+combobox_definition::resolution::resolution(const config& cfg)
+	: resolution_definition(cfg)
+	, text_x_offset(cfg["text_x_offset"])
+	, text_y_offset(cfg["text_y_offset"])
+{
+	// Note the order should be the same as the enum state_t in combobox.hpp.
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for editable text box")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for editable text box")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_focused", _("Missing required state for editable text box")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_hovered", _("Missing required state for editable text box")));
+}
+
+// }---------- BUILDER -----------{
+
+namespace implementation
+{
+
+builder_combobox::builder_combobox(const config& cfg)
+	: builder_styled_widget(cfg)
+	, max_input_length(cfg["max_input_length"])
+	, hint_text(cfg["hint_text"].t_str())
+	, hint_image(cfg["hint_image"])
+	, options_()
+{
+	for(const auto& option : cfg.child_range("option")) {
+		options_.push_back(option);
+	}
+}
+
+std::unique_ptr<widget> builder_combobox::build() const
+{
+	auto widget = std::make_unique<combobox>(*this);
+
+	// A combobox doesn't have a label but a text
+	widget->set_value(label_string);
+
+	if(!options_.empty()) {
+		widget->set_values(options_);
+	}
+
+	widget->set_max_input_length(max_input_length);
+	widget->set_hint_data(hint_text, hint_image);
+
+	DBG_GUI_G << "Window builder: placed text box '" << id
+			  << "' with definition '" << definition << "'.";
+
+	return widget;
+}
+
+} // namespace implementation
+
+// }------------ END --------------
+
+} // namespace gui2

--- a/src/gui/widgets/combobox.hpp
+++ b/src/gui/widgets/combobox.hpp
@@ -1,0 +1,255 @@
+/*
+	Copyright (C) 2008 - 2024
+	by babaissarkar(Subhraman Sarkar) <suvrax@gmail.com>
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "gui/widgets/text_box_base.hpp"
+#include "gui/widgets/text_box.hpp"
+#include "gui/dialogs/drop_down_menu.hpp"
+
+namespace gui2
+{
+namespace implementation
+{
+struct builder_combobox;
+}
+
+// ------------ WIDGET -----------{
+
+/**
+ * @ingroup GUIWidgetWML
+ *
+ * Class for a editable combobox.
+ *
+ * The resolution for a text box also contains the following keys:
+ * Key          |Type                                    |Default  |Description
+ * -------------|----------------------------------------|---------|-----------
+ * text_x_offset| @ref guivartype_f_unsigned "f_unsigned"|""       |The x offset of the text in the text box. This is needed for the code to determine where in the text the mouse clicks, so it can set the cursor properly.
+ * text_y_offset| @ref guivartype_f_unsigned "f_unsigned"|""       |The y offset of the text in the text box.
+ * The following states exist:
+ * * state_enabled - the text box is enabled.
+ * * state_disabled - the text box is disabled.
+ * * state_focussed - the text box has the focus of the keyboard.
+ * The following variables exist:
+ * Key          |Type                                |Default  |Description
+ * -------------|------------------------------------|---------|-----------
+ * label        | @ref guivartype_t_string "t_string"|""       |The initial text of the text box.
+ * history      | @ref guivartype_string "string"    |""       |The name of the history for the text box. A history saves the data entered in a text box between the games. With the up and down arrow it can be accessed. To create a new history item just add a new unique name for this field and the engine will handle the rest.
+ */
+class combobox : public text_box_base
+{
+	friend struct implementation::builder_combobox;
+
+public:
+	explicit combobox(const implementation::builder_styled_widget& builder);
+
+	std::vector<::config> values_;
+
+	unsigned selected_;
+
+	void set_max_input_length(const std::size_t length)
+	{
+		max_input_length_ = length;
+	}
+
+	void set_hint_data(const std::string& text, const std::string& image)
+	{
+		hint_text_ = text;
+		hint_image_ = image;
+
+		update_canvas();
+	}
+
+	void clear()
+	{
+		set_value("");
+	}
+
+	void set_values(const std::vector<::config>& values, unsigned selected = 0);
+
+	void set_selected(unsigned selected, bool fire_event = true);
+
+protected:
+	/***** ***** ***** ***** layout functions ***** ***** ***** *****/
+
+	/** See @ref widget::place. */
+	virtual void place(const point& origin, const point& size) override;
+
+	/***** ***** ***** ***** Inherited ***** ***** ***** *****/
+
+	/** See @ref styled_widget::update_canvas. */
+	virtual void update_canvas() override;
+
+	/** Inherited from text_box_base. */
+	void goto_end_of_line(const bool select = false) override
+	{
+		goto_end_of_data(select);
+	}
+
+	/** Inherited from text_box_base. */
+	void goto_start_of_line(const bool select = false) override
+	{
+		goto_start_of_data(select);
+	}
+
+	/** Inherited from text_box_base. */
+	void delete_char(const bool before_cursor) override;
+
+	/** Inherited from text_box_base. */
+	void delete_selection() override;
+
+	void handle_mouse_selection(point mouse, const bool start_selection);
+
+private:
+
+	/** The maximum length of the text input. */
+	std::size_t max_input_length_;
+
+	/** Size of the dropdown icon
+	 * TODO : Should be dynamically loaded from image
+	 */
+	unsigned const ICON_SIZE = 25;
+
+	/**
+	 * The x offset in the widget where the text starts.
+	 *
+	 * This value is needed to translate a location in the widget to a location
+	 * in the text.
+	 */
+	unsigned text_x_offset_;
+
+	/**
+	 * The y offset in the widget where the text starts.
+	 *
+	 * Needed to determine whether a click is on the text.
+	 */
+	unsigned text_y_offset_;
+
+	/**
+	 * The height of the text itself.
+	 *
+	 * Needed to determine whether a click is on the text.
+	 */
+	unsigned text_height_;
+
+	/** Updates text_x_offset_ and text_y_offset_. */
+	void update_offsets();
+
+	/** Is the mouse in dragging mode, this affects selection in mouse move */
+	bool dragging_;
+
+	/** Helper text to display (such as "Search") if the text box is empty. */
+	std::string hint_text_;
+
+	/** Image (such as a magnifying glass) that accompanies the help text. */
+	std::string hint_image_;
+
+	/**
+	 * Inherited from text_box_base.
+	 *
+	 * Unmodified                 Handled.
+	 * Control                    Ignored.
+	 * Shift                      Ignored.
+	 * Alt                        Ignored.
+	 */
+	void handle_key_up_arrow(SDL_Keymod /*modifier*/, bool& handled) override;
+
+	/**
+	 * Inherited from text_box_base.
+	 *
+	 * Unmodified                 Handled.
+	 * Control                    Ignored.
+	 * Shift                      Ignored.
+	 * Alt                        Ignored.
+	 */
+	void handle_key_down_arrow(SDL_Keymod /*modifier*/, bool& handled) override;
+
+
+	/** Inherited from text_box_base. */
+	void handle_key_clear_line(SDL_Keymod modifier, bool& handled) override;
+
+	/** Update the mouse cursor based on whether it is over button area or text area */
+	void update_mouse_cursor();
+
+public:
+	/** Static type getter that does not rely on the widget being constructed. */
+	static const std::string& type();
+
+private:
+	/** Inherited from styled_widget, implemented by REGISTER_WIDGET. */
+	virtual const std::string& get_control_type() const override;
+
+	/***** ***** ***** signal handlers ***** ****** *****/
+
+	void signal_handler_mouse_enter(const event::ui_event /*event*/, bool& /*handled*/);
+	void signal_handler_mouse_motion(const event::ui_event event,
+									 bool& handled,
+									 const point& coordinate);
+
+	void signal_handler_left_button_down(const event::ui_event event,
+										 bool& handled);
+
+	void signal_handler_left_button_up(const event::ui_event event,
+									   bool& handled);
+
+	void signal_handler_left_button_double_click(const event::ui_event event,
+												 bool& handled);
+};
+
+// }---------- DEFINITION ---------{
+
+struct combobox_definition : public styled_widget_definition
+{
+	explicit combobox_definition(const config& cfg);
+
+	struct resolution : public resolution_definition
+	{
+		explicit resolution(const config& cfg);
+
+		typed_formula<unsigned> text_x_offset;
+		typed_formula<unsigned> text_y_offset;
+	};
+};
+
+// }---------- BUILDER -----------{
+
+namespace implementation
+{
+
+struct builder_combobox : public builder_styled_widget
+{
+public:
+	explicit builder_combobox(const config& cfg);
+
+	using builder_styled_widget::build;
+
+	virtual std::unique_ptr<widget> build() const override;
+
+	std::string history;
+
+	std::size_t max_input_length;
+
+	t_string hint_text;
+	std::string hint_image;
+
+private:
+	std::vector<::config> options_;
+};
+
+} // namespace implementation
+
+// }------------ END --------------
+
+} // namespace gui2

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2008 - 2023
+	Copyright (C) 2008 - 2024
 	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
@@ -202,6 +202,8 @@ void text_box::update_canvas()
 		tmp.set_variable("text_y_offset", wfl::variant(text_y_offset_));
 		tmp.set_variable("text_maximum_width", wfl::variant(max_width));
 		tmp.set_variable("text_maximum_height", wfl::variant(max_height));
+		
+		tmp.set_variable("editable", wfl::variant(is_editable()));
 
 		tmp.set_variable("cursor_offset",
 						 wfl::variant(get_cursor_position(start + length).x));
@@ -425,6 +427,7 @@ builder_text_box::builder_text_box(const config& cfg)
 	, max_input_length(cfg["max_input_length"])
 	, hint_text(cfg["hint_text"].t_str())
 	, hint_image(cfg["hint_image"])
+	, editable(cfg["editable"].to_bool(true))
 {
 }
 
@@ -441,6 +444,7 @@ std::unique_ptr<widget> builder_text_box::build() const
 
 	widget->set_max_input_length(max_input_length);
 	widget->set_hint_data(hint_text, hint_image);
+	widget->set_editable(editable);
 
 	DBG_GUI_G << "Window builder: placed text box '" << id
 			  << "' with definition '" << definition << "'.";

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -1,5 +1,5 @@
 /*
-	Copyright (C) 2008 - 2023
+	Copyright (C) 2008 - 2024
 	by Mark de Wever <koraq@xs4all.nl>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
@@ -351,6 +351,8 @@ public:
 
 	t_string hint_text;
 	std::string hint_image;
+	
+	bool editable;
 };
 
 } // namespace implementation


### PR DESCRIPTION
Intended for 1.19. Contains the combobox widget removed from PR #8199, and the `editable` property support in `text_box`.

**Combobox**
![Screenshot from 2024-01-02 21-00-51](https://github.com/wesnoth/wesnoth/assets/8469888/e0113271-4854-46b9-99f4-985453f8c299)
