### PR TITLE
ui: Add add-ons server identification to the bottom left display in Add-ons Manager

### DIFF
--- a/changelog_entries/addon_server_id_ui.md
+++ b/changelog_entries/addon_server_id_ui.md
@@ -1,0 +1,3 @@
+ ### Add-ons client
+   * The add-ons server identifier (e.g. 1.18) is now displayed on the bottom left after the
+     server address. If debug mode is enabled the server software version is also shown.

--- a/src/addon/client.hpp
+++ b/src/addon/client.hpp
@@ -218,6 +218,16 @@ public:
 		return conn_ && conn_->using_tls();
 	}
 
+	const std::string& server_id() const
+	{
+		return server_id_;
+	}
+
+	const std::string& server_version() const
+	{
+		return server_version_;
+	}
+
 private:
 	enum class transfer_mode {download, connect, upload};
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -325,7 +325,18 @@ void addon_manager::pre_show(window& window)
 	if(addr_visible) {
 		auto addr_box = dynamic_cast<styled_widget*>(addr_visible->find("server_addr", false));
 		if(addr_box) {
-			addr_box->set_label(client_.addr());
+			if(!client_.server_id().empty()) {
+				auto full_id = formatter()
+					<< client_.addr() << ' '
+					<< font::unicode_em_dash << ' '
+					<< client_.server_id();
+				if(game_config::debug && !client_.server_version().empty()) {
+					full_id << " (" << client_.server_version() << ')';
+				}
+				addr_box->set_label(full_id.str());
+			} else {
+				addr_box->set_label(client_.addr());
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport of #8481.