### PR TITLE
fix feeding test.

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/feeding.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/feeding.cfg
@@ -10,10 +10,9 @@
 # The Ghast gains +1 max hp.
 #####
 {GENERIC_UNIT_TEST "feeding_on_living" (
+    {FORCE_CHANCE_TO_HIT (id=alice) (id=ghoul_food) 100 ()}
     [event]
         name=start
-
-        {VARIABLE attack_count 0}
 
         [unit]
             type=Dark Adept
@@ -22,8 +21,6 @@
             id=ghoul_food
             max_hitpoints=1
         [/unit]
-
-        {FORCE_CHANCE_TO_HIT (id=alice) (id=ghoul_food) 100 ()}
 
         [store_unit]
             [filter]
@@ -73,6 +70,7 @@
 # The first Ghast does not gain +1 max hp.
 #####
 {GENERIC_UNIT_TEST "feeding_on_dead" (
+    {FORCE_CHANCE_TO_HIT (id=alice) (id=ghoul_traitor) 100 ()}
     [event]
         name=start
 
@@ -83,8 +81,6 @@
             id=ghoul_traitor
             max_hitpoints=1
         [/unit]
-
-        {FORCE_CHANCE_TO_HIT (id=alice) (id=ghoul_traitor) 100 ()}
 
         [store_unit]
             [filter]


### PR DESCRIPTION
On ubuntu c++17, FORCE_CHANCE_TO_HIT macro don't work and test fail randomly.

If i see correct, then tis commit should fix that.