### PR TITLE
Correct image locations

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -432,13 +432,13 @@ of Healing"
             [then]
                 [set_variable]
                     name=message_image
-                    value="units/undead/bat-se-3.png~CROP(13,15,46,39)~XBRZ(2)"
+                    value="units/bats/bat-se-3.png~CROP(13,15,46,39)~XBRZ(2)"
                 [/set_variable]
             [/then]
             [else]
                 [set_variable]
                     name=message_image
-                    value="units/undead/bloodbat-se-3.png~CROP(13,15,46,39)~XBRZ(2)"
+                    value="units/bats/bloodbat-se-3.png~CROP(13,15,46,39)~XBRZ(2)"
                 [/set_variable]
             [/else]
         [/if]

--- a/data/core/units/saurians/Prophet.cfg
+++ b/data/core/units/saurians/Prophet.cfg
@@ -5,7 +5,7 @@
     race=lizard
     gender=male
     image="units/saurians/prophet/prophet.png"
-    profile="portraits/saurians/augur.png"
+    profile="portraits/saurians/augur.webp"
     hitpoints=43
     movement_type=lizard
     movement=6

--- a/data/core/units/saurians/Seer.cfg
+++ b/data/core/units/saurians/Seer.cfg
@@ -4,7 +4,7 @@
     name= _ "Saurian Seer"
     race=lizard
     image="units/saurians/seer/seer.png"
-    profile="portraits/saurians/augur.png"
+    profile="portraits/saurians/augur.webp"
     hitpoints=39
     movement_type=lizard
     movement=7


### PR DESCRIPTION
Corrects some image paths as flagged by `wmllint`. This complements @pehjota's #8435/#8436 for #8432.

This should probably be back-ported to 1.18 branch.