### PR TITLE
EI S17b: fix buggy dynamic recruit list macro

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
@@ -70,36 +70,21 @@
     [store_gold]
         side={SIDE}
     [/store_gold]
-    [if]
-        [lua]
-            code=<< return wesnoth.current.turn>15 >>
-        [/lua]
-
-        {VARIABLE_CONDITIONAL gold greater_than 150}
-
+    [if] {VARIABLE_CONDITIONAL turn_number greater_than 10}
+         {VARIABLE_CONDITIONAL gold greater_than 300}
         [then]
-            [disallow_recruit]
+            [set_recruit]
                 side={SIDE}
-                type={OLDTYPES}
-            [/disallow_recruit]
-            [allow_recruit]
-                side={SIDE}
-                type={NEWTYPES}
-            [/allow_recruit]
+                recruit={NEWTYPES}
+            [/set_recruit]
         [/then]
-
         [else]
-            [allow_recruit]
+            [set_recruit]
                 side={SIDE}
-                type={OLDTYPES}
-            [/allow_recruit]
-            [disallow_recruit]
-                side={SIDE}
-                type={NEWTYPES}
-            [/disallow_recruit]
+                recruit={OLDTYPES}
+            [/set_recruit]
         [/else]
     [/if]
-
     {CLEAR_VARIABLE gold}
 #enddef
     {REANIMATION_IMPLEMENTATION}

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
@@ -70,8 +70,9 @@
     [store_gold]
         side={SIDE}
     [/store_gold]
-    [if] {VARIABLE_CONDITIONAL turn_number greater_than 10}
-         {VARIABLE_CONDITIONAL gold greater_than 300}
+    [if]
+        {VARIABLE_CONDITIONAL turn_number greater_than 10}
+        {VARIABLE_CONDITIONAL gold greater_than 300}
         [then]
             [set_recruit]
                 side={SIDE}

--- a/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/17b_All-In.cfg
@@ -66,7 +66,7 @@
     {FLAG_VARIANT undead}
 #enddef
 #define CHANGE_RECRUITS_IF_RICH SIDE OLDTYPES NEWTYPES
-    # if we're building a gold reserve (because our keep is too small), allow more expensive recruits
+    # if we're building a gold reserve (because our keep is too small), force the AI to use expensive high-level recruits
     [store_gold]
         side={SIDE}
     [/store_gold]


### PR DESCRIPTION
EI's S17b has a gold refund mechanic, allowing enemies to build up large gold reserves in certain situations.

When gold gets high, enemies are supposed to start recruiting higher-level units so they can spend it faster. The former implementation had some inconsistent issues; this should restore the intended behavior.