### PR TITLE
Fix damage_type types show in unit attack window

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1241,6 +1241,9 @@ std::string attack_type::select_damage_type(const unit_ability_list& damage_type
  */
 std::pair<std::string, std::string> attack_type::damage_type() const
 {
+	if(attack_empty()){
+		return {"", ""};
+	}
 	unit_ability_list damage_type_list = get_specials_and_abilities("damage_type");
 	if(damage_type_list.empty()){
 		return {type(), ""};

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -129,6 +129,11 @@ public:
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
 	bool has_special_or_ability(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	/**
+	 * Returns true if this is a dummy attack_type, for example the placeholder that the unit_attack dialog
+	 * uses when a defender has no weapon for a given range.
+	 */
+	bool attack_empty() const {return (id().empty() && name().empty() && type().empty() && range().empty());}
 
 	// In unit_types.cpp:
 


### PR DESCRIPTION
If [damage_type]apply_to= is applied to a unit that does not have the range attack equivalent to that of the user this type will still be shown, which should not be.