### PR TITLE
[1.18] MP: Aethermaw: Update images with their 1.18 variants

### DIFF
--- a/changelog_entries/aethermaw_images.md
+++ b/changelog_entries/aethermaw_images.md
@@ -1,0 +1,2 @@
+ ### Multiplayer
+   * Fixed some old paths to unit images being used in Aethermaw (issue #8432)

--- a/data/multiplayer/scenarios/2p_Aethermaw.cfg
+++ b/data/multiplayer/scenarios/2p_Aethermaw.cfg
@@ -131,8 +131,8 @@
         {PLACE_IMAGE "units/goblins/wolf-rider-moving.png~FL()~RC(magenta>1)" 48 2}
         {PLACE_IMAGE "units/goblins/wolf-rider-moving.png~FL()~RC(magenta>1)" 46 2}
 
-        {PLACE_IMAGE "units/undead/shadow-s-attack-1.png~RC(magenta>5)" 44 18}
-        {PLACE_IMAGE "units/undead/shadow-n-attack-2.png~RC(magenta>5)" 45 24}
+        {PLACE_IMAGE "units/undead-spirit/shadow-s-attack-1.png~RC(magenta>5)" 44 18}
+        {PLACE_IMAGE "units/undead-spirit/shadow-n-attack-2.png~RC(magenta>5)" 45 24}
         {PLACE_IMAGE "units/undead-skeletal/revenant/revenant-attack-4.png~RC(magenta>5)" 45 21}
         {PLACE_IMAGE "units/undead-skeletal/chocobone-attack-2.png~RC(magenta>5)" 45 18}
         {PLACE_IMAGE "units/undead-skeletal/chocobone-attack-2.png~RC(magenta>5)" 43 22}
@@ -144,9 +144,9 @@
         {PLACE_IMAGE "units/undead-necromancers/ancient-lich-magic-1.png~FL()~RC(magenta>5)" 48 17}
         {PLACE_IMAGE "units/undead/zombie-troll-attack.png~RC(magenta>5)" 45 19}
         {PLACE_IMAGE "units/undead/zombie-troll-attack-n.png~RC(magenta>5)" 49 25}
-        {PLACE_IMAGE "units/undead/shadow-n-3.png~FL()~RC(magenta>5)" 49 23}
+        {PLACE_IMAGE "units/undead-spirit/shadow-n-3.png~FL()~RC(magenta>5)" 49 23}
         {PLACE_IMAGE "units/undead/ghoul-attack-2.png~RC(magenta>5)" 46 22}
-        {PLACE_IMAGE "units/undead/shadow-s-attack-4.png~RC(magenta>5)" 43 21}
+        {PLACE_IMAGE "units/undead-spirit/shadow-s-attack-4.png~RC(magenta>5)" 43 21}
         {PLACE_IMAGE "units/undead/zombie-dwarf-attack-n.png~RC(magenta>5)" 48 24}
         {PLACE_IMAGE "units/undead/zombie-dwarf-attack-n.png~RC(magenta>5)" 48 23}
         {PLACE_IMAGE "units/undead/zombie-dwarf-attack-n.png~RC(magenta>5)" 47 25}
@@ -193,14 +193,14 @@
         {PLACE_IMAGE "units/human-loyalists/pikeman-idle-3.png~FL()~RC(magenta>2)" 6 35}
         {PLACE_IMAGE "units/human-loyalists/shocktrooper-attack-2.png~FL()~RC(magenta>2)" 10 37}
         {PLACE_IMAGE "units/human-loyalists/spearman-death4.png~RC(magenta>2)" 5 37}
-        {PLACE_IMAGE "units/human-loyalists/spearman-attack-se-10.png~RC(magenta>2)" 13 36}
-        {PLACE_IMAGE "units/human-loyalists/spearman-attack-s-6.png~RC(magenta>2)" 14 35}
-        {PLACE_IMAGE "units/human-loyalists/spearman-attack-se-9.png~FL()~RC(magenta>2)" 15 36}
+        {PLACE_IMAGE "units/human-loyalists/spearman-attack-se-2.png~RC(magenta>2)" 13 36}
+        {PLACE_IMAGE "units/human-loyalists/spearman-attack-s-3.png~RC(magenta>2)" 14 35}
+        {PLACE_IMAGE "units/human-loyalists/spearman-attack-se-2.png~FL()~RC(magenta>2)" 15 36}
         {PLACE_IMAGE "units/human-loyalists/pikeman-die-2.png~FL()~RC(magenta>2)" 14 37}
         {PLACE_IMAGE "units/human-loyalists/spearman-idle3.png~RC(magenta>2)" 15 37}
         {PLACE_IMAGE "units/human-loyalists/spearman-death3.png~RC(magenta>2)" 13 37}
         {PLACE_IMAGE "units/human-loyalists/pikeman-die-5.png~RC(magenta>2)" 10 38}
-        {PLACE_IMAGE "units/human-loyalists/general-idle-5.png~RC(magenta>2)" 9 36}
+        {PLACE_IMAGE "units/human-loyalists/marshal-leading.png~RC(magenta>2)" 9 36}
         {PLACE_IMAGE "units/human-loyalists/fencer-die5.png~RC(magenta>2)" 1 35}
         {PLACE_IMAGE "units/human-loyalists/fencer-die3.png~RC(magenta>2)" 9 39}
         {PLACE_IMAGE "units/human-loyalists/master-at-arms-victory-6.png~RC(magenta>2)" 8 33}


### PR DESCRIPTION
Cherry-picked backport of the first commit from @babaissarkar's #8539 (that PR is still in review, but only because the later commits add new art and prose).

Fixes #8432.

I've added a changelog entry when backporting.