### PR TITLE
EI: minor assorted unit stat and item tweaks

### DIFF
--- a/changelog_entries/ei_assorted_changes.md
+++ b/changelog_entries/ei_assorted_changes.md
@@ -1,0 +1,7 @@
+### Campaigns
+   * Eastern Invasion
+     * fixed Gweddry having the wrong HP values
+     * fixed the king being neutral instead of lawful
+     * fixed "Dark Shape" from being neutral instead of chaotic
+     * the king can no longer wield the plague staff
+     * the king and generals can no longer recall undead veterans

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
@@ -65,6 +65,11 @@
         unrenamable=yes
         side=2
         profile=portraits/humans/marshal-2.webp~FL(horiz)
+        [filter_recall]
+            [not]
+                trait=undead
+            [/not]
+        [/filter_recall]
         [modifications]
             {TRAIT_LOYAL_DUMMY}
             {TRAIT_STRONG}
@@ -89,6 +94,11 @@
         unrenamable=yes
         side=3
         profile=portraits/humans/marshal.webp
+        [filter_recall]
+            [not]
+                trait=undead
+            [/not]
+        [/filter_recall]
         [modifications]
             {TRAIT_LOYAL_DUMMY}
             {TRAIT_RESILIENT}
@@ -115,6 +125,11 @@
         side=4
         color=brightorange
         profile=portraits/humans/general.webp
+        [filter_recall]
+            [not]
+                trait=undead
+            [/not]
+        [/filter_recall]
         [modifications]
             {TRAIT_LOYAL_DUMMY}
             {TRAIT_INTELLIGENT}

--- a/data/campaigns/Eastern_Invasion/units/Human_Gweddry_Veteran_Commander.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Gweddry_Veteran_Commander.cfg
@@ -17,7 +17,7 @@
             halo_x,halo_y=19,-30
         [/halo_frame]
     [/leading_anim]
-    hitpoints=60
+    hitpoints=68
     movement_type=smallfoot
     movement=6
     experience=200

--- a/data/campaigns/Eastern_Invasion/units/Human_Gweddry_Veteran_Lieutenant.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Gweddry_Veteran_Lieutenant.cfg
@@ -17,7 +17,7 @@
             halo_x,halo_y=-8,-30
         [/halo_frame]
     [/leading_anim]
-    hitpoints=50
+    hitpoints=55
     movement_type=smallfoot
     movement=6
     level=3

--- a/data/campaigns/Eastern_Invasion/units/Human_Konrad_King_of_Wesnoth.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Konrad_King_of_Wesnoth.cfg
@@ -17,6 +17,7 @@
     experience=250
     {AMLA_DEFAULT}
     level=5
+    alignment=lawful
     cost=200
     usage=fighter
     description=_"Kings are trained rigorously in the combat arts, sometimes out of necessity, more often out of tradition from when their priors made their wealth in war. Fitted in armor so skillfully made as to incite envy even from many dwarvish smiths, these sovereigns are well conditioned to their heavy armor and can maneuver across the battlefield much faster than their gilded plate would suggest."

--- a/data/campaigns/Eastern_Invasion/units/Undead_Ravanal_Dark_Shape.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Undead_Ravanal_Dark_Shape.cfg
@@ -13,7 +13,7 @@
     movement=1
     experience=1
     level=1
-    alignment=neutral
+    alignment=chaotic
     advances_to=null
     cost=1
     usage=scout

--- a/data/campaigns/Eastern_Invasion/utils/character-definitions.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/character-definitions.cfg
@@ -96,6 +96,11 @@
     canrecruit=yes
     unrenamable=yes
     profile=portraits/konrad_II-sceptre.webp
+    [filter_recall]
+        [not]
+            trait=undead
+        [/not]
+    [/filter_recall]
     [modifications]
         {TRAIT_STRONG}
         {TRAIT_INTELLIGENT}

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -775,7 +775,7 @@ plague_staff #enddef
         [/not]
 
         [not]
-            id=Owaec,Gweddry,Dacyn,Hahid al-Ali,Terraent
+            id=Owaec,Gweddry,Dacyn,Hahid al-Ali,Terraent,Konrad
         [/not]
         # messes with existing recruiting, and messes with the S18 cutscene
         # if Dacyn gets this, it also breaks his scripted advancements (and his S17a recruitment)


### PR DESCRIPTION
Fixing several reported issues.

Units: Gweddry has the wrong HP values
Units: Konrad is neutral, should he be lawful
Units: "Dark Shape" is neutral instead of chaotic
Items: prevent Konrad from picking up the plague staff
S16: prevent Konrad and generals from recalling undead
