### PR TITLE
[1.18] Disable the Windows CI builds

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -282,6 +282,8 @@ jobs:
         run: ./run_boost_tests --path=projectfiles/Xcode/build/"$CFG" --executable=unit_tests
 
   windows:
+    if: false # All vcpkg builds require xz. Disabled while vcpkg and xz upstreams discuss recovery from the backdoor.
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Setting up vcpkg tries to build xz from source, which fails because the entire xz repo has now been made private or taken down. The vcpkg team have been advised not to switch to an alternative repo [1], so for now our Windows builds will always fail.

Turn those builds off, so that we don't get familiar with seeing red status markers on all PR's CI results.

[1] `https://github.com/microsoft/vcpkg/pull/37957` - second comment is the vcpkg team's "We have been explicitly asked by security folks to not change the upstream [to a different repo] for liblzma at this time."

Link is in backticks because I didn't intend this to create noise in the vcpkg PR it linked to (the commit itself does, sadly).