### PR TITLE
Lua: Make sure unit type is built before returning it from iteration

### DIFF
--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -176,6 +176,10 @@ static int impl_unit_type_next(lua_State* L)
 	}
 	lua_pushlstring(L, it->first.c_str(), it->first.size());
 	luaW_pushunittype(L, it->second);
+	if(!base) {
+		// Make sure the unit is built.
+		unit_types.build_unit_type(it->second, unit_type::FULL);
+	}
 	return 2;
 }
 


### PR DESCRIPTION
Fixes #8456