### PR TITLE
Make sure animations are skipped when skipping animations in replays

### DIFF
--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -121,7 +121,7 @@ namespace
 		// When the unit advances, it fades to white, and then switches
 		// to the new unit, then fades back to the normal color
 
-		if (animate && !video::headless()) {
+		if (animate && !video::headless() && !resources::controller->is_skipping_replay()) {
 			unit_animator animator;
 			bool with_bars = true;
 			animator.add_animation(u.get_shared_ptr(), "levelout", u->get_location(), map_location(), 0, with_bars);
@@ -142,7 +142,7 @@ namespace
 		u = resources::gameboard->units().find(loc);
 		game_display::get_singleton()->invalidate_unit();
 
-		if (animate && u != resources::gameboard->units().end() && !video::headless()) {
+		if (animate && u != resources::gameboard->units().end() && !video::headless() && !resources::controller->is_skipping_replay()) {
 			unit_animator animator;
 			animator.add_animation(u.get_shared_ptr(), "levelin", u->get_location(), map_location(), 0, true);
 			animator.start_animations();

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -371,7 +371,7 @@ static int impl_add_animation(lua_State* L)
 
 int game_lua_kernel::impl_run_animation(lua_State* L)
 {
-	if(video::headless()) {
+	if(video::headless() || !resources::controller->is_skipping_replay()) {
 		return 0;
 	}
 	events::command_disabler command_disabler;

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -23,6 +23,7 @@
 #include "log.hpp"
 #include "mouse_events.hpp"
 #include "resources.hpp"
+#include "play_controller.hpp"
 #include "color.hpp"
 #include "sound.hpp"
 #include "terrain/filter.hpp"
@@ -166,8 +167,7 @@ int move_unit_between(const map_location& a,
 
 bool do_not_show_anims(display* disp)
 {
-
-	return !disp || video::headless();
+	return !disp || video::headless() || resources::controller->is_skipping_replay();
 }
 
 } // end anon namespace


### PR DESCRIPTION
Fixes #8227

---

I haven't looked deeper to see if there's anything else that needs to be done yet, but it does fix the death animation playing at least.