### PR TITLE
DiD S10: Fix missing line in human heroes' book endings

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -1183,7 +1183,7 @@
                             [/message]
 
                             [message]
-                                role=unit
+                                speaker=unit
                                 message= _ "It’s not catching fire!"
                             [/message]
 
@@ -1211,7 +1211,7 @@
                             [/message]
 
                             [message]
-                                role=unit
+                                speaker=unit
                                 message= _ "It’s not catching fire!"
                             [/message]
 


### PR DESCRIPTION
A simple case of `role=unit` instead of `speaker=unit`, the necessary translatable text was already in the scenario.

Reported by JL42 in https://r.wesnoth.org/p686563 , it's a trivial fix so intending to merge once the CI's sanity checks are done.