### PR TITLE
Move knowledge of attack_type out of movetype

### DIFF
--- a/src/ai/formula/function_table.cpp
+++ b/src/ai/formula/function_table.cpp
@@ -67,9 +67,21 @@ class unit_adapter {
 			}
 		}
 
+		/**
+		 * Estimates the damage this unit or unit_type would take from a single strike of an attack.
+		 *
+		 * Many details aren't taken into account here, for example abilities that are only active
+		 * on offense, or on particular terrain. For unit_type, abilities aren't considered at all.
+		 */
 		int damage_from(const attack_type& attack) const {
 			if(unit_type_ != nullptr) {
-				return unit_type_->movement_type().resistance_against(attack);
+				std::pair<std::string, std::string> types = attack.damage_type();
+				int res = unit_type_->movement_type().resistance_against(types.first);
+				if(!(types.second).empty()){
+					// max not min, resistance_against() returns the percentage taken, so higher means more damage
+					res = std::max(res, unit_type_->movement_type().resistance_against(types.second));
+				}
+				return res;
 			} else {
 				return unit_->damage_from(attack, false, map_location());
 			}

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -23,7 +23,6 @@
 #include "game_config_manager.hpp"
 #include "log.hpp"
 #include "terrain/translation.hpp"
-#include "units/types.hpp" // for attack_type
 
 static lg::log_domain log_config("config");
 #define ERR_CF LOG_STREAM(err, log_config)
@@ -722,7 +721,7 @@ void movetype::terrain_defense::merge(const config & new_data, bool overwrite)
 
 
 /**
- * Returns a map from attack types to resistances.
+ * Returns a map from damage types to resistances.
  */
 utils::string_map_res movetype::resistances::damage_table() const
 {
@@ -734,21 +733,6 @@ utils::string_map_res movetype::resistances::damage_table() const
 
 	return result;
 }
-
-
-/**
- * Returns the resistance against the indicated attack.
- */
-int movetype::resistances::resistance_against(const attack_type & attack) const
-{
-	std::pair<std::string, std::string> types = attack.damage_type();
-	int res = resistance_against(types.first);
-	if(!(types.second).empty()){
-		res = std::max(res, resistance_against(types.second));
-	}
-	return res;
-}
-
 
 /**
  * Returns the resistance against the indicated damage type.

--- a/src/movetype.hpp
+++ b/src/movetype.hpp
@@ -18,7 +18,6 @@
 #include "config.hpp"
 #include "serialization/string_utils.hpp"
 
-class attack_type;
 namespace t_translation { struct terrain_code; }
 
 
@@ -224,11 +223,9 @@ public:
 		resistances() : cfg_() {}
 		explicit resistances(const config & cfg) : cfg_(cfg) {}
 
-		/** Returns a map from attack types to resistances. */
+		/** Returns a map from damage types to resistances. */
 		utils::string_map_res damage_table() const;
-		/** Returns the resistance against the indicated attack. */
-		int resistance_against(const attack_type & attack) const;
-		/** Returns the resistance against the indicated damage type. */
+		/** Returns the vulnerability to the indicated damage type (higher means more damage). */
 		int resistance_against(const std::string & damage_type) const;
 		/** Merges the given config over the existing costs. */
 		void merge(const config & new_data, bool overwrite);
@@ -291,13 +288,10 @@ public:
 	int defense_modifier(const t_translation::terrain_code & terrain) const
 	{ return defense_.defense(terrain); }
 
-	/** Returns the resistance against the indicated attack. */
-	int resistance_against(const attack_type & attack) const
-	{ return resist_.resistance_against(attack); }
-	/** Returns the resistance against the indicated damage type. */
+	/** Returns the vulnerability to the indicated damage type (higher means takes more damage). */
 	int resistance_against(const std::string & damage_type) const
 	{ return resist_.resistance_against(damage_type); }
-	/** Returns a map from attack types to resistances. */
+	/** Returns a map from damage types to resistances. */
 	utils::string_map_res damage_table() const
 	{ return resist_.damage_table(); }
 


### PR DESCRIPTION
The movetype data includes vulnerability to damage types, for example `resistance_against("arcane")`. There was also a convenience wrapper that took an attack_type, and returned the vulnerability to that attack_type's damage type.

The logic of the wrapper is very basic, and does not use unit.cpp's logic to check whether abilities that change the type are active. Although it gained knowledge of alternative damage types in 3910817cf7, it won't always return the same value as the unit.cpp function does.

The wrapper is now only used in FormulaAI, so let's move the code there, which in effect marks it deprecated.