### PR TITLE
GUI2/LuaAPI: add len operator to container widgets

### DIFF
--- a/src/scripting/lua_widget.cpp
+++ b/src/scripting/lua_widget.cpp
@@ -189,14 +189,14 @@ static int impl_widget_collect(lua_State* L)
 // merge in number_of_items stuff from wiget_methods here?
 static int impl_widget_length(lua_State* L)
 {
-	gui2::widget* w = &luaW_checkwidget(L, 1);
-	if(gui2::listbox* list = dynamic_cast<gui2::listbox*>(w)) {
+	gui2::widget& w = luaW_checkwidget(L, 1);
+	if(gui2::listbox* list = dynamic_cast<gui2::listbox*>(&w)) {
 		lua_pushinteger(L, list->get_item_count());
-	} else if(gui2::multi_page* multi_page = dynamic_cast<gui2::multi_page*>(w)) {
+	} else if(gui2::multi_page* multi_page = dynamic_cast<gui2::multi_page*>(&w)) {
 		lua_pushinteger(L, multi_page->get_page_count());
-	} else if(gui2::tree_view* tree_view = dynamic_cast<gui2::tree_view*>(w)) {
+	} else if(gui2::tree_view* tree_view = dynamic_cast<gui2::tree_view*>(&w)) {
 		lua_pushinteger(L, tree_view->get_root_node().count_children());
-	} else if(gui2::tree_view_node* tree_view_node = dynamic_cast<gui2::tree_view_node*>(w)) {
+	} else if(gui2::tree_view_node* tree_view_node = dynamic_cast<gui2::tree_view_node*>(&w)) {
 		lua_pushinteger(L, tree_view_node->count_children());
 	} else {
 		luaW_tableget(L, 1, "type");

--- a/src/scripting/lua_widget.cpp
+++ b/src/scripting/lua_widget.cpp
@@ -199,7 +199,8 @@ static int impl_widget_length(lua_State* L)
 	} else if(gui2::tree_view_node* tree_view_node = dynamic_cast<gui2::tree_view_node*>(w)) {
 		lua_pushinteger(L, tree_view_node->count_children());
 	} else {
-		return luaL_error(L, "unsupported widget for # operator");
+		luaW_tableget(L, 1, "type");
+		return luaL_error(L, "unsupported widget for # operator: %s", luaL_checkstring(L, -1));
 	}
 	return 1;
 }

--- a/src/scripting/lua_widget.cpp
+++ b/src/scripting/lua_widget.cpp
@@ -16,6 +16,10 @@
 #include "scripting/lua_widget.hpp"
 #include "scripting/lua_widget_attributes.hpp"
 
+#include "gui/widgets/listbox.hpp"
+#include "gui/widgets/multi_page.hpp"
+#include "gui/widgets/tree_view.hpp"
+#include "gui/widgets/tree_view_node.hpp"
 #include "gui/widgets/widget.hpp"
 #include "scripting/lua_common.hpp"
 #include "scripting/lua_ptr.hpp"
@@ -182,6 +186,23 @@ static int impl_widget_collect(lua_State* L)
 	return 0;
 }
 
+// merge in number_of_items stuff from wiget_methods here?
+static int impl_widget_length(lua_State* L)
+{
+	gui2::widget* w = &luaW_checkwidget(L, 1);
+	if(gui2::listbox* list = dynamic_cast<gui2::listbox*>(w)) {
+		lua_pushinteger(L, list->get_item_count());
+	} else if(gui2::multi_page* multi_page = dynamic_cast<gui2::multi_page*>(w)) {
+		lua_pushinteger(L, multi_page->get_page_count());
+	} else if(gui2::tree_view* tree_view = dynamic_cast<gui2::tree_view*>(w)) {
+		lua_pushinteger(L, tree_view->get_root_node().count_children());
+	} else if(gui2::tree_view_node* tree_view_node = dynamic_cast<gui2::tree_view_node*>(w)) {
+		lua_pushinteger(L, tree_view_node->count_children());
+	} else {
+		return luaL_error(L, "unsupported widget for # operator");
+	}
+	return 1;
+}
 
 namespace lua_widget {
 	void register_metatable(lua_State* L)
@@ -196,6 +217,8 @@ namespace lua_widget {
 		lua_setfield(L, -2, "__dir");
 		lua_pushcfunction(L, impl_widget_collect);
 		lua_setfield(L, -2, "__gc");
+		lua_pushcfunction(L, impl_widget_length);
+		lua_setfield(L, -2, "__len");
 		lua_pushstring(L, widgetKey);
 		lua_setfield(L, -2, "__metatable");
 	}


### PR DESCRIPTION
Enables length operator for listbox, multi_page, tree_view and tree_view_node, e.g. 
`dialog.lb_slider.max_value = #dialog.lb`

number_of_items() was recently added to lua_widget_methods.cpp.  I kind of feel like that should be moved somewhere where it can be shared, for example I could use it here instead of replicating the work.  Wouldn't save anything here, but it'd be consistent.  I'm just not sure if it's worth doing, or where it would go.  Or perhaps all containers should have the same get_item_count()?