### PR TITLE
add a command line option for disabling log sanitization

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -167,6 +167,9 @@ prevents redirecting logged output to a file. The environment variable WESNOTH_N
 .B --log-to-file
 log output is written to a file. Cancels the effect of --no-log-to-file whether implicit or explicit.
 .TP
+.B --no-log-sanitize
+disables the anonymization that's normally applied when logging, for example replacing usernames with USER.
+.TP
 .B --wnoconsole
 For Windows, when used with --no-log-to-file, results in output being written to cerr/cout instead of CONOUT. Otherwise, does nothing.
 .TP

--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -65,7 +65,7 @@ Skip [story] screens and dialog through the end of the
 event.
 .TP
 .B --clock
-Adds the option to show a clock for testing the drawing timer.
+Adds the option to show a clock for testing the drawing timer. Also adds the option for showing the GUI Test Dialog.
 .TP
 .BI --core \ id_core
 overrides the loaded core with the one whose id is specified.

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -238,8 +238,8 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("log-none", po::value<std::vector<std::string>>()->composing(), "sets the severity level of the specified log domain(s) to 'none'. Similar to --log-error.")
 		("log-precise", "shows the timestamps in log output with more precision.")
 		("no-log-to-file", "log output is written only to standard error rather than to a file. The environment variable WESNOTH_NO_LOG_FILE can also be set as an alternative.")
-		("log-to-file", "log output is written to a file. Cancels the effect of --no-log-to-file whether implicit or explicit.")
-		("no-log-sanitize", "do not sanitize usernames in log")
+		("log-to-file", "log output is written to the log file instead of standard error. Cancels the effect of --no-log-to-file whether implicit or explicit.")
+		("no-log-sanitize", "disables the anonymization that's normally applied when logging, for example replacing usernames with “USER”")
 		("wnoconsole", "For Windows, when used with --no-log-to-file, results in output being written to cerr/cout instead of CONOUT. Otherwise, does nothing.")
 		;
 

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -239,7 +239,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("log-precise", "shows the timestamps in log output with more precision.")
 		("no-log-to-file", "log output is written only to standard error rather than to a file. The environment variable WESNOTH_NO_LOG_FILE can also be set as an alternative.")
 		("log-to-file", "log output is written to the log file instead of standard error. Cancels the effect of --no-log-to-file whether implicit or explicit.")
-		("no-log-sanitize", "disables the anonymization that's normally applied when logging, for example replacing usernames with “USER”")
+		("no-log-sanitize", "disables the anonymization that's normally applied when logging, for example replacing usernames with USER.")
 		("wnoconsole", "For Windows, when used with --no-log-to-file, results in output being written to cerr/cout instead of CONOUT. Otherwise, does nothing.")
 		;
 

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -239,6 +239,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("log-precise", "shows the timestamps in log output with more precision.")
 		("no-log-to-file", "log output is written only to standard error rather than to a file. The environment variable WESNOTH_NO_LOG_FILE can also be set as an alternative.")
 		("log-to-file", "log output is written to a file. Cancels the effect of --no-log-to-file whether implicit or explicit.")
+		("no-log-sanitize", "do not sanitize usernames in log")
 		("wnoconsole", "For Windows, when used with --no-log-to-file, results in output being written to cerr/cout instead of CONOUT. Otherwise, does nothing.")
 		;
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -440,10 +440,11 @@ void set_log_sanitize(bool sanitize) {
 
 std::string sanitize_log(const std::string& logstr)
 {
-	std::string str = logstr;
 	if (!log_sanitization) {
 		return logstr;
 	}
+	
+	std::string str = logstr;
 
 #ifdef _WIN32
 	const char* user_name = getenv("USERNAME");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -443,7 +443,7 @@ std::string sanitize_log(const std::string& logstr)
 	if (!log_sanitization) {
 		return logstr;
 	}
-	
+
 	std::string str = logstr;
 
 #ifdef _WIN32

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -440,7 +440,7 @@ void set_log_sanitize(bool sanitize) {
 
 std::string sanitize_log(const std::string& logstr)
 {
-	if (!log_sanitization) {
+	if(!log_sanitization) {
 		return logstr;
 	}
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -59,6 +59,8 @@ static bool timestamp = true;
 static bool precise_timestamp = false;
 static std::mutex log_mutex;
 
+static bool log_sanitization = true;
+
 /** whether the current logs directory is writable */
 static std::optional<bool> is_log_dir_writable_ = std::nullopt;
 /** alternative stream to write data to */
@@ -432,9 +434,16 @@ static void print_precise_timestamp(std::ostream& out) noexcept
 	} catch(...) {}
 }
 
+void set_log_sanitize(bool sanitize) {
+	log_sanitization = sanitize;
+}
+
 std::string sanitize_log(const std::string& logstr)
 {
 	std::string str = logstr;
+	if (!log_sanitization) {
+		return logstr;
+	}
 
 #ifdef _WIN32
 	const char* user_name = getenv("USERNAME");

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -137,6 +137,9 @@ void set_strict_severity(severity severity);
 void set_strict_severity(const logger &lg);
 bool broke_strict();
 
+/** toggle log sanitization */
+void set_log_sanitize(bool sanitize);
+
 /**
  * Do the initial redirection to a log file if the logs directory is writable.
  * Also performs log rotation to delete old logs.

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -968,7 +968,7 @@ int main(int argc, char** argv)
 		} else if(arg == "--log-to-file") {
 			write_to_log_file = true;
 		}
-		
+
 		if(arg == "--no-log-sanitize") {
 			lg::set_log_sanitize(false);
 		}

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -968,6 +968,10 @@ int main(int argc, char** argv)
 		} else if(arg == "--log-to-file") {
 			write_to_log_file = true;
 		}
+		
+		if(arg == "--no-log-sanitize") {
+			lg::set_log_sanitize(false);
+		}
 
 		if(arg == "--wnoconsole") {
 			no_con = true;


### PR DESCRIPTION
Resolves #8505.

Adds the `--no-log-sanitize` option. When this option is used, the actual username of the user will be shown in the log instead of `USER`.