### PR TITLE
Boost tests: check what config_filters's *_matches_if_present default to

### DIFF
--- a/boost_test_schedule
+++ b/boost_test_schedule
@@ -88,6 +88,9 @@ config_cache/test_lead_spaces_loading
 config_filters/test_int_add_sub_filter
 config_filters/test_int_positive_filter
 config_filters/test_int_signed_filter
+config_filters/test_int_zero_or_default
+config_filters/test_double_zero_or_default
+config_filters/test_without_attribute_filter
 filesystem/test_fs_game_path_reverse_engineering
 filesystem/test_fs_base
 filesystem/test_fs_enum

--- a/src/tests/test_config_filters.cpp
+++ b/src/tests/test_config_filters.cpp
@@ -84,6 +84,30 @@ BOOST_AUTO_TEST_CASE(test_int_add_sub_filter)
 	BOOST_ASSERT(int_matches_if_present_or_negative(sub_2_to_4, add_minus_3, "sub", "add"));
 }
 
+BOOST_AUTO_TEST_CASE(test_int_zero_or_default)
+{
+	config add_0 {"add", 0};
+	config value_0 {"value", 0};
+
+	BOOST_ASSERT(int_matches_if_present(value_0, add_0, "value", 0));
+	BOOST_ASSERT(!int_matches_if_present(value_0, add_0, "value", std::nullopt));
+
+	// Testing for behavior matching 1.18.0, not for desired behavior
+	BOOST_ASSERT(int_matches_if_present(value_0, add_0, "value"));
+}
+
+BOOST_AUTO_TEST_CASE(test_double_zero_or_default)
+{
+	config add_0 {"add", 0.0};
+	config value_0 {"value", 0.0};
+
+	BOOST_ASSERT(double_matches_if_present(value_0, add_0, "value", 0.0));
+	BOOST_ASSERT(!double_matches_if_present(value_0, add_0, "value", std::nullopt));
+
+	// Testing for behavior matching 1.18.0, not for desired behavior
+	BOOST_ASSERT(double_matches_if_present(value_0, add_0, "value"));
+}
+
 BOOST_AUTO_TEST_CASE(test_without_attribute_filter)
 {
 	config add_3 {"add", 3};


### PR DESCRIPTION
These took a std::nullopt defaulted to NULL, but NULL is often defined to be zero rather than std::nullopt.

Ideally this should be using a WML test to find out what the result is for things accessible via FilterWML, but for 1.18 let's check what the low-level function does.

Also add test_without_attribute_filter to boost_test_schedule.