### PR TITLE
wmlscope: fix format of magic comment in documentation

### DIFF
--- a/data/tools/wmlscope
+++ b/data/tools/wmlscope
@@ -47,7 +47,7 @@
 #
 # The following magic comment:
 #
-#     # prune FOOBAR
+#     # wmlscope: prune FOOBAR
 #
 # will cause wmlscope to forget about all but one of the definitions of FOOBAR
 # it has seen.  This will be useful mainly for symbols that have different


### PR DESCRIPTION
It's not just `prune`, but rather `wmlscope: prune`. I discovered this when working on cooljeanius/Flight_Freedom#23 earlier.
