### PR TITLE
Enable clang-tidy for Wesnoth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ option(GLIBCXX_ASSERTIONS "Whether to define _GLIBCXX_ASSERTIONS" OFF)
 option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC. Requires a version of Boost's program_options that's compiled with __GLIBCXX_DEBUG too." OFF)
 option(ENABLE_POT_UPDATE_TARGET "Enables the tools to update the pot files and manuals. This target has extra dependencies." OFF)
 option(FORCE_COLOR_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
+option(CLANG_TIDY "Enable clang-tidy linter checks." OFF)
 
 if(UNIX AND NOT APPLE AND NOT CYGWIN)
 	option(ENABLE_NOTIFICATIONS "Enable Window manager notification messages" ON)
@@ -253,6 +254,11 @@ if(NOT MSVC)
 		elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 			set(COMPILER_FLAGS "${COMPILER_FLAGS} -fcolor-diagnostics")
 		endif()
+	endif()
+
+### Enable clang-tidy linting
+	if (CLANG_TIDY)
+		set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 	endif()
 
 ### Set the final compiler flags.

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          '-*,clang-analyzer-core*'
+WarningsAsErrors: false
+...

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,8 @@ if(NOT ENABLE_SYSTEM_LUA)
 		# silence a Clang specific warning when compiling the lua code
 		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-string-plus-int")
 	endif()
+
+	set_source_files_properties(${lua_sources} PROPERTIES SKIP_LINTING ON)
 endif()
 
 if(WIN32)

--- a/src/ai/default/attack.cpp
+++ b/src/ai/default/attack.cpp
@@ -241,6 +241,9 @@ void attack_analysis::analyze(const gamemap& map, unit_map& units,
 		// Negative average damage (it will advance).
 		avg_damage_inflicted += defend_it->hitpoints() - defend_it->max_hitpoints();
 	} else {
+		// prev_def will only be a nullptr here if movements was empty, but we've asserted it wasn't above,
+		// so avoiding false positive
+		//NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
 		chance_to_kill = prev_def->hp_dist[0];
 		avg_damage_inflicted += defend_it->hitpoints() - prev_def->average_hp(map.gives_healing(defend_it->get_location()));
 	}

--- a/src/formula/callable.hpp
+++ b/src/formula/callable.hpp
@@ -145,6 +145,7 @@ protected:
 
 	virtual int do_compare(const formula_callable* callable) const
 	{
+		assert(callable != nullptr);
 		if(type_ < callable->type_) {
 			return -1;
 		}

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -296,6 +296,7 @@ void mouse_motion::mouse_leave()
 {
 	DBG_GUI_E << LOG_HEADER << "Firing: " << event::MOUSE_LEAVE << ".";
 
+    assert(mouse_focus_ != nullptr);
 	styled_widget* control = dynamic_cast<styled_widget*>(mouse_focus_);
 	if(!control || control->get_active()) {
 		owner_.fire(event::MOUSE_LEAVE, *mouse_focus_);

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -458,6 +458,7 @@ REPORT_GENERATOR(unit_abilities, rc)
 REPORT_GENERATOR(selected_unit_abilities, rc)
 {
 	const unit *u = get_selected_unit(rc);
+	assert(u != nullptr && "Tried to gather ability information on invalid or invisible unit.");
 
 	const map_location& mouseover_hex = rc.screen().mouseover_hex();
 	const unit *visible_unit = get_visible_unit(rc);
@@ -624,6 +625,7 @@ REPORT_GENERATOR(unit_defense,rc)
 REPORT_GENERATOR(selected_unit_defense, rc)
 {
 	const unit *u = get_selected_unit(rc);
+	assert (u != nullptr && "Tried to gather defense information on invalid or invisible unit.");
 	const map_location& attack_indicator_src = game_display::get_singleton()->get_attack_indicator_src();
 	if(attack_indicator_src.valid())
 		return unit_defense(rc, u, attack_indicator_src);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1923,6 +1923,7 @@ int game_lua_kernel::intf_find_path(lua_State *L)
 			lua_warning(L, "wesnoth.paths.find_path: ignore_teleport=false requires a valid viewing_side; continuing with ignore_teleport=true", false);
 			ignore_teleport = true;
 		} else {
+			assert(u != nullptr);
 			teleport_locations = pathfind::get_teleport_locations(*u, board().get_team(viewing_side), see_all, ignore_units);
 		}
 	}

--- a/src/scripting/mapgen_lua_kernel.cpp
+++ b/src/scripting/mapgen_lua_kernel.cpp
@@ -92,6 +92,8 @@ static int intf_default_generate(lua_State *L)
 	generator_data arg;
 	arg.width = width;
 	arg.height = height;
+	arg.default_width = 0;
+	arg.default_height = 0;
 	arg.nplayers = cfg["nplayers"].to_int(2);
 	arg.nvillages = cfg["nvillages"].to_int(0);
 	arg.iterations = cfg["iterations"].to_int(0);

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -960,6 +960,7 @@ void light_surface(surface& nsurf, const surface &lightmap)
 
 void blur_surface(surface& surf, SDL_Rect rect, int depth)
 {
+	assert(depth >= 0 && "Cannot call blur_surface with a negative depth");
 	if(surf == nullptr) {
 		return;
 	}

--- a/src/whiteboard/move.cpp
+++ b/src/whiteboard/move.cpp
@@ -272,6 +272,7 @@ void move::execute(bool& success, bool& complete)
 
 				//Update route_->move_cost
 				route_.reset(new pathfind::marked_route(mark_route(route_->route, true)));
+				// NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
 				arrow_->set_path(route_->steps);
 			}
 		}


### PR DESCRIPTION
To run clang-tidy on the Wesnoth source code, add:
`-DCLANG_TIDY=ON` to your cmake command line. Then, when running `make`, clang-tidy will lint the compiled code for errors.
Right now, only the absolutely required clang-tidy checks are enabled. These mainly catch `nullptr` dereferences and divisions by zero. The fixes I've added (just assert that something isn't a `nullptr`) aren't the best, I'll likely need advice on some of them.