### PR TITLE
[1.18] WoF S11: tweak enemy gold

### DIFF
--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -69,7 +69,7 @@
         side=2
         controller=ai
         recruit=Drake Arbiter, Drake Clasher, Drake Thrasher, Drake Fighter, Drake Warrior, Saurian Augur, Saurian Skirmisher, Saurian Ambusher, Saurian Oracle, Saurian Soothsayer
-        {GOLD4 0 120 240 480}
+        gold=480
         village_gold={ON_DIFFICULTY4    1 1 2 4}
         village_support={ON_DIFFICULTY4 0 1 2 4}
         team_name=karron


### PR DESCRIPTION
Last minute tweak to WoF S11 for the stable branch.

Testing the default difficulty setting by effectively droiding the player's side, the enemy side still lost even with 480 gold and otherwise default difficulty settings - [droid_side1_vs_480g_side2.gz](https://github.com/wesnoth/wesnoth/files/14628065/droid_side1_vs_480g_side2.gz). So upping enemy side gold to 480 for all difficulty levels. (Note I had to manually retreat the non-leader-but-must-survive characters since default AI does not recognize the importance of their survivals).

Will forward port this to master.