### PR TITLE
EI S10: specify that Owaec can recruit

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
@@ -724,6 +724,12 @@
                 [/show_if]
             [/note]
             [note]
+                description= _ "Owaec is a leader, and can recruit"
+                [show_if]
+                    {VARIABLE_CONDITIONAL orcs_attacking equals yes}
+                [/show_if]
+            [/note]
+            [note]
                 description= _ "Dacyn has been here before and will have better outcomes when stepping on runes."
             [/note]
             [note]


### PR DESCRIPTION
https://www.reddit.com/r/wesnoth/comments/1d6a3e7/eastern_invasion_is_much_better_but_still_bad/?rdt=58522

Owaec has a leader icon, but it's not made explicit that he can recruit units. In most scenarios that doesn't matter, but in S10 he becomes isolated from Gweddry and must recruit to survive.

Note that there's already a `[show_objectives][/show_objectives]` when `orcs_attacking` is set.