### PR TITLE
Reduce hardcoded extensions

### DIFF
--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -11,14 +11,26 @@ import sys, os, re, sre_constants, hashlib, glob, gzip
 import string
 import enum
 
+# Extensions
+# Ordering is important, see default extensions below
 map_extensions   = ("map", "mask")
+wml_extensions   = ("cfg",)
 image_extensions = ("png", "jpg", "jpeg", "webp")
 sound_extensions = ("ogg", "wav")
-vc_directories = (".git", ".svn")
-misc_files_extensions = ("-bak", ".DS_Store", "Thumbs.db") # These files and extensions should be included in the `default_blacklist` in filesystem.hpp.
-l10n_directories = ("l10n",)
+
+# Default extensions
+default_map_extension  = "." + map_extensions[0] # ".map" at the moment
+default_mask_extension = "." + map_extensions[1] # ".mask" at the moment
+default_wml_extension  = "." + wml_extensions[0] # ".cfg" at the moment
 resource_extensions = map_extensions + image_extensions + sound_extensions
 image_reference = r"[A-Za-z0-9{}.][A-Za-z0-9_/+{}.\-\[\]~\*,]*\.(png|jpe?g|webp)(?=(~.*)?)"
+
+# Directories
+l10n_directories = ("l10n",)
+vc_directories   = (".git", ".svn")
+
+# Misc files and extensions
+misc_files_extensions = ("-bak", ".DS_Store", "Thumbs.db") # These files and extensions should be included in the `default_blacklist` in filesystem.hpp.
 
 EQUALS = '='
 QUOTE = '"'
@@ -184,7 +196,7 @@ class Forest:
             subtree = []
             rooted = False
             if os.path.isdir(directory): # So we skip .cfgs in a UMC mirror
-                oldmain = os.path.join(os.path.dirname(directory), os.path.basename(directory) + '.cfg')
+                oldmain = os.path.join(os.path.dirname(directory), os.path.basename(directory) + default_wml_extension)
                 if os.path.isfile(oldmain):
                     subtree.append(oldmain)
                 base = os.path.basename(os.path.dirname(os.path.abspath(directory)))
@@ -199,8 +211,8 @@ class Forest:
                             rooted = True
                         elif os.path.basename(root) in roots:
                             for subdir in dirlist:
-                                if subdir + '.cfg' in files:
-                                    files.remove(subdir + '.cfg')
+                                if subdir + default_wml_extension in files:
+                                    files.remove(subdir + default_wml_extension)
                                 dirs.remove(subdir)
                                 dirpath.append(os.path.join(root, subdir))
                             rooted = True
@@ -219,8 +231,8 @@ class Forest:
                             if count >= (stop // 2):
                                 roots.append(os.path.basename(root))
                                 for subdir in dirlist:
-                                    if subdir + '.cfg' in files:
-                                        files.remove(subdir + '.cfg')
+                                    if subdir + default_wml_extension in files:
+                                        files.remove(subdir + default_wml_extension)
                                     dirs.remove(subdir)
                                     dirpath.append(os.path.join(root, subdir))
                     subtree.extend([os.path.normpath(os.path.join(root, x)) for x in files])
@@ -265,9 +277,13 @@ class Forest:
             for filename in tree:
                 yield (directory, filename)
 
+def ismap(filename):
+    "Is this file a map?"
+    return filename.split('.')[-1] in map_extensions
+
 def iswml(filename):
     "Is the specified filename WML?"
-    return filename.endswith(".cfg")
+    return filename.split('.')[-1] in wml_extensions
 
 def issave(filename):
     "Is the specified filename a WML save? (Detects compressed saves too.)"
@@ -1004,7 +1020,7 @@ class CrossRef:
                                 for pattern in split_filenames(match):
                                     for name in expand_square_braces(pattern):
                                         # Catches maps that look like macro names.
-                                        if (name.endswith(".map") or name.endswith(".mask")):
+                                        if (ismap(name)):
                                             if name.startswith("{~"):
                                                 name = name[2:]
                                             elif name.startswith("{"):
@@ -1217,8 +1233,8 @@ def resolve_unit_cfg(namespace, utype, resource=None):
     else:
         resource = utype
     loc = namespace_directory(namespace) + "units/" + resource
-    if not loc.endswith(".cfg"):
-        loc += ".cfg"
+    if not loc.endswith(default_wml_extension):
+        loc += default_wml_extension
     return loc
 
 def resolve_unit_image(namespace, subdir, resource):

--- a/data/tools/wmllint
+++ b/data/tools/wmllint
@@ -3055,10 +3055,6 @@ must be converted manually".format(filename, baseline + y + 1, old, name))
 
 # Generic machinery starts here
 
-def is_map(filename):
-    "Is this file a map?"
-    return filename.endswith(".map") or filename.endswith(".mask")
-
 if 0: # Not used, as there are currently no defined map transforms
     class maptransform_error(BaseException):
         "Error object to be thrown by maptransform."
@@ -3108,7 +3104,7 @@ def translator(filename, mapxforms, textxform):
             return
     # Pull file into an array of lines, CR-stripping as needed
     mfile = []
-    map_only = filename.endswith(".map")
+    map_only = filename.endswith(default_map_extension)
     terminator = "\n"
     UTF8_BOM = "\ufeff"
     for i, line in enumerate(unmodified):
@@ -3145,9 +3141,9 @@ def translator(filename, mapxforms, textxform):
             # Ignore all-caps macro arguments.
             if refname == refname.upper():
                 pass
-            elif 'mask=' in line and not (refname.endswith("}") or refname.endswith(".mask")):
-                print('"%s", line %d: mask file without .mask extension or not a mask file (%s)' \
-                      % (filename, lineno+1, refname))
+            elif 'mask=' in line and not (refname.endswith("}") or refname.endswith(default_mask_extension)):
+                print('"%s", line %d: mask file without %s extension or not a mask file (%s)' \
+                      % (filename, lineno+1, default_mask_extension, refname))
         # Exclude map_data= lines that are just 1 line without
         # continuation, or which contain {}.  The former are
         # pathological and the parse won't handle them, the latter
@@ -3163,7 +3159,7 @@ def translator(filename, mapxforms, textxform):
             maskwarn = False
             maptype = None
             if map_only:
-                if filename.endswith(".mask"):
+                if filename.endswith(default_mask_extension):
                     maptype = "mask"
                 else:
                     maptype = "map"
@@ -3239,8 +3235,8 @@ def translator(filename, mapxforms, textxform):
             refre = re.compile(r"\{@?([^A-Z].*)\}").search(line)
             if refre:
                 mapfile = refre.group(1)
-                if not mapfile.endswith(".map") and is_map(mapfile):
-                    newline = newline.replace(mapfile, mapfile + ".map")
+                if not mapfile.endswith(default_map_extension) and ismap(mapfile):
+                    newline = newline.replace(mapfile, mapfile + default_map_extension)
             newdata.append(newline + terminator)
             if newline != line:
                 if verbose > 0:
@@ -3505,8 +3501,8 @@ vctypes = (".svn", ".git", ".hg")
 
 def interesting(fn):
     "Is a file interesting for conversion purposes?"
-    return (fn.endswith(".cfg") and not fn.endswith("_info.cfg")) \
-           or is_map(fn) or issave(fn)
+    return (fn.endswith(default_wml_extension) and not fn.endswith("_info.cfg")) \
+           or ismap(fn) or issave(fn)
 
 def allcfgfiles(directory):
     "Get the names of all interesting files under directory."

--- a/src/addon/manager.cpp
+++ b/src/addon/manager.cpp
@@ -268,8 +268,7 @@ static filesystem::blacklist_pattern_list read_ignore_patterns(const std::string
 static void archive_file(const std::string& path, const std::string& fname, config& cfg)
 {
 	cfg["name"] = fname;
-	const bool is_cfg = (fname.size() > 4 ? (fname.substr(fname.size() - 4) == ".cfg") : false);
-	cfg["contents"] = encode_binary(strip_cr(filesystem::read_file(path + '/' + fname),is_cfg));
+	cfg["contents"] = encode_binary(strip_cr(filesystem::read_file(path + '/' + fname), filesystem::is_cfg(fname)));
 }
 
 static void archive_dir(const std::string& path, const std::string& dirname, config& cfg, const filesystem::blacklist_pattern_list& ignore_patterns)

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -878,8 +878,7 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 
 			if (dlg.show()) {
 				std::string filepath = dlg.path();
-				if (filepath.substr(filepath.size() - 4) == ".map"
-				    || filepath.substr(filepath.size() - 4) == ".cfg") {
+				if (filesystem::is_map(filepath) || filesystem::is_cfg(filepath)) {
 					// Open map or scenario
 					context_manager_->load_map(filepath, true);
 				} else {

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -255,8 +255,10 @@ void context_manager::change_addon_id()
 	std::string new_addon_id = current_addon_;
 	gui2::dialogs::prompt::execute(new_addon_id);
 
-	if(addon_filename_legal(new_addon_id) && filesystem::rename_dir(filesystem::get_current_editor_dir(current_addon_), filesystem::get_current_editor_dir(new_addon_id))) {
-		std::string main_cfg = filesystem::get_current_editor_dir(new_addon_id)+"/_main.cfg";
+	std::string old_dir = filesystem::get_current_editor_dir(current_addon_);
+	std::string new_dir = filesystem::get_current_editor_dir(new_addon_id);
+	if(addon_filename_legal(new_addon_id) && filesystem::rename_dir(old_dir, new_dir)) {
+		std::string main_cfg = new_dir + "/_main.cfg";
 		std::string main = filesystem::read_file(main_cfg);
 
 		// update paths
@@ -686,8 +688,8 @@ void context_manager::save_map_as_dialog()
 	dlg.set_title(_("Save Map As"))
 	   .set_save_mode(true)
 	   .set_path(input_name)
-	   .set_extension(".map")
-	   .set_extension(".mask");
+	   .set_extension(filesystem::map_extension)
+	   .set_extension(filesystem::mask_extension);
 
 	if(!dlg.show()) {
 		return;
@@ -735,7 +737,7 @@ void context_manager::save_scenario_as_dialog()
 	dlg.set_title(_("Save Scenario As"))
 	   .set_save_mode(true)
 	   .set_path(input_name)
-	   .set_extension(".cfg")
+	   .set_extension(filesystem::wml_extension)
 	   .add_extra_path(desktop::GAME_EDITOR_MAP_DIR);
 
 	if(!dlg.show()) {
@@ -932,7 +934,7 @@ void context_manager::load_map(const std::string& filename, bool new_context)
 		return;
 	}
 
-	if(filesystem::ends_with(filename, ".cfg")) {
+	if(filesystem::is_cfg(filename)) {
 		if(editor_controller::current_addon_id_.empty()) {
 			// if no addon id has been set and the file being loaded is from an addon
 			// then use the file path to determine the addon rather than showing a dialog

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -191,13 +191,17 @@ map_context::map_context(const game_config_view& game_config, const std::string&
 	}
 
 	// 0.3 Not a .map or .cfg file
-	if(!filesystem::ends_with(filename, ".map") && !filesystem::ends_with(filename, ".cfg") && !filesystem::ends_with(filename, ".mask")) {
+	if(!filesystem::is_map(filename)
+		&& !filesystem::is_mask(filename)
+		&& !filesystem::is_cfg(filename))
+	{
 		std::string message = _("File does not have .map, .cfg, or .mask extension");
 		throw editor_map_load_exception(filename, message);
 	}
 
 	// 1.0 Pure map data
-	if(filesystem::ends_with(filename, ".map") || filesystem::ends_with(filename, ".mask")) {
+	if(filesystem::is_map(filename)
+		|| filesystem::is_mask(filename)) {
 		LOG_ED << "Loading map or mask file";
 		map_ = editor_map::from_string(file_string); // throws on error
 		pure_map_ = true;
@@ -385,13 +389,13 @@ config map_context::convert_scenario(const config& old_scenario)
 	config& multiplayer = cfg.add_child("multiplayer");
 	multiplayer.append_attributes(old_scenario);
 	std::string map_data = multiplayer["map_data"];
-	std::string separate_map_file = filesystem::get_current_editor_dir(addon_id_) + "/maps/" + filesystem::base_name(filename_, true) + ".map";
+	std::string separate_map_file = filesystem::get_current_editor_dir(addon_id_) + "/maps/" + filesystem::base_name(filename_, true) + filesystem::map_extension;
 
 	// check that there's embedded map data, since that's how the editor used to save scenarios
 	if(!map_data.empty()) {
 		// check if a .map file already exists as a separate standalone .map in the editor folders or if a .map file already exists in the add-on
 		if(filesystem::file_exists(separate_map_file)) {
-			separate_map_file = filesystem::get_current_editor_dir(addon_id_) + "/maps/" + filesystem::get_next_filename(filesystem::base_name(filename_, true), ".map");
+			separate_map_file = filesystem::get_current_editor_dir(addon_id_) + "/maps/" + filesystem::get_next_filename(filesystem::base_name(filename_, true), filesystem::map_extension);
 		}
 		multiplayer["id"] = filesystem::base_name(separate_map_file, true);
 
@@ -661,8 +665,8 @@ config map_context::to_config()
 	scenario["random_start_time"] = random_time_;
 
 	// write out the map data
-	scenario["map_file"] = scenario_id_ + ".map";
-	filesystem::write_file(filesystem::get_current_editor_dir(addon_id_) + "/maps/" + scenario_id_ + ".map", map_.write());
+	scenario["map_file"] = scenario_id_ + filesystem::map_extension;
+	filesystem::write_file(filesystem::get_current_editor_dir(addon_id_) + "/maps/" + scenario_id_ + filesystem::map_extension, map_.write());
 
 	// find or add the editor's start event
 	config& event = scenario.add_child("event");

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1313,6 +1313,21 @@ std::time_t file_modified_time(const std::string& fname)
 	return mtime;
 }
 
+bool is_map(const std::string& filename)
+{
+	return bfs::path(filename).extension() == map_extension;
+}
+
+bool is_cfg(const std::string& filename)
+{
+	return bfs::path(filename).extension() == wml_extension;
+}
+
+bool is_mask(const std::string& filename)
+{
+	return bfs::path(filename).extension() == mask_extension;
+}
+
 bool is_gzip_file(const std::string& filename)
 {
 	return bfs::path(filename).extension() == ".gz";

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -72,6 +72,11 @@ enum class name_mode { ENTIRE_FILE_PATH, FILE_NAME_ONLY };
 enum class filter_mode { NO_FILTER, SKIP_MEDIA_DIR, SKIP_PBL_FILES };
 enum class reorder_mode { DONT_REORDER, DO_REORDER };
 
+// default extensions
+const std::string map_extension = ".map";
+const std::string mask_extension = ".mask";
+const std::string wml_extension = ".cfg";
+
 // A list of file and directory blacklist patterns
 class blacklist_pattern_list
 {
@@ -249,6 +254,15 @@ bool file_exists(const std::string& name);
 
 /** Get the modification time of a file. */
 std::time_t file_modified_time(const std::string& fname);
+
+/** Returns true if the file ends with the mapfile extension. */
+bool is_map(const std::string& filename);
+
+/** Returns true if the file ends with the wmlfile extension. */
+bool is_cfg(const std::string& filename);
+
+/** Returns true if the file ends with the maskfile extension. */
+bool is_mask(const std::string& filename);
 
 /** Returns true if the file ends with '.gz'. */
 bool is_gzip_file(const std::string& filename);

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -458,19 +458,18 @@ void game_config_manager::load_addons_cfg()
 
 	// Warn player about addons using the no-longer-supported single-file format.
 	for(const std::string& file : user_files) {
-		const int size_minus_extension = file.size() - 4;
 
-		if(file.substr(size_minus_extension, file.size()) == ".cfg") {
+		if(filesystem::is_cfg(file)) {
 			ERR_CONFIG << "error reading usermade add-on '" << file << "'";
 
 			error_addons.push_back(file);
 
-			const int userdata_loc = file.find("data/add-ons") + 5;
+			const std::string short_wml_path = filesystem::get_short_wml_path(file);
 			const std::string log_msg = formatter()
-				<< "The format '~"
-				<< file.substr(userdata_loc)
-				<< "' (for single-file add-ons) is not supported anymore, use '~"
-				<< file.substr(userdata_loc, size_minus_extension - userdata_loc)
+				<< "The format '"
+				<< short_wml_path
+				<< "' (for single-file add-ons) is not supported anymore, use '"
+				<< short_wml_path.substr(0, short_wml_path.size() - filesystem::wml_extension.size())
 				<< "/_main.cfg' instead.";
 
 			error_log.push_back(log_msg);

--- a/src/gui/dialogs/editor/edit_unit.cpp
+++ b/src/gui/dialogs/editor/edit_unit.cpp
@@ -1077,7 +1077,7 @@ void editor_edit_unit::write() {
 	boost::algorithm::replace_all(unit_name, " ", "_");
 
 	// Path to <unit_type_name>.cfg
-	std::string unit_path = filesystem::get_current_editor_dir(addon_id_) + "/units/" + unit_name + ".cfg";
+	std::string unit_path = filesystem::get_current_editor_dir(addon_id_) + "/units/" + unit_name + filesystem::wml_extension;
 
 	// Write to file
 	try {

--- a/src/gui/dialogs/wml_error.cpp
+++ b/src/gui/dialogs/wml_error.cpp
@@ -93,12 +93,10 @@ std::string format_file_list(const std::vector<std::string>& files_original)
 		//
 
 		if(!is_main_cfg) {
-			// Remove the file extension first.
-			static const std::string wml_suffix = ".cfg";
 
-			if(base.size() > wml_suffix.size()) {
-				const std::size_t suffix_pos = base.size() - wml_suffix.size();
-				if(base.substr(suffix_pos) == wml_suffix) {
+			if(base.size() > filesystem::wml_extension.size()) {
+				const std::size_t suffix_pos = base.size() - filesystem::wml_extension.size();
+				if(base.substr(suffix_pos) == filesystem::wml_extension) {
 					base.erase(suffix_pos);
 				}
 			}

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -157,7 +157,7 @@ void menu_handler::save_map()
 	dlg.set_title(_("Save Map As"))
 	   .set_save_mode(true)
 	   .set_path(input_name)
-	   .set_extension(".map");
+	   .set_extension(filesystem::map_extension);
 
 	if(!dlg.show()) {
 		return;

--- a/src/persist_context.cpp
+++ b/src/persist_context.cpp
@@ -28,7 +28,7 @@ config pack_scalar(const std::string &name, const t_string &val)
 }
 
 static std::string get_persist_cfg_name(const std::string &name_space) {
-	return (filesystem::get_dir(filesystem::get_user_data_dir() + "/persist/") + name_space + ".cfg");
+	return (filesystem::get_dir(filesystem::get_user_data_dir() + "/persist/") + name_space + filesystem::wml_extension);
 }
 
 void persist_file_context::load()

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -1770,7 +1770,7 @@ void preprocess_resource(const std::string& res_name,
 
 		// Files in current directory
 		for(const std::string& file : files) {
-			if(filesystem::ends_with(file, ".cfg")) {
+			if(filesystem::is_cfg(file)) {
 				preprocess_resource(file, defines_map, write_cfg, write_plain_cfg, parent_directory);
 			}
 		}


### PR DESCRIPTION
Reduces the the number of hardcoded filenames extensions, especially those that are used in many files (.map, .cfg, .mask). Instead hardcode them only once. For C++, it's in `filesystem.cpp`, for Python tools, it is in `wmltools3.py`.
Also adds new methods for checking if a file is one of these extensions in `filesystem`. (Please use those in new code.)