### PR TITLE
EI - urbanjungle clean-ups

### DIFF
--- a/data/campaigns/Eastern_Invasion/terrain.cfg
+++ b/data/campaigns/Eastern_Invasion/terrain.cfg
@@ -1,28 +1,52 @@
 #textdomain wesnoth-ei
 
+[terrain_type]
+    icon_image=symbols/terrain_type_urban
+    id=urbanjungle
+    string=Vjt
+
+    name= _ "Urban"
+    editor_name= _ "Urban"
+    help_topic_text= _ "Densely packed structures are less suitable for garrison than traditional villages, providing no income or healing. They are difficult to navigate quickly, but offer significant protection."
+    hidden=yes
+[/terrain_type]
+
+[terrain_type]
+    icon_image=symbols/terrain_type_urban
+    symbol_image=urbanjungleA
+    id=urbanjungleA
+    name= _ "Urban Jungle"
+    editor_name= _ "Urban Jungle"
+    description= _ "Urban Jungle"
+    string=^VjA
+    default_base=Rr
+    aliasof=Vjt
+    def_alias=Vt
+    mvt_alias=Mt
+    editor_group=eastern_invasion
+[/terrain_type]
+
 #define URBAN_JUNGLE ID
     [terrain_type]
         icon_image=symbols/terrain_type_urban
         symbol_image=urbanjungle{ID}
         id=urbanjungle{ID}
+        name= _ "Urban Jungle"
+        editor_name= _ "Urban Jungle"
+        description= _ "Urban Jungle"
         string=^Vj{ID}
         default_base=Rr
-
-        def_alias=^Vhc
-        mvt_alias=Mm
+        aliasof=Vjt
+        def_alias=Vt
+        mvt_alias=Mt
         editor_group=eastern_invasion
-
-        name= _ "Urban"
-        editor_name= _ "Urban"
-        description= _ "Urban"
-        help_topic_text= _ "Densely packed structures are less suitable for garrison than traditional villages, providing no income or healing. They are difficult to navigate quickly, but offer significant protection."
+        hide_help=yes
     [/terrain_type]
 #enddef
 
 # NOTE - make sure this matches up with terrain-graphics.cfg
 # "city" images were scaled from 72->64 and had their colors muted (-40 Chroma, +25 Lightness)
 # "rural" images were scaled from 72->48 with no color changes
-{URBAN_JUNGLE A}
 {URBAN_JUNGLE B}
 {URBAN_JUNGLE C}
 {URBAN_JUNGLE D}

--- a/data/campaigns/Eastern_Invasion/terrain.cfg
+++ b/data/campaigns/Eastern_Invasion/terrain.cfg
@@ -12,7 +12,6 @@
 [/terrain_type]
 
 [terrain_type]
-    icon_image=symbols/terrain_type_urban
     symbol_image=urbanjungleA
     id=urbanjungleA
     name= _ "Urban Jungle"
@@ -28,7 +27,6 @@
 
 #define URBAN_JUNGLE ID
     [terrain_type]
-        icon_image=symbols/terrain_type_urban
         symbol_image=urbanjungle{ID}
         id=urbanjungle{ID}
         name= _ "Urban Jungle"

--- a/data/core/team-colors.cfg
+++ b/data/core/team-colors.cfg
@@ -249,6 +249,13 @@
     name= _ "Shroud"
 [/color_range]
 
+# EI - specific terrain type (same rgb as village)
+[color_range]
+    id=urbanjungle
+    rgb=995B51,FFE0DB,24190F,713C33 #995B51
+    name= _ "Urban"
+[/color_range]
+
 # Old-style numeric palette IDs for backwards compatibility
 # The C++ code uses this form heavily in generated RC() markup;
 # these can't be removed until all of those are fixed.


### PR DESCRIPTION
Cleans up the help browser and fixes #8497 (and makes the icon no longer pink).

I'm not sure I like this terrain idea, villages that aren't villages but use the village graphics.  As long as it stays in EI though, I guess it can be OK.