### PR TITLE
 Fix Weapon special filters can be affected by the weapon special leading to infinite recursion[1.18]

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -202,30 +202,26 @@
     {DAMAGE_TYPE_TEST {FILTER_TYPE_BLADE}}
 )}
 
+#undef FILTER_TYPE_BLADE
+
 #####
 # API(s) being tested: [damage]alternative_type=
 ##
 # Actions:
 # Give both Alice and Bob 100% chance to hit.
-# Give Bob one [damage] with alternative_type=cold
+# Give Bob one [damage_type] with alternative_type=cold and another with alternative_type=pierce
 # change resistance Bob to blade to -100% and fire to 0%.
-# Give Alice one [damage] with alternative_type=fire
-# and change resistance to cold to -100% and blade to 0%.
+# Give Alice one [damage_type] with alternative_type=fire
+# and change resistance to cold to -100%, pierce to -50% and blade to 0%.
 # Move Alice next to Bob, and have Alice attack Bob.
 ##
 # Expected end state:
 # Alice attack with blade and Bob use cold.
 #####
-{GENERIC_UNIT_TEST "damage_secondary_type_test" (
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_test" (
     [event]
         name=start
-        [modify_unit]
-            [filter]
-            [/filter]
-            max_hitpoints=100
-            hitpoints=100
-            attacks_left=1
-        [/modify_unit]
+
         [object]
             silent=yes
             [effect]
@@ -240,24 +236,19 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
+                    [damage_type]
+                        alternative_type=pierce
+                    [/damage_type]
                     [damage_type]
                         alternative_type=cold
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
                 id=bob
             [/filter]
         [/object]
+
         [object]
             silent=yes
             [effect]
@@ -265,6 +256,7 @@
                 replace=yes
                 [resistance]
                     cold=200
+                    pierce=150
                     blade=100
                 [/resistance]
             [/effect]
@@ -272,18 +264,9 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=fire
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
@@ -291,60 +274,90 @@
             [/filter]
         [/object]
 
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-            kill=yes
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        [unstore_unit]
-            variable=a
-            find_vacant=yes
-            x,y=$b.x,$b.y
-        [/unstore_unit]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x,y=$a.x,$a.y
-                [/source]
-                [destination]
-                    x,y=$b.x,$b.y
-                [/destination]
-            [/attack]
-        [/do_command]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        #damage without modification are 12, if test fail hitpoints !=76
-        #if succed then damage by alice 24(bob more vulnerable to blade)
-        #if succed then damage by bob 24(alice vulnerable to cold, cold [damage] is used)
-        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 76})}
-        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 76})}
+        # damage without modification is 100
+        # expected damage by alice is 200 (bob is vulnerable to blade, so the alternative isn't used)
+        # expected damage by bob is 200 (alice is most vulnerable to cold, so that alternative is used)
+        {ATTACK_AND_VALIDATE 200}
         {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [filter_self][has_attack]type= in [damage_type]
+##
+# Actions:
+# Give Alice an ability that replace all damage by arcane if Alice has a blade attack
+# Define events that use filter_attack matching Alice's arcane type.
+# Have Alice attack Bob during side 1's turn
+# Have Bob attack Alice during side 2's turn
+##
+# Expected end state:
+# The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (
+    [event]
+        name=start
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage_type]
+                        id=test_arcane_damage
+                        replacement_type=arcane
+                        [filter_student]
+                            [has_attack]
+                                type=blade
+                            [/has_attack]
+                        [/filter_student]
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=alice
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            type=arcane
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 )}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -101,7 +101,7 @@ std::string attack_type::accuracy_parry_description() const
  * Returns whether or not *this matches the given @a filter, ignoring the
  * complexities introduced by [and], [or], and [not].
  */
-static bool matches_simple_filter(const attack_type & attack, const config & filter, const std::string& tag_name)
+static bool matches_simple_filter(const attack_type & attack, const config & filter)
 {
 	const std::set<std::string> filter_range = utils::split_set(filter["range"].str());
 	const std::string& filter_damage = filter["damage"];
@@ -145,17 +145,9 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		return false;
 
 	if (!filter_type.empty()){
-		//if special is type "damage_type" then check attack.type() only for don't have infinite recursion by calling damage_type() below.
-		if(tag_name == "damage_type"){
-			if (filter_type.count(attack.type()) == 0){
-				return false;
-			}
-		} else {
-			//if the type is different from "damage_type" then damage_type() can be called for safe checking.
-			std::pair<std::string, std::string> damage_type = attack.damage_type();
-			if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
-				return false;
-			}
+		std::pair<std::string, std::string> damage_type = attack.damage_type();
+		if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
+			return false;
 		}
 	}
 
@@ -257,25 +249,25 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 /**
  * Returns whether or not *this matches the given @a filter.
  */
-bool attack_type::matches_filter(const config& filter, const std::string& tag_name) const
+bool attack_type::matches_filter(const config& filter) const
 {
 	// Handle the basic filter.
-	bool matches = matches_simple_filter(*this, filter, tag_name);
+	bool matches = matches_simple_filter(*this, filter);
 
 	// Handle [and], [or], and [not] with in-order precedence
 	for (const config::any_child condition : filter.all_children_range() )
 	{
 		// Handle [and]
 		if ( condition.key == "and" )
-			matches = matches && matches_filter(condition.cfg, tag_name);
+			matches = matches && matches_filter(condition.cfg);
 
 		// Handle [or]
 		else if ( condition.key == "or" )
-			matches = matches || matches_filter(condition.cfg, tag_name);
+			matches = matches || matches_filter(condition.cfg);
 
 		// Handle [not]
 		else if ( condition.key == "not" )
-			matches = matches && !matches_filter(condition.cfg, tag_name);
+			matches = matches && !matches_filter(condition.cfg);
 	}
 
 	return matches;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -124,7 +124,7 @@ public:
 
 	// In unit_types.cpp:
 
-	bool matches_filter(const config& filter, const std::string& tag_name = "") const;
+	bool matches_filter(const config& filter) const;
 	bool apply_modification(const config& cfg);
 	bool describe_modification(const config& cfg,std::string* description);
 
@@ -343,6 +343,7 @@ private:
 	int parry_;
 	config specials_;
 	bool changed_;
+	mutable std::set<const config*> num_recursion_ = {};
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -370,6 +370,7 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+0 event_test_filter_damage_type_recursion
 0 damage_secondary_type_with_resistance_ability_test
 0 damage_secondary_type_with_resistance_ability_test_alt
 0 swarms_filter_student_by_type


### PR DESCRIPTION
When for example we have [damage_type][filter_self][has_attack|filter_weapon]type=pierce applied to one or any pierce type attack and the unit does not have an unaffected pierce attack, the change in type triggers an infinite recursion.

this PR fixes the problem and other because filter of weapon specials or formula.

Fix https://github.com/wesnoth/wesnoth/issues/8940