### PR TITLE
SotA S16: Keep Crelanu within his ring of protective holy waters

### DIFF
--- a/changelog_entries/sota_crelanu.md
+++ b/changelog_entries/sota_crelanu.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * Secrets of the Ancients
+     * S16: Keep Crelanu within his ring of protective holy waters (issue #8361)

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/16_The_Mage.cfg
@@ -50,6 +50,10 @@ We crossed the high plateaus, and forded the Arkan-thoria. Then we headed up int
         name= _ "Crelanu"
         team_name=bad
         recruit=Red Mage,White Mage,Mage
+        [ai]
+            # Keep Crelanu within his ring of protective holy waters.
+            passive_leader="yes"
+        [/ai]
         {GOLD 160 180 200}
         {INCOME 10 15 20}
         color=green  # To match his color in LoW


### PR DESCRIPTION
Backport of #8521, fixes #8361.

Changelog added after cherry-picking.

(cherry picked from commit d106238410cf1ffc7f36352ce7b5d24fcfa19b59)