### PR TITLE
Handling empty team in :droid

### DIFF
--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1476,9 +1476,6 @@ void console_handler::do_droid()
 	} else if(menu_handler_.board().get_team(side).is_network()) {
 		command_failed(VGETTEXT("Can't droid networked side: '$side'.", symbols));
 		return;
-	} else if (menu_handler_.board().get_team(side).is_empty()) {
-		command_failed(VGETTEXT("Side '$side' is not a human or AI player.", symbols));
-		return;
 	} else if(menu_handler_.board().get_team(side).is_local()) {
 		bool changed = false;
 
@@ -1566,6 +1563,9 @@ void console_handler::do_droid()
 				psc->set_player_type_changed();
 			}
 		}
+	} else {
+		command_failed(VGETTEXT("Side '$side' is not a human or AI player.", symbols));
+		return;
 	}
 	menu_handler_.textbox_info_.close();
 }

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1476,6 +1476,9 @@ void console_handler::do_droid()
 	} else if(menu_handler_.board().get_team(side).is_network()) {
 		command_failed(VGETTEXT("Can't droid networked side: '$side'.", symbols));
 		return;
+	} else if (menu_handler_.board().get_team(side).is_empty()) {
+		command_failed(VGETTEXT("Side '$side' is not a human or AI player.", symbols));
+		return;
 	} else if(menu_handler_.board().get_team(side).is_local()) {
 		bool changed = false;
 


### PR DESCRIPTION
Closes https://github.com/wesnoth/wesnoth/issues/8879

This PR adds handling for empty/null teams when using the `:droid` command.

It now shows an error message:

<img width="371" alt="Screenshot 2024-08-03 at 12 30 47 PM" src="https://github.com/user-attachments/assets/3dfa4198-3e45-4587-a8a0-51e03f86a567">

