### PR TITLE
Keep laurel decorations consistent with difficulty level

### DIFF
--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -68,6 +68,8 @@ void campaign_difficulty::pre_show(window& window)
 	listbox& list = find_widget<listbox>(&window, "listbox", false);
 	window.keyboard_capture(&list);
 
+	unsigned difficulty_count = 0;
+	const unsigned difficulty_max = difficulties_.child_count("difficulty");
 	for(const config& d : difficulties_.child_range("difficulty")) {
 		widget_data data;
 		widget_item item;
@@ -99,10 +101,31 @@ void campaign_difficulty::pre_show(window& window)
 			list.select_last_row();
 		}
 
-		widget* widget = grid.find("victory", false);
-		if(widget && !preferences::is_campaign_completed(campaign_id_, d["define"])) {
-			widget->set_visible(widget::visibility::hidden);
+		styled_widget &widget = find_widget<styled_widget>(&grid, "victory", false);
+		if(&widget) {
+			// Use different laurels according to the difficulty level, following the
+			// pre-existing convention established in campaign_selection class.
+			// Assumes ascending order of difficulty.
+			if(preferences::is_campaign_completed(campaign_id_, d["define"])) {
+				if(difficulty_count == 0) {
+					widget.set_label(game_config::images::victory_laurel_easy);
+				}
+
+				else if(difficulty_count + 1 >= difficulty_max) {
+					widget.set_label(game_config::images::victory_laurel_hardest);
+				}
+
+				else {
+					widget.set_label(game_config::images::victory_laurel);
+				}
+			}
+
+			else {
+				widget.set_visible(widget::visibility::hidden);
+			}
 		}
+
+		difficulty_count++;
 	}
 }
 

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -101,28 +101,26 @@ void campaign_difficulty::pre_show(window& window)
 			list.select_last_row();
 		}
 
-		styled_widget &widget = find_widget<styled_widget>(&grid, "victory", false);
-		if(&widget) {
+		styled_widget& widget = find_widget<styled_widget>(&grid, "victory", false);
+		if(preferences::is_campaign_completed(campaign_id_, d["define"])) {
 			// Use different laurels according to the difficulty level, following the
 			// pre-existing convention established in campaign_selection class.
 			// Assumes ascending order of difficulty.
-			if(preferences::is_campaign_completed(campaign_id_, d["define"])) {
-				if(difficulty_count == 0) {
-					widget.set_label(game_config::images::victory_laurel_easy);
-				}
+			if(difficulty_count == 0) {
+				widget.set_label(game_config::images::victory_laurel_easy);
+			}
 
-				else if(difficulty_count + 1 >= difficulty_max) {
-					widget.set_label(game_config::images::victory_laurel_hardest);
-				}
-
-				else {
-					widget.set_label(game_config::images::victory_laurel);
-				}
+			else if(difficulty_count + 1 >= difficulty_max) {
+				widget.set_label(game_config::images::victory_laurel_hardest);
 			}
 
 			else {
-				widget.set_visible(widget::visibility::hidden);
+				widget.set_label(game_config::images::victory_laurel);
 			}
+		}
+
+		else {
+			widget.set_visible(widget::visibility::hidden);
 		}
 
 		difficulty_count++;

--- a/src/gui/dialogs/campaign_difficulty.cpp
+++ b/src/gui/dialogs/campaign_difficulty.cpp
@@ -105,21 +105,16 @@ void campaign_difficulty::pre_show(window& window)
 		if(preferences::is_campaign_completed(campaign_id_, d["define"])) {
 			// Use different laurels according to the difficulty level, following the
 			// pre-existing convention established in campaign_selection class.
-			// Assumes ascending order of difficulty.
-			if(difficulty_count == 0) {
-				widget.set_label(game_config::images::victory_laurel_easy);
-			}
-
-			else if(difficulty_count + 1 >= difficulty_max) {
+			// Assumes ascending order of difficulty and gold laurel is set first
+			// in case there is only one difficulty setting.
+			if(difficulty_count + 1 >= difficulty_max) {
 				widget.set_label(game_config::images::victory_laurel_hardest);
-			}
-
-			else {
+			} else if(difficulty_count == 0) {
+				widget.set_label(game_config::images::victory_laurel_easy);
+			} else {
 				widget.set_label(game_config::images::victory_laurel);
 			}
-		}
-
-		else {
+		} else {
 			widget.set_visible(widget::visibility::hidden);
 		}
 


### PR DESCRIPTION
Still feels a bit clunky, but I'm following the pattern already used here:
https://github.com/wesnoth/wesnoth/blob/90a74e1b965b77b6abca46a4b7f94a297a290ab1/src/gui/dialogs/campaign_selection.cpp#L98-L110

This works for me, at least. Thanks to @CelticMinstrel for pointing me in the right direction. If there's a better way than just relying on the count of difficulties, please advise.

Resolves #8442. Should be back-ported to 1.18 branch, I think 1.16 as well unless there's absolutely no way there's going to be another release for it.

![image](https://github.com/wesnoth/wesnoth/assets/13679322/810eefc9-65fb-4b91-b0a6-d9341e4074a0)
