### PR TITLE
[android-support] libffi patch

### DIFF
--- a/packaging/android/build-android-dependencies/libffi.patch
+++ b/packaging/android/build-android-dependencies/libffi.patch
@@ -1,0 +1,46 @@
+From cbfb9b436ab13e4b4aba867d061e11d7f89a351c Mon Sep 17 00:00:00 2001
+From: serge-sans-paille <sguelton@mozilla.com>
+Date: Wed, 1 Feb 2023 18:09:25 +0100
+Subject: [PATCH] Forward declare open_temp_exec_file
+
+It's defined in closures.c and used in tramp.c.
+Also declare it as an hidden symbol, as it should be.
+---
+ include/ffi_common.h | 4 ++++
+ src/tramp.c          | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/include/ffi_common.h b/include/ffi_common.h
+index 2bd31b03d..c53a79493 100644
+--- a/include/ffi_common.h
++++ b/include/ffi_common.h
+@@ -128,6 +128,10 @@ void *ffi_data_to_code_pointer (void *data) FFI_HIDDEN;
+    static trampoline. */
+ int ffi_tramp_is_present (void *closure) FFI_HIDDEN;
+ 
++/* Return a file descriptor of a temporary zero-sized file in a
++   writable and executable filesystem. */
++int open_temp_exec_file(void) FFI_HIDDEN;
++
+ /* Extended cif, used in callback from assembly routine */
+ typedef struct
+ {
+diff --git a/src/tramp.c b/src/tramp.c
+index b9d273a1a..c3f4c9933 100644
+--- a/src/tramp.c
++++ b/src/tramp.c
+@@ -39,6 +39,10 @@
+ #ifdef __linux__
+ #define _GNU_SOURCE 1
+ #endif
++
++#include <ffi.h>
++#include <ffi_common.h>
++
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+ 
+  devel/libffi/Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+

--- a/packaging/android/build-android-dependencies/setup-toolchains.py
+++ b/packaging/android/build-android-dependencies/setup-toolchains.py
@@ -31,6 +31,7 @@ export CC="$TOOLCHAIN/bin/clang -target $TARGET$API"
 export AS=$CC
 export CXX="$TOOLCHAIN/bin/clang++ -target $TARGET$API"
 export LD=$TOOLCHAIN/bin/ld
+export LDFLAGS=-Wl,--undefined-version
 export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
 export STRIP=$TOOLCHAIN/bin/llvm-strip
 export PKG_CONFIG=/usr/bin/pkg-config


### PR DESCRIPTION
Fixes the following error when building libffi
1.
```
/tmp/android-build/src/libffi-3.4.4/src/tramp.c:262:22: error: call to undeclared function 'open_temp_exec_file'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  tramp_globals.fd = open_temp_exec_file ();
```
Fixed by libffi.patch file included here. The patch is from [here](https://github.com/libffi/libffi/pull/764).

2.
```
ld.lld: error: version script assignment of 'LIBFFI_BASE_8.0' to symbol 'ffi_type_longdouble' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBFFI_COMPLEX_8.0' to symbol 'ffi_type_complex_longdouble' failed: symbol not defined
clang-17: error: linker command failed with exit code 1 (use -v to see invocation)
```
Fixed by adding the linker flags `-Wl,--undefined-version` in setup_toolchains.py. This solution is based on the patch [here](https://cgit.freebsd.org/ports/commit/?id=b547544132486acbe86da6d9e729ae13a4fd6e54).

Tested on Devuan Daedalus 5.0.
  