### PR TITLE
'value' attribute in [experimental_filter_ability(_active)] can have 'default' value

### DIFF
--- a/changelog_entries/filter_value_check_default.md
+++ b/changelog_entries/filter_value_check_default.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Added support for `value="default"` to ability filters to match abilities using their default `value` (by explicit setting or absence)

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -10,11 +10,11 @@
 	{SIMPLE_KEY replacement_type string_list}
 	{SIMPLE_KEY alternative_type string_list}
 	{SIMPLE_KEY active_on ability_context}
-	{SIMPLE_KEY value s_int_range_list}
-	{SIMPLE_KEY add s_int_range_list}
-	{SIMPLE_KEY sub s_int_range_list}
-	{SIMPLE_KEY multiply s_real_range_list}
-	{SIMPLE_KEY divide s_real_range_list}
+	{SIMPLE_KEY value s_int_range_list_default}
+	{SIMPLE_KEY add s_int_range_list_default}
+	{SIMPLE_KEY sub s_int_range_list_default}
+	{SIMPLE_KEY multiply s_real_range_list_default}
+	{SIMPLE_KEY divide s_real_range_list_default}
 	{SIMPLE_KEY affect_adjacent s_bool}
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies bool_or_empty}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -135,6 +135,28 @@
         [/element]
     )}
     [type]
+        name=s_int_range_list_default
+        [union]
+            [type]
+                link=s_int_range_list
+            [/type]
+            [type]
+                value=default
+            [/type]
+        [/union]
+    [/type]
+    [type]
+        name=s_real_range_list_default
+        [union]
+            [type]
+                link=s_real_range_list
+            [/type]
+            [type]
+                value=default
+            [/type]
+        [/union]
+    [/type]
+    [type]
         name=alignment
         value="lawful|neutral|chaotic|liminal"
     [/type]

--- a/src/utils/config_filters.cpp
+++ b/src/utils/config_filters.cpp
@@ -62,6 +62,10 @@ bool utils::config_filters::int_matches_if_present(const config& filter, const c
 		return false;
 	}
 
+	//if filter attribute is "default" check if cfg attribute equals to def.
+	if(filter[attribute] == "default" && def){
+		return (cfg[attribute].to_int(*def) == *def);
+	}
 	int value_def = def ? (*def) : 0;
 	return in_ranges<int>(cfg[attribute].to_int(value_def), utils::parse_ranges_int(filter[attribute].str()));
 }
@@ -79,6 +83,10 @@ bool utils::config_filters::int_matches_if_present_or_negative(
 		if(!cfg.has_attribute(opposite) && !def) {
 			return false;
 		}
+		//if filter attribute is "default" check if cfg attribute equals to def.
+		if(filter[attribute] == "default" && def){
+			return (cfg[attribute].to_int(*def) == *def);
+		}
 		int value_def = def ? (*def) : 0;
 		return in_ranges<int>(-cfg[opposite].to_int(value_def), utils::parse_ranges_int(filter[attribute].str()));
 	}
@@ -95,6 +103,10 @@ bool utils::config_filters::double_matches_if_present(const config& filter, cons
 		return false;
 	}
 
+	//if filter attribute is "default" check if cfg attribute equals to def.
+	if(filter[attribute] == "default" && def){
+		return (cfg[attribute].to_int(*def) == *def);
+	}
 	double value_def = def ? (*def) : 1;
 	return in_ranges<double>(cfg[attribute].to_double(value_def), utils::parse_ranges_real(filter[attribute].str()));
 }


### PR DESCRIPTION
for answer to an suggestion of @soliton- who think in filter abilitie, value must could check 'default' value of an abilitie/specials directly without have specify this value in filter