### PR TITLE
Turn Dwarvish Miners into a Level 0 unit

### DIFF
--- a/data/core/units/dwarves/Miner.cfg
+++ b/data/core/units/dwarves/Miner.cfg
@@ -4,7 +4,7 @@
     name= _ "Dwarvish Miner"
     race=dwarf
     image=units/dwarves/miner.png
-    hitpoints=25
+    hitpoints=23
     movement_type=dwarvishfoot
     [resistance]
         blade=90

--- a/data/core/units/dwarves/Miner.cfg
+++ b/data/core/units/dwarves/Miner.cfg
@@ -14,7 +14,7 @@
     movement=4
     level=0
     alignment=neutral
-    advances_to=Dwarvish Fighter,Dwarvish Guardsman,Dwarvish Ulfserker
+    advances_to=Dwarvish Fighter,Dwarvish Guardsman
     experience=24
     cost=11
     usage=fighter

--- a/data/core/units/dwarves/Miner.cfg
+++ b/data/core/units/dwarves/Miner.cfg
@@ -4,7 +4,7 @@
     name= _ "Dwarvish Miner"
     race=dwarf
     image=units/dwarves/miner.png
-    hitpoints=23
+    hitpoints=22
     movement_type=dwarvishfoot
     [resistance]
         blade=90

--- a/data/core/units/dwarves/Miner.cfg
+++ b/data/core/units/dwarves/Miner.cfg
@@ -6,15 +6,19 @@
     image=units/dwarves/miner.png
     hitpoints=25
     movement_type=dwarvishfoot
+    [resistance]
+        blade=90
+        pierce=90
+        impact=90
+    [/resistance]
     movement=4
-    level=1
+    level=0
     alignment=neutral
-    advances_to=null
-    {AMLA_DEFAULT}
-    experience=50
-    cost=5
+    advances_to=Dwarvish Fighter,Dwarvish Guardsman,Dwarvish Ulfserker
+    experience=24
+    cost=11
     usage=fighter
-    description= _ "Dwarvish miners are the grunt workers of dwarvish society. They take the precious ores out of the ground, but do not ever take part in the crafting of weapons or artifacts. They have no military training, but they can still do some damage with their picks."
+    description= _ "Dwarvish Miners are the grunt workers of dwarvish society. They take the precious ores out of the ground, but do not ever take part in the crafting of weapons or artifacts. Despite their lack of military training, their weighty pickaxes can deal substantial damage."
     {DEFENSE_ANIM "units/dwarves/miner-defend-2.png" "units/dwarves/miner-defend-1.png" {SOUND_LIST:DWARF_HIT}}
     die_sound={SOUND_LIST:DWARF_DIE}
     [attack]
@@ -23,7 +27,7 @@
         type=pierce
         range=melee
         damage=4
-        number=2
+        number=3
         icon=attacks/pick-axe.png
     [/attack]
     [standing_anim]


### PR DESCRIPTION
This was proposed in the forums a while back, and I personally think its a good idea. This changes the Dwarvish Miner to a level 0 unit which can advance to a Dwarvish Ulfserker, Fighter or Guardsman. It also reduces its XP from 50 to 19. The Dwarvish Fighter's stats look like a level 0 unit, and I think it would make sense as one. These are all proposals made by various people on this thread, not myself: https://forums.wesnoth.org/viewtopic.php?t=57995