### PR TITLE
Support loading gui2 themes from addons

### DIFF
--- a/changelog_entries/gui2-theme-support-in-addons.md
+++ b/changelog_entries/gui2-theme-support-in-addons.md
@@ -1,0 +1,5 @@
+ ### User interface
+    GUI2 themes can be loaded from add-ons. Requires a `gui-theme.cfg` file in add-on root with a `[gui]` tag that acts as the entry point for the theme.
+
+ ### Lua API
+    Added new function gui.switch_theme() to allow switching to another gui2 theme from inside a scenario.

--- a/data/schema/gui/widget_definitions.cfg
+++ b/data/schema/gui/widget_definitions.cfg
@@ -867,6 +867,8 @@
     min="0"
     max="infinite"
     super="$generic/widget_definition"
+    {REQUIRED_KEY "id" string}
+    {REQUIRED_KEY "description" string}
     [tag]
         name="resolution"
         min="0"

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -327,7 +327,7 @@ auto get_child_impl(Tchildren& children, config_key_type key, int n) -> optional
 
 	auto i = children.find(key);
 	if(i == children.end()) {
-		DBG_CF << "The config object has no child named »" << key << "«.";
+		DBG_CF << "The config object has no child named ‘" << key << "’.";
 		return utils::nullopt;
 	}
 
@@ -338,8 +338,8 @@ auto get_child_impl(Tchildren& children, config_key_type key, int n) -> optional
 	try {
 		return *i->second.at(n);
 	} catch(const std::out_of_range&) {
-		DBG_CF << "The config object has only »" << i->second.size() << "« children named »" << key
-			   << "«; request for the index »" << n << "« cannot be honored.";
+		DBG_CF << "The config object has only ‘" << i->second.size() << "’ children named ‘" << key
+			   << "’; request for the index ‘" << n << "’ cannot be honored.";
 		return utils::nullopt;
 	}
 }
@@ -351,7 +351,7 @@ config& config::mandatory_child(config_key_type key, const std::string& parent)
 	if(auto res = get_child_impl(children_, key, 0)) {
 		return *res;
 	} else {
-		throw error("Mandatory WML child »[" + std::string(key) + "]« missing in »" + parent + "«. Please report this bug.");
+		throw error("Mandatory WML child ‘[" + std::string(key) + "]’ missing in ‘" + parent + "’. Please report this bug.");
 	}
 }
 
@@ -360,7 +360,7 @@ const config& config::mandatory_child(config_key_type key, const std::string& pa
 	if(auto res = get_child_impl(children_, key, 0)) {
 		return *res;
 	} else {
-		throw error("Mandatory WML child »[" + std::string(key) + "]« missing in »" + parent + "«. Please report this bug.");
+		throw error("Mandatory WML child ‘[" + std::string(key) + "]’ missing in ‘" + parent + "’. Please report this bug.");
 	}
 }
 
@@ -788,7 +788,7 @@ optional_config config::find_child(config_key_type key, const std::string& name,
 {
 	const child_map::iterator i = children_.find(key);
 	if(i == children_.end()) {
-		DBG_CF << "Key »" << name << "« value »" << value << "« pair not found as child of key »" << key << "«.";
+		DBG_CF << "Key ‘" << name << "’ value ‘" << value << "’ pair not found as child of key ‘" << key << "’.";
 
 
 		return utils::nullopt;
@@ -805,7 +805,7 @@ optional_config config::find_child(config_key_type key, const std::string& name,
 		return **j;
 	}
 
-	DBG_CF << "Key »" << name << "« value »" << value << "« pair not found as child of key »" << key << "«.";
+	DBG_CF << "Key ‘" << name << "’ value ‘" << value << "’ pair not found as child of key ‘" << key << "’.";
 
 	return utils::nullopt;
 }
@@ -818,6 +818,7 @@ config& config::find_mandatory_child(config_key_type key, const std::string &nam
 	}
 	throw error("Cannot find child [" + std::string(key) + "] with " + name + "=" + value);
 }
+
 const config& config::find_mandatory_child(config_key_type key, const std::string &name, const std::string &value) const
 {
 	auto res = find_child(key, name, value);
@@ -826,7 +827,6 @@ const config& config::find_mandatory_child(config_key_type key, const std::strin
 	}
 	throw error("Cannot find child [" + std::string(key) + "] with " + name + "=" + value);
 }
-
 
 void config::clear()
 {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -396,10 +396,10 @@ public:
 	 */
 	const config& mandatory_child(config_key_type key, int n = 0) const;
 
-	/** Euivalent to @ref mandatory_child, but returns an empty optional if the nth child was not found. */
+	/** Equivalent to @ref mandatory_child, but returns an empty optional if the nth child was not found. */
 	optional_config_impl<config> optional_child(config_key_type key, int n = 0);
 
-	/** Euivalent to @ref mandatory_child, but returns an empty optional if the nth child was not found. */
+	/** Equivalent to @ref mandatory_child, but returns an empty optional if the nth child was not found. */
 	optional_config_impl<const config> optional_child(config_key_type key, int n = 0) const;
 
 	/**
@@ -633,7 +633,6 @@ public:
 
 	const config& find_mandatory_child(config_key_type key, const std::string &name,
 		const std::string &value) const;
-
 
 private:
 	void clear_children_impl(config_key_type key);

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -28,6 +28,7 @@
 #include "game_initialization/multiplayer.hpp"
 #include "generators/map_generator.hpp"
 #include "gettext.hpp"
+#include "gui/gui.hpp"
 #include "gui/dialogs/message.hpp"
 #include "gui/dialogs/outro.hpp"
 #include "gui/widgets/retval.hpp"
@@ -204,7 +205,6 @@ level_result::type campaign_controller::play_game()
 					gui2::dialogs::outro::display(state_.classification());
 				}
 			}
-
 			return res;
 		} else if(res == level_result::type::observer_end && mp_info_ && !mp_info_->is_host) {
 			const int dlg_res = gui2::show_message(_("Game Over"),
@@ -290,4 +290,11 @@ level_result::type campaign_controller::play_game()
 	}
 
 	return level_result::type::victory;
+}
+
+campaign_controller::~campaign_controller()
+{
+	// If the scenario changed the current gui2 theme,
+	// change it back to the value stored in preferences
+	gui2::switch_theme(prefs::get().gui2_theme());
 }

--- a/src/game_initialization/playcampaign.hpp
+++ b/src/game_initialization/playcampaign.hpp
@@ -56,6 +56,8 @@ public:
 	{
 	}
 
+	~campaign_controller();
+
 	level_result::type play_game();
 	level_result::type play_replay()
 	{

--- a/src/gui/core/widget_definition.cpp
+++ b/src/gui/core/widget_definition.cpp
@@ -64,7 +64,7 @@ styled_widget_definition::styled_widget_definition(const config& cfg)
 	 * extra header dependencies.
 	 */
 	config::const_child_itors itors = cfg.child_range("resolution");
-	VALIDATE(!itors.empty(), _("No resolution defined."));
+	VALIDATE(!itors.empty(), _("No resolution defined for ") + id);
 }
 
 } // namespace gui2

--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -129,7 +129,7 @@ void builder_window::read(const config& cfg)
 	DBG_GUI_P << "Window builder: reading data for window " << id_ << ".";
 
 	config::const_child_itors cfgs = cfg.child_range("resolution");
-	VALIDATE(!cfgs.empty(), _("No resolution defined."));
+	VALIDATE(!cfgs.empty(), _("No resolution defined for ") + id_);
 
 	for(const auto& i : cfgs) {
 		resolutions.emplace_back(i);

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -86,18 +86,19 @@ title_screen::~title_screen()
 {
 }
 
-using btn_callback = std::function<void()>;
-
-static void register_button(window& win, const std::string& id, hotkey::HOTKEY_COMMAND hk, btn_callback callback)
+void title_screen::register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, std::function<void()> callback)
 {
 	if(hk != hotkey::HOTKEY_NULL) {
-		win.register_hotkey(hk, std::bind(callback));
+		register_hotkey(hk, std::bind(callback));
 	}
 
-	auto b = find_widget<button>(&win, id, false, false);
-	if(b != nullptr)
-	{
-		connect_signal_mouse_left_click(*b, std::bind(callback));
+	try {
+		button& btn = find_widget<button>(this, id, false);
+		connect_signal_mouse_left_click(btn, std::bind(callback));
+	} catch(const wml_exception& e) {
+		ERR_GUI_P << e.user_message;
+		prefs::get().set_gui2_theme("default");
+		set_retval(RELOAD_UI);
 	}
 }
 
@@ -235,16 +236,16 @@ void title_screen::init_callbacks()
 		update_tip(true);
 	}
 
-	register_button(*this, "next_tip", hotkey::TITLE_SCREEN__NEXT_TIP,
+	register_button("next_tip", hotkey::TITLE_SCREEN__NEXT_TIP,
 		std::bind(&title_screen::update_tip, this, true));
 
-	register_button(*this, "previous_tip", hotkey::TITLE_SCREEN__PREVIOUS_TIP,
+	register_button("previous_tip", hotkey::TITLE_SCREEN__PREVIOUS_TIP,
 		std::bind(&title_screen::update_tip, this, false));
 
 	//
 	// Help
 	//
-	register_button(*this, "help", hotkey::HOTKEY_HELP, []() {
+	register_button("help", hotkey::HOTKEY_HELP, []() {
 		if(gui2::new_widgets) {
 			gui2::dialogs::help_browser::display();
 		}
@@ -255,12 +256,12 @@ void title_screen::init_callbacks()
 	//
 	// About
 	//
-	register_button(*this, "about", hotkey::HOTKEY_NULL, std::bind(&game_version::display<>));
+	register_button("about", hotkey::HOTKEY_NULL, std::bind(&game_version::display<>));
 
 	//
 	// Campaign
 	//
-	register_button(*this, "campaign", hotkey::TITLE_SCREEN__CAMPAIGN, [this]() {
+	register_button("campaign", hotkey::TITLE_SCREEN__CAMPAIGN, [this]() {
 		try{
 			if(game_.new_campaign()) {
 				// Suspend drawing of the title screen,
@@ -276,13 +277,13 @@ void title_screen::init_callbacks()
 	//
 	// Multiplayer
 	//
-	register_button(*this, "multiplayer", hotkey::TITLE_SCREEN__MULTIPLAYER,
+	register_button("multiplayer", hotkey::TITLE_SCREEN__MULTIPLAYER,
 		std::bind(&title_screen::button_callback_multiplayer, this));
 
 	//
 	// Load game
 	//
-	register_button(*this, "load", hotkey::HOTKEY_LOAD_GAME, [this]() {
+	register_button("load", hotkey::HOTKEY_LOAD_GAME, [this]() {
 		if(game_.load_game()) {
 			// Suspend drawing of the title screen,
 			// so it doesn't flicker in between loading screens.
@@ -294,7 +295,7 @@ void title_screen::init_callbacks()
 	//
 	// Addons
 	//
-	register_button(*this, "addons", hotkey::TITLE_SCREEN__ADDONS, [this]() {
+	register_button("addons", hotkey::TITLE_SCREEN__ADDONS, [this]() {
 		if(manage_addons()) {
 			set_retval(RELOAD_GAME_DATA);
 		}
@@ -303,7 +304,7 @@ void title_screen::init_callbacks()
 	//
 	// Editor
 	//
-	register_button(*this, "editor", hotkey::TITLE_SCREEN__EDITOR, [this]() { set_retval(MAP_EDITOR); });
+	register_button("editor", hotkey::TITLE_SCREEN__EDITOR, [this]() { set_retval(MAP_EDITOR); });
 
 	//
 	// Cores
@@ -314,7 +315,7 @@ void title_screen::init_callbacks()
 	//
 	// Language
 	//
-	register_button(*this, "language", hotkey::HOTKEY_LANGUAGE, [this]() {
+	register_button("language", hotkey::HOTKEY_LANGUAGE, [this]() {
 		try {
 			if(game_.change_language()) {
 				on_resize();
@@ -328,53 +329,32 @@ void title_screen::init_callbacks()
 	//
 	// Preferences
 	//
-	register_button(*this, "preferences", hotkey::HOTKEY_PREFERENCES, [this]() {
-		gui2::dialogs::preferences_dialog pref_dlg;
-		pref_dlg.show();
-		if (pref_dlg.get_retval() == RELOAD_UI) {
-			set_retval(RELOAD_UI);
-		}
-
-		// Currently blurred windows don't capture well if there is something
-		// on top of them at the time of blur. Resizing the game window in
-		// preferences will cause the title screen tip and menu panels to
-		// capture the prefs dialog in their blur. This workaround simply
-		// forces them to re-capture the blur after the dialog closes.
-		panel* tip_panel = find_widget<panel>(this, "tip_panel", false, false);
-		if(tip_panel != nullptr) {
-			tip_panel->get_canvas(tip_panel->get_state()).queue_reblur();
-			tip_panel->queue_redraw();
-		}
-		panel* menu_panel = find_widget<panel>(this, "menu_panel", false, false);
-		if(menu_panel != nullptr) {
-			menu_panel->get_canvas(menu_panel->get_state()).queue_reblur();
-			menu_panel->queue_redraw();
-		}
-	});
+	register_button("preferences", hotkey::HOTKEY_PREFERENCES,
+		std::bind(&title_screen::show_preferences, this));
 
 	//
 	// Achievements
 	//
-	register_button(*this, "achievements", hotkey::HOTKEY_ACHIEVEMENTS,
+	register_button("achievements", hotkey::HOTKEY_ACHIEVEMENTS,
 		std::bind(&title_screen::show_achievements, this));
 
 	//
 	// Community
 	//
-	register_button(*this, "community", hotkey::HOTKEY_NULL,
+	register_button("community", hotkey::HOTKEY_NULL,
 		std::bind(&title_screen::show_community, this));
 
 	//
 	// Quit
 	//
-	register_button(*this, "quit", hotkey::HOTKEY_QUIT_TO_DESKTOP, [this]() { set_retval(QUIT_GAME); });
+	register_button("quit", hotkey::HOTKEY_QUIT_TO_DESKTOP, [this]() { set_retval(QUIT_GAME); });
 	// A sanity check, exit immediately if the .cfg file didn't have a "quit" button.
 	find_widget<button>(this, "quit", false, true);
 
 	//
 	// Debug clock
 	//
-	register_button(*this, "clock", hotkey::HOTKEY_NULL,
+	register_button("clock", hotkey::HOTKEY_NULL,
 		std::bind(&title_screen::show_debug_clock_window, this));
 
 	auto clock = find_widget<button>(this, "clock", false, false);
@@ -385,7 +365,7 @@ void title_screen::init_callbacks()
 	//
 	// GUI Test and Debug Window
 	//
-	register_button(*this, "test_dialog", hotkey::HOTKEY_NULL,
+	register_button("test_dialog", hotkey::HOTKEY_NULL,
 		std::bind(&title_screen::show_gui_test_dialog, this));
 
 	auto test_dialog = find_widget<button>(this, "test_dialog", false, false);
@@ -484,11 +464,6 @@ void title_screen::show_debug_clock_window()
 	}
 }
 
-void title_screen::show_gui_test_dialog()
-{
-	gui2::dialogs::gui_test_dialog::execute();
-}
-
 void title_screen::hotkey_callback_select_tests()
 {
 	game_config_manager::get()->load_game_config_for_create(false, true);
@@ -523,6 +498,36 @@ void title_screen::show_community()
 	game_version dlg;
 	// shows the 5th tab, community, when the dialog is shown
 	dlg.display(4);
+}
+
+void title_screen::show_gui_test_dialog()
+{
+	gui2::dialogs::gui_test_dialog::execute();
+}
+
+void title_screen::show_preferences()
+{
+	gui2::dialogs::preferences_dialog pref_dlg;
+	pref_dlg.show();
+	if (pref_dlg.get_retval() == RELOAD_UI) {
+		set_retval(RELOAD_UI);
+	}
+
+	// Currently blurred windows don't capture well if there is something
+	// on top of them at the time of blur. Resizing the game window in
+	// preferences will cause the title screen tip and menu panels to
+	// capture the prefs dialog in their blur. This workaround simply
+	// forces them to re-capture the blur after the dialog closes.
+	panel* tip_panel = find_widget<panel>(this, "tip_panel", false, false);
+	if(tip_panel != nullptr) {
+		tip_panel->get_canvas(tip_panel->get_state()).queue_reblur();
+		tip_panel->queue_redraw();
+	}
+	panel* menu_panel = find_widget<panel>(this, "menu_panel", false, false);
+	if(menu_panel != nullptr) {
+		menu_panel->get_canvas(menu_panel->get_state()).queue_reblur();
+		menu_panel->queue_redraw();
+	}
 }
 
 void title_screen::button_callback_multiplayer()

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -71,6 +71,8 @@ private:
 
 	void init_callbacks();
 
+	void register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, std::function<void()> callback);
+
 	/***** ***** ***** ***** Callbacks ***** ***** ****** *****/
 
 	void on_resize();
@@ -90,6 +92,9 @@ private:
 
 	/** Shows the gui test window. */
 	void show_gui_test_dialog();
+
+	/** Shows the preferences dialog. */
+	void show_preferences();
 
 	void hotkey_callback_select_tests();
 

--- a/src/hotkey/command_executor.cpp
+++ b/src/hotkey/command_executor.cpp
@@ -16,6 +16,7 @@
 #include "hotkey/command_executor.hpp"
 #include "hotkey/hotkey_item.hpp"
 
+#include "gui/gui.hpp"
 #include "gui/dialogs/achievements_dialog.hpp"
 #include "gui/dialogs/lua_interpreter.hpp"
 #include "gui/dialogs/message.hpp"
@@ -361,6 +362,7 @@ bool command_executor::do_execute_command(const hotkey::ui_command& cmd, bool pr
 			quit_confirmation::quit_to_desktop();
 			break;
 		case HOTKEY_QUIT_GAME:
+			gui2::switch_theme(prefs::get().gui2_theme());
 			quit_confirmation::quit_to_title();
 			break;
 		case HOTKEY_SURRENDER:

--- a/src/scripting/lua_gui2.cpp
+++ b/src/scripting/lua_gui2.cpp
@@ -15,6 +15,7 @@
 
 #include "scripting/lua_gui2.hpp"
 
+#include "gui/gui.hpp"
 #include "gui/core/gui_definition.hpp"
 #include "gui/dialogs/drop_down_menu.hpp"
 #include "gui/dialogs/gamestate_inspector.hpp"
@@ -169,6 +170,16 @@ int show_story(lua_State* L) {
 }
 
 /**
+ * Changes the current ui(gui2) theme
+ * - Arg 1: The id of the theme to switch to
+ */
+int switch_theme(lua_State* L) {
+	std::string theme_id = luaL_checkstring(L, 1);
+	gui2::switch_theme(theme_id);
+	return 0;
+}
+
+/**
  * Displays a popup menu at the current mouse position
  * Best used from a [set_menu_item], to show a submenu
  * - Arg 1: Configs defining each item, with keys icon, image/label, second_label, tooltip
@@ -281,6 +292,7 @@ int luaW_open(lua_State* L)
 		{ "show_story",         &show_story },
 		{ "show_prompt",        &show_message_box },
 		{ "show_help",          &show_help   },
+		{ "switch_theme",             &switch_theme   },
 		{ "add_widget_definition",    &intf_add_widget_definition },
 		{ "show_dialog",              &intf_show_dialog   },
 		{ nullptr, nullptr },

--- a/src/scripting/lua_gui2.hpp
+++ b/src/scripting/lua_gui2.hpp
@@ -28,6 +28,7 @@ namespace lua_gui2 {
 int intf_add_widget_definition(lua_State *L);
 int show_message_dialog(lua_State *L);
 int show_popup_dialog(lua_State *L);
+int switch_theme(lua_State* L);
 int show_menu(lua_State* L);
 int show_story(lua_State* L);
 int show_message_box(lua_State* L);

--- a/src/serialization/schema_validator.cpp
+++ b/src/serialization/schema_validator.cpp
@@ -418,6 +418,10 @@ void schema_validator::close_tag()
 
 void schema_validator::print_cache()
 {
+	if (cache_.empty()) {
+		return;
+	}
+
 	for(auto& m : cache_.top()) {
 		for(auto& list : m.second) {
 			print(list);
@@ -432,10 +436,12 @@ void schema_validator::validate(const config& cfg, const std::string& name, int 
 	// close previous errors and print them to output.
 	print_cache();
 
-	// clear cache
-	auto cache_it = cache_.top().find(&cfg);
-	if(cache_it != cache_.top().end()) {
-		cache_it->second.clear();
+	if (!cache_.empty()) {
+		// clear cache
+		auto cache_it = cache_.top().find(&cfg);
+		if(cache_it != cache_.top().end()) {
+			cache_it->second.clear();
+		}
 	}
 
 	// Please note that validating unknown tag keys the result will be false

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -882,6 +882,8 @@ static int do_gameloop(commandline_options& cmdline_opts)
 		case gui2::dialogs::title_screen::RELOAD_GAME_DATA:
 			gui2::dialogs::loading_screen::display([&config_manager]() {
 				config_manager.reload_changed_game_config();
+				gui2::init();
+				gui2::switch_theme(prefs::get().gui2_theme());
 			});
 			break;
 		case gui2::dialogs::title_screen::MAP_EDITOR:

--- a/src/wml_exception.cpp
+++ b/src/wml_exception.cpp
@@ -86,11 +86,11 @@ std::string missing_mandatory_wml_key(
 		symbols["primary_key"] = primary_key;
 		symbols["primary_value"] = primary_value;
 
-		return VGETTEXT("In section '[$section|]' where '$primary_key| = "
-			"$primary_value' the mandatory key '$key|' isn't set.", symbols);
+		return VGETTEXT("In section ‘[$section|]’ where ‘$primary_key|’ = "
+			"$primary_value’ the mandatory key ‘$key|’ isn't set.", symbols);
 	} else {
-		return VGETTEXT("In section '[$section|]' the "
-			"mandatory key '$key|' isn't set.", symbols);
+		return VGETTEXT("In section ‘[$section|]’ the "
+			"mandatory key ‘$key|’ isn't set.", symbols);
 	}
 }
 
@@ -98,6 +98,9 @@ std::string missing_mandatory_wml_tag(
 		  const std::string &section
 		, const std::string &tag)
 {
-	// TODO in 1.19: revisit this when we can add new strings
-	return missing_mandatory_wml_key(section, "[" + tag + "]");
+	utils::string_map symbols;
+	symbols["section"] = section;
+	symbols["tag"] = tag;
+	return VGETTEXT("In section ‘[$section|]’ the "
+				"mandatory subtag ‘[$tag|]’ is missing.", symbols);
 }

--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -88,6 +88,10 @@ function gui.show_lua_console() end
 ---@return integer
 function gui.show_dialog(cfg, preshow, postshow) end
 
+---Changes the current ui (gui2) theme
+---@param theme_id string The id of the gui2 theme to switch to
+function gui.switch_theme(theme_id) end
+
 -- Add a custom widget definition, for use in a custom dialog
 ---@param type string The type of widget the definition applies to
 ---@param id string An ID for the definition, to be referenced from WML


### PR DESCRIPTION
The relevant gui definition should be in `<add-on-dir>/gui-theme.cfg`

**TODO**
- [x] Add a Lua function to change themes from an addon (`gui.switch_theme()`)
- [x] Make sure themes are loaded correctly just after downloading theme from addons server (that is, no restart is needed).
- [x] Allow user to switch in case of defunct theme.