### PR TITLE
Change the list check from [damage_type] to a system that takes into account the opponent's sensitivity

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -171,9 +171,9 @@
 ##
 # Actions:
 # Give both Alice and Bob 100% chance to hit.
-# Give Bob one [damage] with replacement_type=fire and two [damage] with replacement_type=cold
+# Give Bob one [damage_type] with replacement_type=fire and two [damage_type] with replacement_type=cold
 # change resistance of Bob to arcane to 50% and fire to -100%.
-# Give Alice one [damage] with replacement_type=cold, two [damage] with replacement_type=arcane and three with replacement_type=fire
+# Give Alice one [damage_type] with replacement_type=cold, two [damage_type] with replacement_type=arcane and three with replacement_type=fire
 # and change Alice resistance to cold to -100% and fire to 50%.
 # Move Alice next to Bob, and have Alice attack Bob.
 ##
@@ -189,9 +189,9 @@
 ##
 # Actions:
 # Give both Alice and Bob 100% chance to hit.
-# Give Bob one [damage] with replacement_type=fire and two [damage] with replacement_type=cold and filter by type=blade
+# Give Bob one [damage_type] with replacement_type=fire and two [damage_type] with replacement_type=cold and filter by type=blade
 # change resistance of Bob to arcane to 50% and fire to -100%.
-# Give Alice one [damage] with replacement_type=cold, two [damage] with replacement_type=arcane and three with replacement_type=fire
+# Give Alice one [damage_type] with replacement_type=cold, two [damage_type] with replacement_type=arcane and three with replacement_type=fire
 # and change Alice resistance to cold to -100% and fire to 50%.
 # Move Alice next to Bob, and have Alice attack Bob.
 ##
@@ -207,10 +207,10 @@
 ##
 # Actions:
 # Give both Alice and Bob 100% chance to hit.
-# Give Bob one [damage] with alternative_type=cold
+# Give Bob one [damage_type] with alternative_type=cold and another with alternative_type=pierce
 # change resistance Bob to blade to -100% and fire to 0%.
-# Give Alice one [damage] with alternative_type=fire
-# and change resistance to cold to -100% and blade to 0%.
+# Give Alice one [damage_type] with alternative_type=fire
+# and change resistance to cold to -100%, pierce to -50% and blade to 0%.
 # Move Alice next to Bob, and have Alice attack Bob.
 ##
 # Expected end state:
@@ -247,6 +247,9 @@
                         value=12
                     [/damage]
                     [damage_type]
+                        alternative_type=pierce
+                    [/damage_type]
+                    [damage_type]
                         alternative_type=cold
                     [/damage_type]
                     [chance_to_hit]
@@ -265,6 +268,7 @@
                 replace=yes
                 [resistance]
                     cold=200
+                    pierce=150
                     blade=100
                 [/resistance]
             [/effect]


### PR DESCRIPTION


If two [damage_type]altenative_type= are used with two different types, the chosen type displayed in the pre-combat window will be the one to which the opponent will be most vulnerable, and if he is more vulnerable to that one rather than to the type d originally, this is the one that will be used.

On the other hand, in this case, report will not display alternative_type because there is no opponent to check