### PR TITLE
[objectives.lua] improve clarity of error message

### DIFF
--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -87,7 +87,7 @@ local function generate_objectives(cfg)
 					.. color_prefix(r, g, b) .. objective_bullet.. description
 					.. turn_counter .. "</span>" .. "\n"
 			else
-				wesnoth.interface.add_chat_message "[objective] Either condition= is missing or condition= has invalid value (ignoring)."
+				wml.error("[objective] Either condition= is missing or condition= has invalid value (ignoring).")
 			end
 		end
 	end

--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -87,7 +87,7 @@ local function generate_objectives(cfg)
 					.. color_prefix(r, g, b) .. objective_bullet.. description
 					.. turn_counter .. "</span>" .. "\n"
 			else
-				wesnoth.interface.add_chat_message "Unknown condition, ignoring."
+				wesnoth.interface.add_chat_message "Either condition= is missing or condition= has invalid value (ignoring)."
 			end
 		end
 	end

--- a/data/lua/wml/objectives.lua
+++ b/data/lua/wml/objectives.lua
@@ -87,7 +87,7 @@ local function generate_objectives(cfg)
 					.. color_prefix(r, g, b) .. objective_bullet.. description
 					.. turn_counter .. "</span>" .. "\n"
 			else
-				wesnoth.interface.add_chat_message "Either condition= is missing or condition= has invalid value (ignoring)."
+				wesnoth.interface.add_chat_message "[objective] Either condition= is missing or condition= has invalid value (ignoring)."
 			end
 		end
 	end


### PR DESCRIPTION
Current message:
```
Unknown Condition, ignoring
```
This really does not tell me anything of where I might have messed up and can be even more confusing if I have custom lua from the campaign or an add-on being used in the same scenario.

The edited one tells me where I actually have to look for the error message and fix it.