### PR TITLE
Make the Changelog macOS app menu item more relevant

### DIFF
--- a/changelog_entries/macos-bundle-changelog.md
+++ b/changelog_entries/macos-bundle-changelog.md
@@ -1,0 +1,3 @@
+ ### User interface
+   * Made the Changelog option in the macOS app menu link to the changelog for the particular
+     Wesnoth app version rather than the Git master branch changelog.

--- a/src/macosx/SDLMain.mm
+++ b/src/macosx/SDLMain.mm
@@ -77,7 +77,9 @@ static std::vector<char*> gArgs;
 - (IBAction) openChangelog:(id)sender
 {
 	(void) sender;
-	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/wesnoth/wesnoth/blob/master/changelog.md"]];
+	NSString* version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+	NSString* url = [NSString stringWithFormat:@"https://changelog.wesnoth.org/%@", version];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
 }
 
 /* Called when the internal event loop has just started running */


### PR DESCRIPTION
This changes the URL used for the changelog menu item from using a direct GitHub file link to the master branch's changelog.md file to using a https://changelog.wesnoth.org/X.Y.Z link, where X.Y.Z are specifically the version number used in the macOS bundle's Info.plist file.

Note that this may result in incorrect links for +dev versions, where the Changelog link will simply send the user to the page for the latest release and not the future release. This shouldn't be a problem though, since people using those builds, especially on macOS, should really already know where to find the most relevant changelog for the version they're running -- in their own source tree.

---

To add a little more background to this, I remember adding a https://changelog.wesnoth.org/X.Y.Z redirect at some point either to make links easier to craft for release announcements, or to phase out the legacy X.Y-changelog.wesnoth.org domains that would force us to constantly add more and more new domains to the website certificate with each new major version release. So, the infrastructure on wesnoth.org's end for this patch already exists.

However, I still consider this to be kind of a work in progress because I do have an important question for @hrubymar10.

I seem to vaguely remember a conversation before where I was told that when a Mac App Store version needs to be reuploaded for whatever reason, the Z version number in X.Y.Z needs to be bumped regardless of anything else. If this is correct, the implication for this change in particular is that the changelog with the new version number would not be reachable via changelog.wesnoth.org, so this would effectively just lead the user to GitHub's 404 page.

Would it be perhaps more convenient in this case to use `game_config::wesnoth_version` to obtain the required info to build the URL, instead of using the Info.plist value? And in this case, is it okay to just pull `game_version.hpp` into `SDLMain.mm`?