### PR TITLE
Editor enhancements

### DIFF
--- a/data/gui/themes/default/window/editor_edit_unit.cfg
+++ b/data/gui/themes/default/window/editor_edit_unit.cfg
@@ -673,19 +673,24 @@
 							[/label]
 						[/column]
 						[column]
-							grow_factor = 0
+							grow_factor = 1
 
 							border = "all"
 							border_size = 5
 							horizontal_alignment = "left"
-
-							[grid]
-								[row]
-									{_GUI_RADIO_BUTTON range_melee (_"range^Melee")}
-									{_GUI_RADIO_BUTTON range_ranged (_"range^Ranged")}
-								[/row]
-							[/grid]
-
+							
+							[combobox]
+								id = "range_list"
+								definition = "default"
+								[option]
+									label = _ "range^Melee"
+									icon = "icons/profiles/melee_attack.png"
+								[/option]
+								[option]
+									label = _ "range^Ranged"
+									icon = "icons/profiles/ranged_attack.png"
+								[/option]
+							[/combobox]
 						[/column]
 					[/row]
 
@@ -708,10 +713,10 @@
 							border_size = 5
 							horizontal_alignment = "left"
 							
-							[menu_button]
+							[combobox]
 								id = "attack_type_list"
 								definition = "default"
-							[/menu_button]
+							[/combobox]
 						[/column]
 					[/row]
 					
@@ -1162,7 +1167,7 @@
 
 					[label]
 						definition=title
-						label= _ "New Unit Type"
+						label= _ "Unit Type Editor"
 					[/label]
 				[/column]
 			[/row]
@@ -1246,7 +1251,7 @@
 								horizontal_alignment = "right"
 
 								[button]
-									id = "cancel"
+									id = "exit"
 									definition = "default"
 									label = _ "Cancel"
 								[/button]

--- a/src/desktop/paths.cpp
+++ b/src/desktop/paths.cpp
@@ -150,8 +150,10 @@ inline std::string pretty_path(const std::string& path)
 
 inline config get_bookmarks_config()
 {
-	auto cfg = prefs::get().dir_bookmarks();
-	return cfg ? *cfg : config{};
+	const auto& cfg = prefs::get().dir_bookmarks();
+	return cfg.has_value() ? cfg.value() : config();
+
+//	return cfg ? *cfg : config{};
 }
 
 inline void commit_bookmarks_config(config& cfg)

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -57,6 +57,19 @@ std::unique_ptr<editor_action> mouse_action_item::click_left(editor_display& dis
 	return nullptr;
 }
 
+std::unique_ptr<editor_action> mouse_action_item::click_right(editor_display& disp, int x, int y)
+{
+	start_hex_ = disp.hex_clicked_on(x, y);
+	if (!disp.get_map().on_board(start_hex_)) {
+		return nullptr;
+	}
+
+	disp.remove_overlay(start_hex_);
+
+	click_ = true;
+	return nullptr;
+}
+
 std::unique_ptr<editor_action> mouse_action_item::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);

--- a/src/editor/action/mouse/mouse_action_item.hpp
+++ b/src/editor/action/mouse/mouse_action_item.hpp
@@ -37,15 +37,20 @@ public:
 	}
 
 	bool has_context_menu() const override {
-		return true;
+		return false;
 	}
 
 	void move(editor_display& disp, const map_location& hex) override;
 
 	/**
-	 * TODO
+	 * Left clicking places the currently selected item on the x,y map hex
 	 */
 	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
+
+	/**
+	 * Right clicking removes the item on the x,y map hex
+	 */
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
 	/**
 	 * TODO
@@ -59,10 +64,6 @@ public:
 	 * the facing when clicked right.
 	 */
 	std::unique_ptr<editor_action> drag_end_left(editor_display& disp, int x, int y) override;
-
-	std::unique_ptr<editor_action> click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) override {
-		return nullptr;
-	}
 
 	virtual void set_mouse_overlay(editor_display& disp) override;
 	void set_item_mouse_overlay(editor_display& disp, const overlay& u);

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -402,8 +402,11 @@ bool editor_controller::can_execute_command(const hotkey::ui_command& cmd) const
 		case HOTKEY_EDITOR_MAP_SAVE_AS:
 			return true;
 
-		// Only enable when editing a scenario
+		// Can be enabled as long as a valid addon_id is set
 		case HOTKEY_EDITOR_EDIT_UNIT:
+			return !current_addon_id_.empty();
+
+		// Only enable when editing a scenario
 		case HOTKEY_EDITOR_CUSTOM_TODS:
 		case HOTKEY_EDITOR_SCENARIO_SAVE_AS:
 			return !get_current_map_context().is_pure_map();
@@ -850,29 +853,27 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 			return true;
 
 		case HOTKEY_EDITOR_PBL:
-			initialize_addon_if_empty();
-
-			if(!current_addon_id_.empty()) {
+			if(initialize_addon()) {
 				context_manager_->edit_pbl();
 			}
 			return true;
 
 		case HOTKEY_EDITOR_CHANGE_ADDON_ID:
-			initialize_addon_if_empty();
-
-			if(!current_addon_id_.empty()) {
+			if(initialize_addon()) {
 				context_manager_->change_addon_id();
 			}
 			return true;
 
 		case HOTKEY_EDITOR_SELECT_ADDON:
-			current_addon_id_ = editor::initialize_addon();
-			context_manager_->set_addon_id(current_addon_id_);
+			initialize_addon();
 			return true;
 
 		case HOTKEY_EDITOR_OPEN_ADDON:
 		{
-			initialize_addon_if_empty();
+			if (!initialize_addon()) {
+				gui2::show_error_message("Could not initialize add-on!");
+				return true;
+			}
 
 			gui2::dialogs::file_dialog dlg;
 
@@ -1041,9 +1042,7 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 			context_manager_->new_map_dialog();
 			return true;
 		case HOTKEY_EDITOR_SCENARIO_NEW:
-			initialize_addon_if_empty();
-
-			if(!current_addon_id_.empty()) {
+			if(initialize_addon()) {
 				context_manager_->new_scenario_dialog();
 			}
 			return true;
@@ -1057,9 +1056,7 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 			context_manager_->save_map_as_dialog();
 			return true;
 		case HOTKEY_EDITOR_SCENARIO_SAVE_AS:
-			initialize_addon_if_empty();
-
-			if(!current_addon_id_.empty()) {
+			if(initialize_addon()) {
 				context_manager_->save_scenario_as_dialog();
 			}
 			return true;
@@ -1154,11 +1151,13 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 	}
 }
 
-void editor_controller::initialize_addon_if_empty() {
+bool editor_controller::initialize_addon() {
 	if(current_addon_id_.empty()) {
+		// editor::initialize_addon can return empty id in case of failure
 		current_addon_id_ = editor::initialize_addon();
 	}
 	context_manager_->set_addon_id(current_addon_id_);
+	return !current_addon_id_.empty();
 }
 
 void editor_controller::show_help()

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -162,8 +162,10 @@ class editor_controller : public controller_base,
 			return context_manager_->get_map_context();
 		}
 
-		/** Initialize an addon if the addon id is empty */
-		void initialize_addon_if_empty();
+		/** Initialize an addon if the addon id is empty
+		 * @return    If the initialization succeeded.
+		 * */
+		bool initialize_addon();
 
 	protected:
 		/* controller_base overrides */

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -20,6 +20,7 @@
 #include "editor/editor_display.hpp"
 #include "floating_label.hpp"
 #include "font/sdl_ttf_compat.hpp" // for pango_line_width
+#include "formula/string_utils.hpp"
 #include "lexical_cast.hpp"
 #include "overlay.hpp"
 #include "team.hpp"
@@ -111,7 +112,7 @@ void editor_display::layout()
 	display::layout();
 
 	config element;
-	config::attribute_value &text = element.add_child("element")["text"];
+	config::attribute_value& text = element.add_child("element")["text"];
 	// Fill in the terrain report
 	if (get_map().on_board_with_border(mouseoverHex_)) {
 		text = get_map().get_terrain_editor_string(mouseoverHex_);
@@ -155,6 +156,33 @@ const time_of_day& editor_display::get_time_of_day(const map_location& /*loc*/) 
 display::overlay_map& editor_display::get_overlays()
 {
 	return controller_.get_current_map_context().get_overlays();
+}
+
+void editor_display::set_status(const std::string& str, const bool is_success)
+{
+	const color_t color{0, 0, 0, 0xbb};
+	int size = font::SIZE_SMALL;
+	point canvas_size = video::game_canvas_size();
+	const int border = 3;
+
+	std::string formatted_str;
+	if (is_success) {
+		formatted_str = VGETTEXT("<span color='#66ff00'><span face='DejaVuSans'>✔</span> $msg</span>", {{"msg", str}});
+	} else {
+		formatted_str = VGETTEXT("<span color='red'><span face='DejaVuSans'>✘</span> $msg</span>", {{"msg", str}});
+	}
+
+	font::floating_label flabel(formatted_str);
+	flabel.set_font_size(size);
+	flabel.set_position(0, canvas_size.y);
+	flabel.set_bg_color(color);
+	flabel.set_border_size(border);
+	flabel.set_lifetime(1000, 10);
+	flabel.use_markup(true);
+
+	const int f_handle = font::add_floating_label(flabel);
+	const auto& r = font::get_floating_label_rect(f_handle);
+	font::move_floating_label(f_handle, r.w, -r.h);
 }
 
 void editor_display::set_help_string_enabled(bool value)

--- a/src/editor/editor_display.hpp
+++ b/src/editor/editor_display.hpp
@@ -62,6 +62,16 @@ public:
 	}
 
 	/**
+	 * Set a status text at the bottom left of the map area
+	 *
+	 * @param str                 The text to display.
+	 * @param is_success          Type of message.
+	 * When true, message is shown in green with checkmark.
+	 * When false, message is shown in red with cross mark
+	 */
+	void set_status(const std::string& str, const bool is_success);
+
+	/**
 	 * Sets and shows the tooltip-like text at the top or bottom of the map area.
 	 *
 	 * @param str                 The text to display.

--- a/src/editor/map/context_manager.cpp
+++ b/src/editor/map/context_manager.cpp
@@ -887,10 +887,10 @@ bool context_manager::write_scenario(bool display_confirmation)
 	try {
 		get_map_context().save_scenario();
 		if(display_confirmation) {
-			gui2::show_transient_message("", _("Scenario saved."));
+			gui_.set_status(_("Scenario saved."), true);
 		}
 	} catch (const editor_map_save_exception& e) {
-		gui2::show_transient_message("", e.what());
+		gui_.set_status(e.what(), false);
 		return false;
 	}
 
@@ -902,10 +902,10 @@ bool context_manager::write_map(bool display_confirmation)
 	try {
 		get_map_context().save_map();
 		if(display_confirmation) {
-			gui2::show_transient_message("", _("Map saved."));
+			gui_.set_status(_("Map saved"), true);
 		}
 	} catch (const editor_map_save_exception& e) {
-		gui2::show_transient_message("", e.what());
+		gui_.set_status(e.what(), false);
 		return false;
 	}
 

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -122,7 +122,6 @@ void editor_palette<Item>::set_group(const std::string& id)
 			found = true;
 			std::shared_ptr<gui::button> palette_menu_button = gui_.find_menu_button("menu-editor-terrain");
 			if (palette_menu_button) {
-				//palette_menu_button->set_label(group.name);
 				palette_menu_button->set_tooltip_string(group.name);
 				palette_menu_button->set_overlay(group.icon);
 			}
@@ -298,13 +297,11 @@ void editor_palette<Item>::layout()
 		}
 
 		const std::string item_id = active_group()[item_index];
-		//typedef std::map<std::string, Item> item_map_wurscht;
 		typename item_map::iterator item = item_map_.find(item_id);
 
 		texture item_base, item_overlay;
 		std::stringstream tooltip_text;
 		setup_item((*item).second, item_base, item_overlay, tooltip_text);
-
 		bool is_core = non_core_items_.find(get_id((*item).second)) == non_core_items_.end();
 		if (!is_core) {
 			tooltip_text << " "
@@ -317,17 +314,6 @@ void editor_palette<Item>::layout()
 		tile.set_tooltip_string(tooltip_text.str());
 		tile.set_item_image(item_base, item_overlay);
 		tile.set_item_id(item_id);
-
-//		if (get_id((*item).second) == selected_bg_item_
-//				&& get_id((*item).second) == selected_fg_item_) {
-//			tile.set_pressed(gui::tristate_button::BOTH);
-//		} else if (get_id((*item).second) == selected_bg_item_) {
-//			tile.set_pressed(gui::tristate_button::RIGHT);
-//		} else if (get_id((*item).second) == selected_fg_item_) {
-//			tile.set_pressed(gui::tristate_button::LEFT);
-//		} else {
-//			tile.set_pressed(gui::tristate_button::NONE);
-//		}
 
 		if (is_selected_bg_item(get_id(item->second))
 				&& is_selected_fg_item(get_id(item->second))) {

--- a/src/editor/palette/item_palette.cpp
+++ b/src/editor/palette/item_palette.cpp
@@ -29,7 +29,7 @@ namespace editor {
 
 std::string item_palette::get_help_string()
 {
-	return selected_fg_item().name;
+	return _("Left-click: Place item ") + selected_fg_item().name + _(" | Right-click to remove");
 }
 
 void item_palette::setup(const game_config_view& cfg)

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -122,7 +122,7 @@ bool floating_label::create_texture()
 		return false;
 	}
 
-	DBG_FT << "creating floating label texture";
+	DBG_FT << "creating floating label texture, text: " << text_.substr(0,15);
 	font::pango_text& text = font::get_text_renderer();
 
 	text.set_link_aware(false)

--- a/src/gui/dialogs/editor/edit_unit.hpp
+++ b/src/gui/dialogs/editor/edit_unit.hpp
@@ -18,6 +18,7 @@
 #include "game_config_view.hpp"
 #include "gui/dialogs/modal_dialog.hpp"
 #include "gui/widgets/group.hpp"
+#include "gui/widgets/combobox.hpp"
 #include "gui/widgets/menu_button.hpp"
 #include "serialization/preprocessor.hpp"
 
@@ -50,6 +51,7 @@ private:
 	config type_cfg_;
 	config resistances_, defenses_, movement_;
 	preproc_map specials_map_, abilities_map_;
+
 	/**
 	 * Used to control checkboxes for various resistances, defences, etc.
 	 * so that only specific values are overridden.
@@ -126,10 +128,12 @@ private:
 	/** Callback to enable/disable OK button if ID/Name is invalid */
 	void button_state_change();
 
+	/** Quit confirmation */
+	void quit_confirmation();
+
 	/** Utility method to check if ID contains any invalid characters */
 	bool check_id(std::string id);
 
-	/** Utility method to set state of menu_button from a string */
 	void set_selected_from_string(menu_button& list, std::vector<config> values, std::string item) {
 		for (unsigned i = 0; i < values.size(); ++i) {
 			if(values.at(i)["label"] == item) {
@@ -139,11 +143,22 @@ private:
 		}
 	}
 
+	void set_selected_from_string(combobox& list, std::vector<config> values, std::string item) {
+		for (unsigned i = 0; i < values.size(); ++i) {
+			if(values.at(i)["label"] == item) {
+				list.set_selected(i);
+				break;
+			}
+		}
+		list.set_value(item);
+	}
+
 	/* signal handler for Ctrl+O shorcut */
-	void signal_handler_sdl_key_down(const event::ui_event /*event*/,
-									 bool& handled,
-									 const SDL_Keycode key,
-									 SDL_Keymod modifier);
+	void signal_handler_sdl_key_down(
+		const event::ui_event /*event*/,
+		bool& handled,
+		const SDL_Keycode key,
+		SDL_Keymod modifier);
 };
 
 

--- a/src/gui/widgets/combobox.hpp
+++ b/src/gui/widgets/combobox.hpp
@@ -59,8 +59,8 @@ public:
 	}
 
 	void set_values(const std::vector<::config>& values, unsigned selected = 0);
-
 	void set_selected(unsigned selected, bool fire_event = true);
+	unsigned get_selected() const { return selected_; }
 
 protected:
 	/* **** ***** ***** ***** layout functions ***** ***** ***** **** */

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -205,7 +205,7 @@ constexpr std::array<hotkey_command_temp, HOTKEY_NULL - 1> master_hotkey_list {{
 	{ HOTKEY_EDITOR_TOOL_STARTING_POSITION, "editor-tool-starting-position", N_("Starting Positions Tool"), false, scope_editor, HKCAT_TOOLS,  N_("Left mouse button displays player selection, right clears. Number keys scroll to the starting position, alt+number sets respective starting position under cursor, delete clears.") },
 	{ HOTKEY_EDITOR_TOOL_LABEL, "editor-tool-label", N_("Label Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets or drags a label, right clears.") },
 	{ HOTKEY_EDITOR_TOOL_UNIT, "editor-tool-unit", N_("Unit Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets a new unit or moves a unit via drag and drop, right brings up a context menu. Needs a defined side.") },
-	{ HOTKEY_EDITOR_TOOL_ITEM, "editor-tool-item", N_("Item Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets a new item.") },
+	{ HOTKEY_EDITOR_TOOL_ITEM, "editor-tool-item", N_("Item Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets a new item. Right click removes item.") },
 	{ HOTKEY_EDITOR_TOOL_VILLAGE, "editor-tool-village", N_("Village Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets the village ownership to the current side, right clears. Needs a defined side.") },
 
 	{ HOTKEY_EDITOR_UNIT_TOGGLE_CANRECRUIT, "editor-toggle-canrecruit", N_("Can Recruit"), false, scope_editor, HKCAT_TOOLS, N_("Toggle the recruit attribute of a unit.") },

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -819,7 +819,6 @@ class prefs
 		static constexpr std::array unsynced_attributes_{
 			prefs_list::auto_pixel_scale,
 			prefs_list::core,
-			prefs_list::dir_bookmarks,
 			prefs_list::draw_delay,
 			prefs_list::editor_chosen_addon,
 			prefs_list::gui2_theme,
@@ -841,6 +840,7 @@ class prefs
 		};
 		static constexpr std::array unsynced_children_{
 			prefs_list::editor_recent_files,
+			prefs_list::dir_bookmarks,
 		};
 		static_assert(synced_attributes_.size() + synced_children_.size() + unsynced_attributes_.size() + unsynced_children_.size() == prefs_list::values.size(), "attribute missing from lists of synced or unsynced preferences!");
 };


### PR DESCRIPTION
1. Item tool: Right click now removes items from the map (https://forums.wesnoth.org/viewtopic.php?t=54905)

![Screenshot from 2024-08-30 11-59-01](https://github.com/user-attachments/assets/8b8fd4bd-e1ad-4bc1-ae60-6da5b1735b26)

2. If an addon is selected using Select active Add-on option, the Unit menu now becomes active and the Unit Type Editor can be accessed.

3. New validation check for filenames with whitespaces.
![Screenshot from 2024-09-02 08-21-31](https://github.com/user-attachments/assets/2865109e-5c70-4f3f-9c99-c2b22b05de10)

4. Using comboboxes for Attack range and types that show icons. (Partial custom type/range support)
![Screenshot from 2024-09-02 14-54-03](https://github.com/user-attachments/assets/b72e4a54-88ac-47a7-ac68-7b1e0343c2d2)

5. Icons are also shown for race and alignments.
![Screenshot from 2024-09-02 14-35-17](https://github.com/user-attachments/assets/ff4dca0c-66af-4233-bb6e-b1e6e4fa47fd)

6. Fixes a bug that disabled the Save button when a filename was selected from list instead of typed manually.

7. Unit type editor: Add a quit confirmation to cancel button so the user doesn't lose data.

8. File Dialog: Fix a bug that stopped the user bookmarks from getting saved. (Resolves #9298)