### PR TITLE
Minor changes to Eastern Invasion item wording

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -33,8 +33,10 @@
                     image={IMAGE}
                     description={ITEM_DESC}
                     effect={ITEM_USE}
-                    take_string=_"Take it."
-                    leave_string=_"Leave it."
+                    # po: Button label for 'take an item'
+                    take_string=_"Take"
+                    # po: Button label for 'leave an item'
+                    leave_string=_"Leave"
                 [/item_dialog]
                 [if]
                     {VARIABLE_CONDITIONAL item_picked equals yes}
@@ -119,7 +121,7 @@
 <b></b>"
 #enddef
 #define NOTE_SINGLE_USE
-    _"<span size='small'><i>This item can <b>NOT</b> be dropped, and can <b>NOT</b> be reused if its user dies.</i></span>
+    _"<span size='small'><i>This item <b>CANNOT</b> be dropped, and <b>CANNOT</b> be reused if its user dies.</i></span>
 <span size='small'><i>  Picking up an item consumes your moves and attack.</i></span>
 <b></b>"
 #enddef
@@ -1002,8 +1004,8 @@ plague_staff #enddef
             effect=_"<span size='small'><i>  (Elixirs only last for 1 scenario.)</i></span>
 <span size='small'><i>  Picking up an item consumes your moves and attack.</i></span>
 <b></b>"
-            take_string=_"Take it."
-            leave_string=_"Leave it."
+            take_string=_"Take"
+            leave_string=_"Leave"
         [/item_dialog]
         [if]
             {VARIABLE_CONDITIONAL item_picked equals yes}
@@ -1156,7 +1158,7 @@ plague_staff #enddef
         effect=_"<span size='small'><i>  (Elixirs only last for 1 scenario.)</i></span>
 <span size='small'><i>  Picking up an item consumes your moves and attack.</i></span>
 <b></b>"
-        take_string=_"Take it."
+        take_string=_"Take"
     [/item_dialog_musttake]
 #enddef
 #define GIVE_HASTE X Y MODIFICATIONS


### PR DESCRIPTION
Resolves #9070.

@Dalas121 While I was reviewing this, I noticed empty bold blocks and double-spaces at the start of italics blocks. Any reason for this?

https://github.com/wesnoth/wesnoth/blob/888fbf13e55e41cef445770c0479d2706ac5eb37/data/campaigns/Eastern_Invasion/utils/items.cfg#L116-L120