### PR TITLE
[1.18] gui/language_selection: Rephrase text about becoming a translator

### DIFF
--- a/data/gui/window/language_selection.cfg
+++ b/data/gui/window/language_selection.cfg
@@ -77,9 +77,12 @@
 					[label]
 						use_markup = true
 						wrap = true
-						label = _ "<i>Battle for Wesnoth</i> relies on community submissions to provide an accessible game experience for players around the world. Because development of the main game can move faster than volunteer translators are able to keep up with, translations may drift behind or even become abandoned.
+						label = _ "<i>The Battle for Wesnoth</i> relies on volunteers for development, including translation. Translations may drift behind or even become abandoned." + "
 
-If you are a first-time player, we recommend using a mostly-complete translation. If you are interested in translating the game yourself, we suggest visiting the following page for more information and enabling all translations while you work on your contributions:"
+" +
+							# po: Beneath the label widget displaying this text there is a widget displaying
+							# po: a clickable link to <https://gettext.wesnoth.org/> (which opens in the user’s browser).
+							_ "<b>Note:</b> The translation percentages shown apply to the core game interface and in-game help only. More complete stats, including details for each campaign, are available at the following page:"
 					[/label]
 				[/column]
 			[/row]
@@ -100,7 +103,7 @@ If you are a first-time player, we recommend using a mostly-complete translation
 									horizontal_grow = true
 									[label]
 										# Filled in at runtime
-										id = "contrib_url"
+										id = "stats_url"
 										use_markup = true
 										link_aware = true
 										wrap = true
@@ -135,8 +138,8 @@ If you are a first-time player, we recommend using a mostly-complete translation
 						link_aware = true
 						wrap = true
 						# po: Beneath the label widget displaying this text there is a widget displaying
-						# po: a decorated link to <https://gettext.wesnoth.org/>.
-						label = _ "<b>Note:</b> The translation percentages shown apply to the core game interface and in-game help only. More complete stats are available at the following page:"
+						# po: a clickable link to the wiki’s WesnothTranslations page (which opens in the user’s browser).
+						label = _ "If you are interested in translating the game yourself, please follow the link below for more information:"
 					[/label]
 				[/column]
 			[/row]
@@ -157,7 +160,7 @@ If you are a first-time player, we recommend using a mostly-complete translation
 									horizontal_grow = true
 									[label]
 										# Filled in at runtime
-										id = "stats_url"
+										id = "contrib_url"
 										use_markup = true
 										link_aware = true
 										wrap = true


### PR DESCRIPTION
Backport of the still-in-review #8905 - I hope the current wording will be accepted, and if so, I want the CI to have already run.

The link with details about individual compaigns is useful to players, even if they aren't looking to become translators. So move it upwards.

The text about first-time players seemed confusing to me, as the choice is already limited to languages that the player can read. Reworded it, but after discussion in the PR, neither version was better than just removing it.