### PR TITLE
GUI2/Game Load: Apply filter when changing directory

### DIFF
--- a/changelog_entries/game_load_filter.md
+++ b/changelog_entries/game_load_filter.md
@@ -1,0 +1,2 @@
+ ### Miscellaneous and Bug Fixes
+   * Fixed the Load Game dialog forgetting the filename filter when changing directory

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -315,11 +315,16 @@ void game_load::display_savegame()
 
 void game_load::filter_text_changed(const std::string& text)
 {
+	apply_filter_text(text, false);
+}
+
+void game_load::apply_filter_text(const std::string& text, bool force)
+{
 	listbox& list = find_widget<listbox>(get_window(), "savegame_list", false);
 
 	const std::vector<std::string> words = utils::split(text, ' ');
 
-	if(words == last_words_)
+	if(words == last_words_ && !force)
 		return;
 	last_words_ = words;
 
@@ -537,6 +542,9 @@ void game_load::handle_dir_select()
 	}
 
 	populate_game_list();
+	if(auto* filter = find_widget<text_box>(get_window(), "txtFilter", false, true)) {
+		apply_filter_text(filter->get_value(), true);
+	}
 	display_savegame();
 }
 

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -51,6 +51,14 @@ private:
 	void delete_button_callback();
 	void handle_dir_select();
 
+	/**
+	 * Implementation detail of filter_text_changed and handle_dir_select
+	 *
+	 * @param text Current contents of the textbox
+	 * @param force If true, recalculate even if the text is the same as last time
+	 */
+	void apply_filter_text(const std::string& text, bool force);
+
 	/** Part of display_savegame that might throw a config::error if the savegame data is corrupt. */
 	void display_savegame_internal(const savegame::save_info& game);
 	void display_savegame();


### PR DESCRIPTION
When the user types something into the filter box and then changes to a different version, apply the filter immediately instead of showing the full list of files.

The drop-down to switch between directories is hidden unless savegames from other versions are detected. The button will appear at the bottom-left in master, and at the top of the dialog in 1.18.

It's a trivial bug, but still worth backporting IMO.