### PR TITLE
Fix "span" regex

### DIFF
--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -486,7 +486,7 @@ def actualtype(a):
         atype = "percentage"
     elif re.match(r"-?[0-9]+,-?[0-9]+\Z", a):
         atype = "position"
-    elif re.match(r"([0-9]+\-[0-9]+,?|[0-9]+,?)+\Z", a):
+    elif re.match(r"(([0-9]+-)?[0-9]+,)*([0-9]+-)?[0-9]+\Z", a):
         atype = "span"
     elif a in ("melee", "ranged"):
         atype = "range"


### PR DESCRIPTION
This disallows matching "0-11-2" and "1," for example. It also avoids an exponential backtracking issue which could make this regex very slow.