### PR TITLE
EI S04c: only award achievement if all prisoners escape

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -321,20 +321,6 @@
             [/then]
         [/if]
         {VARIABLE first_prisoner_freed yes}
-        [if]
-            [not]
-                [have_unit]
-                    side=8
-                [/have_unit]
-            [/not]
-
-            [then]
-                [set_achievement]
-                    content_for=eastern_invasion
-                    id=ei_S04c
-                [/set_achievement]
-            [/then]
-        [/if]
     [/event]
 #enddef
     [event] # this is a really ugly way to have an additional line for Terraent
@@ -946,6 +932,20 @@
                     image_pos=right
                     mirror=yes
                 [/message]
+            [/then]
+        [/if]
+
+        [if]
+            [have_unit]
+                side=1
+                trait=survivor
+                count=6-999
+            [/have_unit]
+            [then]
+                [set_achievement]
+                    content_for=eastern_invasion
+                    id=ei_S04c
+                [/set_achievement]
             [/then]
         [/if]
     [/event]


### PR DESCRIPTION
EI's S04c has an achievement for rescuing all 6 prisoners. This achievement currently triggers whenever all prisoners are freed, even if they die before escaping the scenario.  This PR changes the achievement to only trigger if all 6 prisoners actually escape.