### PR TITLE
Add a unit test for a weapon-special activating mid-attack

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_recalculation_mid_attack.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_recalculation_mid_attack.cfg
@@ -1,0 +1,65 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]value=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# Make Alice's weapon 1x3 with poison and 100% CTH
+# Make Alice's weapon do 10 points of damage when striking a poisoned opponent.
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Bob is poisoned and has taken 21 damage, because the damage was recalculated between strikes.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_recalculation_mid_attack" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    {WEAPON_SPECIAL_POISON}
+                    [attacks]
+                        value=3
+                    [/attacks]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [damage]
+                        [filter_opponent]
+                            status=poisoned
+                        [/filter_opponent]
+                        value=10
+                        apply_to=self
+                    [/damage]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 79})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -369,6 +369,7 @@
 0 trait_requirement_test
 0 test_remove_ability_by_filter
 0 test_overwrite_specials_filter
+0 damage_recalculation_mid_attack
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test


### PR DESCRIPTION
A weapon with poison, which does extra damage to poisoned opponents. This tests that the weapon-special's filter is checked on each strike, instead of being tested once and then cached during the battle.

(cherry picked from commit 55aa8b44cfd561d0d97f254312f395cebc8ccc6e)