### PR TITLE
fix attack::damage_type bug for abilitie resistance

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
@@ -4,26 +4,19 @@
 # API(s) being tested: [resistance]apply_to= when opponent use [damage_type]alternative_type=
 ##
 # Actions:
-# Give all units vulneraility to arcane damage with a value of -100%
+# Give all units vulnerability to arcane damage with a value of -100%
 # Attack each other with blade,arcane weapons
 ##
 # Expected end state:
 # The damage from the attack is increased by 100%
 #####
-{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_with_resistance_ability_test" (
+{COMMON_KEEP_A_B_UNIT_TEST "negative_resistance_with_two_attack_types" (
     [event]
         name = start
 
         [modify_unit]
             [filter]
             [/filter]
-            [effect]
-                apply_to=resistance
-                replace=yes
-                [resistance]
-                    arcane=100
-                [/resistance]
-            [/effect]
             [effect]
                 apply_to = new_ability
                 [abilities]
@@ -45,7 +38,7 @@
         {ATTACK_AND_VALIDATE 200}
         {SUCCEED}
     [/event]
-)}
+) SIDE1_LEADER="Orcish Grunt"}
 
 #####
 # API(s) being tested: [resistance]apply_to= when opponent use [damage_type]alternative_type=
@@ -55,22 +48,15 @@
 # Attack each other with blade,arcane weapons
 ##
 # Expected end state:
-# The damage from the attack is not changed because blade doing more damage what arcane
+# The damage from the attack is not changed because blade does more damage than arcane
 #####
-{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_with_resistance_ability_test_alt" (
+{COMMON_KEEP_A_B_UNIT_TEST "positive_resistance_with_two_attack_types" (
     [event]
         name = start
 
         [modify_unit]
             [filter]
             [/filter]
-            [effect]
-                apply_to=resistance
-                replace=yes
-                [resistance]
-                    arcane=150
-                [/resistance]
-            [/effect]
             [effect]
                 apply_to = new_ability
                 [abilities]
@@ -92,4 +78,4 @@
         {ATTACK_AND_VALIDATE 100}
         {SUCCEED}
     [/event]
-)}
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
@@ -79,3 +79,60 @@
         {SUCCEED}
     [/event]
 ) SIDE1_LEADER="Orcish Grunt"}
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Bob is a Skeleton, with resistance to blade but weakness to arcane
+# Give Alice's attacks alternative_type=arcane
+# Make Alice teach anti-magic, so that Bob's resistance to arcane is more than his resistance to blade
+# Have Alice attack Bob
+##
+# Expected end state:
+# Alice attacked using the blade stats, not the arcane ones.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "taught_resistance_with_two_attack_types" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage_type]
+                        alternative_type=arcane
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+            [effect]
+                apply_to=new_ability
+                # An ability which reduces damage to both friend and foe, based on the anti-magi aura of EoMa's Matriarch of Emptiness
+                # This doesn't use the TEST_ABILITY macro, because it tests add= rather than value=
+                [abilities]
+                    [resistance]
+                        add=70
+                        max_value=70
+                        apply_to=fire,cold,arcane
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                        [filter_base_value]
+                            less_than=70
+                        [/filter_base_value]
+                    [/resistance]
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        # Skeletons have base +40% vs blade, -20% vs arcane. With the +70% buff, is weaker to blade than arcane.
+        {ATTACK_AND_VALIDATE 100 DAMAGE2=60}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER=Skeleton}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
@@ -1,0 +1,95 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [resistance]apply_to= when opponent use [damage_type]alternative_type=
+##
+# Actions:
+# Give all units vulneraility to arcane damage with a value of -100%
+# Attack each other with blade,arcane weapons
+##
+# Expected end state:
+# The damage from the attack is increased by 100%
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_with_resistance_ability_test" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=resistance
+                replace=yes
+                [resistance]
+                    arcane=100
+                [/resistance]
+            [/effect]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY resistance -100 (max_value=100
+                    apply_to=arcane) SELF=yes}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [damage_type]
+                        alternative_type=arcane
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 200}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [resistance]apply_to= when opponent use [damage_type]alternative_type=
+##
+# Actions:
+# Give all units resistance to arcane damage with a value of 50%
+# Attack each other with blade,arcane weapons
+##
+# Expected end state:
+# The damage from the attack is not changed because blade doing more damage what arcane
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_with_resistance_ability_test_alt" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=resistance
+                replace=yes
+                [resistance]
+                    arcane=150
+                [/resistance]
+            [/effect]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY resistance 50 (max_value=50
+                    apply_to=arcane) SELF=yes}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [damage_type]
+                        alternative_type=arcane
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 100}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1812,6 +1812,7 @@ int unit::resistance_ability(unit_ability_list resistance_abilities, const std::
 			res = 100 - resist_effect.get_composite_value();
 		}
 	}
+
 	return res;
 }
 
@@ -1829,6 +1830,7 @@ int unit::resistance_against(const std::string& damage_name,bool attacker,const 
 	if(!(types.second).empty()){
 		res = std::max(res , resistance_ability(resistance_abilities, types.second, attacker));
 	}
+
 	return res;
 }
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1056,7 +1056,7 @@ private:
 
 	/**
 	 * For the provided list of resistance abilities, determine the damage resistance based on which are active and any max_value that's present.
-	 * 
+	 *
 	 * @param resistance_abilities A list of resistance abilities that the unit has.
 	 * @param damage_name The name of the damage type, for example "blade".
 	 * @param attacker True if the unit is attacking, false if defending.

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1054,6 +1054,8 @@ public:
 private:
 	bool resistance_filter_matches(const config& cfg, bool attacker, const std::string& damage_name, int res) const;
 
+	int resistance_ability(unit_ability_list resistance_abilities, const std::string& damage_name, bool attacker) const;
+
 	/**
 	 * @}
 	 * @defgroup unit_trait Trait and upkeep functions

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1054,6 +1054,14 @@ public:
 private:
 	bool resistance_filter_matches(const config& cfg, bool attacker, const std::string& damage_name, int res) const;
 
+	/**
+	 * For the provided list of resistance abilities, determine the damage resistance based on which are active and any max_value that's present.
+	 * 
+	 * @param resistance_abilities A list of resistance abilities that the unit has.
+	 * @param damage_name The name of the damage type, for example "blade".
+	 * @param attacker True if the unit is attacking, false if defending.
+	 * @return The resistance value for a unit with the provided resistance abilities to the provided damage type.
+	 */
 	int resistance_ability(unit_ability_list resistance_abilities, const std::string& damage_name, bool attacker) const;
 
 	/**

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -369,8 +369,8 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
-0 damage_secondary_type_with_resistance_ability_test
-0 damage_secondary_type_with_resistance_ability_test_alt
+0 negative_resistance_with_two_attack_types
+0 positive_resistance_with_two_attack_types
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -369,6 +369,8 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+0 damage_secondary_type_with_resistance_ability_test
+0 damage_secondary_type_with_resistance_ability_test_alt
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -371,6 +371,7 @@
 0 damage_secondary_type_test
 0 negative_resistance_with_two_attack_types
 0 positive_resistance_with_two_attack_types
+0 taught_resistance_with_two_attack_types
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/8631 issue

When damage_type is used but the opponent uses the resistance ability against the added type it can only detect the original type and the new type is not affected.