### PR TITLE
Fix Weapon special filters can be affected by the weapon special leading to infinite recursion[1.18]

### DIFF
--- a/changelog_entries/fix_infinite_recursion.md
+++ b/changelog_entries/fix_infinite_recursion.md
@@ -1,0 +1,2 @@
+ ### WML Engine
+   * Fix infinite recursion issue what can happen in weapon specials.

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -405,7 +405,7 @@
 # Actions:
 # Define events filtering based on weapon specials.
 # Give Bob a poison special iff the opponent has a specific drain special.
-# Give Alice a drain special iff she has a blade attack.
+# Give Alice a drain special  iff the opponent has a specific poison special or blade attack.
 # Have side 1's unit attack side 2's unit.
 # Have side 2's unit attack side 1's unit.
 ##
@@ -446,6 +446,136 @@
 )}
 
 #undef SPECIAL_CONDITION
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define specials filtering based on weapon specials.
+# Give Bob a poison special iff own a same special active or a blade or pierce attack.
+# Give Alice a drain special iff own a same special active or a blade or pierce attack.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that should trigger for Bob do trigger because special don't check itself.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_student_weapon_condition (
+    [event]
+        name=turn 1
+        # Make sure the attacks hit
+        {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 100 ()}
+        {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 100 ()}
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [poison]
+                        id=ability_poison_blade
+                        [filter_student]
+                            [filter_weapon]
+                                special_id_active=ability_poison_blade
+                                [or]
+                                    type=blade,pierce
+                                [/or]
+                            [/filter_weapon]
+                        [/filter_student]
+                    [/poison]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [drains]
+                        id=ability_drain_blade
+                        [filter_student]
+                            [filter_weapon]
+                                special_id_active=ability_drain_blade
+                                [or]
+                                    type=blade,pierce
+                                [/or]
+                            [/filter_weapon]
+                        [/filter_student]
+                    [/drains]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+        {VARIABLE triggers_on_attack 0}
+        {VARIABLE triggers_on_defense 0}
+        [do_command]
+            [move]
+                x=7,13
+                y=3,4
+            [/move]
+            [attack]
+                [source]
+                    x,y=13,4
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn
+        [do_command]
+            [attack]
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=13,4
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            special_id_active=ability_poison_blade
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 2})}
+        {VARIABLE_OP triggers_on_attack add 1}
+    [/event]
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_second_attack]
+            special_id_active=ability_poison_blade
+        [/filter_second_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers_on_defense add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_defense equals 1})}
+        {SUCCEED}
+    [/event]
+)}
 
 #####
 # API(s) being tested: [event][filter_attack],[event][filter_second_attack]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -294,20 +294,7 @@
     [/event]
 )}
 
-#####
-# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
-##
-# Actions:
-# Define events filtering based on weapon specials.
-# Give Bob a poison special iff the opponent has a specific drain special.
-# Give Alice a drain special iff the opponent has a specific poison special.
-# Have side 1's unit attack side 2's unit.
-# Have side 2's unit attack side 1's unit.
-##
-# Expected end state:
-# Both events that should trigger for Bob do trigger.
-#####
-{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition (
+#define SPECIAL_CONDITION FILTER
     [event]
         name=turn 1
         # Make sure the attacks hit
@@ -339,11 +326,11 @@
                 [abilities]
                     [drains]
                         id=ability_drain_blade
-                        [filter_student]
+                        [filter_opponent]
                             [filter_weapon]
-                                type=blade
+                                {FILTER}
                             [/filter_weapon]
-                        [/filter_student]
+                        [/filter_opponent]
                     [/drains]
                 [/abilities]
             [/effect]
@@ -360,6 +347,8 @@
             [/status]
         [/modify_unit]
         {VARIABLE triggers 0}
+        {VARIABLE triggers_on_attack 0}
+        {VARIABLE triggers_on_defense 0}
         [do_command]
             [move]
                 x=7,13
@@ -408,6 +397,23 @@
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {VARIABLE_OP triggers_on_defense add 1}
     [/event]
+#enddef
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define events filtering based on weapon specials.
+# Give Bob a poison special iff the opponent has a specific drain special.
+# Give Alice a drain special iff she has a blade attack.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that should trigger for Bob do trigger.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition (
+    {SPECIAL_CONDITION (type=blade)}
     [event]
         name=turn 2
         {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 1})}
@@ -415,6 +421,31 @@
         {SUCCEED}
     [/event]
 )}
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define events filtering based on absence of weapon specials.
+# Give Bob a poison special iff the opponent has a specific drain special.
+# Give Alice a drain special iff the opponent has a specific poison special.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that trigger because both special need of other for activate and cause infinite recursion, the specials remains then inactive in that case.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition_no_triggered (
+    {SPECIAL_CONDITION (special_id_active=ability_poison_blade)}
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 0})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_defense equals 0})}
+        {SUCCEED}
+    [/event]
+)}
+
+#undef SPECIAL_CONDITION
 
 #####
 # API(s) being tested: [event][filter_attack],[event][filter_second_attack]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -202,6 +202,8 @@
     {DAMAGE_TYPE_TEST {FILTER_TYPE_BLADE}}
 )}
 
+#undef FILTER_TYPE_BLADE
+
 #####
 # API(s) being tested: [damage]alternative_type=
 ##
@@ -216,16 +218,10 @@
 # Expected end state:
 # Alice attack with blade and Bob use cold.
 #####
-{GENERIC_UNIT_TEST "damage_secondary_type_test" (
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_test" (
     [event]
         name=start
-        [modify_unit]
-            [filter]
-            [/filter]
-            max_hitpoints=100
-            hitpoints=100
-            attacks_left=1
-        [/modify_unit]
+
         [object]
             silent=yes
             [effect]
@@ -240,24 +236,16 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=cold
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
                 id=bob
             [/filter]
         [/object]
+
         [object]
             silent=yes
             [effect]
@@ -272,18 +260,9 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=fire
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
@@ -291,60 +270,90 @@
             [/filter]
         [/object]
 
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-            kill=yes
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        [unstore_unit]
-            variable=a
-            find_vacant=yes
-            x,y=$b.x,$b.y
-        [/unstore_unit]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x,y=$a.x,$a.y
-                [/source]
-                [destination]
-                    x,y=$b.x,$b.y
-                [/destination]
-            [/attack]
-        [/do_command]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        #damage without modification are 12, if test fail hitpoints !=76
-        #if succed then damage by alice 24(bob more vulnerable to blade)
-        #if succed then damage by bob 24(alice vulnerable to cold, cold [damage] is used)
-        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 76})}
-        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 76})}
+        # damage without modification is 100
+        # expected damage by alice is 200 (bob is vulnerable to blade, so the alternative isn't used)
+        # expected damage by bob is 200 (alice is most vulnerable to cold, so that alternative is used)
+        {ATTACK_AND_VALIDATE 200}
         {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [filter_self][has_attack]type= in [damage_type]
+##
+# Actions:
+# Give Alice an ability that replace all damage by arcane if Alice has a blade attack
+# Define events that use filter_attack matching Alice's arcane type.
+# Have Alice attack Bob during side 1's turn
+# Have Bob attack Alice during side 2's turn
+##
+# Expected end state:
+# The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (
+    [event]
+        name=start
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage_type]
+                        id=test_arcane_damage
+                        replacement_type=arcane
+                        [filter_student]
+                            [has_attack]
+                                type=blade
+                            [/has_attack]
+                        [/filter_student]
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=alice
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            type=arcane
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 )}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1822,16 +1822,19 @@ bool attack_type::special_active_impl(
 	//If filter concerns the unit on which special is applied,
 	//then the type of special must be entered to avoid calling
 	//the function of this special in matches_filter()
-	std::string self_tag_name = whom_is_self ? tag_name : "";
+	bool applied_both = special["apply_to"] == "both";
+	std::string self_tag_name = (applied_both || whom_is_self) ? tag_name : "";
 	if (!special_unit_matches(self, other, self_loc, self_attack, special, is_for_listing, filter_self, self_tag_name))
 		return false;
-	std::string opp_tag_name = !whom_is_self ? tag_name : "";
+	std::string opp_tag_name = (applied_both || !whom_is_self) ? tag_name : "";
 	if (!special_unit_matches(other, self, other_loc, other_attack, special_backstab, is_for_listing, "filter_opponent", opp_tag_name))
 		return false;
-	std::string att_tag_name = is_attacker ? tag_name : "";
+	bool applied_to_attacker = applied_both || (whom_is_self && is_attacker) || (!whom_is_self && !is_attacker);
+	std::string att_tag_name = applied_to_attacker ? tag_name : "";
 	if (!special_unit_matches(att, def, att_loc, att_weapon, special, is_for_listing, "filter_attacker", att_tag_name))
 		return false;
-	std::string def_tag_name = !is_attacker ? tag_name : "";
+	bool applied_to_defender = applied_both || (whom_is_self && !is_attacker) || (!whom_is_self && is_attacker);
+	std::string def_tag_name = applied_to_defender ? tag_name : "";
 	if (!special_unit_matches(def, att, def_loc, def_weapon, special, is_for_listing, "filter_defender", def_tag_name))
 		return false;
 

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -97,185 +97,196 @@ std::string attack_type::accuracy_parry_description() const
 	return s.str();
 }
 
-/**
- * Returns whether or not *this matches the given @a filter, ignoring the
- * complexities introduced by [and], [or], and [not].
- */
-static bool matches_simple_filter(const attack_type & attack, const config & filter, const std::string& tag_name)
-{
-	const std::set<std::string> filter_range = utils::split_set(filter["range"].str());
-	const std::string& filter_damage = filter["damage"];
-	const std::string& filter_attacks = filter["number"];
-	const std::string& filter_accuracy = filter["accuracy"];
-	const std::string& filter_parry = filter["parry"];
-	const std::string& filter_movement = filter["movement_used"];
-	const std::string& filter_attacks_used = filter["attacks_used"];
-	const std::set<std::string> filter_name = utils::split_set(filter["name"].str());
-	const std::set<std::string> filter_type = utils::split_set(filter["type"].str());
-	const std::vector<std::string> filter_special = utils::split(filter["special"]);
-	const std::vector<std::string> filter_special_id = utils::split(filter["special_id"]);
-	const std::vector<std::string> filter_special_type = utils::split(filter["special_type"]);
-	const std::vector<std::string> filter_special_active = utils::split(filter["special_active"]);
-	const std::vector<std::string> filter_special_id_active = utils::split(filter["special_id_active"]);
-	const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
-	const std::string filter_formula = filter["formula"];
+namespace { // Helpers for attack_type::matches_filter()
+	bool matches_simple_filter_with_possible_infinite_recursion(const attack_type & attack, const config & filter)
+	{
+		//update and check variable_recursion for prevent check special_id/type_active in case of infinite recursion.
+		attack_type::recursion_guard filter_lock;
+		filter_lock = attack.update_variables_recursion();
+		if(!filter_lock) {
+			return false;
+		}
+		const std::set<std::string> filter_type = utils::split_set(filter["type"].str());
+		const std::vector<std::string> filter_special_active = utils::split(filter["special_active"]);
+		const std::vector<std::string> filter_special_id_active = utils::split(filter["special_id_active"]);
+		const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
+		const std::string filter_formula = filter["formula"];
 
-	if ( !filter_range.empty() && filter_range.count(attack.range()) == 0 )
-		return false;
 
-	if ( !filter_damage.empty() && !in_ranges(attack.damage(), utils::parse_ranges_unsigned(filter_damage)) )
-		return false;
-
-	if (!filter_attacks.empty() && !in_ranges(attack.num_attacks(), utils::parse_ranges_unsigned(filter_attacks)))
-		return false;
-
-	if (!filter_accuracy.empty() && !in_ranges(attack.accuracy(), utils::parse_ranges_int(filter_accuracy)))
-		return false;
-
-	if (!filter_parry.empty() && !in_ranges(attack.parry(), utils::parse_ranges_int(filter_parry)))
-		return false;
-
-	if (!filter_movement.empty() && !in_ranges(attack.movement_used(), utils::parse_ranges_unsigned(filter_movement)))
-		return false;
-
-	if (!filter_attacks_used.empty() && !in_ranges(attack.attacks_used(), utils::parse_ranges_unsigned(filter_attacks_used)))
-		return false;
-
-	if ( !filter_name.empty() && filter_name.count(attack.id()) == 0)
-		return false;
-
-	if (!filter_type.empty()){
-		//if special is type "damage_type" then check attack.type() only for don't have infinite recursion by calling damage_type() below.
-		if(tag_name == "damage_type"){
-			if (filter_type.count(attack.type()) == 0){
-				return false;
-			}
-		} else {
-			//if the type is different from "damage_type" then damage_type() can be called for safe checking.
+		if (!filter_type.empty()){
 			std::pair<std::string, std::string> damage_type = attack.damage_type();
 			if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
 				return false;
 			}
 		}
-	}
 
-	if(!filter_special.empty()) {
-		deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
-		bool found = false;
-		for(auto& special : filter_special) {
-			if(attack.has_special(special, true)) {
-				found = true;
-				break;
+		if(!filter_special_active.empty()) {
+			deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
+			bool found = false;
+			for(auto& special : filter_special_active) {
+				if(attack.has_special(special, false)) {
+					found = true;
+					break;
+				}
 			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-	if(!filter_special_id.empty()) {
-		bool found = false;
-		for(auto& special : filter_special_id) {
-			if(attack.has_special(special, true, true, false)) {
-				found = true;
-				break;
-			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-
-	if(!filter_special_active.empty()) {
-		deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
-		bool found = false;
-		for(auto& special : filter_special_active) {
-			if(attack.has_special(special, false)) {
-				found = true;
-				break;
-			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-	if(!filter_special_id_active.empty()) {
-		bool found = false;
-		for(auto& special : filter_special_id_active) {
-			if(attack.has_special_or_ability(special, true, false)) {
-				found = true;
-				break;
-			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-	if(!filter_special_type.empty()) {
-		bool found = false;
-		for(auto& special : filter_special_type) {
-			if(attack.has_special(special, true, false)) {
-				found = true;
-				break;
-			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-	if(!filter_special_type_active.empty()) {
-		bool found = false;
-		for(auto& special : filter_special_type_active) {
-			if(attack.has_special_or_ability(special, false)) {
-				found = true;
-				break;
-			}
-		}
-		if(!found) {
-			return false;
-		}
-	}
-
-	if (!filter_formula.empty()) {
-		try {
-			const wfl::attack_type_callable callable(attack);
-			const wfl::formula form(filter_formula, new wfl::gamestate_function_symbol_table);
-			if(!form.evaluate(callable).as_bool()) {
+			if(!found) {
 				return false;
 			}
-		} catch(const wfl::formula_error& e) {
-			lg::log_to_chat() << "Formula error in weapon filter: " << e.type << " at " << e.filename << ':' << e.line << ")\n";
-			ERR_WML << "Formula error in weapon filter: " << e.type << " at " << e.filename << ':' << e.line << ")";
-			// Formulae with syntax errors match nothing
-			return false;
 		}
+		if(!filter_special_id_active.empty()) {
+			bool found = false;
+			for(auto& special : filter_special_id_active) {
+				if(attack.has_special_or_ability(special, true, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(!found) {
+				return false;
+			}
+		}
+		if(!filter_special_type_active.empty()) {
+			bool found = false;
+			for(auto& special : filter_special_type_active) {
+				if(attack.has_special_or_ability(special, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(!found) {
+				return false;
+			}
+		}
+
+		if (!filter_formula.empty()) {
+			try {
+				const wfl::attack_type_callable callable(attack);
+				const wfl::formula form(filter_formula, new wfl::gamestate_function_symbol_table);
+				if(!form.evaluate(callable).as_bool()) {
+					return false;
+				}
+			} catch(const wfl::formula_error& e) {
+				lg::log_to_chat() << "Formula error in weapon filter: " << e.type << " at " << e.filename << ':' << e.line << ")\n";
+				ERR_WML << "Formula error in weapon filter: " << e.type << " at " << e.filename << ':' << e.line << ")";
+				// Formulae with syntax errors match nothing
+				return false;
+			}
+		}
+
+		// Passed all tests.
+		return true;
 	}
 
-	// Passed all tests.
-	return true;
+	/**
+	 * Returns whether or not *this matches the given @a filter, ignoring the
+	 * complexities introduced by [and], [or], and [not].
+	 */
+	static bool matches_simple_filter(const attack_type & attack, const config & filter)
+	{
+		const std::set<std::string> filter_range = utils::split_set(filter["range"].str());
+		const std::string& filter_damage = filter["damage"];
+		const std::string& filter_attacks = filter["number"];
+		const std::string& filter_accuracy = filter["accuracy"];
+		const std::string& filter_parry = filter["parry"];
+		const std::string& filter_movement = filter["movement_used"];
+		const std::string& filter_attacks_used = filter["attacks_used"];
+		const std::set<std::string> filter_name = utils::split_set(filter["name"].str());
+		const std::vector<std::string> filter_special = utils::split(filter["special"]);
+		const std::vector<std::string> filter_special_id = utils::split(filter["special_id"]);
+		const std::vector<std::string> filter_special_type = utils::split(filter["special_type"]);
+
+		if ( !filter_range.empty() && filter_range.count(attack.range()) == 0 )
+			return false;
+
+		if ( !filter_damage.empty() && !in_ranges(attack.damage(), utils::parse_ranges_unsigned(filter_damage)) )
+			return false;
+
+		if (!filter_attacks.empty() && !in_ranges(attack.num_attacks(), utils::parse_ranges_unsigned(filter_attacks)))
+			return false;
+
+		if (!filter_accuracy.empty() && !in_ranges(attack.accuracy(), utils::parse_ranges_int(filter_accuracy)))
+			return false;
+
+		if (!filter_parry.empty() && !in_ranges(attack.parry(), utils::parse_ranges_int(filter_parry)))
+			return false;
+
+		if (!filter_movement.empty() && !in_ranges(attack.movement_used(), utils::parse_ranges_unsigned(filter_movement)))
+			return false;
+
+		if (!filter_attacks_used.empty() && !in_ranges(attack.attacks_used(), utils::parse_ranges_unsigned(filter_attacks_used)))
+			return false;
+
+		if ( !filter_name.empty() && filter_name.count(attack.id()) == 0)
+			return false;
+
+		if(!filter_special.empty()) {
+			deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
+			bool found = false;
+			for(auto& special : filter_special) {
+				if(attack.has_special(special, true)) {
+					found = true;
+					break;
+				}
+			}
+			if(!found) {
+				return false;
+			}
+		}
+		if(!filter_special_id.empty()) {
+			bool found = false;
+			for(auto& special : filter_special_id) {
+				if(attack.has_special(special, true, true, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(!found) {
+				return false;
+			}
+		}
+		if(!filter_special_type.empty()) {
+			bool found = false;
+			for(auto& special : filter_special_type) {
+				if(attack.has_special(special, true, false)) {
+					found = true;
+					break;
+				}
+			}
+			if(!found) {
+				return false;
+			}
+		}
+
+		if(!matches_simple_filter_with_possible_infinite_recursion(attack, filter))
+			return false;
+
+		// Passed all tests.
+		return true;
+	}
 }
 
 /**
  * Returns whether or not *this matches the given @a filter.
  */
-bool attack_type::matches_filter(const config& filter, const std::string& tag_name) const
+bool attack_type::matches_filter(const config& filter) const
 {
 	// Handle the basic filter.
-	bool matches = matches_simple_filter(*this, filter, tag_name);
+	bool matches = matches_simple_filter(*this, filter);
 
 	// Handle [and], [or], and [not] with in-order precedence
 	for (const config::any_child condition : filter.all_children_range() )
 	{
 		// Handle [and]
 		if ( condition.key == "and" )
-			matches = matches && matches_filter(condition.cfg, tag_name);
+			matches = matches && matches_filter(condition.cfg);
 
 		// Handle [or]
 		else if ( condition.key == "or" )
-			matches = matches || matches_filter(condition.cfg, tag_name);
+			matches = matches || matches_filter(condition.cfg);
 
 		// Handle [not]
 		else if ( condition.key == "not" )
-			matches = matches && !matches_filter(condition.cfg, tag_name);
+			matches = matches && !matches_filter(condition.cfg);
 	}
 
 	return matches;
@@ -571,6 +582,51 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 	}
 
 	return true;
+}
+
+attack_type::recursion_guard attack_type::update_variables_recursion() const
+{
+	// this shouldn't be const, but replacing the const-and-mutable mess in attack_type is a big task
+	if(num_recursion_ < RECURSION_LIMIT) {
+		return recursion_guard(*this);
+	}
+	return recursion_guard();
+}
+
+attack_type::recursion_guard::recursion_guard() = default;
+
+attack_type::recursion_guard::recursion_guard(const attack_type& weapon)
+	: parent(weapon.shared_from_this())
+{
+	weapon.num_recursion_++;
+}
+
+attack_type::recursion_guard::recursion_guard(attack_type::recursion_guard&& other)
+{
+	std::swap(parent, other.parent);
+}
+
+attack_type::recursion_guard::operator bool() const {
+	return bool(parent);
+}
+
+attack_type::recursion_guard& attack_type::recursion_guard::operator=(attack_type::recursion_guard&& other)
+{
+	// This is only intended to move ownership to a longer-living variable. Assigning to an instance that
+	// already has a parent implies that the caller is going to recurse and needs a recursion allocation,
+	// but is accidentally dropping one of the allocations that it already has; hence the asserts.
+	assert(this != &other);
+	assert(!parent);
+	std::swap(parent, other.parent);
+	return *this;
+}
+
+attack_type::recursion_guard::~recursion_guard()
+{
+	if(parent) {
+		assert(parent->num_recursion_ > 0);
+		parent->num_recursion_--;
+	}
 }
 
 void attack_type::write(config& cfg) const

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -112,11 +112,24 @@ namespace { // Helpers for attack_type::matches_filter()
 		const std::vector<std::string> filter_special_type_active = utils::split(filter["special_type_active"]);
 		const std::string filter_formula = filter["formula"];
 
-
 		if (!filter_type.empty()){
-			std::pair<std::string, std::string> damage_type = attack.damage_type();
-			if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
-				return false;
+			if(attack.check_tag_name() == "damage_type"){
+				if((attack.check_cfg()).has_attribute("replacement_type")){
+					if (filter_type.count(attack.type()) == 0){
+						return false;
+					}
+				}
+				else if((attack.check_cfg()).has_attribute("alternative_type")){
+					std::pair<std::string, std::string> damage_type = attack.damage_type();
+					if (filter_type.count(damage_type.first) == 0){
+						return false;
+					}
+				}
+			} else {
+				std::pair<std::string, std::string> damage_type = attack.damage_type();
+				if (filter_type.count(damage_type.first) == 0 && filter_type.count(damage_type.second) == 0){
+					return false;
+				}
 			}
 		}
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -129,7 +129,7 @@ public:
 
 	// In unit_types.cpp:
 
-	bool matches_filter(const config& filter, const std::string& tag_name = "") const;
+	bool matches_filter(const config& filter) const;
 	bool apply_modification(const config& cfg);
 	bool describe_modification(const config& cfg,std::string* description);
 
@@ -142,6 +142,50 @@ public:
 	inline config to_config() const { config c; write(c); return c; }
 
 	void add_formula_context(wfl::map_formula_callable&) const;
+
+	//used in self infinite recursion case for prevent crash.
+	const std::string& check_tag_name() const {return check_tag_name_;}
+	//used for reinitialise variable of recursion after each cheking.
+	void update_check_tag_name(const std::string& tag_name = "") const {check_tag_name_ = tag_name;}
+	/**
+	 * Helper similar to std::unique_lock for detecting when calculations such as has_special
+	 * have entered infinite recursion.
+	 */
+	class recursion_guard {
+		friend class attack_type;
+		/**
+		 * Only expected to be called in update_variables_recursion(), which handles some of the checks.
+		 */
+		explicit recursion_guard(const attack_type& weapon);
+	public:
+		/**
+		 * Construct an empty instance, only useful for extending the lifetime of a
+		 * recursion_guard returned from weapon.update_variables_recursion() by
+		 * std::moving it to an instance declared in a larger scope.
+		 */
+		explicit recursion_guard();
+
+		/**
+		 * Returns true if the .
+		 */
+		operator bool() const;
+
+		recursion_guard(recursion_guard&& other);
+		recursion_guard(const recursion_guard& other) = delete;
+		recursion_guard& operator=(recursion_guard&&);
+		recursion_guard& operator=(const recursion_guard&) = delete;
+		~recursion_guard();
+	private:
+		std::shared_ptr<const attack_type> parent;
+	};
+
+	/**
+	 * Tests which might otherwise cause infinite recursion should call this, check that the
+	 * returned object evaluates to true, and then keep the object returned as long as the
+	 * recursion might occur, similar to a reentrant mutex that's limited to a small number of
+	 * reentrances.
+	 */
+	recursion_guard update_variables_recursion() const;
 private:
 	// In unit_abilities.cpp:
 
@@ -348,6 +392,11 @@ private:
 	int parry_;
 	config specials_;
 	bool changed_;
+	mutable std::string check_tag_name_ = "";
+	/** Number of instances of recursion_guard that are currently allocated permission to recurse */
+	mutable unsigned int num_recursion_ = 0;
+	/** Value of num_recursion_ at which allocations of further recursion_guards fail */
+	static constexpr unsigned int RECURSION_LIMIT = 4;
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -145,8 +145,12 @@ public:
 
 	//used in self infinite recursion case for prevent crash.
 	const std::string& check_tag_name() const {return check_tag_name_;}
-	//used for reinitialise variable of recursion after each cheking.
+	//used for update variable of recursion after each checking.
 	void update_check_tag_name(const std::string& tag_name = "") const {check_tag_name_ = tag_name;}
+	//used in for prevent recursion by autochecking of weapon special
+	const config& check_cfg() const {return check_cfg_;}
+	//used for update variable of recursion after each checking.
+	void update_check_cfg(const config& cfg) const {check_cfg_ = cfg;}
 	/**
 	 * Helper similar to std::unique_lock for detecting when calculations such as has_special
 	 * have entered infinite recursion.
@@ -393,6 +397,8 @@ private:
 	config specials_;
 	bool changed_;
 	mutable std::string check_tag_name_ = "";
+	/** mutable config used for prevent weapon special to check itself.*/
+	mutable config check_cfg_;
 	/** Number of instances of recursion_guard that are currently allocated permission to recurse */
 	mutable unsigned int num_recursion_ = 0;
 	/** Value of num_recursion_ at which allocations of further recursion_guards fail */

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -164,6 +164,7 @@
 0 event_test_filter_attack_on_moveto
 0 event_test_filter_attack_opponent_weapon_condition
 0 event_test_filter_attack_opponent_weapon_condition_no_triggered
+0 event_test_filter_attack_student_weapon_condition
 0 event_test_filter_wfl
 0 event_test_filter_wfl2
 0 event_test_filter_lua_serializable

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -163,6 +163,7 @@
 0 event_test_filter_attack_specials
 0 event_test_filter_attack_on_moveto
 0 event_test_filter_attack_opponent_weapon_condition
+0 event_test_filter_attack_opponent_weapon_condition_no_triggered
 0 event_test_filter_wfl
 0 event_test_filter_wfl2
 0 event_test_filter_lua_serializable
@@ -374,6 +375,7 @@
 0 damage_secondary_type_test
 0 damage_secondary_type_with_resistance_ability_test
 0 damage_secondary_type_with_resistance_ability_test_alt
+0 event_test_filter_damage_type_recursion
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active


### PR DESCRIPTION
When for example we have [damage_type][filter_self][has_attack|filter_weapon]type=pierce applied to one or any pierce type attack and the unit does not have an unaffected pierce attack, the change in type triggers an infinite recursion.

this PR fixes the problem and other because filter of weapon specials or formula.

Fix https://github.com/wesnoth/wesnoth/issues/8940