### PR TITLE
Schema: add other mp_ keys too

### DIFF
--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -571,7 +571,10 @@
 	#{BASE_COMPATIBILITY_KEYS}
 	{SIMPLE_KEY force_modification string_list}
 	{SIMPLE_KEY require_scenario bool}
+	{SIMPLE_KEY mp_fog bool}
+	{SIMPLE_KEY mp_shroud bool}
 	{SIMPLE_KEY mp_village_gold int}
+	{SIMPLE_KEY mp_village_support int}
 	{SIMPLE_KEY define string}
 	{SIMPLE_KEY carryover_report bool}
 	{LINK_TAG "era/options"}


### PR DESCRIPTION
In addition to the mp_village_gold used in mainline, there exist as well:
- mp_fog
- mp_shroud
- mp_village_support

Not covered by this PR: How to specify what is allowed when using a generator? In 
```
[multiplayer]
    scenario_generation=default
    [generator]
        [scenario]
            mp_* = are  allowed here, but not if map_generation=default is used
```