### PR TITLE
EI S05: fade to silence when recounting the priestess's death (v2)

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -193,6 +193,30 @@
     {PLACE_IMAGE items/bones.png 6 31}
     {PLACE_IMAGE scenery/blood-1.png 7 31}
 
+#define CHANGE_VOLUME VOLUME DELAY
+    [volume]
+        music={VOLUME}
+    [/volume]
+    [delay]
+    time={DELAY}
+    [/delay]
+#enddef
+    [event]
+        name=moveto
+        [filter]
+            x,y=7,31
+        [/filter]
+        {CHANGE_VOLUME 90 20}
+        {CHANGE_VOLUME 80 20}
+        {CHANGE_VOLUME 70 20}
+        {CHANGE_VOLUME 60 20}
+        {CHANGE_VOLUME 50 20}
+        {CHANGE_VOLUME 40 20}
+        {CHANGE_VOLUME 30 20}
+        {CHANGE_VOLUME 20 20}
+        {CHANGE_VOLUME 10 20}
+        {CHANGE_VOLUME  0  0}
+    [/event]
     {PLACE_ITEM_HOLY_AMULET {ID_HOLY_AMULET_1} 7 31}
     [event]
         name=moveto
@@ -204,6 +228,16 @@
             #po: "here lies the dead body of". An amulet was visible on this hex, a unit has moved to pick it up, which triggers this explanation why it's there.
             message= _ "There lies Anwyan, our local priestess. She insisted on hiding the others first and was one of those who didn’t make it to the cellars in time."
         [/message]
+        {CHANGE_VOLUME 10 20}
+        {CHANGE_VOLUME 20 20}
+        {CHANGE_VOLUME 30 20}
+        {CHANGE_VOLUME 40 20}
+        {CHANGE_VOLUME 50 20}
+        {CHANGE_VOLUME 60 20}
+        {CHANGE_VOLUME 70 20}
+        {CHANGE_VOLUME 80 20}
+        {CHANGE_VOLUME 90 20}
+        {CHANGE_VOLUME 100 0}
     [/event]
 
     {PLACE_IMAGE scenery/village-human-burned1.png 6 22}

--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -198,7 +198,7 @@
         music={VOLUME}
     [/volume]
     [delay]
-    time={DELAY}
+        time={DELAY}
     [/delay]
 #enddef
     [event]


### PR DESCRIPTION
In EI's S05, Owaec briefly recounts the bloody fate of his local priestess, killed by undead.

The scenario's music consists of wanderer.ogg and traveling_minstrels.ogg, which are inappropriate for encountering a mangled corpse.

Instead, fade the music out during this section.

This is the second version of this pull request; I did something weird on the first one causing the entire file to change.