### PR TITLE
Tutorial scenario 1 - simplify the quintain's stats

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -578,7 +578,7 @@
 
         [message]
             speaker=Delfador
-            message= _ "Yes. It’s a magical quintain! If it hits you, it does 3 damage, and has 5 chances. If it hits every time, you’ll drop from $student_hp to $($student_hp-15) hitpoints. Brace yourself!"
+            message= _ "Yes. It’s a magical quintain! If it hits you, it does 5 damage, and has 3 chances. If it hits every time, you’ll drop from $student_hp to $($student_hp-15) hitpoints. Brace yourself!"
         [/message]
 
         [allow_end_turn][/allow_end_turn]
@@ -892,7 +892,7 @@
                     [message]
                         speaker=Delfador
                         # po: a strong elf, so +1 damage
-                        message= _ "Your elf used a sword (6×4; or 6 damage on each hit, with 4 attacks), which is a <i>melee</i> attack. The quintain defended with its melee attack (3×5; or 3 damage on each hit, with 5 attacks). The ranged attack (the bow) would have been safer."
+                        message= _ "Your elf used a sword (6×4; or 6 damage on each hit, with 4 attacks), which is a <i>melee</i> attack. The quintain defended with its melee attack (5×3; or 5 damage on each hit, with 3 attacks). The ranged attack (the bow) would have been safer."
                     [/message]
                     [message]
                         speaker=Delfador
@@ -902,7 +902,7 @@
                 [else]
                     [message]
                         speaker=Delfador
-                        message= _ "Your elf used a sword (5×4; or 5 damage on each hit, with 4 attacks), which is a <i>melee</i> attack. The quintain defended with its melee attack (3×5; or 3 damage on each hit, with 5 attacks). The ranged attack (the bow) would have been safer."
+                        message= _ "Your elf used a sword (5×4; or 5 damage on each hit, with 4 attacks), which is a <i>melee</i> attack. The quintain defended with its melee attack (5×3; or 5 damage on each hit, with 3 attacks). The ranged attack (the bow) would have been safer."
                     [/message]
                 [/else]
             [/if]

--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -210,6 +210,26 @@
         [/lua]
     [/event]
 
+    # force the dummy to always land its first hit, or else the "retreat and heal" dialogue might not make sense
+    [event]
+        name=attack
+        [object]
+            [filter]
+                id=Quintain
+            [/filter]
+            [effect]
+                apply_to=attack
+                set_accuracy=100
+            [/effect]
+        [/object]
+        [event]
+            name=defender hits,attack end
+            [remove_object]
+                id=Quintain
+            [/remove_object]
+        [/event]
+    [/event]
+
     # Give a warning to undo last step if target is out of reach
     # Check whether at least one of our units can reach any of the target_loc locations
     [event]

--- a/data/campaigns/tutorial/units/Quintain.cfg
+++ b/data/campaigns/tutorial/units/Quintain.cfg
@@ -5,18 +5,17 @@
     race=mechanical
     image="units/quintain.png"
     movement=1
-    hitpoints=58
+    hitpoints=65
     advances_to=null
     {AMLA_DEFAULT}
     level=0
     cost=10
     usage=fighter
-    movement_type=treefolk
+    movement_type=smallfoot
     alignment=neutral
     description= _ "Quintains are used to practice swordplay and jousting on. It would be extremely unusual to be attacked by one."
     [resistance]
-        blade=100
-        pierce=100
+        arcane=100
     [/resistance]
     {DEFENSE_ANIM "units/quintain.png" "units/quintain.png" staff.ogg}
     [attack]
@@ -28,11 +27,8 @@
         icon=attacks/morning-star.png
         type=impact
         range=melee
-        [specials]
-            {WEAPON_SPECIAL_MAGICAL}
-        [/specials]
-        damage=3
-        number=5
+        damage=5
+        number=3
     [/attack]
     [attack_anim]
         [filter_attack]

--- a/data/campaigns/tutorial/units/Quintain.cfg
+++ b/data/campaigns/tutorial/units/Quintain.cfg
@@ -11,11 +11,12 @@
     level=0
     cost=10
     usage=fighter
-    movement_type=smallfoot
+    movement_type=treefolk
     alignment=neutral
     description= _ "Quintains are used to practice swordplay and jousting on. It would be extremely unusual to be attacked by one."
     [resistance]
-        arcane=100
+        blade=100
+        pierce=100
     [/resistance]
     {DEFENSE_ANIM "units/quintain.png" "units/quintain.png" staff.ogg}
     [attack]
@@ -27,6 +28,9 @@
         icon=attacks/morning-star.png
         type=impact
         range=melee
+        [specials]
+            {WEAPON_SPECIAL_MAGICAL}
+        [/specials]
         damage=5
         number=3
     [/attack]

--- a/data/campaigns/tutorial/units/Quintain.cfg
+++ b/data/campaigns/tutorial/units/Quintain.cfg
@@ -5,7 +5,7 @@
     race=mechanical
     image="units/quintain.png"
     movement=1
-    hitpoints=65
+    hitpoints=58
     advances_to=null
     {AMLA_DEFAULT}
     level=0


### PR DESCRIPTION
The tutorial's quintains are the first enemies a new player is likely to fight. Therefore, their stats should be simple, and representative of the average wesnoth unit.

Currently, quintains deal 3x5 damage with the magical special and the wose movetype - all highly unusual. This PR switches the movetype to smallfoot, removes the magical special, and swaps their attack to 5x3.

Movetype buff and attack nerf should result in unchanged overall strength, so hopefully no rebalancing necessary.