### PR TITLE
EI S99: prevent prisoner income if prisons are captured

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/99_Empire.cfg
@@ -151,21 +151,15 @@
         first_time_only=no
         {RESET_SIDE_AI 2,3,4 defensive 0.9 0.1}
         {MODIFY_SIDE_AI (2) (
-            [avoid] # avoid the prison guards and side 3's leader
-                x=0-24,41-99
-                y=0-12,19-99
+            [avoid] # avoid side 3's leader
+                x=41-99
+                y=19-99
             [/avoid]
         )}
         {MODIFY_SIDE_AI (3) (
-            [avoid] # avoid the prison guards and side 2's leader
-                x=0-24,38-99
-                y=0-12, 0-18
-            [/avoid]
-        )}
-        {MODIFY_SIDE_AI (4) (
-            [avoid] # avoid the prison guards
-                x=0-24
-                y=0-12
+            [avoid] # avoid side 2's leader
+                x=38-99
+                y= 0-18
             [/avoid]
         )}
 
@@ -1062,25 +1056,22 @@ I will not fall easily."
                 [filter]
                     x,y={X},{Y}
                 [/filter]
-
+                hitpoints=$random
                 [object]
+                    id=imprisoned
                     [effect]
                         apply_to=remove_attacks
-
                         [not]
                             name=fire breath
                         [/not]
                     [/effect]
-
                     [effect]
                         apply_to=new_attack
-
                         [filter]
                             [not]
                                 trait=strong
                             [/not]
                         [/filter]
-
                         name=unarmed
                         description= _ "unarmed"
                         icon=attacks/fist-human.png
@@ -1092,11 +1083,9 @@ I will not fall easily."
                     # same as the merman civilian
                     [effect]
                         apply_to=new_attack
-
                         [filter]
                             trait=strong
                         [/filter]
-
                         name=unarmed
                         description= _ "unarmed"
                         icon=attacks/fist-human.png
@@ -1137,6 +1126,9 @@ I will not fall easily."
                 side=1
             [/not]
         [/filter]
+        [filter_condition]
+            {VARIABLE_CONDITIONAL prisons_captured not_equals yes}
+        [/filter_condition]
 
         [filter_second]
             side=1
@@ -1195,6 +1187,64 @@ I will not fall easily."
             name=explain_prisons3
         [/fire_event]
         {IMPRISON_UNIT 18 7}
+    [/event]
+
+    #--------------------
+    # JAILER DIES
+    #--------------------
+    [event]
+        name=die
+        [filter]
+            side=7
+            [not]
+                x,y=21,10
+            [/not]
+        [/filter]
+        [message]
+            speaker=Chief Dra-Nak
+            message= _ "Get away from my jail cells! Filthy traitors, there goes my income..."
+        [/message]
+        [message]
+            speaker=Chief Dra-Nak
+            message= _ "Fine then, I’m done taking prisoners. From here on out, you either submit or die!"
+        [/message]
+        {VARIABLE prisons_captured yes}
+    [/event]
+    [event]
+        name=die
+        [filter]
+            side,x,y=7,16,11
+        [/filter]
+        {MODIFY_TERRAIN Re^Pr/o 16 10}
+        {MODIFY_UNIT side,x,y=6,13-16,7-10 side 2}
+        [remove_object]
+            side=2
+            object_id=imprisoned
+        [/remove_object]
+    [/event]
+    [event]
+        name=die
+        [filter]
+            side,x,y=7,22,8
+        [/filter]
+        {MODIFY_TERRAIN Re^Pr/o 21 8}
+        {MODIFY_UNIT side,x,y=6,18-21,6-8 side 2}
+        [remove_object]
+            side=2
+            object_id=imprisoned
+        [/remove_object]
+    [/event]
+    [event]
+        name=die
+        [filter]
+            side,x,y=7,26,8
+        [/filter]
+        {MODIFY_TERRAIN Re^Pr\o 28 8}
+        {MODIFY_UNIT side,x,y=6,28-31,6-8 side 2}
+        [remove_object]
+            side=2
+            object_id=imprisoned
+        [/remove_object]
     [/event]
 
     #--------------------
@@ -1587,13 +1637,12 @@ I will not fall easily."
     #--------------------
     # DEFEAT
     #--------------------
+    # Dra-Nak dies
     [event]
         name=last breath
-
         [filter]
             id=Chief Dra-Nak
         [/filter]
-
         [message]
             speaker=Chief Dra-Nak
             #po: the chief's last breath


### PR DESCRIPTION
In EI's S99, you gain gold from defeating and capturing hostile drakes.  The drakes are physically moved to prison cells in the middle of the map.

Previously, the player could continue capturing drakes even if enemies overran the prison area. Additionally, the prison cells stayed locked with prisoners inside. This makes no sense in-universe, and also made it a strong strategy to abandon the center and turtle up in a corner of the map. 

This PR fixes this issue. This also adds 2 new strings; I'm planning to backport to 1.18.2, as this is arguably a bugfix.