### PR TITLE
EI: remove duplicate AMLAs

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/amlas.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/amlas.cfg
@@ -86,6 +86,10 @@
         #--------------------
         # ADD AMLAS
         #--------------------
+        [remove_object]
+            object_id=universal_amlas_object
+            id=$unit.id
+        [/remove_object]
         [modify_unit]
             [filter]
                 id=$unit.id


### PR DESCRIPTION
Under some circumstances, units in EI can have their custom AMLAs listed multiple times in the advancement dialog.  This PR should fix that issue.

Also can we backport this?