### PR TITLE
HttT S5b: Fix duplicate loyal trait for Delurin

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05b_Isle_of_the_Damned.cfg
@@ -224,7 +224,6 @@
         {NAMED_LOYAL_UNIT 1 (Outlaw) 20 10 (Delurin) ( _ "Delurin")}
         [+unit]
             [modifications]
-                {TRAIT_LOYAL}
                 {TRAIT_RESILIENT}
                 {TRAIT_INTELLIGENT}
             [/modifications]


### PR DESCRIPTION
NAMED_LOYAL_UNIT has the loyal trait built in, so this results in an extra copy of it being granted to the unit.