### PR TITLE
EI S10, S11, S12: Dacyn difficulty tweaks

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
@@ -2564,7 +2564,7 @@ Nothing is going well. My research has come to a dead end and even the spirits f
         [event]
             name=side 5 turn end
             id=owaec_can_recruit_reminder
-            # in 1.18.2 we'll put a message from Owaec here. For now don't, or else we violate the string freeze.
+            # in 1.18.2 we'll put a message here. For now don't, or else we violate the string freeze.
         [/event]
         [event]
             name=recruit,recall
@@ -2846,8 +2846,11 @@ Nothing is going well. My research has come to a dead end and even the spirits f
             name=human-old-die-1.ogg
         [/sound]
 
-        {MODIFY_UNIT (id=Dacyn) hitpoints 1}
-        {MODIFY_UNIT (id=Dacyn) status.slowed yes}
+        {MODIFY_UNIT id=Dacyn hitpoints 1}
+        {MODIFY_UNIT id=Dacyn experience 0}
+        # experience because 1: showing that the amulet interferes with his MoL-ing, and
+        # experience because 2: preventing the player from deliberately AMLA-ing Dacyn in the next scenario (partially a difficulty issue, but mostly it's bad to punish blind playthroughs / reward foreknowledge)
+        {MODIFY_UNIT id=Dacyn status.slowed yes}
         [message]
             speaker="Dacyn"
             #po: on putting on the amulet, he's been dropped to 1 hp

--- a/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
@@ -2564,7 +2564,7 @@ Nothing is going well. My research has come to a dead end and even the spirits f
         [event]
             name=side 5 turn end
             id=owaec_can_recruit_reminder
-            # in 1.18.2 we'll put a message here. For now don't, or else we violate the string freeze.
+            # in 1.18.2 we'll put a message from Owaec here. For now don't, or else we violate the string freeze.
         [/event]
         [event]
             name=recruit,recall

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -232,6 +232,9 @@
         {RECALL_XY Dacyn 28 13}
         {MODIFY_UNIT id=Dacyn facing se}
 #ifndef EASY
+        # Dacyn needs either full HP or low enough hp that the player realizes he needs to flee.
+        # with medium HP the player might think they're expected to fight, even if it's not likely/possible
+        # 7hp chosen arbitrarily
         {MODIFY_UNIT id=Dacyn hitpoints 7}
 #endif
 

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -231,7 +231,9 @@
 
         {RECALL_XY Dacyn 28 13}
         {MODIFY_UNIT id=Dacyn facing se}
+#ifndef EASY
         {MODIFY_UNIT id=Dacyn hitpoints 7}
+#endif
 
         {RECALL_XY Owaec 26 14}
         {MODIFY_UNIT id=Owaec facing se}
@@ -1629,12 +1631,20 @@ Your punishment is death."
 
         {REMOVE_IMAGE $unit.x $unit.y}
         {REMOVE_LABEL $unit.x $unit.y}
-        [message]
-            speaker=narrator
-            image=wesnoth-icon.png
-            sound=gold.ogg
-            message={MESSAGE}
-        [/message]
+        [sound]
+            name=gold.ogg
+        [/sound]
+        {VARIABLE msg {MESSAGE}}
+        [if]
+            {VARIABLE_CONDITIONAL msg.length greater_than 0}
+            [then]
+                [message]
+                    speaker=narrator
+                    image=wesnoth-icon.png
+                    message={MESSAGE}
+                [/message]
+            [/then]
+        [/if]
         [gold]
             side=1
             amount={AMOUNT}
@@ -1643,6 +1653,11 @@ Your punishment is death."
 #enddef
     {TREASURY_GOLD 34 10 "items/gold-coins-small.png" 70 (_"70 gold") (_"You’ve pillaged 70 orcish gold pieces!")}
     {TREASURY_GOLD 35 11 "items/gold-coins-medium.png" 115 (_"115 gold") (_"You’ve pillaged 115 orcish gold pieces!")}
+
+    # this gold pile draws the player's attention to this hex, which is also a great place to hide Dacyn
+#ifndef HARD 
+    {TREASURY_GOLD 30 10 "items/gold-coins-small.png" 20 (_"These orcs have a pile of 20 gold pieces!") ""}
+#endif
 
     #---------------------------
     # RING OF INVISIBILITY

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -1631,20 +1631,12 @@ Your punishment is death."
 
         {REMOVE_IMAGE $unit.x $unit.y}
         {REMOVE_LABEL $unit.x $unit.y}
-        [sound]
-            name=gold.ogg
-        [/sound]
-        {VARIABLE msg {MESSAGE}}
-        [if]
-            {VARIABLE_CONDITIONAL msg.length greater_than 0}
-            [then]
-                [message]
-                    speaker=narrator
-                    image=wesnoth-icon.png
-                    message={MESSAGE}
-                [/message]
-            [/then]
-        [/if]
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            sound=gold.ogg
+            message={MESSAGE}
+        [/message]
         [gold]
             side=1
             amount={AMOUNT}
@@ -1656,7 +1648,7 @@ Your punishment is death."
 
     # this gold pile draws the player's attention to this hex, which is also a great place to hide Dacyn
 #ifndef HARD 
-    {TREASURY_GOLD 30 10 "items/gold-coins-small.png" 20 (_"These orcs have a pile of 20 gold pieces!") ""}
+    {TREASURY_GOLD 30 10 "items/gold-coins-small.png" 20 (_"20 gold") (_"These orcs have a pile of 20 gold pieces!")}
 #endif
 
     #---------------------------

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -1647,7 +1647,7 @@ Your punishment is death."
     {TREASURY_GOLD 35 11 "items/gold-coins-medium.png" 115 (_"115 gold") (_"You’ve pillaged 115 orcish gold pieces!")}
 
     # this gold pile draws the player's attention to this hex, which is also a great place to hide Dacyn
-#ifndef HARD 
+#ifndef HARD
     {TREASURY_GOLD 30 10 "items/gold-coins-small.png" 20 (_"20 gold") (_"These orcs have a pile of 20 gold pieces!")}
 #endif
 

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -243,7 +243,20 @@
 
         {RECALL_XY Owaec 23 10}
         {RECALL_XY Dacyn 24 11} # he's slow, so put him near the bridge
-        {MODIFY_UNIT id=Dacyn halo ""}
+        [modify_unit]
+            [filter]
+                id=Dacyn
+            [/filter]
+            [object]
+                id=dacyn_no_halo
+                [effect]
+                    apply_to=remove_ability
+                    [experimental_filter_ability]
+                        tag_name=illuminates
+                    [/experimental_filter_ability]
+                [/effect]
+            [/object]
+        [/modify_unit]
         {RECALL_XY Addogin 24 9}
         {RECALL_XY (Hahid al-Ali) 24 9} # he drinks an elixir of haste. To make it more meaningful, put him on the furthest tile from the bridge
         {RECALL_XY Terraent 24 9}
@@ -399,13 +412,31 @@
                 [delay]
                     time=100
                 [/delay]
-
-                {MODIFY_UNIT id=Dacyn halo ""}
+                [modify_unit]
+                    [filter]
+                        id=Dacyn
+                    [/filter]
+                    [object]
+                        id=dacyn_no_halo
+                        [effect]
+                            apply_to=remove_ability
+                            [experimental_filter_ability]
+                                tag_name=illuminates
+                            [/experimental_filter_ability]
+                        [/effect]
+                    [/object]
+                [/modify_unit]
+                [redraw]
+                [/redraw]
                 [delay]
                     time=50
                 [/delay]
-
-                {MODIFY_UNIT id=Dacyn halo "halo/illuminates-aura.png"}
+                [remove_object]
+                    id=Dacyn
+                    object_id=dacyn_no_halo
+                [/remove_object]
+                [redraw]
+                [/redraw]
             [/do]
         [/repeat]
         [delay]
@@ -664,7 +695,10 @@ We should press the attack."
                                 [not]
                                     id=Hahid al-Ali
                                 [/not]
-                                #po: Said by any left-behind unit except Hahid al-Ali (it would be very out of character for him).
+                                [not]
+                                    race=ogre
+                                [/not]
+                                #po: Said by any left-behind unit except ogres (they can't speak fluently) and Hahid al-Ali (it would be very out of character for him).
                                 #po: TODO in 1.19: the "we" in this is a typo. It should be "you must ride ..."
                                 message= _ "At least you three commanders are safe. From here, we must ride swift, ride strong, and ride to save all of Wesnoth!"
                             [/message]

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -263,10 +263,8 @@
         {RECALL_XY Dolburras 23 11} # he's slow, so put him near the bridge
         {RECALL_XY Grug 23 11}
 
-#ifndef EASY
-        #on Easy, Dacyn starts with full hitpoints in the previous scenario, so it would be odd for him to be injured here
-        {MODIFY_UNIT (id=Dacyn) hitpoints 21}
-#endif
+        # on Easy, Dacyn starts with full hitpoints in the previous scenario, so it would be odd for him to be injured here
+        {MODIFY_UNIT (id=Dacyn) hitpoints {ON_DIFFICULTY 47 34 21}}
 
         [objectives]
             side=1

--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -243,27 +243,17 @@
 
         {RECALL_XY Owaec 23 10}
         {RECALL_XY Dacyn 24 11} # he's slow, so put him near the bridge
-        [modify_unit]
-            [filter]
-                id=Dacyn
-            [/filter]
-            [object]
-                id=dacyn_no_halo
-                [effect]
-                    apply_to=remove_ability
-                    [experimental_filter_ability]
-                        tag_name=illuminates
-                    [/experimental_filter_ability]
-                [/effect]
-            [/object]
-        [/modify_unit]
+        {MODIFY_UNIT id=Dacyn halo ""}
         {RECALL_XY Addogin 24 9}
         {RECALL_XY (Hahid al-Ali) 24 9} # he drinks an elixir of haste. To make it more meaningful, put him on the furthest tile from the bridge
         {RECALL_XY Terraent 24 9}
         {RECALL_XY Dolburras 23 11} # he's slow, so put him near the bridge
         {RECALL_XY Grug 23 11}
 
+#ifndef EASY
+        #on Easy, Dacyn starts with full hitpoints in the previous scenario, so it would be odd for him to be injured here
         {MODIFY_UNIT (id=Dacyn) hitpoints 21}
+#endif
 
         [objectives]
             side=1
@@ -409,31 +399,13 @@
                 [delay]
                     time=100
                 [/delay]
-                [modify_unit]
-                    [filter]
-                        id=Dacyn
-                    [/filter]
-                    [object]
-                        id=dacyn_no_halo
-                        [effect]
-                            apply_to=remove_ability
-                            [experimental_filter_ability]
-                                tag_name=illuminates
-                            [/experimental_filter_ability]
-                        [/effect]
-                    [/object]
-                [/modify_unit]
-                [redraw]
-                [/redraw]
+
+                {MODIFY_UNIT id=Dacyn halo ""}
                 [delay]
                     time=50
                 [/delay]
-                [remove_object]
-                    id=Dacyn
-                    object_id=dacyn_no_halo
-                [/remove_object]
-                [redraw]
-                [/redraw]
+
+                {MODIFY_UNIT id=Dacyn halo "halo/illuminates-aura.png"}
             [/do]
         [/repeat]
         [delay]
@@ -692,10 +664,7 @@ We should press the attack."
                                 [not]
                                     id=Hahid al-Ali
                                 [/not]
-                                [not]
-                                    race=ogre
-                                [/not]
-                                #po: Said by any left-behind unit except ogres (they can't speak fluently) and Hahid al-Ali (it would be very out of character for him).
+                                #po: Said by any left-behind unit except Hahid al-Ali (it would be very out of character for him).
                                 #po: TODO in 1.19: the "we" in this is a typo. It should be "you must ride ..."
                                 message= _ "At least you three commanders are safe. From here, we must ride swift, ride strong, and ride to save all of Wesnoth!"
                             [/message]


### PR DESCRIPTION
Resolves #8969

In EI S10, Dacyn picks up a cursed amulet and his HP drops to 1. In EI S11, Dacyn remains on very low HP, and is surrounded by orcs. There's a convenient ford hex he can hide on and be protected, but several players did not notice this hex and complained about difficulty.

In S10, this commit also drops his XP to 0. 1) showing that the amulet interferes with his MoL-ing, and 2) preventing the player from deliberately AMLA-ing Dacyn in the next scenario (partially a difficulty issue, but mostly it's bad to punish blind playthroughs / reward foreknowledge).

In S11, this commit adds a gold pile on Easy/Normal hinting towards the hex, while on Easy Dacyn's HP is fully restored. Hard is unaffected.

In S12, this commit restores Dacyn's HP on Easy (since it would be odd if he had full HP S11 but low HP S12).