### PR TITLE
WoF: fixes for wmllint warnings

### DIFF
--- a/data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/01_The_Hunt.cfg
@@ -58,18 +58,18 @@
     [/side]
     {WOF_DEATHS}
 
-    {SPAWNER_SIDE 2  "Stymphalian"    Mm      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}
-    {SPAWNER_SIDE 3  "Dragonfly"      Ss      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}
-    {SPAWNER_SIDE 4  "Leopard"        *^Ftr   {ON_DIFFICULTY4 0.1  0.25  0.5  1}   6 1}
-    {SPAWNER_SIDE 5  "Horned Scarab"  *^Ft    {ON_DIFFICULTY4 0.1  0.25  0.5  1}   6 1}
-    {SPAWNER_SIDE 6  "Fire Ant"       Dd      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}
-    {SPAWNER_SIDE 7  "Rock Scorpion"  Mm      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   1 1}
-    {SPAWNER_SIDE 8  "Swamp Lizard"   Ss      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   6 1}
-    {SPAWNER_SIDE 9  "Water Serpent"  Wwt^Ew* {ON_DIFFICULTY4 0.05 0.125 0.25 0.5} 3 1}
-    {SPAWNER_SIDE 10 "Dolphin"        Ww      0.05                                 3 2}
-    {SPAWNER_SIDE 11 "Nibbler"        Wwt     {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}
-    {SPAWNER_SIDE 12 "Cuttle Fish"    Wo*     {ON_DIFFICULTY4 0.05 0.125 0.25 0.5} 6 2}
-    {SPAWNER_SIDE 13 "Great Seahorse" Wwr     0.05                                 3 2}
+    {SPAWNER_SIDE 2  "Stymphalian"    Mm      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}    # wmllint: skip-side
+    {SPAWNER_SIDE 3  "Dragonfly"      Ss      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}    # wmllint: skip-side
+    {SPAWNER_SIDE 4  "Leopard"        *^Ftr   {ON_DIFFICULTY4 0.1  0.25  0.5  1}   6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 5  "Horned Scarab"  *^Ft    {ON_DIFFICULTY4 0.1  0.25  0.5  1}   6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 6  "Fire Ant"       Dd      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}    # wmllint: skip-side
+    {SPAWNER_SIDE 7  "Rock Scorpion"  Mm      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   1 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 8  "Swamp Lizard"   Ss      {ON_DIFFICULTY4 0.1  0.25  0.5  1}   6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 9  "Water Serpent"  Wwt^Ew* {ON_DIFFICULTY4 0.05 0.125 0.25 0.5} 3 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 10 "Dolphin"        Ww      0.05                                 3 2}    # wmllint: skip-side
+    {SPAWNER_SIDE 11 "Nibbler"        Wwt     {ON_DIFFICULTY4 0.1  0.25  0.5  1}   9 2}    # wmllint: skip-side
+    {SPAWNER_SIDE 12 "Cuttle Fish"    Wo*     {ON_DIFFICULTY4 0.05 0.125 0.25 0.5} 6 2}    # wmllint: skip-side
+    {SPAWNER_SIDE 13 "Great Seahorse" Wwr     0.05                                 3 2}    # wmllint: skip-side
 
     [event]
         name=prestart

--- a/data/campaigns/Winds_of_Fate/scenarios/05_Threshold.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/05_Threshold.cfg
@@ -213,15 +213,15 @@
         [/ai]
     [/side]
 
-    {SPAWNER_SIDE 4  "Blood Bat"       *^Ft  {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}
-    {SPAWNER_SIDE 5  "Woodland Boar"   *^Ft  {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}
-    {SPAWNER_SIDE 6  "Elder Falcon"    *^Fds {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}
-    {SPAWNER_SIDE 7  "Great Wolf"      *^Fds {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}
-    {SPAWNER_SIDE 8  "Grand Dragonfly" Ss    {ON_DIFFICULTY4 0.05 0.1  0.25 0.5}  6 1}
-    {SPAWNER_SIDE 9  "Swamp Lizard"    Ss    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}
-    {SPAWNER_SIDE 10  "Firebane Ant"   Hd    {ON_DIFFICULTY4 0.05 0.1  0.25 0.5}  6 1}
-    {SPAWNER_SIDE 11  "Firebomb Ant"   Hd    {ON_DIFFICULTY4 0.05 0.1  0.25 0.5}  6 1}
-    {SPAWNER_SIDE 12  "Giant Spider"   Md    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}
+    {SPAWNER_SIDE 4  "Blood Bat"       *^Ft  {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 5  "Woodland Boar"   *^Ft  {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 6  "Elder Falcon"    *^Fds {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 7  "Great Wolf"      *^Fds {ON_DIFFICULTY4 0.1  0.25 0.5  0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 8  "Grand Dragonfly" Ss    {ON_DIFFICULTY4 0.05 0.1  0.25 0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 9  "Swamp Lizard"    Ss    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 10  "Firebane Ant"   Hd    {ON_DIFFICULTY4 0.05 0.1  0.25 0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 11  "Firebomb Ant"   Hd    {ON_DIFFICULTY4 0.05 0.1  0.25 0.5}  6 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 12  "Giant Spider"   Md    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}    # wmllint: skip-side
 
     # Wisp
     [side]

--- a/data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/08_Overlook.cfg
@@ -895,7 +895,7 @@ Just like we did the first one."
             [filter]
                 id=Resha
             [/filter]
-            variable=Resha
+            variable=resha
             kill=yes
         [/store_unit]
         [hide_unit]

--- a/data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg
@@ -65,13 +65,13 @@
         no_leader=yes
     [/side]
 
-    {SPAWNER_SIDE 3  "Gryphon"        Ms    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}
-    {SPAWNER_SIDE 4  "Dread Bat"      Qxu   {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}
-    {SPAWNER_SIDE 5  "Frost Stoat"    Ai    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 3}
-    {SPAWNER_SIDE 6  "Great Icemonax" Aa    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 6 6}
-    {SPAWNER_SIDE 7  "Direwolf"       *^F*  {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 6 6}
-    {SPAWNER_SIDE 8  "Cave Bear"      Ms    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 6 6}
-    {SPAWNER_SIDE 9  "Yeti"           Ms    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 2}
+    {SPAWNER_SIDE 3  "Gryphon"        Ms    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 4  "Dread Bat"      Qxu   {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 1}    # wmllint: skip-side
+    {SPAWNER_SIDE 5  "Frost Stoat"    Ai    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 3}    # wmllint: skip-side
+    {SPAWNER_SIDE 6  "Great Icemonax" Aa    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 6 6}    # wmllint: skip-side
+    {SPAWNER_SIDE 7  "Direwolf"       *^F*  {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 6 6}    # wmllint: skip-side
+    {SPAWNER_SIDE 8  "Cave Bear"      Ms    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 6 6}    # wmllint: skip-side
+    {SPAWNER_SIDE 9  "Yeti"           Ms    {ON_DIFFICULTY4 0.02 0.05 0.1  0.25} 3 2}    # wmllint: skip-side
 
     # wmllint: validate-on
 

--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -75,6 +75,14 @@
         team_name=karron
         user_team_name= _ "Flight Karron"
         {FLAG_VARIANT long}
+        [ai]
+            [leader_goal]
+                x,y=4,36
+                auto_remove=yes
+                id=land_on_keep
+                max_risk=1
+            [/leader_goal]
+        [/ai]
         # wmllint: who KARRON is Karron
         [leader]
             {KARRON (Drake Blademaster)}
@@ -162,14 +170,6 @@
         {GENERIC_UNIT 2 (Drake Warrior)   4 35}
         {GENERIC_UNIT 2 (Drake Warrior)   3 36}
 #endif
-        [ai]
-            [leader_goal]
-                x,y=4,36
-                auto_remove=yes
-                id=land_on_keep
-                max_risk=1
-            [/leader_goal]
-        [/ai]
     [/side]
 
     # wmllint: validate-on


### PR DESCRIPTION
Fixes an issue [discovered](https://github.com/wesnoth/wesnoth/pull/7908#discussion_r1495724310) by @Wedge009 in the wmllint logs, using the magic comment [suggested](https://github.com/wesnoth/wesnoth/pull/7908#discussion_r1496780958) by @CelticMinstrel. Also fixes three other WoF issues reported in the wmllint logs.

At least the "wrongly capitalized variable name" should be considered for backporting to 1.18 since it fixes a player affecting bug of one of their main character units (Resha) losing an upgrade object if it is given to her.