### PR TITLE
Add test store_locations_with_unit_filter

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/InternalActionsWML/store_locations_and_or_not_unit_filter.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/InternalActionsWML/store_locations_and_or_not_unit_filter.cfg
@@ -1,0 +1,103 @@
+#wmllint: no translatables
+
+#####
+# API(s) being tested: [store_locations][and][filter],[store_locations][or][filter],[store_locations][not][filter]
+##
+# Expected end state:
+# Wrapping the SUF in [and], [or] or [not] applies the expected logic.
+#####
+{GENERIC_UNIT_TEST "store_locations_and_or_not_unit_filter" (
+    [event]
+        name = start
+
+        # Explicit [and], explicit [and]
+        [store_locations]
+            [and]
+                [filter]
+                    race=elf
+                [/filter]
+            [/and]
+            [and]
+                [filter]
+                    race=orc
+                [/filter]
+            [/and]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 0})}
+
+        # Implicit [and], explicit [and]
+        [store_locations]
+            [filter]
+                race=elf
+            [/filter]
+            [and]
+                [filter]
+                    race=orc
+                [/filter]
+            [/and]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 0})}
+
+        # Explicit [and], explicit [or]
+        [store_locations]
+            [and]
+                [filter]
+                    race=elf
+                [/filter]
+            [/and]
+            [or]
+                [filter]
+                    race=orc
+                [/filter]
+            [/or]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 2})}
+
+        # Implicit [and], explicit [or]
+        [store_locations]
+            [filter]
+                race=elf
+            [/filter]
+            [or]
+                [filter]
+                    race=orc
+                [/filter]
+            [/or]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 2})}
+
+        # Excluding with [not]
+        # Including the borders, the map is 18 x 10
+        [store_locations]
+            [not]
+                [filter]
+                    race=elf
+                [/filter]
+            [/not]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 179})}
+
+        # Excluding with [not], [not]
+        [store_locations]
+            [not]
+                [filter]
+                    race=elf
+                [/filter]
+            [/not]
+            [not]
+                [filter]
+                    race=orc
+                [/filter]
+            [/not]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 178})}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/InternalActionsWML/store_locations_with_unit_filter.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/ActionWML/InternalActionsWML/store_locations_with_unit_filter.cfg
@@ -1,0 +1,34 @@
+#wmllint: no translatables
+
+#####
+# API(s) being tested: [store_locations][filter]
+##
+# Expected end state:
+# When an SUF is given to [store_locations], only the hexes with matching units are stored.
+#####
+{GENERIC_UNIT_TEST "store_locations_with_unit_filter" (
+    [event]
+        name = start
+
+        # This will store the hexes that Alice and Bob are standing on
+        [store_locations]
+            [filter]
+            [/filter]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 2})}
+
+        # With a filter that excludes elves, this will store the hex that Bob is standing on
+        [store_locations]
+            [filter]
+                [not]
+                    race=elf
+                [/not]
+            [/filter]
+            variable=tmp
+        [/store_locations]
+        {ASSERT ({VARIABLE_CONDITIONAL tmp.length equals 1})}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -439,6 +439,8 @@
 0 filter_this_unit_formula
 0 filter_formula_unit
 9 filter_formula_unit_error
+0 store_locations_with_unit_filter
+0 store_locations_and_or_not_unit_filter
 # Interrupt tag tests
 0 check_interrupts_break
 0 check_interrupts_return


### PR DESCRIPTION
Not sure this is really needed, but it's currently part of a discussion about whether `[filter_weapon][not]special_id_active=foo` should match a unit that has no weapon. So this is checking for reference that `[filter][not]race=elf` excludes every hex that has no unit on it.