### PR TITLE
EI: use "bonus objective" instead of "optional objective"

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
@@ -163,7 +163,7 @@
                 condition=win
             [/objective]
             [objective]
-                {OPTIONAL_OBJECTIVE_CAPTION}
+                {BONUS_OBJECTIVE_CAPTION}
                 description= _ "Kill Addogin (bonus reward)"
                 condition=win
                 [show_if]

--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -429,7 +429,7 @@
                 condition=win
             [/objective]
             [objective]
-                {OPTIONAL_OBJECTIVE_CAPTION}
+                {BONUS_OBJECTIVE_CAPTION}
                 #po: when initially shown there are 6 imprisoned knights, the text doesn't change as they're freed
                 description= _ "Rescue the imprisoned knights"
                 condition=win

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -268,7 +268,7 @@
                 condition=win
             [/objective]
             [objective]
-                {OPTIONAL_OBJECTIVE_CAPTION}
+                {BONUS_OBJECTIVE_CAPTION}
                 #po: two male dwarves
                 description= _ "Move Dolburras next to Pelathsil."
                 condition=win

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -432,7 +432,7 @@
                 condition=win
             [/objective]
             [objective]
-                {OPTIONAL_OBJECTIVE_CAPTION}
+                {BONUS_OBJECTIVE_CAPTION}
                 description= _ "Move Grug next to an enemy ogre."
                 condition=win
                 [show_if]

--- a/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
@@ -1267,12 +1267,7 @@
                 condition=win
             [/objective]
             [objective]
-                {OPTIONAL_OBJECTIVE_CAPTION}
-                description= _ "Capture villages and build up an army before attacking."
-                condition=win
-            [/objective]
-            [objective]
-                {OPTIONAL_OBJECTIVE_CAPTION}
+                {BONUS_OBJECTIVE_CAPTION}
                 description= _ "Loot Addogin’s smugglers’ caches."
                 condition=win
                 [show_if]
@@ -1290,6 +1285,9 @@
             [/gold_carryover]
             [note]
                 description= _ "Enemy leaders are idle until first sighted, but will then abandon their keep and attack you."
+            [/note]
+            [note]
+                description= _ "It may be wise to capture villages and build up an army before attacking."
             [/note]
         [/objectives]
 


### PR DESCRIPTION
"optional" may imply that the scenario will be completed once this objective is finished, which is not accurate.