### PR TITLE
Make status orb work with custom max/min_range

### DIFF
--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -99,7 +99,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 
 	int max_distance = *std::prev(attackable_distances.end());
 
-	for (int dx = -max_distance; dx <= max_distance; ++dx) {
+	for (int dx = -max_distance; dx <= max_distance && !result.attack_here; ++dx) {
 		for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
 			// Adjust for hex grid
 			int adjusted_dy = dy + floor(dx / 2.0);

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -89,24 +89,24 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 	can_move_result result = {false, false};
 	if(u.attacks_left() > 0 && !u.attacks().empty()) {
 		const auto& attacks = u.attacks();
-	
+
 		std::set<int> attackable_distances;
 	    for (const auto& attack : attacks) {
 	        for (int i = attack.min_range(); i <= attack.max_range(); ++i) {
 	            attackable_distances.insert(i);
 	        }
 	    }
-	
+
 		int max_distance = *std::prev(attackable_distances.end());
-	
+
 		for (int dx = -max_distance; dx <= max_distance && !result.attack_here; ++dx) {
 			for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
 				// Adjust for hex grid
 				int adjusted_dy = dy + floor(dx / 2.0);
-	
+
 				map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
 				int distance = distance_between(u.get_location(), locs);
-	
+
 				if (attackable_distances.count(distance) == 0) {
 					continue;
 				}
@@ -127,7 +127,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 		}
 	}
 	// This should probably check if the unit can teleport too
-
+	
 	return result;
 }
 

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -107,7 +107,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 			map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
 			int distance = distance_between(u.get_location(), locs);
 
-			if (attackable_distances.find(distance) == attackable_distances.end()) {
+			if (attackable_distances.count(distance) == 0) {
 				continue;
 			}
 			if (map().on_board(locs)) {

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -87,33 +87,34 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 	const team& current_team = get_team(u.side());
 
 	can_move_result result = {false, false};
-
-	const auto& attacks = u.attacks();
-
-	std::set<int> attackable_distances;
-    for (const auto& attack : attacks) {
-        for (int i = attack.min_range(); i <= attack.max_range(); ++i) {
-            attackable_distances.insert(i);
-        }
-    }
-
-	int max_distance = *std::prev(attackable_distances.end());
-
-	for (int dx = -max_distance; dx <= max_distance && !result.attack_here; ++dx) {
-		for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
-			// Adjust for hex grid
-			int adjusted_dy = dy + floor(dx / 2.0);
-
-			map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
-			int distance = distance_between(u.get_location(), locs);
-
-			if (attackable_distances.count(distance) == 0) {
-				continue;
-			}
-			if (map().on_board(locs)) {
-				const unit_map::const_iterator i = units().find(locs);
-				if (i.valid() && !i->incapacitated() && current_team.is_enemy(i->side()) && i->is_visible_to_team(get_team(u.side()), false)) {
-					result.attack_here = true;
+	if(u.attacks_left() > 0 && !u.attacks().empty()) {
+		const auto& attacks = u.attacks();
+	
+		std::set<int> attackable_distances;
+	    for (const auto& attack : attacks) {
+	        for (int i = attack.min_range(); i <= attack.max_range(); ++i) {
+	            attackable_distances.insert(i);
+	        }
+	    }
+	
+		int max_distance = *std::prev(attackable_distances.end());
+	
+		for (int dx = -max_distance; dx <= max_distance && !result.attack_here; ++dx) {
+			for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
+				// Adjust for hex grid
+				int adjusted_dy = dy + floor(dx / 2.0);
+	
+				map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
+				int distance = distance_between(u.get_location(), locs);
+	
+				if (attackable_distances.count(distance) == 0) {
+					continue;
+				}
+				if (map().on_board(locs)) {
+					const unit_map::const_iterator i = units().find(locs);
+					if (i.valid() && !i->incapacitated() && current_team.is_enemy(i->side()) && i->is_visible_to_team(get_team(u.side()), false)) {
+						result.attack_here = true;
+					}
 				}
 			}
 		}

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -127,7 +127,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 		}
 	}
 	// This should probably check if the unit can teleport too
-	
+
 	return result;
 }
 

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -97,23 +97,25 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 	        }
 	    }
 
-		int max_distance = *std::prev(attackable_distances.end());
+		if(!attackable_distances.empty()) {
+			int max_distance = *std::prev(attackable_distances.end());
 
-		for (int dx = -max_distance; dx <= max_distance && !result.attack_here; ++dx) {
-			for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
-				// Adjust for hex grid
-				int adjusted_dy = dy + floor(dx / 2.0);
+			for (int dx = -max_distance; dx <= max_distance; ++dx) {
+				for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
+					// Adjust for hex grid
+					int adjusted_dy = dy + floor(dx / 2.0);
 
-				map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
-				int distance = distance_between(u.get_location(), locs);
+					map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
+					int distance = distance_between(u.get_location(), locs);
 
-				if (attackable_distances.count(distance) == 0) {
-					continue;
-				}
-				if (map().on_board(locs)) {
-					const unit_map::const_iterator i = units().find(locs);
-					if (i.valid() && !i->incapacitated() && current_team.is_enemy(i->side()) && i->is_visible_to_team(get_team(u.side()), false)) {
-						result.attack_here = true;
+					if (attackable_distances.find(distance) == attackable_distances.end()) {
+						continue;
+					}
+					if (map().on_board(locs)) {
+						const unit_map::const_iterator i = units().find(locs);
+						if (i.valid() && !i->incapacitated() && current_team.is_enemy(i->side()) && i->is_visible_to_team(get_team(u.side()), false)) {
+							result.attack_here = true;
+						}
 					}
 				}
 			}

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -97,7 +97,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 		distance_ranges.emplace_back(min_range , max_range);
 	}
 
-	// Merging it here, may be removed if some checks for every weapon 
+	// Merging it here, may be removed if some checks for every weapon
 	// Should be done individually (Like line-of sight)
 	std::sort(distance_ranges.begin(), distance_ranges.end());
 
@@ -110,7 +110,6 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 		}
 	}
 
-
 	for (const auto& range : merged_ranges) {
 		int min_distance = range.first;
 		int max_distance = range.second;
@@ -119,7 +118,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 			for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
 				// Adjust for hex grid
 				int adjusted_dy = dy + (dx - (dx&1)) / 2;
-				
+
 				map_location locs(u.get_location().x + dx, u.get_location().y + adjusted_dy);
 				int distance = distance_between(u.get_location(), locs);
 

--- a/src/display_context.cpp
+++ b/src/display_context.cpp
@@ -116,7 +116,7 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 		int max_distance = range.second;
 
 		for (int dx = -max_distance; dx <= max_distance; ++dx) {
-			for (int dy = -max_distance; dy <= max_distance; ++dy) {
+			for (int dy = -max_distance; dy <= max_distance && !result.attack_here; ++dy) {
 				// Adjust for hex grid
 				int adjusted_dy = dy + (dx - (dx&1)) / 2;
 				
@@ -129,13 +129,11 @@ display_context::can_move_result display_context::unit_can_move(const unit& u) c
 					const unit_map::const_iterator i = units().find(locs);
 					if (i.valid() && !i->incapacitated() && current_team.is_enemy(i->side()) && i->is_visible_to_team(get_team(u.side()), false)) {
 						result.attack_here = true;
-						goto attack_here_found;
 					}
 				}
 			}
 		}
 	}
-	attack_here_found:
 	for(const map_location& adj : get_adjacent_tiles(u.get_location())) {
 		if (map().on_board(adj)) {
 			if (!result.move && u.movement_cost(map()[adj]) <= u.movement_left()) {


### PR DESCRIPTION
This code sets orb color to can-still-make-an-action if unit has no moves left, and has a visible enemy within max and min range of a weapon.
This also affects if the unit is selectable with 'N' (units that can move or attack).

Currently, it doesn't affect the mainline much, as no unit has a weapon max/min_range different from 1, most notice-able, it marks units with no attack as incapable of action, after having no moves left.

The purpose of this is part of getting real-ranged attacks into the mainline.