### PR TITLE
[1.18] Add unit tests for ability[filter_adjacent_location]adjacent,count=

### DIFF
--- a/data/test/scenarios/README.md
+++ b/data/test/scenarios/README.md
@@ -51,3 +51,7 @@ they may expect a status that is neither `PASS` nor `FAIL`.
 
 Names containing `break` or `error` might be for tests expected to `PASS`. Some of these are testing
 loops, or testing error-handling that is expected to handle the error.
+
+Names containing `_bug_` or ending `_bug` are reserved for tests where consensus is that the
+behavior should change in the development branch, however that it's better to accept the current
+behavior in the stable branch than to risk Out Of Sync errors.

--- a/data/test/scenarios/wml_tests/FilterWML/filter_adjacent_location_count_two_active_bug.cfg
+++ b/data/test/scenarios/wml_tests/FilterWML/filter_adjacent_location_count_two_active_bug.cfg
@@ -1,0 +1,101 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[filter_adjacent_location]adjacent,count=
+##
+# Actions:
+# Give Alice an ability specialX, which is only active if exactly two of the adjacent units have specialY.
+# Give Charlie and Dave has specialY.
+# Test whether the ability is active.
+##
+# Expected end state:
+# Although specialX should be active, it isn't.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "filter_adjacent_location_count_two_active_bug" (
+    # Although this ability is meant to be active when the count of adjacent units with specialY is
+    # zero, the C++ implementation in abilities.cpp returns false (in several places) unless each
+    # direction listed in adjacent= contains a unit with that ability.
+    #
+    # It would be good to fix it before 1.20, but would be a behavior change so can't be backported
+    # to 1.18. When fixing the bug, this test should be renamed without the "_bug" suffix.
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if no adjacent units have specialY"
+                        value=100
+                        apply_to=self
+                        [filter_adjacent_location]
+                            adjacent=n,ne,se,s,sw,nw
+                            count=2
+                            [filter]
+                                [has_attack]
+                                    special_id=specialY
+                                [/has_attack]
+                            [/filter]
+                        [/filter_adjacent_location]
+                    [/damage]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    [damage]
+                        id=specialY
+                        name=_ "specialY"
+                        value=50
+                        apply_to=self
+                    [/damage]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    [damage]
+                        id=specialY
+                        name=_ "specialY"
+                        value=50
+                        apply_to=self
+                    [/damage]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=dave
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    [has_attack]
+                        special_id_active=specialX
+                    [/has_attack]
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/FilterWML/filter_adjacent_location_count_zero_active_bug.cfg
+++ b/data/test/scenarios/wml_tests/FilterWML/filter_adjacent_location_count_zero_active_bug.cfg
@@ -1,0 +1,65 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[filter_adjacent_location]adjacent,count=
+##
+# Actions:
+# Give Alice an ability specialX, which is only active if zero of the adjacent units have specialY.
+# No unit has specialY.
+# Test whether the ability is active.
+##
+# Expected end state:
+# Although specialX should be active, it isn't.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "filter_adjacent_location_count_zero_active_bug" (
+    # Although this ability is meant to be active when the count of adjacent units with specialY is
+    # zero, the C++ implementation in abilities.cpp returns false (in several places) unless each
+    # direction listed in adjacent= contains a unit with that ability.
+    #
+    # It would be good to fix it before 1.20, but would be a behavior change so can't be backported
+    # to 1.18. When fixing the bug, this test should be renamed without the "_bug" suffix.
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if no adjacent units have specialY"
+                        value=100
+                        apply_to=self
+                        [filter_adjacent_location]
+                            adjacent=n,ne,se,s,sw,nw
+                            count=0
+                            [filter]
+                                [has_attack]
+                                    special_id=specialY
+                                [/has_attack]
+                            [/filter]
+                        [/filter_adjacent_location]
+                    [/damage]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    [has_attack]
+                        special_id_active=specialX
+                    [/has_attack]
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/FilterWML/filter_adjacent_location_count_zero_inactive.cfg
+++ b/data/test/scenarios/wml_tests/FilterWML/filter_adjacent_location_count_zero_inactive.cfg
@@ -1,0 +1,75 @@
+#####
+# API(s) being tested: ability[filter_adjacent_location]adjacent,count=
+##
+# Actions:
+# Give Alice an ability specialX, which is only active if zero of the adjacent units have specialY.
+# Give Bob the ability specialY.
+# Test whether specialX ability is active.
+##
+# Expected end state:
+# specialX isn't active.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "filter_adjacent_location_count_zero_inactive" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if no adjacent units have specialY"
+                        value=100
+                        apply_to=self
+                        [filter_adjacent_location]
+                            adjacent=n,ne,se,s,sw,nw
+                            count=0
+                            [filter]
+                                [has_attack]
+                                    special_id=specialY
+                                [/has_attack]
+                            [/filter]
+                        [/filter_adjacent_location]
+                    [/damage]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    [damage]
+                        id=specialY
+                        name=_ "specialY"
+                        value=50
+                        apply_to=self
+                    [/damage]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    [has_attack]
+                        special_id_active=specialX
+                    [/has_attack]
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -376,6 +376,9 @@
 0 damage_secondary_type_with_resistance_ability_test_alt
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
+0 filter_adjacent_location_count_two_active_bug
+0 filter_adjacent_location_count_zero_active_bug
+0 filter_adjacent_location_count_zero_inactive
 0 filter_special_id_active
 0 filter_ability_special_id_active
 0 filter_special_id_not_exists


### PR DESCRIPTION
Adds a new convention, that unit test names containing `_bug_` or ending `_bug` are reserved for tests where consensus is that the behavior should change in the development branch, however that it's better to accept the current behavior in the stable branch than to risk Out Of Sync errors.

I'm assuming the PR review will agree on this being something to fix for 1.20. I believe the bug has been present since `count` and `adjacent` were added in 1.13.2.

The Wiki docs say that count= takes a number or numerical range, and is true if the number of matches in adjacent locations matches that range. However, the implementations that are specific to using it in ability filters are buggy, and returns false if any location in the adjacent= set doesn't match.

There are several implementations of the Standard Location filter. Although this bug is specific to filters used in abilities, it feels to me that the test should be in the FilterWML directory instead of adding more tests to `data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/`. That's just a gut feeling, I'll happily move it if asked.

I already have a fix written, I ran into this bug while writing a new infinite-recursion test.

Ping @newfrenchy83, @CelticMinstrel 