### PR TITLE
[1.18] item tool: add right-click to remove functionality

### DIFF
--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -58,6 +58,19 @@ std::unique_ptr<editor_action> mouse_action_item::click_left(editor_display& dis
 	return nullptr;
 }
 
+std::unique_ptr<editor_action> mouse_action_item::click_right(editor_display& disp, int x, int y)
+{
+	start_hex_ = disp.hex_clicked_on(x, y);
+	if (!disp.get_map().on_board(start_hex_)) {
+		return nullptr;
+	}
+
+	disp.remove_overlay(start_hex_);
+
+	click_ = true;
+	return nullptr;
+}
+
 std::unique_ptr<editor_action> mouse_action_item::drag_left(editor_display& disp, int x, int y, bool& /*partial*/, editor_action* /*last_undo*/)
 {
 	map_location hex = disp.hex_clicked_on(x, y);

--- a/src/editor/action/mouse/mouse_action_item.hpp
+++ b/src/editor/action/mouse/mouse_action_item.hpp
@@ -37,15 +37,20 @@ public:
 	}
 
 	bool has_context_menu() const override {
-		return true;
+		return false;
 	}
 
 	void move(editor_display& disp, const map_location& hex) override;
 
 	/**
-	 * TODO
+	 * Left clicking places the currently selected item on the x,y map hex
 	 */
 	std::unique_ptr<editor_action> click_left(editor_display& disp, int x, int y) override;
+
+	/**
+	 * Right clicking removes the item on the x,y map hex
+	 */
+	std::unique_ptr<editor_action> click_right(editor_display& disp, int x, int y) override;
 
 	/**
 	 * TODO
@@ -59,10 +64,6 @@ public:
 	 * the facing when clicked right.
 	 */
 	std::unique_ptr<editor_action> drag_end_left(editor_display& disp, int x, int y) override;
-
-	std::unique_ptr<editor_action> click_right(editor_display& /*disp*/, int /*x*/, int /*y*/) override {
-		return nullptr;
-	}
 
 	virtual void set_mouse_overlay(editor_display& disp) override;
 	void set_item_mouse_overlay(editor_display& disp, const overlay& u);

--- a/src/editor/palette/editor_palettes.cpp
+++ b/src/editor/palette/editor_palettes.cpp
@@ -124,7 +124,6 @@ void editor_palette<Item>::set_group(const std::string& id)
 			found = true;
 			std::shared_ptr<gui::button> palette_menu_button = gui_.find_menu_button("menu-editor-terrain");
 			if (palette_menu_button) {
-				//palette_menu_button->set_label(group.name);
 				palette_menu_button->set_tooltip_string(group.name);
 				palette_menu_button->set_overlay(group.icon);
 			}
@@ -300,13 +299,11 @@ void editor_palette<Item>::layout()
 		}
 
 		const std::string item_id = active_group()[item_index];
-		//typedef std::map<std::string, Item> item_map_wurscht;
 		typename item_map::iterator item = item_map_.find(item_id);
 
 		texture item_base, item_overlay;
 		std::stringstream tooltip_text;
 		setup_item((*item).second, item_base, item_overlay, tooltip_text);
-
 		bool is_core = non_core_items_.find(get_id((*item).second)) == non_core_items_.end();
 		if (!is_core) {
 			tooltip_text << " "
@@ -319,17 +316,6 @@ void editor_palette<Item>::layout()
 		tile.set_tooltip_string(tooltip_text.str());
 		tile.set_item_image(item_base, item_overlay);
 		tile.set_item_id(item_id);
-
-//		if (get_id((*item).second) == selected_bg_item_
-//				&& get_id((*item).second) == selected_fg_item_) {
-//			tile.set_pressed(gui::tristate_button::BOTH);
-//		} else if (get_id((*item).second) == selected_bg_item_) {
-//			tile.set_pressed(gui::tristate_button::RIGHT);
-//		} else if (get_id((*item).second) == selected_fg_item_) {
-//			tile.set_pressed(gui::tristate_button::LEFT);
-//		} else {
-//			tile.set_pressed(gui::tristate_button::NONE);
-//		}
 
 		if (is_selected_bg_item(get_id(item->second))
 				&& is_selected_fg_item(get_id(item->second))) {

--- a/src/editor/palette/item_palette.cpp
+++ b/src/editor/palette/item_palette.cpp
@@ -29,7 +29,7 @@ namespace editor {
 
 std::string item_palette::get_help_string()
 {
-	return selected_fg_item().name;
+	return _("Left-click: Place item ") + selected_fg_item().name + _(" | Right-click to remove");
 }
 
 void item_palette::setup(const game_config_view& cfg)

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -202,7 +202,7 @@ constexpr std::array<hotkey_command_temp, HOTKEY_NULL - 1> master_hotkey_list {{
 	{ HOTKEY_EDITOR_TOOL_STARTING_POSITION, "editor-tool-starting-position", N_("Starting Positions Tool"), false, scope_editor, HKCAT_TOOLS,  N_("Left mouse button displays player selection, right clears. Number keys scroll to the starting position, alt+number sets respective starting position under cursor, delete clears.") },
 	{ HOTKEY_EDITOR_TOOL_LABEL, "editor-tool-label", N_("Label Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets or drags a label, right clears.") },
 	{ HOTKEY_EDITOR_TOOL_UNIT, "editor-tool-unit", N_("Unit Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets a new unit or moves a unit via drag and drop, right brings up a context menu. Needs a defined side.") },
-	{ HOTKEY_EDITOR_TOOL_ITEM, "editor-tool-item", N_("Item Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets a new item.") },
+	{ HOTKEY_EDITOR_TOOL_ITEM, "editor-tool-item", N_("Item Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets a new item. Right click removes item.") },
 	{ HOTKEY_EDITOR_TOOL_VILLAGE, "editor-tool-village", N_("Village Tool"), false, scope_editor, HKCAT_TOOLS, N_("Left mouse button sets the village ownership to the current side, right clears. Needs a defined side.") },
 
 	{ HOTKEY_EDITOR_UNIT_TOGGLE_CANRECRUIT, "editor-toggle-canrecruit", N_("Can Recruit"), false, scope_editor, HKCAT_TOOLS, N_("Toggle the recruit attribute of a unit.") },


### PR DESCRIPTION
Backport of the item tool improvement from #9273 (https://github.com/wesnoth/wesnoth/commit/7065ed9fde535e14b45a3e8bad1dfc74ea663b9f). This allows to remove items by right clicking with the unit tool.

![363065203-8b8fd4bd-e1ad-4bc1-ae60-6da5b1735b26](https://github.com/user-attachments/assets/d23c3cca-44c8-42ef-9d02-fcb5d7ad7416)
