### PR TITLE
Fix clicking on the sidebar going to the wrong trait

### DIFF
--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -304,7 +304,7 @@ static config unit_traits(const unit* u)
 	config res;
 	const std::vector<t_string> &traits = u->trait_names();
 	const std::vector<t_string> &descriptions = u->trait_descriptions();
-	const std::vector<std::string> &trait_ids = u->get_traits_list();
+	const std::vector<std::string> &trait_ids = u->trait_nonhidden_ids();
 	unsigned nb = traits.size();
 	for (unsigned i = 0; i < nb; ++i)
 	{

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -288,6 +288,7 @@ unit::unit(const unit& o)
 	, facing_(o.facing_)
 	, trait_names_(o.trait_names_)
 	, trait_descriptions_(o.trait_descriptions_)
+	, trait_nonhidden_ids_(o.trait_nonhidden_ids_)
 	, unit_value_(o.unit_value_)
 	, goto_(o.goto_)
 	, interrupted_move_(o.interrupted_move_)
@@ -369,6 +370,7 @@ unit::unit(unit_ctor_t)
 	, facing_(map_location::NDIRECTIONS)
 	, trait_names_()
 	, trait_descriptions_()
+	, trait_nonhidden_ids_()
 	, unit_value_()
 	, goto_()
 	, interrupted_move_()
@@ -920,6 +922,7 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 	// Reset the scalar values first
 	trait_names_.clear();
 	trait_descriptions_.clear();
+	trait_nonhidden_ids_.clear();
 	is_fearless_ = false;
 	is_healthy_ = false;
 	image_mods_.clear();
@@ -2559,6 +2562,7 @@ void unit::add_trait_description(const config& trait, const t_string& descriptio
 	if(!name.empty()) {
 		trait_names_.push_back(name);
 		trait_descriptions_.push_back(description);
+		trait_nonhidden_ids_.push_back(trait["id"]);
 	}
 }
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1106,7 +1106,18 @@ public:
 	}
 
 	/**
-	 * Gets a list of the traits this unit currently has.
+	 * Gets the ids of the traits corresponding to those returned by trait_names() and
+	 * trait_descriptions(). Omits hidden traits, which are those with an empty name.
+	 *
+	 * @returns                   A list of trait IDs.
+	 */
+	std::vector<std::string> trait_nonhidden_ids() const
+	{
+		return trait_nonhidden_ids_;
+	}
+
+	/**
+	 * Gets a list of the traits this unit currently has, including hidden traits.
 	 *
 	 * @returns                   A list of trait IDs.
 	 */
@@ -1967,6 +1978,7 @@ protected:
 private:
 	std::vector<t_string> trait_names_;
 	std::vector<t_string> trait_descriptions_;
+	std::vector<std::string> trait_nonhidden_ids_;
 
 	int unit_value_;
 	map_location goto_, interrupted_move_;


### PR DESCRIPTION
Forward-port of #8684, going to merge when the CI finishes.

If the first trait of a unit has no name, then clicking on the units (other) trait in the sidebar opened the wrong page in the help.

(cherry picked from commit f9af941f1ec7165ad135cba465717203a4007287)