### PR TITLE
SotA S16: Keep Crelanu within his ring of protective holy waters

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg
@@ -50,6 +50,10 @@ We crossed the high plateaus, and forded the Arkan-thoria. Then we headed up int
         name= _ "Crelanu"
         team_name=bad
         recruit=Red Mage,White Mage,Mage
+        [ai]
+            # Keep Crelanu within his ring of protective holy waters.
+            passive_leader="yes"
+        [/ai]
         {GOLD 160 180 200}
         {INCOME 10 15 20}
         color=green  # To match his color in LoW


### PR DESCRIPTION
I play-tested this in master and couldn't get Crelanu to leave his ring, even with as tempting a target such as a weak Ardonna.

Resolves #8361.