### PR TITLE
Add more information to the Language selection UI

### DIFF
--- a/data/gui/window/language_selection.cfg
+++ b/data/gui/window/language_selection.cfg
@@ -72,6 +72,7 @@
 				[column]
 					border = "all"
 					border_size = 5
+					horizontal_grow = true
 
 					[label]
 						use_markup = true
@@ -127,12 +128,45 @@ If you are a first-time player, we recommend using a mostly-complete translation
 				[column]
 					border = "all"
 					border_size = 5
-					horizontal_alignment = "center"
+					horizontal_grow = true
 
-					[toggle_button]
-						id = "show_all"
-						label = _ "Show work-in-progress or abandoned translations"
-					[/toggle_button]
+					[label]
+						use_markup = true
+						link_aware = true
+						wrap = true
+						# po: Beneath the label widget displaying this text there is a widget displaying
+						# po: a decorated link to <https://gettext.wesnoth.org/>.
+						label = _ "<b>Note:</b> The translation percentages shown apply to the core game interface and in-game help only. More complete stats are available at the following page:"
+					[/label]
+				[/column]
+			[/row]
+
+			[row]
+				[column]
+					border = "all"
+					border_size = 5
+					horizontal_grow = true
+
+					[panel]
+						definition = "box_display_no_blur_no_border"
+						[grid]
+							[row]
+								[column]
+									border = "all"
+									border_size = 10
+									horizontal_grow = true
+									[label]
+										# Filled in at runtime
+										id = "stats_url"
+										use_markup = true
+										link_aware = true
+										wrap = true
+										text_alignment = "center"
+									[/label]
+								[/column]
+							[/row]
+						[/grid]
+					[/panel]
 				[/column]
 			[/row]
 		[/definition]
@@ -222,7 +256,7 @@ If you are a first-time player, we recommend using a mostly-complete translation
 				grow_factor = 0
 
 				[column]
-					horizontal_alignment = "right"
+					horizontal_grow = true
 
 					[grid]
 
@@ -232,31 +266,45 @@ If you are a first-time player, we recommend using a mostly-complete translation
 							[column]
 								border = "all"
 								border_size = 5
-								horizontal_alignment = "right"
+								horizontal_alignment = "left"
 
-								[button]
-									id = "ok"
-									definition = "default"
-
-									label = _ "Select"
-								[/button]
-
+								[toggle_button]
+									id = "show_all"
+									label = _ "Show in-progress or abandoned translations"
+								[/toggle_button]
 							[/column]
 
 							[column]
-								border = "all"
-								border_size = 5
 								horizontal_alignment = "right"
 
-								[button]
-									id = "cancel"
-									definition = "default"
+								[grid]
+									[row]
+										[column]
+											border = "all"
+											border_size = 5
+											horizontal_alignment = "right"
 
-									label = _ "Cancel"
-								[/button]
+											[button]
+												id = "ok"
+												definition = "default"
+												label = _ "Select"
+											[/button]
+										[/column]
 
+										[column]
+											border = "all"
+											border_size = 5
+											horizontal_alignment = "right"
+
+											[button]
+												id = "cancel"
+												definition = "default"
+												label = _ "Cancel"
+											[/button]
+										[/column]
+									[/row]
+								[/grid]
 							[/column]
-
 						[/row]
 
 					[/grid]

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -34,6 +34,8 @@ namespace
 
 const std::string translations_wiki_url = "https://wiki.wesnoth.org/WesnothTranslations";
 
+const std::string translations_stats_url = "https://gettext.wesnoth.org/";
+
 }
 
 REGISTER_DIALOG(language_selection)
@@ -65,6 +67,7 @@ language_selection::language_selection()
 	register_bool("show_all", true, show_all);
 	// Markup needs to be enabled for the link to be highlighted
 	register_label("contrib_url", true, translations_wiki_url, true);
+	register_label("stats_url", true, translations_stats_url, true);
 }
 
 void language_selection::shown_filter_callback()

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -99,8 +99,13 @@ void language_selection::pre_show(window& window)
 		widget_data data;
 
 		data["language"]["label"] = lang.language;
+		data["language"]["use_markup"] = "true";
 		data["translated_total"]["label"] = "<span color='" + game_config::red_to_green(lang.percent).to_hex_string() + "'>" + std::to_string(lang.percent) + "%</span>";
 		data["translated_total"]["use_markup"] = "true";
+
+		if(game_config::debug && !lang.localename.empty()) {
+			data["language"]["label"] += "\n<small><tt>" + lang.localename + "</tt></small>";
+		}
 
 		list.add_row(data);
 


### PR DESCRIPTION
This pull request brings a few minor additions to the improved Language selection UI from #7638:

1. Adds text requested by @Pentarctagon to clarify that the percentages shown only correspond to core textdomains, which also includes a pointer to <https://gettext.wesnoth.org/>.
   (Because I know someone will inevitably complain that the explanation isn't exhaustive... There is hardly any point in mentioning every single textdomain counted as "core" in this dialog. If someone really, *really* wants to know, they can either use gettext.wesnoth.org or ask the team about it on Discord/IRC. Listing every single textdomain counted as core here would require writing many words for no tangible gain.)
2. Moves the Show All checkbox from the main panel to the bottom left corner of the dialog to save space in the former and make it more obviously connected to the listbox it affects.
3. Reduces the word count in the Show All checkbox while keeping the meaning clear, to make the "oh no we've run out of space let's add a horizontal scrollbar to the whole dialog" case less likely to happen in translations.
4. Shows locale codes under each language name **only** if debug mode is enabled, to make it easier to identify languages for debugging purposes (mainly for the Wesnoth development team, really).

### Debug mode off
<img width="886" alt="Screenshot 2024-04-22 at 06 27 37" src="https://github.com/wesnoth/wesnoth/assets/489895/58a623f5-10f7-49df-b2cc-87d50a9b6c3e">

### Debug mode on
<img width="886" alt="Screenshot 2024-04-22 at 06 27 27" src="https://github.com/wesnoth/wesnoth/assets/489895/1a593132-19f5-482c-a660-0c6efc6f9f72">
