### PR TITLE
Make goblins a subfolder in orcs

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -148,6 +148,7 @@ In times of strife, the hierarchy of command becomes more adaptable, with the or
         male_name= _ "race^Goblin"
         female_name= _ "race+female^Goblin"
         plural_name= _ "race^Goblins"
+        help_taxonomy=orc
         description= {RACIAL_NOTES_ORCS_AND_GOBLINS} + _ "
 
 Goblins are puny and quite frail, rarely growing past the size and stature of a human child.


### PR DESCRIPTION
Goblins are orcs, right? The race descriptions confirms their the same race, and I think the Goblin Spearman description implies that goblins are orcs and not vice versa. Based on my testing, I don't think this introduces any gameplay issues.