### PR TITLE
Aethermaw Cosmetic Updates

### DIFF
--- a/data/multiplayer/scenarios/2p_Aethermaw.cfg
+++ b/data/multiplayer/scenarios/2p_Aethermaw.cfg
@@ -3,7 +3,7 @@
     id=multiplayer_Aethermaw
     name= _ "2p — Aethermaw"
     # wmllint: local spellings Sulla Aethermaw Paterson
-    description= _ "Long ago, the Great Mage Sulla was imprisoned in the Aethermaw, a nexus of mystical energy whose chaotic nature was able to prevent her escape. Over the centuries, however, Sulla gradually attuned her powers to the maelstrom of disorder that is the Aethermaw, and has now begun to project its influence onto the material plane, drawing in entire regions of land from hundreds of different worlds, realities and time-periods. She experiments with these disparate pieces of the cosmos, manipulating them, merging them and sending them back and forth between the Aethermaw and their place of origin. Perhaps, as her mastery over the Aethermaw grows, Sulla will one day break free of its bonds. Until that time comes, she will continue to amuse herself by arranging battles between the mortal beings unlucky enough to be drawn into its depths. Designed by Doc Paterson."
+    description= _ "Long ago, the Legendary Aether Mage, Sulla, was imprisoned in the Aethermaw, a nexus of mystical energy whose chaotic nature was able to prevent her escape. Over the centuries, however, Sulla gradually attuned her powers to the maelstrom of disorder that is the Aethermaw, and has now begun to project its influence onto the material plane, drawing in entire regions of land from hundreds of different worlds, realities and time-periods. She now experiments with these disparate pieces of the cosmos, manipulating them, merging them and sending them back and forth between the Aethermaw and their place of origin. Perhaps, as her mastery over the Aethermaw grows, Sulla will one day break free of its bonds. Until that time comes, she will continue to amuse herself by arranging battles between the mortal beings unlucky enough to be drawn into its depths. Designed by Doc Paterson."
     map_file=multiplayer/maps/2p_Aethermaw.map
     random_start_time="no"
 
@@ -309,13 +309,13 @@
                 condition=win
             [/objective]
             [note]
-                description= _ "The Great Mage Sulla has transported your armies to this bizarre nexus, and demands that you amuse her by doing battle."
+                description= _ "The Aether Mage Sulla has transported your armies to this bizarre nexus, and demands that you amuse her by doing battle."
             [/note]
             [note]
                 description= _ "Units may not move into a hex with a rock cairn. They may, however, be recruited to, and move from, such hexes."
             [/note]
             [note]
-                description= _ "Beginning on turn 4, the Great Mage Sulla will begin to unite the two halves of the battlefield. The process will be complete by the end of turn 6."
+                description= _ "Beginning on turn 4, the Aether Mage Sulla will begin to unite the two halves of the battlefield. The process will be complete by the end of turn 6."
             [/note]
         [/objectives]
     [/event]


### PR DESCRIPTION
Sulla's power in Aethermaw seem to be far more than what can be expected of a Wesnothian Great Mage, so updated the lore and gave her a new type which seems more apt.
Also planning to add some new images for the new type, if it is something I can do with my skill level.

Yet another reason would be to let players know that the paths human magi can take are as varied as there are human. Currently the main paths are Red vs White mage (and Silver maybe). But other races show that these are not the only types of magic that exist. (I think at this moment it gives a false impression that Red Magi are the best, and only they can become Great Mages). This can slightly alleviate that. (Compare for example War of Legends' magi, where even dual and multielement magi are possible)

Current choice : *Aether Mage*

Also addresses issue https://github.com/wesnoth/wesnoth/issues/8432. (Update missing images to use newer variants found in 1.18)

Associated forum thread : https://forums.wesnoth.org/viewtopic.php?t=57811