### PR TITLE
Remove translation mark from image paths

### DIFF
--- a/data/gui/window/editor_edit_unit.cfg
+++ b/data/gui/window/editor_edit_unit.cfg
@@ -1242,7 +1242,7 @@
 											[column]
 												[widget]
 													id = "tab_image"
-													label = _ "/data/core/images/units/human-loyalists/general.png"
+													label = "/data/core/images/units/human-loyalists/general.png"
 												[/widget]
 												[widget]
 													id = "tab_label"
@@ -1254,7 +1254,7 @@
 											[column]
 												[widget]
 													id = "tab_image"
-													label = _ "/data/core/images/attacks/rectangular-shield.png"
+													label = "/data/core/images/attacks/rectangular-shield.png"
 												[/widget]
 												[widget]
 													id = "tab_label"
@@ -1266,7 +1266,7 @@
 											[column]
 												[widget]
 													id = "tab_image"
-													label = _ "/data/core/images/attacks/sword-human.png"
+													label = "/data/core/images/attacks/sword-human.png"
 												[/widget]
 												[widget]
 													id = "tab_label"
@@ -1278,7 +1278,7 @@
 											[column]
 												[widget]
 													id = "tab_image"
-													label = _ "/data/core/images/attacks/gaze.png"
+													label = "/data/core/images/attacks/gaze.png"
 												[/widget]
 												[widget]
 													id = "tab_label"


### PR DESCRIPTION
I'm assuming these translation marks weren't intended.