### PR TITLE
improve tooltip placement on sidebar

### DIFF
--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -185,7 +185,7 @@ void floating_label::update(int time)
 	// Invalidate new draw loc in preparation
 	draw_manager::invalidate_region(get_bg_rect(draw_loc));
 
-//	DBG_FT << "updating floating label from " << screen_loc_ << " to " << draw_loc;
+	DBG_FT << "updating floating label from " << screen_loc_ << " to " << draw_loc;
 
 	screen_loc_ = draw_loc;
 	alpha_ = new_alpha;
@@ -211,7 +211,7 @@ void floating_label::draw()
 		return;
 	}
 
-//	DBG_FT << "drawing floating label to " << screen_loc_;
+	DBG_FT << "drawing floating label to " << screen_loc_;
 
 	// Clip if appropriate.
 	auto clipper = draw::reduce_clip(clip_rect_);

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -104,6 +104,11 @@ rect floating_label::get_bg_rect(const rect& text_rect) const
 	};
 }
 
+void floating_label::clear_texture()
+{
+	tex_ = {};
+}
+
 bool floating_label::create_texture()
 {
 	if(video::headless()) {
@@ -180,7 +185,7 @@ void floating_label::update(int time)
 	// Invalidate new draw loc in preparation
 	draw_manager::invalidate_region(get_bg_rect(draw_loc));
 
-	DBG_FT << "updating floating label from " << screen_loc_ << " to " << draw_loc;
+//	DBG_FT << "updating floating label from " << screen_loc_ << " to " << draw_loc;
 
 	screen_loc_ = draw_loc;
 	alpha_ = new_alpha;
@@ -206,7 +211,7 @@ void floating_label::draw()
 		return;
 	}
 
-	DBG_FT << "drawing floating label to " << screen_loc_;
+//	DBG_FT << "drawing floating label to " << screen_loc_;
 
 	// Clip if appropriate.
 	auto clipper = draw::reduce_clip(clip_rect_);

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -106,7 +106,7 @@ rect floating_label::get_bg_rect(const rect& text_rect) const
 
 void floating_label::clear_texture()
 {
-	tex_ = {};
+	tex_.reset();
 }
 
 bool floating_label::create_texture()

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -86,7 +86,7 @@ public:
 	 */
 	bool create_texture();
 
-	void clear_texture();  // for testing
+	void clear_texture();
 
 	/** Return the size of the label in drawing coordinates */
 	SDL_Point get_draw_size() const

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -86,6 +86,8 @@ public:
 	 */
 	bool create_texture();
 
+	void clear_texture();  // for testing
+
 	/** Return the size of the label in drawing coordinates */
 	SDL_Point get_draw_size() const
 	{

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -68,7 +68,7 @@ void tooltip::init_label()
 
 	label.set_font_size(font_size);
 	label.set_color(font::NORMAL_COLOR);
-	label.set_clip_rect(huge);  
+	label.set_clip_rect(huge);
 	label.set_width(text_width);   // If tooltip will be too tall for game_canvas, this could be scaled up appropriately
 	label.set_alignment(font::LEFT_ALIGN);
 	label.set_bg_color(bgcolor);
@@ -87,28 +87,22 @@ void tooltip::init_label()
 		//
 		// This block of text is just as tall as the other
 		// one.
-		new_text_width = 2 * text_width * static_cast<float>(static_cast<float>(lsize.y)/game_canvas.h);
+		new_text_width = 2 * text_width * static_cast<float>(lsize.y)/game_canvas.h;
 		if(new_text_width>game_canvas.w) {
 			new_text_width=game_canvas.w;
 		}
 	}
 	if(mydebug) {LOG_FT << "lsize.x,y = " << lsize.x << "," << lsize.y << ", new_text_width = " << new_text_width;}
 
-
-//	label.clear_texture();  // couldn't figure this out  -- just commented out the check if tex_ exists in create_texture()
-
-	label.set_font_size(font_size);
-	label.set_color(font::NORMAL_COLOR);
-	label.set_clip_rect(game_canvas);  
-	label.set_width(new_text_width);   
-	label.set_alignment(font::LEFT_ALIGN);
-	label.set_bg_color(bgcolor);
-	label.set_border_size(border);
+	label.set_clip_rect(game_canvas);
+	label.set_width(new_text_width);
 
 	label.create_texture();
 
-	lsize = label.get_draw_size();
-	if(mydebug) {LOG_FT << "new label lsize.x,y = " << lsize.x << "," << lsize.y;}
+	if(mydebug) {
+		lsize = label.get_draw_size();
+		LOG_FT << "new label lsize.x,y = " << lsize.x << "," << lsize.y;
+	}
 
 	update_label_pos();
 }
@@ -135,10 +129,10 @@ void tooltip::update_label_pos()
 	} else if(((origin.y + origin.h/2 - loc.h/2) >= 0) &&
 		  ((origin.y + origin.h/2 + loc.h/2) <= game_canvas.h*0.95)) {
 		// There is enough room to center it at the tip area
-		loc.y = origin.y + origin.h/2 - loc.h/2;	
+		loc.y = origin.y + origin.h/2 - loc.h/2;
 		if(mydebug) { LOG_FT << "\tCenter: loc = " << loc.x << "," << loc.y << " origin = " << origin.x << "," << origin.y; }
 	} else if(loc.h <= game_canvas.h*0.95) {
-		// There is enough room to center it 
+		// There is enough room to center it
 		loc.y = game_canvas.h/2;
 		if(mydebug) { LOG_FT << "\tScreen Center: loc = " << loc.x << "," << loc.y << " origin = " << origin.x << "," << origin.y; }
 	} else {

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -33,7 +33,7 @@ namespace {
 
 static const int font_size = font::SIZE_SMALL;
 static const int text_width = 400;
-static const float height_fudge = 0.95;  // An artificial "border" to keep tip text from crowding lower edge of viewing area
+static const double height_fudge = 0.95;  // An artificial "border" to keep tip text from crowding lower edge of viewing area
 
 struct tooltip
 {
@@ -87,8 +87,10 @@ void tooltip::init_label()
 		// one.
 		//
 		// Creating this over and over may not be the most efficient route, but it will work and will be quite rare (tip taller than screen).
+		bool wont_fit = false;
 		if(new_text_width>game_canvas.w) {
 			new_text_width=game_canvas.w;
+			wont_fit = true;
 		}
 		DBG_FT << "lsize.x,y = " << lsize.x << "," << lsize.y << ", new_text_width = " << new_text_width;
 
@@ -97,8 +99,11 @@ void tooltip::init_label()
 		label.create_texture();
 
 		lsize = label.get_draw_size();
-		new_text_width *= 1.3;
 		DBG_FT << "new label lsize.x,y = " << lsize.x << "," << lsize.y;
+		if(wont_fit) {
+			break;
+		}
+		new_text_width *= 1.3;
 	}
 	// I don't know if it's strictly necessary to create the texture yet again just to make sure the clip_rect is set to game_canvas
 	// but it seems like the safe course of action.
@@ -141,15 +146,17 @@ void tooltip::update_label_pos()
 		DBG_FT << "\tToo big: loc = " << loc.x << "," << loc.y << " origin = " << origin.x << "," << origin.y;
 	}
 
+	DBG_FT << "\tBefore x adjust: loc.x,y,w,h = " << loc.x << "," << loc.y << "," << loc.w << "," << loc.h << "  origin = " << origin.x << "," << origin.y;
 	// Try to keep it within the screen
 	loc.x = origin.x;
-	if(loc.x < 0) {
-		loc.x = 0;
-	} else if(loc.x + loc.w > game_canvas.w) {
+	if(loc.x + loc.w > game_canvas.w) {
 		loc.x = game_canvas.w - loc.w;
 	}
+	if(loc.x < 0) {
+		loc.x = 0;
+	}
 
-	DBG_FT << "\tFinal: loc = " << loc.x << "," << loc.y << " origin = " << origin.x << "," << origin.y;
+	DBG_FT << "\tFinal: loc.x,y,w,h = " << loc.x << "," << loc.y << "," << loc.w << "," << loc.h << "  origin = " << origin.x << "," << origin.y;
 	label.set_position(loc.x, loc.y);
 }
 


### PR DESCRIPTION
In some cases (LotI), some tooltips for items on the right hand panel of the main scenario screen do not fit.  The current algo to place tips just checks to see if the tip will fit above the origin, and if not places it below (which is often a worse choice).  I made a suggestion for improving this at https://forums.wesnoth.org/viewtopic.php?t=57103 where it was recommended that I submit a PR, even though I'm not a programmer, I don't know C++ (or SDL, or...), etc.  So here it is, warts and all.

The first step, changes to init_label(), is a complete mess.  It's clear I have no idea what I'm doing, except I know I'm doing it wrong.  But it does at least allow me to demonstrate the idea.  Basically, the text_width of the tooltip texture is set to 400.  If a tooltip is too "tall" to fit (and assuming we can't/won't fix that), one possible choice is to stretch the width until the height fits.  It turns out that this is not so easy to do with text, you can't just assume that the same data will fit in the same area by scaling the width by the same ratio as the overflow in height.  Also, I have no idea how to get the height of the text so I did some really ugly stuff.  It works, but it ain't right and I don't have the skills at this point to do it right.

The second piece, update_label_pos() is pretty straight forward.  Just check that the tip will fit before placing it below the origin, and if not find a better way to place it.  That works.  Obviously I need to remove the debugging lines, but I left them in for now in case they are of use to anyone.

P.S.  I did read CONTRIBUTING.md, but understood about none of it.  