### PR TITLE
Bump vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "wesnoth-dependencies",
   "version": "0.0.1",
-  "builtin-baseline": "dafef74af53669ef1cc9015f55e0ce809ead62aa",
+  "builtin-baseline": "1580d2238574df45fa018afcfb375fffbebca244",
   "dependencies": [
     "sdl2",
     {


### PR DESCRIPTION
Gives us (among other things) these updates:

Boost:             1.82                            -> 1.84
OpenSSL/libcrypto: 3.1.0a-dev (runtime 3.1.0a-dev) -> 3.2.0a-dev (runtime 3.2.0a-dev)
libcurl:           8.1.2 (runtime 8.1.2-DEV)       -> 8.6.0 (runtime 8.6.0-DEV)
Cairo:             1.17.8 (runtime 1.17.8)         -> 1.18.0 (runtime 1.18.0)
Pango:             1.50.14 (runtime 1.50.14)       -> 1.50.14 (runtime 1.50.14)
SDL:               2.26.5 (runtime 2.26.5)         -> 2.30.0 (runtime 2.30.0)
SDL_image:         2.6.3 (runtime 2.6.3)           -> 2.8.2 (runtime 2.8.2)
SDL_mixer:         2.6.3 (runtime 2.6.3)           -> 2.8.0 (runtime 2.8.0)