### PR TITLE
Fixes unit moving during attack selection screen

### DIFF
--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -45,16 +45,18 @@ const unsigned int attack_predictions::graph_width = 270;
 const unsigned int attack_predictions::graph_height = 170;
 const unsigned int attack_predictions::graph_max_rows = 10;
 
-attack_predictions::attack_predictions(battle_context& bc, unit_const_ptr attacker, unit_const_ptr defender)
+attack_predictions::attack_predictions(
+	battle_context& bc, unit_const_ptr attacker, unit_const_ptr defender, const int leadership_bonus)
 	: modal_dialog(window_id())
 	, attacker_data_(std::move(attacker), bc.get_attacker_combatant(), bc.get_attacker_stats())
 	, defender_data_(std::move(defender), bc.get_defender_combatant(), bc.get_defender_stats())
+	, leadership_bonus_(leadership_bonus)
 {
 }
 
 void attack_predictions::pre_show()
 {
-	set_data(attacker_data_, defender_data_);
+	set_data(attacker_data_, defender_data_, leadership_bonus_);
 	set_data(defender_data_, attacker_data_);
 }
 
@@ -71,7 +73,7 @@ static std::string get_probability_string(const double prob)
 	return ss.str();
 }
 
-void attack_predictions::set_data(const combatant_data& attacker, const combatant_data& defender)
+void attack_predictions::set_data(const combatant_data& attacker, const combatant_data& defender, int leadership_bonus)
 {
 	// Each data widget in this dialog has its id prefixed by either of these identifiers.
 	const std::string widget_id_prefix = attacker.stats_.is_attacker ? "attacker" : "defender";
@@ -234,8 +236,10 @@ void attack_predictions::set_data(const combatant_data& attacker, const combatan
 	}
 
 	// Leadership bonus.
-	const int leadership_bonus = under_leadership(*attacker.unit_, attacker.unit_->get_location(), weapon, opp_weapon);
-
+	// defender unit won't move before attack so just do calculation here
+	if (leadership_bonus == 0){
+		leadership_bonus = under_leadership(*attacker.unit_, attacker.unit_->get_location(), weapon, opp_weapon);
+	}
 	if(leadership_bonus != 0) {
 		set_label_helper("leadership_modifier", utils::signed_percent(leadership_bonus));
 	} else {

--- a/src/gui/dialogs/attack_predictions.hpp
+++ b/src/gui/dialogs/attack_predictions.hpp
@@ -35,7 +35,7 @@ using hp_probability_vector = std::vector<std::pair<int, double>>;
 class attack_predictions : public modal_dialog
 {
 public:
-	attack_predictions(battle_context& bc, unit_const_ptr attacker, unit_const_ptr defender);
+	attack_predictions(battle_context& bc, unit_const_ptr attacker, unit_const_ptr defender, const int leadership_bonus = 0);
 
 	DEFINE_SIMPLE_DISPLAY_WRAPPER(attack_predictions)
 
@@ -58,7 +58,7 @@ private:
 		unit_const_ptr unit_;
 	};
 
-	void set_data(const combatant_data& attacker, const combatant_data& defender);
+	void set_data(const combatant_data& attacker, const combatant_data& defender, int leadership_bonus = 0);
 
 	hp_probability_vector get_hitpoint_probabilities(const std::vector<double>& hp_dist) const;
 
@@ -70,6 +70,8 @@ private:
 
 	combatant_data attacker_data_;
 	combatant_data defender_data_;
+
+	const int leadership_bonus_;
 };
 
 } // namespace dialogs

--- a/src/gui/dialogs/unit_attack.cpp
+++ b/src/gui/dialogs/unit_attack.cpp
@@ -38,20 +38,24 @@ REGISTER_DIALOG(unit_attack)
 unit_attack::unit_attack(const unit_map::iterator& attacker_itor,
 						   const unit_map::iterator& defender_itor,
 						   std::vector<battle_context>&& weapons,
-						   const int best_weapon)
+						   const int best_weapon,
+						   std::vector<gui2::widget_data>& bc_widget_data_vector,
+						   const int leadership_bonus)
 	: modal_dialog(window_id())
 	, selected_weapon_(-1)
 	, attacker_itor_(attacker_itor)
 	, defender_itor_(defender_itor)
 	, weapons_(std::move(weapons))
 	, best_weapon_(best_weapon)
+	, bc_widget_data_vector_(bc_widget_data_vector)
+	, leadership_bonus_(leadership_bonus)
 {
 }
 
 void unit_attack::damage_calc_callback()
 {
 	const std::size_t index = find_widget<listbox>("weapon_list").get_selected_row();
-	attack_predictions::display(weapons_[index], attacker_itor_.get_shared_ptr(), defender_itor_.get_shared_ptr());
+	attack_predictions::display(weapons_[index], attacker_itor_.get_shared_ptr(), defender_itor_.get_shared_ptr(), leadership_bonus_);
 }
 
 void unit_attack::pre_show()
@@ -71,153 +75,7 @@ void unit_attack::pre_show()
 	listbox& weapon_list = find_widget<listbox>("weapon_list");
 	keyboard_capture(&weapon_list);
 
-	// Possible TODO: If a "blank weapon" is generally useful, add it as a static member in attack_type.
-	static const config empty;
-	static const_attack_ptr no_weapon(new attack_type(empty));
-
-	for(const auto & weapon : weapons_) {
-		const battle_context_unit_stats& attacker = weapon.get_attacker_stats();
-		const battle_context_unit_stats& defender = weapon.get_defender_stats();
-
-		const attack_type& attacker_weapon =
-			*attacker.weapon;
-		const attack_type& defender_weapon = defender.weapon ?
-			*defender.weapon : *no_weapon;
-
-		const color_t a_cth_color = game_config::red_to_green(attacker.chance_to_hit);
-		const color_t d_cth_color = game_config::red_to_green(defender.chance_to_hit);
-
-		const std::string attw_name = !attacker_weapon.name().empty() ? attacker_weapon.name() : " ";
-		const std::string defw_name = !defender_weapon.name().empty() ? defender_weapon.name() : " ";
-
-		std::string range = attacker_weapon.range().empty() ? defender_weapon.range() : attacker_weapon.range();
-		if (!range.empty()) {
-			range = string_table["range_" + range];
-		}
-
-		auto a_ctx = attacker_weapon.specials_context(
-			attacker_itor_.get_shared_ptr(),
-			defender_itor_.get_shared_ptr(),
-			attacker_itor_->get_location(),
-			defender_itor_->get_location(), true, defender.weapon
-		);
-
-		auto d_ctx = defender_weapon.specials_context(
-			defender_itor_.get_shared_ptr(),
-			attacker_itor_.get_shared_ptr(),
-			defender_itor_->get_location(),
-			attacker_itor_->get_location(), false, attacker.weapon
-		);
-
-		std::string types = attacker_weapon.effective_damage_type().first;
-		std::string attw_type = !(types).empty() ? types : attacker_weapon.type();
-		if (!attw_type.empty()) {
-			attw_type = string_table["type_" + attw_type];
-		}
-		std::string def_types = defender_weapon.effective_damage_type().first;
-		std::string defw_type = !(def_types).empty() ? def_types : defender_weapon.type();
-		if (!defw_type.empty()) {
-			defw_type = string_table["type_" + defw_type];
-		}
-
-		const std::set<std::string> checking_tags_other = {"damage_type", "disable", "berserk", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
-		std::string attw_specials = attacker_weapon.weapon_specials();
-		std::string attw_specials_dmg = attacker_weapon.weapon_specials_value({"leadership", "damage"});
-		std::string attw_specials_atk = attacker_weapon.weapon_specials_value({"attacks", "swarm"});
-		std::string attw_specials_cth = attacker_weapon.weapon_specials_value({"chance_to_hit"});
-		std::string attw_specials_others = attacker_weapon.weapon_specials_value(checking_tags_other);
-		bool defender_attack = !(defender_weapon.name().empty() && defender_weapon.damage() == 0 && defender_weapon.num_attacks() == 0 && defender.chance_to_hit == 0);
-		std::string defw_specials = defender_attack ? defender_weapon.weapon_specials() : "";
-		std::string defw_specials_dmg = defender_attack ? defender_weapon.weapon_specials_value({"leadership", "damage"}) : "";
-		std::string defw_specials_atk = defender_attack ? defender_weapon.weapon_specials_value({"attacks", "swarm"}) : "";
-		std::string defw_specials_cth = defender_attack ? defender_weapon.weapon_specials_value({"chance_to_hit"}) : "";
-		std::string defw_specials_others = defender_attack ? defender_weapon.weapon_specials_value(checking_tags_other) : "";
-
-		if(!attw_specials.empty()) {
-			attw_specials = " " + attw_specials;
-		}
-		if(!attw_specials_dmg.empty()) {
-			attw_specials_dmg = " " + attw_specials_dmg;
-		}
-		if(!attw_specials_atk.empty()) {
-			attw_specials_atk = " " + attw_specials_atk;
-		}
-		if(!attw_specials_cth.empty()) {
-			attw_specials_cth = " " + attw_specials_cth;
-		}
-		if(!attw_specials_others.empty()) {
-			attw_specials_others = "\n" + markup::bold(_("Other aspects: ")) + "\n" + markup::italic(attw_specials_others);
-		}
-		if(!defw_specials.empty()) {
-			defw_specials = " " + defw_specials;
-		}
-		if(!defw_specials_dmg.empty()) {
-			defw_specials_dmg = " " + defw_specials_dmg;
-		}
-		if(!defw_specials_atk.empty()) {
-			defw_specials_atk = " " + defw_specials_atk;
-		}
-		if(!defw_specials_cth.empty()) {
-			defw_specials_cth = " " + defw_specials_cth;
-		}
-		if(!defw_specials_others.empty()) {
-			defw_specials_others = "\n" + markup::bold(_("Other aspects: ")) + "\n" + markup::italic(defw_specials_others);
-		}
-
-		std::stringstream attacker_stats, defender_stats, attacker_tooltip, defender_tooltip;
-
-		// Use attacker/defender.num_blows instead of attacker/defender_weapon.num_attacks() because the latter does not consider the swarm weapon special
-		attacker_stats << markup::bold(attw_name) << "\n"
-			<< attw_type << "\n"
-			<< attacker.damage << font::weapon_numbers_sep << attacker.num_blows
-			<< attw_specials << "\n"
-			<< markup::span_color(a_cth_color, attacker.chance_to_hit, "%");
-
-		attacker_tooltip << _("Weapon: ") << markup::bold(attw_name) << "\n"
-			<< _("Type: ") << attw_type << "\n"
-			<< _("Damage: ") << attacker.damage << markup::italic(attw_specials_dmg) << "\n"
-			<< _("Attacks: ") << attacker.num_blows << markup::italic(attw_specials_atk) << "\n"
-			<< _("Chance to hit: ") << markup::span_color(a_cth_color, attacker.chance_to_hit, "%")
-			<< markup::italic(attw_specials_cth) << attw_specials_others;
-
-		defender_stats << markup::bold(defw_name) << "\n"
-			<< defw_type << "\n"
-			<< defender.damage << font::weapon_numbers_sep << defender.num_blows
-			<< defw_specials << "\n"
-			<< markup::span_color(d_cth_color, defender.chance_to_hit, "%");
-
-		defender_tooltip << _("Weapon: ") << markup::bold(defw_name) << "\n"
-			<< _("Type: ") << defw_type << "\n"
-			<< _("Damage: ") << defender.damage << markup::italic(defw_specials_dmg) << "\n"
-			<< _("Attacks: ") << defender.num_blows <<  markup::italic(defw_specials_atk) << "\n"
-			<< _("Chance to hit: ") << markup::span_color(d_cth_color, defender.chance_to_hit, "%")
-			<< markup::italic(defw_specials_cth)
-			<< defw_specials_others;
-
-		widget_data data;
-		widget_item item;
-
-		item["use_markup"] = "true";
-
-		item["label"] = attacker_weapon.icon();
-		data.emplace("attacker_weapon_icon", item);
-
-		item["tooltip"] = attacker_tooltip.str();
-		item["label"] = attacker_stats.str();
-		data.emplace("attacker_weapon", item);
-		item["tooltip"] = "";
-
-		item["label"] = markup::span_color("#a69275", font::unicode_em_dash, " ", range, " ", font::unicode_em_dash);
-		data.emplace("range", item);
-
-		item["tooltip"] = defender_attack ? defender_tooltip.str() : "";
-		item["label"] = defender_stats.str();
-		data.emplace("defender_weapon", item);
-
-		item["tooltip"] = "";
-		item["label"] = defender_weapon.icon();
-		data.emplace("defender_weapon_icon", item);
-
+	for(widget_data& data : bc_widget_data_vector_) {
 		weapon_list.add_row(data);
 	}
 
@@ -234,5 +92,6 @@ void unit_attack::post_show()
 		selected_weapon_ = find_widget<listbox>("weapon_list").get_selected_row();
 	}
 }
+
 
 } // namespace dialogs

--- a/src/gui/dialogs/unit_attack.hpp
+++ b/src/gui/dialogs/unit_attack.hpp
@@ -28,7 +28,9 @@ public:
 	unit_attack(const unit_map::iterator& attacker_itor,
 				 const unit_map::iterator& defender_itor,
 				 std::vector<battle_context>&& weapons,
-				 const int best_weapon);
+				 const int best_weapon,
+				 std::vector<gui2::widget_data>& bc_widget_data_vector,
+				 const int leadership_bonus);
 
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
@@ -60,6 +62,10 @@ private:
 
 	/** The best weapon, aka the one high-lighted. */
 	int best_weapon_;
+
+	std::vector<gui2::widget_data> bc_widget_data_vector_;
+
+	const int leadership_bonus_;
 };
 
 } // namespace dialogs

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -42,6 +42,8 @@
 #include "whiteboard/manager.hpp"  // for manager, etc
 #include "whiteboard/typedefs.hpp" // for whiteboard_lock
 #include "sdl/input.hpp" // for get_mouse_state
+#include "language.hpp"
+#include "serialization/markup.hpp"
 
 #include <cassert>     // for assert
 #include <new>         // for bad_alloc
@@ -943,7 +945,7 @@ void mouse_handler::move_action(bool browse)
 				int choice = -1;
 				{
 					wb::future_map_if_active planned_unit_map; // start planned unit map scope
-					choice = show_attack_dialog(attack_from, clicked_u->get_location());
+					choice = show_attack_dialog(attack_from, clicked_u->get_location(), src);
 				} // end planned unit map scope
 
 				if(choice >= 0) {
@@ -974,8 +976,7 @@ void mouse_handler::move_action(bool browse)
 
 					// block where we temporary move the unit
 					{
-						temporary_unit_mover temp_mover(pc_.get_units(), src, attack_from, itor->move_left, true);
-						choice = show_attack_dialog(attack_from, clicked_u->get_location());
+						choice = show_attack_dialog(attack_from, clicked_u->get_location(), src);
 					}
 
 					if(choice < 0) {
@@ -1336,28 +1337,193 @@ int mouse_handler::fill_weapon_choices(
 	return best;
 }
 
-int mouse_handler::show_attack_dialog(const map_location& attacker_loc, const map_location& defender_loc)
+int mouse_handler::show_attack_dialog(const map_location& attacker_loc, const map_location& defender_loc, const map_location& attacker_src)
 {
 	game_board& board = pc_.gamestate().board_;
-
-	unit_map::iterator attacker = board.units().find(attacker_loc);
-	unit_map::iterator defender = board.units().find(defender_loc);
-
-	if(!attacker || !defender) {
-		ERR_NG << "One fighter is missing, can't attack";
-		return -1; // abort, click will do nothing
-	}
-
+	unit_map::iterator attacker;
+	unit_map::iterator defender;
 	std::vector<battle_context> bc_vector;
-	const int best = fill_weapon_choices(bc_vector, attacker, defender);
+	std::vector<gui2::widget_data> bc_widget_data_vector;
+	int best;
+	int leadership_bonus = 0;
+	{
+		pathfind::paths::dest_vect::const_iterator itor = current_paths_.destinations.find(attacker_loc);
+		temporary_unit_mover temp_mover(pc_.get_units(), attacker_src, attacker_loc, itor->move_left, true);
 
-	if(bc_vector.empty()) {
-		gui2::show_transient_message(_("No Attacks"), _("This unit has no usable weapons."));
+		attacker = board.units().find(attacker_loc);
+		defender = board.units().find(defender_loc);
 
-		return -1;
+		if(!attacker || !defender) {
+			ERR_NG << "One fighter is missing, can't attack";
+			return -1; // abort, click will do nothing
+		}
+
+		best = fill_weapon_choices(bc_vector, attacker, defender);
+
+		if (bc_vector.empty()) {
+			gui2::show_transient_message(_("No Attacks"), _("This unit has no usable weapons."));
+
+			return -1;
+		}
+
+		static const config empty;
+		static const_attack_ptr no_weapon(new attack_type(empty));
+
+		// Possible TODO: If a "blank weapon" is generally useful, add it as a static member in attack_type.
+		for(const auto& weapon : bc_vector) {
+			const battle_context_unit_stats& attacker_stats = weapon.get_attacker_stats();
+			const battle_context_unit_stats& defender_stats = weapon.get_defender_stats();
+
+			const attack_type& attacker_weapon = *attacker_stats.weapon;
+			const attack_type& defender_weapon = defender_stats.weapon ? *defender_stats.weapon : *no_weapon;
+
+			if(leadership_bonus == 0) {
+				leadership_bonus
+					= under_leadership(*attacker, attacker_loc, attacker_stats.weapon, defender_stats.weapon);
+			}
+
+			const color_t a_cth_color = game_config::red_to_green(attacker_stats.chance_to_hit);
+			const color_t d_cth_color = game_config::red_to_green(defender_stats.chance_to_hit);
+
+			const std::string attw_name = !attacker_weapon.name().empty() ? attacker_weapon.name() : " ";
+			const std::string defw_name = !defender_weapon.name().empty() ? defender_weapon.name() : " ";
+
+			std::string range = attacker_weapon.range().empty() ? defender_weapon.range() : attacker_weapon.range();
+			if(!range.empty()) {
+				range = string_table["range_" + range];
+			}
+
+			auto a_ctx = attacker_weapon.specials_context(attacker.get_shared_ptr(), defender.get_shared_ptr(),
+				attacker->get_location(), defender->get_location(), true, defender_stats.weapon);
+
+			auto d_ctx = defender_weapon.specials_context(defender.get_shared_ptr(), attacker.get_shared_ptr(),
+				defender->get_location(), attacker->get_location(), false, attacker_stats.weapon);
+
+			std::string types = attacker_weapon.effective_damage_type().first;
+			std::string attw_type = !(types).empty() ? types : attacker_weapon.type();
+			if(!attw_type.empty()) {
+				attw_type = string_table["type_" + attw_type];
+			}
+			std::string def_types = defender_weapon.effective_damage_type().first;
+			std::string defw_type = !(def_types).empty() ? def_types : defender_weapon.type();
+			if(!defw_type.empty()) {
+				defw_type = string_table["type_" + defw_type];
+			}
+
+			const std::set<std::string> checking_tags_other = {"damage_type", "disable", "berserk", "drains",
+				"heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison"};
+			std::string attw_specials = attacker_weapon.weapon_specials();
+			std::string attw_specials_dmg = attacker_weapon.weapon_specials_value({"leadership", "damage"});
+			std::string attw_specials_atk = attacker_weapon.weapon_specials_value({"attacks", "swarm"});
+			std::string attw_specials_cth = attacker_weapon.weapon_specials_value({"chance_to_hit"});
+			std::string attw_specials_others = attacker_weapon.weapon_specials_value(checking_tags_other);
+			bool defender_attack = !(defender_weapon.name().empty() && defender_weapon.damage() == 0
+				&& defender_weapon.num_attacks() == 0 && defender_stats.chance_to_hit == 0);
+			std::string defw_specials = defender_attack ? defender_weapon.weapon_specials() : "";
+			std::string defw_specials_dmg
+				= defender_attack ? defender_weapon.weapon_specials_value({"leadership", "damage"}) : "";
+			std::string defw_specials_atk
+				= defender_attack ? defender_weapon.weapon_specials_value({"attacks", "swarm"}) : "";
+			std::string defw_specials_cth
+				= defender_attack ? defender_weapon.weapon_specials_value({"chance_to_hit"}) : "";
+			std::string defw_specials_others
+				= defender_attack ? defender_weapon.weapon_specials_value(checking_tags_other) : "";
+
+			if(!attw_specials.empty()) {
+				attw_specials = " " + attw_specials;
+			}
+			if(!attw_specials_dmg.empty()) {
+				attw_specials_dmg = " " + attw_specials_dmg;
+			}
+			if(!attw_specials_atk.empty()) {
+				attw_specials_atk = " " + attw_specials_atk;
+			}
+			if(!attw_specials_cth.empty()) {
+				attw_specials_cth = " " + attw_specials_cth;
+			}
+			if(!attw_specials_others.empty()) {
+				attw_specials_others
+					= "\n" + markup::bold(_("Other aspects: ")) + "\n" + markup::italic(attw_specials_others);
+			}
+			if(!defw_specials.empty()) {
+				defw_specials = " " + defw_specials;
+			}
+			if(!defw_specials_dmg.empty()) {
+				defw_specials_dmg = " " + defw_specials_dmg;
+			}
+			if(!defw_specials_atk.empty()) {
+				defw_specials_atk = " " + defw_specials_atk;
+			}
+			if(!defw_specials_cth.empty()) {
+				defw_specials_cth = " " + defw_specials_cth;
+			}
+			if(!defw_specials_others.empty()) {
+				defw_specials_others
+					= "\n" + markup::bold(_("Other aspects: ")) + "\n" + markup::italic(defw_specials_others);
+			}
+
+			std::stringstream attacker_stats_str, defender_stats_str, attacker_tooltip, defender_tooltip;
+
+			// Use attacker/defender.num_blows instead of attacker/defender_weapon.num_attacks() because the latter does
+			// not consider the swarm weapon special
+			attacker_stats_str << markup::bold(attw_name) << "\n"
+							   << attw_type << "\n"
+							   << attacker_stats.damage << font::weapon_numbers_sep << attacker_stats.num_blows
+							   << attw_specials << "\n"
+							   << markup::span_color(a_cth_color,  attacker_stats.chance_to_hit, "%");
+
+			attacker_tooltip << _("Weapon: ") << markup::bold(attw_name) << "\n"
+							 << _("Type: ") << attw_type << "\n"
+							 << _("Damage: ") << attacker_stats.damage << markup::italic(attw_specials_dmg) << "\n"
+							 << _("Attacks: ") << attacker_stats.num_blows << markup::italic(attw_specials_atk) << "\n"
+							 << _("Chance to hit: ")
+							 << markup::span_color(a_cth_color, attacker_stats.chance_to_hit, "%")
+							 << markup::italic(attw_specials_cth) << attw_specials_others;
+
+			defender_stats_str << markup::bold(defw_name) << "\n"
+							   << defw_type << "\n"
+							   << defender_stats.damage << font::weapon_numbers_sep << defender_stats.num_blows
+							   << defw_specials << "\n"
+							   << markup::span_color(d_cth_color, defender_stats.chance_to_hit, "%");
+
+			defender_tooltip << _("Weapon: ") << markup::bold(defw_name) << "\n"
+							 << _("Type: ") << defw_type << "\n"
+							 << _("Damage: ") << defender_stats.damage << markup::italic(defw_specials_dmg) << "\n"
+							 << _("Attacks: ") << defender_stats.num_blows << markup::italic(defw_specials_atk) << "\n"
+							 << _("Chance to hit: ")
+							 << markup::span_color(d_cth_color, defender_stats.chance_to_hit, "%")
+							 << markup::italic(defw_specials_cth) << defw_specials_others;
+
+			gui2::widget_data data;
+			gui2::widget_item item;
+
+			item["use_markup"] = "true";
+
+			item["label"] = attacker_weapon.icon();
+			data.emplace("attacker_weapon_icon", item);
+
+			item["tooltip"] = attacker_tooltip.str();
+			item["label"] = attacker_stats_str.str();
+			data.emplace("attacker_weapon", item);
+			item["tooltip"] = "";
+
+			item["label"]
+				= markup::span_color("#a69275", font::unicode_em_dash, " ", range, " ", font::unicode_em_dash);
+			data.emplace("range", item);
+
+			item["tooltip"] = defender_attack ? defender_tooltip.str() : "";
+			item["label"] = defender_stats_str.str();
+			data.emplace("defender_weapon", item);
+
+			item["tooltip"] = "";
+			item["label"] = defender_weapon.icon();
+			data.emplace("defender_weapon_icon", item);
+
+			bc_widget_data_vector.emplace_back(data);
+		}
 	}
-
-	gui2::dialogs::unit_attack dlg(attacker, defender, std::move(bc_vector), best);
+	// bc_widget_data_vector won't be empty when it reaches here.
+	gui2::dialogs::unit_attack dlg(attacker, defender, std::move(bc_vector), best, bc_widget_data_vector, leadership_bonus);
 
 	if(dlg.show()) {
 		return dlg.get_selected_weapon();

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -71,7 +71,7 @@ public:
 
 	// show the attack dialog and return the choice made
 	// which can be invalid if 'cancel' was used
-	int show_attack_dialog(const map_location& attacker_loc, const map_location& defender_loc);
+	int show_attack_dialog(const map_location& attacker_loc, const map_location& defender_loc, const map_location& attacker_src);
 	// wrapper to catch bad_alloc so this should be called
 	void attack_enemy(const map_location& attacker_loc, const map_location& defender_loc, int choice);
 


### PR DESCRIPTION
### Goal of the PR
- Resolves #8728.
### How does the PR work?
- By keeping the unit place not changed, and deal with the logic that a unit must stand beside the other in order to launch an attack.
### Does it resolve any reported issue?
- #8728
### If not a bug fix, why is this PR needed? What use cases does it solve?
- This is a bug fix.

## To do

Adjust possibly missed related method. If the ranged attack units(which can attack from 2 or more hexes away) come into being, more changes need to take place for backward compat.

This PR is Ready for Review.

## How to test
Compile and run, see the test video I uploaded, or see changes in the src.