### PR TITLE
EI - fix S11 cell-door-open event

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -1041,8 +1041,8 @@
             side=1
             [filter_location]
                 x=23,30
-                y=11,14
-                radius=6
+                y=12,15
+                radius=5
             [/filter_location]
         [/filter]
         [remove_shroud]
@@ -1354,8 +1354,8 @@ Your punishment is death."
         [filter]
             side=1
             [filter_location]
-                x,y=25,6
-                radius=1
+                x=25,26
+                y=7,6
             [/filter_location]
         [/filter]
 


### PR DESCRIPTION
You begin the scenario locked in a cell needing to escape through some caves, but it's possible to open the cell from the inside.  This fixes it.  #8386 