### PR TITLE
[1.18] Avoid invalid pointer access on recall

### DIFF
--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -641,9 +641,10 @@ const listbox::order_pair listbox::get_active_sorting_option()
 {
 	for(unsigned int column = 0; column < orders_.size(); ++column) {
 		selectable_item* w = orders_[column].first;
-		sort_order::type sort = sort_order::get_enum(w->get_value()).value_or(sort_order::type::none);
+		if(!w) continue;
 
-		if(w && sort != sort_order::type::none) {
+		sort_order::type sort = sort_order::get_enum(w->get_value()).value_or(sort_order::type::none);
+		if(sort != sort_order::type::none) {
 			return std::pair(column, sort);
 		}
 	}


### PR DESCRIPTION
Backport of #8788, fixes #8778.

(cherry picked from commit 5ec648a1b2b8675a2a6bb7dcb8b50404b7d2c800)