### PR TITLE
[1.18] HttT S17 Don't erase castles from other leaders

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -32,7 +32,6 @@
             jagged=50
             [item_location]
                 id = 1
-                place_castle = yes
             [/item_location]
         [/chamber]
 
@@ -48,7 +47,6 @@
             {PASSAGE_NORMAL player 2 10 10}
             [item_location]
                 id = 2
-                place_castle = yes
             [/item_location]
         [/chamber]
         [chamber]
@@ -61,7 +59,6 @@
             {PASSAGE_CHANCE 40 antechamber_1 1 9 9}
             [item_location]
                 id = 3
-                place_castle = yes
             [/item_location]
         [/chamber]
 
@@ -156,7 +153,6 @@
             {PASSAGE_CHANCE 40 antechamber_2 1 5 2}
             [item_location]
                 id = 4
-                place_castle = yes
             [/item_location]
         [/chamber]
         [chamber]
@@ -171,7 +167,6 @@
             {PASSAGE_CHANCE 40 mini_3 1 5 2}
             [item_location]
                 id = 5
-                place_castle = yes
             [/item_location]
         [/chamber]
         [chamber]
@@ -185,7 +180,6 @@
             {PASSAGE_CHANCE 40 mini_3 1 5 2}
             [item_location]
                 id = 6
-                place_castle = yes
             [/item_location]
         [/chamber]
         [chamber]
@@ -200,7 +194,6 @@
             {PASSAGE_CHANCE 40 antechamber_2 1 5 2}
             [item_location]
                 id = 7
-                place_castle = yes
             [/item_location]
         [/chamber]
     [/generator]
@@ -422,7 +415,6 @@
 #ifdef HARD
 #else
         {VARIABLE_OP side_kill rand "4..7"}
-        {ERASE_CASTLE $side_kill Uu}
         [kill]
             side=$side_kill
         [/kill]
@@ -432,7 +424,6 @@
         [/modify_side]
 #endif
         {VARIABLE_OP side_kill rand "2..3"}
-        {ERASE_CASTLE $side_kill Uu}
         [kill]
             side=$side_kill
         [/kill]
@@ -442,33 +433,33 @@
         [/modify_side]
         {CLEAR_VARIABLE side_kill}
 
-        # just making sure that the starting castle is big enough that
-        # no recalled units can end up inside walls
-        [store_locations]
+        # The [generator][chamber] tags have overlapping areas for placement of the chambers, which
+        # means can generate a map where two sides' starting locations are on adjacent hexes.
+        # If the generator places castles, erasing side_kill's castle needs care to ensure that it
+        # doesn't remove the keep of a nearby leader too.
+        #
+        # Therefore, instead of using the generator's place_castle functionality, we place keeps on
+        # any hex that now has a leader on it, and then convert the surrounding non-keep hexes into
+        # castle hexes. In addition to handling the AI sides, this ensures that the player's
+        # starting castle is big enough that no recalled units can end up inside walls.
+        [terrain]
+            terrain=Kud
             [and]
                 [filter]
-                    id=Konrad
+                    canrecruit=yes
                 [/filter]
-
+            [/and]
+        [/terrain]
+        [terrain]
+            terrain=Cud
+            [and]
+                terrain=K*
                 radius=1
             [/and]
-
             [not]
-                terrain=C*,K*
+                terrain=K*
             [/not]
-
-            variable=adjacent_to_starting_loc
-        [/store_locations]
-
-        [foreach]
-            array=adjacent_to_starting_loc
-            [do]
-                [terrain]
-                    x,y=$this_item.x,$this_item.y
-                    terrain=Cud
-                [/terrain]
-            [/do]
-        [/foreach]
+        [/terrain]
 
         {CLEAR_VARIABLE adjacent_to_starting_loc}
     [/event]

--- a/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/httt_utils.cfg
@@ -463,6 +463,7 @@ fire:  +10%"
     [/passage]
 #enddef
 
+# Unused, but left as-is for a change that backports to 1.18.
 #define ERASE_CASTLE SIDE TERRAIN
     [store_unit]
         variable=side_store

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/terrain_with_location_filter.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/DirectActionsWML/terrain_with_location_filter.cfg
@@ -1,0 +1,61 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [terrain]
+##
+# Actions:
+# Use [terrain] to remove all overlays (as the entire map has a ^Kov overlay)
+# Use [terrain] to change any castle that's not adjacent to a keep into cave
+##
+# Expected end state:
+# 14 hexes are transformed to cave
+#####
+{GENERIC_UNIT_TEST "terrain_with_location_filter" (
+    [event]
+        name = start
+
+        # The entire map has a ^Kov overlay, which at least needs commenting on,
+        # so it might as well be removed before the main part of the test.
+        [terrain]
+            layer=overlay
+            terrain=^
+        [/terrain]
+
+        # Rather than taking a subtag for a Standard Location Filter, [terrain] is an SLF,
+        # except for the terrain= attribute, which is removed first. It's documented on
+        # the Wiki that [and]terrain= can be used for filtering the affected hexes.
+        [terrain]
+            terrain=Uu
+            [and]
+                terrain=C*
+            [/and]
+            [not]
+                terrain=K*
+                radius=1
+            [/not]
+        [/terrain]
+
+        {ASSERT (
+            [have_location]
+                count=2
+                terrain=K*
+            [/have_location]
+        )}
+
+        {ASSERT (
+            [have_location]
+                count=2
+                terrain=C*
+            [/have_location]
+        )}
+
+        {ASSERT (
+            [have_location]
+                count=14
+                terrain=Uu
+            [/have_location]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -217,6 +217,7 @@
 0 events-test_die
 0 events-test_pre_attack_base
 0 events-test_pre_attack_change_weapon
+0 terrain_with_location_filter
 0 test_store_unit_defense_on
 9 test_store_unit_defense_deprecated
 0 special_note_from_movetype


### PR DESCRIPTION
The random map generator can generate starting locations so close that ERASE_CASTLE removed not just the intended castle, but also the keep of the nearby leader. To avoid that, remove the intended keep, then castle that isn't adjacent to a keep.

The ERASE_CASTLE macro is obsolete, using location_id makes the code simple enough that a macro isn't useful. However, as this change is being applied to 1.18, I'm only adding a comment about it.

Fixes #9042. For obvious reasons, tested alongside #9045.