### PR TITLE
campaign_dialog.cfg - Explain the RNG options better

### DIFF
--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -316,19 +316,19 @@
 					[option]
 						label = _ "Default RNG"
 						tooltip = _ "Pure, unbiased randomness; the way Wesnoth is intended to be played.
-<span> </span>
+
 Example: if you strike twice with 50% accuracy, you’re most likely to hit once and miss once, but might also hit twice or miss twice."
 					[/option]
 					[option]
 						label = _ "Predictable RNG"
 						tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
-<span> </span>
+
 Example: you strike twice and get lucky, hitting both strikes. You then load an earlier save and make the same attack again. Both strikes will still hit."
 					[/option]
 					[option]
 						label = _ "Reduced RNG"
 						tooltip = _ "Hits and misses are much more consistent. This tends to make small-scale engagements easier to plan.
-<span> </span>
+
 Example: if you strike three times with 50% accuracy, you will always hit at least once and miss at least once."
 					[/option]
 				[/menu_button]

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -315,15 +315,21 @@
 
 					[option]
 						label = _ "Default RNG"
-						tooltip = _ "Reloading alters future combat outcomes"
+						tooltip = _ "Pure, unbiased randomness; the way Wesnoth is intended to be played.
+<span> </span>
+Example: if you strike four times with 50% accuracy, you’re most likely to hit twice and miss twice, but might hit four times, miss four times, or anywhere in between."
 					[/option]
 					[option]
 						label = _ "Predictable RNG"
-						tooltip = _ "Combat outcomes remain constant when reloading"
+						tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
+<span> </span>
+Example: you strike four times and get lucky, hitting all four strikes. You then load an earlier save and make the same attack again. All four strikes will still hit."
 					[/option]
 					[option]
-						label = _ "Biased RNG (experimental)"
-						tooltip = _ "Combat outcomes are more in line with displayed probabilities and unaffected by reloading"
+						label = _ "Reduced RNG"
+						tooltip = _ "Attacks are much more consistent. Since humans plan more intelligently than Wesnoth’s AI, this tends to make the AI easier to outsmart.
+<span> </span>
+Example: if you strike four times with 50% accuracy, you will always hit twice and miss twice."
 					[/option]
 				[/menu_button]
 			[/column]

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -327,7 +327,7 @@ Example: you strike twice and get lucky, hitting both strikes. You then load an 
 					[/option]
 					[option]
 						label = _ "Reduced RNG"
-						tooltip = _ "Hits and misses are much more consistent. Since humans plan more intelligently than Wesnoth’s AI, this tends to make the AI easier to outsmart.
+						tooltip = _ "Hits and misses are much more consistent. This tends to make small-scale engagements easier to plan.
 <span> </span>
 Example: if you strike three times with 50% accuracy, you will always hit at least once and miss at least once."
 					[/option]

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -329,7 +329,7 @@ Example: you strike twice and get lucky, hitting both strikes. You then load an 
 						label = _ "Reduced RNG"
 						tooltip = _ "Hits and misses are much more consistent. Since humans plan more intelligently than Wesnoth’s AI, this tends to make the AI easier to outsmart.
 <span> </span>
-Example: if you strike twice with 50% accuracy, you will always hit once and miss once."
+Example: if you strike three times with 50% accuracy, you will always hit at least once and miss at least once."
 					[/option]
 				[/menu_button]
 			[/column]

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -317,19 +317,19 @@
 						label = _ "Default RNG"
 						tooltip = _ "Pure, unbiased randomness; the way Wesnoth is intended to be played.
 <span> </span>
-Example: if you strike four times with 50% accuracy, you’re most likely to hit twice and miss twice, but might hit four times, miss four times, or anywhere in between."
+Example: if you strike twice with 50% accuracy, you’re most likely to hit once and miss once, but might also hit twice or miss twice."
 					[/option]
 					[option]
 						label = _ "Predictable RNG"
 						tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
 <span> </span>
-Example: you strike four times and get lucky, hitting all four strikes. You then load an earlier save and make the same attack again. All four strikes will still hit."
+Example: you strike twice and get lucky, hitting both strikes. You then load an earlier save and make the same attack again. BOth strikes will still hit."
 					[/option]
 					[option]
 						label = _ "Reduced RNG"
-						tooltip = _ "Attacks are much more consistent. Since humans plan more intelligently than Wesnoth’s AI, this tends to make the AI easier to outsmart.
+						tooltip = _ "Hits and misses are much more consistent. Since humans plan more intelligently than Wesnoth’s AI, this tends to make the AI easier to outsmart.
 <span> </span>
-Example: if you strike four times with 50% accuracy, you will always hit twice and miss twice."
+Example: if you strike twice with 50% accuracy, you will always hit once and miss once."
 					[/option]
 				[/menu_button]
 			[/column]

--- a/data/gui/window/campaign_dialog.cfg
+++ b/data/gui/window/campaign_dialog.cfg
@@ -323,7 +323,7 @@ Example: if you strike twice with 50% accuracy, you’re most likely to hit once
 						label = _ "Predictable RNG"
 						tooltip = _ "Identical to Default RNG, except loading a saved game will not change the outcome of an attack.
 <span> </span>
-Example: you strike twice and get lucky, hitting both strikes. You then load an earlier save and make the same attack again. BOth strikes will still hit."
+Example: you strike twice and get lucky, hitting both strikes. You then load an earlier save and make the same attack again. Both strikes will still hit."
 					[/option]
 					[option]
 						label = _ "Reduced RNG"


### PR DESCRIPTION
The different RNG options available when choosing a new campaign could use more in-depth explanations with examples, to make them easier for new players to understand.

As part of this, I've also renamed "Biased RNG (experimental)" to "Reduced RNG", which I believe is a more intuitive name.

![Screenshot_2024-03-23_19-18-58](https://github.com/wesnoth/wesnoth/assets/33790750/5cbb05d0-2506-4583-a22f-8c2f07c56b1e)
