### PR TITLE
WoF: fix Lua type error with cast to number

### DIFF
--- a/data/campaigns/Winds_of_Fate/utils/macros.cfg
+++ b/data/campaigns/Winds_of_Fate/utils/macros.cfg
@@ -122,7 +122,7 @@
                 [if]
                     [lua]
                         code=<< local t = ...
-                                return (mathx.random() < t.rate) >>
+                                return (mathx.random() < tonumber(t.rate)) >>
                         [args]
                             rate={RATE}
                         [/args]


### PR DESCRIPTION
Lua was getting this variable without being told it is a number rather than a string. On some systems it is interpreted as a string which breaks the monster spawner code and throws Lua error messages onto the player's screen.

This is a critical fix which needs a back port for 1.18.1.