### PR TITLE
SoF S6: Remove reference to finding Alanin

### DIFF
--- a/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/6_Towards_the_Caves.cfg
@@ -454,7 +454,7 @@
         [/message]
         [message]
             speaker=Rugnur
-            message= _"The country between here and Knalga will be swarming with elves. We had better head back to the abandoned mines north of the Arkan-thoria, where we gathered our gold and coal. At least there Alanin will have some hope of finding us."
+            message= _"The country between here and Knalga will be swarming with elves. We had better head back to the abandoned mines north of the Arkan-thoria, where we gathered our gold and coal."
         [/message]
         [message]
             speaker=Alanin


### PR DESCRIPTION
...since he is already present among the dwarves, as highlighted by @doofus-01.

Given this is a bug in the meaning of the text, I think it warrants back-porting to 1.18. However, if others disagree, so be it.

Resolves #8311.