### PR TITLE
Update the help page entry for the Item tool

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -242,7 +242,10 @@ This tool is only available in Scenario Mode; the decorations are implemented in
     title= _ "Item Tool (Scenery Tool)"
     text= "<img>src=icons/action/editor-tool-item_60.png align=left box=yes</img>" + _ "The Item Tool allows placing decorations such as windmills, bookcases and monoliths. Multiple items can be placed on the same hex.
 
-<bold>text='Note:'</bold> the tool doesn’t support deleting items once placed, nor does it support undo. Mistakes can currently only be fixed by editing the generated WML file.
+• Left-click will place a decoration on the clicked hex.
+• Right-click will remove the decoration.
+
+<bold>text='Note:'</bold> the tool doesn’t support undo.
 
 This tool is only available in Scenario Mode; the decorations are not part of the terrain and are implemented in the scenario using WML’s <italic>text='[item]'</italic> tag."
 [/topic]


### PR DESCRIPTION
Updates the help page entry for the item tool to reflect the changes in 7065ed9fde535e14b45a3e8bad1dfc74ea663b9f, in particular, that removal of items is now possible. Should be backported.