### PR TITLE
AToTB: Use month names instead of Roman Numerals

### DIFF
--- a/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/01_Rooting_Out_a_Mage.cfg
@@ -69,7 +69,7 @@ Skeletons and zombies killed cattle and fired fields. <i>“Fear and obey Mordak
             background=story/Two_Brothers_M1P2.webp
         [/part]
         [part]
-            story=_ "12 V, 363 YW
+            story=_ "12 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Baran of Maghre
 
 If I could but face this ‘Mordak’! I think my magic might prove stronger than his. But he bides in the hills, well-guarded by his servants, and I muster frightened peasants to fight his minions with blades and sticks.

--- a/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/02_The_Chase.cfg
@@ -31,7 +31,7 @@
         # wmllint: local spelling Grey
         [part]
             background=story/Two_Brothers_M2P1.webp
-            story=_ "16 V, 363 YW
+            story=_ "16 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Arvith of Maghre
 
 We’ve been searching three days for Baran, and turned up nothing. My best hunch was to head north into the borderlands, where the necromancer’s minions could safely hide; everywhere else is more farmland. At first I thought the search might be useless, but late in the first day we found a set of tracks. Some of them had been made by skeletal feet, although after their first campsite the tracks were merely those of men carrying heavy loads.
@@ -40,7 +40,7 @@ We’re close enough to be certain now: those tracks are heading into the Grey W
         [/part]
         [part]
             background=story/Two_Brothers_M2P1.webp
-            story=_ "16 V, 363 YW
+            story=_ "16 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Arvith of Maghre
 
 But I’m past superstitions now; I’ve seen enough of the world to guess at the truth behind these sorts of tales. The forest is home to elves — unfriendly ones, if the stories have any basis at all. I worry for my men; horses don’t fight well in forests, and the elves will be more dangerous in their own territory. But there are things that need done and questions that need answered. Something bigger is happening. One necromancer terrorizing townsfolk is nothing new, but why didn’t his servants scatter when he was killed? Where are they headed now? And most importantly, why did they take Baran with them?

--- a/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/03_Guarded_Castle.cfg
@@ -23,7 +23,7 @@
         # Diary entries split into two parts until story screens allow vertical scrolling (FR #17492).
         [part]
             # wmllint: local spelling clanless
-            story=_"19 V, 363 YW
+            story=_"19 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Rotharik the Clanless
 
 The last of Mordak’s servants arrived this morning bearing the news of his death, as well as a bundle so well-bound it was barely recognizable as a man. Mordak was always reckless. This whole desperate scheme was his, and I suppose I could blame him for everything that we have suffered through if it still mattered. It was he who brought the wrath of the orcs down on us, too. But all the same, he managed to accomplish what he set out to do. I still cannot believe the finality of what has happened; until now we had always managed to make it through somehow.
@@ -31,7 +31,7 @@ The last of Mordak’s servants arrived this morning bearing the news of his dea
 We had hoped to deliver the mage to Tairach in return for our lives. I do not know what the warlord wants with this man, but he matches the description. I suppose that Mordak’s plan would have worked perfectly if not for the appearance of the horse warriors. Now they are coming here, led by a man rumored to be this mage’s brother. If that is true, he will stop at nothing, no more than would I if they held Mordak."
         [/part]
         [part]
-            story=_ "19 V, 363 YW
+            story=_ "19 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Rotharik the Clanless
 
 I have done what I can to fortify this dilapidated castle. The orcs who came with us stand guard at the gates, and I am gathering all of my servants to me in the inner sanctum. But ill fate awaits. Whether I defeat this horse-warrior or no, the orcs will still come for me; they have been scouring the borderlands and raiding the northern farm country in search of us.

--- a/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/04_Return_to_the_Village.cfg
@@ -23,7 +23,7 @@
         # Diary entries split into two parts until story screens allow vertical scrolling (FR #17492).
         # wmllint: local spelling Grey
         [part]
-            story=_"27 V, 363 YW
+            story=_"27 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Baran of Maghre
 
 Almost home now. The last week has been full of mixed feelings for me — blissful and difficult by turns. It was wonderful to be out of that dungeon cell and in the sunlight again without the threat of death or worse hanging over my head... but with that behind me, I turned to the almost equally daunting task of making amends with my brother.
@@ -31,7 +31,7 @@ Almost home now. The last week has been full of mixed feelings for me — blissf
 Arvith had largely forgiven me by the time he freed me from my cell. All the same, it has taken all of the past week for us to rebuild the sense of comfort in each other we once had. It is fortunate that we have been able to take our time getting back — we gave the Grey Woods a wide berth, and on our way around it we traveled through some truly beautiful countryside. It has given us plenty of time to talk."
         [/part]
         [part]
-            story=_ "27 V, 363 YW
+            story=_ "27 Scryer’s Bloom, 363 YW
 Excerpt from the journal of Baran of Maghre
 
 Though I am more at ease now, my thoughts often turn back to Toen Caric. We should have been able to repel the orcs without great loss — the pincer attack Arvith devised would surely have carried the day but for me. It was reckless of me to leave my men behind — I wounded the warlord and forced him to flee the field, but the cost far outweighed the gain. Those under my command could have been saved if I had remained with them.

--- a/data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg
+++ b/data/campaigns/Two_Brothers/scenarios/05_Epilogue.cfg
@@ -15,7 +15,7 @@
         # Diary entries split into two parts until story screens allow vertical scrolling (FR #17492).
         [part]
             show_title=yes
-            story= _ "22 IX, 365 YW
+            story= _ "22 Stillseed, 365 YW
 Excerpt from the journal of Arvith of Maghre
 
 Maghre is looking much better than the last time I saw it. Baran has done wonders in two years. The village is rebuilt, and the surrounding farmlands are restored and reoccupied. Despite my brother’s worries, our people have faced no new threats in that time.
@@ -24,7 +24,7 @@ It has been more difficult to stay away in those two years, but I have my callin
             background=story/Two_Brothers_M4P1_the_end.webp
         [/part]
         [part]
-            story=_ "22 IX, 365 YW
+            story=_ "22 Stillseed, 365 YW
 Excerpt from the journal of Arvith of Maghre
 
 This patron is, of all things, an elf. I never thought I’d befriend one, but he is less arrogant than the rest. Kalenz, he calls himself. He’s seen too much; I can tell that just by meeting his eyes. I think we will have to work for our pay soon.


### PR DESCRIPTION
A small tweak to the story text in AToTB that replaces roman numerals for months with Wesnoth’s fictional month names. The months are shown in the in-game encyclopedia. As far as I’m aware, these are 
only used in Liberty and  Eastern Invasion. Presuming they map to the Gregorian months, Scryer’s Bloom is around May and Stillseed is around September.