### PR TITLE
THoT S6 Music Tweak

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg
@@ -11,7 +11,7 @@
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC       elvish-theme.ogg}
-    {EXTRA_SCENARIO_MUSIC traveling_minstrels.ogg}
+    {EXTRA_SCENARIO_MUSIC vengeful.ogg}
     {EXTRA_SCENARIO_MUSIC frantic.ogg}
 
     {THOT_TRACK {JOURNEY_STAGE6}}


### PR DESCRIPTION
Somewhat adresses #8507 (SotA is unaffected)

This replaces the song Travelling Minstrels with Vengeful Pursuit in S6 of THoT (Forbidden Forest). In my opinion, this is much more fitting to the scenario.