### PR TITLE
Fix some GCC-14 warnings

### DIFF
--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -29,6 +29,7 @@
 
 #include "exceptions.hpp"
 #include "game_version.hpp"
+#include "global.hpp"
 
 namespace game_config {
 extern std::string path;
@@ -426,7 +427,7 @@ void clear_binary_paths_cache();
  * Returns a vector with all possible paths to a given type of binary,
  * e.g. 'images', 'sounds', etc,
  */
-const std::vector<std::string>& get_binary_paths(const std::string& type);
+NOT_DANGLING const std::vector<std::string>& get_binary_paths(const std::string& type);
 
 /**
  * Returns a complete path to the actual file of a given @a type

--- a/src/global.hpp
+++ b/src/global.hpp
@@ -40,3 +40,23 @@
 
 #if defined(__GNUC__) && !defined(__clang__)
 #endif
+
+/*
+ * GCC-13 and GCC-14 warn about functions that return a reference and whose arguments also include a
+ * reference to a temporary, because they assume that the returned reference may point into the
+ * argument. This causes false positives for functions that take a std::map-like object as a
+ * separate argument (or as their "this" pointer), where the temporary being passed in is only used
+ * as a key to find an object in the map, and the returned reference points to an object owned by
+ * the map. Similarly, it's a false positive for data owned by a singleton.
+ *
+ * GCC-14 supports supressing the warnings with [[gnu::no_dangling]]. Clang complains about unknown
+ * attributes in the gnu:: namespace, so has to have the #if, and the #if means we need the #ifdef.
+ */
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(gnu::no_dangling)
+#define NOT_DANGLING [[gnu::no_dangling]]
+#endif
+#endif
+#ifndef NOT_DANGLING
+#define NOT_DANGLING
+#endif

--- a/src/gui/auxiliary/find_widget.hpp
+++ b/src/gui/auxiliary/find_widget.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "global.hpp"
 #include "gui/widgets/helper.hpp"
 #include "gui/widgets/widget.hpp"
 #include "utils/const_clone.hpp"
@@ -66,7 +67,7 @@ T& get_parent(widget& child)
  * @returns                   The widget with the id.
  */
 template <class T>
-T* find_widget(utils::const_clone_ptr<widget, T> widget,
+NOT_DANGLING T* find_widget(utils::const_clone_ptr<widget, T> widget,
 			   const std::string& id,
 			   const bool must_be_active,
 			   const bool must_exist)
@@ -93,7 +94,7 @@ T* find_widget(utils::const_clone_ptr<widget, T> widget,
  * @returns                   The widget with the id.
  */
 template <class T>
-T& find_widget(utils::const_clone_ptr<widget, T> widget,
+NOT_DANGLING T& find_widget(utils::const_clone_ptr<widget, T> widget,
 			   const std::string& id,
 			   const bool must_be_active)
 {

--- a/src/gui/auxiliary/typed_formula.hpp
+++ b/src/gui/auxiliary/typed_formula.hpp
@@ -58,7 +58,7 @@ public:
 	 *                            be converted to the type T.
 	 * @param value               The default value for the object.
 	 */
-	explicit typed_formula<T>(const std::string& str, const T value = T());
+	explicit typed_formula(const std::string& str, const T value = T());
 
 	/**
 	 * Returns the value, can only be used if the data is no formula.

--- a/src/gui/dialogs/unit_advance.cpp
+++ b/src/gui/dialogs/unit_advance.cpp
@@ -63,7 +63,8 @@ void unit_advance::pre_show(window& window)
 		// This checks if we've finished iterating over the last unit type advancements
 		// and are into the modification-based advancements.
 		if(i >= last_real_advancement_) {
-			const auto& back = sample.get_modifications().child_range("advancement").back();
+			const auto range = sample.get_modifications().child_range("advancement");
+			const auto& back = range.back();
 
 			if(back.has_attribute("image")) {
 				image_string = back["image"].str();

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -1313,7 +1313,7 @@ const topic *find_topic(const section &sec, const std::string &id)
 
 const section *find_section(const section &sec, const std::string &id)
 {
-	const auto &sit =
+	const auto sit =
 		std::find_if(sec.sections.begin(), sec.sections.end(), has_id(id));
 	if (sit != sec.sections.end()) {
 		return &*sit;

--- a/src/hotkey/hotkey_command.hpp
+++ b/src/hotkey/hotkey_command.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "global.hpp"
 #include "tooltips.hpp"
 #include "tstring.hpp"
 
@@ -307,7 +308,7 @@ private:
 const std::map<std::string_view, hotkey::hotkey_command>& get_hotkey_commands();
 
 /** returns the hotkey_command with the given name */
-const hotkey_command& get_hotkey_command(const std::string& command);
+NOT_DANGLING const hotkey_command& get_hotkey_command(const std::string& command);
 
 bool is_scope_active(scope s);
 bool is_scope_active(hk_scopes s);

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -23,6 +23,7 @@
 #include "color.hpp"
 #include "config.hpp"
 #include "generic_event.hpp"
+#include "global.hpp"
 #include "sdl/rect.hpp"
 
 #include <memory>
@@ -320,7 +321,7 @@ public:
 	static void set_known_themes(const game_config_view* cfg);
 
 	/** Returns the saved config for the theme with the given ID. */
-	static const config& get_theme_config(const std::string& id);
+	NOT_DANGLING static const config& get_theme_config(const std::string& id);
 
 	/** Returns minimal info about saved themes, optionally including hidden ones. */
 	static std::vector<theme_info> get_basic_theme_info(bool include_hidden = false);

--- a/src/units/race.hpp
+++ b/src/units/race.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "config.hpp"
+#include "global.hpp"
 #include "utils/name_generator.hpp"
 
 #include <array>
@@ -94,9 +95,10 @@ const std::string& gender_string(unit_race::GENDER gender);
 
 /**
  * Chooses a value from the given config based on gender. If the value for
- * the specified gender is blank, then @a default_key is chosen instead.
+ * the specified gender is blank, then @a default_key is used to look up a
+ * value instead.
  */
-const config::attribute_value & gender_value(
+NOT_DANGLING const config::attribute_value & gender_value(
     const config & cfg, unit_race::GENDER gender, const std::string & male_key,
     const std::string & female_key, const std::string & default_key);
 


### PR DESCRIPTION
Forward-port of
* #8998 
* #9006 

Fixes most of #8979. There are still warnings in src/actions/attack.cpp, but that area is being worked on for an infinite recursion bug, and those warnings log in a single batch instead of being spread across multiple .cpp files.