### PR TITLE
SotA S2: Avoid destroying unit potentially already occupying target hex

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -379,6 +379,8 @@ of Healing"
         [unstore_unit]
             variable=frightened_bat
             x, y=16, 7
+            find_vacant=yes
+            check_passability=yes
         [/unstore_unit]
         # If there is a bat with a role, it's still on the recall list at this point,
         # though there is a copy of it on the map as well.


### PR DESCRIPTION
Work-around for #9150. If a unit already occupies the hex, it doesn't do anything about the break in animation, but at least the unit present won't be destroyed - and it won't fail the scenario if Ardonna is the one occupying the hex.