### PR TITLE
[For CI] Bump min Boost to 1.82

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,10 +51,10 @@ jobs:
       if: matrix.language == 'cpp'
       run: |
         sudo apt update
-        sudo apt install scons libboost-system1.82-dev libboost-filesystem1.82-dev libboost-iostreams1.82-dev \
-          libboost-serialization1.82-dev libboost-locale1.82-dev libboost-regex1.82-dev libboost-random1.82-dev \
-          libboost-program-options1.82-dev libboost-thread1.82-dev libboost-context1.82-dev libboost-test-dev \
-          libboost-coroutine1.82-dev libboost-graph1.82-dev libasio-dev libsdl2-dev libsdl2-image-dev \
+        sudo apt install scons libboost-system1.83-dev libboost-filesystem1.83-dev libboost-iostreams1.83-dev \
+          libboost-serialization1.83-dev libboost-locale1.83-dev libboost-regex1.83-dev libboost-random1.83-dev \
+          libboost-program-options1.83-dev libboost-thread1.83-dev libboost-context1.83-dev libboost-test-dev \
+          libboost-coroutine1.83-dev libboost-graph1.83-dev libasio-dev libsdl2-dev libsdl2-image-dev \
           libsdl2-mixer-dev libvorbis-dev libpango1.0-dev libssl-dev libcurl4-openssl-dev liblua5.4-dev
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     - name: Autobuild

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,10 +51,10 @@ jobs:
       if: matrix.language == 'cpp'
       run: |
         sudo apt update
-        sudo apt install scons libboost-system1.74-dev libboost-filesystem1.74-dev libboost-iostreams1.74-dev \
-          libboost-serialization1.74-dev libboost-locale1.74-dev libboost-regex1.74-dev libboost-random1.74-dev \
-          libboost-program-options1.74-dev libboost-thread1.74-dev libboost-context1.74-dev libboost-test-dev \
-          libboost-coroutine1.74-dev libboost-graph1.74-dev libasio-dev libsdl2-dev libsdl2-image-dev \
+        sudo apt install scons libboost-system1.82-dev libboost-filesystem1.82-dev libboost-iostreams1.82-dev \
+          libboost-serialization1.82-dev libboost-locale1.82-dev libboost-regex1.82-dev libboost-random1.82-dev \
+          libboost-program-options1.82-dev libboost-thread1.82-dev libboost-context1.82-dev libboost-test-dev \
+          libboost-coroutine1.82-dev libboost-graph1.82-dev libasio-dev libsdl2-dev libsdl2-image-dev \
           libsdl2-mixer-dev libvorbis-dev libpango1.0-dev libssl-dev libcurl4-openssl-dev liblua5.4-dev
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     - name: Autobuild

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     permissions:
       actions: read

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ option(ENABLE_MYSQL "Enable building MP/add-ons servers with mysql support" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 
-set(BOOST_VERSION "1.67")
+set(BOOST_VERSION "1.82")
 
 if(NOT WIN32)
 	set(Lua_FIND_VERSION_MAJOR 5)
@@ -76,7 +76,7 @@ endif()
 
 # set what std version to use
 if(NOT CXX_STD)
-	set(CXX_STD "17")
+	set(CXX_STD "23")
 endif()
 set(CMAKE_CXX_STANDARD ${CXX_STD})
 # make sure to force using it

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 # set what std version to use
 if(NOT CXX_STD)
-	set(CXX_STD "23")
+	set(CXX_STD "17")
 endif()
 set(CMAKE_CXX_STANDARD ${CXX_STD})
 # make sure to force using it

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ later, or a version of Clang with equivalent support.
 You'll need to have these libraries and their development headers installed in
 order to build Wesnoth:
 
- * Boost libraries             >= 1.66.0
+ * Boost libraries             >= 1.82.0
      Most headers plus the following binary libs:
    * Filesystem
    * Locale

--- a/SConstruct
+++ b/SConstruct
@@ -189,7 +189,7 @@ if env['distcc']:
 
 if env['ccache']: env.Tool('ccache')
 
-boost_version = "1.67"
+boost_version = "1.82"
 
 def SortHelpText(a, b):
     return (a > b) - (a < b)

--- a/changelog_entries/boost-to-82.md
+++ b/changelog_entries/boost-to-82.md
@@ -1,0 +1,2 @@
+### Packaging
+  * The minimum required Boost version is now 1.82.

--- a/packaging/flatpak/org.wesnoth.Wesnoth.json
+++ b/packaging/flatpak/org.wesnoth.Wesnoth.json
@@ -34,12 +34,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2",
-                    "sha256": "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba"
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2",
+                    "sha256": "a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6"
                 }
             ],
             "build-commands": [
-                "./bootstrap.sh --prefix=/app --with-libraries=filesystem,locale,iostreams,program_options,regex,random,thread,coroutine,context,graph",
+                "./bootstrap.sh --prefix=/app --with-libraries=system,filesystem,locale,iostreams,program_options,regex,random,thread,coroutine,context,graph",
                 "./b2 -j$FLATPAK_BUILDER_N_JOBS install cxxflags='-fPIE -fstack-protector-strong' define=_FORTIFY_SOURCE=2 link=static variant=release address-model=64 --layout=system"
             ]
         },


### PR DESCRIPTION
1.82 adds boost::mysql, which Pent means to make use of, and 1.78 adds boost::span, which I want to make use of.