### PR TITLE
Fix a warning in the sdl2 conftest

### DIFF
--- a/src/conftests/sdl2.cpp
+++ b/src/conftests/sdl2.cpp
@@ -22,7 +22,7 @@
 #error SDL is too old!
 #endif
 
-int main(int, char** argv)
+int main(int, char**)
 {
     SDL_Init(0);
     SDL_Quit();


### PR DESCRIPTION
The argv variable was unused. The build still succeeded, but GCC emited a warning about it.