### PR TITLE
Preferences: move the Apply button and disable it unless needed

### DIFF
--- a/data/gui/themes/default/window/preferences.cfg
+++ b/data/gui/themes/default/window/preferences.cfg
@@ -429,16 +429,6 @@
 								border = "all"
 								border_size = 5
 								[button]
-									id = "apply"
-									definition = "default"
-									label = _ "Apply"
-								[/button]
-							[/column]
-
-							[column]
-								border = "all"
-								border_size = 5
-								[button]
 									id = "ok"
 									definition = "default"
 									label = _ "Close"

--- a/data/gui/themes/default/window/preferences/03_display.cfg
+++ b/data/gui/themes/default/window/preferences/03_display.cfg
@@ -196,14 +196,29 @@
 				[/row]
 				[row]
 					[column]
-						border = "all"
-						border_size = 5
-						horizontal_alignment = "left"
+						[grid]
+							[row]
+								[column]
+									border = "all"
+									border_size = 5
+									horizontal_alignment = "left"
 
-						[menu_button]
-							id = "choose_gui2_theme"
-							tooltip = _ "Change the UI (GUI2) theme. Additional themes may be provided by community-made add-ons"
-						[/menu_button]
+									[menu_button]
+										id = "choose_gui2_theme"
+										tooltip = _ "Change the UI (GUI2) theme. Additional themes may be provided by community-made add-ons"
+									[/menu_button]
+								[/column]
+								[column]
+									border = "all"
+									border_size = 5
+									[button]
+										id = "apply"
+										definition = "default"
+										label = _ "Apply"
+									[/button]
+								[/column]
+							[/row]
+						[/grid]
 					[/column]
 				[/row]
 			[/grid]

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -591,6 +591,10 @@ void preferences_dialog::initialize_callbacks()
 	/* SELECT GUI2 THEME */
 	menu_button& gui2_theme_list = find_widget<menu_button>(this, "choose_gui2_theme", false);
 	set_gui2_theme_list(gui2_theme_list);
+	connect_signal_notify_modified(find_widget<menu_button>(this, "choose_gui2_theme", false), std::bind([&]() {
+		find_widget<button>(this, "apply", false).set_active(true);
+	}));
+	find_widget<button>(this, "apply", false).set_active(false);
 	connect_signal_mouse_left_click(find_widget<button>(this, "apply", false),
 		std::bind(&preferences_dialog::handle_gui2_theme_select, this));
 


### PR DESCRIPTION
Moves the Apply button beside the UI Theme list and disables it unless the theme is changed.
This also makes it obvious that the Apply button is used only for UI theme selection, and is not a global Apply button.

![Screenshot from 2024-09-10 06-56-03](https://github.com/user-attachments/assets/12ff5615-d5e6-44c0-8f7d-154d68eee952)
