### PR TITLE
[1.18] Put the community dialog's strings in the wesnoth-lib domain

### DIFF
--- a/data/gui/window/community_dialog.cfg
+++ b/data/gui/window/community_dialog.cfg
@@ -1,3 +1,5 @@
+#textdomain wesnoth-lib
+
 [window]
 	id = "community_dialog"
 	description = "Dialog for links to different places related to Wesnoth's community"
@@ -35,7 +37,8 @@
 								[label]
 									definition = "title"
 									
-									#po: this is on a button that opens a dialog with links to various Wesnoth community websites
+									#po: On the title screen, this is the button to open the "Community" dialog, a multi-tab dialog which also includes the “About” info.
+									#po: Within the “Community” dialog, this chooses a tab with links to various Wesnoth websites.
 									label = _ "Community"
 								[/label]
 			
@@ -52,13 +55,13 @@
 					border = "all"
 					border_size = 10
 
-                    [button]
-                        id = "forums"
-                        definition = "default"
+					[button]
+						id = "forums"
+						definition = "default"
 
 						#po: this is on a button that opens the Wesnoth forums webpage
-                        label = _ "Forums"
-                    [/button]
+						label = _ "Forums"
+					[/button]
 				
 				[/column]
 			
@@ -71,13 +74,13 @@
 					border = "all"
 					border_size = 10
 
-                    [button]
-                        id = "discord"
-                        definition = "default"
+					[button]
+						id = "discord"
+						definition = "default"
 
 						#po: this is on a button that opens the Wesnoth Discord server webpage
-                        label = _ "Discord"
-                    [/button]
+						label = _ "Discord"
+					[/button]
 				
 				[/column]
 			
@@ -90,13 +93,13 @@
 					border = "all"
 					border_size = 10
 
-                    [button]
-                        id = "irc"
-                        definition = "default"
+					[button]
+						id = "irc"
+						definition = "default"
 
 						#po: this is on a button that opens the Wesnoth IRC webpage. IRC is an acronym for Internet Relay Chat
-                        label = _ "IRC"
-                    [/button]
+						label = _ "IRC"
+					[/button]
 				
 				[/column]
 			
@@ -109,13 +112,13 @@
 					border = "all"
 					border_size = 10
 
-                    [button]
-                        id = "steam"
-                        definition = "default"
+					[button]
+						id = "steam"
+						definition = "default"
 
 						#po: this is on a button that opens the Wesnoth Steam forums webpage
-                        label = _ "Steam"
-                    [/button]
+						label = _ "Steam"
+					[/button]
 				
 				[/column]
 			
@@ -128,13 +131,13 @@
 					border = "all"
 					border_size = 10
 
-                    [button]
-                        id = "reddit"
-                        definition = "default"
+					[button]
+						id = "reddit"
+						definition = "default"
 
 						#po: this is on a button that opens the Wesnoth Reddit webpage
-                        label = _ "Reddit"
-                    [/button]
+						label = _ "Reddit"
+					[/button]
 				
 				[/column]
 			
@@ -147,13 +150,13 @@
 					border = "all"
 					border_size = 10
 
-                    [button]
-                        id = "donate"
-                        definition = "default"
+					[button]
+						id = "donate"
+						definition = "default"
 
 						#po: this is on a button that opens the Wesnoth SPI webpage for sending donations
-                        label = _ "Donate"
-                    [/button]
+						label = _ "Donate"
+					[/button]
 				
 				[/column]
 			


### PR DESCRIPTION
Most of the GUI, including the title screen's "Community" button, is already in wesnoth-lib. So making this consistent also means we're only adding one copy of "Community" to the .pot files.

Make the whitespace in this file consistent (using tabs).