### PR TITLE
Tutorial S01: Better timing for the hints

### DIFF
--- a/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
+++ b/data/campaigns/tutorial/scenarios/01_Tutorial_part_1.cfg
@@ -512,6 +512,11 @@
             id=student
         [/filter]
 
+        # No longer need the hint about how to attack
+        [hint_message]
+            remove=yes
+        [/hint_message]
+
         [message]
             speaker=student
             message= _ "Hey! This quintain fights back!"
@@ -532,18 +537,6 @@
             speaker=Delfador
             message= _ "Good idea!"
         [/message]
-
-        {GENDER (
-            [hint_message]
-                caption= _ "Crowns"
-                message= _ "The tiny golden crown above your leader (Konrad) indicates he is a side leader. In most scenarios, you will lose if your leader is killed. Be sure to keep him safe!"
-            [/hint_message]
-        ) (
-            [hint_message]
-                caption= _ "Crowns"
-                message= _ "The tiny golden crown above your leader (Li’sar) indicates she is a side leader. In most scenarios, you will lose if your leader is killed. Be sure to keep her safe!"
-            [/hint_message]
-        )}
 
         # Check where Delfador is, to set the remaining moves accordingly
         [if]
@@ -619,6 +612,10 @@
         {ALLOW_END_TURN_AFTER_ATTACK}
 
         {CLEAR_PRINT}
+
+        [hint_message]
+            remove=yes
+        [/hint_message]
 
         [message]
             speaker=student
@@ -760,10 +757,18 @@
 
             {CLEAR_PRINT}
 
-            [hint_message]
-                caption= _ "Traits"
-                message= _"Be sure to examine the <i>traits</i> of your new recruits. They are listed under its race in the sidebar. Traits can subtly affect how you use your troops. For example, units with the <i>quick</i> trait can move an extra hex each turn, and units with the <i>intelligent</i> trait require 20% less experience to level up."
-            [/hint_message]
+            # The player has some units to compare their leader to, and this is also a hint it won't be game over if the recruited units die
+            {GENDER (
+                [hint_message]
+                    caption= _ "Crowns"
+                    message= _ "The tiny golden crown above your leader (Konrad) indicates he is a side leader. In most scenarios, you will lose if your leader is killed. Be sure to keep him safe!"
+                [/hint_message]
+            ) (
+                [hint_message]
+                    caption= _ "Crowns"
+                    message= _ "The tiny golden crown above your leader (Li’sar) indicates she is a side leader. In most scenarios, you will lose if your leader is killed. Be sure to keep her safe!"
+                [/hint_message]
+            )}
 
             # Allow our hero to move freely until next turn without undo messages now that the recruiting is done
             {VARIABLE enable_undo_messages no}
@@ -839,6 +844,12 @@
         [/message]
 
         {PRINT ( _ "Attack the quintain with your fighters")}
+
+        # The hint about traits is shown here because strong and dexterous can influence the player's choice of attack
+        [hint_message]
+            caption= _ "Traits"
+            message= _ "Be sure to examine the <i>traits</i> of your new recruits. They are listed under its race in the sidebar. Traits can subtly affect how you use your troops. For example, units with the <i>quick</i> trait can move an extra hex each turn, and units with the <i>intelligent</i> trait require 20% less experience to level up."
+        [/hint_message]
 
         [event]
             name=select


### PR DESCRIPTION
Forward-port of #8647, intending to merge when the CI passes.

No string changes, just adjusting when the hints at the top-left of the screen appear and disappear.

The hint about crowns now appears after recruiting both elves, so that there are units to compare the leader to, who have the same orb color but no crown.

The hint about traits appears when told to attack the quintain with the elves. The player will probably find a strong or dexterous trait, and Delfador already comments about those traits after attacking. Even if neither elf has those, speedy or robust could also influence whether to use melee or ranged attacks.

There's now no hint on screen when first choosing which village to use for healing; previously it was the hint about crowns which didn't seem relevant. No strings are added in this commit, but a hint about checking the quintain's movement range would fit here, see <https://r.wesnoth.org/t54644>.

(cherry picked from commit f7a0f119de8f07d128d64374d7e872a2b3250cb5)