### PR TITLE
allow quick reload of gui2 themes, no restart of wesnoth needed

### DIFF
--- a/data/gui/themes/default/window/preferences.cfg
+++ b/data/gui/themes/default/window/preferences.cfg
@@ -419,16 +419,33 @@
 						tooltip = _ "Display the game version and build information"
 					[/button]
 				[/column]
-
+				
 				[column]
 					horizontal_alignment = "right"
-					border = "all"
-					border_size = 5
-					[button]
-						id = "ok"
-						definition = "default"
-						label = _ "Close"
-					[/button]
+					
+					[grid]
+						[row]
+							[column]
+								border = "all"
+								border_size = 5
+								[button]
+									id = "apply"
+									definition = "default"
+									label = _ "Apply"
+								[/button]
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								[button]
+									id = "ok"
+									definition = "default"
+									label = _ "Close"
+								[/button]
+							[/column]
+						[/row]
+					[/grid]
 				[/column]
 
 			[/row]

--- a/data/gui/themes/default/window/preferences/03_display.cfg
+++ b/data/gui/themes/default/window/preferences/03_display.cfg
@@ -196,7 +196,7 @@
 				[/row]
 				[row]
 					[column]
-						border = "top,left,right"
+						border = "all"
 						border_size = 5
 						horizontal_alignment = "left"
 
@@ -204,20 +204,6 @@
 							id = "choose_gui2_theme"
 							tooltip = _ "Change the UI (GUI2) theme. Additional themes may be provided by community-made add-ons"
 						[/menu_button]
-					[/column]
-				[/row]
-				[row]
-					[column]
-						border = "bottom,left,right"
-						border_size = 5
-						horizontal_alignment = "left"
-
-						[label]
-							id = restart_msg
-							label = _ "<span color='red'>*restart required</span>"
-							definition = "default_small"
-							use_markup = true
-						[/label]
 					[/column]
 				[/row]
 			[/grid]

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -1217,7 +1217,7 @@ void preferences_dialog::handle_gui2_theme_select()
 	if (selected_theme != current_gui_theme_) {
 		current_gui_theme_ = selected_theme;
 		prefs::get().set_gui_theme(gui2_themes_.at(selected_theme));
-		gui2::init();
+		gui2::init(gui2_themes_.at(selected_theme), false);
 		set_retval(gui2::dialogs::title_screen::RELOAD_UI);
 	}
 }

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -25,6 +25,7 @@
 #include "formula/string_utils.hpp"
 #include "game_data.hpp"
 #include "gettext.hpp"
+#include "gui/gui.hpp"
 #include "gui/core/gui_definition.hpp"
 #include "hotkey/hotkey_item.hpp"
 #include "lexical_cast.hpp"
@@ -38,6 +39,7 @@
 #include "gui/dialogs/log_settings.hpp"
 #include "gui/dialogs/multiplayer/mp_alerts_options.hpp"
 #include "gui/dialogs/select_orb_colors.hpp"
+#include "gui/dialogs/title_screen.hpp"
 
 #include "gui/auxiliary/find_widget.hpp"
 #include "gui/dialogs/game_version_dialog.hpp"
@@ -1137,9 +1139,6 @@ void preferences_dialog::pre_show(window& window)
 	VALIDATE(selector.get_item_count() == pager.get_layer_count(),
 		"The preferences pager and its selector listbox do not have the same number of items.");
 
-	// don't show the "*restart required" message for UI theme at start
-	find_widget<label>(&window, "restart_msg", false).set_visible(widget::visibility::invisible);
-
 	const int main_index = index_in_pager_range(initial_index_.first, pager);
 
 	// Loops through each pager layer and checks if it has both a tab bar
@@ -1213,9 +1212,11 @@ void preferences_dialog::handle_theme_select()
 
 void preferences_dialog::handle_gui2_theme_select()
 {
-	find_widget<label>(get_window(), "restart_msg", false).set_visible(widget::visibility::visible);
 	menu_button& gui2_theme_list = find_widget<menu_button>(this, "choose_gui2_theme", false);
 	prefs::get().set_gui_theme(gui2_themes_.at(gui2_theme_list.get_value()));
+
+	gui2::init();
+	set_retval(gui2::dialogs::title_screen::RELOAD_GAME_DATA);
 }
 
 void preferences_dialog::on_page_select()

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -592,7 +592,7 @@ void preferences_dialog::initialize_callbacks()
 	/* SELECT GUI2 THEME */
 	menu_button& gui2_theme_list = find_widget<menu_button>(this, "choose_gui2_theme", false);
 	set_gui2_theme_list(gui2_theme_list);
-	connect_signal_notify_modified(gui2_theme_list,
+	connect_signal_mouse_left_click(find_widget<button>(this, "apply", false),
 		std::bind(&preferences_dialog::handle_gui2_theme_select, this));
 
 	//
@@ -1218,7 +1218,7 @@ void preferences_dialog::handle_gui2_theme_select()
 		current_gui_theme_ = selected_theme;
 		prefs::get().set_gui_theme(gui2_themes_.at(selected_theme));
 		gui2::init();
-		set_retval(gui2::dialogs::title_screen::RELOAD_GAME_DATA);
+		set_retval(gui2::dialogs::title_screen::RELOAD_UI);
 	}
 }
 

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -25,7 +25,6 @@
 #include "formula/string_utils.hpp"
 #include "game_data.hpp"
 #include "gettext.hpp"
-#include "gui/gui.hpp"
 #include "gui/core/gui_definition.hpp"
 #include "hotkey/hotkey_item.hpp"
 #include "lexical_cast.hpp"
@@ -1217,7 +1216,6 @@ void preferences_dialog::handle_gui2_theme_select()
 	if (selected_theme != current_gui_theme_) {
 		current_gui_theme_ = selected_theme;
 		prefs::get().set_gui_theme(gui2_themes_.at(selected_theme));
-		gui2::init(gui2_themes_.at(selected_theme), false);
 		set_retval(gui2::dialogs::title_screen::RELOAD_UI);
 	}
 }

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -112,6 +112,7 @@ preferences_dialog::preferences_dialog(const pref_constants::PREFERENCE_VIEW ini
 	, themes_() // populated by set_theme_list
 	, gui2_themes_() // populated by set_gui2_theme_list
 	, last_selected_item_(0)
+	, current_gui_theme_(0)
 	, accl_speeds_({0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 3, 4, 8, 16})
 	, visible_hotkeys_()
 	, visible_categories_()
@@ -165,17 +166,16 @@ void preferences_dialog::set_theme_list(menu_button& theme_list)
 
 void preferences_dialog::set_gui2_theme_list(menu_button& theme_list)
 {
-	std::string current_theme_name = prefs::get().gui_theme();
+	std::string current_gui_theme_name = prefs::get().gui_theme();
 
 	std::vector<config> options;
-	std::size_t current_theme = 0;
 	bool theme_found = false;
 	unsigned i = 0;
 	for(auto& gui : guis) {
 		gui2_themes_.emplace_back(gui.first);
 		options.emplace_back("label", gui.second.description());
-		if (current_theme_name == gui.first) {
-			current_theme = i;
+		if (current_gui_theme_name == gui.first) {
+			current_gui_theme_ = i;
 			theme_found = true;
 		}
 		if (!theme_found) {
@@ -184,7 +184,7 @@ void preferences_dialog::set_gui2_theme_list(menu_button& theme_list)
 	}
 
 	theme_list.set_values(options);
-	theme_list.set_selected(current_theme);
+	theme_list.set_selected(current_gui_theme_);
 }
 
 widget_data preferences_dialog::get_friends_list_row_data(const preferences::acquaintance& entry)
@@ -1213,10 +1213,13 @@ void preferences_dialog::handle_theme_select()
 void preferences_dialog::handle_gui2_theme_select()
 {
 	menu_button& gui2_theme_list = find_widget<menu_button>(this, "choose_gui2_theme", false);
-	prefs::get().set_gui_theme(gui2_themes_.at(gui2_theme_list.get_value()));
-
-	gui2::init();
-	set_retval(gui2::dialogs::title_screen::RELOAD_GAME_DATA);
+	unsigned selected_theme = gui2_theme_list.get_value();
+	if (selected_theme != current_gui_theme_) {
+		current_gui_theme_ = selected_theme;
+		prefs::get().set_gui_theme(gui2_themes_.at(selected_theme));
+		gui2::init();
+		set_retval(gui2::dialogs::title_screen::RELOAD_GAME_DATA);
+	}
 }
 
 void preferences_dialog::on_page_select()

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -110,6 +110,7 @@ private:
 	std::vector<std::string> gui2_themes_;
 
 	int last_selected_item_;
+	unsigned current_gui_theme_;
 
 	std::vector<double> accl_speeds_;
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -330,7 +330,11 @@ void title_screen::init_callbacks()
 	// Preferences
 	//
 	register_button(*this, "preferences", hotkey::HOTKEY_PREFERENCES, [this]() {
-		gui2::dialogs::preferences_dialog::display();
+		gui2::dialogs::preferences_dialog pref_dlg;
+		pref_dlg.show();
+		if (pref_dlg.get_retval() == RELOAD_GAME_DATA) {
+			set_retval(RELOAD_GAME_DATA);
+		}
 
 		// Currently blurred windows don't capture well if there is something
 		// on top of them at the time of blur. Resizing the game window in

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -332,8 +332,8 @@ void title_screen::init_callbacks()
 	register_button(*this, "preferences", hotkey::HOTKEY_PREFERENCES, [this]() {
 		gui2::dialogs::preferences_dialog pref_dlg;
 		pref_dlg.show();
-		if (pref_dlg.get_retval() == RELOAD_GAME_DATA) {
-			set_retval(RELOAD_GAME_DATA);
+		if (pref_dlg.get_retval() == RELOAD_UI) {
+			set_retval(RELOAD_UI);
 		}
 
 		// Currently blurred windows don't capture well if there is something

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -61,6 +61,9 @@ public:
 		QUIT_GAME,
 		// Used to reload all game data
 		RELOAD_GAME_DATA,
+		// Dummy retval used to reshow the titlescreen,
+		// for example, in case of a gui2 theme change
+		RELOAD_UI,
 	};
 
 private:

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -61,8 +61,8 @@ public:
 		QUIT_GAME,
 		// Used to reload all game data
 		RELOAD_GAME_DATA,
-		// Dummy retval used to reshow the titlescreen,
-		// for example, in case of a gui2 theme change
+		// Used to reshow the titlescreen, for example,
+		// in the case of a gui2 theme change
 		RELOAD_UI,
 	};
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -31,10 +31,6 @@
 namespace gui2
 {
 
-namespace {
-config guis_cfg;
-}
-
 void init()
 {
 	LOG_GUI_G << "Initializing UI subststem.";
@@ -45,6 +41,7 @@ void init()
 	//
 	// Read and validate the WML files.
 	//
+	config guis_cfg;
 	try {
 		schema_validation::schema_validator validator(filesystem::get_wml_location("schema/gui.cfg").value());
 
@@ -85,7 +82,10 @@ void switch_theme(const std::string& current_theme)
 			if (gui.first == current_theme) {
 				current_gui = gui_itor;
 			}
-			gui_itor++;
+			
+			if (gui_itor != guis.end) {
+				gui_itor++;
+			}
 		}
 
 		if(current_gui == guis.end()) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -31,14 +31,9 @@
 
 namespace gui2
 {
-static bool initialized = false;
 
 void init()
 {
-//	if(initialized) {
-//		return;
-//	}
-
 	LOG_GUI_G << "Initializing UI subststem.";
 
 	// Save current screen size.
@@ -92,8 +87,6 @@ void init()
 	}
 
 	current_gui->second.activate();
-
-	initialized = true;
 }
 
 } // namespace gui2

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -35,9 +35,9 @@ static bool initialized = false;
 
 void init()
 {
-	if(initialized) {
-		return;
-	}
+//	if(initialized) {
+//		return;
+//	}
 
 	LOG_GUI_G << "Initializing UI subststem.";
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -35,7 +35,7 @@ namespace {
 config guis_cfg;
 }
 
-void init(const std::string& current_theme, bool force_read)
+void init()
 {
 	LOG_GUI_G << "Initializing UI subststem.";
 
@@ -45,20 +45,18 @@ void init(const std::string& current_theme, bool force_read)
 	//
 	// Read and validate the WML files.
 	//
-	if (guis_cfg.empty() || force_read) {
-		try {
-			schema_validation::schema_validator validator(filesystem::get_wml_location("schema/gui.cfg").value());
+	try {
+		schema_validation::schema_validator validator(filesystem::get_wml_location("schema/gui.cfg").value());
 
-			preproc_map preproc(game_config::config_cache::instance().get_preproc_map());
-			filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location("gui/_main.cfg").value(), &preproc);
-			read(guis_cfg, *stream, &validator);
-		} catch(const config::error& e) {
-			ERR_GUI_P << e.what();
-			ERR_GUI_P << "Setting: could not read file 'data/gui/_main.cfg'.";
-		} catch(const abstract_validator::error& e) {
-			ERR_GUI_P << "Setting: could not read file 'data/schema/gui.cfg'.";
-			ERR_GUI_P << e.message;
-		}
+		preproc_map preproc(game_config::config_cache::instance().get_preproc_map());
+		filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location("gui/_main.cfg").value(), &preproc);
+		read(guis_cfg, *stream, &validator);
+	} catch(const config::error& e) {
+		ERR_GUI_P << e.what();
+		ERR_GUI_P << "Setting: could not read file 'data/gui/_main.cfg'.";
+	} catch(const abstract_validator::error& e) {
+		ERR_GUI_P << "Setting: could not read file 'data/schema/gui.cfg'.";
+		ERR_GUI_P << e.message;
 	}
 
 	//
@@ -75,8 +73,6 @@ void init(const std::string& current_theme, bool force_read)
 	}
 
 	VALIDATE(default_gui != guis.end(), _("No default gui defined."));
-
-	switch_theme(current_theme);
 }
 
 void switch_theme(const std::string& current_theme)

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -72,19 +72,30 @@ void init(const std::string& current_theme, bool force_read)
 		if(id == "default") {
 			default_gui = iter;
 		}
-
-		if(!current_theme.empty() && id == current_theme) {
-			current_gui = iter;
-		}
 	}
 
 	VALIDATE(default_gui != guis.end(), _("No default gui defined."));
 
-	if(current_theme.empty()) {
+	switch_theme(current_theme);
+}
+
+void switch_theme(const std::string& current_theme)
+{
+	if (current_theme.empty() || current_theme == "default") {
 		current_gui = default_gui;
-	} else if(current_gui == guis.end()) {
-		ERR_GUI_P << "Missing [gui] definition for '" << current_theme << "'";
-		current_gui = default_gui;
+	} else {
+		gui_theme_map_t::iterator gui_itor = guis.begin();
+		for (const auto& gui : guis) {
+			if (gui.first == current_theme) {
+				current_gui = gui_itor;
+			}
+			gui_itor++;
+		}
+
+		if(current_gui == guis.end()) {
+			ERR_GUI_P << "Missing [gui] definition for '" << current_theme << "'";
+			current_gui = default_gui;
+		}
 	}
 
 	current_gui->second.activate();

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -83,7 +83,7 @@ void switch_theme(const std::string& current_theme)
 				current_gui = gui_itor;
 			}
 			
-			if (gui_itor != guis.end) {
+			if (gui_itor != guis.end()) {
 				gui_itor++;
 			}
 		}

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -82,7 +82,7 @@ void switch_theme(const std::string& current_theme)
 			if (gui.first == current_theme) {
 				current_gui = gui_itor;
 			}
-			
+
 			if (gui_itor != guis.end()) {
 				gui_itor++;
 			}

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -32,7 +32,11 @@
 namespace gui2
 {
 
-void init()
+namespace {
+config guis_cfg;
+}
+
+void init(bool force_read)
 {
 	LOG_GUI_G << "Initializing UI subststem.";
 
@@ -49,13 +53,14 @@ void init()
 		preproc_map preproc(game_config::config_cache::instance().get_preproc_map());
 		filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location("gui/_main.cfg").value(), &preproc);
 
-		read(cfg, *stream, &validator);
-	} catch(const config::error& e) {
-		ERR_GUI_P << e.what();
-		ERR_GUI_P << "Setting: could not read file 'data/gui/_main.cfg'.";
-	} catch(const abstract_validator::error& e) {
-		ERR_GUI_P << "Setting: could not read file 'data/schema/gui.cfg'.";
-		ERR_GUI_P << e.message;
+			read(guis_cfg, *stream, &validator);
+		} catch(const config::error& e) {
+			ERR_GUI_P << e.what();
+			ERR_GUI_P << "Setting: could not read file 'data/gui/_main.cfg'.";
+		} catch(const abstract_validator::error& e) {
+			ERR_GUI_P << "Setting: could not read file 'data/schema/gui.cfg'.";
+			ERR_GUI_P << e.message;
+		}
 	}
 
 	//
@@ -63,7 +68,7 @@ void init()
 	//
 	const std::string& current_theme = prefs::get().gui_theme();
 
-	for(const config& g : cfg.child_range("gui")) {
+	for(const config& g : guis_cfg.child_range("gui")) {
 		const std::string id = g["id"];
 
 		auto iter = guis.emplace(id, gui_definition(g)).first;

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -23,11 +23,9 @@ namespace gui2
  * Initializes the GUI subsystems.
  *
  * @note This function must be called before other parts of the UI engine
- * are used.
- * @param current_theme         the theme to switch to
- * @param force_read    force rereading of gui from file even when cache is non-empty
+ * are used. Use @ref switch_theme below to actually activate the theme.
  */
-void init(const std::string& current_theme = "", bool force_read = false);
+void init();
 
 /**
  * Set and activate the given gui2 theme

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -29,4 +29,12 @@ namespace gui2
  */
 void init(const std::string& current_theme = "", bool force_read = false);
 
+/**
+ * Set and activate the given gui2 theme
+ *
+ * @param current_theme    the name of the gui2 theme to switch to
+ */
+void switch_theme(const std::string& current_theme);
+
+
 } // namespace gui2

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -22,7 +22,8 @@ namespace gui2
  *
  * @note This function must be called before other parts of the UI engine
  * are used.
+ * @param force_read    force rereading of gui from file even when cache is non-empty
  */
-void init();
+void init(bool force_read = false);
 
 } // namespace gui2

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace gui2
 {
 /**
@@ -22,8 +24,9 @@ namespace gui2
  *
  * @note This function must be called before other parts of the UI engine
  * are used.
+ * @param theme         the theme to switch to
  * @param force_read    force rereading of gui from file even when cache is non-empty
  */
-void init(bool force_read = false);
+void init(const std::string& current_theme = "", bool force_read = false);
 
 } // namespace gui2

--- a/src/gui/gui.hpp
+++ b/src/gui/gui.hpp
@@ -24,7 +24,7 @@ namespace gui2
  *
  * @note This function must be called before other parts of the UI engine
  * are used.
- * @param theme         the theme to switch to
+ * @param current_theme         the theme to switch to
  * @param force_read    force rereading of gui from file even when cache is non-empty
  */
 void init(const std::string& current_theme = "", bool force_read = false);

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -87,6 +87,7 @@ struct wesnoth_global_fixture {
 		test_utils::get_fake_display(1024, 768);
 
 		gui2::init();
+		gui2::switch_theme("default");
 		static const gui2::event::manager gui_event_manager;
 
 		// TODO: For some reason this fails on MacOS and prevents any tests from running

--- a/src/tests/utils/game_config_manager_tests.cpp
+++ b/src/tests/utils/game_config_manager_tests.cpp
@@ -76,6 +76,7 @@ namespace test_utils {
 
 			font::load_font_config();
 			gui2::init();
+			gui2::switch_theme("default");
 			load_language_list();
 			game_config::config_cache::instance().add_define("TEST");
 			game_config::config_cache::instance().get_config(game_config::path + "/data/test/", cfg_);

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -848,7 +848,7 @@ static int do_gameloop(const std::vector<std::string>& args)
 		case gui2::dialogs::title_screen::REDRAW_BACKGROUND:
 			break;
 		case gui2::dialogs::title_screen::RELOAD_UI:
-			gui2::init(prefs::get().gui_theme(), false);
+			gui2::switch_theme(prefs::get().gui_theme());
 			break;
 		}
 	}

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -36,6 +36,7 @@
 #include "gui/dialogs/title_screen.hpp" // for title_screen, etc
 #include "gui/gui.hpp"                  // for init
 #include "log.hpp"                      // for LOG_STREAM, general, logger, etc
+#include "preferences/preferences.hpp"
 #include "scripting/application_lua_kernel.hpp"
 #include "scripting/plugins/context.hpp"
 #include "scripting/plugins/manager.hpp"
@@ -667,7 +668,7 @@ static int do_gameloop(const std::vector<std::string>& args)
 	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
 #endif
 
-	gui2::init();
+	gui2::init(prefs::get().gui_theme());
 	const gui2::event::manager gui_event_manager;
 
 	// if the log directory is not writable, then this is the error condition so show the error message.

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -844,6 +844,8 @@ static int do_gameloop(const std::vector<std::string>& args)
 			break;
 		case gui2::dialogs::title_screen::REDRAW_BACKGROUND:
 			break;
+		//gui2::dialogs::title_screen::RELOAD_UI intentionally left out
+		//not handling it causes the dialog to be closed and reshown with changes
 		}
 	}
 }

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -808,7 +808,9 @@ static int do_gameloop(const std::vector<std::string>& args)
 		{ // scope to not keep the title screen alive all game
 			gui2::dialogs::title_screen dlg(*game);
 
-			// Allows re-layout on resize
+			// Allows re-layout on resize.
+			// Since RELOAD_UI is not checked here, it causes
+			// the dialog to be closed and reshown with changes.
 			while(dlg.get_retval() == gui2::dialogs::title_screen::REDRAW_BACKGROUND) {
 				dlg.show();
 			}
@@ -843,9 +845,8 @@ static int do_gameloop(const std::vector<std::string>& args)
 			game->launch_game(game_launcher::reload_mode::RELOAD_DATA);
 			break;
 		case gui2::dialogs::title_screen::REDRAW_BACKGROUND:
+		case gui2::dialogs::title_screen::RELOAD_UI:
 			break;
-		//gui2::dialogs::title_screen::RELOAD_UI intentionally left out
-		//not handling it causes the dialog to be closed and reshown with changes
 		}
 	}
 }

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -846,7 +846,9 @@ static int do_gameloop(const std::vector<std::string>& args)
 			game->launch_game(game_launcher::reload_mode::RELOAD_DATA);
 			break;
 		case gui2::dialogs::title_screen::REDRAW_BACKGROUND:
+			break;
 		case gui2::dialogs::title_screen::RELOAD_UI:
+			gui2::init(prefs::get().gui_theme(), false);
 			break;
 		}
 	}

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -668,7 +668,8 @@ static int do_gameloop(const std::vector<std::string>& args)
 	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
 #endif
 
-	gui2::init(prefs::get().gui_theme());
+	gui2::init();
+	gui2::switch_theme(prefs::get().gui_theme());
 	const gui2::event::manager gui_event_manager;
 
 	// if the log directory is not writable, then this is the error condition so show the error message.


### PR DESCRIPTION
With this, after changing the gui2 theme using **Preferences -> Display -> UI Theme**, no restart of wesnoth is required. The theme gets reloaded after the user presses the "Apply" button.