### PR TITLE
Death Squire optional advancement macro and damage nerf

### DIFF
--- a/data/core/macros/optional_unit_advancements.cfg
+++ b/data/core/macros/optional_unit_advancements.cfg
@@ -72,6 +72,11 @@
     {ENABLE_ADVANCEMENT "Revenant" "Death Knight" (set_experience=85)}
 #enddef
 
+#define ENABLE_DEATH_SQUIRE
+    # Place in a campaign or scenario definition to allow Skeleton to advance to Death Knight.
+    {ENABLE_ADVANCEMENT "Skeleton" "Death Squire" ()}
+#enddef
+
 #define ENABLE_WOSE_SHAMAN
     # Place in a campaign or scenario definition to allow Wose to advance to Wose Shaman.
     {ENABLE_ADVANCEMENT "Wose" "Wose Shaman" ()}

--- a/data/core/units/undead/Skele_Death_Squire.cfg
+++ b/data/core/units/undead/Skele_Death_Squire.cfg
@@ -14,11 +14,11 @@
         pierce=40
     [/resistance]
     movement=5
-    experience=91
+    experience=90
     level=2
     alignment=chaotic
     advances_to=Death Knight
-    cost=39
+    cost=32
     [abilities]
         {ABILITY_LEADERSHIP}
         {ABILITY_SUBMERGE}

--- a/data/core/units/undead/Skele_Death_Squire.cfg
+++ b/data/core/units/undead/Skele_Death_Squire.cfg
@@ -51,8 +51,8 @@
         description=_"axe"
         type=blade
         range=melee
-        damage=8
-        number=4
+        damage=9
+        number=3
         icon="attacks/axe-undead.png"
     [/attack]
     [attack_anim]


### PR DESCRIPTION
The existing {ENABLE_DEATH_KNIGHT} macro allows Revenants to advance to Death Knights. The newly core-ed Death Squire also advances to Death Knight, but has no {ENABLE_DEATH_SQUIRE} macro.

I suggest adding a new {ENABLE_DEATH_SQUIRE} macro, while keeping the old {ENABLE_DEATH_KNIGHT} for backwards compatibility.

I also propose reducing the Death Squire's attack from 8x4 to 9x3, to make the Revenant a more competitive advancement.

Who's the current maintainer of SotA? Should {ENABLE_DEATH_SQUIRE} be used there, or should we continue using {ENABLE_DEATH_KNIGHT}?

Hejnewar, if you approve, what cost should the Death Squire be after this change?