### PR TITLE
fix build with musl libc

### DIFF
--- a/src/utils/config_filters.cpp
+++ b/src/utils/config_filters.cpp
@@ -53,7 +53,7 @@ bool utils::config_filters::unsigned_matches_if_present(const config& filter, co
 	return in_ranges<int>(cfg[attribute].to_int(0), utils::parse_ranges_unsigned(filter[attribute].str()));
 }
 
-bool utils::config_filters::int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<int> def)
+bool utils::config_filters::int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, int def)
 {
 	if(!filter.has_attribute(attribute)) {
 		return true;
@@ -62,12 +62,11 @@ bool utils::config_filters::int_matches_if_present(const config& filter, const c
 		return false;
 	}
 
-	int value_def = def ? (*def) : 0;
-	return in_ranges<int>(cfg[attribute].to_int(value_def), utils::parse_ranges_int(filter[attribute].str()));
+	return in_ranges<int>(cfg[attribute].to_int(def), utils::parse_ranges_int(filter[attribute].str()));
 }
 
 bool utils::config_filters::int_matches_if_present_or_negative(
-	const config& filter, const config& cfg, const std::string& attribute, const std::string& opposite, std::optional<int> def)
+	const config& filter, const config& cfg, const std::string& attribute, const std::string& opposite, int def)
 {
 	if(int_matches_if_present(filter, cfg, attribute, def)) {
 		return true;
@@ -79,14 +78,13 @@ bool utils::config_filters::int_matches_if_present_or_negative(
 		if(!cfg.has_attribute(opposite) && !def) {
 			return false;
 		}
-		int value_def = def ? (*def) : 0;
-		return in_ranges<int>(-cfg[opposite].to_int(value_def), utils::parse_ranges_int(filter[attribute].str()));
+		return in_ranges<int>(-cfg[opposite].to_int(def), utils::parse_ranges_int(filter[attribute].str()));
 	}
 
 	return false;
 }
 
-bool utils::config_filters::double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<double> def)
+bool utils::config_filters::double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, double def)
 {
 	if(!filter.has_attribute(attribute)) {
 		return true;
@@ -95,8 +93,7 @@ bool utils::config_filters::double_matches_if_present(const config& filter, cons
 		return false;
 	}
 
-	double value_def = def ? (*def) : 1;
-	return in_ranges<double>(cfg[attribute].to_double(value_def), utils::parse_ranges_real(filter[attribute].str()));
+	return in_ranges<double>(cfg[attribute].to_double(def), utils::parse_ranges_real(filter[attribute].str()));
 }
 
 bool utils::config_filters::bool_or_empty(const config& filter, const config& cfg, const std::string& attribute)

--- a/src/utils/config_filters.hpp
+++ b/src/utils/config_filters.hpp
@@ -40,8 +40,8 @@ bool bool_matches_if_present(const config& filter, const config& cfg, const std:
  *
  * Always returns true if the filter puts no restriction on the value of @a cfg[@a attribute].
  */
-bool double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<double> def = NULL);
-bool int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<int> def = NULL);
+bool double_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, double def = 1);
+bool int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, int def = 0);
 
 /**
  * Restricts filters to only looking for values that are zero or more.
@@ -62,7 +62,7 @@ bool unsigned_matches_if_present(const config& filter, const config& cfg, const 
  * The function is named "negative" in case we later want to add a "reciprocal" for the "multiply"/"divide" pair.
  */
 bool int_matches_if_present_or_negative(
-	const config& filter, const config& cfg, const std::string& attribute, const std::string& opposite, std::optional<int> def = NULL);
+	const config& filter, const config& cfg, const std::string& attribute, const std::string& opposite, int def = 0);
 
 bool string_matches_if_present(
 	const config& filter, const config& cfg, const std::string& attribute, const std::string& def);


### PR DESCRIPTION
Wesnoth was unable to build with musl.
Error message: ```error: could not convert 'nullptr' from 'std::nullptr_t' to 'int'``` 
It was for strings 43, 44, 65.
I found the same error but with other program: https://github.com/dotnet/runtime/issues/67763
And after changing 'NULL' to '0' build was successful.