### PR TITLE
Support events in [abilities] and [specials] tags

### DIFF
--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -43,6 +43,8 @@
 	{FILTER_TAG "filter_adjacent_location" adjacent_location ()}
 	{FILTER_TAG "filter_base_value" base_value ()}
 	{WML_MERGE_KEYS}
+
+	{LINK_TAG "event"}
 [/tag]
 [tag]
 	name="heals"

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -19,6 +19,8 @@
 	{FILTER_TAG "filter_attacker" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{FILTER_TAG "filter_defender" unit {FILTER_TAG "filter_weapon" weapon ()}}
 	{WML_MERGE_KEYS}
+
+	{LINK_TAG "event"}
 [/tag]
 # A few specials inheriting from ~generic~ are included here so that unit abilities can then inherit from them.
 [tag]

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events_in_ability_and_special_tags.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events_in_ability_and_special_tags.cfg
@@ -1,0 +1,326 @@
+#####
+# API(s) being tested: [unit][abilities][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) ability tag in a unit made with ActionWML
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_ability_in_unit" (
+    [event]
+        name=start
+        [unit]
+            type=Elvish Lady
+            [abilities]
+                [dummy]
+                    id=ability_in_unit
+                    [event]
+                        name=event_in_ability_in_unit
+                        {VARIABLE variable_in_event_in_ability_in_unit 1}
+                    [/event]
+                [/dummy]
+            [/abilities]
+        [/unit]
+        {VARIABLE variable_in_event_in_ability_in_unit 0}
+        [fire_event]
+            name=event_in_ability_in_unit
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_ability_in_unit equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [unit][specials][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) weapon special tag in a unit made with ActionWML
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_special_in_unit" (
+    [event]
+        name=start
+        [unit]
+            type=Elvish Lady
+            [attack]
+                name=stick
+                type=impact
+                range=melee
+                damage=2
+                number=2
+                [specials]
+                    [dummy]
+                        id=special_in_unit
+                        [event]
+                            name=event_in_special_in_unit
+                            {VARIABLE variable_in_event_in_special_in_unit 1}
+                        [/event]
+                    [/dummy]
+                [/specials]
+            [/attack]
+        [/unit]
+        {VARIABLE variable_in_event_in_special_in_unit 0}
+        [fire_event]
+            name=event_in_special_in_unit
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_special_in_unit equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [side][unit][abilities][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) ability tag in a unit made in a side with SideWML
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_ability_in_unit_in_side" (
+    [side]
+        side=3
+        [unit]
+            type=Elvish Lady
+            [abilities]
+                [dummy]
+                    id=ability_in_unit_in_side
+                    [event]
+                        name=event_in_ability_in_unit_in_side
+                        {VARIABLE variable_in_event_in_ability_in_unit_in_side 1}
+                    [/event]
+                [/dummy]
+            [/abilities]
+        [/unit]
+    [/side]
+    [event]
+        name=start
+        {VARIABLE variable_in_event_in_ability_in_unit_in_side 0}
+        [fire_event]
+            name=event_in_ability_in_unit_in_side
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_ability_in_unit_in_side equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [side][unit][specials][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) weapon special tag in a unit made in a side with SideWML
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_special_in_unit_in_side" (
+    [side]
+        side=3
+        [unit]
+            type=Elvish Lady
+            [attack]
+                name=stick
+                type=impact
+                range=melee
+                damage=2
+                number=2
+                [specials]
+                    [dummy]
+                        id=special_in_unit_in_side
+                        [event]
+                            name=event_in_special_in_unit_in_side
+                            {VARIABLE variable_in_event_in_special_in_unit_in_side 1}
+                        [/event]
+                    [/dummy]
+                [/specials]
+            [/attack]
+        [/unit]
+    [/side]
+    [event]
+        name=start
+        {VARIABLE variable_in_event_in_special_in_unit_in_side 0}
+        [fire_event]
+            name=event_in_special_in_unit_in_side
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_special_in_unit_in_side equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [unit_type][abilities][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) ability tag in a unit type
+# Add unit of this unit_type
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_ability_in_unit_type" (
+    [event]
+        name=start
+        {VARIABLE variable_in_event_in_ability_in_unit_type 0}
+        [unit]
+            type=Test Unit Ability Event
+        [/unit]
+        [fire_event]
+            name=event_in_ability_in_unit_type
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_ability_in_unit_type equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [unit_type][specials][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) special tag in a unit type
+# Add unit of this unit_type
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_special_in_unit_type" (
+    [event]
+        name=start
+        {VARIABLE variable_in_event_in_special_in_unit_type 0}
+        [unit]
+            type=Test Unit Special Event
+        [/unit]
+        [fire_event]
+            name=event_in_special_in_unit_type
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_special_in_unit_type equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [modify_unit][effect][abilities][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) ability tag in an effect applying a new ability
+# Apply the effect to a unit
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_ability_in_effect" (
+    [event]
+        name=start
+        [unit]
+            type=Elvish Lady
+        [/unit]
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [dummy]
+                        id=ability_in_effect
+                        [event]
+                            name=event_in_ability_in_effect
+                            {VARIABLE variable_in_event_in_ability_in_effect 1}
+                        [/event]
+                    [/dummy]
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+        {VARIABLE variable_in_event_in_ability_in_effect 0}
+        [fire_event]
+            name=event_in_ability_in_effect
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_ability_in_effect equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [modify_unit][effect][specials][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) special tag in an effect applying a new attack
+# Apply the effect to a unit
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_special_in_effect" (
+    [event]
+        name=start
+        [unit]
+            type=Elvish Lady
+        [/unit]
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=new_attack
+                [specials]
+                    [dummy]
+                        id=special_in_effect
+                        [event]
+                            name=event_in_special_in_effect
+                            {VARIABLE variable_in_event_in_special_in_effect 1}
+                        [/event]
+                    [/dummy]
+                [/specials]
+            [/effect]
+        [/modify_unit]
+        {VARIABLE variable_in_event_in_special_in_effect 0}
+        [fire_event]
+            name=event_in_special_in_effect
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_special_in_effect equals 1})}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [modify_unit][effect][set_specials][dummy][event]
+##
+# Actions:
+# Define a custom event in an (arbitrarily named) special tag in an effect applying a new special to an existing attack
+# Apply the effect to a unit
+# Fire the custom event
+##
+# Expected end state:
+# The custom event has executed
+#####
+{GENERIC_UNIT_TEST "event_in_set_special_in_effect" (
+    [event]
+        name=start
+        [unit]
+            type=Elvish Lady
+        [/unit]
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=attack
+                range=melee
+                [set_specials]
+                    mode=append
+                    [dummy]
+                        id=set_special_in_effect
+                        [event]
+                            name=event_in_set_special_in_effect
+                            {VARIABLE variable_in_event_in_set_special_in_effect 1}
+                        [/event]
+                    [/dummy]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+        {VARIABLE variable_in_event_in_set_special_in_effect 0}
+        [fire_event]
+            name=event_in_set_special_in_effect
+        [/fire_event]
+        {RETURN ({VARIABLE_CONDITIONAL variable_in_event_in_set_special_in_effect equals 1})}
+    [/event]
+)}

--- a/data/test/units/events_in_ability_and_special_tags.cfg
+++ b/data/test/units/events_in_ability_and_special_tags.cfg
@@ -1,0 +1,55 @@
+#textdomain wesnoth-test
+
+[unit_type]
+    id=Test Unit Ability Event
+    race=test
+    image="misc/blank-hex.png"
+    hitpoints=1
+    movement_type=fly
+    movement=1
+    experience=1
+    level=1
+    alignment=neutral
+    advances_to=null
+    cost=1
+    usage=scout
+    hide_help=yes
+    do_not_list=yes
+    [abilities]
+        [dummy]
+            id=ability_in_unit_type
+            [event]
+                name=event_in_ability_in_unit_type
+                {VARIABLE variable_in_event_in_ability_in_unit_type 1}
+            [/event]
+        [/dummy]
+    [/abilities]
+[/unit_type]
+
+[unit_type]
+    id=Test Unit Special Event
+    race=test
+    image="misc/blank-hex.png"
+    hitpoints=1
+    movement_type=fly
+    movement=1
+    experience=1
+    level=1
+    alignment=neutral
+    advances_to=null
+    cost=1
+    usage=scout
+    hide_help=yes
+    do_not_list=yes
+    [attack]
+        [specials]
+            [dummy]
+                id=special_in_unit_type
+                [event]
+                    name=event_in_special_in_unit_type
+                    {VARIABLE variable_in_event_in_special_in_unit_type 1}
+                [/event]
+            [/dummy]
+        [/specials]
+    [/attack]
+[/unit_type]

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -434,11 +434,50 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 		for(const vconfig& e : events) {
 			events_.add_child("event", e.get_config());
 		}
+		const vconfig::child_list& abilities_tags = vcfg->get_children("abilities");
+		for(const vconfig& abilities_tag : abilities_tags) {
+			for(const auto& [key, child] : abilities_tag.all_ordered()) {
+				const vconfig::child_list& ability_events = child.get_children("event");
+				for(const vconfig& ability_event : ability_events) {
+					events_.add_child("event", ability_event.get_config());
+				}
+			}
+		}
+		const vconfig::child_list& attacks = vcfg->get_children("attack");
+		for(const vconfig& attack : attacks) {
+			const vconfig::child_list& specials_tags = attack.get_children("specials");
+			for(const vconfig& specials_tag : specials_tags) {
+				for(const auto& [key, child] : specials_tag.all_ordered()) {
+					const vconfig::child_list& special_events = child.get_children("event");
+					for(const vconfig& special_event : special_events) {
+						events_.add_child("event", special_event.get_config());
+					}
+				}
+			}
+		}
 	} else {
 		filter_recall_ = cfg.child_or_empty("filter_recall");
 
 		for(const config& unit_event : cfg.child_range("event")) {
 			events_.add_child("event", unit_event);
+		}
+		for(const config& abilities : cfg.child_range("abilities")) {
+			for(const config::any_child child : abilities.all_children_range()) {
+				const config& ability = child.cfg;
+				for(const config& ability_event : ability.child_range("event")) {
+					events_.add_child("event", ability_event);
+				}
+			}
+		}
+		for(const config& attack : cfg.child_range("attack")) {
+			for(const config& specials : attack.child_range("specials")) {
+				for(const config::any_child child : specials.all_children_range()) {
+					const config& special = child.cfg;
+					for(const config& special_event : special.child_range("event")) {
+						events_.add_child("event", special_event);
+					}
+				}
+			}
 		}
 	}
 
@@ -1037,7 +1076,30 @@ void unit::advance_to(const unit_type& u_type, bool use_traits)
 
 	// In case the unit carries EventWML, apply it now
 	if(resources::game_events && resources::lua_kernel) {
-		resources::game_events->add_events(new_type.events(), *resources::lua_kernel, new_type.id());
+		config events;
+		const config& cfg = new_type.get_cfg();
+		for(const config& unit_event : cfg.child_range("event")) {
+			events.add_child("event", unit_event);
+		}
+		for(const config& abilities : cfg.child_range("abilities")) {
+			for(const config::any_child child : abilities.all_children_range()) {
+				const config& ability = child.cfg;
+				for(const config& ability_event : ability.child_range("event")) {
+					events.add_child("event", ability_event);
+				}
+			}
+		}
+		for(const config& attack : cfg.child_range("attack")) {
+			for(const config& specials : attack.child_range("specials")) {
+				for(const config::any_child child : specials.all_children_range()) {
+					const config& special = child.cfg;
+					for(const config& special_event : special.child_range("event")) {
+						events.add_child("event", special_event);
+					}
+				}
+			}
+		}
+		resources::game_events->add_events(events.child_range("event"), *resources::lua_kernel, new_type.id());
 	}
 	bool bool_small_profile = get_attr_changed(UA_SMALL_PROFILE);
 	bool bool_profile = get_attr_changed(UA_PROFILE);
@@ -1987,6 +2049,7 @@ std::string unit::describe_builtin_effect(std::string apply_to, const config& ef
 
 void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 {
+	config events;
 	appearance_changed_ = true;
 	if(apply_to == "fearless") {
 		set_attr_changed(UA_IS_FEARLESS);
@@ -2022,6 +2085,14 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 	} else if(apply_to == "new_attack") {
 		set_attr_changed(UA_ATTACKS);
 		attacks_.emplace_back(new attack_type(effect));
+		for(const config& specials : effect.child_range("specials")) {
+			for(const config::any_child child : specials.all_children_range()) {
+				const config& special = child.cfg;
+				for(const config& special_event : special.child_range("event")) {
+					events.add_child("event", special_event);
+				}
+			}
+		}
 	} else if(apply_to == "remove_attacks") {
 		set_attr_changed(UA_ATTACKS);
 		auto iter = std::remove_if(attacks_.begin(), attacks_.end(), [&effect](attack_ptr a) {
@@ -2033,6 +2104,14 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		set_attr_changed(UA_ATTACKS);
 		for(attack_ptr a : attacks_) {
 			a->apply_modification(effect);
+			for(const config& specials : effect.child_range("set_specials")) {
+				for(const config::any_child child : specials.all_children_range()) {
+					const config& special = child.cfg;
+					for(const config& special_event : special.child_range("event")) {
+						events.add_child("event", special_event);
+					}
+				}
+			}
 		}
 	} else if(apply_to == "hitpoints") {
 		LOG_UT << "applying hitpoint mod..." << hit_points_ << "/" << max_hit_points_;
@@ -2192,6 +2271,9 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 			for(const config::any_child ab : ab_effect->all_children_range()) {
 				if(!has_ability_by_id(ab.cfg["id"])) {
 					to_append.add_child(ab.key, ab.cfg);
+					for(const config& event : ab.cfg.child_range("event")) {
+						events.add_child("event", event);
+					}
 				}
 			}
 			abilities_.append(to_append);
@@ -2363,6 +2445,11 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		if(!increase.empty()) {
 			level_ += lexical_cast_default<int>(increase);
 		}
+	}
+
+	// In case the effect carries EventWML, apply it now
+	if(resources::game_events && resources::lua_kernel) {
+		resources::game_events->add_events(events.child_range("event"), *resources::lua_kernel);
 	}
 }
 


### PR DESCRIPTION
This aims to better support abilities and weapon specials which rely on events written in WML, like those on this [page](https://wiki.wesnoth.org/Wml_abilities
). Currently such event code has to be loaded explicitly in each `[campaign]`, `[scenario]`, `[era]`, or `[resource]` where the custom ability or special will be used, or otherwise written directly in the `[unit_type]`. By supporting embedded events in the `[abilities]` and `[specials]` tags this code can load automatically whenever a unit with a custom ability or special is spawned.