### PR TITLE
[Lua] Make wesnoth.read_location return its result in standard named tuple format

### DIFF
--- a/data/lua/core/map.lua
+++ b/data/lua/core/map.lua
@@ -27,9 +27,9 @@ function wesnoth.map.read_location(...)
 		else
 			return nil, 0
 		end
-		return {x = x, y = y}, 1
+		return wesnoth.named_tuple({x, y}, {'x', 'y'}), 1
 	elseif type(x) == 'number' and type(y) == 'number' then
-		return {x = x, y = y}, 2
+		return wesnoth.named_tuple({x, y}, {'x', 'y'}), 2
 	end
 	return nil, 0
 end
@@ -269,9 +269,12 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	---@return terrain_hex
 	---@overload fun(loc:location):terrain_hex
 	function wesnoth.map.get(x, y)
+		-- Make the linter assume the location is non-nil.
+		-- It's not smart enough to realize that n==0 means that loc is non-nil.
+		---@type location
 		local loc, n = wesnoth.map.read_location(x, y)
 		if n == 0 then error('Missing or invalid coordinate') end
-		return setmetatable(loc, hex_mt)
+		return setmetatable({x = loc.x, y = loc.y}, hex_mt)
 	end
 
 	local find_locations = wesnoth.map.find


### PR DESCRIPTION
This is for consistency with other things that return locations in the engine.