### PR TITLE
Ignore GCC-14 and Clang false positives about dangling pointers

### DIFF
--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -29,6 +29,7 @@
 
 #include "exceptions.hpp"
 #include "game_version.hpp"
+#include "global.hpp"
 
 namespace game_config {
 extern std::string path;
@@ -417,7 +418,7 @@ void clear_binary_paths_cache();
  * Returns a vector with all possible paths to a given type of binary,
  * e.g. 'images', 'sounds', etc,
  */
-const std::vector<std::string>& get_binary_paths(const std::string& type);
+NOT_DANGLING const std::vector<std::string>& get_binary_paths(const std::string& type);
 
 /**
  * Returns a complete path to the actual file of a given @a type

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -40,3 +40,21 @@
 
 #if defined(__GNUC__) && !defined(__clang__)
 #endif
+
+/*
+ * GCC-13 and GCC-14 warn about functions that take a reference and return a
+ * reference, assuming the returned reference may point into the argument, they
+ * have false positives for functions that take an id string and return a
+ * string. GCC-14 supports supressing the warnings with [[gnu::no_dangling]].
+ *
+ * Clang complains about unknown attributes in the gnu:: namespace, so has to
+ * have the #if, and the #if means we need the #ifdef.
+ */
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(gnu::no_dangling)
+#define NOT_DANGLING [[gnu::no_dangling]]
+#endif
+#endif
+#ifndef NOT_DANGLING
+#define NOT_DANGLING
+#endif

--- a/src/gui/auxiliary/find_widget.hpp
+++ b/src/gui/auxiliary/find_widget.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "global.hpp"
 #include "gui/widgets/helper.hpp"
 #include "gui/widgets/widget.hpp"
 #include "utils/const_clone.hpp"
@@ -66,7 +67,7 @@ T& get_parent(widget& child)
  * @returns                   The widget with the id.
  */
 template <class T>
-T* find_widget(utils::const_clone_ptr<widget, T> widget,
+NOT_DANGLING T* find_widget(utils::const_clone_ptr<widget, T> widget,
 			   const std::string& id,
 			   const bool must_be_active,
 			   const bool must_exist)
@@ -93,7 +94,7 @@ T* find_widget(utils::const_clone_ptr<widget, T> widget,
  * @returns                   The widget with the id.
  */
 template <class T>
-T& find_widget(utils::const_clone_ptr<widget, T> widget,
+NOT_DANGLING T& find_widget(utils::const_clone_ptr<widget, T> widget,
 			   const std::string& id,
 			   const bool must_be_active)
 {

--- a/src/hotkey/hotkey_command.hpp
+++ b/src/hotkey/hotkey_command.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "global.hpp"
 #include "tooltips.hpp"
 #include "tstring.hpp"
 
@@ -306,7 +307,7 @@ private:
 const std::map<std::string_view, hotkey::hotkey_command>& get_hotkey_commands();
 
 /** returns the hotkey_command with the given name */
-const hotkey_command& get_hotkey_command(const std::string& command);
+NOT_DANGLING const hotkey_command& get_hotkey_command(const std::string& command);
 
 bool is_scope_active(scope s);
 bool is_scope_active(hk_scopes s);

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -23,6 +23,7 @@
 #include "color.hpp"
 #include "config.hpp"
 #include "generic_event.hpp"
+#include "global.hpp"
 #include "sdl/rect.hpp"
 
 #include <memory>
@@ -320,7 +321,7 @@ public:
 	static void set_known_themes(const game_config_view* cfg);
 
 	/** Returns the saved config for the theme with the given ID. */
-	static const config& get_theme_config(const std::string& id);
+	NOT_DANGLING static const config& get_theme_config(const std::string& id);
 
 	/** Returns minimal info about saved themes, optionally including hidden ones. */
 	static std::vector<theme_info> get_basic_theme_info(bool include_hidden = false);

--- a/src/units/race.hpp
+++ b/src/units/race.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "config.hpp"
+#include "global.hpp"
 #include "utils/name_generator.hpp"
 
 #include <array>
@@ -94,9 +95,10 @@ const std::string& gender_string(unit_race::GENDER gender);
 
 /**
  * Chooses a value from the given config based on gender. If the value for
- * the specified gender is blank, then @a default_key is chosen instead.
+ * the specified gender is blank, then @a default_key is used to look up a
+ * value instead.
  */
-const config::attribute_value & gender_value(
+NOT_DANGLING const config::attribute_value & gender_value(
     const config & cfg, unit_race::GENDER gender, const std::string & male_key,
     const std::string & female_key, const std::string & default_key);
 


### PR DESCRIPTION
For GCC-13, cfb28fbfb52ed5c75d93e283738d2e45061f9c84 (in master) added -Wno-dangling-reference, and that commit explains why the false positive is triggered by calling find_widget. For GCC-14 there's an attribute so we can flag this specific function as ok.

Clang complains about unknown attributes in the gnu:: namespace, so has to have the #if, and the #if means we need the #ifdef.  I'm intending to leave this PR open a couple of weeks (until the end of June) for discussion about whether there's a less unpleasant alternative.

There are still warnings in src/actions/attack.cpp, but that area is being worked on for an infinite recursion bug, and those warnings log in a single batch instead of being spread across multiple .cpp files.

Fixes part of #8979, will forward-port along with #8998.