### PR TITLE
EI S12: fix Dra-Nak having inconsistent traits and portrait

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -71,7 +71,7 @@
         canrecruit=yes
         facing=sw
         [modifications]
-            {TRAIT_RESILIENT}
+            {TRAIT_INTELLIGENT}
             {TRAIT_STRONG}
         [/modifications]
         controller=ai
@@ -118,6 +118,7 @@
             [then]
                 {MODIFY_UNIT id=Varrak-Klar name _"Chief Dra-Nak"}
                 {ADVANCE_UNIT id=Varrak-Klar "Orcish Sovereign"}
+                {MODIFY_UNIT id=Varrak-Klar profile portraits/orcs/ruler-2.webp}
             [/then]
         [/if]
     [/event]


### PR DESCRIPTION
In EI S11, the player encounters an orcish warlord named Dra-Nak. If not killed in S11, he continues pursuing the player in S12, but the current S12 gives him different traits and a different portrait. This PR fixes the issue.