### PR TITLE
Disable WML tests for debug builds

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -128,10 +128,12 @@ jobs:
             printf '%s-path: %s\n' "$opt" "$output"
           done
       - name: WML validation
-        if: success() || steps.build.outcome == 'success'
+        # only run on release builds (takes ~10 times as long on debug)
+        if: matrix.cfg == 'release' && (success() || steps.build.outcome == 'success')
         run: ./utils/CI/schema_validation.sh
       - name: Run WML tests
-        if: success() || steps.build.outcome == 'success'
+        # only run on release builds (takes ~6 times as long on debug)
+        if: matrix.cfg == 'release' && (success() || steps.build.outcome == 'success')
         run: ./run_wml_tests -g -c -t 20 -bt 1000
       - name: Run play tests
         if: success() || steps.build.outcome == 'success'


### PR DESCRIPTION
Not that useful to run them with debug as well as release binaries and it takes a lot of time.

Adresses #9167.