### PR TITLE
Gamestate Inspector: replace scroll_label with scroll_text

### DIFF
--- a/data/gui/themes/default/window/gamestate_inspector.cfg
+++ b/data/gui/themes/default/window/gamestate_inspector.cfg
@@ -133,7 +133,7 @@
 										id = "stuff_list"
 										definition = "default"
 										horizontal_scrollbar_mode = "never"
-										vertical_scrollbar_mode = "always"
+										vertical_scrollbar_mode = "auto"
 										indentation_step_size = 15
 
 										{_GUI_INSPECTOR_NODE "basic" (
@@ -302,10 +302,11 @@
 								horizontal_grow = true
 								vertical_grow = true
 
-								[scroll_label]
+								[scroll_text]
 									id = "inspect"
 									definition = "verbatim"
-								[/scroll_label]
+									editable = false
+								[/scroll_text]
 							[/column]
 
 						[/row]

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -161,8 +161,8 @@ public:
 	/**
 	 * Gets the location for the cursor, in drawing coordinates.
 	 *
-	 * @param column              The column offset of the cursor.
-	 * @param line                The line offset of the cursor.
+	 * @param column              The column character index of the cursor.
+	 * @param line                The line character index of the cursor.
 	 *
 	 * @returns                   The position of the top of the cursor. It the
 	 *                            requested location is out of range 0,0 is
@@ -172,16 +172,15 @@ public:
 		const unsigned column, const unsigned line = 0) const;
 
 	/**
-	 * Gets the correct number of columns to move the cursor
-	 * from Pango. Needed in case the text contains multibyte
-	 * characters. Return value == column if the text has no
-	 * multibyte characters.
+	 * Gets the location for the cursor, in drawing coordinates.
 	 *
-	 * @param column              The column offset of the cursor.
+	 * @param offset              The column byte index of the cursor.
 	 *
-	 * @returns                   Corrected column offset.
+	 * @returns                   The position of the top of the cursor. It the
+	 *                            requested location is out of range 0,0 is
+	 *                            returned.
 	 */
-	int get_byte_offset(const unsigned column) const;
+	point get_cursor_pos_from_index(const unsigned offset) const;
 
 	/**
 	 * Get maximum length.
@@ -234,6 +233,25 @@ public:
 	 *       least once.
 	 */
 	std::vector<std::string> get_lines() const;
+
+	/**
+	 * Get a specific line from the pango layout
+	 *
+	 * @param index    the line number of the line to retrieve
+	 *
+	 * @returns        the PangoLayoutLine* corresponding to line number index
+	 */
+	PangoLayoutLine* get_line(int index);
+
+	/**
+	 * Given a byte index, find out at which line the corresponding character
+	 * is located.
+	 *
+	 * @param offset   the byte index
+	 *
+	 * @returns        the line number corresponding to the given index
+	 */
+	int get_line_num_from_offset(const unsigned offset);
 
 	/**
 	 * Get number of lines in the text.
@@ -424,9 +442,6 @@ private:
 	 */
 	PangoAttrList* global_attribute_list_;
 
-	/** Hash for the global_attribute_list_ */
-	std::size_t attrib_hash_;
-
 	/** The pixel scale, used to render high-DPI text. */
 	int pixel_scale_;
 
@@ -435,9 +450,6 @@ private:
 
 	/** Calculates surface size. */
 	PangoRectangle calculate_size(PangoLayout& layout) const;
-
-	/** Allow specialization of std::hash for pango_text. */
-	friend struct std::hash<pango_text>;
 
 	/**
 	 * Equivalent to create_surface(viewport), where the viewport's top-left is
@@ -545,14 +557,3 @@ int get_max_height(unsigned size, font::family_class fclass = font::FONT_SANS_SE
 constexpr float get_line_spacing_factor() { return 1.3f; };
 
 } // namespace font
-
-// Specialize std::hash for pango_text
-namespace std
-{
-template<>
-struct hash<font::pango_text>
-{
-	std::size_t operator()(const font::pango_text&) const;
-};
-
-} // namespace std

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -1,6 +1,6 @@
 /*
 	Copyright (C) 2023 - 2024
-	by babaissarkar(Subhraman Sarkar) <suvrax@gmail.com>
+	by Subhraman Sarkar (babaissarkar) <suvrax@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 #include "gui/widgets/text_box_base.hpp"
 #include "gui/widgets/text_box.hpp"
 #include "gui/widgets/window.hpp"
+#include "serialization/unicode.hpp"
 
 namespace gui2
 {
@@ -71,12 +72,6 @@ public:
 		set_value("");
 	}
 
-	unsigned get_line_no()
-	{
-		set_line_num_from_offset();
-		return line_num_;
-	}
-
 	point get_cursor_pos()
 	{
 		return get_cursor_position(get_selection_start());
@@ -84,7 +79,8 @@ public:
 
 	int get_line_end_pos()
 	{
-		return get_cursor_position(get_line_end_offset(line_num_)).x;
+		unsigned line_num = get_line_number(get_selection_start());
+		return get_cursor_position(get_line_end_offset(line_num)).x;
 	}
 
 	point get_text_end_pos()
@@ -114,7 +110,6 @@ protected:
 	void set_cursor(const std::size_t offset, const bool select) override
 	{
 		text_box_base::set_cursor(offset, select);
-		set_line_num_from_offset();
 		// Whenever cursor moves, this tells scroll_text to update the scrollbars
 		update_layout();
 	}
@@ -123,15 +118,15 @@ public:
 	/** Inherited from text_box_base. */
 	void goto_end_of_line(const bool select = false) override
 	{
-		set_line_num_from_offset();
-		set_cursor(get_line_end_offset(line_num_), select);
+		unsigned line_num = get_line_number(get_selection_start());
+		set_cursor(get_line_end_offset(line_num), select);
 	}
 
 	/** Inherited from text_box_base. */
 	void goto_start_of_line(const bool select = false) override
 	{
-		set_line_num_from_offset();
-		set_cursor(get_line_start_offset(line_num_), select);
+		unsigned line_num = get_line_number(get_selection_start());
+		set_cursor(get_line_start_offset(line_num), select);
 	}
 
 	/** Inherited from text_box_base. */
@@ -205,17 +200,13 @@ private:
 	/** Image (such as a magnifying glass) that accompanies the help text. */
 	std::string hint_image_;
 
-	/** Line number of text */
-	unsigned line_num_;
-
-	/** utility function to calculate and set line_num_ from offset */
-	void set_line_num_from_offset();
-	unsigned get_line_num_from_offset(unsigned offset);
-
-	/** Utility function to calculate the offset of the end of the line
+	/**
+	 *  Utility function to calculate the offset of the end of the line
 	 */
 	unsigned get_line_end_offset(unsigned line_no);
-	/** Utility function to calculate the offset of the end of the line
+
+	/**
+	 *  Utility function to calculate the offset of the end of the line
 	 */
 	unsigned get_line_start_offset(unsigned line_no);
 

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -363,10 +363,6 @@ void text_box::signal_handler_left_button_down(const event::ui_event event,
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
 
-	/*
-	 * Copied from the base class see how we can do inheritance with the new
-	 * system...
-	 */
 	get_window()->keyboard_capture(this);
 	get_window()->mouse_capture();
 

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -80,21 +80,42 @@ public:
 	}
 
 	/**
+	 * Wrapper function, returns the line corresponding
+	 * to index.
+	 * See @ref font::pango_text::get_line.
+	 */
+	PangoLayoutLine* get_line(int index)
+	{
+		return text_.get_line(index);
+	}
+
+	/**
+	 * Wrapper function, return the line number
+	 * given the byte index.
+	 * See @ref font::pango_text::get_line_num_from_offset.
+	 */
+	int get_line_number(const unsigned offset)
+	{
+		return text_.get_line_num_from_offset(offset);
+	}
+
+	/**
+	 * Wrapper function, return the cursor position
+	 * given the byte index.
+	 * See @ref font::pango_text::get_cursor_pos_from_index.
+	 */
+	point get_cursor_pos_from_index(const unsigned offset) const
+	{
+		return text_.get_cursor_pos_from_index(offset);
+	}
+
+	/**
 	 * Wrapper function, return number of lines.
 	 * See @ref font::pango_text::get_lines_count.
 	 */
 	unsigned get_lines_count() const
 	{
 		return text_.get_lines_count();
-	}
-
-	/**
-	 * Wrapper function, returns corrected column offset from pango.
-	 * See @ref font::pango_text::get_byte_offset.
-	 */
-	int get_byte_offset(const unsigned column) const
-	{
-		return text_.get_byte_offset(column);
 	}
 
 	/**


### PR DESCRIPTION
Resolves #8032.
Uses `scroll_text` instead of `scroll_label` so that text can be copied.
(Should not be squashed.)

_Known issue:_
Could face slight slowdown for large texts, but it won't crash while selecting text or lag during loading.