### PR TITLE
EI 12_Evacuation.cfg: fix Dacyn's halo not flickering

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -243,8 +243,20 @@
 
         {RECALL_XY Owaec 23 10}
         {RECALL_XY Dacyn 24 11} # he's slow, so put him near the bridge
-        {MODIFY_UNIT id=Dacyn halo ""}
-        {RECALL_XY Addogin 24 9}
+        [modify_unit]
+            [filter]
+                id=Dacyn
+            [/filter]
+            [object]
+                id=dacyn_no_halo
+                [effect]
+                    apply_to=remove_ability
+                    [experimental_filter_ability]
+                        tag_name=illuminates
+                    [/experimental_filter_ability]
+                [/effect]
+            [/object]
+        [/modify_unit]
         {RECALL_XY (Hahid al-Ali) 24 9} # he drinks an elixir of haste. To make it more meaningful, put him on the furthest tile from the bridge
         {RECALL_XY Terraent 24 9}
         {RECALL_XY Dolburras 23 11} # he's slow, so put him near the bridge
@@ -396,13 +408,31 @@
                 [delay]
                     time=100
                 [/delay]
-
-                {MODIFY_UNIT id=Dacyn halo ""}
+                [modify_unit]
+                    [filter]
+                        id=Dacyn
+                    [/filter]
+                    [object]
+                        id=dacyn_no_halo
+                        [effect]
+                            apply_to=remove_ability
+                            [experimental_filter_ability]
+                                tag_name=illuminates
+                            [/experimental_filter_ability]
+                        [/effect]
+                    [/object]
+                [/modify_unit]
+                [redraw]
+                [/redraw]
                 [delay]
                     time=50
                 [/delay]
-
-                {MODIFY_UNIT id=Dacyn halo "halo/illuminates-aura.png"}
+                [remove_object]
+                    id=Dacyn
+                    object_id=dacyn_no_halo
+                [/remove_object]
+                [redraw]
+                [/redraw]
             [/do]
         [/repeat]
         [delay]

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -257,6 +257,7 @@
                 [/effect]
             [/object]
         [/modify_unit]
+        {RECALL_XY Addogin 24 9}
         {RECALL_XY (Hahid al-Ali) 24 9} # he drinks an elixir of haste. To make it more meaningful, put him on the furthest tile from the bridge
         {RECALL_XY Terraent 24 9}
         {RECALL_XY Dolburras 23 11} # he's slow, so put him near the bridge


### PR DESCRIPTION
The "illuminates" ability was recently changed to create its own halo, instead of relying on the unit's halo. This caused issues in a section of EI where Dacyn (a mage of light) is supposed to have a flickering halo. This PR fixes that EI bug.

Fixes issue #8675