### PR TITLE
Fix multiline_text's overriding of set_cursor

### DIFF
--- a/src/gui/widgets/multiline_text.cpp
+++ b/src/gui/widgets/multiline_text.cpp
@@ -211,8 +211,7 @@ void multiline_text::handle_mouse_selection(point mouse, const bool start_select
 
 	line_num_ = get_line_num_from_offset(offset);
 
-	// moving scrollbars during click causes viewport to jump
-	set_cursor(offset, !start_selection, false);
+	set_cursor(offset, !start_selection);
 
 	update_canvas();
 	queue_redraw();

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -132,7 +132,7 @@ protected:
 		update_layout();
 	}
 
-	/** Inherited from text_box_base, defaults the autoscroll argument to true. */
+	/** Inherited from text_box_base */
 	void set_cursor(const std::size_t offset, const bool select) override
 	{
 		text_box_base::set_cursor(offset, select);

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -132,8 +132,14 @@ protected:
 		update_layout();
 	}
 
-	/** Inherited from text_box_base. */
-	void set_cursor(const std::size_t offset, const bool select, const bool autoscroll = true)
+	/** Inherited from text_box_base, defaults the autoscroll argument to true. */
+	void set_cursor(const std::size_t offset, const bool select) override
+	{
+		// Because the two-argument form is virtual, adding a three-argument form requires
+		// a separate function, otherwise callers in text_box_base will ignore the override.
+		set_cursor(offset, select, true);
+	}
+	virtual void set_cursor(const std::size_t offset, const bool select, const bool autoscroll)
 	{
 		text_box_base::set_cursor(offset, select);
 		set_line_num_from_offset();

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -135,19 +135,10 @@ protected:
 	/** Inherited from text_box_base, defaults the autoscroll argument to true. */
 	void set_cursor(const std::size_t offset, const bool select) override
 	{
-		// Because the two-argument form is virtual, adding a three-argument form requires
-		// a separate function, otherwise callers in text_box_base will ignore the override.
-		set_cursor(offset, select, true);
-	}
-	virtual void set_cursor(const std::size_t offset, const bool select, const bool autoscroll)
-	{
 		text_box_base::set_cursor(offset, select);
 		set_line_num_from_offset();
-
-		if (autoscroll) {
-			// Whenever cursor moves, this tells scroll_text to update the scrollbars
-			update_layout();
-		}
+		// Whenever cursor moves, this tells scroll_text to update the scrollbars
+		update_layout();
 	}
 
 	/** Inherited from text_box_base. */

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -163,7 +163,7 @@ private:
 		return vertical_scrollbar()->get_positioner_offset();
 	}
 
-	void place(const point& origin, const point& size);
+	void place(const point& origin, const point& size) override;
 
 	/** See @ref widget::calculate_best_size. */
 	point calculate_best_size() const override;


### PR DESCRIPTION
When code in text_box_base.cpp calls the virtual method, it will only consider the 2-argument version, and thus skip the 3-argument wrapper. Override the 2-argument method to catch the calls and have the intended extra effect.

Note: in testing I don't see a difference in what happens in the UI, but I'm not familiar with the edge cases of this widget.
I just checked the stack traces to confirm that the call from text_box_base::insert_char skipped the wrapper.

This fixes a Clang warning, although the warning itself points out the opposite effect - that the 3-argument version hid the 2-argument one in the subclass.

Also fix a Clang warning that scroll_text could mark a method as an override.