### PR TITLE
EI: Bind stock translatable strings in Barrow Wight's definition to the wesnoth-units textdomain

### DIFF
--- a/data/campaigns/Eastern_Invasion/units/Undead_Horse_Barrow_Wight.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Undead_Horse_Barrow_Wight.cfg
@@ -44,6 +44,7 @@
     [attack]
         name=sword
         icon=attacks/greatsword-orcish.png
+        #textdomain wesnoth-units
         description=_"sword"
         type=blade
         range=melee
@@ -54,6 +55,7 @@
         name=trample
         icon="attacks/hoof-skeletal.png"
         description=_"trample"
+        #textdomain wesnoth-ei
         type=impact
         range=melee
         damage=14


### PR DESCRIPTION
Barrow Wight's definition includes a couple of attack name strings from the wesnoth-units textdomain bound to wesnoth-ei by default instead, which creates two unnecessary extra strings for translators to translate. This PR fixes this by binding these two strings to wesnoth-units so their existing translations can be used.

(Pyre Wight does not require this change since it already uses the wesnoth-units textdomain for the single attack name it uses.)