### PR TITLE
EI: use fancy script for "Part II" "Part III" storytext

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -23,11 +23,15 @@
 
     [story]
         [part]
-            title= _ "<b><span color='#00cc99'>Part II: The Wildlands</span></b>"
+            #po: newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+            title=_"<span font_family='Oldania ADF Std' size='90000'>
+
+
+<i>Part II: The Wildlands </i></span>"
+            title_alignment=center
             music=silence.ogg
         [/part]
         [part]
-            title= _ "<b><span color='#00cc99'>Part II: The Wildlands</span></b>"
             story= _ "Gweddry and his men made good time past the Great River’s northern banks, leaving the undead far behind. With winter drawing near, they unexpectedly stumbled upon an inhabited valley..."
             {EI_BIGMAP}
         [/part]

--- a/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
@@ -22,7 +22,12 @@
 
     [story]
         [part]
-            title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
+            #po: newlines at the beginning help to (depending on the screne size) center this vertically. The space at the end stops the last letter from getting cut off
+            title=_"<span font_family='Oldania ADF Std' size='90000'>
+
+
+<i>Part III: Wesnoth at War </i></span>"
+            title_alignment=center
             music=silence.ogg
         [/part]
         [if]
@@ -32,13 +37,11 @@
             [/variable]
             [then]
                 [part]
-                    title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
                     story= _ "As Gweddry, Owaec, and Dacyn fled across the Listra, a frenzy of shouts, screams, and roars broke out from behind. Neither the orcs nor the drakes attempted to give pursuit."
                 [/part]
             [/then]
         [/if]
         [part]
-            title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
             story= _ "Leaving the tumultuous wildlands far behind, the soldiers of Wesnoth prepared to cross the Great River once more and return to their homeland..."
             {EI_BIGMAP}
         [/part]


### PR DESCRIPTION
In add-on form, EI used images to display "Part II" and "Part III".  For translation reasons this got replaced with ugly title_text when the add-on went mainline.

This PR once again makes the "Part II" "Part III" storytext more fancy, while maintaining translatability.