### PR TITLE
Fix infinite recursion (no recursion-counting version)

### DIFF
--- a/changelog_entries/fix_infinite_recursion.md
+++ b/changelog_entries/fix_infinite_recursion.md
@@ -1,0 +1,2 @@
+ ### WML Engine
+   * Fix infinite recursion method changed by checking config of special.

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/two_cycle_recursion_by_id.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/two_cycle_recursion_by_id.cfg
@@ -1,0 +1,85 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_id_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# Give Alice's weapon specials specialN.
+# Give Bob's weapon specials specialX.
+# specialN (damage) is active if specialX is active
+# specialX (poison) is active if specialN is active
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing, but BROKE STRICT.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "two_cycle_recursion_by_id" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialX
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialN
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -163,7 +163,7 @@ public:
 		/**
 		 * Only expected to be called in update_variables_recursion(), which handles some of the checks.
 		 */
-		explicit recursion_guard(const attack_type& weapon);
+		explicit recursion_guard(const attack_type& weapon, const config& special);
 	public:
 		/**
 		 * Construct an empty instance, only useful for extending the lifetime of a
@@ -193,12 +193,11 @@ public:
 	 * recursion might occur, similar to a reentrant mutex that's limited to a small number of
 	 * reentrances.
 	 *
-	 * This is a cheap function, so no reason to optimise by doing some filters before calling it.
-	 * However, it only expects to be called in a single thread, but the whole of attack_type makes
+	 * This only expects to be called in a single thread, but the whole of attack_type makes
 	 * that assumption, for example its' mutable members are assumed to be set up by the current
 	 * caller (or caller's caller, probably several layers up).
 	 */
-	recursion_guard update_variables_recursion() const;
+	recursion_guard update_variables_recursion(const config& special) const;
 
 private:
 	// In unit_abilities.cpp:
@@ -415,8 +414,12 @@ private:
 	int parry_;
 	config specials_;
 	bool changed_;
-	/** Number of instances of recursion_guard that are currently allocated permission to recurse */
-	mutable unsigned int num_recursion_ = 0;
+	/**
+	 * While processing a recursive match, all the filters that are currently being checked, oldest first.
+	 * Each will have an instance of recursion_guard that is currently allocated permission to recurse, and
+	 * which will pop the config off this stack when the recursion_guard is finalized.
+	 */
+	mutable std::vector<config> open_queries_;
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -380,6 +380,7 @@
 9 damage_type_apply_to_both_filter_self_opponent
 9 damage_type_apply_to_attacker_filter_attacker_defender
 9 event_test_filter_damage_type_recursion
+9 two_cycle_recursion_by_id
 9 four_cycle_recursion_branching
 9 four_cycle_recursion_by_id
 9 four_cycle_recursion_by_tagname


### PR DESCRIPTION


When for example we have [damage_type][filter_self][has_attack|filter_weapon]type=pierce applied to one or any pierce type attack and the unit does not have an unaffected pierce attack, the change in type triggers an infinite recursion.

this PR fixes the problem and other because filter of weapon specials or formula except if special A [filter_self]special_id_active=B special B [filter_self]special_id_active=A.

Fix https://github.com/wesnoth/wesnoth/issues/8940