### PR TITLE
[Lua][typing] Add map access typing to terrain_map

### DIFF
--- a/utils/emmylua/wesnoth/map.lua
+++ b/utils/emmylua/wesnoth/map.lua
@@ -21,7 +21,7 @@
 ---@class wesnoth.map
 wesnoth.map = {}
 
----@class terrain_map : wesnoth.map
+---@class terrain_map : wesnoth.map, {[{[1]:integer, [2]:integer}]: string}
 ---@field width integer
 ---@field height integer
 ---@field playable_width integer


### PR DESCRIPTION
This make terrain read/write described in https://wiki.wesnoth.org/LuaAPI/types/map (Terrain) better typed.