### PR TITLE
Remove unit recursion of special_unit_matches() 

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1480,12 +1480,6 @@ namespace { // Helpers for attack_type::special_active()
 		if (!u) {
 			return false;
 		}
-		//update and check variable_recursion for prevent check ability_id/type_active in case of infinite recursion.
-		unit::recursion_guard special_lock = (*u).update_variables_recursion();
-		if(!special_lock) {
-			show_recursion_warning(*u, filter);
-			return false;
-		}
 
 		unit_filter ufilt{vconfig(*filter_child)};
 


### PR DESCRIPTION
Like unit recursion depth is to 3 and attack recursion 4, what count begin if and only if ability_(id/type) active called is more appropriate.