### PR TITLE
Fix common OOS error #8960

### DIFF
--- a/src/synced_context.cpp
+++ b/src/synced_context.cpp
@@ -222,7 +222,7 @@ bool synced_context::undo_blocked()
 	// if the turn has ended undoing is blocked.
 	return is_simultaneous_
 	    || is_undo_blocked_
-	    || (randomness::generator->get_random_calls() != 0)
+	    || (is_synced() && (randomness::generator->get_random_calls() != 0))
 	    || resources::controller->is_regular_game_end()
 	    || resources::gamedata->end_turn_forced();
 }


### PR DESCRIPTION
Previously `synced_context::undo_blocked()` sometimes returned the worng result, leading to OOS because `synced_context::undo_blocked()` was used to determine whether we can send action to the other clients.

With this patch `synced_context::undo_blocked()` not doesn't always return true  when its called during "local choices".

I am curently not even sure whether that line is needed at all since using the rng should always set is_simultaneous_ to true.