### PR TITLE
DM: S18 recall fix

### DIFF
--- a/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
@@ -442,10 +442,7 @@
                     id=Delfador
                 [/not]
             [/filter]
-            [put_to_recall_list]
-                id=$unit.id
-                heal=yes
-            [/put_to_recall_list]
+			{DELFADOR_ESCAPED_UNITS}
         [/event]
 
         [event]
@@ -485,6 +482,7 @@
                         time=10
                     [/delay]
                     {COLOR_ADJUST 0 0 0}
+					{MEMOIRS_UNSTORE_UNITS delfador_escaped_units}
                     [endlevel]
                         result=victory
                     [/endlevel]

--- a/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
+++ b/data/campaigns/Delfadors_Memoirs/scenarios/18_The_Portal_of_Doom.cfg
@@ -442,7 +442,7 @@
                     id=Delfador
                 [/not]
             [/filter]
-			{DELFADOR_ESCAPED_UNITS}
+            {DELFADOR_ESCAPED_UNITS}
         [/event]
 
         [event]
@@ -482,7 +482,8 @@
                         time=10
                     [/delay]
                     {COLOR_ADJUST 0 0 0}
-					{MEMOIRS_UNSTORE_UNITS delfador_escaped_units}
+                    {MEMOIRS_UNSTORE_UNITS delfador_escaped_units}
+                    {CLEAR_VARIABLE delfador_escaped_units}
                     [endlevel]
                         result=victory
                     [/endlevel]

--- a/data/campaigns/Delfadors_Memoirs/utils/sides.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/sides.cfg
@@ -396,7 +396,7 @@
 #define DELFADOR_ESCAPED_UNITS
     [store_unit]
         kill=yes
-		mode=append
+        mode=append
         variable=delfador_escaped_units
         [filter]
             id=$unit.id

--- a/data/campaigns/Delfadors_Memoirs/utils/sides.cfg
+++ b/data/campaigns/Delfadors_Memoirs/utils/sides.cfg
@@ -391,6 +391,19 @@
     [/allow_recruit]
 #enddef
 
+# Store units who escape through the tunnel in Portal of Doom (18), so that they can no longer be recalled in the same scenario.
+
+#define DELFADOR_ESCAPED_UNITS
+    [store_unit]
+        kill=yes
+		mode=append
+        variable=delfador_escaped_units
+        [filter]
+            id=$unit.id
+        [/filter]
+    [/store_unit]
+#enddef
+
 # At the beginning of Showdown in the Northern Swamp (19), Kalenz
 # rejoins Delfador. Chantal is not here for this one.
 


### PR DESCRIPTION
In S18 Portal of Doom, all player units must escape through the tunnel, after which Delfador will follow them.
However, if unit entered the tunnel, it magically appeared in the recall list and could be recalled again. I fixed it, and now the escaped units are not available until the next scenario.