### PR TITLE
wmllint: drop the rule about [campaign]rank= being a multiple of 5

### DIFF
--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -1729,8 +1729,8 @@ def local_sanity_check(filename, nav, key, prefix, value, comment):
                     if campaign_rank < 300:
                         print(errlead + "rank for add-on campaigns should be greater than or equal to 300")
                 elif "campaigns" in filename:
-                    if campaign_rank >= 300 or (campaign_rank % 5) != 0:
-                        print(errlead + "rank for mainline campaigns should be a multiple of 5 between 0 and 299 (included)")  
+                    if campaign_rank >= 300:
+                        print(errlead + "rank for mainline campaigns should be between 0 and 299 (included)")  
             except ValueError:
                 print(errlead + "rank must be a numeric value")
 


### PR DESCRIPTION
The idea of using multiples of 5 seems like a way to avoid having to change multiple campaigns' ranks at once, because it leaves space to rearrange a mainline campaign between two other campaigns.

But enforcing "it must be a multiple of 5, even if that means changing other campaigns" loses the advantage of using multiples. For example, WoF currently has rank=152, which triggers the warning, which has caused a PR to be opened that changes WoF, SoF, LoW and SotA - because keeping them in order requires four campaigns to change.

Closes #7224, removes a commit from #8447, will itself be obsoleted by #8321.