### PR TITLE
[Fwdport] Opens load map/save map as dialogs in correct folders

### DIFF
--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -208,7 +208,11 @@ void context_manager::load_map_dialog(bool force_same_context /* = false */)
 {
 	std::string fn = get_map_context().get_filename();
 	if(fn.empty()) {
-		fn = filesystem::get_current_editor_dir(current_addon_) +"/maps";
+		if (editor_controller::current_addon_id_.empty()) {
+			fn = filesystem::get_legacy_editor_dir() + "/maps";
+		} else {
+			fn = filesystem::get_current_editor_dir(editor_controller::current_addon_id_) + "/maps";
+		}
 	}
 
 	gui2::dialogs::file_dialog dlg;
@@ -680,7 +684,11 @@ void context_manager::save_map_as_dialog()
 	std::string input_name = get_map_context().get_filename();
 	if(input_name.empty()) {
 		first_pick = true;
-		input_name = filesystem::get_current_editor_dir(editor_controller::current_addon_id_)+"/maps";
+		if (editor_controller::current_addon_id_.empty()) {
+			input_name = filesystem::get_legacy_editor_dir() + "/maps";
+		} else {
+			input_name = filesystem::get_current_editor_dir(editor_controller::current_addon_id_) + "/maps";
+		}
 	}
 
 	gui2::dialogs::file_dialog dlg;


### PR DESCRIPTION
Forward port of the new commit in #9062. (88fc3cda4fb66d09cf670c7e456f042fcb3d0fdb)
Opens load map/save map as dialogs in the addon's map directory.
With no addon selected they open in the `editor/maps` directory.