### PR TITLE
lua: use correct method to attach on_left_click signal

### DIFF
--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -485,7 +485,7 @@ WIDGET_SETTER("on_left_click", lua_index_raw, gui2::widget)
 	}
 	lua_pushvalue(L, value.index);
 	if (!luaW_setwidgetcallback(L, &w, wd, "on_left_click")) {
-		connect_signal_notify_modified(w, std::bind(&dialog_callback, L, lua_ptr<gui2::widget>(w), "on_left_click"));
+		connect_signal_mouse_left_click(w, std::bind(&dialog_callback, L, lua_ptr<gui2::widget>(w), "on_left_click"));
 	}
 }
 


### PR DESCRIPTION
the signal is "on_left_click", so logically the correct method is `connect_signal_mouse_left_click`.
(AFAIK notify_modified is not available for most widgets and doesn't do the same thing as left_click either.)