### PR TITLE
Test calculations of abilities with add and sub

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_calculations.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_calculations.cfg
@@ -95,7 +95,7 @@
 # API(s) being tested: [attacks]sub=
 ##
 # Expected end state:
-# Bob's attack has 7 strikes. The difference to add2_add3_cumulative is that sub chooses the lower value.
+# Bob's attack has 7 strikes. The difference to add2_add3_cumulative is that sub chooses the lower value, and the order of the abilities determines the order of the calculations.
 #####
 {TWO_CALCULATION_UNIT_TEST add2_sub_minus3_cumulative 5 (cumulative,add=yes,2) (cumulative,sub=yes,-3) 7}
 #####
@@ -137,16 +137,18 @@
 # API(s) being tested: [attacks]add=,[attacks]sub=
 ##
 # Expected end state:
-# Bob's attack has 2 strikes. Even in separate [attacks] tags, without separate ids the sub overwrites the add.
+# Bob's attack has 2 strikes. In separate [attacks] without separate ids, the order of the abilities determines which one is used.
 #####
-{TWO_CALCULATION_UNIT_TEST add_sub_separated 5 (cumulative,add=yes,2) (cumulative,sub=yes,3) 2}
+{TWO_CALCULATION_UNIT_TEST add_sub_separated 5 (add=2) (sub=3) 2}
+{TWO_CALCULATION_UNIT_TEST sub_add_separated 5 (sub=2) (add=3) 8}
 #####
 # API(s) being tested: [attacks]cumulative=
 ##
 # Expected end state:
-# Bob's attack has 2 strikes. These tags don't specify ids, and cumulative doesn't affect add or sub.
+# Bob's attack has 2 strikes. These tags don't specify ids, and cumulative doesn't affect add or sub, so the order of the abilities determines which one is used.
 #####
 {TWO_CALCULATION_UNIT_TEST add_sub_cumulative 5 (cumulative,add=yes,2) (cumulative,sub=yes,3) 2}
+{TWO_CALCULATION_UNIT_TEST sub_add_cumulative 5 (cumulative,sub=yes,2) (cumulative,add=yes,3) 8}
 #####
 # API(s) being tested: [attacks]id=
 ##

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -420,6 +420,8 @@
 0 special_calculation_multiply_float_2dp
 0 special_calculation_multiply_float_3dp
 0 special_calculation_sub
+0 special_calculation_sub_add_cumulative
+0 special_calculation_sub_add_separated
 0 special_calculation_sub2_sub3_cumulative
 0 special_calculation_sub3_sub2_cumulative
 0 test_add_in_leadership_abilities


### PR DESCRIPTION
Fix a typo in the add_sub_separated test, because it was testing exactly the same code as add_sub_cumulative.

Add two new tests and clarify documentation, because in these tests the order of the abilities determines whether the add or sub value is used, it isn't that sub always overrides add.

Will merge-conflict with #7271, but I'd prefer to have this merge first, documenting what the behavior was, and then have #7271 change the tests as documentation of what it changes.