### PR TITLE
gui/unit_recall: Add alignment and race hints for filtering

### DIFF
--- a/changelog_entries/recruit_recall_filtering.md
+++ b/changelog_entries/recruit_recall_filtering.md
@@ -1,0 +1,3 @@
+ ### User interface
+   * Added unit type level as a filter criterion in the Recruit Unit dialog.
+   * Added unit race and alignment as additional filter criteria in the Recall Unit dialog.

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -37,6 +37,7 @@
 #include "team.hpp"
 #include "units/unit.hpp"
 #include "units/ptr.hpp"
+#include "units/types.hpp"
 #include <functional>
 #include "whiteboard/manager.hpp"
 
@@ -257,7 +258,11 @@ void unit_recall::pre_show(window& window)
 
 		// Since the table widgets use heavy formatting, we save a bare copy
 		// of certain options to filter on.
-		std::string filter_text = unit->type_name() + " " + name + " " + std::to_string(unit->level());
+		std::string filter_text = unit->type_name() + " " + name + " " + std::to_string(unit->level())
+			+ " " + unit_type::alignment_description(unit->alignment(), unit->gender());
+		if(const auto* race = unit->race()) {
+			filter_text += " " + race->name(unit->gender()) + " " + race->plural_name();
+		}
 
 		if(recallable) {
 			// This is to allow filtering for recallable units by typing "vvv" in the search box.

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -79,11 +79,18 @@ void unit_recruit::filter_text_changed(const std::string& text)
 			const unit_type* type = recruit_list_[i];
 			if(!type) continue;
 
+			auto default_gender = !type->genders().empty()
+				? type->genders().front() : unit_race::MALE;
+			const auto* race = type->race();
+
 			// List of possible match criteria for this unit type. Empty values will
 			// never match.
 			auto criteria = std::make_tuple(
 				(game_config::debug ? type->id() : ""),
-				type->type_name()
+				type->type_name(),
+				unit_type::alignment_description(type->alignment(), default_gender),
+				(race ? race->name(default_gender) : ""),
+				(race ? race->plural_name() : "")
 			);
 
 			bool found = false;

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -79,13 +79,21 @@ void unit_recruit::filter_text_changed(const std::string& text)
 			const unit_type* type = recruit_list_[i];
 			if(!type) continue;
 
+			// List of possible match criteria for this unit type. Empty values will
+			// never match.
+			auto criteria = std::make_tuple(
+				(game_config::debug ? type->id() : ""),
+				type->type_name()
+			);
+
 			bool found = false;
 			for(const auto & word : words)
 			{
 				// Search for the name in the local language.
 				// In debug mode, also search for the type id.
-				found = (game_config::debug && translation::ci_search(type->id(), word)) ||
-				        translation::ci_search(type->type_name(), word);
+				std::apply([&](auto&&... criterion) {
+					found = (translation::ci_search(criterion, word) || ...);
+				}, criteria);
 
 				if(!found) {
 					// one word doesn't match, we don't reach words.end()

--- a/src/gui/dialogs/unit_recruit.cpp
+++ b/src/gui/dialogs/unit_recruit.cpp
@@ -88,6 +88,7 @@ void unit_recruit::filter_text_changed(const std::string& text)
 			auto criteria = std::make_tuple(
 				(game_config::debug ? type->id() : ""),
 				type->type_name(),
+				std::to_string(type->level()),
 				unit_type::alignment_description(type->alignment(), default_gender),
 				(race ? race->name(default_gender) : ""),
 				(race ? race->plural_name() : "")


### PR DESCRIPTION
This adds the human-readable version of each unit's alignment and their (gendered) race name and plural race name as hints for the filter box functionality, so that players can enter keywords such as "liminal", "dwarves", "mermaid" and get what they expect even if those words are not literally part of the unit type names.

Inspired by this Ideas forum thread: https://forums.wesnoth.org/viewtopic.php?t=57749

Still a work in progress since I want to do the same for the Recruit dialog, which seems a little more involved due to it using a different mechanism for handling the Filter box.

I'm curious if @Pentarctagon and @Vultraz believe this is a reasonable candidate for backporting to 1.18 since it's not a massively impactful change and — especially for the Recall dialog when playing longer singleplayer campaigns — it constitutes a nice QoL improvement.