### PR TITLE
Back-port vcpkg base-line

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "wesnoth-dependencies",
   "version": "0.0.1",
-  "builtin-baseline": "dafef74af53669ef1cc9015f55e0ce809ead62aa",
+  "builtin-baseline": "1580d2238574df45fa018afcfb375fffbebca244",
   "dependencies": [
     "sdl2",
     {


### PR DESCRIPTION
I was not able to build current 1.18 branch on MSVC without this. Also means master and 1.18 use same vcpkg base-line again.