### PR TITLE
hotkey: Identify Alt as "opt" on macOS

### DIFF
--- a/changelog_entries/macos-option-key-label.md
+++ b/changelog_entries/macos-option-key-label.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * Option key is now identified as such instead of Alt in the Hotkeys preferences section on macOS builds

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -55,7 +55,11 @@ const std::string hotkey_base::get_name() const
 
 	ret += (!ret.empty() && !boost::algorithm::ends_with(ret, "+") ? "+" : "");
 	if(mod_ & KMOD_ALT) {
+#ifdef __APPLE__
+		ret += "opt";
+#else
 		ret += "alt";
+#endif
 	}
 
 	ret += (!ret.empty() && !boost::algorithm::ends_with(ret, "+") ? "+" : "");


### PR DESCRIPTION
Addresses #9172.

A couple of additional remarks about this:

* It is common for macOS apps to use the standards icons for key modifiers rather than their textual labels, i.e. ⌥ for Option, ⌃ for Control, ⌘ for Command. However, I don't believe there are any official guidelines specifically encouraging this, and since Wesnoth is a game it kind of violates most user interface design guidelines as it is anyway.
* It may make sense to add a combo-based Advanced preferences entry that lets the player choose between "Native", "PC" and "Mac" key labels, but at the same time it's a lot of effort for a niche use case (people with mismatched keyboards that struggle to translate between Mac and PC keyboard layouts).