### PR TITLE
ui: Visibly misaligned button text labels on Windows

### DIFF
--- a/data/gui/widget/button_default.cfg
+++ b/data/gui/widget/button_default.cfg
@@ -6,21 +6,6 @@
 #define _GUI_BUTTON_FONT_SIZE
 16 #enddef
 
-# Same as GUI__CENTERED_TEXT but with a slight vertical offset for the text to make it look better
-#define _GUI_BUTTON_TEXT FONT_SIZE FONT_STYLE FONT_COLOR
-	[text]
-		x = {GUI__TEXT_HORIZONTALLY_CENTRED}
-		y = "(max((height - text_height - 2) / 2, 0))"
-		w = "(text_width)"
-		h = "(text_height)"
-		font_size = {FONT_SIZE}
-		font_style = {FONT_STYLE}
-		color = {FONT_COLOR}
-		text = "(text)"
-		text_markup = "(text_markup)"
-	[/text]
-#enddef
-
 #define _GUI_STATE BACKGROUND_IMAGE BORDER_COLOR BORDER_COLOR_DARK HIGHLIGHT_LINE_COLOR IPF
 	{GUI__BUTTON_NORMAL_FRAME buttons/button_normal/{BACKGROUND_IMAGE}
 		({BORDER_COLOR})
@@ -56,7 +41,7 @@
 					({GUI__BORDER_COLOR      ALPHA={ALPHA}})
 					({GUI__BORDER_COLOR_DARK ALPHA={ALPHA}}) ("21, 79, 109, 255") {IPF}}
 
-				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
+				{GUI__CENTERED_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
 
 			[/draw]
 
@@ -71,7 +56,7 @@
 					("89,  89,  89,  {ALPHA}")
 					("60,  60,  60, 255") "~GS(){IPF}"}
 
-				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_DISABLED__TITLE})}
+				{GUI__CENTERED_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_DISABLED__TITLE})}
 
 			[/draw]
 
@@ -85,7 +70,7 @@
 					({GUI__BORDER_COLOR      ALPHA={ALPHA}})
 					({GUI__BORDER_COLOR_DARK ALPHA={ALPHA}}) ("1, 10, 16, 255") {IPF}}
 
-				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
+				{GUI__CENTERED_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
 
 			[/draw]
 
@@ -99,7 +84,7 @@
 					({GUI__BORDER_COLOR      ALPHA={ALPHA}})
 					({GUI__BORDER_COLOR_DARK ALPHA={ALPHA}}) ("12, 108, 157, 255") {IPF}}
 
-				{_GUI_BUTTON_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
+				{GUI__CENTERED_TEXT ({FONT_SIZE}) () ({GUI__FONT_COLOR_ENABLED__TITLE})}
 
 			[/draw]
 
@@ -281,7 +266,6 @@
 [/button_definition]
 
 #undef _GUI_BUTTON_FONT_SIZE
-#undef _GUI_BUTTON_TEXT
 #undef _GUI_STATE
 #undef _GUI_RESOLUTION
 #undef _GUI_RESOLUTION_ICON_ONLY


### PR DESCRIPTION
Since some unknown point in Wesnoth 1.17.x's development, button text labels became horribly misaligned on Windows on 1080p screens, potentially as a side effect of one of the many changes intended to help in high DPI configurations.

I attempted a fix for this in this PR by removing the -2 px vertical offset from button labels, but it seems to have unexpected consequences on Linux (1080p) and macOS (high DPI) causing the labels to be visibly closer to the bottom of the button frame, which is not quite ideal either — even if it **does** solve the more visible misalignment on 1080p Windows. I can't quite tell if there might be a Windows-specific issue going on affecting the GUI canvas measurements.

## Windows (1080p)

**Before**
![Screenshot_1089](https://github.com/wesnoth/wesnoth/assets/489895/eaf987cb-3b76-4981-8cb6-297980f93d3b)

**After**
![Screenshot_1090](https://github.com/wesnoth/wesnoth/assets/489895/3cdc9d39-7273-4077-b7d2-0730a24cebd0)

## Linux (1080p)

**Before**
![Screenshot_20240218_201535](https://github.com/wesnoth/wesnoth/assets/489895/02798f88-e0b7-42d8-b3d6-033125e3e763)

**After**
![Screenshot_20240218_201619](https://github.com/wesnoth/wesnoth/assets/489895/6d79f261-7a10-46ea-bcea-d2953af33d9e)

## macOS (high DPI)

**Before**
![Screenshot 2024-02-18 at 20 14 38](https://github.com/wesnoth/wesnoth/assets/489895/066cd151-64a2-4fbe-88fa-d85bc0af2cc1)

**After**
![Screenshot 2024-02-18 at 20 14 12](https://github.com/wesnoth/wesnoth/assets/489895/61ee377a-7efe-4062-8b44-d23b7e2d724b)
