### PR TITLE
ui: Add add-ons server identification to the bottom left display in Add-ons Manager

### DIFF
--- a/changelog_entries/addon_server_id_ui.md
+++ b/changelog_entries/addon_server_id_ui.md
@@ -1,0 +1,3 @@
+ ### Add-ons client
+   * The add-ons server identifier (e.g. 1.18) is now displayed on the bottom left after the
+     server address. If debug mode is enabled the server software version is also shown.

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -218,6 +218,16 @@ public:
 		return conn_ && conn_->using_tls();
 	}
 
+	const std::string& server_id() const
+	{
+		return server_id_;
+	}
+
+	const std::string& server_version() const
+	{
+		return server_version_;
+	}
+
 private:
 	enum class transfer_mode {download, connect, upload};
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -325,7 +325,18 @@ void addon_manager::pre_show(window& window)
 	if(addr_visible) {
 		auto addr_box = dynamic_cast<styled_widget*>(addr_visible->find("server_addr", false));
 		if(addr_box) {
-			addr_box->set_label(client_.addr());
+			if(!client_.server_id().empty()) {
+				auto full_id = formatter()
+					<< client_.addr() << ' '
+					<< font::unicode_em_dash << ' '
+					<< client_.server_id();
+				if(game_config::debug && !client_.server_version().empty()) {
+					full_id << " (" << client_.server_version() << ')';
+				}
+				addr_box->set_label(full_id.str());
+			} else {
+				addr_box->set_label(client_.addr());
+			}
 		}
 	}
 


### PR DESCRIPTION
This expands the server display at the bottom left of the Add-ons Manager window to include the server-provided server id and version after the server address. The goal with this is to make proper use of the `[server_id]` command (already sent during every connection since 1.15.x) and be able to differentiate server instances more easily when the port number is not part of the connection address.

<img width="960" alt="Screenshot 2024-02-29 at 20 43 51" src="https://github.com/wesnoth/wesnoth/assets/489895/67580243-bcec-4d8e-acdf-87c320253199">

**Default view (debug mode disabled):**

<img width="235" alt="Screenshot 2024-02-29 at 20 43 51" src="https://github.com/wesnoth/wesnoth/assets/489895/8d88b46a-fdc4-428b-a4c7-85ea8177a155">

**Detailed view (debug mode enabled):**

<img width="235" alt="Screenshot 2024-02-29 at 20 44 22" src="https://github.com/wesnoth/wesnoth/assets/489895/a997ee44-ab9d-486d-b2b0-7b8fb8a380b0">

If the `[server_id]` info is not available (e.g. when connecting to obsolete pre-1.15.x servers), the instance id/version are simply not shown.

As a reminder, the `[server_id]` is part of the add-ons server protocol and the `id=` field in it is a free-form string specified by the server admins, while the `version=` is the campaignd build version, which does not necessarily match the server id. Because sometimes the campaignd version number does not reflect the server id/the server's intended target client version, it could potentially be confusing or misleading to see it by default, hence it's hidden behind debug mode in this PR.

Finally, these changes don't add any new translatable strings so IMO they are worth considering for merging into 1.18 too. My original intention was to implement some form of UI for `[server_id]` back in 1.15.x anyway, I just never remembered to do it.