### PR TITLE
fix [filter_weapon][not] cannot detect in special weapon filters the absence of the attribute when the weapon does not exist (1.19 branch and later)

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/opponent_has_no_weapon.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/opponent_has_no_weapon.cfg
@@ -1,0 +1,71 @@
+#####
+# API(s) being tested: [attacks][filter_opponent][filter_weapon][not]special_id_active=
+##
+# Actions:
+# Give alice an attacks ability which is active when the opponent don't has an ability with a specific id.
+# remove all attack to bob.
+# Have bob and alice fight.
+##
+# Expected end state:
+# alice's ability does activate, leaving her with 3 strikes.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "opponent_weapon_has_no_weapon" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [attacks]
+                        value=3
+                        [filter_opponent]
+                            race=orc
+                            [filter_weapon]
+                                [not]
+                                    special_id_active=test_cth
+                                [/not]
+                            [/filter_weapon]
+                        [/filter_opponent]
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=remove_attacks
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 35})}
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -389,6 +389,7 @@
 0 leadership_when_other_has_no_special
 0 effect_increase_attacks
 0 opponent_weapon_has_no_special
+0 opponent_weapon_has_no_weapon
 0 opponent_weapon_has_special
 0 plague_without_priority
 0 student_teacher_are_same


### PR DESCRIPTION

when a special weapon works under the condition that the opponent does not have a variable (no poison special weapon), the condition is only true if the opponent opposes a non-poisoned weapon but is false if no weapon at all is used when it should be true.