### PR TITLE
UtBS luck smoothing: scenario 1

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -1036,14 +1036,6 @@
                 {VARIABLE expected_elf_pool_gold_value "$($total_elf_pool_gold_value|*$seen_camps|/$outer_villages.length|)"}
                 {VARIABLE luckiness "$($current_elf_pool_gold_value_received - $expected_elf_pool_gold_value)"}
                 {VARIABLE_OP seen_camps add 1}
-                [message]
-                    speaker=Kaleh
-                    message= _ "$fate, $expected_elf_pool_gold_value, $current_elf_pool_gold_value_received, $luckiness, $max_fate"
-                [/message]
-                [message]
-                    speaker=Kaleh
-                    message= _ "$($max_fate|*{ON_DIFFICULTY 0.6 0.5 0.4} - $luckiness|)"
-                [/message]
                 [if]
                     [variable]
                         name=fate

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -221,9 +221,11 @@
                 gender=male
             [/value]
         [/set_variables]
+
         # Smooth out camp luck
-        {VARIABLE total_camp_luck 0}
-        {VARIABLE current_camp_luck 0}
+        {VARIABLE total_elf_pool_gold_value 0}
+        {VARIABLE current_elf_pool_gold_value_received 0}
+        {VARIABLE seen_camps 0}
         [foreach]
             array=elf_pool
             [do]
@@ -231,9 +233,11 @@
                     type = $this_item.type
                     variable = utbs_unit_type
                 [/store_unit_type]
-                {VARIABLE_OP total_camp_luck add "$($utbs_unit_type.cost*{ON_DIFFICULTY 0.6 0.5 0.4})"}
+                {VARIABLE_OP total_elf_pool_gold_value add "$utbs_unit_type.cost"}
                 {CLEAR_VARIABLE utbs_unit_type}
             [/do]
+            # This will be further reduced when outer_villages are calculated
+            {VARIABLE_OP total_elf_pool_gold_value multiply {ON_DIFFICULTY .6 .5 .4}}
         [/foreach]
     [/event]
 
@@ -985,7 +989,10 @@
                 [/or]
             [/not]
         [/store_locations]
-        {VARIABLE remaining_camps "$outer_villages.length"}
+        # Scale average gold value to the number of villages, not size of pool
+        {VARIABLE_OP total_elf_pool_gold_value multiply "$outer_villages.length"}
+        {VARIABLE_OP total_elf_pool_gold_value divide "$elf_pool.length"}
+        
     [/event]
 
     [event]
@@ -1015,19 +1022,16 @@
             # if this village wasn't captured by undead first, the
             # player has a chance of finding a random elf
             [then]
-                {VARIABLE_OP remaining_camps sub 1}
-                {VARIABLE_OP fate rand "1..100"}
-                [message]
-                    speaker=Kaleh
-                    message= _ "$fate"
-                [/message]
-                {VARIABLE seen_camps "$($outer_villages.length-$remaining_camps)"}
-                {VARIABLE expected_camp_luck "$($total_camp_luck|/$outer_villages.length|*($seen_camps|))"}
-                {VARIABLE luckiness "$($current_camp_luck - $expected_camp_luck)"}
+                # If you want more variability, increase the range.
+                {VARIABLE max_fate 50}
+                {VARIABLE_OP fate rand "1..$max_fate"}
+                {VARIABLE expected_elf_pool_gold_value "$($total_elf_pool_gold_value|*$seen_camps|/$outer_villages.length|)"}
+                {VARIABLE luckiness "$($current_elf_pool_gold_value_received - $expected_elf_pool_gold_value)"}
+                {VARIABLE_OP seen_camps add 1}
                 [if]
                     [variable]
                         name=fate
-                        less_than_equal_to="$(50 - $luckiness)"
+                        less_than_equal_to="$($max_fate*{ON_DIFFICULTY .6 .5 .4} - $luckiness)"
                     [/variable]
                     [then]
                         # So the RNG smiled upon the player, time to pick a
@@ -1049,11 +1053,13 @@
                             [/modifications]
 #endif
                         [/unit]
+
+                        # Add gold value of the unit to luck counter
                         [store_unit_type]
                             type = $elf_pool[$random_elf_pool_index].type
                             variable = utbs_unit_type
                         [/store_unit_type]
-                        {VARIABLE_OP current_camp_luck add "$utbs_unit_type.cost"}
+                        {VARIABLE_OP current_elf_pool_gold_value_received add "$utbs_unit_type.cost"}
                         {CLEAR_VARIABLE utbs_unit_type}
 
                         # When done remove unit from the pool
@@ -1076,6 +1082,9 @@
                     [/else]
                 [/if]
                 {CLEAR_VARIABLE fate}
+                {CLEAR_VARIABLE max_fate}
+                {CLEAR_VARIABLE expected_elf_pool_gold_value}
+                {CLEAR_VARIABLE luckiness}
             [/then]
 
             # If this village was captured by undead first, the player
@@ -1466,8 +1475,8 @@
         {CLEAR_VARIABLE found_garak}
         {CLEAR_VARIABLE found_zhul}
         {CLEAR_VARIABLE bridge_event}
-        {CLEAR_VARIABLE total_camp_luck}
-        {CLEAR_VARIABLE current_camp_luck}
+        {CLEAR_VARIABLE total_elf_pool_gold_value}
+        {CLEAR_VARIABLE current_elf_pool_gold_value_received}
         {CLEAR_VARIABLE remaining_camps}
 
         # This clears all those village-specific containers that were holding

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -1022,7 +1022,15 @@
             # if this village wasn't captured by undead first, the
             # player has a chance of finding a random elf
             [then]
-                # If you want more variability, increase the range.
+                # Check if it's lower than a threshold of
+                # finding an unit that's dependent on difficulty
+                # level: 60% on easy, 50% on normal, 40% on
+                # hard. We use preprocesor to choose appropriate
+                # chance. We also account for luckiness, which is
+                # the difference between expected gold value of
+                # the elf pool and the gold value of the units
+                # already found.
+                # If you want more variability, increase max_fate.
                 {VARIABLE max_fate 50}
                 {VARIABLE_OP fate rand "1..$max_fate"}
                 {VARIABLE expected_elf_pool_gold_value "$($total_elf_pool_gold_value|*$seen_camps|/$outer_villages.length|)"}
@@ -1477,7 +1485,7 @@
         {CLEAR_VARIABLE bridge_event}
         {CLEAR_VARIABLE total_elf_pool_gold_value}
         {CLEAR_VARIABLE current_elf_pool_gold_value_received}
-        {CLEAR_VARIABLE remaining_camps}
+        {CLEAR_VARIABLE seen_camps}
 
         # This clears all those village-specific containers that were holding
         # information about who had visited the village

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -236,9 +236,9 @@
                 {VARIABLE_OP total_elf_pool_gold_value add "$utbs_unit_type.cost"}
                 {CLEAR_VARIABLE utbs_unit_type}
             [/do]
-            # This will be further reduced when outer_villages are calculated
-            {VARIABLE_OP total_elf_pool_gold_value multiply {ON_DIFFICULTY .6 .5 .4}}
         [/foreach]
+        # This will be further reduced when outer_villages are calculated
+        {VARIABLE_OP total_elf_pool_gold_value multiply "$({ON_DIFFICULTY 0.6 0.5 0.4})"}
     [/event]
 
     # Dialog at start of scenario
@@ -989,10 +989,10 @@
                 [/or]
             [/not]
         [/store_locations]
+
         # Scale average gold value to the number of villages, not size of pool
         {VARIABLE_OP total_elf_pool_gold_value multiply "$outer_villages.length"}
         {VARIABLE_OP total_elf_pool_gold_value divide "$elf_pool.length"}
-        
     [/event]
 
     [event]
@@ -1031,15 +1031,23 @@
                 # the elf pool and the gold value of the units
                 # already found.
                 # If you want more variability, increase max_fate.
-                {VARIABLE max_fate 50}
+                {VARIABLE max_fate 30}
                 {VARIABLE_OP fate rand "1..$max_fate"}
                 {VARIABLE expected_elf_pool_gold_value "$($total_elf_pool_gold_value|*$seen_camps|/$outer_villages.length|)"}
                 {VARIABLE luckiness "$($current_elf_pool_gold_value_received - $expected_elf_pool_gold_value)"}
                 {VARIABLE_OP seen_camps add 1}
+                [message]
+                    speaker=Kaleh
+                    message= _ "$fate, $expected_elf_pool_gold_value, $current_elf_pool_gold_value_received, $luckiness, $max_fate"
+                [/message]
+                [message]
+                    speaker=Kaleh
+                    message= _ "$($max_fate|*{ON_DIFFICULTY 0.6 0.5 0.4} - $luckiness|)"
+                [/message]
                 [if]
                     [variable]
                         name=fate
-                        less_than_equal_to="$($max_fate*{ON_DIFFICULTY .6 .5 .4} - $luckiness)"
+                        less_than_equal_to="$($max_fate|*{ON_DIFFICULTY 0.6 0.5 0.4} - $luckiness|)"
                     [/variable]
                     [then]
                         # So the RNG smiled upon the player, time to pick a

--- a/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/scenarios/01_The_Morning_After.cfg
@@ -221,6 +221,20 @@
                 gender=male
             [/value]
         [/set_variables]
+        # Smooth out camp luck
+        {VARIABLE total_camp_luck 0}
+        {VARIABLE current_camp_luck 0}
+        [foreach]
+            array=elf_pool
+            [do]
+                [store_unit_type]
+                    type = $this_item.type
+                    variable = utbs_unit_type
+                [/store_unit_type]
+                {VARIABLE_OP total_camp_luck add "$($utbs_unit_type.cost*{ON_DIFFICULTY 0.6 0.5 0.4})"}
+                {CLEAR_VARIABLE utbs_unit_type}
+            [/do]
+        [/foreach]
     [/event]
 
     # Dialog at start of scenario
@@ -971,6 +985,7 @@
                 [/or]
             [/not]
         [/store_locations]
+        {VARIABLE remaining_camps "$outer_villages.length"}
     [/event]
 
     [event]
@@ -1000,17 +1015,19 @@
             # if this village wasn't captured by undead first, the
             # player has a chance of finding a random elf
             [then]
+                {VARIABLE_OP remaining_camps sub 1}
                 {VARIABLE_OP fate rand "1..100"}
-
-                # And check if it's lower than a threshold of
-                # finding an unit that's dependent on difficulty
-                # level: 60% on easy, 50% on normal, 40% on
-                # hard. We use preprocesor to choose appropriate
-                # chance
+                [message]
+                    speaker=Kaleh
+                    message= _ "$fate"
+                [/message]
+                {VARIABLE seen_camps "$($outer_villages.length-$remaining_camps)"}
+                {VARIABLE expected_camp_luck "$($total_camp_luck|/$outer_villages.length|*($seen_camps|))"}
+                {VARIABLE luckiness "$($current_camp_luck - $expected_camp_luck)"}
                 [if]
                     [variable]
                         name=fate
-                        less_than_equal_to={ON_DIFFICULTY 60 50 40}
+                        less_than_equal_to="$(50 - $luckiness)"
                     [/variable]
                     [then]
                         # So the RNG smiled upon the player, time to pick a
@@ -1032,6 +1049,12 @@
                             [/modifications]
 #endif
                         [/unit]
+                        [store_unit_type]
+                            type = $elf_pool[$random_elf_pool_index].type
+                            variable = utbs_unit_type
+                        [/store_unit_type]
+                        {VARIABLE_OP current_camp_luck add "$utbs_unit_type.cost"}
+                        {CLEAR_VARIABLE utbs_unit_type}
 
                         # When done remove unit from the pool
                         {CLEAR_VARIABLE elf_pool[$random_elf_pool_index]}
@@ -1443,6 +1466,9 @@
         {CLEAR_VARIABLE found_garak}
         {CLEAR_VARIABLE found_zhul}
         {CLEAR_VARIABLE bridge_event}
+        {CLEAR_VARIABLE total_camp_luck}
+        {CLEAR_VARIABLE current_camp_luck}
+        {CLEAR_VARIABLE remaining_camps}
 
         # This clears all those village-specific containers that were holding
         # information about who had visited the village


### PR DESCRIPTION
Adjusts chance of finding a unit in village (by difficulty and unit value), making it less likely to have long streaks of luck or unluck.

https://docs.google.com/spreadsheets/d/1Wqrb6ytW3FeYcWXlfKBlNgi6bcklNyk7bXDfdl1QsJ4/edit#gid=0 is a quick and dirty analysis of different max_fate values on how much an empty village, fighter, scout, or tauroch adjusts your chances in all future villages.