### PR TITLE
[MP][Hornshark Island] Fix mudcrawlers after #8837

### DIFF
--- a/data/multiplayer/scenarios/2p_Hornshark_Island.cfg
+++ b/data/multiplayer/scenarios/2p_Hornshark_Island.cfg
@@ -473,6 +473,19 @@
                     [modifications]
                         {TRAIT_QUICK}
                         {TRAIT_RESILIENT}
+                        [trait]
+                            name=_ "hemerophile"
+                            description=_ "Receives 60 % defense in castles and villages"
+                            help_text=_ "<italic>text='Hemerophile'</italic> units have adapted to civilized folks, resulting in their defenses in castles and villages being higher than their wild relatives’."
+                            [effect]
+                                apply_to=defense
+                                replace=yes
+                                [defense]
+                                    castle=40
+                                    village=40
+                                [/defense]
+                            [/effect]
+                        [/trait]
                     [/modifications]
                 [/unit]
                 [unit]
@@ -900,6 +913,19 @@
                     [modifications]
                         {TRAIT_QUICK}
                         {TRAIT_RESILIENT}
+                        [trait]
+                            name=_ "hemerophile"
+                            description=_ "Receives 60 % defense in castles and villages"
+                            help_text=_ "<italic>text='Hemerophile'</italic> units have adapted to civilized folks, resulting in their defenses in castles and villages being higher than their wild relatives’."
+                            [effect]
+                                apply_to=defense
+                                replace=yes
+                                [defense]
+                                    castle=40
+                                    village=40
+                                [/defense]
+                            [/effect]
+                        [/trait]
                     [/modifications]
                 [/unit]
                 [unit]


### PR DESCRIPTION
This commit restores the pre-#8837 defenses of the mudcrawlers in 2p Hornshark Island by adding a new "hemerophile" trait, which works as an opposite of the "feral" trait.
Movement is not affected as all swamp hexes in the map are also villages.