### PR TITLE
Remove WmlDefineState class disabled-as-comment/string

### DIFF
--- a/data/tools/pywmlx/state/wml_states.py
+++ b/data/tools/pywmlx/state/wml_states.py
@@ -24,42 +24,6 @@ class WmlIdleState:
 
 
 
-'''
-class WmlDefineState:
-    def __init__(self):
-        self.regex = re.compile('\s*#(define|enddef|\s+wmlxgettext:\s+)', re.I)
-        self.iffail = 'wml_checkdom'
-
-    def run(self, xline, lineno, match):
-        if match.group(1).lower() == 'define':
-            # define
-            xline = None
-            if pywmlx.nodemanip.onDefineMacro is False:
-                pywmlx.nodemanip.onDefineMacro = True
-            else:
-                err_message = ("expected an #enddef before opening ANOTHER " +
-                               "macro definition with #define")
-                finfo = pywmlx.nodemanip.fileref + ":" + str(lineno)
-                wmlerr(finfo, err_message)
-        elif match.group(1).lower() == 'enddef':
-            # enddef
-            xline = None
-            if pywmlx.nodemanip.onDefineMacro is True:
-                pywmlx.nodemanip.onDefineMacro = False
-            else:
-                err_message = ("found an #enddef, but no macro definition " +
-                               "is pending. Perhaps you forgot to put a " +
-                               "#define somewhere?")
-                finfo = pywmlx.nodemanip.fileref + ":" + str(lineno)
-                wmlerr(finfo, err_message)
-        else:
-            # wmlxgettext: {WML CODE}
-            xline = xline [ match.end(): ]
-        return (xline, 'wml_idle')
-'''
-
-
-
 class WmlCheckdomState:
     def __init__(self):
         self.regex = re.compile(r'\s*#textdomain\s+(\S+)', re.I)


### PR DESCRIPTION
Resolves #8867.

As best as I can tell, this class isn't mentioned or used anywhere else. Not sure if these tools are intended to be used from the stable branch - this probably should be back-ported if that's the case.