### PR TITLE
Remove version-specific info from xcode projectfile

### DIFF
--- a/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
+++ b/projectfiles/Xcode/The Battle for Wesnoth.xcodeproj/project.pbxproj
@@ -1423,7 +1423,7 @@
 		ECF0F80323A09933004A2011 /* lua_wml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECF0F80223A09932004A2011 /* lua_wml.cpp */; };
 		ECF2393426B5935F00F2884F /* lobby_player_list_helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECF2393126B592C800F2884F /* lobby_player_list_helper.cpp */; };
 		ECF44F6A1FC8A82B00B404D6 /* make.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECF44F681FC8A82A00B404D6 /* make.cpp */; };
-		ECF9D43D19F3FF9400E6C9D9 /* filesystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECF9D43C19F3FF9400E6C9D9 /* filesystem.cpp */; settings = {COMPILER_FLAGS = "-DPREFERENCES_DIR='\"Library/Application Support/Wesnoth_1.17\"' -DHAS_RELATIVE_LOCALEDIR"; }; };
+		ECF9D43D19F3FF9400E6C9D9 /* filesystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECF9D43C19F3FF9400E6C9D9 /* filesystem.cpp */; };
 		ECF9D43E19F3FF9400E6C9D9 /* filesystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECF9D43C19F3FF9400E6C9D9 /* filesystem.cpp */; };
 		ECFA82E3184E59F3006782FB /* command_executor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECFA82DA184E59F3006782FB /* command_executor.cpp */; };
 		ECFA82E4184E59F3006782FB /* hotkey_command.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECFA82DC184E59F3006782FB /* hotkey_command.cpp */; };

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -670,6 +670,11 @@ void set_user_data_dir(std::string newprefdir)
 		newprefdir = PREFERENCES_DIR;
 		relative_ok = true;
 	}
+#elif defined(__APPLE__)
+	if(newprefdir.empty()) {
+		newprefdir = "Library/Application Support/Wesnoth_"+get_version_path_suffix();
+		relative_ok = true;
+	}
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
Instead set the Apple preferences folder from within the code rather than using -DPREFERENCES_DIR. Remove -DHAS_RELATIVE_LOCALEDIR since that doesn't appear to actually do anything since its only usage is in filesystem_common.cpp, not filesystem.cpp.