### PR TITLE
 Fix [has_attack]type= cause infinite recursion when called from [damage_type] which concerns the filtered attack.

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -202,8 +202,8 @@
     {DAMAGE_TYPE_TEST {FILTER_TYPE_BLADE}}
 )}
 
-#####
-# API(s) being tested: [damage]alternative_type=
+#undef FILTER_TYPE_BLADE
+
 ##
 # Actions:
 # Give both Alice and Bob 100% chance to hit.
@@ -216,16 +216,10 @@
 # Expected end state:
 # Alice attack with blade and Bob use cold.
 #####
-{GENERIC_UNIT_TEST "damage_secondary_type_test" (
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_test" (
     [event]
         name=start
-        [modify_unit]
-            [filter]
-            [/filter]
-            max_hitpoints=100
-            hitpoints=100
-            attacks_left=1
-        [/modify_unit]
+
         [object]
             silent=yes
             [effect]
@@ -240,27 +234,19 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=pierce
                     [/damage_type]
                     [damage_type]
                         alternative_type=cold
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
                 id=bob
             [/filter]
         [/object]
+
         [object]
             silent=yes
             [effect]
@@ -276,18 +262,9 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=fire
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
@@ -295,60 +272,90 @@
             [/filter]
         [/object]
 
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-            kill=yes
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        [unstore_unit]
-            variable=a
-            find_vacant=yes
-            x,y=$b.x,$b.y
-        [/unstore_unit]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x,y=$a.x,$a.y
-                [/source]
-                [destination]
-                    x,y=$b.x,$b.y
-                [/destination]
-            [/attack]
-        [/do_command]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        #damage without modification are 12, if test fail hitpoints !=76
-        #if succed then damage by alice 24(bob more vulnerable to blade)
-        #if succed then damage by bob 24(alice vulnerable to cold, cold [damage] is used)
-        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 76})}
-        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 76})}
+        # damage without modification is 100
+        # expected damage by alice is 200 (bob is vulnerable to blade, so the alternative isn't used)
+        # expected damage by bob is 200 (alice is most vulnerable to cold, so that alternative is used)
+        {ATTACK_AND_VALIDATE 200}
         {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [filter_self][has_attack]type= in [damage_type]
+##
+# Actions:
+# Give Alice an ability that replace all damage by arcane if Alice has a blade attack
+# Define events that use filter_attack matching Alice's arcane type.
+# Have Alice attack Bob during side 1's turn
+# Have Bob attack Alice during side 2's turn
+##
+# Expected end state:
+# The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (
+    [event]
+        name=start
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage_type]
+                        id=test_arcane_damage
+                        replacement_type=arcane
+                        [filter_student]
+                            [has_attack]
+                                type=blade
+                            [/has_attack]
+                        [/filter_student]
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=alice
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            type=arcane
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 )}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1372,7 +1372,16 @@ namespace { // Helpers for attack_type::special_active()
 			return false;
 		}
 
-		unit_filter ufilt{vconfig(*filter_child)};
+		//'inform' u.matches what called from a weapon special if filter_child contain "has_attack" child.
+		config cfg = *filter_child;
+		if ((*filter_child).has_child("has_attack") ) {
+			config& filter_has_attack = cfg.mandatory_child("has_attack");
+			filter_has_attack["bug_8940"] = tag_name;
+		}
+
+		const config& final_filter_child = (*filter_child).has_child("has_attack") ? cfg : *filter_child;
+
+		unit_filter ufilt{vconfig(final_filter_child)};
 
 		// If the other unit doesn't exist, try matching without it
 

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -849,8 +849,10 @@ void unit_filter_compound::fill(vconfig cfg)
 			}
 			else if (child.first == "has_attack") {
 				create_child(child.second, [](const vconfig& c, const unit_filter_args& args) {
+					//if called from a special weapon, 'inform' the matches_filter function.
+					std::string weapon_type = c.has_attribute("bug_8940") ? c["bug_8940"].str() : "";
 					for(const attack_type& a : args.u.attacks()) {
-						if(a.matches_filter(c.get_parsed_config())) {
+						if(a.matches_filter(c.get_parsed_config(), weapon_type)) {
 							return true;
 						}
 					}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -373,6 +373,7 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+0 event_test_filter_damage_type_recursion
 0 negative_resistance_with_two_attack_types
 0 positive_resistance_with_two_attack_types
 0 taught_resistance_with_two_attack_types


### PR DESCRIPTION
When for example we have [damage_type][filter_self][has_attack]type=pierce applied to one or any pierce type attack and the unit does not have an unaffected pierce attack, the change in type triggers an infinite recursion.

this PR fixes the problem in the same way as for [filter_weapon]