### PR TITLE
Remove new strings that were used for VALIDATE_WML_CHILD

### DIFF
--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -230,10 +230,10 @@ scroll_text_definition::resolution::resolution(const config& cfg)
 	: resolution_definition(cfg), grid(nullptr)
 {
 	// Note the order should be the same as the enum state_t is scroll_text.hpp.
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for scroll text control")));
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for scroll text control")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", missing_mandatory_wml_tag("scroll_text", "state_enabled")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", missing_mandatory_wml_tag("scroll_text", "state_disabled")));
 
-	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for scroll text control"));
+	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("scroll_text", "grid"));
 	grid = std::make_shared<builder_grid>(child);
 }
 

--- a/src/gui/widgets/spinner.cpp
+++ b/src/gui/widgets/spinner.cpp
@@ -140,10 +140,10 @@ spinner_definition::resolution::resolution(const config& cfg)
 	: resolution_definition(cfg), grid(nullptr)
 {
 	// Note the order should be the same as the enum state_t is spinner.hpp.
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", _("Missing required state for spinner control")));
-	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", _("Missing required state for spinner control")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_enabled", missing_mandatory_wml_tag("spinner", "state_enabled")));
+	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", missing_mandatory_wml_tag("spinner", "state_disabled")));
 
-	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for spinner control"));
+	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("spinner", "grid"));
 	grid = std::make_shared<builder_grid>(child);
 }
 

--- a/src/wml_exception.cpp
+++ b/src/wml_exception.cpp
@@ -93,3 +93,11 @@ std::string missing_mandatory_wml_key(
 			"mandatory key '$key|' isn't set.", symbols);
 	}
 }
+
+std::string missing_mandatory_wml_tag(
+		  const std::string &section
+		, const std::string &tag)
+{
+	// TODO in 1.19: revisit this when we can add new strings
+	return missing_mandatory_wml_key(section, "[" + tag + "]");
+}

--- a/src/wml_exception.hpp
+++ b/src/wml_exception.hpp
@@ -130,7 +130,7 @@ private:
 };
 
 /**
- * Returns a standard message for a missing wml key.
+ * Returns a standard message for a missing wml key (attribute).
  *
  * @param section                 The section in which the key should appear.
  *                                Shouldn't include leading or trailing brackets,
@@ -150,3 +150,16 @@ std::string missing_mandatory_wml_key(
 		, const std::string& key
 		, const std::string& primary_key = ""
 		, const std::string& primary_value = "");
+
+/**
+ * Returns a standard message for a missing wml child (tag).
+ *
+ * @param section                 The section in which the child should appear.
+ *                                Same meaning as for missing_mandatory_wml_key().
+ * @param tag                     The omitted tag.
+ *
+ * @returns                       The error message.
+ */
+std::string missing_mandatory_wml_tag(
+		  const std::string& section
+		, const std::string& tag);


### PR DESCRIPTION
This adds a new missing_mandatory_wml_tag() function, which returns a message using a common string, similar to the existing missing_mandatory_wml_key.

To avoid new strings in 1.18, the current implementation just calls missing_mandatory_wml_key directly.