### PR TITLE
add debug_border to gui2 objects

### DIFF
--- a/data/schema/gui/widget_instances.cfg
+++ b/data/schema/gui/widget_instances.cfg
@@ -8,6 +8,8 @@
     {DEFAULT_KEY "horizontal_grow" bool false}
     {DEFAULT_KEY "vertical_alignment" v_align ""}
     {DEFAULT_KEY "vertical_grow" bool false}
+    {DEFAULT_KEY "debug_border_mode" unsigned 0}
+    {DEFAULT_KEY "debug_border_color" color ""}
     [tag]
         name="grid"
         min="1"
@@ -23,9 +25,13 @@
                 super="$cell"
             [/tag]
             {DEFAULT_KEY "grow_factor" unsigned 0}
+            {DEFAULT_KEY "debug_border_mode" unsigned 0}
+            {DEFAULT_KEY "debug_border_color" color ""}
         [/tag]
         {DEFAULT_KEY "id" string ""}
         {DEFAULT_KEY "linked_group" string 0}
+        {DEFAULT_KEY "debug_border_mode" unsigned 0}
+        {DEFAULT_KEY "debug_border_color" color ""}
     [/tag]
     [tag]
         name="addon_list"
@@ -193,7 +199,6 @@
         {DEFAULT_KEY "text_alignment" h_align "left"}
         {DEFAULT_KEY "link_aware" bool false}
         {DEFAULT_KEY "width" unsigned 500}
-        
     [/tag]
     [tag]
         name="grid_listbox"

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -188,7 +188,7 @@ void draw::dotted_border(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, 
 	for(int i = rect.x; i < rect.x + rect.w; i += 2) {
 		// the top, left to right
 		points.push_back({i, rect.y});
-		// the botton, right to left
+		// the bottom, right to left
 		points.push_back({rect.x + rect.w - (i - rect.x), rect.y + rect.h - 1});
 	}
 	// the sides

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -177,6 +177,109 @@ void draw::rect(const SDL_Rect& rect, const color_t& c)
 	draw::rect(rect, c.r, c.g, c.b, c.a);
 }
 
+void draw::dotted_border(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	DBG_D << "dotted border " << rect << ' ' << color_t{r,g,b,a};
+	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
+	std::vector<SDL_Point> points;
+
+	// a little funky math here ensures the corner sizes stay relatively balanced
+	// the top/bottom
+	for(int i = rect.x; i < rect.x + rect.w; i += 2) {
+		// the top, left to right
+		points.push_back({i, rect.y});
+		// the botton, right to left
+		points.push_back({rect.x + rect.w - (i - rect.x), rect.y + rect.h - 1});
+	}
+	// the sides
+	for(int i = rect.y; i < rect.y + rect.h; i += 2) {
+		// the right, top to bottom
+		points.push_back({rect.x + rect.w - 1, i});
+		// the left, bottom to top
+		points.push_back({rect.x, rect.y + rect.h - (i - rect.y)});
+	}
+	draw::points(points);
+}
+
+void draw::dotted_border(const SDL_Rect& rect, const color_t& c)
+{
+	draw::dotted_border(rect, c.r, c.g, c.b, c.a);
+}
+
+void draw::dashed_border(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	DBG_D << "dashed border " << rect << ' ' << color_t{r,g,b,a};
+	SDL_SetRenderDrawColor(renderer(), r, g, b, a);
+	std::vector<SDL_Point> points;
+
+	// a little funky math here ensures the corner sizes stay relatively balanced
+	// the top/bottom
+	int i;
+	for(i = rect.x; i < rect.x + rect.w - 5; i += 5) {
+		// the top, left to right, three shaded pixels
+		points.push_back({i, rect.y});
+		points.push_back({i + 1, rect.y});
+		points.push_back({i + 2, rect.y});
+		// the botton, right to left, three shaded pixels
+		points.push_back({rect.x + rect.w - (i - rect.x), rect.y + rect.h - 1});
+		points.push_back({rect.x + rect.w - (i - rect.x - 1), rect.y + rect.h - 1});
+		points.push_back({rect.x + rect.w - (i - rect.x - 2), rect.y + rect.h - 1});
+		// then skip two pixels
+	}
+	// finish up the top/bottom lines when there's not enough room left for the full five pixel sequence
+	switch(rect.x + rect.w - i) {
+		case 4:
+			[[fallthrough]];
+		case 3:
+			points.push_back({i + 2, rect.y});
+			points.push_back({rect.x + rect.w - (i - rect.x - 2), rect.y + rect.h - 1});
+			[[fallthrough]];
+		case 2:
+			points.push_back({i + 1, rect.y});
+			points.push_back({rect.x + rect.w - (i - rect.x - 1), rect.y + rect.h - 1});
+			[[fallthrough]];
+		case 1:
+			points.push_back({i, rect.y});
+			points.push_back({rect.x + rect.w - (i - rect.x), rect.y + rect.h - 1});
+	}
+	// the sides
+	for(i = rect.y; i < rect.y + rect.h - 5; i += 5) {
+		// the right, top to bottom
+		points.push_back({rect.x + rect.w - 1, i});
+		points.push_back({rect.x + rect.w - 1, i + 1});
+		points.push_back({rect.x + rect.w - 1, i + 2});
+		// the left, bottom to top
+		points.push_back({rect.x, rect.y + rect.h - (i - rect.y)});
+		points.push_back({rect.x, rect.y + rect.h - (i - rect.y - 1)});
+		points.push_back({rect.x, rect.y + rect.h - (i - rect.y - 2)});
+	}
+	// finish up the right/left lines when there's not enough room left for the full five pixel sequence
+	switch(rect.y + rect.h - i) {
+		case 4:
+			[[fallthrough]];
+		case 3:
+			points.push_back({rect.x + rect.w - 1, i + 2});
+			points.push_back({rect.x, rect.y + rect.h - (i - rect.y - 2)});
+			[[fallthrough]];
+		case 2:
+			points.push_back({rect.x + rect.w - 1, i + 1});
+			points.push_back({rect.x, rect.y + rect.h - (i - rect.y - 1)});
+			[[fallthrough]];
+		case 1:
+			 points.push_back({rect.x + rect.w - 1, i});
+			 points.push_back({rect.x, rect.y + rect.h - (i - rect.y)});
+	}
+
+	draw::points(points);
+}
+
+void draw::dashed_border(const SDL_Rect& rect, const color_t& c)
+{
+	draw::dashed_border(rect, c.r, c.g, c.b, c.a);
+}
+
+
+
 void draw::line(int from_x, int from_y, int to_x, int to_y)
 {
 	DBG_D << "line from (" << from_x << ',' << from_y

--- a/src/draw.hpp
+++ b/src/draw.hpp
@@ -139,6 +139,30 @@ void rect(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b);
 void rect(const SDL_Rect& rect, const color_t& color);
 
 /**
+ * Draw a rectangle with a dotted border using the given colour.
+ *
+ * @param rect      The rectangle to draw, in drawing coordinates.
+ * @param r         The red   component of the drawing colour, 0-255.
+ * @param g         The green component of the drawing colour, 0-255.
+ * @param b         The blue  component of the drawing colour, 0-255.
+ * @param a         The alpha component of the drawing colour, 0-255.
+ */
+void dotted_border(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+void dotted_border(const SDL_Rect& rect, const color_t& color);
+
+/**
+ * Draw a rectangle with a dashed border using the given colour.
+ *
+ * @param rect      The rectangle to draw, in drawing coordinates.
+ * @param r         The red   component of the drawing colour, 0-255.
+ * @param g         The green component of the drawing colour, 0-255.
+ * @param b         The blue  component of the drawing colour, 0-255.
+ * @param a         The alpha component of the drawing colour, 0-255.
+ */
+void dashed_border(const SDL_Rect& rect, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+void dashed_border(const SDL_Rect& rect, const color_t& color);
+
+/**
  * Draw a line.
  *
  * Uses the current drawing colour set by set_color().

--- a/src/gui/core/window_builder.hpp
+++ b/src/gui/core/window_builder.hpp
@@ -125,6 +125,12 @@ struct builder_grid : public builder_widget
 	std::vector<unsigned> row_grow_factor;
 	std::vector<unsigned> col_grow_factor;
 
+	/** The debug_borders for the rows / columns. */
+	std::vector<widget::debug_border> row_debug_border_mode;
+	std::vector<color_t> row_debug_border_color;
+	std::vector<widget::debug_border> col_debug_border_mode;
+	std::vector<color_t> col_debug_border_color;
+
 	/** The flags per grid cell. */
 	std::vector<unsigned> flags;
 
@@ -133,6 +139,10 @@ struct builder_grid : public builder_widget
 
 	/** The widgets per grid cell. */
 	std::vector<builder_widget_ptr> widgets;
+
+	/** The debug_border for the grid */
+	widget::debug_border debug_border_mode;
+	color_t debug_border_color;
 
 	/** Inherited from @ref builder_widget. */
 	virtual std::unique_ptr<widget> build() const override;

--- a/src/gui/widgets/grid.cpp
+++ b/src/gui/widgets/grid.cpp
@@ -1007,7 +1007,6 @@ void grid::impl_draw_children()
 
 	assert(get_visible() == widget::visibility::visible);
 
-
 	// TODO: draw_manager - don't draw children outside clip area. This is problematic because either clip area is not correct here or widget positions are not absolute
 	for(auto & child : children_)
 	{
@@ -1069,6 +1068,12 @@ void grid::impl_draw_children()
 					break;
 				case 2:
 					draw::fill(rect{x,y,static_cast<int>(col_width_[col]),static_cast<int>(row_height_[row])},col_debug_border_color_[i]);
+					break;
+				case 3:
+					draw::dotted_border(rect{x,y,static_cast<int>(col_width_[col]),static_cast<int>(row_height_[row])},col_debug_border_color_[i]);
+					break;
+				case 4:
+					draw::dashed_border(rect{x,y,static_cast<int>(col_width_[col]),static_cast<int>(row_height_[row])},col_debug_border_color_[i]);
 			}
 			x += col_width_[col];
 		}
@@ -1082,6 +1087,12 @@ void grid::impl_draw_children()
 				break;
 			case 2:
 				draw::fill(rect{0,y,x,static_cast<int>(row_height_[row])},row_debug_border_color_[row]);
+				break;
+			case 3:
+				draw::dotted_border(rect{0,y,x,static_cast<int>(row_height_[row])},row_debug_border_color_[row]);
+				break;
+			case 4:
+				draw::dashed_border(rect{0,y,x,static_cast<int>(row_height_[row])},row_debug_border_color_[row]);
 		}
 		x = 0;
 		y += row_height_[row];

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -106,6 +106,43 @@ public:
 		queue_redraw(); // TODO: draw_manager - relayout?
 	}
 
+
+	/** Set debug border for grid */
+	void set_debug_border_mode(const widget::debug_border dbm)
+	{
+		debug_border_mode_ = dbm;
+	}
+
+	void set_debug_border_color(const color_t dbc)
+	{
+		debug_border_color_ = dbc;
+	}
+
+	/** Set debug border for rows/columns */
+	void set_row_debug_border_mode(const unsigned row, const widget::debug_border dbm)
+	{
+		    assert(row < row_debug_border_mode_.size());
+			    row_debug_border_mode_[row] = dbm;
+	}
+
+	void set_row_debug_border_color(const unsigned row, const color_t dbc)
+	{
+		    assert(row < row_debug_border_color_.size());
+			    row_debug_border_color_[row] = dbc;
+	}
+
+	void set_column_debug_border_mode(const unsigned col, const widget::debug_border dbm)
+	{
+		    assert(col < col_debug_border_mode_.size());
+			    col_debug_border_mode_[col] = dbm;
+	}
+
+	void set_column_debug_border_color(const unsigned col, const color_t dbc)
+	{
+		    assert(col < col_debug_border_color_.size());
+			    col_debug_border_color_[col] = dbc;
+	}
+
 	/***** ***** ***** ***** CHILD MANIPULATION ***** ***** ***** *****/
 
 	/**
@@ -492,6 +529,10 @@ private:
 	/** The number of grid columns. */
 	unsigned cols_;
 
+	/** Debug border for the grid */
+	widget::debug_border debug_border_mode_;
+	color_t debug_border_color_;
+
 	/***** ***** ***** ***** size caching ***** ***** ***** *****/
 
 	/** The row heights in the grid. */
@@ -505,6 +546,18 @@ private:
 
 	/** The grow factor for all columns. */
 	std::vector<unsigned> col_grow_factor_;
+
+	/** The debug border mode for all rows.  */
+	std::vector<widget::debug_border> row_debug_border_mode_;
+
+	/** The debug border color for all rows.  */
+	std::vector<color_t> row_debug_border_color_;
+
+	/** The debug border mode for all columns.  */
+	std::vector<widget::debug_border> col_debug_border_mode_;
+
+	/** The debug border color for all columns.  */
+	std::vector<color_t> col_debug_border_color_;
 
 	/**
 	 * The child items.

--- a/src/gui/widgets/grid.hpp
+++ b/src/gui/widgets/grid.hpp
@@ -106,7 +106,6 @@ public:
 		queue_redraw(); // TODO: draw_manager - relayout?
 	}
 
-
 	/** Set debug border for grid */
 	void set_debug_border_mode(const widget::debug_border dbm)
 	{

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -596,6 +596,8 @@ builder_styled_widget::builder_styled_widget(const config& cfg)
 	, help(cfg["help"].t_str())
 	, use_tooltip_on_label_overflow(true)
 	, use_markup(cfg["use_markup"].to_bool(false))
+	, debug_border_mode(static_cast<widget::debug_border>(cfg["debug_border_mode"].to_int()))
+	, debug_border_color(decode_color(cfg["debug_border_color"]))
 {
 	if(definition.empty()) {
 		definition = "default";

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -546,6 +546,8 @@ public:
 	t_string help;
 	bool use_tooltip_on_label_overflow;
 	bool use_markup;
+	widget::debug_border debug_border_mode;
+	color_t debug_border_color;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/widget.cpp
+++ b/src/gui/widgets/widget.cpp
@@ -529,6 +529,14 @@ void widget::draw_debug_border()
 			draw::fill(rect{{0, 0}, get_size()}, debug_border_color_);
 			break;
 
+		case debug_border::dotted:
+			draw::dotted_border(rect{{0, 0}, get_size()}, debug_border_color_);
+			break;
+
+		case debug_border::dashed:
+			draw::dashed_border(rect{{0, 0}, get_size()}, debug_border_color_);
+			break;
+
 		default:
 			assert(false);
 	}

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -131,6 +131,10 @@ public:
 		outline,
 		/** Flood-filled rectangle. */
 		fill,
+		/** Single pixel dotted outline */
+		dotted,
+		/** Dashed line outline */
+		dashed
 	};
 
 	/***** ***** ***** Constructor and destructor. ***** ***** *****/


### PR DESCRIPTION
Completes debug_border support for styled_widget, and adds grid/row/column support.

Adds dotted border (questionable value) and dashed border, to add additional clarity especially for those who see a limited color range.

Getting things to line up properly in GUI2 can be frustrating.  For example, in the image, my text is left aligned, why is it centered??? (it's left aligned in the label, but the label is centered in the column).  I always wished there was a way to draw borders around objects so I could see what was going on.  I was excited to discover debug_border, unfortunately from what I can tell, "This function is only meant for debugging and might not be available in all Wesnoth binaries" really means "This function is only meant for debugging and is not available at all".

Silly example with nested grids and different modes/colors/objects:

![debug_border_example](https://github.com/user-attachments/assets/99369535-acb7-49cc-afec-ca62e720e2a7)
