### PR TITLE
Fix Weapon special filters can be affected by the weapon special leading to infinite recursion

### DIFF
--- a/changelog_entries/fix_infinite_recursion.md
+++ b/changelog_entries/fix_infinite_recursion.md
@@ -1,0 +1,2 @@
+ ### WML Engine
+   * Fix infinite recursion issue what can happen in weapon specials.

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -405,7 +405,7 @@
 # Actions:
 # Define events filtering based on weapon specials.
 # Give Bob a poison special iff the opponent has a specific drain special.
-# Give Alice a drain special iff she has a blade attack.
+# Give Alice a drain special  iff the opponent has a specific poison special or blade attack.
 # Have side 1's unit attack side 2's unit.
 # Have side 2's unit attack side 1's unit.
 ##
@@ -446,6 +446,136 @@
 )}
 
 #undef SPECIAL_CONDITION
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define specials filtering based on weapon specials.
+# Give Bob a poison special iff own a same special active or a blade or pierce attack.
+# Give Alice a drain special iff own a same special active or a blade or pierce attack.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that should trigger for Bob do trigger because special don't check itself.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_student_weapon_condition (
+    [event]
+        name=turn 1
+        # Make sure the attacks hit
+        {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 100 ()}
+        {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 100 ()}
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [poison]
+                        id=ability_poison_blade
+                        [filter_student]
+                            [filter_weapon]
+                                special_id_active=ability_poison_blade
+                                [or]
+                                    type=blade,pierce
+                                [/or]
+                            [/filter_weapon]
+                        [/filter_student]
+                    [/poison]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [drains]
+                        id=ability_drain_blade
+                        [filter_student]
+                            [filter_weapon]
+                                special_id_active=ability_drain_blade
+                                [or]
+                                    type=blade,pierce
+                                [/or]
+                            [/filter_weapon]
+                        [/filter_student]
+                    [/drains]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+        {VARIABLE triggers_on_attack 0}
+        {VARIABLE triggers_on_defense 0}
+        [do_command]
+            [move]
+                x=7,13
+                y=3,4
+            [/move]
+            [attack]
+                [source]
+                    x,y=13,4
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn
+        [do_command]
+            [attack]
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=13,4
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            special_id_active=ability_poison_blade
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 2})}
+        {VARIABLE_OP triggers_on_attack add 1}
+    [/event]
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_second_attack]
+            special_id_active=ability_poison_blade
+        [/filter_second_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers_on_defense add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_defense equals 1})}
+        {SUCCEED}
+    [/event]
+)}
 
 #####
 # API(s) being tested: [event][filter_attack],[event][filter_second_attack]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -294,20 +294,7 @@
     [/event]
 )}
 
-#####
-# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
-##
-# Actions:
-# Define events filtering based on weapon specials.
-# Give Bob a poison special iff the opponent has a specific drain special.
-# Give Alice a drain special iff the opponent has a specific poison special.
-# Have side 1's unit attack side 2's unit.
-# Have side 2's unit attack side 1's unit.
-##
-# Expected end state:
-# Both events that should trigger for Bob do trigger.
-#####
-{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition (
+#define SPECIAL_CONDITION FILTER
     [event]
         name=turn 1
         # Make sure the attacks hit
@@ -339,11 +326,11 @@
                 [abilities]
                     [drains]
                         id=ability_drain_blade
-                        [filter_student]
+                        [filter_opponent]
                             [filter_weapon]
-                                type=blade
+                                {FILTER}
                             [/filter_weapon]
-                        [/filter_student]
+                        [/filter_opponent]
                     [/drains]
                 [/abilities]
             [/effect]
@@ -360,6 +347,8 @@
             [/status]
         [/modify_unit]
         {VARIABLE triggers 0}
+        {VARIABLE triggers_on_attack 0}
+        {VARIABLE triggers_on_defense 0}
         [do_command]
             [move]
                 x=7,13
@@ -408,6 +397,23 @@
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {VARIABLE_OP triggers_on_defense add 1}
     [/event]
+#enddef
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define events filtering based on weapon specials.
+# Give Bob a poison special iff the opponent has a specific drain special.
+# Give Alice a drain special iff she has a blade attack.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that should trigger for Bob do trigger.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition (
+    {SPECIAL_CONDITION (type=blade)}
     [event]
         name=turn 2
         {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 1})}
@@ -415,6 +421,31 @@
         {SUCCEED}
     [/event]
 )}
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define events filtering based on absence of weapon specials.
+# Give Bob a poison special iff the opponent has a specific drain special.
+# Give Alice a drain special iff the opponent has a specific poison special.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that trigger because both special need of other for activate and cause infinite recursion, the specials remains then inactive in that case.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition_no_triggered (
+    {SPECIAL_CONDITION (special_id_active=ability_poison_blade)}
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 0})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_defense equals 0})}
+        {SUCCEED}
+    [/event]
+)}
+
+#undef SPECIAL_CONDITION
 
 #####
 # API(s) being tested: [event][filter_attack],[event][filter_second_attack]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_branching.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_branching.cfg
@@ -1,0 +1,127 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_type_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain (10x1 melee attack)
+# Give Alice's weapon specialN and specialM.
+# Give Bob's weapon specialX, specialY, specialX2 and specialY2.
+# specialN (damage) is active if a poison special (specialX or specialX2) is active
+# specialX (poison) is active if a slow special (specialM) is active
+# specialM (slow) is active if a parry special (specialY, specialY2) is active
+# specialY (parry) is active if a damge special (specialN) is active
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "four_cycle_recursion_branching" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=poison
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                    [slow]
+                        id=specialM
+                        name= _ "specialM"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=parry
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/slow]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=damage
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY
+                        name= _ "specialY"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=slow
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                    [poison]
+                        id=specialX2
+                        name= _ "specialX2"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=damage
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY2
+                        name= _ "specialY2"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=slow
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_id.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_id.cfg
@@ -1,0 +1,107 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_id_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# Give Alice's weapon specials specialN and specialM.
+# Give Bob's weapon specials specialX and specialY.
+# specialN (damage) is active if specialX is active
+# specialX (poison) is active if specialM is active
+# specialM (slow) is active if specialY is active
+# specialY (parry) is active if specialN is active
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "four_cycle_recursion_by_id" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialX
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                    [slow]
+                        id=specialM
+                        name= _ "specialM"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialY
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/slow]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialM
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY
+                        name= _ "specialY"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialN
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_tagname.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_tagname.cfg
@@ -1,0 +1,108 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_type_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain (10x1 melee attack)
+# Give Alice's weapon specialN and specialM.
+# Give Bob's weapon specialX, specialY, specialX2 and specialY2.
+# specialN (damage) is active if a poison special (specialX) is active
+# specialX (poison) is active if a slow special (specialM) is active
+# specialM (slow) is active if a parry special (specialY) is active
+# specialY (parry) is active if a damge special (specialN) is active
+# specialX2 and specialY2 have the same filters as specialX and specialY
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "four_cycle_recursion_by_tagname" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=poison
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                    [slow]
+                        id=specialM
+                        name= _ "specialM"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=parry
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/slow]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=damage
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY
+                        name= _ "specialY"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=slow
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/opponent_weapon_has_no_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/opponent_weapon_has_no_special.cfg
@@ -89,3 +89,89 @@
         {SUCCEED}
     [/event]
 )}
+
+#####
+# API(s) being tested: [attacks][filter_opponent][filter_weapon][not]special_id_active=
+##
+# Actions:
+# Give bob an attacks ability which is active when the opponent don't has an ability with a specific id.
+# remove all attack to alice.
+# Have bob and alice fight.
+##
+# Expected end state:
+# bob's ability does activate, leaving him with 3 strikes.
+#####
+{GENERIC_UNIT_TEST "opponent_weapon_has_no_weapon" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [attacks]
+                        value=3
+                        [filter_opponent]
+                            race=elf
+                            [filter_weapon]
+                                [not]
+                                    special_id_active=test_cth
+                                [/not]
+                            [/filter_weapon]
+                        [/filter_opponent]
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=remove_attacks
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [do_command]
+            [move]
+                x=7,12
+                y=3,3
+            [/move]
+        [/do_command]
+
+        [do_command]
+            [attack]
+                weapon=0
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=12,3
+                [/destination]
+            [/attack]
+        [/do_command]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=elf
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL elf.hitpoints equals 26})}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -202,6 +202,8 @@
     {DAMAGE_TYPE_TEST {FILTER_TYPE_BLADE}}
 )}
 
+#undef FILTER_TYPE_BLADE
+
 #####
 # API(s) being tested: [damage]alternative_type=
 ##
@@ -216,16 +218,10 @@
 # Expected end state:
 # Alice attack with blade and Bob use cold.
 #####
-{GENERIC_UNIT_TEST "damage_secondary_type_test" (
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_test" (
     [event]
         name=start
-        [modify_unit]
-            [filter]
-            [/filter]
-            max_hitpoints=100
-            hitpoints=100
-            attacks_left=1
-        [/modify_unit]
+
         [object]
             silent=yes
             [effect]
@@ -240,27 +236,19 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=pierce
                     [/damage_type]
                     [damage_type]
                         alternative_type=cold
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
                 id=bob
             [/filter]
         [/object]
+
         [object]
             silent=yes
             [effect]
@@ -276,18 +264,9 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=fire
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
@@ -295,60 +274,90 @@
             [/filter]
         [/object]
 
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-            kill=yes
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        [unstore_unit]
-            variable=a
-            find_vacant=yes
-            x,y=$b.x,$b.y
-        [/unstore_unit]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x,y=$a.x,$a.y
-                [/source]
-                [destination]
-                    x,y=$b.x,$b.y
-                [/destination]
-            [/attack]
-        [/do_command]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        #damage without modification are 12, if test fail hitpoints !=76
-        #if succed then damage by alice 24(bob more vulnerable to blade)
-        #if succed then damage by bob 24(alice vulnerable to cold, cold [damage] is used)
-        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 76})}
-        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 76})}
+        # damage without modification is 100
+        # expected damage by alice is 200 (bob is vulnerable to blade, so the alternative isn't used)
+        # expected damage by bob is 200 (alice is most vulnerable to cold, so that alternative is used)
+        {ATTACK_AND_VALIDATE 200}
         {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [filter_self][has_attack]type= in [damage_type]
+##
+# Actions:
+# Give Alice an ability that replace all damage by arcane if Alice has a blade attack
+# Define events that use filter_attack matching Alice's arcane type.
+# Have Alice attack Bob during side 1's turn
+# Have Bob attack Alice during side 2's turn
+##
+# Expected end state:
+# The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (
+    [event]
+        name=start
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage_type]
+                        id=test_arcane_damage
+                        replacement_type=arcane
+                        [filter_student]
+                            [has_attack]
+                                type=blade
+                            [/has_attack]
+                        [/filter_student]
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=alice
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            type=arcane
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 )}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1338,6 +1338,73 @@ namespace { // Helpers for attack_type::special_active()
 		return false;
 	}
 
+	//return false if an attribute detected inside filter.
+	static bool matches_simple_filter_without_weapon(const config & filter)
+	{
+		if(filter.has_attribute("range"))
+			return false;
+		if(filter.has_attribute("damage"))
+			return false;
+		if(filter.has_attribute("number"))
+			return false;
+		if(filter.has_attribute("accuracy"))
+			return false;
+		if(filter.has_attribute("parry"))
+			return false;
+		if(filter.has_attribute("movement_used"))
+			return false;
+		if(filter.has_attribute("attacks_used"))
+			return false;
+		if(filter.has_attribute("name"))
+			return false;
+		if(filter.has_attribute("special"))
+			return false;
+		if(filter.has_attribute("special_id"))
+			return false;
+		if(filter.has_attribute("special_type"))
+			return false;
+		if(filter.has_attribute("special_active"))
+			return false;
+		if(filter.has_attribute("special_id_active"))
+			return false;
+		if(filter.has_attribute("special_type_active"))
+			return false;
+		if(filter.has_attribute("formula"))
+			return false;
+		if(filter.has_attribute("type"))
+			return false;
+
+		// Passed all tests.
+		return true;
+	}
+
+	/**
+	 * Returns whether or not if @a filter empty or not.
+	 */
+	bool matches_filter_without_weapon(const config& filter)
+	{
+		// Handle the basic filter.
+		bool matches = matches_simple_filter_without_weapon(filter);
+
+		// Handle [and], [or], and [not] with in-order precedence
+		for (const config::any_child condition : filter.all_children_range() )
+		{
+			// Handle [and]
+			if ( condition.key == "and" )
+				matches = matches && matches_filter_without_weapon(condition.cfg);
+
+			// Handle [or]
+			else if ( condition.key == "or" )
+				matches = matches || matches_filter_without_weapon(condition.cfg);
+
+			// Handle [not]
+			else if ( condition.key == "not" )
+				matches = matches && !matches_filter_without_weapon(condition.cfg);
+		}
+
+		return matches;
+	}
+
 	/**
 	 * Determines if a unit/weapon combination matches the specified child
 	 * (normally a [filter_*] child) of the provided filter.
@@ -1383,8 +1450,10 @@ namespace { // Helpers for attack_type::special_active()
 
 		// Check for a weapon match.
 		if (auto filter_weapon = filter_child->optional_child("filter_weapon") ) {
-			if ( !weapon || !weapon->matches_filter(*filter_weapon, tag_name) )
+			bool matches = weapon ? weapon->matches_filter(*filter_weapon, tag_name) : matches_filter_without_weapon(*filter_weapon);
+			if (!matches){
 				return false;
+			}
 		}
 
 		// Passed.

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1406,6 +1406,17 @@ namespace { // Helpers for attack_type::special_active()
 	}
 
 	/**
+	 * update check_tag_name_ variable if weapon exist.
+	 * @param  weapon      the attack where modification applied
+	 * @param  tag_name  string used for modification
+	 */
+	void update_tag_name_variable(const_attack_ptr& weapon, const std::string& tag_name)
+	{
+		if(weapon){
+			weapon->update_check_tag_name(tag_name);
+		}
+	}
+	/**
 	 * Determines if a unit/weapon combination matches the specified child
 	 * (normally a [filter_*] child) of the provided filter.
 	 * @param[in]  u           A unit to filter.
@@ -1420,7 +1431,7 @@ namespace { // Helpers for attack_type::special_active()
 	static bool special_unit_matches(unit_const_ptr & u,
 		                             unit_const_ptr & u2,
 		                             const map_location & loc,
-		                             const_attack_ptr weapon,
+		                             const_attack_ptr& weapon,
 		                             const config & filter,
 									 const bool for_listing,
 		                             const std::string & child_tag, const std::string& tag_name)
@@ -1443,6 +1454,8 @@ namespace { // Helpers for attack_type::special_active()
 			return false;
 		}
 
+		update_tag_name_variable(weapon, tag_name);
+
 		unit_filter ufilt{vconfig(*filter_child)};
 
 		// If the other unit doesn't exist, try matching without it
@@ -1450,18 +1463,25 @@ namespace { // Helpers for attack_type::special_active()
 
 		// Check for a weapon match.
 		if (auto filter_weapon = filter_child->optional_child("filter_weapon") ) {
-			bool matches = weapon ? weapon->matches_filter(*filter_weapon, tag_name) : matches_filter_without_weapon(*filter_weapon);
+			bool matches = weapon ? weapon->matches_filter(*filter_weapon) : matches_filter_without_weapon(*filter_weapon);
 			if (!matches){
+				update_tag_name_variable(weapon, "");
 				return false;
 			}
 		}
 
 		// Passed.
 		// If the other unit doesn't exist, try matching without it
+		bool u_match = false;
 		if (!u2) {
-			return ufilt.matches(*u, loc);
+			u_match = ufilt.matches(*u, loc);
+			//reinitialise check_tag_name before return result of checking
+			update_tag_name_variable(weapon, "");
+			return u_match;
 		}
-		return ufilt.matches(*u, loc, *u2);
+		u_match = ufilt.matches(*u, loc, *u2);
+		update_tag_name_variable(weapon, "");
+		return u_match;
 	}
 
 }//anonymous namespace
@@ -1494,6 +1514,9 @@ unit_ability_list attack_type::get_weapon_ability(const std::string& ability) co
 
 unit_ability_list attack_type::get_specials_and_abilities(const std::string& special) const
 {
+	if(check_tag_name() == special){
+		return {};
+	}
 	// get all weapon specials of the provided type
 	unit_ability_list abil_list = get_specials(special);
 	// append all such weapon specials as abilities as well
@@ -2058,8 +2081,8 @@ bool attack_type::special_active_impl(
 	unit_const_ptr & def = is_attacker ? other : self;
 	const map_location & att_loc   = is_attacker ? self_loc : other_loc;
 	const map_location & def_loc   = is_attacker ? other_loc : self_loc;
-	const_attack_ptr att_weapon = is_attacker ? self_attack : other_attack;
-	const_attack_ptr def_weapon = is_attacker ? other_attack : self_attack;
+	const_attack_ptr& att_weapon = is_attacker ? self_attack : other_attack;
+	const_attack_ptr& def_weapon = is_attacker ? other_attack : self_attack;
 
 	// Filter firststrike here, if both units have first strike then the effects cancel out. Only check
 	// the opponent if "whom" is the defender, otherwise this leads to infinite recursion.
@@ -2087,7 +2110,6 @@ bool attack_type::special_active_impl(
 	}
 	const config& special_backstab = special["backstab"].to_bool() ? cfg : special;
 
-	// Filter the units involved.
 	//If filter concerns the unit on which special is applied,
 	//then the type of special must be entered to avoid calling
 	//the function of this special in matches_filter()

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -2022,16 +2022,19 @@ bool attack_type::special_active_impl(
 	//If filter concerns the unit on which special is applied,
 	//then the type of special must be entered to avoid calling
 	//the function of this special in matches_filter()
-	std::string self_tag_name = whom_is_self ? tag_name : "";
+	bool applied_both = special["apply_to"] == "both";
+	std::string self_tag_name = (applied_both || whom_is_self) ? tag_name : "";
 	if (!special_unit_matches(self, other, self_loc, self_attack, special, is_for_listing, filter_self, self_tag_name))
 		return false;
-	std::string opp_tag_name = !whom_is_self ? tag_name : "";
+	std::string opp_tag_name = (applied_both || !whom_is_self) ? tag_name : "";
 	if (!special_unit_matches(other, self, other_loc, other_attack, special_backstab, is_for_listing, "filter_opponent", opp_tag_name))
 		return false;
-	std::string att_tag_name = is_attacker ? tag_name : "";
+	bool applied_to_attacker = applied_both || (whom_is_self && is_attacker) || (!whom_is_self && !is_attacker);
+	std::string att_tag_name = applied_to_attacker ? tag_name : "";
 	if (!special_unit_matches(att, def, att_loc, att_weapon, special, is_for_listing, "filter_attacker", att_tag_name))
 		return false;
-	std::string def_tag_name = !is_attacker ? tag_name : "";
+	bool applied_to_defender = applied_both || (whom_is_self && !is_attacker) || (!whom_is_self && is_attacker);
+	std::string def_tag_name = applied_to_defender ? tag_name : "";
 	if (!special_unit_matches(def, att, def_loc, def_weapon, special, is_for_listing, "filter_defender", def_tag_name))
 		return false;
 

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -111,11 +111,24 @@ namespace { // Helpers for attack_type::matches_filter()
 		const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
 		const std::string filter_formula = filter["formula"];
 
-
 		if (!filter_type.empty()){
-			std::pair<std::string, std::string> damage_type = attack.damage_type();
-			if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
-				return false;
+			if(attack.check_tag_name() == "damage_type"){
+				if((attack.check_cfg()).has_attribute("replacement_type")){
+					if (filter_type.count(attack.type()) == 0){
+						return false;
+					}
+				}
+				else if((attack.check_cfg()).has_attribute("alternative_type")){
+					std::pair<std::string, std::string> damage_type = attack.damage_type();
+					if (filter_type.count(damage_type.first) == 0){
+						return false;
+					}
+				}
+			} else {
+				std::pair<std::string, std::string> damage_type = attack.damage_type();
+				if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
+					return false;
+				}
 			}
 		}
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -137,7 +137,7 @@ public:
 
 	// In unit_types.cpp:
 
-	bool matches_filter(const config& filter, const std::string& tag_name = "") const;
+	bool matches_filter(const config& filter) const;
 	bool apply_modification(const config& cfg);
 	bool describe_modification(const config& cfg,std::string* description);
 
@@ -150,6 +150,50 @@ public:
 	inline config to_config() const { config c; write(c); return c; }
 
 	void add_formula_context(wfl::map_formula_callable&) const;
+
+	//used in self infinite recursion case for prevent crash.
+	const std::string& check_tag_name() const {return check_tag_name_;}
+	//used for reinitialise variable of recursion after each cheking.
+	void update_check_tag_name(const std::string& tag_name = "") const {check_tag_name_ = tag_name;}
+	/**
+	 * Helper similar to std::unique_lock for detecting when calculations such as has_special
+	 * have entered infinite recursion.
+	 */
+	class recursion_guard {
+		friend class attack_type;
+		/**
+		 * Only expected to be called in update_variables_recursion(), which handles some of the checks.
+		 */
+		explicit recursion_guard(const attack_type& weapon);
+	public:
+		/**
+		 * Construct an empty instance, only useful for extending the lifetime of a
+		 * recursion_guard returned from weapon.update_variables_recursion() by
+		 * std::moving it to an instance declared in a larger scope.
+		 */
+		explicit recursion_guard();
+
+		/**
+		 * Returns true if the .
+		 */
+		operator bool() const;
+
+		recursion_guard(recursion_guard&& other);
+		recursion_guard(const recursion_guard& other) = delete;
+		recursion_guard& operator=(recursion_guard&&);
+		recursion_guard& operator=(const recursion_guard&) = delete;
+		~recursion_guard();
+	private:
+		std::shared_ptr<const attack_type> parent;
+	};
+
+	/**
+	 * Tests which might otherwise cause infinite recursion should call this, check that the
+	 * returned object evaluates to true, and then keep the object returned as long as the
+	 * recursion might occur, similar to a reentrant mutex that's limited to a small number of
+	 * reentrances.
+	 */
+	recursion_guard update_variables_recursion() const;
 private:
 	// In unit_abilities.cpp:
 
@@ -365,6 +409,11 @@ private:
 	int parry_;
 	config specials_;
 	bool changed_;
+	mutable std::string check_tag_name_ = "";
+	/** Number of instances of recursion_guard that are currently allocated permission to recurse */
+	mutable unsigned int num_recursion_ = 0;
+	/** Value of num_recursion_ at which allocations of further recursion_guards fail */
+	static constexpr unsigned int RECURSION_LIMIT = 4;
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -153,8 +153,12 @@ public:
 
 	//used in self infinite recursion case for prevent crash.
 	const std::string& check_tag_name() const {return check_tag_name_;}
-	//used for reinitialise variable of recursion after each cheking.
+	//used for update variable of recursion after each checking.
 	void update_check_tag_name(const std::string& tag_name = "") const {check_tag_name_ = tag_name;}
+	//used in for prevent recursion by autochecking of weapon special
+	const config& check_cfg() const {return check_cfg_;}
+	//used for update variable of recursion after each checking.
+	void update_check_cfg(const config& cfg) const {check_cfg_ = cfg;}
 	/**
 	 * Helper similar to std::unique_lock for detecting when calculations such as has_special
 	 * have entered infinite recursion.
@@ -410,6 +414,8 @@ private:
 	config specials_;
 	bool changed_;
 	mutable std::string check_tag_name_ = "";
+	/** mutable config used for prevent weapon special to check itself.*/
+	mutable config check_cfg_;
 	/** Number of instances of recursion_guard that are currently allocated permission to recurse */
 	mutable unsigned int num_recursion_ = 0;
 	/** Value of num_recursion_ at which allocations of further recursion_guards fail */

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -389,6 +389,7 @@
 0 leadership_when_other_has_no_special
 0 effect_increase_attacks
 0 opponent_weapon_has_no_special
+0 opponent_weapon_has_no_weapon
 0 opponent_weapon_has_special
 0 plague_without_priority
 0 student_teacher_are_same

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -166,6 +166,7 @@
 0 event_test_filter_attack_specials
 0 event_test_filter_attack_on_moveto
 0 event_test_filter_attack_opponent_weapon_condition
+0 event_test_filter_attack_opponent_weapon_condition_no_triggered
 0 event_test_filter_wfl
 0 event_test_filter_wfl2
 0 event_test_filter_lua_serializable
@@ -375,6 +376,7 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+0 event_test_filter_damage_type_recursion
 0 negative_resistance_with_two_attack_types
 0 positive_resistance_with_two_attack_types
 0 taught_resistance_with_two_attack_types

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -378,6 +378,9 @@
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
 0 event_test_filter_damage_type_recursion
+0 four_cycle_recursion_branching
+0 four_cycle_recursion_by_id
+0 four_cycle_recursion_by_tagname
 0 negative_resistance_with_two_attack_types
 0 positive_resistance_with_two_attack_types
 0 taught_resistance_with_two_attack_types

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -167,6 +167,7 @@
 0 event_test_filter_attack_on_moveto
 0 event_test_filter_attack_opponent_weapon_condition
 0 event_test_filter_attack_opponent_weapon_condition_no_triggered
+0 event_test_filter_attack_student_weapon_condition
 0 event_test_filter_wfl
 0 event_test_filter_wfl2
 0 event_test_filter_lua_serializable


### PR DESCRIPTION
When for example we have [damage_type][filter_self][has_attack|filter_weapon]type=pierce applied to one or any pierce type attack and the unit does not have an unaffected pierce attack, the change in type triggers an infinite recursion.

this PR fixes the problem and other because filter of weapon specials or formula.

Fix https://github.com/wesnoth/wesnoth/issues/8940