### PR TITLE
Add a second unit test for TEST_FORCE_CHANCE_TO_HIT

### DIFF
--- a/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_nested.cfg
+++ b/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_nested.cfg
@@ -1,8 +1,8 @@
 #####
-# API(s) being tested: FORCE_CHANCE_TO_HIT
+# API(s) being tested: FORCE_CHANCE_TO_HIT,[event]
 ##
 # Actions:
-# Give alice and bob a 0% chance to hit each other with FORCE_CHANCE_TO_HIT.
+# Inside the start event, give alice and bob a 0% chance to hit each other with FORCE_CHANCE_TO_HIT.
 # Give alice and bob a [chance_to_hit] weapon special that grants 100% hit chance.
 # Give alice and bob 10 strikes each.
 # Have alice attack bob.
@@ -10,12 +10,12 @@
 # Expected end state:
 # All strikes for both units miss.
 #####
-{GENERIC_UNIT_TEST "test_force_chance_to_hit_macro" (
-    {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 0 ()}
-    {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 0 ()}
-
+{COMMON_KEEP_A_B_UNIT_TEST "test_force_chance_to_hit_macro_nested" (
     [event]
         name=start
+
+        {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 0 ()}
+        {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 0 ()}
 
         [modify_unit]
             [filter]
@@ -87,46 +87,11 @@
             [/filter]
         [/object]
 
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-            kill=yes
-        [/store_unit]
-
-        [store_unit]
-            [filter]
-                id=bob
-            [/filter]
-            variable=b
-        [/store_unit]
-
-        [unstore_unit]
-            variable=a
-            find_vacant=yes
-            x,y=$b.x,$b.y
-        [/unstore_unit]
-
-        [store_unit]
-            [filter]
-                id=alice
-            [/filter]
-            variable=a
-        [/store_unit]
-
-        [do_command]
-            [attack]
-                weapon=0
-                defender_weapon=0
-                [source]
-                    x,y=$a.x,$a.y
-                [/source]
-                [destination]
-                    x,y=$b.x,$b.y
-                [/destination]
-            [/attack]
-        [/do_command]
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
 
         {SUCCEED}
     [/event]

--- a/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_toplevel.cfg
+++ b/data/test/scenarios/macro_tests/test_force_chance_to_hit_macro_toplevel.cfg
@@ -1,0 +1,139 @@
+#####
+# API(s) being tested: FORCE_CHANCE_TO_HIT
+##
+# Actions:
+# Using the macro outside an event, give alice and bob a 0% chance to hit each other with FORCE_CHANCE_TO_HIT.
+# Give alice and bob a [chance_to_hit] weapon special that grants 100% hit chance.
+# Give alice and bob 10 strikes each.
+# Have alice attack bob.
+##
+# Expected end state:
+# All strikes for both units miss.
+#####
+{GENERIC_UNIT_TEST "test_force_chance_to_hit_macro_toplevel" (
+    {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 0 ()}
+    {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 0 ()}
+
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=10
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bob
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=10
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+            [effect]#test if macro work when ability with overwrite_special is used
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        overwrite_specials=one_side
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+            kill=yes
+        [/store_unit]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=b
+        [/store_unit]
+
+        [unstore_unit]
+            variable=a
+            find_vacant=yes
+            x,y=$b.x,$b.y
+        [/unstore_unit]
+
+        [store_unit]
+            [filter]
+                id=alice
+            [/filter]
+            variable=a
+        [/store_unit]
+
+        [do_command]
+            [attack]
+                weapon=0
+                defender_weapon=0
+                [source]
+                    x,y=$a.x,$a.y
+                [/source]
+                [destination]
+                    x,y=$b.x,$b.y
+                [/destination]
+            [/attack]
+        [/do_command]
+
+        {SUCCEED}
+    [/event]
+
+    [event]
+        name=attacker hits,defender hits
+        first_time_only=no
+        {FAIL}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -368,7 +368,8 @@
 0 poison_opponent
 0 unslowable_status_test
 0 unpetrifiable_status_test
-0 test_force_chance_to_hit_macro
+0 test_force_chance_to_hit_macro_nested
+0 test_force_chance_to_hit_macro_toplevel
 0 trait_exclusion_test
 0 trait_requirement_test
 0 test_remove_ability_by_filter


### PR DESCRIPTION
It should work even when the macro appears in the same event as the attack; this tests that.

The new one uses the COMMON_KEEP macro, but I've left the existing one unchanged, except for the renaming.