### PR TITLE
add test for apply_to=both and apply_to=attacker/defender when both type of self and opponent weapon are filtered.

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_apply_to_attacker_filter_attacker_defender.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_apply_to_attacker_filter_attacker_defender.cfg
@@ -1,0 +1,80 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: apply_to=both with [filter_attacker][filter_weapon]type= and [filter_defender][filter_weapon]type=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# change type of attack of pierce and resistance to -50%.
+# Give bob's weapon specials [damage_type]applied to attacker and active if attacker and defender attack are type=pierce.
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# BROKE_STRICT - error logged due to recursive ability.
+# Damage_type is active
+# Bob takes 15 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_apply_to_attacker_filter_attacker_defender" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=resistance
+                replace=yes
+                [resistance]
+                    arcane=150
+                [/resistance]
+            [/effect]
+            [effect]
+                apply_to=attack
+                set_type=pierce
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage_type]
+                        id=special_arcane
+                        alternative_type=arcane
+                        apply_to=attacker
+                        [filter_attacker]
+                            [filter_weapon]
+                                type=pierce
+                            [/filter_weapon]
+                        [/filter_attacker]
+                        [filter_defender]
+                            [filter_weapon]
+                                type=pierce
+                            [/filter_weapon]
+                        [/filter_defender]
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 85})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_apply_to_both_filter_self_opponent.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage_type/damage_type_apply_to_both_filter_self_opponent.cfg
@@ -1,0 +1,80 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: apply_to=both with [filter_self][filter_weapon]type= and [filter_opponent][filter_weapon]type=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# change type of attack of pierce and resistance to -50%.
+# Give Alice's weapon specials [damage_type]applied to both active if alice and bob attack are type=pierce.
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# BROKE_STRICT - error logged due to recursive ability.
+# Damage_type is active
+# Bob takes 15 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_type_apply_to_both_filter_self_opponent" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to=resistance
+                replace=yes
+                [resistance]
+                    arcane=150
+                [/resistance]
+            [/effect]
+            [effect]
+                apply_to=attack
+                set_type=pierce
+            [/effect]
+        [/modify_unit]
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage_type]
+                        id=special_arcane
+                        alternative_type=arcane
+                        apply_to=both
+                        [filter_self]
+                            [filter_weapon]
+                                type=pierce
+                            [/filter_weapon]
+                        [/filter_self]
+                        [filter_opponent]
+                            [filter_weapon]
+                                type=pierce
+                            [/filter_weapon]
+                        [/filter_opponent]
+                    [/damage_type]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 85})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -377,6 +377,8 @@
 0 damage_type_test
 0 damage_type_with_filter_test
 0 damage_secondary_type_test
+9 damage_type_apply_to_both_filter_self_opponent
+9 damage_type_apply_to_attacker_filter_attacker_defender
 9 event_test_filter_damage_type_recursion
 9 four_cycle_recursion_branching
 9 four_cycle_recursion_by_id


### PR DESCRIPTION
if filtering type of damage in [damage_type] for both self and opponent when apply_to=both, it will create a recursion issue.

Idem for apply_to=attacker/defender when applied to opponent of owner of special.