### PR TITLE
[1.18]fix shema validation for overwrite_specials

### DIFF
--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -45,7 +45,7 @@
 	# Using invalid characters to ensure it doesn't match a real tag.
 	name="~value~"
 	max=0
-	super="units/unit_type/attack/specials/~generic~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
 	{SIMPLE_KEY value s_f_int}
 	{SIMPLE_KEY add f_int}
 	{SIMPLE_KEY sub f_int}
@@ -54,6 +54,10 @@
 	{SIMPLE_KEY cumulative bool}
 	{DEPRECATED_KEY backstab bool}
 	{FILTER_TAG "filter_base_value" base_value ()}
+[/tag]
+[tag]
+	name="~overwrite_special~"
+	max=0
 	{DEFAULT_KEY overwrite_specials ability_overwrite none}
 	[tag]
 		name="overwrite"
@@ -79,15 +83,9 @@
 [tag]
 	name="damage_type"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
 	{SIMPLE_KEY replacement_type string}
 	{SIMPLE_KEY alternative_type string}
-	{DEFAULT_KEY overwrite_specials ability_overwrite none}
-	[tag]
-		name="overwrite"
-		{FILTER_TAG "experimental_filter_specials" abilities ()}
-		{SIMPLE_KEY priority real}
-	[/tag]
 [/tag]
 [tag]
 	name="drains"
@@ -102,26 +100,20 @@
 [tag]
 	name="berserk"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
 	{SIMPLE_KEY value f_int}
 	{SIMPLE_KEY cumulative bool}
 [/tag]
 [tag]
 	name="plague"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
 	{SIMPLE_KEY type string}
-	{DEFAULT_KEY overwrite_specials ability_overwrite none}
-	[tag]
-		name="overwrite"
-		{FILTER_TAG "experimental_filter_specials" abilities ()}
-		{SIMPLE_KEY priority real}
-	[/tag]
 [/tag]
 [tag]
 	name="swarm"
 	max=infinite
-	super="units/unit_type/attack/specials/~generic~"
+	super="units/unit_type/attack/specials/~generic~,units/unit_type/attack/specials/~overwrite_special~"
 	{SIMPLE_KEY swarm_attacks_max f_int}
 	{SIMPLE_KEY swarm_attacks_min f_int}
 [/tag]


### PR DESCRIPTION
some weapon special can use overwrite_specials but i forget to put it in shema validation