### PR TITLE
SotBE S6: replace bad advice at turn 2

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/06_Black_Flag.cfg
@@ -240,7 +240,7 @@
 
         [message]
             speaker="Kapou'e"
-            message= _ "Wise decision. We have actually come to speak to the shamans, but while we are here we must help you out of this scrape. Grüü, hold them while I run to the keep and organize our forces to counterattack. We can’t defeat them by sea without ships, but we can destroy the foothold they have gained on the land."
+            message= _ "Wise decision. We have actually come to speak to the shamans, but while we are here we must help you out of this scrape. Grüü, fight the humans if you must, but don’t be reckless. Getting me to the Tirigaz keep so I can rally our forces for the counterattack must be our first priority. And, I need you to stay alive. We can’t defeat them by sea without ships, but we can destroy the foothold they have gained on the land."
         [/message]
 
         [message]


### PR DESCRIPTION
- Making Gruu do a suicidal solo charge? Yeah, no.

- To win this scenario, it's imperative that Kapou'e can reach the unoccupied keep at Tirigaz Harbor. His only starting units are Gruu, and maybe Jetto (if he's alive). So, he delays by even a turn, it's a full restart...Thus, we give some hint to the player to focus on the first goal: getting Kapou'e to the keep. 

- Sending Gruu to face side 2 loyalists alone is suicide. He is easily overwhelmed even at level 3 Great Troll.