### PR TITLE
Locale and language dialog: retrieve country code using boost::locale

### DIFF
--- a/data/languages/bn_BD.cfg
+++ b/data/languages/bn_BD.cfg
@@ -1,5 +1,6 @@
 [locale]
-    name="বাংলা"
+    name="বাংলা (Bangla)"
+    sort_name="Bengali"
     locale=bn_BD
     alternates=bn_IN
     percent=56

--- a/data/languages/en_GB.cfg
+++ b/data/languages/en_GB.cfg
@@ -1,5 +1,5 @@
 [locale]
-    name="English (GB)"
+    name="English"
     locale=en_GB
     alternates=en_AG, en_AU, en_BW, en_IE, en_IN, en_NG, en_NZ, en_SG, en_ZA, en_ZW
     percent=99

--- a/data/languages/en_US.cfg
+++ b/data/languages/en_US.cfg
@@ -1,5 +1,5 @@
 [locale]
-    name="English (US)"
+    name="English"
     locale=en_US
     alternates=C, en_PH
     percent=100

--- a/data/languages/pt_BR.cfg
+++ b/data/languages/pt_BR.cfg
@@ -1,5 +1,5 @@
 [locale]
-    name="Português do Brasil"
+    name="Português"
     locale=pt_BR
     percent=90
 [/locale]

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -94,8 +94,8 @@ void language_selection::pre_show(window& window)
 			&language_selection::shown_filter_callback, this));
 
 	const language_def& current_language = get_language();
-	
-	
+
+
 	for(auto& lang : langs_) {
 		widget_data data;
 		data["language"]["label"] = lang.language + (lang.rtl ? " ," : ", ") + country(lang);

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -26,10 +26,6 @@
 #include "language.hpp"
 #include "preferences/preferences.hpp"
 
-#include <boost/locale.hpp>
-#include <boost/locale/info.hpp>
-#include <locale>
-
 namespace gui2::dialogs
 {
 
@@ -99,11 +95,10 @@ void language_selection::pre_show(window& window)
 
 	const language_def& current_language = get_language();
 	
-	boost::locale::generator gen;
-	for(const auto& lang : langs_) {
+	
+	for(auto& lang : langs_) {
 		widget_data data;
-		std::locale loc = gen(lang.localename);
-		data["language"]["label"] = lang.language + (lang.rtl ? " ," : ", ") + std::use_facet<boost::locale::info>(loc).country();
+		data["language"]["label"] = lang.language + (lang.rtl ? " ," : ", ") + country(lang);
 		data["language"]["use_markup"] = "true";
 		data["translated_total"]["label"] = "<span color='" + game_config::red_to_green(lang.percent).to_hex_string() + "'>" + std::to_string(lang.percent) + "%</span>";
 		data["translated_total"]["use_markup"] = "true";

--- a/src/gui/dialogs/language_selection.cpp
+++ b/src/gui/dialogs/language_selection.cpp
@@ -26,6 +26,10 @@
 #include "language.hpp"
 #include "preferences/preferences.hpp"
 
+#include <boost/locale.hpp>
+#include <boost/locale/info.hpp>
+#include <locale>
+
 namespace gui2::dialogs
 {
 
@@ -94,11 +98,12 @@ void language_selection::pre_show(window& window)
 			&language_selection::shown_filter_callback, this));
 
 	const language_def& current_language = get_language();
-
+	
+	boost::locale::generator gen;
 	for(const auto& lang : langs_) {
 		widget_data data;
-
-		data["language"]["label"] = lang.language;
+		std::locale loc = gen(lang.localename);
+		data["language"]["label"] = lang.language + (lang.rtl ? " ," : ", ") + std::use_facet<boost::locale::info>(loc).country();
 		data["language"]["use_markup"] = "true";
 		data["translated_total"]["label"] = "<span color='" + game_config::red_to_green(lang.percent).to_hex_string() + "'>" + std::to_string(lang.percent) + "%</span>";
 		data["translated_total"]["use_markup"] = "true";

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -22,6 +22,9 @@
 #include "serialization/preprocessor.hpp"
 #include "game_config_manager.hpp"
 
+#include <boost/locale.hpp>
+#include <boost/locale/info.hpp>
+#include <locale>
 #include <clocale>
 
 #ifdef _WIN32
@@ -366,6 +369,13 @@ const language_def& get_locale()
 
 	LOG_G << "locale could not be determined; defaulting to system locale";
 	return known_languages[0];
+}
+
+const std::string country(const language_def& locale)
+{
+	boost::locale::generator gen;
+	std::locale loc = gen(locale.localename);
+	return std::use_facet<boost::locale::info>(loc).country();
 }
 
 void init_textdomains(const game_config_view& cfg)

--- a/src/language.hpp
+++ b/src/language.hpp
@@ -112,6 +112,9 @@ bool current_language_rtl();
 //function which attempts to query and return the locale on the system
 const language_def& get_locale();
 
+/** Get the country for the given language definition */
+const std::string country(const language_def& locale);
+
 /** Initializes the list of textdomains from a configuration object */
 void init_textdomains(const game_config_view& cfg);
 


### PR DESCRIPTION
1. Remove embedded country code from `English (US)` and `English (GB)`. Countries will be programmatically retrieved using `boost::locale`.
2. Update Bengali locale info (add transliteration and `sort_name`)
3. Slightly reorganize the language selection dialog so that country codes are shown for each language. The country code is calculated from the locale's `locale` key.

![Screenshot from 2024-07-14 22-27-29](https://github.com/user-attachments/assets/291f8440-605d-47c1-a685-a8d325485372)
