### PR TITLE
fix double scrollbar bug in WC Help dialog

### DIFF
--- a/changelog_entries/wc-double-scrollbar-bugfix.md
+++ b/changelog_entries/wc-double-scrollbar-bugfix.md
@@ -1,2 +1,3 @@
-### Multiplayer
-	* Fix World Conquest's Help dialog showing double scrollbars due to the left tree having it's vertical scrollbar disabled. Changed both vertical and horizontal scrollbar modes to automatic.
+ ### Campaigns
+    * World Conquest
+      Fix World Conquest's Help dialog showing double scrollbars due to the left tree having it's vertical scrollbar disabled. Changed both vertical and horizontal scrollbar modes to automatic. (issue #8576)

--- a/changelog_entries/wc-double-scrollbar-bugfix.md
+++ b/changelog_entries/wc-double-scrollbar-bugfix.md
@@ -1,0 +1,2 @@
+### Multiplayer
+	* Fix World Conquest's Help dialog showing double scrollbars due to the left tree having it's vertical scrollbar disabled. Changed both vertical and horizontal scrollbar modes to automatic.

--- a/data/campaigns/World_Conquest/gui/help_dialog.cfg
+++ b/data/campaigns/World_Conquest/gui/help_dialog.cfg
@@ -63,7 +63,7 @@
                             [tree_view]
                                 id = "treeview_topics"
                                 definition = "default"
-                                horizontal_scrollbar_mode = "auto"
+                                horizontal_scrollbar_mode = "never"
                                 vertical_scrollbar_mode = "auto"
                                 indentation_step_size = 35
                                 [node]

--- a/data/campaigns/World_Conquest/gui/help_dialog.cfg
+++ b/data/campaigns/World_Conquest/gui/help_dialog.cfg
@@ -63,8 +63,8 @@
                             [tree_view]
                                 id = "treeview_topics"
                                 definition = "default"
-                                horizontal_scrollbar_mode = "never"
-                                vertical_scrollbar_mode = "never"
+                                horizontal_scrollbar_mode = "auto"
+                                vertical_scrollbar_mode = "auto"
                                 indentation_step_size = 35
                                 [node]
                                     id = "subcategory"

--- a/data/gui/window/achievements_dialog.cfg
+++ b/data/gui/window/achievements_dialog.cfg
@@ -45,7 +45,6 @@
 		horizontal_placement = "center"
 
 		maximum_width = 800
-		maximum_height = 600
 
 		[tooltip]
 			id = "tooltip"
@@ -111,8 +110,8 @@
 						[listbox]
 							id = "achievements_list"
 
-							vertical_scrollbar_mode = "auto"
-							horizontal_scrollbar_mode = "auto"
+							vertical_scrollbar_mode = "always"
+							horizontal_scrollbar_mode = "never"
 					
 							[list_definition]
 					

--- a/data/gui/window/achievements_dialog.cfg
+++ b/data/gui/window/achievements_dialog.cfg
@@ -45,6 +45,7 @@
 		horizontal_placement = "center"
 
 		maximum_width = 800
+		maximum_height = 600
 
 		[tooltip]
 			id = "tooltip"
@@ -110,8 +111,8 @@
 						[listbox]
 							id = "achievements_list"
 
-							vertical_scrollbar_mode = "always"
-							horizontal_scrollbar_mode = "never"
+							vertical_scrollbar_mode = "auto"
+							horizontal_scrollbar_mode = "auto"
 					
 							[list_definition]
 					


### PR DESCRIPTION
Caused by the fact that the vertical scollbar mode in the left hand treeview was set to `never`. Setting it to `auto` allows the scrollbar to grow, and prevent the window from showing it's own scrollbar. (Issue #8576)
