### PR TITLE
damage_type tests

### DIFF
--- a/data/test/_main.cfg
+++ b/data/test/_main.cfg
@@ -82,6 +82,7 @@
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML/berserk}
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit}
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage}
+{test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type}
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heals}
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML/hides}
 {test/scenarios/wml_tests/UnitsWML/AbilitiesWML/illuminates}

--- a/data/test/macros/wml_unit_test_macros.cfg
+++ b/data/test/macros/wml_unit_test_macros.cfg
@@ -76,6 +76,60 @@
     [/if]
 #enddef
 
+#define GIVE_ALL_TYPES DAMAGE STRIKES
+    [modify_unit]
+        [filter]
+        [/filter]
+        [effect]
+            apply_to = new_attack
+            name = "arcane"
+            type = "arcane"
+            range = "melee"
+            damage = {DAMAGE}
+            number = {STRIKES}
+        [/effect]
+        [effect]
+            apply_to = new_attack
+            name = "fire"
+            type = "fire"
+            range = "melee"
+            damage = {DAMAGE}
+            number = {STRIKES}
+        [/effect]
+        [effect]
+            apply_to = new_attack
+            name = "cold"
+            type = "cold"
+            range = "melee"
+            damage = {DAMAGE}
+            number = {STRIKES}
+        [/effect]
+        [effect]
+            apply_to = new_attack
+            name = "pierce"
+            type = "pierce"
+            range = "melee"
+            damage = {DAMAGE}
+            number = {STRIKES}
+        [/effect]
+        [effect]
+            apply_to = new_attack
+            name = "impact"
+            type = "impact"
+            range = "melee"
+            damage = {DAMAGE}
+            number = {STRIKES}
+        [/effect]
+        [effect]
+            apply_to = attack
+            name = "sword"
+            set_name = "blade"
+            set_damage = {DAMAGE}
+            set_attacks = {STRIKES}
+        [/effect]
+    [/modify_unit]
+#enddef
+
 # Have one adjacent unit attack another adjacent unit.
 # Each unit is given 1000 hp and their attack is made to 100×1, with a 100% chance of hitting.
 #

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_arcane.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_arcane.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternate_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with an arcane type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to arcane damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_arcane" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "arcane"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    arcane = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_blade.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_blade.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a blade type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to blade damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_blade" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    blade = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_cold.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_cold.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a cold type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to cold damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_cold" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "cold"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    cold = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_fire.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_fire.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a fire type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to fire damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_fire" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "fire"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    fire = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_impact.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_impact.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with an impact type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to impact damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_impact" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "impact"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    impact = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_pierce.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_pierce.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternate_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a pierce type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_pierce" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "pierce"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_three.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_three.cfg
@@ -1,0 +1,50 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Give the leaders two damage_type abilities with a pierce type
+# Give the leaders one damage_type ability with a blade type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (gives best damage result)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_three" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        alternative_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        alternative_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_two.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_alternative_two.cfg
@@ -1,0 +1,47 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=
+##
+# Actions:
+# Give the leaders one damage_type ability with a pierce type
+# Give the leaders one damage_type ability with a blade type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (gives best damage result)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_alternative_two" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        alternative_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_same_alternative_best.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_same_alternative_best.cfg
@@ -1,0 +1,45 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=,replacement_type=
+##
+# Actions:
+# Give the leaders one damage_type ability with a pierce type as the alternative_type
+# Give the leaders one damage_type ability with a blade type as the replacement_type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (uses alternative_type)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_both_same_alternative_best" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "pierce"
+                        replacement_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_same_replacement_best.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_same_replacement_best.cfg
@@ -1,0 +1,45 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=,replacement_type=
+##
+# Actions:
+# Give the leaders one damage_type ability with a pierce type as the replacement_type
+# Give the leaders one damage_type ability with a blade type as the alternative_type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (uses replacement_type)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_both_same_replacement_best" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                        alternative_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_separate_alternative_best.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_separate_alternative_best.cfg
@@ -1,0 +1,47 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=,[damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders one damage_type ability with a pierce type as the alternative_type
+# Give the leaders one damage_type ability with a blade type as the replacement_type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (uses alternative_type)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_both_separate_alternative_best" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        alternative_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_separate_replacement_best.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_both_separate_replacement_best.cfg
@@ -1,0 +1,47 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=,[damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders one damage_type ability with a pierce type as the replacement_type
+# Give the leaders one damage_type ability with a blade type as the alternative_type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (uses replacement_type)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_both_separate_replacement_best" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        alternative_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_many.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_many.cfg
@@ -1,0 +1,64 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]alternative_type=,replacement_type=
+##
+# Actions:
+# Give the leaders damage_type abilities with
+#   replacement_type=pierce, 3x
+#   replacement_type=arcane, 1x
+#   alternative_type=blade, 3x
+#   alternative_type=arcane, 1x
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage, 40% weakness to arcane, and 20% weakness to blade
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_many" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                        alternative_type = "blade"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "arcane"
+                        alternative_type = "blade"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "pierce"
+                        alternative_type = "arcane"
+                    [/damage_type]
+                    [damage_type]
+                        alternative_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                    arcane = 140
+                    blade = 120
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_arcane.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_arcane.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with an arcane type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to arcane damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_arcane" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "arcane"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    arcane = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_blade.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_blade.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a blade type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to blade damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_blade" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    blade = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_cold.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_cold.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a cold type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to cold damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_cold" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "cold"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    cold = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_fire.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_fire.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a fire type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to fire damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_fire" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "fire"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    fire = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_impact.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_impact.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with an impact type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to impact damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_impact" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "impact"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    impact = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_pierce.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_pierce.cfg
@@ -1,0 +1,43 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders a damage_type ability with a pierce type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_pierce" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_three.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_three.cfg
@@ -1,0 +1,50 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders two damage_type abilities with a pierce type
+# Give the leaders one damage_type ability with a blade type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 4 damage since it uses the pierce damage type (most instances of damage_type)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_three" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 4 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_two.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_replacement_two.cfg
@@ -1,0 +1,47 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage_type]replacement_type=
+##
+# Actions:
+# Give the leaders one damage_type ability with a pierce type
+# Give the leaders one damage_type ability with a blade type
+# Give the leaders a melee weapon for each of the 6 mainline damage types
+# Give the leaders a 100% weakness to pierce damage
+# Have the side 1 leader attack the side 2 leader with all its weapons
+##
+# Expected end state:
+# The side 1 leader has 6 weapons all of which deal 2 damage since it uses the blade damage type (alphabetically first)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_replacement_two" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    [damage_type]
+                        replacement_type = "pierce"
+                    [/damage_type]
+                    [damage_type]
+                        replacement_type = "blade"
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [effect]
+                apply_to = resistance
+                replace = yes
+                [resistance]
+                    pierce = 200
+                [/resistance]
+            [/effect]
+        [/modify_unit]
+
+        {GIVE_ALL_TYPES 2 1}
+        {ATTACK_AND_VALIDATE 2 WEAPON_COUNT=6 (DAMAGE_VALUE=)}
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Orcish Grunt"}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -851,6 +851,28 @@
 0 damage_overwrite_specials_two_both_sides
 0 damage_overwrite_specials_two_one_side
 0 damage_overwrite_specials_mixed
+# damage_type ability tests
+0 damage_type_replacement_arcane
+0 damage_type_replacement_blade
+0 damage_type_replacement_cold
+0 damage_type_replacement_fire
+0 damage_type_replacement_impact
+0 damage_type_replacement_pierce
+0 damage_type_alternative_arcane
+0 damage_type_alternative_blade
+0 damage_type_alternative_cold
+0 damage_type_alternative_fire
+0 damage_type_alternative_impact
+0 damage_type_alternative_pierce
+0 damage_type_replacement_two
+0 damage_type_replacement_three
+0 damage_type_alternative_two
+0 damage_type_alternative_three
+0 damage_type_both_separate_replacement_best
+0 damage_type_both_separate_alternative_best
+0 damage_type_both_same_replacement_best
+0 damage_type_both_same_alternative_best
+0 damage_type_many
 # Warnings about WML
 0 unknown_scenario_false_positives
 0 unknown_scenario_interpolated


### PR DESCRIPTION
@newfrenchy83 currently the alternate_type tests fail since only the defender uses the damage type that deals more damage. The attacker uses the original damage type even though the alternate type would deal more damage.