### PR TITLE
sylph and enchantress attack description changes (cosmetic)

### DIFF
--- a/data/core/units/elves/Enchantress.cfg
+++ b/data/core/units/elves/Enchantress.cfg
@@ -33,7 +33,7 @@
     [/attack]
     [attack]
         name=entangle
-        description=_"entangle"
+        description=_"ethereal web"
         type=impact
         [specials]
             {WEAPON_SPECIAL_SLOW}
@@ -41,6 +41,7 @@
         damage=7
         number=4
         range=ranged
+        icon=attacks/web.png
     [/attack]
     [attack]
         name=faerie fire

--- a/data/core/units/elves/Enchantress.cfg
+++ b/data/core/units/elves/Enchantress.cfg
@@ -33,6 +33,7 @@
     [/attack]
     [attack]
         name=entangle
+        # po: in game mechanics an upgrade of the Shaman’s slowing “entangle”, but in lore has the different magic style of the Enchantress’s unit description
         description=_"ethereal web"
         type=impact
         [specials]

--- a/data/core/units/elves/Sylph.cfg
+++ b/data/core/units/elves/Sylph.cfg
@@ -38,7 +38,7 @@
     [/attack]
     [attack]
         name=gossamer
-        description=_"gossamer"
+        description=_"ethereal web"
         type=impact
         [specials]
             {WEAPON_SPECIAL_SLOW}


### PR DESCRIPTION
Elvish Sylph's gossamer and Enchantress' entangle attacks' user visible name is changed to _ethereal web_ to make them more consistent with the new lore introduced in Wesnoth 1.16. (Issue #8583)

Enchantress' attack icon is also changed to make it consistent with the description.

All changes are purely cosmetic and should not break any existing mainline or UMC content.