### PR TITLE
SotBE S7: UX improvements

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/maps/07_The_Desert_of_Death.map
+++ b/data/campaigns/Son_Of_The_Black_Eye/maps/07_The_Desert_of_Death.map
@@ -9,8 +9,8 @@ Dd, Hd, Dd, Rd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Hd, Hd, Ds, Dd, Rd, Ds, Dd, 
 Dd, Dd, Dd, Rd, Rd, Dd, Dd^Vdt, Dd, Rd, Rd, Rd, Dd, Ds, Dd^Vdt, Hd, Dd, Dd, Dd, Ds, Dd, Hd, Hd, Hd, Ww, Ww, Ww, Dd^Do, Dd, Dd, Dd, Ds, Ds, Ds, Ds, Dd, Dd, Ds, Dd, Dd, Dd
 Dd, Dd, Dd, Dd, Dd, Rd, Dd, Dd, Ds, Dd, Dd, Rd, Dd, Hd, Dd, Hd, Ds, Dd, Ds, Dd, Dd, Hd, Hd, Ww, Ww, Ww, Dd, Dd, Ds, Ds, Ds, Ds, Ds, Dd, Dd, Dd, Dd, Dd, Dd, Dd
 Hd, Hd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Ds, Ds, Dd, Dd, Ds, Dd, Ds, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Ds, Ds, Ds, Ds, Ds, Ds, Dd, Dd, Dd, Ds, Ds, Dd, Dd, Dd
-Hd, Hd, Hd, Hd, Ds, Dd, Hd, Dd, Dd, Ds, Dd, Ds, Dd, Rd, Ds, Ds, Dd, Ds, Dd, Ds, Ds, Dd, Dd, Dd, Hd, Hd, Ds, Ds, Ds, Ds, Ds, Dd, Rd, Ds, Hd, Hd, Ds, Dd, Ds, Ds
-Hd, Hd, Hd, Hd, Ds, Hd, Dd, Dd, Dd, Dd, Dd, Dd, Dd^Vdt, Rd, Dd, Dd, Dd, Dd, Dd, Ds, Ds, Dd, Dd, Dd, Ds, Dd, Dd, Ds, Ds, Ds, Rd, Rd, Dd, Dd, Ds, Ds, Dd, Dd, Dd, Dd
+Hd, Hd, Hd, Hd, Ds, Dd, Hd, Dd, Dd, Ds, Dd, Ds, Dd, Rd, Ds, Ds, Dd, Ds, Dd, Cer, Ker, Dd, Dd, Dd, Hd, Hd, Ds, Ds, Ds, Ds, Ds, Dd, Rd, Ds, Hd, Hd, Ds, Dd, Ds, Ds
+Hd, Hd, Hd, Hd, Ds, Hd, Dd, Dd, Dd, Dd, Dd, Dd, Dd^Vdt, Rd, Dd, Dd, Dd, Dd, Dd, Ds, Cer, Dd, Dd, Dd, Ds, Dd, Dd, Ds, Ds, Ds, Rd, Rd, Dd, Dd, Ds, Ds, Dd, Dd, Dd, Dd
 Hd, Hd, Ds, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Hd, Rd, Rd, Dd, Dd, Dd, Dd, Ds, Dd, Dd, Dd, Ds, Ds, Dd, Dd, Ds, Ds, Ds, Rd, Ds, Ds, Ds, Ds, Ds, Dd, Dd, Hd, Hd
 Hd, Hd, Hd, Ds, Ds, Dd, Dd, Ds, Dd, Dd, Hd, Hd, Dd, Dd, Dd, Dd, Dd, Dd, Ds, Ds, Ds, Dd, Dd, Ds, Ds, Dd, Dd, Dd, Rd, Rd, Dd, Dd, Dd, Dd, Dd, Ds, Dd, Ds, Hd, Hd
 Hd, Hd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Dd, Hd, Dd, Dd, Dd^Vdt, Rd, Rd, Dd, Dd, Ds, Hd, Dd, Ds, Ds, Ds, Dd, Dd, Ds, Ds, Dd, Dd, Dd, Dd, Dd, Ds, Ds, Dd, Dd, Hd, Hd

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/07_The_Desert_of_Death.cfg
@@ -106,6 +106,10 @@
                 [/criteria]
                 value=3
             [/goal]
+            # avoid villages
+            [avoid]
+                terrain="*^V*"
+            [/avoid]
         [/ai]
     [/side]
 


### PR DESCRIPTION
- add auxiliary camp keep and camp

There is fog of war enabled and no distinct way to tell what the enemy sides are (unless you are playing as a veteran with foreknowledge). We add second keep and camp of 2 hexes to allow player to react to facing the bandits (as in, to recall/recruit a Grunt/Whelp to combat as these types would not be usually recalled since Sand Scuttlers are heavily resistant vs Impact)

- make scorpions avoid villages

Some players have expressed that "it's not fair" that the scorpions would spawn behind them and then damage their per turn income (by stealing villages), leading to low bonus gold at scenario end.  