### PR TITLE
Fix #9241, Liberty S1 dialogue item tweak

### DIFF
--- a/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
+++ b/data/campaigns/Liberty/scenarios/01_The_Raid.cfg
@@ -413,7 +413,7 @@ Months... seven months it’s been since the Crown did send a single guard here 
 
         [message]
             speaker=Harper
-            message= _ "Hey, someone left their pack here. I could use it to carry some more rocks."
+            message= _ "Hey, someone left their pack here. I could use it to carry some heavier rocks."
         [/message]
 
         [sound]


### PR DESCRIPTION
Extends damage and not the number of hits, so use "heavier rocks" instead of "more rocks".