### PR TITLE
action menu support for menu_button

### DIFF
--- a/data/gui/themes/default/widget/menu_button_default.cfg
+++ b/data/gui/themes/default/widget/menu_button_default.cfg
@@ -3,9 +3,9 @@
 ### Definition of the default button.
 ###
 
-#define _GUI_TEXT FONT_SIZE FONT_COLOR
+#define _GUI_TEXT FONT_SIZE FONT_COLOR TEXT_X
 	[text]
-		x = 8 # 3px border + 5px padding inside
+                x = {TEXT_X}
 		y = {GUI__TEXT_VERTICALLY_CENTRED}
 		w = "(text_width)"
 		h = "(text_height)"
@@ -26,7 +26,12 @@
 	}
 #enddef
 
-#define _GUI_RESOLUTION RESOLUTION MIN_WIDTH DEFAULT_WIDTH HEIGHT EXTRA_WIDTH EXTRA_HEIGHT FONT_SIZE BASE_NAME IPF
+#define _GUI_RESOLUTION RESOLUTION MIN_WIDTH DEFAULT_WIDTH HEIGHT EXTRA_WIDTH EXTRA_HEIGHT FONT_SIZE BASE_NAME IPF ARROW_ENABLED ARROW_DISABLED ARROW_PRESSED ARROW_FOCUSED
+#arg TEXT_X
+8
+#endarg
+# 8 = 3px border + 5px padding inside
+
 	[resolution]
 
 		{RESOLUTION}
@@ -50,13 +55,9 @@
 
 				{_GUI_BUTTON_FRAME () ({GUI__BORDER_COLOR}) ({GUI__BORDER_COLOR_DARK}) ("21, 79, 109, 255") {IPF}}
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE})}
+				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) ({TEXT_X})}
 
-				[image]
-					x = "(width - 25)"
-					y = 2
-					name = "icons/arrows/short_arrow_ornate_left_25.png~ROTATE(-90)"
-				[/image]
+                                {ARROW_ENABLED}
 			[/draw]
 
 		[/state_enabled]
@@ -67,13 +68,9 @@
 
 				{_GUI_BUTTON_FRAME () ({GUI__FONT_COLOR_DISABLED__DEFAULT}) ("89,  89,  89,  255") ("60,  60,  60, 255") "~GS(){IPF}"}
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE})}
+				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__TITLE}) ({TEXT_X})}
 
-				[image]
-					x = "(width - 25)"
-					y = 2
-					name = "icons/arrows/short_arrow_ornate_left_25.png~ROTATE(-90)~GS()"
-				[/image]
+                                {ARROW_DISABLED}
 			[/draw]
 
 		[/state_disabled]
@@ -84,13 +81,9 @@
 
 				{_GUI_BUTTON_FRAME () ({GUI__BORDER_COLOR}) ({GUI__BORDER_COLOR_DARK}) ("1, 10, 16, 255") {IPF}}
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE})}
+				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) ({TEXT_X})}
 
-				[image]
-					x = "(width - 25)"
-					y = 2
-					name = "icons/arrows/short_arrow_ornate_left_25-pressed.png~ROTATE(-90)"
-				[/image]
+                                {ARROW_PRESSED}
 			[/draw]
 
 		[/state_pressed]
@@ -102,13 +95,9 @@
 				# Doesn't have its own 'active' variation image
 				{_GUI_BUTTON_FRAME -pressed ({GUI__BORDER_COLOR}) ({GUI__BORDER_COLOR_DARK}) ("12, 108, 157, 255") {IPF}}
 
-				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE})}
+				{_GUI_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__TITLE}) ({TEXT_X})}
 
-				[image]
-					x = "(width - 25)"
-					y = 2
-					name = "icons/arrows/short_arrow_ornate_left_25-active.png~ROTATE(-90)"
-				[/image]
+                                {ARROW_FOCUSED}
 			[/draw]
 
 		[/state_focused]
@@ -116,17 +105,65 @@
 	[/resolution]
 #enddef
 
+#define _GUI_ARROW_ENABLED
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25.png~ROTATE(-90)"
+				[/image]
+#enddef
+
+#define _GUI_ARROW_DISABLED
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25.png~ROTATE(-90)~GS()"
+				[/image]
+#enddef
+
+#define _GUI_ARROW_PRESSED
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25-pressed.png~ROTATE(-90)"
+				[/image]
+#enddef
+
+#define _GUI_ARROW_FOCUSED
+				[image]
+					x = "(width - 25)"
+					y = 2
+					name = "icons/arrows/short_arrow_ornate_left_25-active.png~ROTATE(-90)"
+				[/image]
+#enddef
+
+
 [menu_button_definition]
 
 	id = "default"
 	description = "Default button"
 
-	{_GUI_RESOLUTION (window_width,window_height=680,480) 40 80 30 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" ()}
-	{_GUI_RESOLUTION (window_width,window_height=801,601) 40 120 30 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" ()}
-	{_GUI_RESOLUTION (window_width,window_height=1025,765) 40 180 30 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" ()}
+	{_GUI_RESOLUTION (window_width,window_height=680,480) 40 80 30 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" () 
+            {_GUI_ARROW_ENABLED} {_GUI_ARROW_DISABLED} {_GUI_ARROW_PRESSED} {_GUI_ARROW_FOCUSED}}
+	{_GUI_RESOLUTION (window_width,window_height=801,601) 40 120 30 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" ()
+            {_GUI_ARROW_ENABLED} {_GUI_ARROW_DISABLED} {_GUI_ARROW_PRESSED} {_GUI_ARROW_FOCUSED}}
+	{_GUI_RESOLUTION (window_width,window_height=1025,765) 40 180 30 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" ()
+            {_GUI_ARROW_ENABLED} {_GUI_ARROW_DISABLED} {_GUI_ARROW_PRESSED} {_GUI_ARROW_FOCUSED}}
 
 [/menu_button_definition]
 
+[menu_button_definition]
+        id = "game_actions"
+        description = "Menu/Actions button for in-game menubar, centered, no arrow"
+
+        {_GUI_RESOLUTION () 100 100 27 13 4 ({GUI_FONT_SIZE_SMALL}) "button_dropdown/button_dropdown" () () () () () (TEXT_X="((width - text_width) / 2)")}
+
+[/menu_button_definition]
+
+#undef _GUI_ARROW_FOCUSED
+#undef _GUI_ARROW_PRESSED
+#undef _GUI_ARROW_DISABLED
+#undef _GUI_ARROW_ENABLED
 #undef _GUI_BUTTON_FRAME
 #undef _GUI_RESOLUTION
 #undef _GUI_TEXT

--- a/data/schema/gui/widget_instances.cfg
+++ b/data/schema/gui/widget_instances.cfg
@@ -77,6 +77,7 @@
             {DEFAULT_KEY "icon" string ""}
             {DEFAULT_KEY "details" t_string ""}
         [/tag]
+        {DEFAULT_KEY "update_label" bool false}
     [/tag]
     [tag]
         name="multiline_text"
@@ -193,7 +194,6 @@
         {DEFAULT_KEY "text_alignment" h_align "left"}
         {DEFAULT_KEY "link_aware" bool false}
         {DEFAULT_KEY "width" unsigned 500}
-        
     [/tag]
     [tag]
         name="grid_listbox"

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -44,6 +44,7 @@ menu_button::menu_button(const implementation::builder_menu_button& builder)
 	, values_()
 	, selected_(0)
 	, keep_open_(false)
+	, update_label_(builder.update_label)
 {
 	values_.emplace_back("label", this->get_label());
 
@@ -194,7 +195,9 @@ void menu_button::set_values(const std::vector<::config>& values, unsigned selec
 	values_ = values;
 	selected_ = selected;
 
-	set_label(values_[selected_]["label"]);
+	if(update_label_) {
+		set_label(values_[selected_]["label"]);
+	}
 }
 
 void menu_button::set_selected(unsigned selected, bool fire_event)
@@ -208,7 +211,10 @@ void menu_button::set_selected(unsigned selected, bool fire_event)
 
 	selected_ = selected;
 
-	set_label(values_[selected_]["label"]);
+	if(update_label_) {
+		set_label(values_[selected_]["label"]);
+	}
+
 	if (fire_event) {
 		fire(event::NOTIFY_MODIFIED, *this, nullptr);
 	}
@@ -242,6 +248,7 @@ namespace implementation
 builder_menu_button::builder_menu_button(const config& cfg)
 	: builder_styled_widget(cfg)
 	, options_()
+	, update_label(cfg["update_label_"].to_bool(false))
 {
 	for(const auto& option : cfg.child_range("option")) {
 		options_.push_back(option);

--- a/src/gui/widgets/menu_button.hpp
+++ b/src/gui/widgets/menu_button.hpp
@@ -77,6 +77,7 @@ public:
 		keep_open_ = keep_open;
 	}
 
+
 private:
 	/**
 	 * Possible states of the widget.
@@ -106,6 +107,8 @@ private:
 
 	bool keep_open_;
 
+	/* Whether or not the button's label should be updated when an option is selected */
+	bool update_label_;
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
 	static const std::string& type();
@@ -157,8 +160,10 @@ public:
 
 	virtual std::unique_ptr<widget> build() const override;
 
+	bool update_label;
 private:
 	std::vector<::config> options_;
+
 };
 
 } // namespace implementation


### PR DESCRIPTION
Allows menu_button to act like Menu/Actions buttons on main game screen.
- Adds update_label parameter to determine whether to update the button text when value changes
- Adds new definition that nearly matches existing Menu/Actions buttons (I don't think available font options will allow an exact match)