### PR TITLE
Clean up `config_attribute_value::operator==`

### DIFF
--- a/src/config_attribute_value.cpp
+++ b/src/config_attribute_value.cpp
@@ -418,23 +418,6 @@ bool config_attribute_value::operator==(const config_attribute_value& other) con
 	return utils::visit(equality_visitor(), value_, other.value_);
 }
 
-/**
- * Checks for equality of the attribute values when viewed as strings.
- * Exception: Boolean synonyms can be equal ("yes" == "true").
- * Note: Blanks have no string representation, so do not equal "" (an empty string).
- * Also note that translatable string are never equal to non translatable strings.
- */
-bool config_attribute_value::equals(const std::string& str) const
-{
-	config_attribute_value v;
-	v = str;
-	return *this == v;
-	// if c["a"] = "1" then this solution would have resulted in c["a"] == "1" being false
-	// because a["a"] is '1' and not '"1"'.
-	// return boost::apply_visitor(std::bind( equality_visitor(), std::placeholders::_1, std::cref(str) ), value_);
-	// that's why we don't use it.
-}
-
 std::ostream& operator<<(std::ostream& os, const config_attribute_value& v)
 {
 	// Simple implementation, but defined out-of-line because of the templating

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -162,7 +162,6 @@ public:
 	/** Tests for an attribute that either was never set or was set to "". */
 	bool empty() const;
 
-
 	// Comparisons:
 	bool operator==(const config_attribute_value &other) const;
 	bool operator!=(const config_attribute_value &other) const
@@ -170,39 +169,36 @@ public:
 		return !operator==(other);
 	}
 
-	bool equals(const std::string& str) const;
-	// These function prevent t_string creation in case of c["a"] == "b" comparisons.
-	// The templates are needed to prevent using these function in case of c["a"] == 0 comparisons.
-	template<typename T>
-	std::enable_if_t<std::is_same_v<const std::string, std::add_const_t<T>>, bool>
-		friend operator==(const config_attribute_value &val, const T &str)
+	bool operator==(bool comp) const
 	{
-		return val.equals(str);
+		const bool has_bool =
+			utils::holds_alternative<yes_no>(value_) ||
+			utils::holds_alternative<true_false>(value_);
+		return has_bool && to_bool() == comp;
 	}
 
 	template<typename T>
-	std::enable_if_t<std::is_same_v<const char*, T>, bool>
-		friend operator==(const config_attribute_value& val, T str)
+	bool operator==(const T& comp) const
 	{
-		return val.equals(std::string(str));
-	}
-
-	template<typename T>
-	bool friend operator==(const T& str, const config_attribute_value& val)
-	{
-		return val == str;
+		if constexpr(std::is_convertible_v<T, std::string>) {
+			config_attribute_value v;
+			v = comp;
+			return *this == v;
+		} else {
+			return utils::holds_alternative<T>(value_) && T(*this) == comp;
+		}
 	}
 
 	template<typename T>
 	bool friend operator!=(const config_attribute_value& val, const T& str)
 	{
-		return !(val == str);
+		return !val.operator==(str);
 	}
 
 	template<typename T>
 	bool friend operator!=(const T &str, const config_attribute_value& val)
 	{
-		return !(val == str);
+		return !val.operator==(str);
 	}
 
 	// Streaming:

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -214,6 +214,26 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 	x_str = c["x"].str();
 	BOOST_CHECK_EQUAL(x_str, "123456789123");
 
+// check heterogeneous comparison
+	c["x"] = 987654321;
+	BOOST_CHECK_EQUAL(c["x"], 987654321);
+	c["x"] = "1";
+	BOOST_CHECK_EQUAL(c["x"], "1");
+	c["x"] = 222;
+	BOOST_CHECK_EQUAL(c["x"], "222");
+	c["x"] = "test";
+	BOOST_CHECK_EQUAL(c["x"], "test");
+	c["x"] = "33333";
+	BOOST_CHECK_EQUAL(c["x"], 33333);
+	c["x"] = "yes";
+	BOOST_CHECK_EQUAL(c["x"], true);
+	c["x"] = false;
+	BOOST_CHECK_EQUAL(c["x"], "no");
+	c["x"] = "sfvsdgdsfg";
+	BOOST_CHECK_NE(c["x"], 0);
+	BOOST_CHECK_NE(c["x"], true);
+	BOOST_CHECK_NE(c["x"], "a random string");
+
 	// blank != "" test.
 	c.clear();
 	BOOST_CHECK(cc["x"] != "");


### PR DESCRIPTION
The old implementation was recursive when building with C++20 due to primary operator reordering. More importantly, however, it would fail this test:
```
	c["x"] = "yes";
	BOOST_CHECK_EQUAL(c["x"], true);
```