### PR TITLE
EI S11-S18: Add more PO hints

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
@@ -216,6 +216,7 @@
         [/message]
         [message]
             speaker=Vaelya
+            #po: followed by a delay and then the elves switching from allies to enemies
             message= _ "I am sorry to hear of your misfortune. Our scouts had spotted undead in this area, but I am shocked to hear that they are attacking Wesnoth. And if they are hunting you, then..."
         [/message]
 
@@ -278,11 +279,13 @@
         [/unit]
         [message]
             speaker=Nafga
+            #po: What are your orders for me to perform, Addogin?
             message= _ "And what about me?"
         [/message]
         [message]
             speaker=Addogin
             #po: "you" being a single male Orcish Slayer or Orcish Nightblade
+            #po: later in the campaign, it's revealed that the necromancers are buying corpses, and a lot are being sold
             message= _ "Into the forest with you. If it comes to bloodshed, strike at them from behind. And don’t even think of running off with any corpses before I can collect our bounty!"
         [/message]
         [store_unit]
@@ -360,7 +363,7 @@
         [then]
             [message]
                 speaker=Vaelya
-                #po: to the remaining orcish mercenaries
+                #po: to the remaining mercenaries, who are orcs and human outlaws
                 message= _ "No, we need your help! Please come back!"
             [/message]
             [message]
@@ -411,10 +414,12 @@
         {MOVE_UNIT id=$second_unit.id 15 1}
         [message]
             speaker=$second_unit.id
+            #po: capturing Addogin, spoken by the unit fighting him
             message= _ "Oh no you don’t! You and your band of mercenaries have caused us enough trouble! How do we know you won’t rally your men and attack us again?"
         [/message]
         [message]
             speaker=Gweddry
+            #po: capturing Addogin
             message= _ "I suppose we’ll have to bring him with us, at least for a time. Tie him up so he doesn’t run away."
         [/message]
         [message]
@@ -490,6 +495,7 @@
 
         [message]
             speaker=Nafga
+            #po: last breath
             message= _ "No! This is the first and last time I have failed a mission!"
         [/message]
     [/event]
@@ -502,6 +508,7 @@
 
         [message]
             speaker=Vaelya
+            #po: last breath
             message= _ "I only wanted... to protect my people..."
         [/message]
         {KILL id=Vaelya}
@@ -538,6 +545,7 @@
 
         [message]
             speaker=unit
+            #po: The valley of the River Weldyn, although there's also a city with the same name.
             message= _ "I’ve made it through the forest and I can see the valley Weldyn open on the other side!"
         [/message]
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04b_Ill_Humors.cfg
@@ -418,6 +418,7 @@
             message= _ "Quiet, someone approaches..."
         [/message]
         [message]
+            #po: Speaker (not the spoken text), but used both for humans in S04b and later for the voices from the amulet
             caption= _ "Unknown"
             image=units/unknown-unit1.png
             #po: male speaker talking to female
@@ -426,6 +427,7 @@
             message= _ "It must be here somewhere! I’m telling you, alswdan only grows in swamps, and this is the grandest one on the continent."
         [/message]
         [message]
+            #po: Speaker (not the spoken text), but used both for humans in S04b and later for the voices from the amulet
             caption= _ "Unknown 2"
             image=units/unknown-unit2.png
             #po: female speaker talking to male, but "us" being a group of at least 5

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -730,7 +730,7 @@
                 [/delay]
 
                 [if]
-                    # elixer of elements and yetiburger grant immunity to frostbite
+                    # elixir of elements and yetiburger grant immunity to frostbite
                     # (there's only 2 immunity items and you have 3 heroes, so this isn't abusable to farm infinite gold)
                     [have_unit]
                         id=$unit.id
@@ -740,7 +740,7 @@
                     [then]
                         [floating_text]
                             x,y=$unit.x,$unit.y
-                            #po: other units are taking damage from the cold, but this unit is immune (through the elixer or yetiburger)
+                            #po: other units are taking damage from the cold, but this unit is immune (through the elixir or yetiburger)
                             text= _ "<span color='#00FF00' size='small'>resist</span>"
                         [/floating_text]
                     [/then]

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -125,6 +125,7 @@
         color=white
         type=Orcish Warlord
         id=Varrak-Klar
+        #po: In S11, an orc with so much gold for recruitment that the player can't beat them, acts as a turn limit.
         name=_"Varrak-Klar" # this guy reappears in S12 Evacuation, if you kill Dra-Nak
         [modifications]
             {TRAIT_RESILIENT}
@@ -150,6 +151,7 @@
         color=white
         type=Orcish Slurbow
         id=Rakkha
+        #po: In S11, an orc with so much gold for recruitment that the player can't beat them, acts as a turn limit.
         name=_"Rakkha" # this guy reappears in S12 Evacuation
         [modifications]
             {TRAIT_QUICK}
@@ -649,6 +651,8 @@
 
         [message]
             speaker=narrator
+            #po: Exactly four units are in this jail cell, identified as "role=escapee ..." in the po hints.
+            #po: 3 were in Gweddry's recall list, but escapee sidekick 2 deserted from another Wesnoth commander
             message= _ "Several of Gweddry’s men find themselves locked away in a crude orcish cell."
             image=wesnoth-icon.png
         [/message]
@@ -658,7 +662,7 @@
         [/message]
         [message]
             role=escapee sidekick 2
-            #po: Speaker is the male deserter, however the other units don't know their backstory yet
+            #po: Speaker is the male deserter, however the other units don't know his backstory yet
             message= _ "I’m sure your commanders will come and save us!"
         [/message]
         [message]
@@ -714,6 +718,7 @@
                 condition=win
             [/objective]
             [objective]
+                #po: Initially shown with 4 escapees.
                 description= _ "Death of the escapees"
                 condition=lose
             [/objective]
@@ -732,6 +737,7 @@
         [/filter]
         [message]
             speaker=unit
+            #po: the escapees' cell door
             message= _ "The door won’t open from this side."
         [/message]
     [/event]
@@ -750,9 +756,11 @@
             {STORE_UNIT_VAR (role=escapee sidekick 2) name deserter_name}
             [message]
                 role=escapee sidekick 1
-                #po: The speaker is male. The deserter, "escapee sidekick 2", will always be male. The other escapees are random units from the player's recall list
+                #po: The speaker is male. The deserter, "escapee sidekick 2", will always be male.
+                #po: The other escapees, including the speaker, are 3 random units from the player's recall list.
                 message= _ "$deserter_name, I don’t recognize you, and you look like you’ve been locked up longer than the rest of us. How did you get here?"
-                #po: The speaker is female. The deserter, "escapee sidekick 2", will always be male. The other escapees are random units from the player's recall list
+                #po: The speaker is female. The deserter, "escapee sidekick 2", will always be male.
+                #po: The other escapees, including the speaker, are 3 random units from the player's recall list.
                 female_message= _ "female^$deserter_name, I don’t recognize you, and you look like you’ve been locked up longer than the rest of us. How did you get here?"
             [/message]
             {CLEAR_VARIABLE deserter_name}
@@ -1035,11 +1043,15 @@
         {MODIFY_UNIT (id=Chief Dra-Nak) resting no}
     [/event]
 
+    # unshroud the throne room when the disguised character can see it
     [event]
         name=moveto
         [filter]
             side=1
             [filter_location]
+                # The disguised character still needs to stay outside the ZoC of all the guards.
+                # That leaves two routes to the cells - near the west wall (passing near 23,12),
+                # or a loop south and behind the throne (passing near 30,15).
                 x=23,30
                 y=12,15
                 radius=5
@@ -1064,10 +1076,12 @@
         {SCROLL_TO 30 15}
         [message]
             speaker=Chief Dra-Nak
+            #po: Gweddry, Dacyn and Owaec are being held by guards in front of Dra-Nak's throne
             message= _ "You’ve been a difficult prize to capture, but well worth the cost! Human corpses may not sell as well as dwarf or drake tribute, but with this many of you, I’ll still fetch a hefty bounty."
         [/message]
         [message]
             speaker=Gweddry
+            #po: The nearest guards are orcs, but there are drakes guarding the edge of the room.
             message= _ "Drakes, surely you can see that this orc does not have your best interests at heart? He is bleeding your numbers to fund his empire while your leader stands by and does nothing!"
         [/message]
         [message]
@@ -1136,22 +1150,27 @@ I serve his will."
         [/animate_unit]
         [message]
             speaker=Chief Dra-Nak
+            #po: Owaec has attacked the orc
             message= _ "Hah, that almost hurt! I’m gonna enjoy shipping you lot down south. Maybe this time, the necromancers will let me watch..."
         [/message]
 
         {SCROLL_TO 21 16}
         [message]
             speaker=unit
+            #po: speaker is the escapee wearing the orc disguise, there are around 10 guards
             message={WHISPER _"Opening the cells should confuse the guards for a moment. But I better not get too close to them..."}
         [/message]
 
         [objectives]
             side=1
             [objective]
+                #po: At least one cell is still locked. There's one with 8 Wesnothians, one with 6 Wesnothians,
+                #po: and one containing 4 Wesnothians plus 2 Drakes.
                 description= _ "Release the other prisoners"
                 condition=win
             [/objective]
             [objective]
+                #po: Later shown meaning all of the released prisoners. Some can die, just not all.
                 description= _ "Death of the escapees"
                 condition=lose
             [/objective]
@@ -1220,9 +1239,9 @@ I serve his will."
             [/have_unit]
 
             [then]
-                # when we're still stealthy
                 [message]
                     speaker=unit
+                    #po: while the speaker is still in disguise
                     message= _"Here’s one of the prison cells! As soon as I open this, all hell is going to break loose."
                 [/message]
             [/then]
@@ -1273,8 +1292,10 @@ I serve his will."
         [/fire_event]
         [message]
             speaker=unit
+            #po: prompt to the player
             message= _ "Open the cell?"
             [option]
+                #po: choice when prompted "open the cell?"
                 label= _ "Yes! <i>(freed units will incur upkeep)</i>"
                 [command]
                     [sound]
@@ -1305,6 +1326,7 @@ I serve his will."
                 [/command]
             [/option]
             [option]
+                #po: choice when prompted "open the cell?"
                 label= _ "Not yet..."
                 [command]
                 [/command]
@@ -1324,7 +1346,7 @@ Never again shall I be prisoner!"
         [/message]
         [message]
             speaker=Verash
-            #po: Ga'all and Verash are drakes from S10
+            #po: Ga'all and Verash are drakes from S10, this is followed by Verash killing Ga'all
             message= _ "You disobey the Aspirant.
 For your treachery,
 Your punishment is death."
@@ -1465,6 +1487,8 @@ Your punishment is death."
 
                 [message]
                     speaker=Chief Dra-Nak
+                    #po: shouted to the two leaders who are positioned outside the orcs' caves, happens 2 turns after the main escape starts
+                    #po: combined with removing shroud to reveal that those two leaders recruited last turn (and have full castles on normal or hard)
                     message= _ "The prisoners are escaping! Get in here and stop them!"
                 [/message]
                 [remove_shroud]
@@ -1479,10 +1503,12 @@ Your punishment is death."
                 [/remove_shroud]
                 [message]
                     speaker=Rakkha
+                    #po: orc leader who was guarding against external threats sends troops into the orcs' throneroom
                     message= _ "Protect the Chief!"
                 [/message]
                 [message]
                     speaker=Varrak-Klar
+                    #po: orc leader who was guarding against external threats sends troops into the orcs' throneroom
                     message= _ "Into the caves!"
                 [/message]
                 [if]
@@ -1522,18 +1548,22 @@ Your punishment is death."
                         name=side 1 turn end
                         [message]
                             speaker=Owaec
+                            #po: 3 turns after the main escape starts
                             message= _ "Such carnage in this dark confined cave... how I long to once again gaze upon the rolling plains of my homeland. These lands are cold, but the thought of my fellow Clansmen is as a fire burning in my breast."
                         [/message]
                         [message]
                             speaker=Gweddry
+                            #po: "there" being the Horse Clans' plains
                             message= _ "Wesnoth’s best horses and much of Weldyn’s food is come from there. I’m sure it’s well-defended, despite never having visited there myself."
                         [/message]
                         [message]
                             speaker=Owaec
+                            #po: "them" being the Horse Clans' plains
                             message= _ "There is naught that I can speak that would truly do them justice! You will have to see the plains yourself to appreciate their majesty."
                         [/message]
                         [message]
                             speaker=Gweddry
+                            #po: "them" being the Horse Clans' plains
                             message= _ "Then let us return quickly to Wesnoth to aid in their defense!"
                         [/message]
                     [/event]
@@ -1627,16 +1657,19 @@ Your punishment is death."
         {SCROLL_TO 31 21}
         [message]
             speaker=unit
+            #po: goblin with a ring of invisibility
             message= _ "Oooh so shiny, my precious... what a great gift from the Chief..."
         [/message]
         [message]
             speaker=unit
+            #po: goblin with a ring of invisibility (although not enough sense to wear it when running away)
             message= _ "Aaah! Humans! Run away run away!"
         [/message]
         {MOVE_UNIT (id=Cowardly Goblin) 34 28}
         {KILL (id=Cowardly Goblin)}
         [message]
             speaker=second_unit
+            #po: unit who discovered the goblin with a ring of invisibility
             message= _ "Hmm, looks like he dropped something."
         [/message]
     [/event]
@@ -1658,6 +1691,7 @@ Your punishment is death."
         [/filter]
         [message]
             speaker=unit
+            #po: if the disguised unit runs out of the caves alone, without rescuing any other prisoners
             message= _ "Phew! I made it."
         [/message]
         [message]
@@ -1667,6 +1701,7 @@ Your punishment is death."
                 x,y=$x1,$y1
             [/not]
 
+            #po: if the disguised unit runs out of the caves alone, without rescuing any other prisoners
             message= _ "Where are you going?! Come back!"
         [/message]
         [endlevel]
@@ -1684,6 +1719,7 @@ Your punishment is death."
         [/filter]
         [message]
             speaker=unit
+            #po: One of the main heroes gets outside, triggering the victory condition
             message= _ "I’ve reached the exit! We’ll have to make a run for it!"
         [/message]
         [message]
@@ -1714,6 +1750,7 @@ Your punishment is death."
 
         [message]
             speaker="Chief Dra-Nak"
+            #po: immediate response to Boja's death
             message= _ "You killed my bear, you filthy humans! You’ll pay for that!"
         [/message]
 
@@ -1750,6 +1787,7 @@ Your punishment is death."
 
         [message]
             speaker="Chief Dra-Nak"
+            #po: last breath event for Chief Dra-Nak
             message= _ "Curse you all! Why couldn’t you have just died as tribute like everyone else? Now my glorious golden Empire will never be..."
         [/message]
         {VARIABLE dra_nak_dead yes}
@@ -1770,6 +1808,7 @@ Your punishment is death."
 
         [message]
             speaker=Gweddry
+            #po: die event for Chief Dra-Nak
             message= _ "Look, he was carrying the key to their treasury!"
         [/message]
         {SCROLL_TO 34 11}

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -655,7 +655,7 @@ We should press the attack."
                                     id=Hahid al-Ali
                                 [/not]
                                 #po: Said by any left-behind unit except Hahid al-Ali (it would be very out of character for him).
-                                #po: TODO is the "we" in this a typo? It seems more likely to be "you must ride ..."
+                                #po: TODO in 1.19: the "we" in this is a typo. It should be "you must ride ..."
                                 message= _ "At least you three commanders are safe. From here, we must ride swift, ride strong, and ride to save all of Wesnoth!"
                             [/message]
                         [/then]

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -65,6 +65,8 @@
         side=2
         type=Orcish Warlord
         id=Varrak-Klar
+        #po: In S12, a leader with a high but not unbeatable amount of gold.
+        #po: However, if Chief Dra-Nak survived S11 then S12's Varrak-Klar will be changed to an Orcish Sovereign and renamed to appear to be the Chief pursuing the escapees.
         name= _ "Varrak-Klar"
         canrecruit=yes
         facing=sw
@@ -176,6 +178,7 @@
         side=4
         type=Orcish Slurbow
         id=Rakkha
+        #po: In S12, a leader with a high but not unbeatable amount of gold.
         name= _ "Rakkha"
         canrecruit=yes
         facing=sw
@@ -378,10 +381,13 @@
         [/if]
         [message]
             speaker=Owaec
+            #po: Although Dacyn is a Mage of Light, he currently doesn't have a halo.
+            #po: In the unlikely case that he was still L2 when he picked up the amulet, he's automatically advanced at that point in S10.
             message= _ "Small wonder your Light has abandoned you, if you would leave our companions to the mercy of the orcs! We should all cross together and leave none behind!"
         [/message]
         [message]
             speaker=Dacyn
+            #po: After this message the halo flickers and then stays on.
             message= _ "(cough) My light? ...oh, oh yes, yes of course. Just one moment."
         [/message]
         [repeat]
@@ -415,6 +421,7 @@
         [/filter_condition]
         [message]
             speaker=Hahid al-Ali
+            #po: He drinks an elixir between this message and the next one
             message= _ "Trapped among barbarians and pursued by orcs... how in the sands did I get here? Time to break out something I’ve been saving for a rainy day..."
         [/message]
 
@@ -427,6 +434,7 @@
 
         [message]
             speaker=Hahid al-Ali
+            #po: He drank an elixir between the last message and this one
             message= _ "Nothing like some extra speed to help me get away!"
         [/message]
     [/event]
@@ -435,6 +443,8 @@
         name=turn 5
         [message]
             speaker=Owaec
+            #po: Addressed to Gweddry, but many of the heroes except Dacyn are together in this conversation, assuming the player managed to collect them.
+            #po: It has to still make sense with only Gweddry and Owaec talking to each other.
             message= _ "Gweddry, you saw how Dacyn struggled to channel his Light. What do you think of this?"
         [/message]
         [message]
@@ -459,12 +469,12 @@
         [/message]
         [message]
             speaker=Hahid al-Ali
+            #po: Last message in the "Gweddry, you saw how Dacyn struggled to channel his Light" conversation
             message= _ "Bah, magic! There’s a reason the civilized people of my world eschew magic — we would never have to deal with problems like this back in my homeland."
         [/message]
     [/event]
 
     # orcs announce their daytime retreat (and drakes complain about it)
-    # give the player a chance to react. By now they should know that enemies retreat during the day, but it's especially important to know now so you can evacuate
     [event]
         name=turn 7
 
@@ -483,10 +493,12 @@
         [message]
             race=orc
             canrecruit=yes
+            #po: Speaker might be any of Chief Dra-Nak, Varrak-Klar or Rakkha; all three are male orcs.
             message= _ "(squinting) I can’t see anything in this searing sunlight. Fall back, wait for dusk!"
         [/message]
         [message]
             id=Mortic
+            #po: to the male orc leader who's ordering the retreat
             message= _ "The sun strengthens my kin.
 Daytime is our Domain.
 We should press the attack."
@@ -494,6 +506,8 @@ We should press the attack."
         [message]
             race=orc
             canrecruit=yes
+            #po: The messages in this event give the player a chance to react to the retreat.
+            #po: By now they should know that enemies retreat during the day, but it's especially important to know now so they can evacuate.
             message= _ "You heard me, wyrm! Wait. For. Dusk."
         [/message]
     [/event]
@@ -570,6 +584,7 @@ We should press the attack."
                         [then]
                             [message]
                                 speaker=Dacyn
+                                #po: Owaec has just destroyed the bridge
                                 message= _ "Owaec, you fool! I am trapped on the east bank! Without my help Wesnoth will surely fall to Mal-Ravanal..."
                             [/message]
                             [endlevel]
@@ -583,6 +598,7 @@ We should press the attack."
                         [then]
                             [message]
                                 speaker=Dacyn
+                                #po: Owaec has just destroyed the bridge
                                 message= _ "Owaec, you fool! Gweddry is trapped on the east bank! Without his help Wesnoth will surely fall to Mal-Ravanal..."
                             [/message]
                             [endlevel]
@@ -603,7 +619,7 @@ We should press the attack."
 
                     # if we have a meaningful amount of leveled units, play a brief cutscene
                     {STORE_RECALLS (level=2-99) left_behind_units} # first just store the 2-99 level units, so we can check the count
-                    {STORE_RECALLS (level=2-99) gweddrys_remnants} # save these units in a new variable, which we'll use for S20 (the original variable gets modified)
+                    {STORE_RECALLS (level=2-99) gweddrys_remnants} # save these units in a new variable, which we'll use for the bonus scenario S99 (the original variable gets modified)
                     [if]
                         {VARIABLE_CONDITIONAL left_behind_units.length greater_than_equal_to 2}
                         [then]
@@ -627,6 +643,7 @@ We should press the attack."
 
                             [message]
                                 speaker=Owaec
+                                #po: Several high-level units were left unrecalled. For a brief cutscene, 10 unrecalled units (high levels preferred) appear on the starting castle.
                                 message= _ "Alas, what have I done? So many brave soldiers of Wesnoth, left behind in the wildlands..."
                             [/message]
                             [message]
@@ -637,7 +654,8 @@ We should press the attack."
                                 [not]
                                     id=Hahid al-Ali
                                 [/not]
-                                # would be very out of character for him
+                                #po: Said by any left-behind unit except Hahid al-Ali (it would be very out of character for him).
+                                #po: TODO is the "we" in this a typo? It seems more likely to be "you must ride ..."
                                 message= _ "At least you three commanders are safe. From here, we must ride swift, ride strong, and ride to save all of Wesnoth!"
                             [/message]
                         [/then]
@@ -645,6 +663,7 @@ We should press the attack."
                         [else]
                             [message]
                                 speaker=Owaec
+                                #po: either got everyone across or left behind at most one L2 or L3 unit
                                 message= _ "Huzzah, we have escaped the northerners! A true Clansman would never willingly leave his companions behind, and so have we clutched victory from the jaws of defeat!"
                             [/message]
                         [/else]
@@ -683,10 +702,10 @@ We should press the attack."
                         [/have_unit]
 
                         [then]
-                            # it's ok if the orcs don't have a speaker
                             [message]
                                 race=orc
                                 canrecruit=yes
+                                #po: Spoken to Mortic, but at this point it's possible that all the orc leaders are dead, in which case it doesn't get said.
                                 message= _ "Useless pathetic ugly weakling wyrms! Fly across and chase after them, or we’ll sell you <i>all</i> to the necromancers!"
                             [/message]
                             [if]
@@ -694,6 +713,7 @@ We should press the attack."
                                 [then]
                                     [message]
                                         speaker=Mortic
+                                        #po: to his fellow drakes, and any surviving orcs
                                         message= _ "Dra-Nak is dead,
 His armies weakened,
 His prey fled."
@@ -703,6 +723,7 @@ His prey fled."
                                 [else]
                                     [message]
                                         speaker=Mortic
+                                        #po: to his fellow drakes, and any surviving orcs
                                         message= _ "Dra-Nak is feeble,
 His armies weakened,
 His prey fled."
@@ -711,6 +732,7 @@ His prey fled."
                             [/if]
                             [message]
                                 speaker=Mortic
+                                #po: to his fellow drakes, and any surviving orcs
                                 message= _ "Long has our Honor been stained.
 No longer shall it be.
 Now we reclaim our Aerie,
@@ -736,6 +758,7 @@ And the strength of our Flight."
                             {MOVE_UNIT id=Mortic $found_unit.x $found_unit.y}
                             [message]
                                 speaker=$found_unit.id
+                                #po: Speaker is an orc, and Mortic is flying towards them. "What? Hey!" *gets killed by Mortic*
                                 message= _ "Wha- hey!"
                             [/message]
                             [animate_unit]
@@ -759,7 +782,7 @@ And the strength of our Flight."
 The orcs our prey!
 Flight of Mortic, we fight!"
                             [/message]
-                            {VARIABLE drakes_rebelling yes} # used for S13 into text
+                            {VARIABLE drakes_rebelling yes} # used for S13 intro text
                         [/then]
                     [/if]
 
@@ -811,6 +834,7 @@ Capture the west bank."
                 [message]
                     side=2,4
                     canrecruit=yes
+                    #po: spoken by the leader of either orc side. Lots of drakes appear immediately after this.
                     message= _ "We need help over here! Where are the rest of those lousy drakes? They should be in position by now!"
                 [/message]
             [/then]
@@ -904,6 +928,7 @@ Capture the west bank."
 
         [message]
             speaker=Mortic
+            #po: Aspirant is a drake military rank
             message= _ "I am Aspirant no more."
         [/message]
         {VARIABLE mortic_dead yes}

--- a/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
@@ -273,6 +273,7 @@
         color=teal
         type=Necromancer
         id=Mal-Yrna
+        #po: female necromancer, will be renamed to Mal-Mana if Mal-Mana wasn't killed in a previous scenario
         name= _ "Mal-Yrna"
         canrecruit=yes
         controller=ai
@@ -514,6 +515,7 @@
                 [/show_if]
             [/objective]
             [objective]
+                #po: Mal-Yrna, a female necromancer
                 description= _ "Defeat the southern necromancer"
                 condition=win
             [/objective]
@@ -542,9 +544,11 @@
                 carryover_percentage=40
             [/gold_carryover]
             [note]
+                #po: two prisoners and one jailer per gang
                 description= _ "Prisoner gangs will alternate arriving on north and south paths."
             [/note]
             [note]
+                #po: "enemy" in this case meaning "player's unit"
                 description= _ "Bats prefer to fly towards the nearest enemy."
                 [show_if]
                     [have_unit]
@@ -584,6 +588,8 @@
         {MOVE_UNIT side=1 42 4}
         [message]
             id=Owaec,Terraent
+            #po: TODO for 1.19? There's a cut-scene running up to this, but it's unclear what's happened until I read the WML and found that player's full starting roster is exactly one *horseman* for this scenario.
+            #po: The fastest-moving of the player's units has been trying to catch up with a bat, but the bat has flow over the river to the Mal-Yrna / Mal-Mana.
             message= _ "Alas, I have failed in my mission! The undead scout has already reported back to its mistress."
         [/message]
 
@@ -593,6 +599,7 @@
 
         [message]
             speaker=Mal-Yrna
+            #po: speaking to a bat
             message= _ "Minion, what’s this? Soldiers of Wesnoth approach from the north? That area should have been cleansed over a month ago."
         [/message]
         [message]
@@ -610,6 +617,7 @@
         {EXECUTE_PRISONERS}
         [message]
             x,y=31,23
+            #po: Vovan has been turned into a ghoul, and the other prisoner has been too.
             message= _ "I... Hunger..."
         [/message]
 
@@ -632,6 +640,7 @@
 
         [message]
             id=Owaec,Terraent
+            #po: two dwarves, with a Deathblade as the jailer
             message= _ "More prisoners approach from the northwest! I have not the time to depart and return with Gweddry, or those dwarves will surely be slain."
         [/message]
         [message]
@@ -656,6 +665,7 @@
 
         [message]
             speaker=Mal-Yrna
+            #po: the speaker was renamed to Mal-Mana at the start
             message= _ "Wait — I remember you! You’re one of the ones who fled from me last autumn near Soradoc!"
         [/message]
         [message]
@@ -825,6 +835,7 @@
 
         [message]
             speaker=Nargaril
+            #po: to a Deathblade
             message= _ "Get yer filthy chains off my wrists, ye pile o’ bones!"
         [/message]
     [/event]
@@ -897,10 +908,12 @@
 
         [message]
             speaker=Vinreddoc
+            #po: spoken between two prisoners, "them" being the undead forces
             message= _ "How are there so many of them? Is this the end of all Wesnoth?"
         [/message]
         [message]
             speaker=Tunreoryr
+            #po: spoken between two prisoners
             message= _ "Don’t worry. I’m sure the Crown has a plan..."
         [/message]
     [/event]
@@ -914,6 +927,7 @@
         [/filter]
         [message]
             speaker=Vinreddoc
+            #po: Vinreddoc is a mage, but with random gender
             message= _ "Thank you! When the undead overran the academy I thought I was dead for sure. I just wonder what has happened to my friends..."
         [/message]
         [message]
@@ -996,6 +1010,7 @@
         [/filter]
         [message]
             speaker=Ugzush
+            #po: he's just been rescued
             message= _ "Cruddy undead think they can chain me up! I’ll grind their bones into dust!"
         [/message]
         {MODIFY_UNIT id=Ugzush side 1}
@@ -1055,10 +1070,12 @@
 
         [message]
             speaker=Gaennell
+            #po: this Dark Adept is a prisoner too
             message= _ "I swear, it was an accident! Please, if you’ll just let me talk to Mel Guthrak, I’m sure this can all be straightened out."
         [/message]
         [message]
             speaker=Syner
+            #po: to Gaennell
             message= _ "Your time is done, necromancer. If I have one small comfort, it’s that I’ll get to watch you die alongside me."
         [/message]
     [/event]
@@ -1072,6 +1089,7 @@
         [/filter]
         [message]
             speaker=Syner
+            #po: speaking of Gaennell
             message= _ "I’m free! Now I’ll have the pleasure of killing this dark adept myself."
         [/message]
 
@@ -1084,10 +1102,12 @@
             [then]
                 [message]
                     speaker=Terraent
+                    #po: speaking to Syner about Gaennell
                     message= _ "Stay your hand, man of Wesnoth! A killing in cold blood is no justice and revenge will bring you no peace."
                 [/message]
                 [message]
                     speaker=Syner
+                    #po: speaking of Gaennell
                     message= _ "Are you mad? That woman is a necromancer!"
                 [/message]
                 [message]
@@ -1152,6 +1172,7 @@
                 {MODIFY_UNIT id=Syner experience 8}
                 [message]
                     speaker=Owaec
+                    #po: speaking to Syner, who has just killed Gaennell
                     message= _ "And so justice has been served! Such is the fate of all evildoers."
                 [/message]
             [/else]
@@ -1222,6 +1243,7 @@
         [/message]
         [message]
             speaker=Mame
+            #po: a Mermaid Priestess as prisoner, the line ends with the jailer hitting her
             message= _ "We’re going as fast as we can! Maybe if you’d let us swim-"
         [/message]
         [animate_unit]
@@ -1262,6 +1284,7 @@
         [/fire_event]
         [message]
             id=Owaec,Terraent
+            #po: "we" being the speaker and the prisoners that they've rescued
             message= _ "Now we come for you, necromancer!"
         [/message]
         [show_objectives]
@@ -1310,6 +1333,7 @@
             [then]
                 [message]
                     speaker=Mal-Yrna
+                    #po: each bat-summoning event is triggered by the player rescuing prisoners
                     message= _ "Of course, just because I said I wouldn’t summon bats doesn’t mean I can’t..."
                 [/message]
             [/then]
@@ -1317,6 +1341,7 @@
             [else]
                 [message]
                     speaker=Mal-Yrna
+                    #po: each bat-summoning event is triggered by the player rescuing prisoners
                     message= _ "My prisoners!! You’ll pay for that..."
                 [/message]
             [/else]
@@ -1326,7 +1351,7 @@
         {RECRUIT_UNIT 4 ({ON_DIFFICULTY "none"        "none"        "Vampire Bat"}) 29 23}
         [message]
             speaker=Mal-Yrna
-            #po: this is a common misquote from the wizard of oz
+            #po: this is a common misquote from the wizard of oz, she's talking to her bats
             message= _ "Fly, my pretties, fly!"
         [/message]
         [show_objectives]
@@ -1353,6 +1378,7 @@
                 [then]
                     [message]
                         speaker=Mal-Yrna
+                        #po: to Terraent. She's summoning bats.
                         message= _ "Not again! Do not test me, paladin of Wesnoth..."
                     [/message]
                 [/then]
@@ -1360,7 +1386,9 @@
                 [else]
                     [message]
                         speaker=Mal-Yrna
-                        message= _ "Not again! Do not test me, lord of the swamps..." # allusion to drowned plains
+                        #po: to Owaec. She's summoning bats.
+                        #po: The text is an allusion to drowned plains, which the next scenario will reveal to be the current state of the Horse Clans' beloved plains.
+                        message= _ "Not again! Do not test me, lord of the swamps..."
                     [/message]
                 [/else]
             [/if]
@@ -1383,6 +1411,7 @@
 
                 [message]
                     speaker=Mal-Yrna
+                    #po: More prisoners rescued, more bats get summoned.
                     message= _ "You are starting to become rather irritating."
                 [/message]
                 {RECRUIT_UNIT 4 ({ON_DIFFICULTY "none"      "Vampire Bat" "Vampire Bat"}) 31 23}
@@ -1511,6 +1540,7 @@
             [then]
                 [message]
                     speaker=Gweddry
+                    #po: victory event, and the rest of the player's units catch up
                     message= _ "Hail, Terraent! We feared the worst when you did not return, yet here I find you alive and well!"
                 [/message]
             [/then]
@@ -1518,6 +1548,7 @@
             [else]
                 [message]
                     speaker=Gweddry
+                    #po: victory event, and the rest of the player's units catch up
                     message= _ "Hail, Owaec! We feared the worst when you did not return, yet here I find you alive and well!"
                 [/message]
             [/else]
@@ -1609,6 +1640,7 @@
         [/if]
         [message]
             speaker=Mal-Yrna
+            #po: she dispatches a messenger bat after this, leading to Dacyn saying all is lost
             message= _ "Can it be? Dacyn the mage? We thought you perished in the wild northlands, but now I find you alive and isolated from Wesnoth! I must inform Mal-Ravanal!"
         [/message]
         [animate_unit]

--- a/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
@@ -37,6 +37,7 @@
 
     [story]
         [part]
+            #po: In this scenario, there's circa 18 ghosts, each with a single line of speech, you'll recognise them because most start and end with ellipsis. The WML would need to be restructured to put po hints on those lines themselves.
             story= _ "Anxious to rendezvous with the Wesnothian army, Gweddry, Owaec, and Dacyn pressed hurriedly westward. Their hearts sank as they passed battlefield after battlefield, in the ruins of what used to be Wesnoth’s thriving eastern provinces."
             music=silence.ogg
             {EI_BIGMAP}
@@ -147,6 +148,8 @@
             type=Skeletal Dragon
             facing=ne
             id=Khrakrahs
+            #po: Date of death unknown, seen alive in 40 YW during the Sceptre of Fire campaign.
+            #po: Male; he's been canon in many versions of Wesnoth that only had male drakes, thus will surely have been male in any translation that needed to know his gender.
             name=_"Khrakrahs"
         [/leader]
         side=4
@@ -322,6 +325,7 @@
         side=9
         controller=null
         team_name=good,undead
+        #po: neutral side, is only horses (although the user_team_name is vaguer than that)
         user_team_name=_"Animals"
         gold=0
         no_leader=yes
@@ -440,6 +444,7 @@
     [/if]
     {CLEAR_VARIABLE yesno,ghost_type,ghost_name}
 #enddef
+
         {VARIABLE ghost_i 0}
         {GHOST_WANDERER {ON_DIFFICULTY (yes)(yes)(yes)}   1  1 _"... I failed you all..."}
         {GHOST_WANDERER {ON_DIFFICULTY (no )(yes)(yes)}  10  1 _"... my daughter... what has happened to my daughter?"}
@@ -539,6 +544,7 @@
         name=explain_ambushers
         [message]
             speaker=unit
+            #po: Player's unit has just been ambushed. Some other nearby corpses have awoken too, but the player will find that out during the enemy turn.
             message= _ "Gah, undead! This one was mired face-first in the swamp, dormant until I stumbled upon it. They must be lying everywhere in this muck."
         [/message]
         [message]
@@ -549,10 +555,12 @@
             name=new turn
             [message]
                 speaker=Gweddry
+                #po: Player's unit trigger an ambush last turn. During the enemy turn, some other nearby corpses started moving too.
                 message= _ "Whenever we stumble upon a corpse, it awakens its nearby allies! What will happen when we wake their leaders?"
             [/message]
             [message]
                 speaker=Dacyn
+                #po: The keeps are visible, so the player can guess where the leaders themselves are.
                 message= _ "It may be prudent to clear the swamp near the undead leaders before we sight them."
             [/message]
         [/event]
@@ -828,6 +836,7 @@
 
         [message]
             speaker=Owaec
+            #po: The player hasn't recruited yet, so listening are Gweddry, Dacyn, and the auto-recalled optional loyals (at most 8 people in total).
             message= _ "At last we have reached the Horse Plains, the fair homeland of my people! Here we can finally reunite with our comrades-in-arms and vanquish the undead once and for all."
         [/message]
         {MOVE_UNIT (id=Owaec) 48 26}
@@ -837,6 +846,7 @@
         [/redraw]
         [message]
             speaker=Owaec
+            #po: Shouted to the landscape, expecting to find living comrades. What will answer is walking corpses and ghosts.
             message= _ "Hail, Clansmen! Come and greet one of your own!"
         [/message]
 
@@ -896,6 +906,7 @@
 
         [message]
             speaker=Owaec
+            #po: Dacyn is bleeding and about to take damage from an unknown source
             message= _ "Are you even listening?!?"
         [/message]
         [harm_unit]
@@ -912,6 +923,7 @@
 
         [message]
             speaker=Gweddry
+            #po: Dacyn is bleeding and taking damage, from an unknown source
             message= _ "Dacyn, what’s wrong? Are you all right?"
         [/message]
 
@@ -923,6 +935,7 @@
 
         [message]
             speaker=Dacyn
+            #po: Dacyn steps away from the initial encampment, and is about take a lot of damage
             message= _ "...I can’t-"
         [/message]
 
@@ -969,6 +982,7 @@
         {GATE 54 28} {MODIFY_UNIT id=Dacyn hitpoints 15}
         [message]
             speaker=Dacyn
+            #po: Dacyn stepped away from the castle, the six hexes around him have changed to chasms and he's down to 15 hp.
             message= _ "I’ve lost control of the Amulet! I must-"
         [/message]
 
@@ -992,6 +1006,7 @@
         [message]
             caption= _ "Unknown"
             image=units/unknown-unit1.png
+            #po: up to 6 ghosts or wraiths come out of the chasms, depending on difficulty and how many auto-recalled loyals the player has
             message= _ "<span size='small' font-style='italic'>And most importantly...</span>"
         [/message]
 
@@ -1004,6 +1019,7 @@
 
         [message]
             speaker=Lord Alric
+            #po: speaker is a wraith, he's emerged from the chasms around Dacyn
             message= _ "Owaec, my son..."
         [/message]
         [message]
@@ -1016,6 +1032,7 @@
         [/message]
         [message]
             speaker=Gweddry
+            #po: Owaec rides off to the south, into the shroud, and disappears
             message= _ "Owaec, wait!"
         [/message]
 
@@ -1056,6 +1073,8 @@
 
         [message]
             speaker=Dacyn
+            #po: The chasms are filled with sand, so all terrain near the keep is walkable again.
+            #po: Dacyn has healed back to full HP, although that's for gameplay reasons because he needs to fight the ghosts, there isn't a story reason for it.
             message= _ "(gasping) I have regained control!"
         [/message]
         [message]
@@ -1068,6 +1087,7 @@
         [/message]
         [message]
             speaker=Dacyn
+            #po: loses his halo and advances to an L4 Twilight Mage (liminal, heals +4, does not illuminate, melee attack gains "drain")
             message= _ "... but it is a necessary price to pay. I will not let up until Mal-Ravanal is defeated, whatever the cost may be."
         [/message]
         {ADVANCE_UNIT id=Dacyn (Twilight Mage)}
@@ -1145,6 +1165,7 @@
 
         [message]
             speaker=Owaec
+            #po: Owaec is near his father's castle, and there's a dead (not undead) skeleton on the keep
             message= _ "...so it is true. My lord and father is dead."
         [/message]
         [delay]
@@ -1153,6 +1174,7 @@
 
         [message]
             speaker=Owaec
+            #po: today is when he learns the news of that, not when it happened
             message= _ "Today truly is a day of ill fortune. My family is slain, my kinsmen scattered, my homeland defiled."
         [/message]
         [message]
@@ -1251,6 +1273,7 @@
                 [/sound]
                 [message]
                     speaker=Hahid al-Ali
+                    #po: player bought the elixir of ulfserker fury
                     message= _ "Try not to die too quickly!"
                 [/message]
                 {ELIXIR_OF_FURY 13 26} # by Owaec. He doesn't have to drink it, but he's the best choice
@@ -1259,6 +1282,7 @@
                 name=ignore_elixir
                 [message]
                     speaker=Hahid al-Ali
+                    #po: player declined the elixir of ulfserker fury
                     message= _ "Suit yourself! Don’t expect me to drink that though, I’m not suicidal!"
                 [/message]
             [/event]
@@ -1303,10 +1327,12 @@
 
         [message]
             speaker=Addogin
+            #po: Wait a moment... this landscape looks familiar.
             message= _ "Hol’ up... some of this place is lookin’ mighty familiar. Yeah, few years back I used to work for a smuggler ’round these parts."
         [/message]
         [message]
             speaker=Addogin
+            #po: hint about the smuggler's hidden gold, will be followed by adding three "go here" markers to the map
             message= _ "I’m sure the undead have burned down his storehouse, but there might still be a cache or three hidden ’round here."
         [/message]
 
@@ -1381,6 +1407,7 @@
             name=cache_found
             [message]
                 speaker=Addogin
+                #po: although there are three map markers to explore, the first one that the player explores always has this gold, and the second is always empty
                 message= _ "That’s the first cache. Lookee here, my smuggler friend left us 45 gold pieces."
             [/message]
             [sound]
@@ -1450,7 +1477,6 @@
     #---------------------------
     # FLAVOR MESSAGES
     #---------------------------
-    # this is probably grug's first time fighting squishy undead (though there were a few in S10)
     [event]
         name=attack
 
@@ -1464,6 +1490,7 @@
 
         [message]
             speaker=Grug
+            #po: this is probably grug's first time fighting squishy undead (though there were a few in S10)
             message= _ "Squishy fun to squash! Squash squish squash!"
         [/message]
     [/event]
@@ -1485,6 +1512,7 @@
         [/filter]
         [message]
             speaker=unit
+            #po: "odd that his body didn't become undead"
             message= _ "This man looks to have been dead for about a month. Odd that his body yet lies still."
         [/message]
     [/event]
@@ -1502,12 +1530,14 @@
         [/message]
         [message]
             speaker=unit
+            #po: Reading from a dead horseman's journal. This is a warning to the player that there's a Skeletal Dragon in the scenario.
             message= _ "<i>... we thought the enemy had erred, that the battle could yet be won. Taking advantage of the gap, our swiftest riders drove toward the exposed heart of the skeletal formation. But even as they wrought destruction within the necromancers’ ranks, from out of the water came a great tremor, as if Irdya herself shivered in morbid anticipation.
 
 For a moment, I espied a great bony figure, a shambling mass of tooth and claw and wing. Then it fell upon us from behind, and the enemy closed their ranks, and we were encircled by death.</i>"
         [/message]
         [message]
             speaker=unit
+            #po: Reading more from the dead horseman's journal, whose corpse prompted the "odd that his body didn't become undead" comment.
             message= _ "<i>I fled, coward that I am, riding breakneck through the night before my injuries overcame my strength. And so it comes that I have earned no honorable death in battle, only the slow fatigue and fever borne by rot and poison.
 
 I offer one final prayer to the Light, that at least my family may be spared and that my soul may be kept from undeath...</i>"
@@ -1556,6 +1586,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         {REVEAL $unit.x $unit.y}
         [message]
             speaker=Sir Seoraery
+            #po: no-one sends a messenger, he's talking about memories from before he died
             message= _ "... we need... reinforcements... send a messenger..."
         [/message]
         [message]
@@ -1564,6 +1595,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         [/message]
         [message]
             speaker=Sir Seoraery
+            #po: he's talking of a memory, not the current situation
             message= _ "...must... hold... the line."
         [/message]
         {VARIABLE seoraery_active yes}
@@ -1615,6 +1647,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         {REVEAL $unit.x $unit.y}
         [message]
             speaker=Sir Efran
+            #po: he's talking of a memory, not the current situation
             message= _ "... there’s... too many."
         [/message]
         [message]
@@ -1623,6 +1656,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         [/message]
         [message]
             speaker=Sir Efran
+            #po: he's talking to a memory, not the unit that triggered the event
             message= _ "... I would sooner... die... than yield to you... necromancer."
         [/message]
         {VARIABLE efran_active yes}
@@ -1698,6 +1732,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         {REVEAL $unit.x $unit.y}
         [message]
             speaker=unit
+            #po: undead dragon, talking to a memory rather than the unit that triggered him
             message= _ "... Lich, you do not belong here... leave, or I shall... rend you..."
         [/message]
         [message]
@@ -1710,6 +1745,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         [/message]
         [message]
             speaker=unit
+            #po: undead dragon, again talking to a memory rather than anyone currently on the map
             message= _ "... I warned you... Ravanal... now <b>burn</b>."
         [/message]
         {VARIABLE khrakrahs_active yes}
@@ -1800,10 +1836,12 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=second_unit
+            #po: speaker is one of the undead leaders, in an [event]name=attack
             message= _ "... Owaec... why do you fight me? Join us... ride alongside your father... defend the plains..."
         [/message]
         [message]
             speaker=Owaec
+            #po: speaking to one of the undead leaders, in an [event]name=attack
             message= _ "Abomination!! Clansmen though you once were, I have no choice but to grind you into dust now."
         [/message]
     [/event]
@@ -1820,6 +1858,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=Owaec
+            #po: speaking to Khrakrahs in an [event]name=attack, although the anger seems misdirected
             message= _ "You! You are the cause of this destruction!! Vengeance for my fallen people!"
         [/message]
     [/event]
@@ -1836,6 +1875,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=Terraent
+            #po: speaking to one of the undead leaders (horseman, not dragon) in an [event]name=attack
             message= _ "All things deserve redemption, but I fear the undead will never find it. May this place be cleansed in holy fire!"
         [/message]
     [/event]
@@ -1852,6 +1892,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=Terraent
+            #po: speaking to Khrakrahs in an [event]name=attack
             message= _ "I have faced worse terrors than you, lizard! Through piety and the holy Light, this place will be sanctified once more."
         [/message]
     [/event]
@@ -1868,10 +1909,12 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=second_unit
+            #po: speaker is an undead horseman, who's fighting Gaennell. Unclear whether this is to a memory, or because Gaennell is a Shadow Mage
             message= _ "... Necromancer... you are a blight..."
         [/message]
         [message]
             speaker=Gaennell
+            #po: to an undead horseman in an [event]name=attack
             message= _ "Not sure what you’d call me anymore, but definitely not more of a blight than you."
         [/message]
     [/event]
@@ -1888,6 +1931,9 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=second_unit
+            #po: Attacked with a fireball from an L2 or higher mage.
+            #po: Shek’kahan was Khrakrahs' brother, but died during TRoW, 6 centuries ago.
+            #po: The date of Khrakrahs' own death isn't canon, he was still alive in 40 YW (he appears in SoF).
             message= _ "... Shek’kahan, your fire grows weak... you are hardly... a rival."
         [/message]
     [/event]
@@ -1904,6 +1950,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=second_unit
+            #po: speaker is Khrakrahs when attacked by a dwarf, but remembering one he met in 40 YW.
             message= _ "... Thursagan... I warned you not... to enter my lair."
         [/message]
     [/event]
@@ -1920,6 +1967,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=Lord Alric
+            #po: last breath request from the ghost of Lord Alric
             message= _ "... please, watch over my son for me."
         [/message]
     [/event]
@@ -1944,6 +1992,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=Sir Efran
+            #po: last breath, but still talking to a memory rather than the unit currently fighting him
             message= _ "... Necromancer... Wesnoth will defeat you... in the end."
         [/message]
     [/event]
@@ -1956,6 +2005,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
 
         [message]
             speaker=Khrakrahs
+            #po: last breath
             message= _ "I am... ...<i>cold</i>."
         [/message]
     [/event]
@@ -1976,6 +2026,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
                 name=new turn
                 [message]
                     speaker=Gweddry
+                    #po: spoken at the start of a new turn after killing the first undead leader
                     message= _ "Dacyn, I’ve been thinking. This artifact has had such a draining effect on you. Perhaps you should rest and take a moment to regain your strength? I could carry the Amulet for a while, or we could store it away."
                 [/message]
                 [message]
@@ -1985,16 +2036,19 @@ I offer one final prayer to the Light, that at least my family may be spared and
                 [message]
                     caption= _ "Unknown"
                     image=units/unknown-unit1.png
+                    #po: voices from the amulet talking to Dacyn
                     message= _ "<span size='small' font-style='italic'>You have a great weapon... and you would simply lock it away?</span>"
                 [/message]
                 [message]
                     caption= _ "Unknown 2"
                     image=units/unknown-unit2.png
+                    #po: voices from the amulet talking to Dacyn, speaking of Gweddry
                     message= _ "<span size='small' font-style='italic'>His intent is good, but his spirit is weak... he would be corrupted...</span>"
                 [/message]
                 [message]
                     caption= _ "Unknown"
                     image=units/unknown-unit1.png
+                    #po: voices from the amulet talking to Dacyn
                     message= _ "<span size='small' font-style='italic'>Only you can be trusted with this responsibility.</span>"
                 [/message]
                 [message]
@@ -2029,10 +2083,12 @@ I offer one final prayer to the Light, that at least my family may be spared and
         name=side 1 turn {SCENARIO_TURN_LIMIT} end
         [message]
             speaker=Dacyn
+            #po: time over, talking to Owaec
             message= _ "Enough of this. We have wasted too much time here already; give up your foolish quest of vengeance and travel on."
         [/message]
         [message]
             speaker=Owaec
+            #po: time over, talking to Dacyn
             message= _ "Your search for foul magic has caused enough harm already, and now you would leave my countrymen’s bodies defiled by undeath? I will slay everything that moves in this swamp, and once I am done, perhaps my hammer will find you next!"
         [/message]
         [message]
@@ -2103,6 +2159,7 @@ The fates may yet reveal that our journey north was necessary, even at such a st
         [/message]
         [message]
             speaker=Owaec
+            #po: to Dacyn
             message= _ "Make no mistake, I still do not approve of your plan! It will lead you only to ruin and death! Yet, at least now I believe that your intentions are good despite your questionable methods."
         [/message]
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/15_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/15_Return_to_Wesnoth.cfg
@@ -809,9 +809,9 @@
         [lock_view]
         [/lock_view]
 
-        # the council discusses the northern alliance
         [message]
             speaker=Aeraeka
+            #po: the council discusses the northern alliance
             message= _ "Well try again! It is absolutely imperative that we get a response from the Northerners."
         [/message]
         [message]
@@ -829,11 +829,13 @@
         [/animate_unit]
         [message]
             speaker=Mefel
+            #po: the speaker, a male Silver Mage, has just teleported in
             message= _ "Urgent report from the south, Sire! I’m afraid it can’t wait."
         [/message]
         [message]
             speaker=Konrad
             image=portraits/konrad_II.webp
+            #po: Denogyc is a male Lancer.
             message= _ "Denogyc, you’re excused. Get some rest. Minister Mefel, what news of Kerlath?"
         [/message]
         [move_unit] # silently
@@ -845,6 +847,7 @@
         {MOVE_UNIT id=Mefel 10 9}
         [message]
             speaker=Mefel
+            #po: Kerlath Province is the area around Westin
             message= _ "The siege around Westin has been broken, but Kerlath’s forces are badly depleted. I’m afraid we won’t be able to mount a counter-offensive in time to support you, especially with Mal-Xlana still holding Fort Tahn."
         [/message]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
@@ -868,6 +868,7 @@
         [/message]
         [message]
             speaker=sibling_corpse
+            #po: Mal-Skraat or Mal-Kallat is still alive, this is their dead brother/sister reanimated as a Soulless
             message= _ "Rev... enge..."
         [/message]
     [/event]
@@ -1075,6 +1076,7 @@
 
         [message]
             speaker=Gweddry
+            # TODO: does it? the WML seems to say DEFAULT_SCHEDULE_MORNING, but maybe there's some change in-game
             message= _ "Night approaches, and with it the undead hordes. I stand ready."
         [/message]
         [message]
@@ -1311,6 +1313,7 @@
         {FIND_NEARBY (side,canrecruit=$owner_side,yes) 30 22 99}
         [message]
             speaker=$found_unit.id
+            #po: one of the AI generals when the player takes their village
             message= _ "Sire, you are of course welcome to capture any of my villages if you need them, but please know that it will make it more difficult to heal my injured soldiers."
         [/message]
     [/event]
@@ -1333,6 +1336,7 @@
         name=turn 6 # dawn. "side turn" ensures that the "new turn" doesn't trigger until next turn
         [message]
             speaker=Konrad
+            #po: "light of dawn" is merely because it's that time of day
             message= _ "Stand strong, men of Wesnoth! Rally under the light of dawn, and drive the undead back!"
         [/message]
 
@@ -1349,6 +1353,7 @@
         [/message]
         [message]
             speaker=Mal-Ravanal
+            #po: according to the turn counter, it's dawn; Mal-Ravanal is claiming to be able to control that
             message= _ "It’s been fun watching this little squabble unfold, but it’s time to move things along. Night will now fall, and the city with it."
         [/message]
 
@@ -1480,6 +1485,7 @@ And leave eternal night to remain."
             [then]
                 [message]
                     speaker=Gweddry
+                    #po: as well as changing the time-of-day schedule, fog of war has just been enabled
                     message= _ "I’m nearly blind in this fog, but I think the undead have been reinforced!"
                 [/message]
             [/then]
@@ -1530,16 +1536,19 @@ And leave eternal night to remain."
                     speaker=Dacyn
                     caption= _ "Unknown"
                     image=units/unknown-unit1.png
+                    #po: speaker is one of the voices from the amulet, speaking to Dacyn
                     message= _ "<span size='small' font-style='italic'>You see? Mal-Ravanal has grown too powerful. Wesnoth is helpless!</span>"
                 [/message]
                 [message]
                     speaker=Dacyn
                     caption= _ "Unknown 2"
                     image=units/unknown-unit2.png
+                    #po: speaker is one of the voices from the amulet, speaking to Dacyn
                     message= _ "<span size='small' font-style='italic'>Use the Amulet. There is no other way! Use us!</span>"
                 [/message]
                 [message]
                     speaker=Dacyn
+                    #po: after this, Dacyn gets unpoisonable, undrainable, unplagueable and changes to a Fallen Mage
                     message= _ "I must... defeat Ravan! I must be strong enough to stand alone... I alone must wield this fullness of power!"
                 [/message]
                 [sound]
@@ -1667,6 +1676,7 @@ And leave eternal night to remain."
                             [else]
                                 [message]
                                     speaker=Dacyn
+                                    #po: Gweddry and Owaec are dead during this scenario, and Terraent isn't here either
                                     message= _ "The sun has pierced through the night’s fog; Mal-Ravanal’s spell begins to wane. I need neither Gweddry nor Owaec. I will finish this battle on my own."
                                 [/message]
                             [/else]
@@ -1703,6 +1713,8 @@ And leave eternal night to remain."
         {KILL_UNDEAD_NEAR_HUMANS 5 yes 3}
         [message]
             speaker=Dacyn
+            #po: any undead unit from side 5 (except the leader) that was within 3 hexes of a living unit has died
+            #po: followed immediately after this line by similar for sides 6 and 7.
             message= _ "Mal-Ravanal’s necromancers have overexerted themselves. They are struggling to maintain all their minions."
         [/message]
     [/event]
@@ -1797,6 +1809,7 @@ And leave eternal night to remain."
         [/cancel_action]
         [message]
             speaker=Konrad
+            #po: the scenario doesn't let the player move Konrad away from his castle
             message= _ "I will not abandon my post!"
         [/message]
         {MOVE_UNIT (id=Konrad) $x2 $y2}
@@ -1813,6 +1826,7 @@ And leave eternal night to remain."
         [/filter]
         [message]
             speaker=narrator
+            #po: plaque on a statue
             message= _ "<i>Haldric the First, Dragonslayer, first king of Wesnoth.</i>"
             image=wesnoth-icon.png
         [/message]
@@ -1829,6 +1843,7 @@ And leave eternal night to remain."
         [/filter]
         [message]
             speaker=narrator
+            #po: plaque on a statue
             message= _ "<i>Delfador the Great, sage of Wesnoth, restorer of the throne.</i>"
             image=wesnoth-icon.png
         [/message]
@@ -1846,14 +1861,17 @@ And leave eternal night to remain."
         [/filter]
         [message]
             speaker=Mel Guthrak
+            #po: last breath of Mel Guthrak
             message= _ "Wha- but how?"
         [/message]
         [message]
             speaker=Gaennell
+            #po: last breath of Mel Guthrak
             message= _ "Good riddance..."
         [/message]
         [message]
             speaker=Halrod
+            #po: last breath of Mel Guthrak
             message= _ "Impressive tactics! I’ll begin redeploying towards other threats."
         [/message]
     [/event]
@@ -1942,6 +1960,7 @@ And leave eternal night to remain."
         [/filter]
         [message]
             speaker=unit
+            #po: last breath of the reanimated (Soulless) Mal-Skraat or Mal-Kallat
             message= _ "Gruhhh..."
         [/message]
     [/event]
@@ -2108,6 +2127,7 @@ And leave eternal night to remain."
                     [then]
                         [message]
                             speaker=Gweddry
+                            #po: although there's a lot of dead troops, this is mainly "to mourn for Owaec"
                             message= _ "The city grows still at last. I wish there was time to mourn, but we still must decide how to deal with Mal-Ravanal."
                         [/message]
                         [message]
@@ -2194,6 +2214,7 @@ And leave eternal night to remain."
                                 [/command]
                             [/option]
                             [option]
+                                #po: both Gweddry and Owaec are dead, so this goes from "challenging" to "very hard"
                                 label= _ "defeat Mal-Ravanal in pitched battle. <i>(very hard)</i>"
                                 [command]
                                     [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
@@ -1076,7 +1076,7 @@
 
         [message]
             speaker=Gweddry
-            # TODO: does it? the WML seems to say DEFAULT_SCHEDULE_MORNING, but maybe there's some change in-game
+            # TODO: the scenario's schedule has changed, this is currently being said at DEFAULT_SCHEDULE_MORNING.
             message= _ "Night approaches, and with it the undead hordes. I stand ready."
         [/message]
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17a_The_Duel.cfg
@@ -21,6 +21,7 @@
 
     [story]
         [part]
+            #po: a human messenger
             story= _ "As the messenger passed out of the city gates, silence settled over the valley of the Weldyn. Children buried their fathers, mothers entombed their sons; soldiers slept where they stood, spears still clutched behind pale knuckles. The only sound was the incessant drum-march of skeletal feet, ever-growing outside the walls."
             music=silence.ogg
         [/part]

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
@@ -24,6 +24,7 @@
 
     [story]
         [part]
+            #po: the river has the same name as the city
             story= _ "The morning sun shone bright upon the valley of the Weldyn, glinting off swords and lances innumerable, arrayed in tight formation inside the city walls."
             music=silence.ogg
         [/part]
@@ -310,6 +311,7 @@
         color=brightgreen
         type=Dark Adept
         id=Lethin
+        #po: in the unlikely event that Mal-Tar survived S03, Lethin gets renamed and has dialogue as Mal-Tar
         name= _ "Lethin"
         canrecruit=yes
         facing=sw
@@ -367,13 +369,14 @@
             [filter]
                 id=Lethin
             [/filter]
-            # really Mal-Tar
             [message]
                 speaker=unit
+                #po: last breath for Mal-Tar
                 message= _ "Wait, wait, stop, I surrender! I know your leader Gweddry!"
             [/message]
             [message]
                 speaker=unit
+                #po: last breath for Mal-Tar
                 message= _ "He defeated me back in the Estmarks but still let me live! Let me go and I promise you’ll never see me again!"
             [/message]
             [message]
@@ -384,6 +387,7 @@
             {KILL id=Lethin}
             [message]
                 speaker=Gweddry
+                #po: speaking of Mal-Tar
                 message= _ "It’s been an entire war, and that guy still hasn’t improved his magic..."
             [/message]
         [/event]
@@ -1029,6 +1033,7 @@
         [/filter_condition]
         [message]
             speaker=Konrad
+            #po: killed a lich
             message= _ "That’s one down! The undead must still be in disarray after their failed attack during the long night."
         [/message]
     [/event]
@@ -1042,6 +1047,7 @@
         ) 34 38 999}
         [message]
             speaker=$found_unit.id
+            #po: speaker is a random lich
             message= _ "Night falls on Weldyn! Your counterattack may have caught us by surprise, but this hour is our domain."
         [/message]
         {FIND_NEARBY (
@@ -1050,6 +1056,7 @@
         ) 61 9 999}
         [message]
             speaker=$found_unit.id
+            #po: speaker is a random lich, almost certainly a different one than the previous speaker
             message= _ "Now you will pay for your arrogance!"
         [/message]
     [/event]
@@ -1071,6 +1078,7 @@
         [/cancel_action]
         [message]
             speaker=Konrad
+            #po: the player is trying to move him away
             message= _ "A king belongs in his capital! I will not abandon my post!"
         [/message]
         {MOVE_UNIT (id=Konrad) $x2 $y2}
@@ -1202,6 +1210,7 @@
 
         [floating_text]
             x,y=$unit.x,$unit.y
+            #po: the parts to translate here are "gold refunded" and "per side"
             text= _ "<span color='#FFD700' size='x-small'>gold refunded</span>
 <span color='#FFFFFF' size='xx-small'>  (1/$side_count per side)</span>"
         [/floating_text]
@@ -1475,7 +1484,7 @@
         {REPLACE_SCENARIO_MUSIC silence.ogg}
         {SCROLL_TO $unit.x $unit.y}
 
-        # guarantee Ravanal has at least a 6-hex encapmpent to recruit on
+        # guarantee Ravanal has at least a 6-hex encampment to recruit on
         [terrain]
             x,y=$unit.x,$unit.y
             radius=1

--- a/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
@@ -194,6 +194,7 @@
         name=start
         [message]
             speaker=Renaerawan
+            #po: the speaker is a white mage who first appears in this epilogue
             message= _ "We are gathered here today in remembrance of our dear colleague and friend, Dacyn, who fell even as he vanquished the arch-lich Mal-Ravanal."
         [/message]
         [message]
@@ -220,6 +221,7 @@
         [/message]
         [message]
             speaker=Owaec
+            #po: he's alive, this isn't a plaque on a tomb
             message= _ "My duty is done; the Clans have been avenged. At last, I can rest in peace."
         [/message]
 
@@ -241,6 +243,9 @@
                 [message]
                     speaker=Konrad
                     image=portraits/konrad_II.webp
+                    #po: TODO for 1.19? Make clear who this is addressing, and make variations depending on whether it's to one person or two.
+                    #po: To Owaec, Gweddry or both; but I only know that because I can see the condition and the alternative line if they're both dead.
+                    #po: The "we" could be the royal pronoun (first person singular), but "we" as in "everyone in the Kingdom" fits too.
                     message= _ "It shall be so. But first, know that you have served Us, and Our Kingdom, full well. We are minded to reward you."
                 [/message]
             [/then]
@@ -249,6 +254,8 @@
                 [message]
                     speaker=Konrad
                     image=portraits/konrad_II.webp
+                    #po: All three heroes are dead.
+                    #po: The "we" could be the royal pronoun (first person singular), but "we" as in "everyone in the Kingdom" fits too.
                     message= _ "I had a mind to share this victory with those who made it possible, yet so many of them now lie dead. Lieutenant Gweddry, Lord Owaec, Advisor Dacyn, we thank you for your sacrifice."
                 [/message]
             [/else]
@@ -273,6 +280,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: the player chose to give Grug the plague staff
                             message= _ "Grug, a necromancer ogre is something wholly new to Us, but know that Wesnoth will never tolerate your kind. You shall surrender that accursed stave to be destroyed, you shall foreswear the practice of all magic on penalty of death, and are hereby exiled from Wesnoth. Be grateful for Our mercy."
                         [/message]
                         [message]
@@ -313,6 +321,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: the player chose to give Dolburras the plague staff
                             message= _ "Dwarf, <i>necromancer</i>, know that Wesnoth will never tolerate your kind. You shall surrender that accursed stave to be destroyed, you shall foreswear the practice of all magic on penalty of death, and you are hereby exiled from Wesnoth. Be grateful for Our mercy."
                         [/message]
                         [message]
@@ -345,6 +354,7 @@
                             [else]
                                 [message]
                                     speaker=Dolburras
+                                    #po: Owaec's dead
                                     message= _ "Aye, I be honored. I only wish he were here to see the Clans avenged."
                                 [/message]
                             [/else]
@@ -373,6 +383,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: the player chose to give Addogin the plague staff
                             message= _ "Mercenary, <i>necromancer</i>, know that Wesnoth will never tolerate your kind. You shall surrender that accursed stave to be destroyed, you shall foreswear the practice of all magic on penalty of death, and you are hereby exiled from Wesnoth. Be grateful for Our mercy."
                         [/message]
                         [message]
@@ -418,6 +429,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: the player chose to give Hahid the plague staff
                             message= _ "Southerner, <i>necromancer</i>, know that Wesnoth will never tolerate your kind. You shall surrender that accursed stave to be destroyed, you shall foreswear the practice of all magic on penalty of death, and you are hereby exiled back to the desert wastes. Be grateful for Our mercy."
                         [/message]
                         [message]
@@ -492,6 +504,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: whether or not she has the plague staff now, her previous crimes are helf against her
                             message= _ "As for you, <i>necromancer</i>. We are not as like as Terraent to show mercy unto evil, but he speaks well of you, and so mercy shall be shown. Go from here a free woman, but know that you are hereby forbidden to practice magic in any form, at penalty of death."
                         [/message]
                     [/then]
@@ -500,6 +513,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: whether or not she has the plague staff now, her previous crimes are helf against her
                             message= _ "As for you, <i>necromancer</i>. We are not as like as Terraent to show mercy unto evil, but in honor of his sacrifice We will show it now. Go from here a free woman, but know that you are hereby forbidden to practice magic in any form, at penalty of death."
                         [/message]
                     [/else]
@@ -534,6 +548,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: a unit has the plague staff, but they're not one of the loyals. This version of the line is used if Gaennell is here.
                             message= _ "And the same goes for you, wielder of that accursed stave. You shall surrender it to be destroyed, and leave here forbidden to practice magic. Be grateful for Our mercy."
                         [/message]
                     [/then]
@@ -542,6 +557,7 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
+                            #po: a unit has the plague staff, but they're not one of the loyals, and the player doesn't have Gaennell
                             message= _ "As for you, <i>necromancer</i>. You shall surrender that accursed stave to be destroyed, and are hereby forbidden to practice magic in any form, at penalty of death. Be grateful for Our mercy."
                         [/message]
                     [/else]
@@ -591,6 +607,7 @@
                 [message]
                     speaker=Konrad
                     image=portraits/konrad_II.webp
+                    #po: Owaec is dead too
                     message= _ "But alas, what of the Clansmen? Their horses have been scattered, their Lords were broken, and now the last prince has fallen defending the walls of Weldyn. I fear that the Horse Clans will never again return to their former glory."
                 [/message]
             [/else]

--- a/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
@@ -504,7 +504,8 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
-                            #po: whether or not she has the plague staff now, her previous crimes are helf against her
+                            #po: Gaennell’s previous crimes are held against her, regardless of whether or not she has the plague staff now.
+                            #po: Terraent is alive, "speaks well of you" meaning he's asked the King to pardon Gaennell.
                             message= _ "As for you, <i>necromancer</i>. We are not as like as Terraent to show mercy unto evil, but he speaks well of you, and so mercy shall be shown. Go from here a free woman, but know that you are hereby forbidden to practice magic in any form, at penalty of death."
                         [/message]
                     [/then]
@@ -513,7 +514,8 @@
                         [message]
                             speaker=Konrad
                             image=portraits/konrad_II.webp
-                            #po: whether or not she has the plague staff now, her previous crimes are helf against her
+                            #po: Gaennell’s previous crimes are held against her, regardless of whether or not she has the plague staff now.
+                            #po: Terraent is dead.
                             message= _ "As for you, <i>necromancer</i>. We are not as like as Terraent to show mercy unto evil, but in honor of his sacrifice We will show it now. Go from here a free woman, but know that you are hereby forbidden to practice magic in any form, at penalty of death."
                         [/message]
                     [/else]

--- a/data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg
@@ -638,18 +638,21 @@
     [if]
         {VARIABLE_CONDITIONAL side equals 2}
         [then]
+            #po: said by Dra-Nak as an insult to Mortic in the latter's last-breath event
             {VARIABLE taunt_message _"Some ‘leader’."                                                    }
         [/then]
     [/if]
     [if]
         {VARIABLE_CONDITIONAL side equals 3}
         [then]
+            #po: said by Dra-Nak as an insult to Goag in the latter's last-breath event
             {VARIABLE taunt_message _"That’ll teach him. Where was that loyalty when he used to obey me?"}
         [/then]
     [/if]
     [if]
         {VARIABLE_CONDITIONAL side equals 4}
         [then]
+            #po: said by Dra-Nak as an insult to Gra’ritos in the latter's last-breath event
             {VARIABLE taunt_message _"What happened to dying slow? So much for him."                     }
         [/then]
     [/if]
@@ -849,6 +852,7 @@ There is no choice."
 
         [message]
             speaker=Mortic
+            #po: Mortic's last breath
             message= _ "Surrender brings death.
 Battle brings death.
 All is death..."
@@ -911,6 +915,7 @@ Until the end."
 
         [message]
             speaker=Gra'ritos
+            #po: to Dra-Nak
             message= _ "You are Prey.
 I am Hunter.
 I will not fall easily."
@@ -950,6 +955,7 @@ I will not fall easily."
 
         [message]
             speaker=Chief Dra-Nak
+            #po: as the west bridge is broken, the Wesnothians who were left behind are trying to get though the orc's caves and out the east side
             message= _ "Haw, back so soon? Too bad your ‘friends’ abandoned you on MY side of the river. But it’s your lucky day, I’m a fair orc. Surrender now and I might be merciful."
         [/message]
         [message]
@@ -1006,6 +1012,7 @@ I will not fall easily."
         name=explain_imprison
         [message]
             speaker=Chief Dra-Nak
+            #po: the necromancers are apparently paying gold immediately when each prisoner is captured
             message= _ "That’s right, bleed them down and lock them up! I need gold to win this fight!"
         [/message]
         [sound]
@@ -1023,6 +1030,7 @@ I will not fall easily."
         name=explain_prisons2
         [message]
             speaker=Unik
+            #po: the hole where the escape in S11 started
             message= _ "Things are starting to get really crowded over here Chief. Shame the fourth cell has a hole in the back..."
         [/message]
     [/event]
@@ -1426,6 +1434,7 @@ I will not fall easily."
         [/message]
         [message]
             speaker=Chief Dra-Nak
+            #po: all the prisoners
             message= _ "Now kill them all."
         [/message]
 
@@ -1541,10 +1550,12 @@ I will not fall easily."
         # jailer protests
         [message]
             speaker=Unik
+            #po: already paid them for the prisoners
             message= _ "But Chief, the necromancers already paid us! We can’t just-"
         [/message]
         [message]
             speaker=Chief Dra-Nak
+            #po: all the necromancers
             message= _ "Then I’ll kill them all too! I’m done working with others!"
         [/message]
         {KILL_COUNT 4 (
@@ -1585,6 +1596,7 @@ I will not fall easily."
 
         [message]
             speaker=Chief Dra-Nak
+            #po: the chief's last breath
             message= _ "FILTHY... Rotten... ...traitors... ..."
         [/message]
         [endlevel]


### PR DESCRIPTION
Has a few updates to S04a, S04b, S09 and S99 too. This isn't the complete set for S99, but it feels like a good stopping point if I want to get it reviewed in time for this weekend's release.

Lore: this declares Khrakrahs (dragon seen in SoF) to be male. He's been in many versions of Wesnoth that only had male drakes, thus will surely already be male in any translation where the gender has an effect on the wording.

There's a few questions and "TODO for 1.19" comments added:

* In S12, the left behind units say "we must ride ... to save Wesnoth", but it looks like that should be "you must ride".
* The intro of S13 is confusing, there's little indication of why you only have one unit, or what mission he failed.
* In S16, Gweddry says "night approaches" on turn 1 (morning)

This shouldn't cause merge conflicts with #8416, or with the (currently WIP) fix for #8389.