### PR TITLE
add [filter_wml] to filter_abilities code

### DIFF
--- a/changelog_entries/add_filter_wml_in_filter_ability.md
+++ b/changelog_entries/add_filter_wml_in_filter_ability.md
@@ -1,0 +1,2 @@
+ ### WML Engine
+   * add [filter_wml] to [experimental_filter_ability(_active)] or [overwrite][experimental_filter_specials]

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -19,5 +19,11 @@
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies bool_or_empty}
 	{SIMPLE_KEY affect_enemies s_bool}
+	[tag]
+		name="filter_wml"
+		max=infinite
+		any_tag=yes
+		{ANY_KEY string}
+	[/tag]
 	{FILTER_BOOLEAN_OPS abilities}
 [/tag]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -226,6 +226,76 @@
     [/event]
 )}
 
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST.
+# Add an event with a filter_wml matching Alice's drains ability.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST.
+##
+# Expected end state:
+# The filtered event is triggered exactly once.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_wml (
+    {FILTER_ABILITY_TEST}
+    [event]
+        name=attack
+        first_time_only=no
+        [filter]
+            [experimental_filter_ability]
+                tag_name=drains
+                [filter_wml]
+                    [filter]
+                        [filter_location]
+                            time_of_day=neutral
+                        [/filter_location]
+                    [/filter]
+                [/filter_wml]
+            [/experimental_filter_ability]
+        [/filter]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
+    [/event]
+)}
+
+##
+# Actions:
+# Use the common setup from FILTER_ABILITY_TEST.
+# Add an event with a filter_wml not matching Alice's drains ability.
+# Alice attacks Bob and then Bob attacks Alice, as defined in FILTER_ABILITY_TEST.
+##
+# Expected end state:
+# The filtered event is never triggered.
+#####
+{GENERIC_UNIT_TEST event_test_filter_ability_wml_no_match (
+    {FILTER_ABILITY_TEST}
+    [event]
+        name=attack
+        first_time_only=no
+        [filter]
+            [experimental_filter_ability]
+                tag_name=drains
+                [filter_wml]
+                    [filter]
+                        [filter_location]
+                            time_of_day=lawful
+                        [/filter_location]
+                    [/filter]
+                [/filter_wml]
+            [/experimental_filter_ability]
+        [/filter]
+        {FAIL}
+    [/event]
+    [event]
+        name=turn 2
+        {SUCCEED}
+    [/event]
+)}
+
 #####
 # API(s) being tested: [event][filter][experimental_filter_ability_active]
 ##

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1524,6 +1524,16 @@ static bool matches_ability_filter(const config & cfg, const std::string& tag_na
 	if(!double_matches_if_present(filter, cfg, "divide"))
 		return false;
 
+	//the wml_filter is used in cases where the attribute we are looking for is not
+	//previously listed or to check the contents of the sub_tags ([filter_adjacent],[filter_self],[filter_opponent] etc.
+	//If the checked set does not exactly match the content of the capability, the function returns a false response.
+	auto fwml = filter.optional_child("filter_wml");
+	if (fwml){
+		if(!cfg.matches(*fwml)){
+			return false;
+		}
+	}
+
 	// Passed all tests.
 	return true;
 }

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -149,6 +149,8 @@
 0 event_test_filter_ability_neg_value
 0 event_test_filter_ability_no_match
 0 event_test_filter_ability_no_match_neg_prefix
+0 event_test_filter_ability_wml
+0 event_test_filter_ability_wml_no_match
 0 event_test_filter_ability_active
 0 event_test_filter_ability_active_inactive
 0 event_test_filter_ability_with_value_by_default


### PR DESCRIPTION
 
adding a sub-filter should make it possible to take into account the sub_tags of the abilities in the checking

use https://github.com/wesnoth/wesnoth/pull/8561/commits/596a64c00c76ddffffbaa7fbb224acc6f486d121 commit like base