### PR TITLE
[1.18] HttT S17 Don't create lava near the Sceptre

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -699,7 +699,7 @@
     [event]
         name=victory
 
-        {CLEAR_VARIABLE concentrating,moved_too_close,lava_body,lava_count,sceptre_x,sceptre_y}
+        {CLEAR_VARIABLE concentrating,moved_too_close,lava_body,lava_count}
     [/event]
 
     [event]

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -520,8 +520,7 @@ fire:  +10%"
         [/filter_adjacent_location]
         [not]
             # don't start near the cave floor around the sceptre
-            x=$sceptre_x
-            y=$sceptre_y
+            location_id=sceptre
             radius=5
         [/not]
         [not]
@@ -598,7 +597,7 @@ fire:  +10%"
         [/not]
         [not]
             # don't go anywhere near the cave floor around the sceptre
-            x,y=$sceptre_x,$sceptre_y
+            location_id=sceptre
             radius=4
             [filter_radius]
                 terrain=U*,Re


### PR DESCRIPTION
The lava is supposed to stay away from the Sceptre itself. However, 60d114b changed from using sceptre_x,sceptre_y to using a location_id, and missed updating these macros.

Fixes #9038.