### PR TITLE
Removed deprecated unit message from fog clearer

### DIFF
--- a/data/core/units/fake/Fog_Clearer.cfg
+++ b/data/core/units/fake/Fog_Clearer.cfg
@@ -32,5 +32,4 @@
     usage=scout
     hide_help=yes
     do_not_list=yes
-    {DEPRECATED_UNIT "Fog Clearer" "" 1.15}
 [/unit_type]


### PR DESCRIPTION
Version 1.15 has passed and this unit has not been removed. Based on the comment at the start of the file, this is unlikely to be removed in the near future. The message shown is hence unnecessary and could potentially lead to confusion.