### PR TITLE
Attempt to fix data migration for steam

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -621,7 +621,7 @@ static void setup_user_data_dir()
 #if defined(__APPLE__) && !defined(__IPHONEOS__)
 	migrate_apple_config_directory_for_unsandboxed_builds();
 #endif
-	if(!file_exists(user_data_dir)) {
+	if(!file_exists(user_data_dir / "logs")) {
 		game_config::check_migration = true;
 	}
 


### PR DESCRIPTION
It *appears* that the migration prompt doesn't show up for steam players because steam automatically creates the <userdata>/saves/steam_autocloud.vdf file on start, since the saves folder is what's synced. Since the migration logic is looking for whether the userdata folder exists, this means it always exists when launched from steam.

So, fix that by checking a different subfolder under userdata (checking the logs folder is arbitrary, it could be any of them aside from the saves folder).