### PR TITLE
Update copyrights: Write CSV as UTF-8

### DIFF
--- a/update_copyrights
+++ b/update_copyrights
@@ -133,7 +133,7 @@ final_output = missing_fields + extra_fields + added + changed + incomplete + up
 final_output.sort(key=itemgetter(1))
 
 if options.output != "":
-    with open(options.output, 'w') as f:
+    with open(options.output, 'w', encoding="utf-8") as f:
         writer = csv.writer(f, lineterminator="\n")
         writer.writerow(["Date", "File", "License", "Author - Real Name(other name);Real Name(other name);etc", "Notes", "Needs Update", "MD5"])
         writer.writerows(final_output)


### PR DESCRIPTION
This surprises me, but quoting https://docs.python.org/3/library/functions.html#open:

> In text mode, if encoding is not specified the encoding used is platform-dependent...

At any rate, 'explicit is better than implicit'.