### PR TITLE
[1.18] Fix some GCC-14 warnings

### DIFF
--- a/src/gui/auxiliary/typed_formula.hpp
+++ b/src/gui/auxiliary/typed_formula.hpp
@@ -58,7 +58,7 @@ public:
 	 *                            be converted to the type T.
 	 * @param value               The default value for the object.
 	 */
-	explicit typed_formula<T>(const std::string& str, const T value = T());
+	explicit typed_formula(const std::string& str, const T value = T());
 
 	/**
 	 * Returns the value, can only be used if the data is no formula.

--- a/src/gui/dialogs/unit_advance.cpp
+++ b/src/gui/dialogs/unit_advance.cpp
@@ -66,7 +66,8 @@ void unit_advance::pre_show(window& window)
 		// This checks if we've finished iterating over the last unit type advancements
 		// and are into the modification-based advancements.
 		if(i >= last_real_advancement_) {
-			const auto& back = sample.get_modifications().child_range("advancement").back();
+			const auto range = sample.get_modifications().child_range("advancement");
+			const auto& back = range.back();
 
 			if(back.has_attribute("image")) {
 				image_string = back["image"].str();

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1305,7 +1305,7 @@ const topic *find_topic(const section &sec, const std::string &id)
 
 const section *find_section(const section &sec, const std::string &id)
 {
-	const auto &sit =
+	const auto sit =
 		std::find_if(sec.sections.begin(), sec.sections.end(), has_id(id));
 	if (sit != sec.sections.end()) {
 		return &*sit;


### PR DESCRIPTION
Fix warnings about a template id in a constructor, which is redundant, and GCC-14 warns that this isn't allowed in C++20.

An iterator can often be a struct containing a single pointer, so creating a reference to such a small struct doesn't make sense.

The structure returned by child_range is likely to be exactly two pointers, so it's not a burden to keep it even though back() has already finished accessing the child_iterator.

This fixes half of #8979, as I'm splitting the PRs by estimated amount of discussion. Once it's merged I'll open a PR that pastes 6 copies of the following block into header files, but request that comments on that wait until that PR opens.
```c++
#ifdef __has_cpp_attribute
#if __has_cpp_attribute(gnu::no_dangling)
[[gnu::no_dangling]]
#endif
#endif
```