### PR TITLE
Re-add libraries due to https://github.com/ValveSoftware/steam-runtime/issues/647

### DIFF
--- a/utils/dockerbuilds/CI/Dockerfile-base-steamrt
+++ b/utils/dockerbuilds/CI/Dockerfile-base-steamrt
@@ -9,3 +9,9 @@ RUN apt-get install -y scons libreadline-dev expect-dev
 RUN wget --max-redirect 3 https://boostorg.jfrog.io/artifactory/main/release/$BOOST_VERSION/source/boost_$BOOST_VERSION_.tar.gz
 RUN mkdir -p /src/boost && tar zxf boost_${BOOST_VERSION_}.tar.gz -C /src/boost --strip-components=1
 RUN cd /src/boost && ./bootstrap.sh --with-libraries=iostreams,regex,system,filesystem,program_options,random,locale,context,coroutine,graph && ./b2 toolset=gcc-10 --layout=system link=static variant=release cxxflags='-fPIE -fstack-protector-strong' define=_FORTIFY_SOURCE=2 install
+
+RUN wget https://www.openssl.org/source/openssl-1.1.1l.tar.gz --no-check-certificate
+RUN mkdir -p /src/openssl && tar zxf openssl-1.1.1l.tar.gz -C /src/openssl --strip-components=1
+RUN cd /src/openssl && ./config --prefix=/usr/local --openssldir=/etc/ssl && make && make install
+
+RUN mkdir -p /staging/lib64 && cp /usr/lib/x86_64-linux-gnu/libicu*.so.* /lib/x86_64-linux-gnu/libhistory.so.8.1 /usr/local/lib/libcrypto.so.1.1 /usr/local/lib/libssl.so.1.1 /staging/lib64/

--- a/utils/dockerbuilds/steamrt/start.sh
+++ b/utils/dockerbuilds/steamrt/start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 gamedir=${0%/*}
 cd "$gamedir" || exit
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$gamedir/lib64"
 exec ./wesnoth "$@"


### PR DESCRIPTION
Currently on the steam deck wesnoth is not properly setup to use the sniper runtime, and this can only be updated by a valve developer. So until that happens, we need to go back to providing these libraries ourselves.