### PR TITLE
[1.18] Boost tests: run test_without_attribute_filter

### DIFF
--- a/boost_test_schedule
+++ b/boost_test_schedule
@@ -88,6 +88,7 @@ config_cache/test_lead_spaces_loading
 config_filters/test_int_add_sub_filter
 config_filters/test_int_positive_filter
 config_filters/test_int_signed_filter
+config_filters/test_without_attribute_filter
 filesystem/test_fs_game_path_reverse_engineering
 filesystem/test_fs_base
 filesystem/test_fs_enum


### PR DESCRIPTION
It was added in 532d17f958969186baa0646c5528c2477bcb65b3, but that commit missed adding it to boost_test_schedule.