### PR TITLE
Extend case-insensitive filtering beyond ASCII characters

### DIFF
--- a/changelog_entries/non-ascii-case-insensitve-filtering.md
+++ b/changelog_entries/non-ascii-case-insensitve-filtering.md
@@ -1,0 +1,2 @@
+ ### User interface
+   * Search filter should now be case-insensitive for more than just ASCII characters (#9328)

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -500,10 +500,7 @@ bool game_info::match_string_filter(const std::string& filter) const
 {
 	const std::string& s1 = name;
 	const std::string& s2 = map_info;
-	return std::search(s1.begin(), s1.end(), filter.begin(), filter.end(),
-			utils::chars_equal_insensitive) != s1.end()
-	    || std::search(s2.begin(), s2.end(), filter.begin(), filter.end(),
-			utils::chars_equal_insensitive) != s2.end();
+	return translation::ci_search(s1, filter) || translation::ci_search(s2, filter);
 }
 
 }

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -65,12 +65,7 @@ namespace {
 				for(const auto& attribute : cfg.attribute_range())
 				{
 					std::string val = attribute.second.str();
-					if(std::search(val.begin(),
-						val.end(),
-						filter.begin(),
-						filter.end(),
-						utils::chars_equal_insensitive)
-						!= val.end())
+					if(translation::ci_search(val, filter))
 					{
 						found = true;
 						break;

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -336,13 +336,7 @@ void game_load::apply_filter_text(const std::string& text, bool force)
 			bool found = false;
 			for(const auto & word : words)
 			{
-				found = std::search(games_[i].name().begin(),
-									games_[i].name().end(),
-									word.begin(),
-									word.end(),
-									utils::chars_equal_insensitive)
-						!= games_[i].name().end();
-
+				found = translation::ci_search(games_[i].name(), word);
 				if(!found) {
 					// one word doesn't match, we don't reach words.end()
 					break;

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1389,22 +1389,17 @@ void menu_handler::do_search(const std::string& new_search)
 		if(!gui_->shrouded(loc)) {
 			const terrain_label* label = gui_->labels().get_label(loc);
 			if(label) {
-				std::string label_text = label->text().str();
-				if(std::search(label_text.begin(), label_text.end(), last_search_.begin(), last_search_.end(),
-						   utils::chars_equal_insensitive)
-						!= label_text.end()) {
-					found = true;
-				}
+				const std::string& label_text = label->text().str();
+				found = translation::ci_search(label_text, last_search_);
 			}
 		}
+
 		// Search unit name
 		if(!gui_->fogged(loc)) {
 			unit_map::const_iterator ui = pc_.get_units().find(loc);
 			if(ui != pc_.get_units().end()) {
-				const std::string name = ui->name();
-				if(std::search(
-						   name.begin(), name.end(), last_search_.begin(), last_search_.end(), utils::chars_equal_insensitive)
-						!= name.end()) {
+				const std::string& unit_name = ui->name();
+				if(translation::ci_search(unit_name, last_search_)) {
 					if(!gui_->viewing_team().is_enemy(ui->side())
 							|| !ui->invisible(ui->get_location())) {
 						found = true;


### PR DESCRIPTION
Attempt to resolve #9328.

Caveats:
1. This is based purely on the discussion from the linked issue. I don't know if I've covered all the details discussed therein.
2. This seems to work for me, but at present I don't have non-ASCII characters in my saved game names, so I can't properly test this.
3. The game load dialogue isn't the only place where case-insensitive searching is limited to ASCII characters. If this change is accepted, then potentially it could be applied to other searches:

https://github.com/wesnoth/wesnoth/blob/47642719bf4e5519945f99d579c926d43725a04d/src/gui/dialogs/addon/manager.cpp#L68-L77

https://github.com/wesnoth/wesnoth/blob/47642719bf4e5519945f99d579c926d43725a04d/src/menu_events.cpp#L1393-L1397

https://github.com/wesnoth/wesnoth/blob/47642719bf4e5519945f99d579c926d43725a04d/src/game_initialization/lobby_data.cpp#L503-L506

https://github.com/wesnoth/wesnoth/blob/47642719bf4e5519945f99d579c926d43725a04d/src/serialization/string_utils.cpp#L664-L669

Also, given this is an improvement at least for players using non-ASCII translations, it could possibly be back-ported.