### PR TITLE
EI: simplify S16 achievement

### DIFF
--- a/data/campaigns/Eastern_Invasion/achievements.cfg
+++ b/data/campaigns/Eastern_Invasion/achievements.cfg
@@ -66,7 +66,7 @@ data/core/images#enddef
     {ACHIEVEMENT {CORE_PATH}/icons/book.png
     "ei_S14"    _"Scenario 14: Historian"                     _"Read the story of the Clans’ defeat in ‘<i>The Drowned Plains</i>’."}
     {ACHIEVEMENT {CORE_PATH}/icons/helmet_frogmouth.png
-    "ei_S16"    _"Scenario 16: Alternate History"             _"Complete ‘<i>Eleventh Hour</i>’ with no recalling and no items."}
+    "ei_S16"    _"Scenario 16: Alternate History"             _"Complete ‘<i>Eleventh Hour</i>’ with no recalling and no droppable items."}
     {ACHIEVEMENT {PATH}/pacifist.png
     "ei_S17a"   _"Scenario 17a: Pacifist"                     _"Kill no enemies before defeating Mal-Ravanal in ‘<i>The Duel</i>’."}
     {ACHIEVEMENT {PATH}/skull.png

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
@@ -2242,7 +2242,7 @@ And leave eternal night to remain."
         name=side 1 turn end
         [if]
             [have_unit]
-                trait=TRAIT_{ID_CRYSTAL_QUIVER},TRAIT_{ID_HOLY_AMULET_1},TRAIT_{ID_HOLY_AMULET_2},TRAIT_{ID_HOLY_AMULET_3},TRAIT_{ID_SENTINEL},TRAIT_{ID_YETIBURGER},TRAIT_{ID_BANEBLADE},TRAIT_{ID_BARKSKIN},TRAIT_{ID_INVISIBILITY},TRAIT_{ID_PLAGUE_STAFF},TRAIT_ant_ambrosia01,TRAIT_ant_ambrosia02,TRAIT_ant_ambrosia03,TRAIT_ant_ambrosia04,TRAIT_ant_ambrosia05,TRAIT_ant_ambrosia06,TRAIT_ant_ambrosia07,TRAIT_ant_ambrosia08,TRAIT_ant_ambrosia09,TRAIT_ant_ambrosia10,TRAIT_ant_ambrosia11,TRAIT_ant_ambrosia12,TRAIT_ant_ambrosia13,TRAIT_ant_ambrosia14,TRAIT_ant_ambrosia15,TRAIT_ant_ambrosia16,TRAIT_ant_ambrosia17,TRAIT_ant_ambrosia18,TRAIT_ant_ambrosia19,TRAIT_ant_ambrosia20
+                trait=TRAIT_{ID_CRYSTAL_QUIVER},TRAIT_{ID_HOLY_AMULET_1},TRAIT_{ID_HOLY_AMULET_2},TRAIT_{ID_HOLY_AMULET_3},TRAIT_{ID_SENTINEL},TRAIT_{ID_BANEBLADE},TRAIT_{ID_INVISIBILITY},TRAIT_{ID_PLAGUE_STAFF}
             [/have_unit]
 
             [then]


### PR DESCRIPTION
The current S16 achievement requires that the player don't recall any units or have any items.

Some items are undroppable, which can make this achievement impossible if you give one to a loyal auto-recalled unit early in the campaign.

This PR alters the achievement to only care about droppable items.