### PR TITLE
about dialog : correctly open the initial tab

### DIFF
--- a/src/gui/dialogs/game_version_dialog.cpp
+++ b/src/gui/dialogs/game_version_dialog.cpp
@@ -236,7 +236,7 @@ void game_version::pre_show(window& window)
 	// Set-up page stack and auxiliary controls last.
 	//
 
-	tabs.select_tab(0);
+	tabs.select_tab(start_page_);
 }
 
 void game_version::browse_directory_callback(const std::string& path)


### PR DESCRIPTION
Fix typo that stops the initial tab from opening correctly. (It's opening tab id 0 instead of tab id = `start_page_`)