### PR TITLE
gui: Better positioning of submenus in the main UI

### DIFF
--- a/changelog_entries/submenu-positioning.md
+++ b/changelog_entries/submenu-positioning.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * Submenus are now positioned at the location of the menu item that spawned them, rather than the location of the mouse cursor at the time of click

--- a/src/gui/dialogs/drop_down_menu.cpp
+++ b/src/gui/dialogs/drop_down_menu.cpp
@@ -85,6 +85,7 @@ drop_down_menu::drop_down_menu(styled_widget* parent, const std::vector<config>&
 	, items_(items.begin(), items.end())
 	, button_pos_(parent->get_rectangle())
 	, selected_item_(selected_item)
+	, selected_item_pos_(-1, -1)
 	, use_markup_(parent->get_use_markup())
 	, keep_open_(keep_open)
 	, mouse_down_happened_(false)
@@ -241,7 +242,17 @@ void drop_down_menu::pre_show()
 
 void drop_down_menu::post_show()
 {
-	selected_item_ = find_widget<listbox>("list", true).get_selected_row();
+	const listbox& list = find_widget<listbox>("list", true);
+	selected_item_ = list.get_selected_row();
+	if(selected_item_ != -1) {
+		const grid* row_grid = list.get_row_grid(selected_item_);
+		if(row_grid) {
+			selected_item_pos_.x = row_grid->get_x();
+			selected_item_pos_.y = row_grid->get_y();
+		}
+	} else {
+		selected_item_pos_.x = selected_item_pos_.y = -1;
+	}
 }
 
 boost::dynamic_bitset<> drop_down_menu::get_toggle_states() const

--- a/src/gui/dialogs/drop_down_menu.hpp
+++ b/src/gui/dialogs/drop_down_menu.hpp
@@ -44,6 +44,11 @@ public:
 		return selected_item_;
 	}
 
+	point selected_item_pos() const
+	{
+		return selected_item_pos_;
+	}
+
 	/** If a toggle button widget is present, returns the toggled state of each row's button. */
 	boost::dynamic_bitset<> get_toggle_states() const;
 
@@ -86,6 +91,7 @@ private:
 	SDL_Rect button_pos_;
 
 	int selected_item_;
+	point selected_item_pos_;
 
 	bool use_markup_;
 

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -417,11 +417,19 @@ void command_executor::show_menu(const std::vector<config>& items_arg, int xloc,
 	get_menu_images(gui, items);
 
 	int res = -1;
+	point selection_pos;
 	{
 		SDL_Rect pos {xloc, yloc, 1, 1};
 		gui2::dialogs::drop_down_menu mmenu(pos, items, -1, true, false); // TODO: last value should be variable
 		if(mmenu.show()) {
 			res = mmenu.selected_item();
+			if(res >= 0) {
+				// Get selection coordinates for a potential submenu below
+				selection_pos = mmenu.selected_item_pos();
+				// Compensate for borders
+				selection_pos.x--;
+				selection_pos.y--;
+			}
 		}
 	} // This will kill the dialog.
 	if (res < 0 || std::size_t(res) >= items.size()) return;
@@ -429,8 +437,7 @@ void command_executor::show_menu(const std::vector<config>& items_arg, int xloc,
 	std::string id = items[res]["id"];
 	const theme::menu* submenu = gui.get_theme().get_menu_item(id);
 	if (submenu) {
-		auto [x, y] = sdl::get_mouse_location();
-		this->show_menu(submenu->items(), x, y, submenu->is_context(), gui);
+		this->show_menu(submenu->items(), selection_pos.x, selection_pos.y, submenu->is_context(), gui);
 	} else {
 		hotkey::ui_command cmd = hotkey::ui_command(id, res);
 		do_execute_command(cmd);


### PR DESCRIPTION
This is an attempt to improve the way menus work in Wesnoth. The current implementation handles each menu as a modal dialog of its own, in particular allowing there to be at most only one menu on screen. It goes without saying that when dealing with menus that have submenus (such as the in-game turn and replay menus, as well as the editor's MRU list) this is very suboptimal. I'd like to look into changing this later, but for now I've at least figured out a way to improve the **positioning** of submenus.

Currently, when a menu item that spawns a submenu is selected, the latter is displayed with its top left coordinate at the exact position of the mouse cursor. This means that the top left corner of a **submenu** is not so much dependent on where the **parent menu item** that is associated with it is located on the screen, but rather where the mouse cursor is at the time the event that selected it goes through. This results in this funny quirk where the same menu spawns at different locations each time.

In the absence of a way to have both the submenu and its parent menu displayed on screen at the same time, I've decided it would still be a marked improvement if at least the submenu position on screen stayed consistent and made a little more sense overall.

This initial version of the PR makes it so the **submenu's** top left corner is set to the top left corner of the **parent menu item**, with a small shift to compensate for the dialog (menu) borders. Below is an example of what it looks like when a submenu is displayed without moving the mouse cursor after clicking on the parent menu item-

**Parent menu**
<img width="555" alt="menu1" src="https://github.com/wesnoth/wesnoth/assets/489895/248f6d4c-9001-445d-a311-16eeceb2588a">

**Submenu**
<img width="555" alt="menu2" src="https://github.com/wesnoth/wesnoth/assets/489895/cda1c0fc-d76b-4dc7-bd33-e30b128eb969">

(Please ignore the weird colouring of the mouse cursor. That's fully unrelated to this commit and doesn't actually happen on my screen.)

Note that I'm not entirely sure what happens when the parent menu item is on an edge case (no pun intended) location such as close to the right bottom corner of the screen. It seems like this *should*, at least in theory, be handled by the WFL in the WML definition of the dropdown menu window, but I'm not entirely sure. It may be necessary to make additional changes to it. I'm sure @Vultraz may be able to provide me with more insight on this.