### PR TITLE
Add submerge to oasis terrain

### DIFF
--- a/data/core/terrain.cfg
+++ b/data/core/terrain.cfg
@@ -357,6 +357,7 @@ Most units receive 20 to 40% defense in sand."
     aliasof=Dt, Wst
     def_alias=_bas, Wst
     mvt_alias=_bas, Wst
+    submerge=0.3
     heals=8
     editor_group=desert, water
     help_topic_text= _ "A welcome sight to any traveler, an oasis allows units to heal as if stationed in a village, but provides no income or defensive advantage."


### PR DESCRIPTION
Follow up to #8783 this makes a unit on an oasis tile visibly sink slightly into its waters, just like with ford terrain.