### PR TITLE
filesystem.hpp: include missing <cstdint>

### DIFF
--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <ctime>
+#include <cstdint>
 #include <fstream>
 #include <iosfwd>
 #include <memory>


### PR DESCRIPTION
Without the change build fails on upcoming `gcc-15` as:

    In file included from src/desktop/paths.cpp:20:
    src/filesystem.hpp:232:13: error: 'uint8_t' was not declared in this scope
      232 | std::vector<uint8_t> read_file_binary(const std::string& fname);
          |             ^~~~~~~