### PR TITLE
SoF S7: fewer and slower enemy outriders

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/7_Outriding_the_Outriders.cfg
@@ -144,8 +144,8 @@
             x,y=18,1
             side=2
             [modifications]
-                {TRAIT_QUICK}
-                {TRAIT_DEXTROUS}
+                {TRAIT_STRONG}
+                {TRAIT_RESILIENT}
             [/modifications]
         [/unit]
         [unit]
@@ -156,8 +156,8 @@
             side=2
             facing=sw
             [modifications]
-                {TRAIT_STRONG}
-                {TRAIT_QUICK}
+                {TRAIT_DEXTROUS}
+                {TRAIT_RESILIENT}
             [/modifications]
         [/unit]
         [unit]
@@ -169,18 +169,6 @@
             facing=sw
             [modifications]
                 {TRAIT_STRONG}
-                {TRAIT_RESILIENT}
-            [/modifications]
-        [/unit]
-        [unit]
-            type=Elvish Outrider
-            id=Ealin
-            name= _ "Ealin"
-            x,y=18,1
-            side=2
-            facing=sw
-            [modifications]
-                {TRAIT_QUICK}
                 {TRAIT_RESILIENT}
             [/modifications]
         [/unit]


### PR DESCRIPTION
Backport of #8680.

This is to counteract the swifter and deadlier Elvish Outrider after the 1.18 core unit balance changes.

(cherry picked from commit b3802f44ea1d50364c83e00d207e8dcef04645b4)