### PR TITLE
replace deprecated CURLOPT_PROTOCOLS with CURLOPT_PROTOCOLS_STR

### DIFF
--- a/src/network_download_file.cpp
+++ b/src/network_download_file.cpp
@@ -53,7 +53,7 @@ namespace network
             curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);
             curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
             curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 5000L);
-            #if LIBCURL_VERSION_NUM > 0x075500
+            #if LIBCURL_VERSION_NUM >= 0x075500
 	            curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, CURLPROTO_HTTPS);
 	        #else
 	            curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);

--- a/src/network_download_file.cpp
+++ b/src/network_download_file.cpp
@@ -53,7 +53,11 @@ namespace network
             curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);
             curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
             curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 5000L);
-            curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, CURLPROTO_HTTPS);
+            #if LIBCURL_VERSION_NUM > 0x075500
+	            curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, CURLPROTO_HTTPS);
+	        #else
+	            curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+	        #endif
 
             CURLcode res = curl_easy_perform(curl);
 

--- a/src/network_download_file.cpp
+++ b/src/network_download_file.cpp
@@ -53,7 +53,7 @@ namespace network
             curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);
             curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
             curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 5000L);
-            curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+            curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, CURLPROTO_HTTPS);
 
             CURLcode res = curl_easy_perform(curl);
 


### PR DESCRIPTION
According to [Curl Docs](https://curl.se/libcurl/c/CURLOPT_PROTOCOLS.html), CURLOPT_PROTOCOLS is deprecated with `curl_easy_setopt()`.