### PR TITLE
Fix #7478 game crash after reloading a mp game in debug mode

### DIFF
--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -253,7 +253,7 @@ level_result::type campaign_controller::play_game()
 
 				ng::connect_engine connect_engine(state_, false, mp_info_);
 
-				if(!connect_engine.can_start_game() || (game_config::debug && state_.classification().is_multiplayer())) {
+				if(!connect_engine.can_start_game()) {
 					// Opens staging dialog to allow users to make an adjustments for scenario.
 					if(!mp::goto_mp_staging(connect_engine)) {
 						return level_result::type::quit;


### PR DESCRIPTION
This is not an optiomal fix as it can still crash if can_start_game() returns false, but its clearly am improvment to the situation in #7478 .

This also removes the "always show mp staging between scenarios in debug mode" feature, which imo never was that useful anyways.