### PR TITLE
[Units][Skeletal Dragon] Update Stats

### DIFF
--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=297
+    cost=288
     usage=fighter
     [resistance]
         blade=60

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -6,7 +6,7 @@
     race=undead
     image="units/monsters/skeletal-dragon/skeletal-dragon.png"
     image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(0,0,160,160)"
-    hitpoints=86
+    hitpoints=171
     movement_type=undeadfly
     movement=5
     experience=200
@@ -14,14 +14,14 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=100
+    cost=297
     usage=fighter
     [resistance]
         blade=60
         pierce=40
         impact=120
-        fire=100
-        arcane=100
+        fire=120
+        arcane=120
     [/resistance]
     description= _ "Long ago one of the mightiest living creatures, the feared Dragon has become only bones and dark sinew. Long after its death, it was raised through the dark powers of necromancy, which it now serves. The Skeletal Dragon may look like nothing more than a pile of bones, but few people who thought that way lived long enough to change their minds."
     die_sound=skeleton-big-die.ogg
@@ -34,7 +34,7 @@
         [specials]
             {WEAPON_SPECIAL_DRAIN}
         [/specials]
-        damage=10
+        damage=17
         number=4
     [/attack]
     [attack]
@@ -42,8 +42,8 @@
         description= _"claws"
         type=blade
         range=melee
-        damage=25
-        number=2
+        damage=24
+        number=3
     [/attack]
     {DEFENSE_ANIM "units/monsters/skeletal-dragon/skeletal-dragon.png" "units/monsters/skeletal-dragon/skeletal-dragon.png" {SOUND_LIST:SKELETON_BIG_HIT} }
     [attack_anim]

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -21,7 +21,6 @@
         pierce=40
         impact=120
         fire=100
-        #you have many arcane units by now, probably, and he shouldn't die all that easily.
         arcane=100
     [/resistance]
     description= _ "Long ago one of the mightiest living creatures, the feared Dragon has become only bones and dark sinew. Long after its death, it was raised through the dark powers of necromancy, which it now serves. The Skeletal Dragon may look like nothing more than a pile of bones, but few people who thought that way lived long enough to change their minds."


### PR DESCRIPTION
This comment existed when the unit was still in EI campaign. It's been moved to core ages ago and yet, the comment, now no longer relevant outside of EI still persisted...

Also, why is this _undead_ unit still in `units/monsters/` when `units/undead/` exists?