### PR TITLE
Multiline Text Area bugfix

### DIFF
--- a/data/gui/widget/multiline_text_default.cfg
+++ b/data/gui/widget/multiline_text_default.cfg
@@ -151,7 +151,7 @@
 		default_height = {HEIGHT}
 
 		max_width = 0
-		max_height = {HEIGHT}
+		max_height = 0
 
 		text_font_size = {FONT_SIZE}
 		text_font_family = {FONT_FAMILY}

--- a/data/schema/schema.cfg
+++ b/data/schema/schema.cfg
@@ -56,13 +56,13 @@
 		name="bool"
 		value="yes|no|true|false"
 	[/type]
-    # Used to override a required key into an optional key with no allowed values.
-    # This should be used for the `name` key in certain tags where it is not allowed,
-    # as the schema can't override a supertag key with its absence.
-    [type]
-        name="disallowed"
-        value="]^"
-    [/type]
+	# Used to override a required key into an optional key with no allowed values.
+	# This should be used for the `name` key in certain tags where it is not allowed,
+	# as the schema can't override a supertag key with its absence.
+	[type]
+		name="disallowed"
+		value="]^"
+	[/type]
 	[tag]
 		name="root"
 		min=1
@@ -85,7 +85,7 @@
 								name="type"
 								max=infinite
 								super="wml_schema/type"
-                                # The `name` key should not exist in a union tag.
+								# The `name` key should not exist in a union tag.
 								{SIMPLE_KEY name disallowed}
 							[/tag]
 						[/tag]
@@ -101,7 +101,7 @@
 									name="type"
 									max=infinite
 									super="wml_schema/type"
-                                    # The `name` key should not exist in an intersection tag.
+									# The `name` key should not exist in an intersection tag.
 									{SIMPLE_KEY name disallowed}
 								[/tag]
 							[/tag]
@@ -121,7 +121,7 @@
 									name="element"
 									max=infinite
 									super="wml_schema/type"
-                                    # The `name` key should not exist in a list/element tag.
+									# The `name` key should not exist in a list/element tag.
 									{SIMPLE_KEY name disallowed}
 								[/tag]
 							[/tag]
@@ -174,14 +174,14 @@
 						super="wml_schema/tag"
 						{REQUIRED_KEY value string}
 						{DEFAULT_KEY trigger_if_missing bool no}
-                        # The `name` key should not exist in a switch/case tag.
-                        {SIMPLE_KEY name disallowed}
+						# The `name` key should not exist in a switch/case tag.
+						{SIMPLE_KEY name disallowed}
 					[/tag]
 					[tag]
 						name="else"
 						super="wml_schema/tag"
-                        # The `name` key should not exist in a switch/else tag.
-                        {SIMPLE_KEY name disallowed}
+						# The `name` key should not exist in a switch/else tag.
+						{SIMPLE_KEY name disallowed}
 					[/tag]
 				[/tag]
 				[tag]
@@ -192,8 +192,8 @@
 					[tag]
 						name="then"
 						super="wml_schema/tag"
-                        # The `name` key should not exist in an if/then tag.
-                        {SIMPLE_KEY name disallowed}
+						# The `name` key should not exist in an if/then tag.
+						{SIMPLE_KEY name disallowed}
 					[/tag]
 					[tag]
 						name="elseif"
@@ -204,15 +204,15 @@
 							name="then"
 							min=1
 							super="wml_schema/tag"
-                            # The `name` key should not exist in an if/elseif/then tag.
-                            {SIMPLE_KEY name disallowed}
+							# The `name` key should not exist in an if/elseif/then tag.
+							{SIMPLE_KEY name disallowed}
 						[/tag]
 					[/tag]
 					[tag]
 						name="else"
 						super="wml_schema/tag"
-                        # The `name` key should not exist in an if/else tag.
-                        {SIMPLE_KEY name disallowed}
+						# The `name` key should not exist in an if/else tag.
+						{SIMPLE_KEY name disallowed}
 					[/tag]
 				[/tag]
 			[/tag]

--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -163,7 +163,7 @@ void scroll_text::place(const point& origin, const point& size) {
 			scroll_vertical_scrollbar(scrollbar_base::BEGIN);
 		}
 	}
-	
+
 	set_max_size(widget->get_config_default_size());
 }
 

--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -30,7 +30,6 @@
 #include "wml_exception.hpp"
 
 #include <functional>
-#include <iostream>
 
 #define LOG_SCOPE_HEADER get_control_type() + " [" + id() + "] " + __func__
 #define LOG_HEADER LOG_SCOPE_HEADER + ':'
@@ -47,6 +46,8 @@ scroll_text::scroll_text(const implementation::builder_scroll_text& builder)
 	, state_(ENABLED)
 	, wrap_on_(false)
 	, text_alignment_(builder.text_alignment)
+	, editable_(true)
+	, max_size_(point(0,0))
 {
 	connect_signal<event::LEFT_BUTTON_DOWN>(
 		std::bind(&scroll_text::signal_handler_left_button_down, this, std::placeholders::_2),
@@ -134,8 +135,9 @@ void scroll_text::finalize_subclass()
 
 void scroll_text::place(const point& origin, const point& size) {
 	scrollbar_container::place(origin, size);
+	multiline_text* widget = get_internal_text_box();
 
-	if(multiline_text* widget = get_internal_text_box()) {
+	if(widget) {
 		const SDL_Rect& visible_area = content_visible_area();
 
 		if (widget->get_cursor_pos().x < visible_area.w/2.0) {
@@ -161,6 +163,8 @@ void scroll_text::place(const point& origin, const point& size) {
 			scroll_vertical_scrollbar(scrollbar_base::BEGIN);
 		}
 	}
+	
+	set_max_size(widget->get_config_default_size());
 }
 
 void scroll_text::set_can_wrap(bool can_wrap)

--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -135,9 +135,8 @@ void scroll_text::finalize_subclass()
 
 void scroll_text::place(const point& origin, const point& size) {
 	scrollbar_container::place(origin, size);
-	multiline_text* widget = get_internal_text_box();
 
-	if(widget) {
+	if(multiline_text* widget = get_internal_text_box()) {
 		const SDL_Rect& visible_area = content_visible_area();
 
 		if (widget->get_cursor_pos().x < visible_area.w/2.0) {
@@ -162,7 +161,7 @@ void scroll_text::place(const point& origin, const point& size) {
 			scroll_horizontal_scrollbar(scrollbar_base::BEGIN);
 			scroll_vertical_scrollbar(scrollbar_base::BEGIN);
 		}
-		
+
 		set_max_size(widget->get_config_default_size());
 	}
 }

--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -162,10 +162,43 @@ void scroll_text::place(const point& origin, const point& size) {
 			scroll_horizontal_scrollbar(scrollbar_base::BEGIN);
 			scroll_vertical_scrollbar(scrollbar_base::BEGIN);
 		}
+		
+		set_max_size(widget->get_config_default_size());
+	}
+}
+
+point scroll_text::calculate_best_size() const
+{
+	point calc_size = scrollbar_container::calculate_best_size();
+
+	if ((calc_size.x > max_size_.x) && (max_size_.x != 0)) {
+		calc_size.x = max_size_.x;
 	}
 
-	set_max_size(widget->get_config_default_size());
+	if ((calc_size.y > max_size_.y) && (max_size_.y != 0)) {
+		calc_size.y = max_size_.y;
+	}
+
+	return calc_size;
 }
+
+void scroll_text::set_max_size(point max_size)
+{
+	// ------ get vertical scrollbar size ------
+	const point vertical_scrollbar = get_vertical_scrollbar_grid()->get_visible() == widget::visibility::invisible
+		? point()
+		: get_vertical_scrollbar_grid()->get_best_size();
+
+	// ------ get horizontal scrollbar size ------
+	const point horizontal_scrollbar = get_horizontal_scrollbar_grid()->get_visible() == widget::visibility::invisible
+		? point()
+		: get_horizontal_scrollbar_grid()->get_best_size();
+
+	// padding = 3
+	max_size_ = point(max_size.x + vertical_scrollbar.x + 3, max_size.y + horizontal_scrollbar.y + 3);
+}
+
+
 
 void scroll_text::set_can_wrap(bool can_wrap)
 {
@@ -189,7 +222,7 @@ void scroll_text::signal_handler_left_button_down(const event::ui_event event)
 scroll_text_definition::scroll_text_definition(const config& cfg)
 	: styled_widget_definition(cfg)
 {
-	DBG_GUI_P << "Parsing scroll label " << id;
+	DBG_GUI_P << "Parsing scroll text " << id;
 
 	load_resolutions<resolution>(cfg);
 }
@@ -198,10 +231,10 @@ scroll_text_definition::resolution::resolution(const config& cfg)
 	: resolution_definition(cfg), grid(nullptr)
 {
 	// Note the order should be the same as the enum state_t is scroll_text.hpp.
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for scroll label control")));
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for scroll label control")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for scroll text control")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for scroll text control")));
 
-	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for scroll label control"));
+	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for scroll text control"));
 	grid = std::make_shared<builder_grid>(child);
 }
 
@@ -217,7 +250,7 @@ builder_scroll_text::builder_scroll_text(const config& cfg)
 	, text_alignment(decode_text_alignment(cfg["text_alignment"]))
 	, editable(cfg["editable"].to_bool(true))
 {
-	/** Horizontal scrollbar default to auto. AUTO_VISIBLE_FIRST_RUN doesn't work. */
+	// Scrollbar default to auto. AUTO_VISIBLE_FIRST_RUN doesn't work.
 	if (horizontal_scrollbar_mode == scrollbar_container::AUTO_VISIBLE_FIRST_RUN) {
 		horizontal_scrollbar_mode = scrollbar_container::AUTO_VISIBLE;
 	}
@@ -242,7 +275,7 @@ std::unique_ptr<widget> builder_scroll_text::build() const
 	widget->init_grid(*conf->grid);
 	widget->finalize_setup();
 
-	DBG_GUI_G << "Window builder: placed scroll label '" << id
+	DBG_GUI_G << "Window builder: placed scroll text '" << id
 			  << "' with definition '" << definition << "'.";
 
 	return widget;

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -143,7 +143,7 @@ private:
 	PangoAlignment text_alignment_;
 
 	bool editable_;
-	
+
 	point max_size_;
 
 	void finalize_subclass() override;
@@ -164,23 +164,23 @@ private:
 	}
 
 	void place(const point& origin, const point& size);
-	
+
 	/** See @ref widget::calculate_best_size. */
 	point calculate_best_size() const override
 	{
 		point calc_size = scrollbar_container::calculate_best_size();
-		
+
 		if ((calc_size.x > max_size_.x) && (max_size_.x != 0)) {
 			calc_size.x = max_size_.x;
 		}
-		
+
 		if ((calc_size.y > max_size_.y) && (max_size_.y != 0)) {
 			calc_size.y = max_size_.y;
 		}
-		
+
 		return calc_size;
 	}
-	
+
 	void set_max_size(point max_size)
 	{
 		/***** get vertical scrollbar size *****/
@@ -192,7 +192,7 @@ private:
 		const point horizontal_scrollbar = get_horizontal_scrollbar_grid()->get_visible() == widget::visibility::invisible
 			? point()
 			: get_horizontal_scrollbar_grid()->get_best_size();
-		
+
 		// padding = 3
 		max_size_ = point(max_size.x + vertical_scrollbar.x + 3, max_size.y + horizontal_scrollbar.y + 3);
 	}

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -143,6 +143,8 @@ private:
 	PangoAlignment text_alignment_;
 
 	bool editable_;
+	
+	point max_size_;
 
 	void finalize_subclass() override;
 
@@ -162,6 +164,38 @@ private:
 	}
 
 	void place(const point& origin, const point& size);
+	
+	/** See @ref widget::calculate_best_size. */
+	point calculate_best_size() const override
+	{
+		point calc_size = scrollbar_container::calculate_best_size();
+		
+		if ((calc_size.x > max_size_.x) && (max_size_.x != 0)) {
+			calc_size.x = max_size_.x;
+		}
+		
+		if ((calc_size.y > max_size_.y) && (max_size_.y != 0)) {
+			calc_size.y = max_size_.y;
+		}
+		
+		return calc_size;
+	}
+	
+	void set_max_size(point max_size)
+	{
+		/***** get vertical scrollbar size *****/
+		const point vertical_scrollbar = get_vertical_scrollbar_grid()->get_visible() == widget::visibility::invisible
+			? point()
+			: get_vertical_scrollbar_grid()->get_best_size();
+
+		/***** get horizontal scrollbar size *****/
+		const point horizontal_scrollbar = get_horizontal_scrollbar_grid()->get_visible() == widget::visibility::invisible
+			? point()
+			: get_horizontal_scrollbar_grid()->get_best_size();
+		
+		// padding = 3
+		max_size_ = point(max_size.x + vertical_scrollbar.x + 3, max_size.y + horizontal_scrollbar.y + 3);
+	}
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -166,36 +166,10 @@ private:
 	void place(const point& origin, const point& size);
 
 	/** See @ref widget::calculate_best_size. */
-	point calculate_best_size() const override
-	{
-		point calc_size = scrollbar_container::calculate_best_size();
+	point calculate_best_size() const override;
 
-		if ((calc_size.x > max_size_.x) && (max_size_.x != 0)) {
-			calc_size.x = max_size_.x;
-		}
-
-		if ((calc_size.y > max_size_.y) && (max_size_.y != 0)) {
-			calc_size.y = max_size_.y;
-		}
-
-		return calc_size;
-	}
-
-	void set_max_size(point max_size)
-	{
-		/***** get vertical scrollbar size *****/
-		const point vertical_scrollbar = get_vertical_scrollbar_grid()->get_visible() == widget::visibility::invisible
-			? point()
-			: get_vertical_scrollbar_grid()->get_best_size();
-
-		/***** get horizontal scrollbar size *****/
-		const point horizontal_scrollbar = get_horizontal_scrollbar_grid()->get_visible() == widget::visibility::invisible
-			? point()
-			: get_horizontal_scrollbar_grid()->get_best_size();
-
-		// padding = 3
-		max_size_ = point(max_size.x + vertical_scrollbar.x + 3, max_size.y + horizontal_scrollbar.y + 3);
-	}
+	/** Sets the size of the text beyond which scrollbars should be visible. */
+	void set_max_size(point max_size);
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/scrollbar_container.hpp
+++ b/src/gui/widgets/scrollbar_container.hpp
@@ -101,7 +101,7 @@ public:
 	 */
 	virtual bool can_wrap() const override;
 
-private:
+protected:
 	/** See @ref widget::calculate_best_size. */
 	virtual point calculate_best_size() const override;
 

--- a/src/gui/widgets/spinner.cpp
+++ b/src/gui/widgets/spinner.cpp
@@ -140,10 +140,10 @@ spinner_definition::resolution::resolution(const config& cfg)
 	: resolution_definition(cfg), grid(nullptr)
 {
 	// Note the order should be the same as the enum state_t is spinner.hpp.
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for scroll label control")));
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for scroll label control")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for spinner control")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for spinner control")));
 
-	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for scroll label control"));
+	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for spinner control"));
 	grid = std::make_shared<builder_grid>(child);
 }
 


### PR DESCRIPTION
Fixes the following bugs :
1. Stop `scroll_text` from growing infinitely and instead show the scrollbars when the text dimensions exceed the default size of the underlying `multiline_text` in some dialogs (such as edit_pbl, the pbl publishing editor).
2. Allow `horizontal_grow`/`vertical_grow` to work correctly. Currently, the widget stops vertically growing due to absence of `max_height=0`, again in some specific dialogs.