### PR TITLE
Document why the Fog Clearer's traits show in help

### DIFF
--- a/data/core/units/fake/Fog_Clearer.cfg
+++ b/data/core/units/fake/Fog_Clearer.cfg
@@ -16,6 +16,9 @@
     # These traits don't occur elsewhere in mainline races or units and are added here
     # so they will appear in the traits section in help. The Fog Clearer doesn't receive
     # traits because it is a monster, so these shouldn't affect umc use.
+    #
+    # This will not work in any other unit that has hide_help=yes, special treatment of
+    # the Fog Clearer is hardcoded into the C++ code (HIDDEN_BUT_SHOW_MACROS).
     {TRAIT_LOYAL}
     {TRAIT_AGED}
     hitpoints=1


### PR DESCRIPTION
Not mentioned here, but turning on debug mode also affects which units, and therefore which units' traits, are shown in help.

Having looked back into the history while wondering why it was done this way in e9603e6e01, back then we needed a fix that could be backported to 1.14, so couldn't add a new attribute to [unit_type]. The feature request to do it properly is #5139.