### PR TITLE
fix [has_attack] can cause infinite recursion in weapon special

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -202,6 +202,8 @@
     {DAMAGE_TYPE_TEST {FILTER_TYPE_BLADE}}
 )}
 
+#undef FILTER_TYPE_BLADE
+
 #####
 # API(s) being tested: [damage]alternative_type=
 ##
@@ -350,5 +352,100 @@
         {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 76})}
         {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 76})}
         {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [filter_self][has_attack]type= in [damage_type]
+##
+# Actions:
+# Give Alice an ability that replace all damage by arcane if Alice has a blade attack
+# Define events that use filter_attack matching Alice's arcane type.
+# Have Alice attack Bob.
+##
+# Expected end state:
+# An event triggers when Alice attacks during side 1's turn because type=arcane detected without [has_attack] cause infinite recursion.
+#####
+{GENERIC_UNIT_TEST event_test_filter_damage_type_recursion (
+    [event]
+        name=start
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage_type]
+                        id=test_arcane_damage
+                        replacement_type=arcane
+                        [filter_student]
+                            [has_attack]
+                                type=blade
+                            [/has_attack]
+                        [/filter_student]
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [do_command]
+            [move]
+                x=7,13
+                y=3,4
+            [/move]
+            [attack]
+                [source]
+                    x,y=13,4
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [do_command]
+            [attack]
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=13,4
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            type=arcane
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 )}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1381,6 +1381,19 @@ namespace { // Helpers for attack_type::special_active()
 				return false;
 		}
 
+		// Check for if unit has attack who match.
+		if (auto filter_attack = filter_child->optional_child("has_attack") ) {
+			bool has_attack = false;
+			for(const attack_type& a : (*u).attacks())
+				if(a.matches_filter(*filter_attack, tag_name)) {
+					has_attack = true;
+					break;
+				}
+			if(!has_attack){
+				return false;
+			}
+		}
+
 		// Passed.
 		// If the other unit doesn't exist, try matching without it
 		if (!u2) {

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -371,6 +371,7 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+0 event_test_filter_damage_type_recursion
 0 negative_resistance_with_two_attack_types
 0 positive_resistance_with_two_attack_types
 0 taught_resistance_with_two_attack_types


### PR DESCRIPTION
Fix [https://github.com/wesnoth/wesnoth/issues/8939 issues/8939](https://github.com/wesnoth/wesnoth/issues/8940)

I is not ideal because  check repeated one time, but recursion is not infinite.