### PR TITLE
Re-add the renamed/removed unit images in MP Aethermaw (#8432)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Whitespace and WML indentation check
         if: success() || failure()
         run: ./utils/CI/fix_whitespace.sh; git status; git diff --exit-code
+      - name: WML missing images check
+        if: success() || failure()
+        run: utils/CI/check_wml_images.sh
       - name: Run luacheck
         if: success() || failure()
         run: luacheck .

--- a/utils/CI/check_wml_images.sh
+++ b/utils/CI/check_wml_images.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Find missing images referenced by WML (as in issue #8432)
+#
+# Requires sort with -s option (stable sort, disable further byte-by-byte
+# comparison of lines that collate equally by specified sort key), e.g. from
+# GNU coreutils
+#
+# Example output:
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:134: missing image: units/undead/shadow-s-attack-1.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:135: missing image: units/undead/shadow-n-attack-2.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:147: missing image: units/undead/shadow-n-3.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:149: missing image: units/undead/shadow-s-attack-4.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:196: missing image: units/human-loyalists/spearman-attack-se-10.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:197: missing image: units/human-loyalists/spearman-attack-s-6.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:198: missing image: units/human-loyalists/spearman-attack-se-9.png
+#     data/multiplayer/scenarios/2p_Aethermaw.cfg:203: missing image: units/human-loyalists/general-idle-5.png
+
+set -eu
+
+# Parsing WML with a regular expression isn't ideal, but it's easy and it works.
+# Note that this only matches images specified with "PLACE_IMAGE" and
+# "PLACE_IMAGE_SUBMERGED" macros, not "[item]" "image=" images.
+IMG_RE='
+	^               ; Beginning of line
+	[^#]*           ; Zero or more characters other than hash (do not match
+	                ; commented-out images)
+	[{]             ; Open curly brace
+	PLACE_IMAGE     ; "PLACE_IMAGE" macro name
+	[^ \t]*         ; Optional non-whitespace characters (e.g. "_SUBMERGED")
+	[ \t]+          ; One or more spaces or tabs after macro name
+	[(]?            ; One optional open parenthesis
+	"?              ; One optional double quote around image file name
+	([^{}$ \t~")]+) ; Capture image file name (one or more characters other
+	                ; than curly braces, dollar, space, tab, tilde, double
+	                ; quote, or close parenthesis)
+	[ \t~")}]       ; One space, tab, tilde, double quote, close
+	                ; parenthesis, or close curly brace after the file name
+	.*              ; Any character(s)
+	$               ; End of line
+	'
+# Somewhat simulate Perl's "/x" modifier ("Extend your pattern's legibility by
+# permitting whitespace and comments"):
+IMG_RE="$(printf '%s' "${IMG_RE}" | sed '
+	s|^[ \t]*||;     # Strip leading whitespace
+	s|;.*$||;        # Strip comments (use ";" since "#" is used in the RE)
+	s|[ \t]*$||;     # Strip trailing whitespace
+	' | tr -d '\n')" # Remove all newlines
+
+# In `! { COMMANDS | grep -- '.'; }` below, `grep -- '.'` returns a successful
+# exit status if `COMMANDS` produce output, and `!` inverts it into an error
+# status.  A less clever/obscure solution would be `es=true` before the loop,
+# `es=false` inside the loop after all the `continue`s, and `${es}` at the end;
+# but that won't work because all commands in pipelines run in subshells that
+# can't affect variables in the parent shell.
+
+! { git grep -EIn -- "${IMG_RE}" data/ | while IFS=':' read -r wml ln img; do
+	img="$(printf '%s' "${img}" | sed -E "s|${IMG_RE}|\\1|")"
+	[ -e "data/core/images/${img}" ] && continue
+	[ -e "${img}" ] && continue
+	case "${wml}" in
+		data/campaigns/*)
+			sfx="${wml#data/campaigns/*/}"
+			[ -e "${wml%/${sfx}}/images/${img}" ] && continue
+			;;
+	esac
+	printf '%s:%d: missing image: %s\n' "${wml}" "${ln}" "${img}"
+done | sort -t ':' -k 2n,2n | sort -t ':' -k 1,1 -s | grep -- '.'; }


### PR DESCRIPTION
Playing the multiplayer scenario Aethermaw as Loyalists vs. Undead revealed some image errors (#8432):

    20240219 06:50:21 error image: could not open image 'units/undead/shadow-s-attack-1.png'
    20240219 06:50:21 error image: could not open image 'units/undead/shadow-s-attack-4.png'
    20240219 06:50:21 error image: could not open image 'units/undead/shadow-n-3.png'
    20240219 06:50:22 error image: could not open image 'units/undead/shadow-n-attack-2.png'
    20240219 06:50:26 error image: could not open image 'units/human-loyalists/spearman-attack-se-9.png'
    20240219 06:50:26 error image: could not open image 'units/human-loyalists/spearman-attack-se-10.png'
    20240219 06:50:26 error image: could not open image 'units/human-loyalists/spearman-attack-s-6.png'
    20240219 06:50:26 error image: could not open image 'units/human-loyalists/general-idle-5.png'

units/undead/shadow-* images were moved to units/undead-spirit/shadow-* in 1.17.4 commit a2ad3ae1988, specifically the "1.17 undead sprite cleanup" commit 961b8a3a323 of PR #6655.  This was documented on the forums:
https://forums.wesnoth.org/viewtopic.php?p=684291&hilit=units%2Fundead-spirit%2F#p684291

wmllint handles renamed images, but it also makes an enormous number of other (often questionable at best) changes (issue #5799).  So for now, instead of using wmllint, just update Aethermaw for these renamed images as follows (requires GNU sed):

    git grep -Fl -- 'units/undead/shadow-' \
        | grep -v '^data/tools/wmllint$' \
        | xargs sed -i 's|units/undead/shadow-|units/undead-spirit/shadow-|'

These units/human-loyalists/ images were removed in 1.17.12 commit 8e38cfd01ad, specifically the "spearman image cleanup" commit 775e7f8 and the "remove left-over old general frames" commit e07d554 in PR #7208.  But Aethermaw still uses them.

Restore the removed images that are still used:

    git grep -EIh -- '^[^#]*[{]PLACE_IMAGE[^ ]* +[(]?"?[^{}$ ~")]+[ ~")].*$' data/ \
        | sed -E 's|^.*[{]PLACE_IMAGE[^ ]* +[(]?"?([^{}$ ~")]+)[ ~")].*$|\1|' \
        | while read -r img; do
            [ -e data/core/images/${img} ] && continue
            [ -e data/campaigns/*/images/${img} ] && continue
            [ -e ${img} ] && continue
            git show 8e38cfd01ad~1:data/core/images/${img} 1>data/core/images/${img}
        done

Also add a CI check to prevent this from happening in the future. Example output without these Aethermaw fixes:

    data/multiplayer/scenarios/2p_Aethermaw.cfg:134: missing image: units/undead/shadow-s-attack-1.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:135: missing image: units/undead/shadow-n-attack-2.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:147: missing image: units/undead/shadow-n-3.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:149: missing image: units/undead/shadow-s-attack-4.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:196: missing image: units/human-loyalists/spearman-attack-se-10.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:197: missing image: units/human-loyalists/spearman-attack-s-6.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:198: missing image: units/human-loyalists/spearman-attack-se-9.png
    data/multiplayer/scenarios/2p_Aethermaw.cfg:203: missing image: units/human-loyalists/general-idle-5.png

See also #8436 for 1.18.