### PR TITLE
Fix "implicit conversion turns floating-point number into integer" warnings

### DIFF
--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -548,7 +548,7 @@ color_t red_to_green(double val, bool for_text)
 	const std::vector<color_t>& color_scale = for_text ? red_green_scale_text : red_green_scale;
 
 	const double val_scaled = std::clamp(0.01 * val, 0.0, 1.0);
-	const int lvl = std::nearbyint((color_scale.size() - 1) * val_scaled);
+	const int lvl = int(std::nearbyint((color_scale.size() - 1) * val_scaled));
 
 	return color_scale[lvl];
 }
@@ -558,7 +558,7 @@ color_t blue_to_white(double val, bool for_text)
 	const std::vector<color_t>& color_scale = for_text ? blue_white_scale_text : blue_white_scale;
 
 	const double val_scaled = std::clamp(0.01 * val, 0.0, 1.0);
-	const int lvl = std::nearbyint((color_scale.size() - 1) * val_scaled);
+	const int lvl = int(std::nearbyint((color_scale.size() - 1) * val_scaled));
 
 	return color_scale[lvl];
 }


### PR DESCRIPTION
Found with Xcode 15.3:

`/Users/iris/Projects/wesnoth/src/game_config.cpp:551:18 Implicit conversion turns floating-point number into integer: 'double' to 'const int'`