### PR TITLE
Fix game sending actions too soon leading to OOS erros

### DIFF
--- a/src/synced_context.cpp
+++ b/src/synced_context.cpp
@@ -217,7 +217,7 @@ bool synced_context::undo_blocked()
 	// if the game has ended, undoing is blocked.
 	// if the turn has ended undoing is blocked.
 	return is_simultaneous_
-	    || (randomness::generator->get_random_calls() != 0)
+	    || (is_synced() && (randomness::generator->get_random_calls() != 0))
 	    || resources::controller->is_regular_game_end()
 	    || resources::gamedata->end_turn_forced();
 }


### PR DESCRIPTION
Previously undo_blocked() would return false positive results. Leading to OOS erros because the game would then send actions to other clients even though they were still undoable. This would then result in OOS erros when the player attempts to undo the move.

This line is probably not needed at all since using the rng should always set is_simultaneous_ to true, but lets keep the changes minimal for the 1.18 stable branch.