### PR TITLE
Use proper apostrophe to spell Shek’kahan

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -66,7 +66,7 @@
         [/entry]
         [entry]
             name = "pixelmind"
-            comment = "Shek'kahan portrait"
+            comment = "Shek’kahan portrait"
         [/entry]
     [/about]
     [about]

--- a/data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/09_Ancestor.cfg
@@ -360,7 +360,7 @@ Fly, my pets! Sweep this place of every scaleless beast so I will have no distra
         [/message]
         [message]
             speaker=Zedrix
-            message= _ "Shek'kahan, do you not recognize Khrakrahs...?"
+            message= _ "Shek’kahan, do you not recognize Khrakrahs...?"
         [/message]
         [objectives]
             [objective]
@@ -483,7 +483,7 @@ Fly, my pets! Sweep this place of every scaleless beast so I will have no distra
         {CLEAR_VARIABLE gorlack_location}
         [message]
             speaker=Zedrix
-            message= _ "Behold, mighty Shek'kahan!"
+            message= _ "Behold, mighty Shek’kahan!"
         [/message]
         [message]
             speaker=Khrakrahs
@@ -495,7 +495,7 @@ Fly, my pets! Sweep this place of every scaleless beast so I will have no distra
             speaker=Zedrix
             message= _ "Impossster?!
 
-I am elder of Green Swamp Clan and all my years Shek'kahan protected usss. I could never missstake sssome impossster for him!"
+I am elder of Green Swamp Clan and all my years Shek’kahan protected usss. I could never missstake sssome impossster for him!"
         [/message]
         [message]
             speaker=Zedrix
@@ -567,7 +567,7 @@ I am elder of Green Swamp Clan and all my years Shek'kahan protected usss. I cou
         [/move_unit]
         [message]
             speaker=Gorlack
-            message= _ "Ancestor, you spoke that Shek'kahan grew weak...
+            message= _ "Ancestor, you spoke that Shek’kahan grew weak...
 
 Yet to his last breath, he was fearless."
         [/message]
@@ -575,7 +575,7 @@ Yet to his last breath, he was fearless."
             speaker=Khrakrahs
             image_pos=right
             mirror=yes
-            message= _ "Yes, Shek'kahan was fearless."
+            message= _ "Yes, Shek’kahan was fearless."
         [/message]
         [message]
             speaker=Khrakrahs


### PR DESCRIPTION
This follows the typography style guide.