### PR TITLE
use the currently selected map's path when opening a new file

### DIFF
--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -207,11 +207,9 @@ std::size_t context_manager::modified_maps(std::string& message)
 
 void context_manager::load_map_dialog(bool force_same_context /* = false */)
 {
-	std::string fn = filesystem::directory_name(get_map_context().get_filename());
-	if(current_addon_ == "") {
+	std::string fn = get_map_context().get_filename();
+	if(fn.empty()) {
 		fn = filesystem::get_legacy_editor_dir()+"/maps";
-	} else if(fn.empty()) {
-		fn = filesystem::get_dir(filesystem::get_current_editor_dir(current_addon_) + "/maps");
 	}
 
 	gui2::dialogs::file_dialog dlg;
@@ -678,10 +676,8 @@ void context_manager::resize_map_dialog()
 void context_manager::save_map_as_dialog()
 {
 	std::string input_name = get_map_context().get_filename();
-	if(current_addon_ == "") {
+	if(input_name.empty()) {
 		input_name = filesystem::get_legacy_editor_dir()+"/maps";
-	} else if(input_name.empty() || input_name.find("/maps") == std::string::npos) {
-		input_name = filesystem::get_dir(filesystem::get_current_editor_dir(current_addon_) +  + "/maps");
 	}
 
 	gui2::dialogs::file_dialog dlg;
@@ -712,8 +708,8 @@ void context_manager::save_map_as_dialog()
 void context_manager::save_scenario_as_dialog()
 {
 	std::string input_name = get_map_context().get_filename();
-	if(input_name.empty() || input_name.find("/scenarios") == std::string::npos) {
-		input_name = filesystem::get_dir(filesystem::get_current_editor_dir(current_addon_) + "/scenarios");
+	if(input_name.empty()) {
+		input_name = filesystem::get_legacy_editor_dir()+"/scenarios";
 	}
 
 	gui2::dialogs::file_dialog dlg;


### PR DESCRIPTION
currently the editor defaults to its maps directory even when you open a map file somewhere without it being in an "add-on", for example opening a map in a mainline campaign's maps folder.