### PR TITLE
add amla advancement to [modify_unit_type] and fix male/female/variation subtags not supported

### DIFF
--- a/changelog_entries/fix_modify_unit_type_male_female_variation.md
+++ b/changelog_entries/fix_modify_unit_type_male_female_variation.md
@@ -1,0 +1,3 @@
+### WML Engine
+* [modify_unit_type] can add a list of AMLAs in the unit_type, if a list is already written, it will be replaced.
+* [modify_unit_type] can modify [male/female] or [variation] subtags if already written in unit_type.

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -162,6 +162,9 @@
 		{SIMPLE_KEY set_advances_to string_list}
 		{SIMPLE_KEY set_cost int}
 		{SIMPLE_KEY set_experience int}
+		# link the advancement tag
+		# to enable AMLA support
+		{LINK_TAG "units/$modifications/advancement"}
 	[/tag]
 	{DATA_TAG "world_conquest_data" 0 1 any}
 [/tag]

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -165,6 +165,39 @@
 		# link the advancement tag
 		# to enable AMLA support
 		{LINK_TAG "units/$modifications/advancement"}
+		[tag]
+			name="male"
+			{SIMPLE_KEY add_advancement string_list}
+			{SIMPLE_KEY remove_advancement string_list}
+			{SIMPLE_KEY set_advances_to string_list}
+			{SIMPLE_KEY set_cost int}
+			{SIMPLE_KEY set_experience int}
+			# link the advancement tag
+			# to enable AMLA support
+			{LINK_TAG "units/$modifications/advancement"}
+		[/tag]
+		[tag]
+			name="female"
+			{SIMPLE_KEY add_advancement string_list}
+			{SIMPLE_KEY remove_advancement string_list}
+			{SIMPLE_KEY set_advances_to string_list}
+			{SIMPLE_KEY set_cost int}
+			{SIMPLE_KEY set_experience int}
+			# link the advancement tag
+			# to enable AMLA support
+			{LINK_TAG "units/$modifications/advancement"}
+		[/tag]
+		[tag]
+			name="variation"
+			{SIMPLE_KEY add_advancement string_list}
+			{SIMPLE_KEY remove_advancement string_list}
+			{SIMPLE_KEY set_advances_to string_list}
+			{SIMPLE_KEY set_cost int}
+			{SIMPLE_KEY set_experience int}
+			# link the advancement tag
+			# to enable AMLA support
+			{LINK_TAG "units/$modifications/advancement"}
+		[/tag]
 	[/tag]
 	{DATA_TAG "world_conquest_data" 0 1 any}
 [/tag]

--- a/data/test/scenarios/wml_tests/ScenarioWML/add_advancements.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/add_advancements.cfg
@@ -71,3 +71,47 @@
         {SUCCEED}
     [/event]
 )}
+
+#####
+# API(s) being tested: [modify_unit_type][advancement]
+##
+# Actions:
+# Modify the cavalier unit type to add add_level amla.
+# Spawn a cavalier unit.
+# Make advances cavalier
+##
+# Expected end state:
+# The spawned cavalier should have level=4.
+#####
+{GENERIC_UNIT_TEST "add_or_replace_amla" (
+    [modify_unit_type]
+        type="Cavalier"
+        [advancement]
+            id = add_level
+            [effect]
+                apply_to = level
+                increase=1
+            [/effect]
+        [/advancement]
+    [/modify_unit_type]
+    [event]
+        name=start
+        [unit]
+            x = 1
+            y = 1
+            type = Cavalier
+            side = 1
+            id = charlie
+            canrecruit = no
+        [/unit]
+        {ADVANCE_UNIT id=charlie ""}
+        [store_unit]
+            variable=cavalier
+            [filter]
+                id = charlie
+            [/filter]
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL cavalier.level equals 4})}
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/ScenarioWML/add_advancements.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/add_advancements.cfg
@@ -115,3 +115,97 @@
         {SUCCEED}
     [/event]
 )}
+
+#####
+# API(s) being tested: [modify_unit_type][female][advancement]
+##
+# Actions:
+# Modify the Elvish Sharpshooter unit type to add add_level amla to female only.
+# Spawn a Elvish Sharpshooter female unit.
+# Make advances Elvish Sharpshooter
+##
+# Expected end state:
+# The spawned Elvish Sharpshooter should have level=4.
+#####
+{GENERIC_UNIT_TEST "add_specific_female_amla_on_female" (
+    [modify_unit_type]
+        type="Elvish Sharpshooter"
+        [female]
+            [advancement]
+                id = add_level
+                [effect]
+                    apply_to = level
+                    increase=1
+                [/effect]
+            [/advancement]
+        [/female]
+    [/modify_unit_type]
+    [event]
+        name=start
+        [unit]
+            x = 1
+            y = 1
+            type = Elvish Sharpshooter
+            gender=female
+            side = 1
+            id = charlie
+            canrecruit = no
+        [/unit]
+        {ADVANCE_UNIT id=charlie ""}
+        [store_unit]
+            variable=sharpshooter
+            [filter]
+                id = charlie
+            [/filter]
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL sharpshooter.level equals 4})}
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [modify_unit_type][female][advancement]
+##
+# Actions:
+# Modify the Elvish Sharpshooter unit type to add add_level amla to female only.
+# Spawn a Elvish Sharpshooter male unit.
+# Make advances Elvish Sharpshooter
+##
+# Expected end state:
+# The spawned Elvish Sharpshooter level=3 because don't have female advancement.
+#####
+{GENERIC_UNIT_TEST "add_specific_female_amla_on_male" (
+    [modify_unit_type]
+        type="Elvish Sharpshooter"
+        [female]
+            [advancement]
+                id = add_level
+                [effect]
+                    apply_to = level
+                    increase=1
+                [/effect]
+            [/advancement]
+        [/female]
+    [/modify_unit_type]
+    [event]
+        name=start
+        [unit]
+            x = 1
+            y = 1
+            type = Elvish Sharpshooter
+            gender= male
+            side = 1
+            id = charlie
+            canrecruit = no
+        [/unit]
+        {ADVANCE_UNIT id=charlie ""}
+        [store_unit]
+            variable=sharpshooter
+            [filter]
+                id = charlie
+            [/filter]
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL sharpshooter.level equals 3})}
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -86,6 +86,7 @@ unit_type::unit_type(const unit_type& o)
 	, hide_help_(o.hide_help_)
 	, do_not_list_(o.do_not_list_)
 	, advances_to_(o.advances_to_)
+	, advancements_(o.advancements_)
 	, experience_needed_(o.experience_needed_)
 	, alignment_(o.alignment_)
 	, movement_type_(o.movement_type_)
@@ -137,6 +138,7 @@ unit_type::unit_type(defaut_ctor_t, const config& cfg, const std::string & paren
 	, hide_help_(false)
 	, do_not_list_()
 	, advances_to_()
+	, advancements_(cfg.child_range("advancement"))
 	, experience_needed_(0)
 	, alignment_(unit_alignments::type::neutral)
 	, movement_type_()
@@ -1395,6 +1397,10 @@ void unit_type::apply_scenario_fix(const config& cfg)
 		}
 	}
 
+	if(cfg.has_child("advancement")) {
+		advancements_ = cfg.child_range("advancement");
+	}
+
 	// apply recursively to subtypes.
 	for(int gender = 0; gender <= 1; ++gender) {
 		if(!gender_types_[gender]) {
@@ -1444,6 +1450,7 @@ void unit_type::remove_scenario_fixes()
 	for(auto& v : variations_) {
 		v.second.remove_scenario_fixes();
 	}
+	advancements_ = get_cfg().child_range("advancement");
 }
 
 void unit_type_data::remove_scenario_fixes()

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -1407,13 +1407,24 @@ void unit_type::apply_scenario_fix(const config& cfg)
 			continue;
 		}
 		gender_types_[gender]->apply_scenario_fix(cfg);
+		std::string gender_str = gender == 0 ? "male" : "female";
+		if(cfg.has_child(gender_str)) {
+			auto gender_cfg = cfg.optional_child(gender_str);
+			if(gender_cfg){
+				gender_types_[gender]->apply_scenario_fix(*gender_cfg);
+			}
+		}
 	}
 
 	if(get_cfg().has_child("variation")) {
 		// Make sure the variations are created.
 		unit_types.build_unit_type(*this, VARIATIONS);
-		for(auto& v : variations_) {
-			v.second.apply_scenario_fix(cfg);
+		for (auto& cv : cfg.child_range("variation")){
+			for(auto& v : variations_) {
+				if(v.first == cv["variation_id"]){
+					v.second.apply_scenario_fix(cv);
+				}
+			}
 		}
 	}
 }

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -118,7 +118,7 @@ public:
 
 	/** Returns two iterators pointing to a range of AMLA configs. */
 	config::const_child_itors modification_advancements() const
-	{ return get_cfg().child_range("advancement"); }
+	{ return advancements_; }
 
 	/**
 	 * Returns a gendered variant of this unit_type.
@@ -235,7 +235,7 @@ public:
 	{ return get_cfg().child_or_empty("abilities"); }
 
 	config::const_child_itors advancements() const
-	{ return get_cfg().child_range("advancement"); }
+	{ return advancements_; }
 
 	config::const_child_itors events() const
 	{ return get_cfg().child_range("event"); }
@@ -364,6 +364,7 @@ private:
 	bool zoc_, hide_help_, do_not_list_;
 
 	std::vector<std::string> advances_to_;
+	config::const_child_itors advancements_;
 	int experience_needed_;
 
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -231,6 +231,7 @@
 0 test_attacks_used
 0 no_duplicate_advancements
 0 add_advancement
+0 add_or_replace_amla
 0 harm_unit_survivable_experience_no
 0 harm_unit_survivable_experience_unset
 0 harm_unit_survivable_experience_yes

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -232,6 +232,8 @@
 0 no_duplicate_advancements
 0 add_advancement
 0 add_or_replace_amla
+0 add_specific_female_amla_on_female
+0 add_specific_female_amla_on_male
 0 harm_unit_survivable_experience_no
 0 harm_unit_survivable_experience_unset
 0 harm_unit_survivable_experience_yes


### PR DESCRIPTION
Addresses https://github.com/wesnoth/wesnoth/issues/9309 

when used, the amlas in [unit_type] are replaced by list of amlas in [modify_unit_type],i cannot done add [advancement] without erase amla already present.