### PR TITLE
make sure bullets in about dialog use a font that has those characters

### DIFF
--- a/data/gui/window/game_version.cfg
+++ b/data/gui/window/game_version.cfg
@@ -119,7 +119,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "✦ <b>Version:</b>"
+										label = _ "<span font_family='DejaVu Sans'>✦</span> <b>Version:</b>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -147,7 +147,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "✦ <b>Running on:</b>"
+										label = _ "<span font_family='DejaVu Sans'>✦</span> <b>Running on:</b>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -176,7 +176,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "✦ <b>Architecture:</b>"
+										label = _ "<span font_family='DejaVu Sans'>✦</span> <b>Architecture:</b>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -204,7 +204,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "✦ <b>Homepage:</b>"
+										label = _ "<span font_family='DejaVu Sans'>✦</span> <b>Homepage:</b>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -234,7 +234,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "✦ <b>Wiki:</b>"
+										label = _ "<span font_family='DejaVu Sans'>✦</span> <b>Wiki:</b>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -272,7 +272,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "<i>➤ Copy a full report here:</i>"
+										label = _ "<i><span font_family='DejaVu Sans'>➤</span> Copy a full report here:</i>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -292,7 +292,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "<i>➤ Report an issue or request a feature:</i>"
+										label = _ "<i><span font_family='DejaVu Sans'>➤</span> Report an issue or request a feature:</i>"
 										use_markup = yes
 									[/label]
 								[/column]
@@ -315,7 +315,7 @@
 								[column]
 									horizontal_alignment = left
 									[label]
-										label = _ "<i>➤ Re-open the version migrator dialog:</i>"
+										label = _ "<i><span font_family='DejaVu Sans'>➤</span> Re-open the version migrator dialog:</i>"
 										use_markup = yes
 									[/label]
 								[/column]


### PR DESCRIPTION
In some platforms, the bullet characters ✦ (U+2726) and ➤ (U+27A4) used in the About dialog will not be visible unless they are using a font that actually has those characters.