### PR TITLE
SP campaigns: rename beginner difficulty level

### DIFF
--- a/data/campaigns/The_South_Guard/_main.cfg
+++ b/data/campaigns/The_South_Guard/_main.cfg
@@ -22,9 +22,9 @@
 " + _"(Novice level, 8 scenarios.)"
     # wmllint: markcheck on
 
-    {CAMPAIGN_DIFFICULTY EASY   "units/human-peasants/peasant.png~RC(magenta>red)" ( _ "Civilian") ( _ "Beginner")}
-    {CAMPAIGN_DIFFICULTY NORMAL "units/human-loyalists/spearman.png~RC(magenta>red)" ( _ "Recruit") ( _ "Easy")} {DEFAULT_DIFFICULTY}
-    {CAMPAIGN_DIFFICULTY HARD   "units/human-loyalists/javelineer.png~RC(magenta>red)" ( _ "Soldier") ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY EASY   "units/human-peasants/peasant.png~RC(magenta>red)" ( _ "Civilian") ( _ "Easy")}
+    {CAMPAIGN_DIFFICULTY NORMAL "units/human-loyalists/spearman.png~RC(magenta>red)" ( _ "Recruit") ( _ "Normal")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD   "units/human-loyalists/javelineer.png~RC(magenta>red)" ( _ "Soldier") ( _ "Challenging")}
 
     first_scenario=01_Born_to_the_Banner
 

--- a/data/campaigns/Two_Brothers/_main.cfg
+++ b/data/campaigns/Two_Brothers/_main.cfg
@@ -15,7 +15,7 @@
     define="CAMPAIGN_TWO_BROTHERS"
     first_scenario="01_Rooting_Out_a_Mage"
 
-    {CAMPAIGN_DIFFICULTY EASY "units/human-loyalists/horseman/horseman.png~RC(magenta>red)" ( _ "Horseman") ( _ "Beginner")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY EASY "units/human-loyalists/horseman/horseman.png~RC(magenta>red)" ( _ "Horseman") ( _ "Easy")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD "units/human-loyalists/grand-knight/grand-knight.png~RC(magenta>red)" ( _ "Grand Knight") ( _ "Challenging")}
 
     description= _ "An evil mage is threatening the small village of Maghre and its inhabitants. The village’s mage sends to his warrior brother for help, but not all goes as planned. Can you help?

--- a/data/campaigns/Winds_of_Fate/_main.cfg
+++ b/data/campaigns/Winds_of_Fate/_main.cfg
@@ -22,9 +22,9 @@
 " + _ "<i>Features full recall costs and no gold carryover.</i>" + "
 " + _ "(Hard level, 11 scenarios.)"
 
-    {CAMPAIGN_DIFFICULTY EASY      "units/drakes/burner-fly-1.png~CROP(0,0,72,72)~RC(magenta>red)"        ( _ "Aspirant")  ( _ "Easy")}
-    {CAMPAIGN_DIFFICULTY NORMAL    "units/drakes/fire-fire-se-1.png~RC(magenta>red)"                      ( _ "Intendant") ( _ "Normal")} {DEFAULT_DIFFICULTY}
-    {CAMPAIGN_DIFFICULTY HARD      "units/drakes/inferno-fire-se-3.png~RC(magenta>red)"                   ( _ "Dominant")  ( _ "Hard")}
+    {CAMPAIGN_DIFFICULTY EASY      "units/drakes/burner-fly-1.png~CROP(0,0,72,72)~RC(magenta>red)"        ( _ "Aspirant")  ( _ "Normal")}
+    {CAMPAIGN_DIFFICULTY NORMAL    "units/drakes/fire-fire-se-1.png~RC(magenta>red)"                      ( _ "Intendant") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
+    {CAMPAIGN_DIFFICULTY HARD      "units/drakes/inferno-fire-se-3.png~RC(magenta>red)"                   ( _ "Dominant")  ( _ "Difficult")}
     {CAMPAIGN_DIFFICULTY NIGHTMARE "units/drakes/armageddon-melee-6.png~CROP(0,19,62,64)~RC(magenta>red)" ( _ "Ancestor")  ( _ "Nightmare")}
 
     {ENABLE_ADVANCEMENT "Cuttle Fish" "Kraken" (set_experience=80)}


### PR DESCRIPTION
As the title says. We have enough campaign difficulties and as @Dalas121 rightly pointed out, I doubt players are going to want to stoop to a difficulty level they deem as "beginner". Having Easy/Normal take the place of the older lower difficulty levels will probably make people feel better about themselves. 