### PR TITLE
Reduce Corpse/Soulless arcane vulnerablility from -40% to -20%

### DIFF
--- a/data/core/units/undead/Corpse_Soulless.cfg
+++ b/data/core/units/undead/Corpse_Soulless.cfg
@@ -126,7 +126,7 @@
     [/attack]
 
     [resistance]
-        arcane=140
+        arcane=120
     [/resistance]
     [movement_costs]
         deep_water=4

--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -127,7 +127,7 @@ NOP#endarg
     [/attack]
 
     [resistance]
-        arcane=140
+        arcane=120
     [/resistance]
     [movement_costs]
         deep_water=4


### PR DESCRIPTION
Resolves #9224

Hejnewar says he doesn't have strong feelings about this right now, but that originally it was an oversight to leave Corpse/Soulless arcane resist at -40%. Making this PR to keep things consistent, and also because I think it's a generally positive change.