### PR TITLE
EI - recolor achievement icon

### DIFF
--- a/data/campaigns/Eastern_Invasion/achievements.cfg
+++ b/data/campaigns/Eastern_Invasion/achievements.cfg
@@ -39,7 +39,7 @@ data/core/images#enddef
     "ei_S04a"   _"Scenario 4a: Scorched Earth"                _"Defeat both the bandit and elven leaders in ‘<i>Elven Interlude</i>’."}
     {ACHIEVEMENT {PATH}/coins_gold.png
     "ei_S04b"   _"Scenario 4b: Mercenary"                     _"Recruit the dunefolk in ‘<i>Ill Humours</i>’."}
-    {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(84,84)~BLIT({CORE_PATH}/units/human-loyalists/knight/knight.png,1,5)~BLIT(data/campaigns/Eastern_Invasion/images/items/horse-cage.png,8,10)"
+    {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(84,84)~BLIT({CORE_PATH}/units/human-loyalists/knight/knight.png~RC(magenta>white),1,5)~BLIT(data/campaigns/Eastern_Invasion/images/items/horse-cage.png,8,10)"
     "ei_S04c"   _"Scenario 4c: No (Horse)Man Left Behind"     _"Rescue all 6 prisoners from ‘<i>Mal Ravanal’s Capital</i>’."}
     {ACHIEVEMENT {CORE_PATH}/icons/hat-huntsman.png
     "ei_S05"    _"Scenario 5: Folk Hero"                      _"Complete ‘<i>Northern Outpost</i>’ without any peasants dying."}


### PR DESCRIPTION
Replace the magenta coloring on the S04 achievement icon with white, reflecting the in-game unit color.

Very minor change. Thanks to Konrad2 for pointing this out.