### PR TITLE
[1.14] Backport compatibility fixes for Boost 1.81 and 1.83

### DIFF
--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -173,7 +173,11 @@ namespace
 			return msg;
 		}
 
+#if BOOST_VERSION < 108300
 		const char* get(int domain_id, const char* ctx, const char* sid, int n) const override
+#else
+		const char* get(int domain_id, const char* ctx, const char* sid, bl::count_type n) const override
+#endif
 		{
 			auto& base = get_base();
 			const char* msg = base.get(domain_id, ctx, sid, n);

--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -495,8 +495,13 @@ int icompare(const std::string& s1, const std::string& s2)
 	std::lock_guard<std::mutex> lock(get_mutex());
 
 	try {
+#if BOOST_VERSION < 108100
 		return std::use_facet<bl::collator<char>>(get_manager().get_locale()).compare(
 			bl::collator_base::secondary, s1, s2);
+#else
+		return std::use_facet<bl::collator<char>>(get_manager().get_locale()).compare(
+			bl::collate_level::secondary, s1, s2);
+#endif
 	} catch(const std::bad_cast&) {
 		static bool bad_cast_once = false;
 

--- a/src/gettext_boost.cpp
+++ b/src/gettext_boost.cpp
@@ -28,6 +28,7 @@
 // including boost/thread fixes linking of boost locale for msvc on boost 1.60
 #include <boost/thread.hpp>
 #include <set>
+#include <type_traits>
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
@@ -228,8 +229,13 @@ namespace
 			}
 
 			generator_.use_ansi_encoding(false);
+#if BOOST_VERSION < 108100
 			generator_.categories(bl::message_facet | bl::information_facet | bl::collation_facet | bl::formatting_facet | bl::convert_facet);
 			generator_.characters(bl::char_facet);
+#else
+			generator_.categories(bl::category_t::message | bl::category_t::information | bl::category_t::collation | bl::category_t::formatting | bl::category_t::convert);
+			generator_.characters(bl::char_facet_t::char_f);
+#endif
 			// We cannot have current_locale_ be a non boost-generated locale since it might not supply
 			// the bl::info facet. As soon as we add message paths, update_locale_internal might fail,
 			// for example because of invalid .mo files. So make sure we call it at least once before adding paths/domains
@@ -347,7 +353,12 @@ namespace
 			if(std::has_facet<bl::collator<char>>(current_locale_)) {
 				res << "has bl::collator<char> facet, ";
 			}
+#if BOOST_VERSION < 108100
 			res << "generator categories='" << generator_.categories() << "'";
+#else
+			res << "generator categories='" <<
+				static_cast<std::underlying_type<bl::category_t>::type>(generator_.categories()) << "'";
+#endif
 			return res.str();
 		}
 


### PR DESCRIPTION
Needed these while trying to work out when #8643 was introduced, which is part of sanity-checking the fix for that bug.

Planning to merge once the CI confirms that it builds on all platforms.