### PR TITLE
Tutorial S2: Only trigger comment about the orc if it is still alive

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -751,6 +751,12 @@ Please report the bug."
             [filter_second]
                 id=Dumbo
             [/filter_second]
+            [filter_condition]
+                [variable]
+                    name=second_unit.hitpoints
+                    greater_than=0
+                [/variable]
+            [/filter_condition]
 
             [if]
                 [variable]


### PR DESCRIPTION
Addresses the final point mentioned in #5544.

The advice about the Elvish Shamans is lost in the scenario where the orc dies during the first attack of Turn 3, but I suppose a player would have been _very_ lucky to be in this situation, plus I think there are still plenty of notes about Shamans as healers elsewhere.