### PR TITLE
Add -Wno-shorten-64-to-32 to compiler flags in Xcode

### DIFF
--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -6769,8 +6769,14 @@
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LLVM_LTO = YES_THIN;
-				OTHER_CFLAGS = "-Wall";
-				OTHER_CPLUSPLUSFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -6824,7 +6830,10 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INSTALL_PATH = /usr/local/bin;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks \"@loader_path/The Battle for Wesnoth.app/Contents/Frameworks\" @loader_path/Frameworks";
-				OTHER_CFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wesnoth.wesnothd;
 				PRODUCT_NAME = wesnothd;
 				WARNING_CFLAGS = "";
@@ -7060,7 +7069,10 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INSTALL_PATH = /usr/local/bin;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks \"@loader_path/The Battle for Wesnoth.app/Contents/Frameworks\" @loader_path/Frameworks";
-				OTHER_CFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wesnoth.wesnothd;
 				PRODUCT_NAME = wesnothd;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -7104,7 +7116,10 @@
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				INSTALL_PATH = /usr/local/bin;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks \"@loader_path/The Battle for Wesnoth.app/Contents/Frameworks\" @loader_path/Frameworks";
-				OTHER_CFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wesnoth.wesnothd;
 				PRODUCT_NAME = wesnothd;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -7163,8 +7178,14 @@
 				LD_CLASSIC_1400 = "";
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_CFLAGS = "-Wall";
-				OTHER_CPLUSPLUSFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -7230,8 +7251,14 @@
 				LD_CLASSIC_1500 = "-ld_classic";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				LLVM_LTO = YES_THIN;
-				OTHER_CFLAGS = "-Wall";
-				OTHER_CPLUSPLUSFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",
@@ -7317,7 +7344,10 @@
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/lib";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wall";
+				OTHER_CFLAGS = (
+					"-Wall",
+					"-Wno-shorten-64-to-32",
+				);
 				OTHER_LDFLAGS = (
 					"-lz",
 					"-lbz2",


### PR DESCRIPTION
This is necessary with Xcode 15.3 to avoid about 750 warnings across all of the codebase regarding "Implicit conversion loses integer precision", most of which apply in cases where theoretical limits are involved because of conversions from unsigned 64-bit integers (usually `size_t`) to signed 32-bit (`int`).

Ideally we want to address these warnings, but given how many of them there are all over the place this is not something that can reasonably be done in such short notice before Wesnoth 1.18.0 is released, and in the meantime they make the compiler output with Xcode unnecessarily noisy and completely bury any relevant warnings from actual code changes. In the meantime, this is best for productivity until we can get to a place where we can fix all of them and force using -Wshorten-64-to-32 for all platforms in CI.

*(Read: I can't properly see warnings in my own code without this change lol)*