### PR TITLE
[1.18] Automatically replace missing .jpg images with .webp if found

### DIFF
--- a/changelog_entries/jpg_to_webp.md
+++ b/changelog_entries/jpg_to_webp.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Trying to load an image filename ending ".jpg" will now automatically try ".webp" if the ".jpg" isn’t found.

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -367,7 +367,8 @@ static surface load_image_file(const image::locator& loc)
 	// Many images have been converted from PNG to WEBP format,
 	// but the old filename may still be saved in savegame files etc.
 	// If the file does not exist in ".png" format, also try ".webp".
-	if(location.empty() && filesystem::ends_with(name, ".png")) {
+	// Similarly for ".jpg", which conveniently has the same number of letters as ".png".
+	if(location.empty() && (filesystem::ends_with(name, ".png") || filesystem::ends_with(name, ".jpg"))) {
 		std::string webp_name = name.substr(0, name.size() - 4) + ".webp";
 		location = filesystem::get_binary_file_location("images", webp_name);
 		if(!location.empty()) {


### PR DESCRIPTION
Give .jpg files the same logic that .png files were given in 8f06da197462e376bf25704253299a886622ba58, because many files were renamed in 51b58ad218fc285717c7d5889fdfeda59f017ca6. UMC using the old name for images will trigger a warning, but the player will still see the image file.

This is just a cosmetic change that doesn't change compatibility, because have_asset("images", "blah.jpg") won't be automatically redirected to "blah.webp". Thanks to @ProditorMagnus for pointing that out. I feel it should merge for 1.18.1, and it can then be cleanly cherry-picked for master - if it's not going into 1.18, no reason to add it to master as UMC will be updated anyway for 1.18.