### PR TITLE
EI - dra_nak_dead branch bugfix

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -879,22 +879,30 @@ Capture the west bank."
     [/event]
 
     [event]
-        name=victory
-        {CLEAR_VARIABLE dra_nak_dead}
-    [/event]
-
-    [event]
         name=last breath
 
         [filter]
             id=Varrak-Klar
         [/filter]
 
-        [message]
-            speaker="Varrak-Klar"
-            message= _ "Graahh! Stupid humans..."
-        [/message]
+        [if]
+            {VARIABLE_CONDITIONAL dra_nak_dead equals yes}
+            [then]
+                [message]
+                    speaker="Varrak-Klar"
+                    message= _ "Graahh! Stupid humans..."
+                [/message]
+            [/then]
+            [else]
+                [message]
+                    speaker="Varrak-Klar" # name is 'Chief Dra-Nak' here
+                    message= _ "Curse you all! Why couldn’t you have just died as tribute like everyone else? Now my glorious golden Empire will never be..."
+                [/message]
+                {VARIABLE dra_nak_dead yes}
+            [/else]
+        [/if]
     [/event]
+    
     [event]
         name=last breath
 

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -515,6 +515,10 @@ We should press the attack."
             type_adv_tree=Drake Fighter,Drake Burner,Drake Glider
         [/not]
 
+        [not]
+            variation=drake,falcon,gryphon,bat
+        [/not]
+
         fire_event=yes
         animate=yes
     [/kill]
@@ -599,6 +603,9 @@ We should press the attack."
                     {PUT_TO_RECALL_LIST (
                         side=1
                         {NOT_ACROSS_RIVER}
+                        [not]
+                            variation=drake,falcon,gryphon,bat
+                        [/not]
                     )}
 
                     # if we have a meaningful amount of leveled units, play a brief cutscene
@@ -766,6 +773,9 @@ Flight of Mortic, we fight!"
                     [kill]
                         side=1
                         {NOT_ACROSS_RIVER}
+                        [not]
+                            variation=drake,falcon,gryphon,bat
+                        [/not]
                     [/kill]
 
                     [endlevel]

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -902,7 +902,6 @@ Capture the west bank."
             [/else]
         [/if]
     [/event]
-    
     [event]
         name=last breath
 


### PR DESCRIPTION
Fixes #8414.

S18 conditionally forwards the player to the bonus scenario, S99. One of the required conditions is that dra_nak_dead is not yes. The victory event of S12 unconditionally clears dra_nak_dead, meaning that that test in S18 will always pass.

S12 tests dra_nak_dead to see if he was killed in S11, and if he wasn't then it renames "Varrak-Klar" to "Chief Dra-Nak", as if Dra-Nak was pursuing the heroes. However, S12 doesn't set the dra_nak_dead variable if the renamed Varrak-Klar dies.
