### PR TITLE
EI S13: fix gaoler rebuild breaking "free prisoner" events

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
@@ -37,11 +37,13 @@
             [/variable]
             [then]
                 [part]
+                    title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
                     story= _ "As Gweddry, Owaec, and Dacyn fled across the Listra, a frenzy of shouts, screams, and roars broke out from behind. Neither the orcs nor the drakes attempted to give pursuit."
                 [/part]
             [/then]
         [/if]
         [part]
+            title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
             story= _ "Leaving the tumultuous wildlands far behind, the soldiers of Wesnoth prepared to cross the Great River once more and return to their homeland..."
             {EI_BIGMAP}
         [/part]
@@ -846,10 +848,10 @@
         name=die
         [filter]
             id=Gaoler_Dwarves
-            [filter_wml]
-                max_moves=0 # so that these don't trigger after prisoners are executed
-            [/filter_wml]
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker=Urmarol
             #po: "Thank you kindly for freeing us! My runesmithing arts are not meant to be used outside of knalga, but I think now is an exception. I just hope the East Gate didn't fare too bad after I was captured..."
@@ -924,10 +926,10 @@
         name=die
         [filter]
             id=Gaoler_Loyalists
-            [filter_wml]
-                max_moves=0 # so that these don't trigger after prisoners are executed
-            [/filter_wml]
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker=Vinreddoc
             #po: Vinreddoc is a mage, but with random gender
@@ -1007,10 +1009,10 @@
         name=die
         [filter]
             id=Gaoler_Orcs
-            [filter_wml]
-                max_moves=0 # so that these don't trigger after prisoners are executed
-            [/filter_wml]
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker=Ugzush
             #po: he's just been rescued
@@ -1091,10 +1093,10 @@
         name=die
         [filter]
             id=Gaoler_DarkAdept
-            [filter_wml]
-                max_moves=0 # so that these don't trigger after prisoners are executed
-            [/filter_wml]
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker=Syner
             #po: speaking of Gaennell
@@ -1276,10 +1278,10 @@
         name=die
         [filter]
             id=Gaoler_Merfolk
-            [filter_wml]
-                max_moves=0 # so that these don't trigger after prisoners are executed
-            [/filter_wml]
         [/filter]
+        [filter_second]
+            side=1
+        [/filter_second]
         [message]
             speaker=Mame
             message= _ "Thanks stranger! I do not recognize these lands, but I do recognize a kind heart when I meet one. Should I ever find my way home to the coast, I will be sure to tell my kinsmen of your actions here."

--- a/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
@@ -37,13 +37,11 @@
             [/variable]
             [then]
                 [part]
-                    title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
                     story= _ "As Gweddry, Owaec, and Dacyn fled across the Listra, a frenzy of shouts, screams, and roars broke out from behind. Neither the orcs nor the drakes attempted to give pursuit."
                 [/part]
             [/then]
         [/if]
         [part]
-            title= _ "<b><span color='#ff0000'>Part III: Wesnoth at War</span></b>"
             story= _ "Leaving the tumultuous wildlands far behind, the soldiers of Wesnoth prepared to cross the Great River once more and return to their homeland..."
             {EI_BIGMAP}
         [/part]


### PR DESCRIPTION
Formerly, EI S13 uses various Deathblades' max-moves status instead of [filter_second] for some reason. This breaks when deathblades get rebuild, which in the bug report was caused by the sentinel shield.  Use [filter_second] instead.