### PR TITLE
Fix indices in widget.add_item_of_type()

### DIFF
--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -242,7 +242,6 @@ namespace
 			index = max;
 		}
 
-		// todo: does a "negative indicies to "
 		if(*index <= 0 || *index > max) {
 			luaL_argerror(L, arg, "widget child index out of range");
 		}
@@ -437,19 +436,22 @@ static int intf_add_item_of_type(lua_State* L)
  */
 static int intf_add_dialog_item(lua_State* L)
 {
-
 	gui2::widget* w = &luaW_checkwidget(L, 1);
+	utils::optional<int> insert_pos = lua_check<utils::optional<int>>(L, 2);
+
 	gui2::widget* res = nullptr;
 	static const gui2::widget_data data;
 
 	if(gui2::listbox* lb = dynamic_cast<gui2::listbox*>(w)) {
-		res = &lb->add_row(data);
+		int realpos = check_index(L, 2, *lb, true, insert_pos);
+		res = &lb->add_row(data, realpos);
 	} else {
 		return luaL_argerror(L, lua_gettop(L), "unsupported widget");
 	}
 	if(res) {
 		luaW_pushwidget(L, *res);
-		return 1;
+		lua_push(L, insert_pos.value());
+		return 2;
 	}
 	return 0;
 }

--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -398,7 +398,7 @@ static int intf_set_dialog_focus(lua_State* L)
 
 
 /**
- * Sets a widget's state to active or inactive
+ * Adds an item to a container widget that supports different types of items, for example a treeview.
  * - Arg 1: widget.
  * - Arg 2: string, the type (id of [node_definition]) of the new item.
  * - Arg 3: integer (optional), where to insert the new item.
@@ -431,7 +431,7 @@ static int intf_add_item_of_type(lua_State* L)
 	return 0;
 }
 /**
- * Sets a widget's state to active or inactive
+ * Adds an item to a container widget, for example a listbox
  * - Arg 1: widget.
  * - Arg 2: integer (optional), where to insert the new item.
  */

--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -400,8 +400,8 @@ static int intf_set_dialog_focus(lua_State* L)
 /**
  * Sets a widget's state to active or inactive
  * - Arg 1: widget.
- * - Arg 2: string, the type (id of [node_definition]) of the new node.
- * - Arg 3: integer (optional), where to insert the new node.
+ * - Arg 2: string, the type (id of [node_definition]) of the new item.
+ * - Arg 3: integer (optional), where to insert the new item.
  */
 static int intf_add_item_of_type(lua_State* L)
 {
@@ -433,6 +433,7 @@ static int intf_add_item_of_type(lua_State* L)
 /**
  * Sets a widget's state to active or inactive
  * - Arg 1: widget.
+ * - Arg 2: integer (optional), where to insert the new item.
  */
 static int intf_add_dialog_item(lua_State* L)
 {

--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -208,8 +208,8 @@ function gui.widget.add_item(widget, position) end
 ---Add an item to a heterogenous container widget
 ---@param widget widget
 ---@param category string
----@param position integer
----@param count integer
+---@param position? integer
+---@param count? integer
 ---@return widget
 ---@return integer
 function gui.widget.add_item_of_type(widget, category, position, count) end


### PR DESCRIPTION
previously this function used c++ 0-based indexing, and could  lead to assertions when wrong indicies were used, now it used lua 1-based indicies and throws lua errors on wrong indicies.