### PR TITLE
[Campaign][Dead Water] S9: improve event handling of bat units in player side (fixes #8766)

### DIFF
--- a/data/campaigns/Dead_Water/scenarios/09_The_Mage.cfg
+++ b/data/campaigns/Dead_Water/scenarios/09_The_Mage.cfg
@@ -52,6 +52,10 @@
         shroud=yes
         [ai]
             village_value=0
+            [avoid]
+                # Caladon’s shack
+                x,y=8,5
+            [/avoid]
         [/ai]
     [/side]
 
@@ -69,6 +73,48 @@
             [objective]
                 description= _ "Find Caladon the mage"
                 condition=win
+                [show_if]
+                    [variable]
+                        name=Caladon_discovered
+                        not_equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "Move a merfolk unit to Caladon’s shack and talk to him"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=Caladon_discovered
+                        equals=yes
+                    [/variable]
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "You can also visit Caladon with Keshan"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=Caladon_discovered
+                        equals=yes
+                    [/variable]
+                    [have_unit]
+                        id=Keshan
+                    [/have_unit]
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "You can also visit Caladon with Inky"
+                condition=win
+                [show_if]
+                    [variable]
+                        name=Caladon_discovered
+                        equals=yes
+                    [/variable]
+                    [have_unit]
+                        id=Inky
+                    [/have_unit]
+                [/show_if]
             [/objective]
 
             {HOW_TO_LOSE}
@@ -80,6 +126,28 @@
         [/objectives]
 
         {PLACE_IMAGE scenery/temple1.png 8 5}
+
+        [unit]
+            type=Silver Mage
+            x=8
+            y=5
+            side=1
+            id=Caladon
+            name= _ "Caladon"
+            unrenamable=yes
+            [modifications]
+                {TRAIT_LOYAL_HERO}
+                {TRAIT_QUICK}
+            [/modifications]
+            profile=portraits/caladon.webp
+        [/unit]
+        [store_unit]
+            [filter]
+                id=Caladon
+            [/filter]
+            variable=Caladon_stored
+            kill=yes
+        [/store_unit]
 
         [unit]
             type=Giant Spider
@@ -108,6 +176,10 @@
             variable=scorp
             [filter_location]
                 include_borders=no
+                [not]
+                    # Caladon’s shack
+                    x,y=8,5
+                [/not]
                 [not]
                     # In water or a chasm
                     terrain=Qx*,W*
@@ -193,9 +265,6 @@
     [/foreach]
 
     {CLEAR_VARIABLE chasm_hexes}
-#enddef
-
-#define BATS_ENTER_CAVE
 #enddef
 
     [event]
@@ -365,6 +434,162 @@
         [/if]
     [/event]
     # ***** END BATS SECTION********************END BATS SECTION*****
+    [event]
+        name=moveto
+        [filter]
+            side=1
+            x,y=8,5
+            [and]
+                # Either a living or an undead bat
+                race=bats
+                [or]
+                    variation=bat
+                [/or]
+            [/and]
+        [/filter]
+        [message]
+            speaker=unit
+            message= _ "Neep, neep, neep!"
+        [/message]
+        [unstore_unit]
+            variable=Caladon_stored
+            find_vacant=yes
+        [/unstore_unit]
+        [message]
+            speaker=Caladon
+            message= _ "Another of these ACCURSED bats! BEGONE!"
+        [/message]
+        [animate_unit]
+            [filter]
+                id=Caladon
+            [/filter]
+            flag = attack
+            [primary_attack]
+                range=ranged
+            [/primary_attack]
+            [facing]
+                x,y=$x1,$y1
+            [/facing]
+            hits=no
+        [/animate_unit]
+        [sound]
+            name=bat-flapping.wav
+        [/sound]
+        [floating_text]
+            x,y=$x1,$y1
+            text= "<span color='red'>" + _ "SHRIEK!" + "</span>"
+        [/floating_text]
+        [move_unit]
+            x,y=$x1,$y1
+            to_x=10
+            to_y=6
+        [/move_unit]
+        [move_unit]
+            id=Caladon
+            to_x=8
+            to_y=5
+        [/move_unit]
+        [delay]
+            time=400
+            accelerate=yes
+        [/delay]
+        [store_unit]
+            [filter]
+                id=Caladon
+            [/filter]
+            variable=Caladon_stored
+            kill=yes
+        [/store_unit]
+        [message]
+            speaker=Cylanna
+            message= _ "Caladon does not seem to be very happy about the bat infestation." + " " + _ "He might be more welcoming of one of our people."
+        [/message]
+        [message]
+            speaker=Kai Krellis
+            message= _ "Let’s go, men!"
+        [/message]
+        [label]
+            x,y=8,5
+            text= _ "Caladon’s shack"
+        [/label]
+        [set_variable]
+            name=Caladon_discovered
+            value=yes
+        [/set_variable]
+        [show_objectives]
+        [/show_objectives]
+    [/event]
+
+    [event]
+        name=moveto
+        [filter]
+            race=undead
+            [not]
+                variation=bat
+            [/not]
+            x,y=8,5
+        [/filter]
+        [unstore_unit]
+            variable=Caladon_stored
+            find_vacant=yes
+        [/unstore_unit]
+        [message]
+            speaker=Caladon
+            message= _ "What kind of abomination is THAT!?!"
+        [/message]
+        [animate_unit]
+            [filter]
+                id=Caladon
+            [/filter]
+            flag = attack
+            [primary_attack]
+                range=melee
+            [/primary_attack]
+            [facing]
+                x,y=$x1,$y1
+            [/facing]
+            hits=yes
+        [/animate_unit]
+        [move_unit]
+            x,y=$x1,$y1
+            to_x=8
+            to_y=6
+        [/move_unit]
+        [move_unit]
+            id=Caladon
+            to_x=8
+            to_y=5
+        [/move_unit]
+        [delay]
+            time=400
+            accelerate=yes
+        [/delay]
+        [store_unit]
+            [filter]
+                id=Caladon
+            [/filter]
+            variable=Caladon_stored
+            kill=yes
+        [/store_unit]
+        [message]
+            speaker=Cylanna
+            message= _ "It appears that Caladon does not want to deal with the undead." + " " + _ "He might be more welcoming of one of our people."
+        [/message]
+        [message]
+            speaker=Kai Krellis
+            message= _ "Let’s go, men!"
+        [/message]
+        [label]
+            x,y=8,5
+            text= _ "Caladon’s shack"
+        [/label]
+        [set_variable]
+            name=Caladon_discovered
+            value=yes
+        [/set_variable]
+        [show_objectives]
+        [/show_objectives]
+    [/event]
 
     [event]
         name=moveto
@@ -372,33 +597,40 @@
             side=1
             x=8
             y=5
+            [not]
+                race=bats
+            [/not]
+            [not]
+                race=undead
+            [/not]
         [/filter]
 
-        [unit]
-            type=Silver Mage
-            x=8
-            y=5
-            side=1
-            id=Caladon
-            name= _ "Caladon"
-            unrenamable=yes
-            [modifications]
-                {TRAIT_LOYAL_HERO}
-                {TRAIT_QUICK}
-            [/modifications]
-            profile=portraits/caladon.webp
-        [/unit]
-
+        [unstore_unit]
+            variable=Caladon_stored
+            find_vacant=yes
+        [/unstore_unit]
         [if]
             [have_unit]
                 x,y=$x1,$y1
                 id=Keshan,Inky
             [/have_unit]
             [then]
-                [message]
-                    speaker=Keshan
-                    message= _ "There is somebody here."
-                [/message]
+                [if]
+                    [have_unit]
+                        x,y=$x1,$y1
+                        id=Keshan
+                    [/have_unit]
+                    [message]
+                        speaker=unit
+                        message= _ "There is somebody here."
+                    [/message]
+                    [else]
+                        [message]
+                            speaker=unit
+                            message= _ "Gllllbbbg!"
+                        [/message]
+                    [/else]
+                [/if]
                 [message]
                     speaker=Caladon
                     message= _ "Whoa there! BACK off or else!"
@@ -409,24 +641,10 @@
                 [/message]
             [/then]
             [else]
-                [if]
-                    [variable]
-                        name=unit.id
-                        contains=Bat
-                    [/variable]
-                    [then]
-                        [message]
-                            speaker=unit
-                            message= _ "Neep, neep, neep!"
-                        [/message]
-                    [/then]
-                    [else]
-                        [message]
-                            speaker=unit
-                            message= _ "Hey, I found somebody!"
-                        [/message]
-                    [/else]
-                [/if]
+                [message]
+                    speaker=unit
+                    message= _ "Hey, I found somebody!"
+                [/message]
             [/else]
         [/if]
         [message]
@@ -467,6 +685,12 @@
         [/clear_variable]
         [clear_variable]
             name=time_of_day
+        [/clear_variable]
+        [clear_variable]
+            name=Caladon_stored
+        [/clear_variable]
+        [clear_variable]
+            name=Caladon_discovered
         [/clear_variable]
 
         [endlevel]


### PR DESCRIPTION
This PR adds a dialog, when you enter Caladon's house with a bat to prevent the scenario being too easy.