### PR TITLE
Don't duplicate player names per mod used

### DIFF
--- a/src/gui/dialogs/multiplayer/match_history.cpp
+++ b/src/gui/dialogs/multiplayer/match_history.cpp
@@ -138,6 +138,7 @@ bool mp_match_history::update_display()
 
 	listbox* tab_bar = find_widget<listbox>(get_window(), "tab_bar", false, true);
 	connect_signal_notify_modified(*tab_bar, std::bind(&mp_match_history::tab_switch_callback, this));
+	tab_bar->select_row(0);
 
 	int i = 0;
 	for(const config& game : history.mandatory_child("game_history_results").child_range("game_history_result")) {


### PR DESCRIPTION
Currently even though the results ultimately don't display duplicate information for the modifications used, the resultset coming back does have a row per modification and player, so it appears as though the player list is duplicated.

Fixes #8619

---

Draft since I haven't tested it locally yet - my local database instance seems to have vanished, so I need to see what's going on with that.