### PR TITLE
set buttons inactive when irrelevant

### DIFF
--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -185,6 +185,16 @@ public:
 			pages_->set_label(out.str());
 			left_->set_visible(widget::visibility::visible);
 			right_->set_visible(widget::visibility::visible);
+			if(current_page_ > 0) {
+				left_->set_active(true);
+			} else {
+				left_->set_active(false);
+			}
+			if(current_page_ < n_pages - 1) {
+				right_->set_active(true);
+			} else	{
+				right_->set_active(false);
+			}
 		} else {
 			pages_->set_label("");
 			left_->set_visible(widget::visibility::invisible);

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -185,16 +185,8 @@ public:
 			pages_->set_label(out.str());
 			left_->set_visible(widget::visibility::visible);
 			right_->set_visible(widget::visibility::visible);
-			if(current_page_ > 0) {
-				left_->set_active(true);
-			} else {
-				left_->set_active(false);
-			}
-			if(current_page_ < n_pages - 1) {
-				right_->set_active(true);
-			} else	{
-				right_->set_active(false);
-			}
+			left_->set_active(current_page_ > 0);
+			right_->set_active(current_page_ < n_pages - 1);
 		} else {
 			pages_->set_label("");
 			left_->set_visible(widget::visibility::invisible);


### PR DESCRIPTION
Setting visibility::hidden would be consistent with the only other example I could find, the arrows in the help menu.  I think it looks weird to have buttons just disappear completely (except when none would be available), but I'd change it if that's the standard.