### PR TITLE
fix invalid escape sequence

### DIFF
--- a/data/tools/pywmlx/state/machine.py
+++ b/data/tools/pywmlx/state/machine.py
@@ -162,7 +162,7 @@ class PendingPlural:
 
     def addline(self, value, isfirstline=False):
         if self.pluraltype != 3:
-            value = re.sub('\\\s*$', '', value)
+            value = re.sub(r'\s*$', '', value)
         else:
             value = value.replace('\\', r'\\')
         if isfirstline:
@@ -203,7 +203,7 @@ class PendingLuaString:
 
     def addline(self, value, isfirstline=False):
         if self.luatype != 'luastr3':
-            value = re.sub('\\\s*$', '', value)
+            value = re.sub(r'\s*$', '', value)
         else:
             value = value.replace('\\', r'\\')
         if isfirstline:


### PR DESCRIPTION
Backport of #8577

(cherry picked from commit 4be9aa85849010e93a9a3b0f0701d0630e7b9368)