### PR TITLE
Remove gzip/bzip2 (de)compression commandline options

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -47,18 +47,6 @@ campaigns, and share them with others.
 Show all translations in the in-game language selection list,
 even if they are deemed insufficiently complete.
 .TP
-.BI --bunzip2 \ infile.bz2
-decompresses a file which should be in bzip2 format and stores it
-without the .bz2 suffix. The
-.I infile.bz2
-will be removed.
-.TP
-.BI --bzip2 \ infile
-compresses a file in bzip2 format, stores it as
-.IR infile .bz2
-and removes
-.IR infile .
-.TP
 .BI -c[ id_campaign ],\ --campaign[ =id_campaign ]
 goes directly to the campaign with id
 .IR id_campaign .
@@ -127,18 +115,6 @@ in the userdata directory.
 .TP
 .B -f, --fullscreen
 runs the game in full screen mode.
-.TP
-.BI --gunzip \ infile.gz
-decompresses a file which should be in gzip format and stores it
-without the .gz suffix. The
-.I infile.gz
-will be removed.
-.TP
-.BI --gzip \ infile
-compresses a file in gzip format, stores it as
-.IR infile .gz
-and removes
-.IR infile .
 .TP
 .B -h, --help
 displays a summary of command line options to standard output, and exits.

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -64,9 +64,7 @@ bad_commandline_tuple::bad_commandline_tuple(const std::string& str,
 
 
 commandline_options::commandline_options(const std::vector<std::string>& args)
-	: bunzip2()
-	, bzip2()
-	, campaign()
+	: campaign()
 	, campaign_difficulty()
 	, campaign_scenario()
 	, campaign_skip_story(false)
@@ -85,8 +83,6 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 	, editor()
 	, fps(false)
 	, fullscreen(false)
-	, gunzip()
-	, gzip()
 	, help()
 	, language()
 	, log()
@@ -173,8 +169,6 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 	po::options_description general_opts("General options");
 	general_opts.add_options()
 		("all-translations", "Show all translations, even incomplete ones.")
-		("bunzip2", po::value<std::string>(), "decompresses a file (<arg>.bz2) in bzip2 format and stores it without the .bz2 suffix. <arg>.bz2 will be removed." IMPLY_TERMINAL)
-		("bzip2", po::value<std::string>(), "compresses a file (<arg>) in bzip2 format, stores it as <arg>.bz2 and removes <arg>." IMPLY_TERMINAL)
 		("clock", "Adds the option to show a clock for testing the drawing timer.")
 		("config-dir", po::value<std::string>(), "sets the path of the userdata directory to $HOME/<arg> or My Documents\\My Games\\<arg> for Windows. You can specify also an absolute path outside the $HOME or My Documents\\My Games directory. DEPRECATED: use userdata-dir instead.")
 		("config-path", "prints the path of the userdata directory and exits. DEPRECATED: use userdata-path instead." IMPLY_TERMINAL)
@@ -190,8 +184,6 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("debug-dot-domain", po::value<std::string>(), "sets the domain of the debug dot files. <arg> should be a comma separated list of domains. See --debug-dot-level for more info. Available domains: show (generate the data when the dialog is about to be shown), layout (generate the data during the layout phase - might result in multiple files). The data can also be generated when the F12 is pressed in a dialog.")
 #endif
 		("editor,e", po::value<std::string>()->implicit_value(std::string()), "starts the in-game map editor directly. If file <arg> is specified, equivalent to -e --load <arg>.")
-		("gunzip", po::value<std::string>(), "decompresses a file (<arg>.gz) in gzip format and stores it without the .gz suffix. <arg>.gz will be removed." IMPLY_TERMINAL)
-		("gzip", po::value<std::string>(), "compresses a file (<arg>) in gzip format, stores it as <arg>.gz and removes <arg>." IMPLY_TERMINAL)
 		("help,h", "prints this message and exits." IMPLY_TERMINAL)
 		("language,L", po::value<std::string>(), "uses language <arg> (symbol) this session. Example: --language ang_GB@latin")
 		("load,l", po::value<std::string>(), "loads the save <arg> from the standard save game directory. When launching the map editor via -e, the map <arg> is loaded, relative to the current directory. If it is a directory, the editor will start with a load map dialog opened there.")
@@ -326,10 +318,6 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		multiplayer_ai_config = parse_to_uint_string_tuples_(vm["ai-config"].as<std::vector<std::string>>());
 	if(vm.count("algorithm"))
 		multiplayer_algorithm = parse_to_uint_string_tuples_(vm["algorithm"].as<std::vector<std::string>>());
-	if(vm.count("bunzip2"))
-		bunzip2 = vm["bunzip2"].as<std::string>();
-	if(vm.count("bzip2"))
-		bzip2 = vm["bzip2"].as<std::string>();
 	if(vm.count("campaign"))
 		campaign = vm["campaign"].as<std::string>();
 	if(vm.count("campaign-difficulty"))
@@ -378,10 +366,6 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		fps = true;
 	if(vm.count("fullscreen"))
 		fullscreen = true;
-	if(vm.count("gunzip"))
-		gunzip = vm["gunzip"].as<std::string>();
-	if(vm.count("gzip"))
-		gzip = vm["gzip"].as<std::string>();
 	if(vm.count("help"))
 		help = true;
 	if(vm.count("ignore-map-settings"))

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -53,10 +53,6 @@ public:
 	/** True if the --validate or any of the --validate-*  options are given. */
 	bool any_validation_option() const;
 
-	/** Non-empty if --bunzip2 was given on the command line. Uncompresses a .bz2 file and exits. */
-	std::optional<std::string> bunzip2;
-	/** Non-empty if --bzip2 was given on the command line. Compresses a file to .bz2 and exits. */
-	std::optional<std::string> bzip2;
 	/** Non-empty if --campaign was given on the command line. ID of the campaign we want to start. */
 	std::optional<std::string> campaign;
 	/** Non-empty if --campaign-difficulty was given on the command line. Numerical difficulty of the campaign to be played. Dependent on --campaign. */
@@ -97,10 +93,6 @@ public:
 	bool fps;
 	/** True if --fullscreen was given on the command line. Starts Wesnoth in fullscreen mode. */
 	bool fullscreen;
-	/** Non-empty if --gunzip was given on the command line. Uncompresses a .gz file and exits. */
-	std::optional<std::string> gunzip;
-	/** Non-empty if --gzip was given on the command line. Compresses a file to .gz and exits. */
-	std::optional<std::string> gzip;
 	/** True if --help was given on the command line. Prints help and exits. */
 	bool help;
 	/** Non-empty if --language was given on the command line. Sets the language for this session. */

--- a/src/tests/test_commandline_options.cpp
+++ b/src/tests/test_commandline_options.cpp
@@ -41,8 +41,6 @@ BOOST_AUTO_TEST_CASE (test_empty_options)
 	BOOST_CHECK(!co.editor);
 	BOOST_CHECK(!co.fps);
 	BOOST_CHECK(!co.fullscreen);
-	BOOST_CHECK(!co.gunzip);
-	BOOST_CHECK(!co.gzip);
 	BOOST_CHECK(!co.help);
 	BOOST_CHECK(!co.load);
 	BOOST_CHECK(!co.log);
@@ -116,8 +114,6 @@ BOOST_AUTO_TEST_CASE (test_default_options)
 	BOOST_CHECK(co.editor && co.editor->empty());
 	BOOST_CHECK(!co.fps);
 	BOOST_CHECK(!co.fullscreen);
-	BOOST_CHECK(!co.gunzip);
-	BOOST_CHECK(!co.gzip);
 	BOOST_CHECK(!co.help);
 	BOOST_CHECK(!co.load);
 	BOOST_CHECK(!co.log);
@@ -191,8 +187,6 @@ BOOST_AUTO_TEST_CASE (test_full_options)
 		"--exit-at-end",
 		"--fps",
 		"--fullscreen",
-		"--gunzip=gunzipfoo.gz",
-		"--gzip=gzipfoo",
 		"--help",
 		"--ignore-map-settings",
 		"--label=labelfoo",
@@ -251,8 +245,6 @@ BOOST_AUTO_TEST_CASE (test_full_options)
 	BOOST_CHECK(co.editor && *co.editor == "editfoo");
 	BOOST_CHECK(co.fps);
 	BOOST_CHECK(co.fullscreen);
-	BOOST_CHECK(co.gunzip && *co.gunzip == "gunzipfoo.gz");
-	BOOST_CHECK(co.gzip && *co.gzip == "gzipfoo");
 	BOOST_CHECK(co.help);
 	BOOST_CHECK(co.load && *co.load == "loadfoo");
 	BOOST_CHECK(co.log);
@@ -344,8 +336,6 @@ BOOST_AUTO_TEST_CASE (test_positional_options)
 	BOOST_CHECK(!co.editor);
 	BOOST_CHECK(!co.fps);
 	BOOST_CHECK(!co.fullscreen);
-	BOOST_CHECK(!co.gunzip);
-	BOOST_CHECK(!co.gzip);
 	BOOST_CHECK(!co.help);
 	BOOST_CHECK(!co.load);
 	BOOST_CHECK(!co.log);

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -442,40 +442,6 @@ static int process_command_args(const commandline_options& cmdline_opts)
 		game_config::strict_lua = true;
 	}
 
-	if(cmdline_opts.gunzip) {
-		const std::string input_file(*cmdline_opts.gunzip);
-		if(!filesystem::is_gzip_file(input_file)) {
-			PLAIN_LOG << "file '" << input_file << "'isn't a .gz file";
-			return 2;
-		}
-
-		const std::string output_file(input_file, 0, input_file.length() - 3);
-		gzip_decode(input_file, output_file);
-	}
-
-	if(cmdline_opts.bunzip2) {
-		const std::string input_file(*cmdline_opts.bunzip2);
-		if(!filesystem::is_bzip2_file(input_file)) {
-			PLAIN_LOG << "file '" << input_file << "'isn't a .bz2 file";
-			return 2;
-		}
-
-		const std::string output_file(input_file, 0, input_file.length() - 4);
-		bzip2_decode(input_file, output_file);
-	}
-
-	if(cmdline_opts.gzip) {
-		const std::string input_file(*cmdline_opts.gzip);
-		const std::string output_file(*cmdline_opts.gzip + ".gz");
-		gzip_encode(input_file, output_file);
-	}
-
-	if(cmdline_opts.bzip2) {
-		const std::string input_file(*cmdline_opts.bzip2);
-		const std::string output_file(*cmdline_opts.bzip2 + ".bz2");
-		bzip2_encode(input_file, output_file);
-	}
-
 	if(cmdline_opts.help) {
 		std::cout << cmdline_opts;
 		return 0;
@@ -1077,8 +1043,8 @@ int main(int argc, char** argv)
 		// the first = character, or in a subsequent argv entry which we don't
 		// care about -- we just want to see if the switch is there.
 		static const std::set<std::string> terminal_arg_switches = {
-			"--bunzip2", "--bzip2", "-D", "--diff", "--gunzip", "--gzip", "-p", "--preprocess", "-P", "--patch",
-			"--render-image", "--screenshot", "-u", "--unit", "-V", "--validate", "--validate-schema"
+			"-D", "--diff", "-p", "--preprocess", "-P", "--patch", "--render-image", "--screenshot",
+			"-u", "--unit", "-V", "--validate", "--validate-schema"
 		};
 
 		auto switch_matches_arg = [&arg](const std::string& sw) {


### PR DESCRIPTION
The pull request removes the `--gzip`, ` --gunzip`, `--bzip2`, and `--bunzip2` command line options and related documentation.

These options allow compression and decompression of gzip and bzip2 archives from the command line. Given the widespread availability of third-party compression tools, these options most likely have no real use case. Also, it looks like Windows 11, starting from build 23493, can natively handle gzip and bzip2 files (I didn't test how well it works). 

Resolves #8065