### PR TITLE
Update copyrights: Always use slashes for the file path

### DIFF
--- a/update_copyrights
+++ b/update_copyrights
@@ -103,28 +103,31 @@ for root, _, files in os.walk(options.repo):
     for filename in files:
         filetype = Path(filename).suffix
         if filetype == ".png" or filetype == ".jpg" or filetype == ".webp" or filetype == ".wav" or filetype == ".ogg":
-            file = os.path.normpath(os.path.join(root, filename))
-            hash = do_hash(file)
+            file_path = os.path.normpath(os.path.join(root, filename))
+            if os.path.sep != '/':
+                # Always use slashes for the file path irrespective of OS used to run the update
+                file_path = file_path.replace(os.path.sep, '/')
+            file_hash = do_hash(file_path)
 
-            if not file in csv_data:
-                added.append(["", file, "", "", "", do_git(file), hash])
-            elif len(csv_data[file]) < 7:
-                missing_fields.append(csv_data[file])
-            elif len(csv_data[file]) > 7:
-                extra_fields.append(csv_data[file])
-            elif csv_data[file][5] != "":
-                update.append(csv_data[file])
-            elif csv_data[file][6] != hash:
-                csv_data[file][5] = do_git(file)
-                csv_data[file][6] = hash
-                changed.append(csv_data[file])
-            elif csv_data[file][2].strip() == "" or csv_data[file][3].strip() == "":
-                incomplete.append(csv_data[file])
-            elif not csv_data[file][2] in known_licenses:
-                unknown_licenses.append(csv_data[file][2])
-                incomplete.append(csv_data[file])
+            if not file_path in csv_data:
+                added.append(["", file_path, "", "", "", do_git(file_path), file_hash])
+            elif len(csv_data[file_path]) < 7:
+                missing_fields.append(csv_data[file_path])
+            elif len(csv_data[file_path]) > 7:
+                extra_fields.append(csv_data[file_path])
+            elif csv_data[file_path][5] != "":
+                update.append(csv_data[file_path])
+            elif csv_data[file_path][6] != file_hash:
+                csv_data[file_path][5] = do_git(file_path)
+                csv_data[file_path][6] = file_hash
+                changed.append(csv_data[file_path])
+            elif csv_data[file_path][2].strip() == "" or csv_data[file_path][3].strip() == "":
+                incomplete.append(csv_data[file_path])
+            elif not csv_data[file_path][2] in known_licenses:
+                unknown_licenses.append(csv_data[file_path][2])
+                incomplete.append(csv_data[file_path])
             else:
-                unchanged.append(csv_data[file])
+                unchanged.append(csv_data[file_path])
 
 final_output = missing_fields + extra_fields + added + changed + incomplete + update + unchanged
 final_output.sort(key=itemgetter(1))


### PR DESCRIPTION
Avoid discarding the entire copyrights.csv when running the update on Windows, and force slashes in file path strings if adding new files.

Also rename hash object to avoid collision with built-in hash function. Clarified file object is representing a file path string as opposed to an actual open file object.

See https://github.com/wesnoth/wesnoth/pull/9063#issuecomment-2224076873 for why I settled on this particular resolution.