### PR TITLE
SoF S7: fewer and slower enemy outriders

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
@@ -144,8 +144,8 @@
             x,y=18,1
             side=2
             [modifications]
-                {TRAIT_QUICK}
-                {TRAIT_DEXTROUS}
+                {TRAIT_STRONG}
+                {TRAIT_RESILIENT}
             [/modifications]
         [/unit]
         [unit]
@@ -156,8 +156,8 @@
             side=2
             facing=sw
             [modifications]
-                {TRAIT_STRONG}
-                {TRAIT_QUICK}
+                {TRAIT_DEXTROUS}
+                {TRAIT_RESILIENT}
             [/modifications]
         [/unit]
         [unit]
@@ -169,18 +169,6 @@
             facing=sw
             [modifications]
                 {TRAIT_STRONG}
-                {TRAIT_RESILIENT}
-            [/modifications]
-        [/unit]
-        [unit]
-            type=Elvish Outrider
-            id=Ealin
-            name= _ "Ealin"
-            x,y=18,1
-            side=2
-            facing=sw
-            [modifications]
-                {TRAIT_QUICK}
                 {TRAIT_RESILIENT}
             [/modifications]
         [/unit]


### PR DESCRIPTION
This is to counteract the swifter and deadlier Elvish Outrider after the 1.18 core unit balance changes. It reduces the number of Elvish Outriders at the beginning of the scenario from 5 to 4 and ensures none of them has the  `quick` trait.

This should get back ported to 1.18.

Closes #8589