### PR TITLE
Change id tag in appstream manifest to what is expected

### DIFF
--- a/packaging/org.wesnoth.Wesnoth.appdata.xml
+++ b/packaging/org.wesnoth.Wesnoth.appdata.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 The Battle for Wesnoth Project -->
 <component type="desktop">
-  <id>org.wesnoth.Wesnoth.desktop</id>
+  <id>org.wesnoth.Wesnoth</id>
+  <provides>
+    <id>org.wesnoth.Wesnoth.desktop</id>
+  </provides>
+  <replaces>
+    <id>org.wesnoth.Wesnoth.desktop</id>
+  </replaces>
   <launchable type="desktop-id">org.wesnoth.Wesnoth.desktop</launchable>
   <metadata_license>GFDL-1.3</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>


### PR DESCRIPTION
Flathub linter complains about mismatched id in flatpak manifest and
appstream. Based on appstream docs it seems that reverse-DNS name is
expected without .desktop extension so appstream should be changed.
Extra `<provides>` and `<replaces>` tags added as per
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#renaming-id-tag
