### PR TITLE
Make the Changelog macOS app menu item more relevant (development branch forward-port version)

### DIFF
--- a/changelog_entries/macos-bundle-changelog.md
+++ b/changelog_entries/macos-bundle-changelog.md
@@ -1,0 +1,3 @@
+ ### User interface
+   * Made the Changelog option in the macOS app menu link to the changelog for the particular
+     Wesnoth app version rather than the Git master branch changelog.

--- a/src/macosx/SDLMain.mm
+++ b/src/macosx/SDLMain.mm
@@ -77,7 +77,9 @@ static std::vector<char*> gArgs;
 - (IBAction) openChangelog:(id)sender
 {
 	(void) sender;
-	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://github.com/wesnoth/wesnoth/blob/master/changelog.md"]];
+	NSString* version = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+	NSString* url = [NSString stringWithFormat:@"https://changelog.wesnoth.org/%@", version];
+	[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
 }
 
 /* Called when the internal event loop has just started running */


### PR DESCRIPTION
Just running a forward-port of #8572 through CI build.