### PR TITLE
[1.18]EI: Barrow Wight Resistance to Arcane On Defence Ability Doesn't Work Against Mixed Damage Type Weapons

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/abilities.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/abilities.cfg
@@ -527,3 +527,29 @@ When an enemy unit of lower level within a 2 hex radius engages in combat, its a
         apply_to=fire,arcane
     [/resistance]
 #enddef
+
+#define WEAPON_SPECIAL_ARCANE_EI
+    [damage_type]
+        id=arcane_damage
+        #textdomain wesnoth-help
+        name= _ "arcane"
+        description= _ "This attack combines the arcane type with the type of weapon used so that resistance to the arcane type does not penalize the user."
+        special_note=_ "This unit can use the arcane type when the opponent is particularly sensitive to it in relation to the weapon on which it is applied."
+        #textdomain wesnoth-ei
+        alternative_type=arcane
+        active_on=offense
+        [filter_opponent]
+            [not]
+                [experimental_filter_ability_active]
+                    tag_name=resistance
+                    id=shroud
+                [/experimental_filter_ability_active]
+            [/not]
+        [/filter_opponent]
+    [/damage_type]
+    [damage_type]
+        id=arcane_damage_defense
+        alternative_type=arcane
+        active_on=defense
+    [/damage_type]
+#enddef

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -144,7 +144,7 @@ crystal_quiver #enddef
             range=ranged
             [set_specials]
                 mode=append
-                {WEAPON_SPECIAL_ARCANE}
+                {WEAPON_SPECIAL_ARCANE_EI}
             [/set_specials]
             name=bow,crossbow,composite bow
         [/effect]
@@ -201,7 +201,7 @@ holy_amulet_3 #enddef
             apply_to=attack
             [set_specials]
                 mode=append
-                {WEAPON_SPECIAL_ARCANE}
+                {WEAPON_SPECIAL_ARCANE_EI}
             [/set_specials]
         [/effect]
         [effect]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/resistance/resistance_to_damage_type_special.cfg
@@ -1,0 +1,95 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [resistance]apply_to= when opponent use [damage_type]alternative_type=
+##
+# Actions:
+# Give all units vulneraility to arcane damage with a value of -100%
+# Attack each other with blade,arcane weapons
+##
+# Expected end state:
+# The damage from the attack is not changed because a bug in[damage_type] not resolved before stable branch
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_with_resistance_ability_test" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=resistance
+                replace=yes
+                [resistance]
+                    arcane=100
+                [/resistance]
+            [/effect]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY resistance -100 (max_value=100
+                    apply_to=arcane) SELF=yes}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [damage_type]
+                        alternative_type=arcane
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 100}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [resistance]apply_to= when opponent use [damage_type]alternative_type=
+##
+# Actions:
+# Give all units resistance to arcane damage with a value of 50%
+# Attack each other with blade,arcane weapons
+##
+# Expected end state:
+# The damage from the attack is not changed because bug in [damage_type]
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_with_resistance_ability_test_alt" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=resistance
+                replace=yes
+                [resistance]
+                    arcane=150
+                [/resistance]
+            [/effect]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY resistance 50 (max_value=50
+                    apply_to=arcane) SELF=yes}
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [damage_type]
+                        alternative_type=arcane
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 150}
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -369,6 +369,8 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+0 damage_secondary_type_with_resistance_ability_test
+0 damage_secondary_type_with_resistance_ability_test_alt
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/8631 issue

When damage_type is used but the opponent uses the resistance ability against the added type it can only detect the original type and the new type is not affected.