### PR TITLE
Add date/time reference to translation hint

### DIFF
--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -1046,8 +1046,10 @@ static std::string format_addon_time(std::time_t time)
 
 		const std::string format = preferences::use_twelve_hour_clock_format()
 			// TRANSLATORS: Month + day of month + year + 12-hour time, eg 'November 02 2021, 1:59 PM'. Format for your locale.
+			// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
 			? _("%B %d %Y, %I:%M %p")
 			// TRANSLATORS: Month + day of month + year + 24-hour time, eg 'November 02 2021, 13:59'. Format for your locale.
+			// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
 			: _("%B %d %Y, %H:%M");
 
 		ss << translation::strftime(format, std::localtime(&time));


### PR DESCRIPTION
Backport of #8826, fixes #8822

Current implementation of translation::strftime() uses boost. Boost docs do not appear to have a 'current' or 'latest' link, instead only making documentation available by explicit version number.

(cherry picked from commit 5e9260570b3f1401603b294ecd63119d8ca732d1)