### PR TITLE
Image metadata CI check

### DIFF
--- a/.github/workflows/image_metadata.yml
+++ b/.github/workflows/image_metadata.yml
@@ -1,0 +1,67 @@
+name: Image metadata check CI
+
+on:
+  #push:
+  #  branches: [master]
+  pull_request:
+    paths:
+      - '**.webp'
+      - '**.png'
+      - '**.jpg'
+  
+jobs:
+  build:
+    name: Ubuntu - Image Metadata
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      pull-requests: write
+
+    env:
+      SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+      - name: exiftool installation
+        run: |
+          sudo apt-get install --assume-yes exiftool
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: read/export image metadata
+        run: |
+          mapfile -t image_files < <(git diff --name-only ${BASE_SHA} ${SHA} | grep '\.webp$')
+
+          git status
+          # array of accepted copyright strings
+          accepted_cr=("GNU GPL v2+" "CC BY-SA 4.0")
+          # cycle through the changed image files, make sure they have the right fields
+          for file in "${image_files[@]}"; do
+            # check -Artist tag, fail if missing
+            artist="$(exiftool -Artist $file)"
+            artist="${artist#*: }"
+            if [ -z "$artist" ] ; then
+              echo "no Artist EXIF tag in $file"
+              exit 1
+            else
+              echo "Artist tag in $file is $artist"
+            fi
+            # check -Copyright tag, fail if missing or wrong type
+            copyright="$(exiftool -Copyright $file)"
+            copyright="${copyright#*: }"
+            if [ -z "$copyright" ] ; then
+              echo "no Copyright EXIF tag in $file"
+              exit 1
+            elif [[ ( "$copyright" != ${accepted_cr[0]} ) && ( "$copyright" != ${accepted_cr[1]}) ]] ; then
+              echo "$copyright is not an accepted license"
+              exit 1
+            else
+              echo "Copyright tag in $file is $copyright"
+            fi
+          done
+#      - name: The image_check step has failed
+#        if: ${{ failure() && steps.image_check.conclusion == 'failure' }}
+        

--- a/.github/workflows/image_metadata.yml
+++ b/.github/workflows/image_metadata.yml
@@ -8,6 +8,7 @@ on:
       - '**.webp'
       - '**.png'
       - '**.jpg'
+      - '**.jpeg'
   
 jobs:
   build:


### PR DESCRIPTION
I don't know how to test this directly in the PR, but I did test in a different repository.

- It only tests for Artist and Copyright tags, I guess the other tags can be optional.
- It doesn't sift through all images in the repository, it just looks at images in a PR.