### PR TITLE
Make parse_ranges_unsigned actually return an unsigned range

### DIFF
--- a/src/game_events/conditional_wml.cpp
+++ b/src/game_events/conditional_wml.cpp
@@ -46,14 +46,14 @@ static lg::log_domain log_wml("wml");
 namespace game_events {
 
 namespace builtin_conditions {
-	std::vector<std::pair<int,int>> default_counts = utils::parse_ranges_unsigned("1-infinity");
+	std::vector<std::pair<unsigned, unsigned>> default_counts = utils::parse_ranges_unsigned("1-infinity");
 
 	bool have_unit(const vconfig& cfg)
 	{
 		if(!resources::gameboard) {
 			return false;
 		}
-		std::vector<std::pair<int,int>> counts = cfg.has_attribute("count")
+		std::vector<std::pair<unsigned, unsigned>> counts = cfg.has_attribute("count")
 			? utils::parse_ranges_unsigned(cfg["count"]) : default_counts;
 		int match_count = 0;
 		const unit_filter ufilt(cfg);
@@ -82,7 +82,7 @@ namespace builtin_conditions {
 				}
 			}
 		}
-		return in_ranges(match_count, counts);
+		return in_ranges<unsigned>(match_count, counts);
 	}
 
 	bool have_location(const vconfig& cfg)
@@ -90,9 +90,9 @@ namespace builtin_conditions {
 		std::set<map_location> res;
 		terrain_filter(cfg, resources::filter_con, false).get_locations(res);
 
-		std::vector<std::pair<int,int>> counts = cfg.has_attribute("count")
+		std::vector<std::pair<unsigned, unsigned>> counts = cfg.has_attribute("count")
 		? utils::parse_ranges_unsigned(cfg["count"]) : default_counts;
-		return in_ranges<int>(res.size(), counts);
+		return in_ranges<unsigned>(res.size(), counts);
 	}
 
 	bool variable_matches(const vconfig& values)

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -918,15 +918,16 @@ std::pair<double, double> parse_range_real(const std::string& str)
 	return res;
 }
 
-std::vector<std::pair<int, int>> parse_ranges_unsigned(const std::string& str)
+std::vector<std::pair<unsigned, unsigned>> parse_ranges_unsigned(const std::string& str)
 {
-	auto to_return = parse_ranges_int(str);
-	if(std::any_of(to_return.begin(), to_return.end(), [](const std::pair<int, int>& r) { return r.first < 0; })) {
+	auto temp = parse_ranges_int(str);
+	if(std::any_of(temp.begin(), temp.end(), [](const std::pair<int, int>& r) { return r.first < 0; })) {
 		ERR_GENERAL << "Invalid range (expected values to be zero or positive): " << str;
 		return {};
 	}
 
-	return to_return;
+	// Convert to strongly-typed unsigned range
+	return { temp.begin(), temp.end() };
 }
 
 std::vector<std::pair<double, double>> parse_ranges_real(const std::string& str)

--- a/src/serialization/string_utils.hpp
+++ b/src/serialization/string_utils.hpp
@@ -294,7 +294,7 @@ std::pair<int, int> parse_range(const std::string& str);
  * negative values. Will return an empty list if any of the ranges have a minimum that's below
  * zero.
  */
-std::vector<std::pair<int, int>> parse_ranges_unsigned(const std::string& str);
+std::vector<std::pair<unsigned, unsigned>> parse_ranges_unsigned(const std::string& str);
 
 /**
  * Handles a comma-separated list of inputs to parse_range.

--- a/src/side_filter.cpp
+++ b/src/side_filter.cpp
@@ -71,16 +71,7 @@ std::vector<int> side_filter::get_teams() const
 
 static bool check_side_number(const team &t, const std::string &str)
 {
-		std::vector<std::pair<int,int>> ranges = utils::parse_ranges_unsigned(str);
-		int side_number = t.side();
-
-		std::vector<std::pair<int,int>>::const_iterator range, range_end = ranges.end();
-		for (range = ranges.begin(); range != range_end; ++range) {
-			if(side_number >= range->first && side_number <= range->second) {
-				return true;
-			}
-		}
-		return false;
+	return in_ranges<unsigned>(t.side(), utils::parse_ranges_unsigned(str));
 }
 
 bool side_filter::match_internal(const team &t) const

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -248,10 +248,10 @@ bool terrain_filter::match_internal(const map_location& loc, const unit* ref_uni
 					}
 				}
 			}
-			static std::vector<std::pair<int,int>> default_counts = utils::parse_ranges_unsigned("1-6");
-			std::vector<std::pair<int,int>> counts = (*i).has_attribute("count")
+			static std::vector<std::pair<unsigned, unsigned>> default_counts = utils::parse_ranges_unsigned("1-6");
+			std::vector<std::pair<unsigned, unsigned>> counts = (*i).has_attribute("count")
 				? utils::parse_ranges_unsigned((*i)["count"]) : default_counts;
-			if(!in_ranges(match_count, counts)) {
+			if(!in_ranges<unsigned>(match_count, counts)) {
 				return false;
 			}
 		}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -389,7 +389,7 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 		if (i["count"].empty() && count != dirs.size()) {
 			return false;
 		}
-		if (!in_ranges<int>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
+		if (!in_ranges<unsigned>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
 			return false;
 		}
 	}
@@ -414,7 +414,7 @@ bool unit::ability_active(const std::string& ability,const config& cfg,const map
 		if (i["count"].empty() && count != dirs.size()) {
 			return false;
 		}
-		if (!in_ranges<int>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
+		if (!in_ranges<unsigned>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
 			return false;
 		}
 	}
@@ -1919,7 +1919,7 @@ bool attack_type::special_active_impl(
 		if (i["count"].empty() && count != dirs.size()) {
 			return false;
 		}
-		if (!in_ranges<int>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
+		if (!in_ranges<unsigned>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
 			return false;
 		}
 	}
@@ -1942,7 +1942,7 @@ bool attack_type::special_active_impl(
 		if (i["count"].empty() && count != dirs.size()) {
 			return false;
 		}
-		if (!in_ranges<int>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
+		if (!in_ranges<unsigned>(count, utils::parse_ranges_unsigned(i["count"].str()))) {
 			return false;
 		}
 	}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -122,10 +122,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if ( !filter_range.empty() && filter_range.count(attack.range()) == 0 )
 		return false;
 
-	if ( !filter_damage.empty() && !in_ranges(attack.damage(), utils::parse_ranges_unsigned(filter_damage)) )
+	if ( !filter_damage.empty() && !in_ranges<unsigned>(attack.damage(), utils::parse_ranges_unsigned(filter_damage)) )
 		return false;
 
-	if (!filter_attacks.empty() && !in_ranges(attack.num_attacks(), utils::parse_ranges_unsigned(filter_attacks)))
+	if (!filter_attacks.empty() && !in_ranges<unsigned>(attack.num_attacks(), utils::parse_ranges_unsigned(filter_attacks)))
 		return false;
 
 	if (!filter_accuracy.empty() && !in_ranges(attack.accuracy(), utils::parse_ranges_int(filter_accuracy)))
@@ -134,10 +134,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if (!filter_parry.empty() && !in_ranges(attack.parry(), utils::parse_ranges_int(filter_parry)))
 		return false;
 
-	if (!filter_movement.empty() && !in_ranges(attack.movement_used(), utils::parse_ranges_unsigned(filter_movement)))
+	if (!filter_movement.empty() && !in_ranges<unsigned>(attack.movement_used(), utils::parse_ranges_unsigned(filter_movement)))
 		return false;
 
-	if (!filter_attacks_used.empty() && !in_ranges(attack.attacks_used(), utils::parse_ranges_unsigned(filter_attacks_used)))
+	if (!filter_attacks_used.empty() && !in_ranges<unsigned>(attack.attacks_used(), utils::parse_ranges_unsigned(filter_attacks_used)))
 		return false;
 
 	if ( !filter_name.empty() && filter_name.count(attack.id()) == 0)

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -149,9 +149,9 @@ struct unit_filter_adjacent : public unit_filter_base
 			++match_count;
 		}
 
-		static std::vector<std::pair<int,int>> default_counts = utils::parse_ranges_unsigned("1-6");
+		static std::vector<std::pair<unsigned, unsigned>> default_counts = utils::parse_ranges_unsigned("1-6");
 		config::attribute_value i_count = cfg_["count"];
-		return in_ranges(match_count, !i_count.blank() ? utils::parse_ranges_unsigned(i_count) : default_counts);
+		return in_ranges<unsigned>(match_count, !i_count.blank() ? utils::parse_ranges_unsigned(i_count) : default_counts);
 	}
 
 	const unit_filter_compound child_;
@@ -599,83 +599,53 @@ void unit_filter_compound::fill(vconfig cfg)
 
 		create_attribute(literal["recall_cost"],
 			[](const config::attribute_value& c) { return utils::parse_ranges_unsigned(c.str()); },
-			[](const std::vector<std::pair<int,int>>& ranges, const unit_filter_args& args)
+			[](const std::vector<std::pair<unsigned, unsigned>>& ranges, const unit_filter_args& args)
 			{
-				for(auto cost : ranges) {
-					if(cost.first <= args.u.recall_cost() && args.u.recall_cost() <= cost.second) {
-						return true;
-					}
-				}
-				return false;
+				return in_ranges<unsigned>(args.u.recall_cost(), ranges);
 			}
 		);
 
 		create_attribute(literal["level"],
 			[](const config::attribute_value& c) { return utils::parse_ranges_unsigned(c.str()); },
-			[](const std::vector<std::pair<int,int>>& ranges, const unit_filter_args& args)
+			[](const std::vector<std::pair<unsigned, unsigned>>& ranges, const unit_filter_args& args)
 			{
-				for(auto lvl : ranges) {
-					if(lvl.first <= args.u.level() && args.u.level() <= lvl.second) {
-						return true;
-					}
-				}
-				return false;
+				return in_ranges<unsigned>(args.u.level(), ranges);
 			}
 		);
 
 		create_attribute(literal["defense"],
 			[](const config::attribute_value& c) { return utils::parse_ranges_unsigned(c.str()); },
-			[](const std::vector<std::pair<int,int>>& ranges, const unit_filter_args& args)
+			[](const std::vector<std::pair<unsigned, unsigned>>& ranges, const unit_filter_args& args)
 			{
 				int actual_defense = args.u.defense_modifier(args.context().get_disp_context().map().get_terrain(args.loc));
-				for(auto def : ranges) {
-					if(def.first <= actual_defense && actual_defense <= def.second) {
-						return true;
-					}
-				}
-				return false;
+				return in_ranges<unsigned>(actual_defense, ranges);
 			}
 		);
 
 		create_attribute(literal["movement_cost"],
 			[](const config::attribute_value& c) { return utils::parse_ranges_unsigned(c.str()); },
-			[](const std::vector<std::pair<int,int>>& ranges, const unit_filter_args& args)
+			[](const std::vector<std::pair<unsigned, unsigned>>& ranges, const unit_filter_args& args)
 			{
 				int actual_cost = args.u.movement_cost(args.context().get_disp_context().map().get_terrain(args.loc));
-				for(auto cost : ranges) {
-					if(cost.first <= actual_cost && actual_cost <= cost.second) {
-						return true;
-					}
-				}
-				return false;
+				return in_ranges<unsigned>(actual_cost, ranges);
 			}
 		);
 
 		create_attribute(literal["vision_cost"],
 			[](const config::attribute_value& c) { return utils::parse_ranges_unsigned(c.str()); },
-			[](const std::vector<std::pair<int,int>>& ranges, const unit_filter_args& args)
+			[](const std::vector<std::pair<unsigned, unsigned>>& ranges, const unit_filter_args& args)
 			{
 				int actual_cost = args.u.vision_cost(args.context().get_disp_context().map().get_terrain(args.loc));
-				for(auto cost : ranges) {
-					if(cost.first <= actual_cost && actual_cost <= cost.second) {
-						return true;
-					}
-				}
-				return false;
+				return in_ranges<unsigned>(actual_cost, ranges);
 			}
 		);
 
 		create_attribute(literal["jamming_cost"],
 			[](const config::attribute_value& c) { return utils::parse_ranges_unsigned(c.str()); },
-			[](const std::vector<std::pair<int,int>>& ranges, const unit_filter_args& args)
+			[](const std::vector<std::pair<unsigned, unsigned>>& ranges, const unit_filter_args& args)
 			{
 				int actual_cost = args.u.jamming_cost(args.context().get_disp_context().map().get_terrain(args.loc));
-				for(auto cost : ranges) {
-					if(cost.first <= actual_cost && actual_cost <= cost.second) {
-						return true;
-					}
-				}
-				return false;
+				return in_ranges<unsigned>(actual_cost, ranges);
 			}
 		);
 

--- a/src/utils/config_filters.cpp
+++ b/src/utils/config_filters.cpp
@@ -71,7 +71,7 @@ bool utils::config_filters::unsigned_matches_if_present(const config& filter, co
 		return false;
 	}
 
-	return in_ranges<int>(cfg[attribute].to_int(0), utils::parse_ranges_unsigned(filter[attribute].str()));
+	return in_ranges<unsigned>(cfg[attribute].to_unsigned(0), utils::parse_ranges_unsigned(filter[attribute].str()));
 }
 
 bool utils::config_filters::int_matches_if_present(const config& filter, const config& cfg, const std::string& attribute, std::optional<int> def)


### PR DESCRIPTION
This shouldn't result in any behavior changes, just makes the typing more strict. Also cleans up some of the relevant code using in_ranges. It does raise the question as to whether a lot of these variables should be unsigned instead of int, but that's a different matter altogether...