### PR TITLE
Fix weapon special filters can lead to infinite recursion(1.18 backport)

### DIFF
--- a/changelog_entries/fix_infinite_recursion.md
+++ b/changelog_entries/fix_infinite_recursion.md
@@ -1,0 +1,2 @@
+ ### WML Engine
+   * Fix crash when weapon specials' filters lead to infinite recursion (issue #8940)

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filters.cfg
@@ -294,20 +294,7 @@
     [/event]
 )}
 
-#####
-# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
-##
-# Actions:
-# Define events filtering based on weapon specials.
-# Give Bob a poison special iff the opponent has a specific drain special.
-# Give Alice a drain special iff the opponent has a specific poison special.
-# Have side 1's unit attack side 2's unit.
-# Have side 2's unit attack side 1's unit.
-##
-# Expected end state:
-# Both events that should trigger for Bob do trigger.
-#####
-{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition (
+#define SPECIAL_CONDITION FILTER
     [event]
         name=turn 1
         # Make sure the attacks hit
@@ -339,9 +326,183 @@
                 [abilities]
                     [drains]
                         id=ability_drain_blade
+                        [filter_opponent]
+                            [filter_weapon]
+                                {FILTER}
+                            [/filter_weapon]
+                        [/filter_opponent]
+                    [/drains]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+        {VARIABLE triggers_on_attack 0}
+        {VARIABLE triggers_on_defense 0}
+        [do_command]
+            [move]
+                x=7,13
+                y=3,4
+            [/move]
+            [attack]
+                [source]
+                    x,y=13,4
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=side 2 turn
+        [do_command]
+            [attack]
+                [source]
+                    x,y=13,3
+                [/source]
+                [destination]
+                    x,y=13,4
+                [/destination]
+            [/attack]
+        [/do_command]
+        [end_turn][/end_turn]
+    [/event]
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            special_id_active=ability_poison_blade
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 2})}
+        {VARIABLE_OP triggers_on_attack add 1}
+    [/event]
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_second_attack]
+            special_id_active=ability_poison_blade
+        [/filter_second_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {VARIABLE_OP triggers_on_defense add 1}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define events filtering based on weapon specials.
+# Give Bob a poison special iff the opponent has a specific drain special.
+# Give Alice a drain special iff the opponent has a blade attack.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# Both events that should trigger for Bob do trigger.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition (
+    {SPECIAL_CONDITION (type=blade)}
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_defense equals 1})}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define events filtering based on absence of weapon specials.
+# Give Bob a poison special iff the opponent has a specific drain special, and that special is active.
+# Give Alice a drain special iff the opponent has a specific poison special, and that special is active.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# BROKE STRICT because testing the special_id_active conditions led to infinite recursion.
+# The events don't trigger. Both specials depend on the other one being active, so the calculation would need infinate recursion; instead, the engine decides that both are inactive.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_opponent_weapon_condition_no_triggered (
+    {SPECIAL_CONDITION (special_id_active=ability_poison_blade)}
+    [event]
+        name=turn 2
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_attack equals 0})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers_on_defense equals 0})}
+        {SUCCEED}
+    [/event]
+)}
+
+#undef SPECIAL_CONDITION
+
+#####
+# API(s) being tested: [event][filter_attack],[event][filter_second_attack]
+##
+# Actions:
+# Define specials filtering based on weapon specials.
+# Give Bob a poison special iff own a same special active or a blade or pierce attack.
+# Give Alice a drain special iff own a same special active or a blade or pierce attack.
+# Have side 1's unit attack side 2's unit.
+# Have side 2's unit attack side 1's unit.
+##
+# Expected end state:
+# BROKE STRICT because testing the special_id_active conditions led to infinite recursion.
+# Both events trigger for Bob because testing type=blade,pierce only requires a reasonable depth of recursion.
+#####
+{GENERIC_UNIT_TEST event_test_filter_attack_student_weapon_condition (
+    [event]
+        name=turn 1
+        # Make sure the attacks hit
+        {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 100 ()}
+        {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 100 ()}
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [poison]
+                        id=ability_poison_blade
                         [filter_student]
                             [filter_weapon]
-                                type=blade
+                                special_id_active=ability_poison_blade
+                                [or]
+                                    type=blade,pierce
+                                [/or]
+                            [/filter_weapon]
+                        [/filter_student]
+                    [/poison]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [drains]
+                        id=ability_drain_blade
+                        [filter_student]
+                            [filter_weapon]
+                                special_id_active=ability_drain_blade
+                                [or]
+                                    type=blade,pierce
+                                [/or]
                             [/filter_weapon]
                         [/filter_student]
                     [/drains]
@@ -360,6 +521,8 @@
             [/status]
         [/modify_unit]
         {VARIABLE triggers 0}
+        {VARIABLE triggers_on_attack 0}
+        {VARIABLE triggers_on_defense 0}
         [do_command]
             [move]
                 x=7,13

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_branching.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_branching.cfg
@@ -1,0 +1,127 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_type_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain (10x1 melee attack)
+# Give Alice's weapon specialN and specialM.
+# Give Bob's weapon specialX, specialY, specialX2 and specialY2.
+# specialN (damage) is active if a poison special (specialX or specialX2) is active
+# specialX (poison) is active if a slow special (specialM) is active
+# specialM (slow) is active if a parry special (specialY, specialY2) is active
+# specialY (parry) is active if a damage special (specialN) is active
+# Have Alice attack with her weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing, but BROKE STRICT.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "four_cycle_recursion_branching" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=poison
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                    [slow]
+                        id=specialM
+                        name= _ "specialM"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=parry
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/slow]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=damage
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY
+                        name= _ "specialY"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=slow
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                    [poison]
+                        id=specialX2
+                        name= _ "specialX2"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=damage
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY2
+                        name= _ "specialY2"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=slow
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_id.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_id.cfg
@@ -1,0 +1,107 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_id_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# Give Alice's weapon specials specialN and specialM.
+# Give Bob's weapon specials specialX and specialY.
+# specialN (damage) is active if specialX is active
+# specialX (poison) is active if specialM is active
+# specialM (slow) is active if specialY is active
+# specialY (parry) is active if specialN is active
+# Have Alice attack with her weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing, but BROKE STRICT.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "four_cycle_recursion_by_id" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialX
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                    [slow]
+                        id=specialM
+                        name= _ "specialM"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialY
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/slow]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialM
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY
+                        name= _ "specialY"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=specialN
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_tagname.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/four_cycle_recursion_by_tagname.cfg
@@ -1,0 +1,108 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_weapon]special_type_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain (10x1 melee attack)
+# Give Alice's weapon specialN and specialM.
+# Give Bob's weapon specialX, specialY, specialX2 and specialY2.
+# specialN (damage) is active if a poison special (specialX) is active
+# specialX (poison) is active if a slow special (specialM) is active
+# specialM (slow) is active if a parry special (specialY) is active
+# specialY (parry) is active if a damage special (specialN) is active
+# specialX2 and specialY2 have the same filters as specialX and specialY
+# Have Alice attack with her weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing, but BROKE STRICT.
+# All the specials are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "four_cycle_recursion_by_tagname" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [damage]
+                        id=specialN
+                        name= _ "specialN"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=poison
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        value=20
+                        apply_to=self
+                    [/damage]
+                    [slow]
+                        id=specialM
+                        name= _ "specialM"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=parry
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/slow]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [modify_unit]
+            [filter]
+                id=bob
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=replace
+                    [poison]
+                        id=specialX
+                        name= _ "specialX"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=damage
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/poison]
+                    [parry]
+                        id=specialY
+                        name= _ "specialY"
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_type_active=slow
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        apply_to=self
+                    [/parry]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -196,11 +196,13 @@
 # Move Alice next to Bob, and have Alice attack Bob.
 ##
 # Expected end state:
-# Alice attack with fire; and Bob use cold because Bob [damage] filter must check type=blade and not the replacement type, that who cause infinite recursion.
+# Alice attacks with fire and Bob uses cold because Bob's [damage] filter must check type=blade and not the replacement type. That's partly because it could otherwise cause infinite recursion, and partly because having a set limit to the number of recursions would make it unpredictable which specials are active.
 #####
 {GENERIC_UNIT_TEST "damage_type_with_filter_test" (
     {DAMAGE_TYPE_TEST {FILTER_TYPE_BLADE}}
 )}
+
+#undef FILTER_TYPE_BLADE
 
 #####
 # API(s) being tested: [damage]alternative_type=
@@ -216,16 +218,10 @@
 # Expected end state:
 # Alice attack with blade and Bob use cold.
 #####
-{GENERIC_UNIT_TEST "damage_secondary_type_test" (
+{COMMON_KEEP_A_B_UNIT_TEST "damage_secondary_type_test" (
     [event]
         name=start
-        [modify_unit]
-            [filter]
-            [/filter]
-            max_hitpoints=100
-            hitpoints=100
-            attacks_left=1
-        [/modify_unit]
+
         [object]
             silent=yes
             [effect]
@@ -240,24 +236,16 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=cold
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
                 id=bob
             [/filter]
         [/object]
+
         [object]
             silent=yes
             [effect]
@@ -272,18 +260,9 @@
                 apply_to=attack
                 [set_specials]
                     mode=append
-                    [attacks]
-                        value=1
-                    [/attacks]
-                    [damage]
-                        value=12
-                    [/damage]
                     [damage_type]
                         alternative_type=fire
                     [/damage_type]
-                    [chance_to_hit]
-                        value=100
-                    [/chance_to_hit]
                 [/set_specials]
             [/effect]
             [filter]
@@ -291,60 +270,91 @@
             [/filter]
         [/object]
 
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-            kill=yes
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        [unstore_unit]
-            variable=a
-            find_vacant=yes
-            x,y=$b.x,$b.y
-        [/unstore_unit]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x,y=$a.x,$a.y
-                [/source]
-                [destination]
-                    x,y=$b.x,$b.y
-                [/destination]
-            [/attack]
-        [/do_command]
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-        #damage without modification are 12, if test fail hitpoints !=76
-        #if succed then damage by alice 24(bob more vulnerable to blade)
-        #if succed then damage by bob 24(alice vulnerable to cold, cold [damage] is used)
-        {ASSERT ({VARIABLE_CONDITIONAL a.hitpoints equals 76})}
-        {ASSERT ({VARIABLE_CONDITIONAL b.hitpoints equals 76})}
+        # damage without modification is 100
+        # expected damage by alice is 200 (bob is vulnerable to blade, so the alternative isn't used)
+        # expected damage by bob is 200 (alice is most vulnerable to cold, so that alternative is used)
+        {ATTACK_AND_VALIDATE 200}
         {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [filter_self][has_attack]type= in [damage_type]
+##
+# Actions:
+# Give Alice an ability that changes all damage types to arcane if Alice has a blade attack
+# Define events that use filter_attack matching Alice's arcane type.
+# Have Alice attack Bob during side 1's turn
+# Have Bob attack Alice during side 2's turn
+##
+# Expected end state:
+# BROKE STRICT due to infinite recursion.
+# The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (
+    [event]
+        name=start
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage_type]
+                        id=test_arcane_damage
+                        replacement_type=arcane
+                        [filter_student]
+                            [has_attack]
+                                type=blade
+                            [/has_attack]
+                        [/filter_student]
+                    [/damage_type]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        {VARIABLE triggers 0}
+    [/event]
+    [event]
+        name=side 1 turn 1
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=alice
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    # Event when Alice attacks
+    [event]
+        name=attack
+        first_time_only=no
+        [filter_attack]
+            type=arcane
+        [/filter_attack]
+        {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
+        {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
+        {VARIABLE_OP triggers add 1}
+    [/event]
+    [event]
+        name=turn 2
+        {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 )}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -47,6 +47,27 @@ static lg::log_domain log_unit("unit");
 static lg::log_domain log_wml("wml");
 #define ERR_WML LOG_STREAM(err, log_wml)
 
+namespace {
+/**
+ * Value of attack_type::num_recursion_ at which allocations of further recursion_guards fail. This
+ * value is used per weapon, so if two weapon specials are depending on each other being active then
+ * with ATTACK_RECURSION_LIMIT = 3 the recursion could go 6 levels deep (and then return false on
+ * the 7th call to matches_simple_filter).
+ *
+ * The counter is checked at the start of matches_simple_filter, and even the first level needs an
+ * allocation; setting the limit to zero would make matches_simple_filter always return false.
+ *
+ * With the recursion limit set to 1, the following tests fail; they just need a reasonable depth.
+ * event_test_filter_attack_specials
+ * event_test_filter_attack_opponent_weapon_condition
+ * event_test_filter_attack_student_weapon_condition
+ *
+ * With the limit set to 2, all tests pass, but as the limit only affects cases that would otherwise
+ * lead to a crash, it seems reasonable to leave a little headroom for more complex logic.
+ */
+constexpr unsigned int ATTACK_RECURSION_LIMIT = 4;
+};
+
 attack_type::attack_type(const config& cfg) :
 	self_loc_(),
 	other_loc_(),
@@ -97,12 +118,50 @@ std::string attack_type::accuracy_parry_description() const
 	return s.str();
 }
 
+namespace {
+/**
+ * Print "Recursion limit reached" log messages, including deduplication if the same problem has
+ * already been logged.
+ */
+void show_recursion_warning(const attack_type& attack, const config& filter) {
+	// This function is only called when the recursion limit has already been reached, meaning the
+	// filter has already been parsed multiple times, so I'm not trying to optimize the performance
+	// of this; it's merely to prevent the logs getting spammed. For example, each of
+	// four_cycle_recursion_branching and event_test_filter_attack_student_weapon_condition only log
+	// 3 unique messages, but without deduplication they'd log 1280 and 392 respectively.
+	static std::vector<std::tuple<std::string, std::string>> already_shown;
+
+	auto identifier = std::tuple<std::string, std::string>{attack.id(), filter.debug()};
+	if(utils::contains(already_shown, identifier)) {
+		return;
+	}
+
+	std::string_view filter_text_view = std::get<1>(identifier);
+	utils::trim(filter_text_view);
+	ERR_UT << "Recursion limit reached for weapon '" << attack.id()
+		<< "' while checking filter '" << filter_text_view << "'";
+
+	// Arbitrary limit, just ensuring that having a huge number of specials causing recursion
+	// warnings can't lead to unbounded memory consumption here.
+	if(already_shown.size() > 100) {
+		already_shown.clear();
+	}
+	already_shown.push_back(std::move(identifier));
+}
+
 /**
  * Returns whether or not *this matches the given @a filter, ignoring the
  * complexities introduced by [and], [or], and [not].
  */
-static bool matches_simple_filter(const attack_type & attack, const config & filter, const std::string& tag_name)
+bool matches_simple_filter(const attack_type& attack, const config& filter, const std::string& tag_name)
 {
+	//update and check variable_recursion for prevent check special_id/type_active in case of infinite recursion.
+	attack_type::recursion_guard filter_lock= attack.update_variables_recursion();
+	if(!filter_lock) {
+		show_recursion_warning(attack, filter);
+		return false;
+	}
+
 	const std::set<std::string> filter_range = utils::split_set(filter["range"].str());
 	const std::string& filter_damage = filter["damage"];
 	const std::string& filter_attacks = filter["number"];
@@ -145,7 +204,10 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		return false;
 
 	if (!filter_type.empty()){
-		//if special is type "damage_type" then check attack.type() only for don't have infinite recursion by calling damage_type() below.
+		// Although there's a general guard against infinite recursion, the "damage_type" special
+		// should always use the base type of the weapon. Otherwise it will flip-flop between the
+		// special being active or inactive based on whether ATTACK_RECURSION_LIMIT is even or odd;
+		// without this it will also behave differently when calculating resistance_against.
 		if(tag_name == "damage_type"){
 			if (filter_type.count(attack.type()) == 0){
 				return false;
@@ -253,6 +315,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	// Passed all tests.
 	return true;
 }
+} // anonymous namespace
 
 /**
  * Returns whether or not *this matches the given @a filter.
@@ -571,6 +634,50 @@ bool attack_type::describe_modification(const config& cfg,std::string* descripti
 	}
 
 	return true;
+}
+
+attack_type::recursion_guard attack_type::update_variables_recursion() const
+{
+	if(num_recursion_ < ATTACK_RECURSION_LIMIT) {
+		return recursion_guard(*this);
+	}
+	return recursion_guard();
+}
+
+attack_type::recursion_guard::recursion_guard() = default;
+
+attack_type::recursion_guard::recursion_guard(const attack_type& weapon)
+	: parent(weapon.shared_from_this())
+{
+	weapon.num_recursion_++;
+}
+
+attack_type::recursion_guard::recursion_guard(attack_type::recursion_guard&& other)
+{
+	std::swap(parent, other.parent);
+}
+
+attack_type::recursion_guard::operator bool() const {
+	return bool(parent);
+}
+
+attack_type::recursion_guard& attack_type::recursion_guard::operator=(attack_type::recursion_guard&& other)
+{
+	// This is only intended to move ownership to a longer-living variable. Assigning to an instance that
+	// already has a parent implies that the caller is going to recurse and needs a recursion allocation,
+	// but is accidentally dropping one of the allocations that it already has; hence the asserts.
+	assert(this != &other);
+	assert(!parent);
+	std::swap(parent, other.parent);
+	return *this;
+}
+
+attack_type::recursion_guard::~recursion_guard()
+{
+	if(parent) {
+		assert(parent->num_recursion_ > 0);
+		parent->num_recursion_--;
+	}
 }
 
 void attack_type::write(config& cfg) const

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -142,6 +142,56 @@ public:
 	inline config to_config() const { config c; write(c); return c; }
 
 	void add_formula_context(wfl::map_formula_callable&) const;
+
+	/**
+	 * Helper similar to std::unique_lock for detecting when calculations such as has_special
+	 * have entered infinite recursion.
+	 *
+	 * This assumes that there's only a single thread accessing the attack_type, it's a lightweight
+	 * increment/decrement counter rather than a mutex.
+	 */
+	class recursion_guard {
+		friend class attack_type;
+		/**
+		 * Only expected to be called in update_variables_recursion(), which handles some of the checks.
+		 */
+		explicit recursion_guard(const attack_type& weapon);
+	public:
+		/**
+		 * Construct an empty instance, only useful for extending the lifetime of a
+		 * recursion_guard returned from weapon.update_variables_recursion() by
+		 * std::moving it to an instance declared in a larger scope.
+		 */
+		explicit recursion_guard();
+
+		/**
+		 * Returns true if a level of recursion was available at the time when update_variables_recursion()
+		 * created this object.
+		 */
+		operator bool() const;
+
+		recursion_guard(recursion_guard&& other);
+		recursion_guard(const recursion_guard& other) = delete;
+		recursion_guard& operator=(recursion_guard&&);
+		recursion_guard& operator=(const recursion_guard&) = delete;
+		~recursion_guard();
+	private:
+		std::shared_ptr<const attack_type> parent;
+	};
+
+	/**
+	 * Tests which might otherwise cause infinite recursion should call this, check that the
+	 * returned object evaluates to true, and then keep the object returned as long as the
+	 * recursion might occur, similar to a reentrant mutex that's limited to a small number of
+	 * reentrances.
+	 *
+	 * This is a cheap function, so no reason to optimise by doing some filters before calling it.
+	 * However, it only expects to be called in a single thread, but the whole of attack_type makes
+	 * that assumption, for example its mutable members are assumed to be set up by the current
+	 * caller (or caller's caller, probably several layers up).
+	 */
+	recursion_guard update_variables_recursion() const;
+
 private:
 	// In unit_abilities.cpp:
 
@@ -348,6 +398,8 @@ private:
 	int parry_;
 	config specials_;
 	bool changed_;
+	/** Number of instances of recursion_guard that are currently allocated permission to recurse */
+	mutable unsigned int num_recursion_ = 0;
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -163,6 +163,8 @@
 0 event_test_filter_attack_specials
 0 event_test_filter_attack_on_moveto
 0 event_test_filter_attack_opponent_weapon_condition
+9 event_test_filter_attack_opponent_weapon_condition_no_triggered
+9 event_test_filter_attack_student_weapon_condition
 0 event_test_filter_wfl
 0 event_test_filter_wfl2
 0 event_test_filter_lua_serializable
@@ -375,6 +377,10 @@
 0 damage_secondary_type_test
 0 damage_secondary_type_with_resistance_ability_test
 0 damage_secondary_type_with_resistance_ability_test_alt
+9 event_test_filter_damage_type_recursion
+9 four_cycle_recursion_branching
+9 four_cycle_recursion_by_id
+9 four_cycle_recursion_by_tagname
 0 swarms_filter_student_by_type
 0 swarms_effects_not_checkable
 0 filter_special_id_active


### PR DESCRIPTION
this is a backport of https://github.com/wesnoth/wesnoth/commits?author=stevecotton https://github.com/wesnoth/wesnoth/commit/4afdc92f13eff33f89684e4e9489ff66f87bf17e comit because one change of behavior is to prevent crashes of game

This adds a recursion counter which runs on a per-weapon basis; if the recursion limit is reached then the last level of recursion is assumed to have returned false. A warning is printed (with error severity).

At the user-visible layer, that gives the following logic:

* Abilities that depend on another ability being active will be inactive.
* Pairs of abilities, where X depends on Y being inactive and Y depends on X being inactive, will end up with them both inactive.

The limit is defined by ATTACK_RECURSION_LIMIT in attack_type.cpp. The minimum for passing all the unit tests is 2, but I've left some headroom by setting it to 4.

With the recursion limit set to 1, the following tests fail, which seems reasonable because they're checking that the special is on a particular type of weapon.
* event_test_filter_attack_specials
* event_test_filter_attack_opponent_weapon_condition
* event_test_filter_attack_student_weapon_condition

Output from the four_cycle_recursion_branching test:
```
error unit: Recursion limit reached for weapon 'melee_attack' while checking filter 'special_type_active = parry'
error unit: Recursion limit reached for weapon 'melee_attack' while checking filter 'special_type_active = poison'
error unit: Recursion limit reached for weapon 'melee_attack' while checking filter 'special_type_active = damage'
```

There's deduplication to prevent the logfiles getting spammed during AI turns. As implemented, the two tests mentioned below print 3 messages each; these tests are added in separate commits because the tests are shared between PRs while we discuss the right mechanism for guarding against recursion.

With no rate limit:
* four_cycle_recursion_branching prints 1280 logs
* event_test_filter_attack_student_weapon_condition prints 320

With a rate limit via a flag that's reset in recursion_guard's destructor:
* four_cycle_recursion_branching prints 80 logs
* event_test_filter_attack_student_weapon_condition prints 160

Resetting the flag in specials_context_t's destructor gets better numbers, but splits the logic across .cpp files. I think the trade-off isn't worth it:
* four_cycle_recursion_branching prints 40 logs
* event_test_filter_attack_student_weapon_condition prints 132

Co-authored-by: newfrenchy83