### PR TITLE
update bengali locale info

### DIFF
--- a/data/languages/bn_BD.cfg
+++ b/data/languages/bn_BD.cfg
@@ -1,5 +1,6 @@
 [locale]
-    name="বাংলা"
+    name="বাংলা (Bangla)"
+    sort_name="Bengali"
     locale=bn_BD
     alternates=bn_IN
     percent=56


### PR DESCRIPTION
Adds a `sort_name` key as well as makes the naming consistent with other languages.
Without this Bengali will be sorted at the end of the language selection list