### PR TITLE
Tutorial: Specify the side of Li'sar in the char select

### DIFF
--- a/data/campaigns/tutorial/lua/character_selection.lua
+++ b/data/campaigns/tutorial/lua/character_selection.lua
@@ -20,6 +20,7 @@ function wml_actions.select_character()
 	if character == 2 then
 		wesnoth.units.to_map({
 			type = "Fighteress",
+			side = 1,
 			id = unit.id,
 			name = _"Li’sar",
 			unrenamable = true,


### PR DESCRIPTION
When a unit data passed to `to_map` either lacks a side or has side zero, implementation automatically sets it to 1, thus the existing code worked fine. However:

1. The lack of a `side` caused a warning in EmmyLua.

2. The tutorial should be good example code, and the special-case in the C++ code that made this work is a case of "assume it's a SP situation, and choose the result that benefits side 1".

Cherry-picked from #7359.