### PR TITLE
Multiline markup and link support and MP lobby text copy support

### DIFF
--- a/data/gui/themes/default/widget/chatbox.cfg
+++ b/data/gui/themes/default/widget/chatbox.cfg
@@ -72,15 +72,17 @@
 					horizontal_grow = true
 					vertical_grow = true
 
-					[scroll_label]
+					[scroll_text]
 						id = "log_text"
 						definition = "description_small"
 
-						vertical_scrollbar_mode = "always"
+						vertical_scrollbar_mode = "auto"
 						horizontal_scrollbar_mode = "never"
 
+						editable = false
 						link_aware = true
-					[/scroll_label]
+						use_markup = true
+					[/scroll_text]
 				[/column]
 			[/row]
 		[/page_definition]

--- a/data/gui/themes/default/widget/multiline_text_default.cfg
+++ b/data/gui/themes/default/widget/multiline_text_default.cfg
@@ -150,7 +150,7 @@
 		text_font_size = {FONT_SIZE}
 		text_font_family = {FONT_FAMILY}
 		text_x_offset = {X_OFFSET}
-		text_y_offset = 2
+		text_y_offset = {X_OFFSET}
 		text_extra_width = {EXTRA_WIDTH}
 
 		[state_enabled]
@@ -216,6 +216,75 @@
 
 #enddef
 
+#define _GUI_RESOLUTION_TRANSPARENT RESOLUTION MIN_WIDTH DEFAULT_WIDTH HEIGHT X_OFFSET EXTRA_WIDTH FONT_SIZE BACKGROUND_ENABLED BACKGROUND_DISABLED
+#arg FONT_FAMILY
+#endarg
+	[resolution]
+
+		{RESOLUTION}
+
+		min_width = {MIN_WIDTH}
+		min_height = {HEIGHT}
+
+		default_width = {DEFAULT_WIDTH}
+		default_height = {HEIGHT}
+
+		max_width = 0
+		max_height = 0
+
+		text_font_size = {FONT_SIZE}
+		text_font_family = {FONT_FAMILY}
+		text_x_offset = {X_OFFSET}
+		text_y_offset = {X_OFFSET}
+		text_extra_width = {EXTRA_WIDTH}
+
+		[state_enabled]
+
+			[draw]
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+			[/draw]
+
+		[/state_enabled]
+
+		[state_disabled]
+
+			[draw]
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_DISABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+			[/draw]
+
+		[/state_disabled]
+
+		[state_focused]
+
+			[draw]
+
+				# We never draw the hint text or image if focused
+				{_GUI_DRAW_TEXT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+				{_GUI_DRAW_CURSOR ({X_OFFSET}) }
+
+			[/draw]
+
+		[/state_focused]
+
+		[state_hovered]
+
+			[draw]
+
+				{_GUI_DRAW_TEXT_OR_HINT ({FONT_SIZE}) ({GUI__FONT_COLOR_ENABLED__DEFAULT}) FONT_FAMILY={FONT_FAMILY} }
+
+			[/draw]
+
+		[/state_hovered]
+
+	[/resolution]
+
+#enddef
+
 [multiline_text_definition]
 	id = "default"
 	description = "Default multiline text box"
@@ -227,7 +296,7 @@
 	id = "transparent"
 	description = "Background-less multiline text box, used for WML messages"
 
-	{_GUI_RESOLUTION () 40 250 90 5 10 ({GUI_FONT_SIZE_DEFAULT}) () ()}
+	{_GUI_RESOLUTION_TRANSPARENT () 40 250 90 8 10 ({GUI_FONT_SIZE_DEFAULT}) () ()}
 
 [/multiline_text_definition]
 

--- a/data/gui/themes/default/widget/multiline_text_default.cfg
+++ b/data/gui/themes/default/widget/multiline_text_default.cfg
@@ -57,6 +57,8 @@
 			inactive_color = ["{GUI__FONT_COLOR_DISABLED__DEFAULT}"]
 		)"
 		text = "(text)"
+		text_link_aware = "(text_link_aware)"
+		text_markup = "(text_markup)"
 		highlight_color = "21, 53, 80"
 		highlight_start = "(highlight_start)"
 		highlight_end = "(highlight_end)"
@@ -96,6 +98,8 @@
 				reg_color = [{COLOR}]
 			)"
 
+		text_link_aware = "(text_link_aware)"
+		text_markup = "(text_markup)"
 		text = "(
 			if(text = '' and hint_text != '', hint_text, text))"
 	[/text]
@@ -148,8 +152,6 @@
 		text_x_offset = {X_OFFSET}
 		text_y_offset = 2
 		text_extra_width = {EXTRA_WIDTH}
-
-		#functions = "(def show_hint_text() (text = '' and hint_text != '');)"
 
 		[state_enabled]
 

--- a/data/gui/themes/default/widget/scroll_text_default.cfg
+++ b/data/gui/themes/default/widget/scroll_text_default.cfg
@@ -26,6 +26,25 @@
 		[state_enabled]
 
 			[draw]
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+
+					border_thickness = 1
+					border_color = {GUI__BORDER_COLOR_DARK}
+				[/rectangle]
+				
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+
+					#fill_color = {GUI__BACKGROUND_COLOR_ENABLED}
+					fill_color = "0,0,0,255"
+				[/rectangle]
 			[/draw]
 
 		[/state_enabled]
@@ -33,6 +52,24 @@
 		[state_disabled]
 
 			[draw]
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+
+					border_thickness = 1
+					border_color = {GUI__FONT_COLOR_DISABLED_DARK__DEFAULT}
+				[/rectangle]
+				
+				[rectangle]
+					x = 0
+					y = 0
+					w = "(width)"
+					h = "(height)"
+
+					fill_color = {GUI__BACKGROUND_COLOR_DISABLED}
+				[/rectangle]
 			[/draw]
 
 		[/state_disabled]
@@ -60,7 +97,7 @@
 
 								[multiline_text]
 									id="_text"
-									definition="default"
+									definition="transparent"
 								[/multiline_text]
 
 							[/column]

--- a/src/desktop/clipboard.cpp
+++ b/src/desktop/clipboard.cpp
@@ -20,21 +20,16 @@
 
 #define CLIPBOARD_FUNCS_DEFINED
 
-/*
- * Note SDL 2.0 has its own clipboard routines, but they don't support
- * different clipboards (yet).
- */
-
 namespace desktop {
 
 namespace clipboard {
 
-void copy_to_clipboard(const std::string& text, const bool)
+void copy_to_clipboard(const std::string& text)
 {
 	SDL_SetClipboardText(text.c_str());
 }
 
-std::string copy_from_clipboard(const bool)
+std::string copy_from_clipboard()
 {
 	char* clipboard = SDL_GetClipboardText();
 	if(!clipboard) {
@@ -44,15 +39,6 @@ std::string copy_from_clipboard(const bool)
 	const std::string result(clipboard);
 	SDL_free(clipboard);
 	return result;
-}
-
-void handle_system_event(const SDL_Event& /*event*/)
-{
-}
-
-bool available()
-{
-	return true;
 }
 
 } // end namespace clipboard

--- a/src/desktop/clipboard.hpp
+++ b/src/desktop/clipboard.hpp
@@ -27,27 +27,15 @@ namespace clipboard {
  * Copies text to the clipboard.
  *
  * @param text         The text to copy.
- * @param mouse        Is the selection done by the mouse? On UNIX systems there
- *                     are multiple clipboards and the mouse selection uses a
- *                     different clipboard. Ignored on other systems.
  */
-void copy_to_clipboard(const std::string& text, const bool mouse);
+void copy_to_clipboard(const std::string& text);
 
 /**
  * Copies text from the clipboard.
  *
- * @param mouse        Is the pasting done by the mouse?
- *
  * @returns            String on clipbaord.
  */
-std::string copy_from_clipboard(const bool mouse);
-
-void handle_system_event(const SDL_Event& ev);
-
-/**
- * Whether wesnoth was compiled with support for a clipboard.
- */
-bool available();
+std::string copy_from_clipboard();
 
 } // end namespace clipboard
 

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -1376,7 +1376,7 @@ void editor_controller::export_selection_coords()
 			++i;
 		}
 		ssx << "\n" << ssy.str() << "\n";
-		desktop::clipboard::copy_to_clipboard(ssx.str(), false);
+		desktop::clipboard::copy_to_clipboard(ssx.str());
 	}
 }
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -694,14 +694,6 @@ void pump()
 		}
 #endif
 
-#if defined(_X11) && !defined(__APPLE__)
-		case SDL_SYSWMEVENT: {
-			// clipboard support for X11
-			desktop::clipboard::handle_system_event(event);
-			break;
-		}
-#endif
-
 #if defined _WIN32
 		case SDL_SYSWMEVENT: {
 			windows_tray_notification::handle_system_event(event);

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -132,10 +132,11 @@ public:
 	 *
 	 * @param offset              The position to insert the text.
 	 * @param text                The UTF-8 text to insert.
+	 * @param use_markup          If the text is formatted or not.
 	 *
 	 * @returns                   The number of characters inserted.
 	 */
-	unsigned insert_text(const unsigned offset, const std::string& text);
+	unsigned insert_text(const unsigned offset, const std::string& text, const bool use_markup = false);
 
 	/***** ***** ***** ***** Font flags ***** ***** ***** *****/
 

--- a/src/gui/dialogs/chat_log.cpp
+++ b/src/gui/dialogs/chat_log.cpp
@@ -193,7 +193,7 @@ public:
 	{
 		std::ostringstream s;
 		stream_log(s, first, last, true);
-		desktop::clipboard::copy_to_clipboard(s.str(), false);
+		desktop::clipboard::copy_to_clipboard(s.str());
 	}
 };
 
@@ -391,10 +391,6 @@ public:
 				std::bind(&view::handle_copy_button_clicked,
 							this,
 							std::ref(window)));
-		if (!desktop::clipboard::available()) {
-			model_.copy_button->set_active(false);
-			model_.copy_button->set_tooltip(_("Clipboard support not found, contact your packager"));
-		}
 
 		model_.page_label = find_widget<styled_widget>(&window, "page_label", false, true);
 

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -90,11 +90,6 @@ void custom_tod::pre_show(window& window)
 
 		connect_signal_mouse_left_click(copy_w,
 			std::bind(&custom_tod::copy_to_clipboard_callback, this, data));
-
-		if(!desktop::clipboard::available()) {
-			copy_w.set_active(false);
-			copy_w.set_tooltip(_("Clipboard support not found, contact your packager"));
-		}
 	}
 
 	connect_signal_mouse_left_click(
@@ -333,7 +328,7 @@ void custom_tod::copy_to_clipboard_callback(std::pair<std::string, tod_attribute
 {
 	auto& [type, getter] = data;
 	button& copy_w = find_widget<button>(get_window(), "copy_" + type, false);
-	desktop::clipboard::copy_to_clipboard(getter(get_selected_tod()).second, false);
+	desktop::clipboard::copy_to_clipboard(getter(get_selected_tod()).second);
 	copy_w.set_success(true);
 }
 

--- a/src/gui/dialogs/game_cache_options.cpp
+++ b/src/gui/dialogs/game_cache_options.cpp
@@ -63,10 +63,6 @@ void game_cache_options::pre_show(window& window)
 	connect_signal_mouse_left_click(copy,
 									std::bind(&game_cache_options::copy_to_clipboard_callback,
 												this));
-	if (!desktop::clipboard::available()) {
-		copy.set_active(false);
-		copy.set_tooltip(_("Clipboard support not found, contact your packager"));
-	}
 
 	button& browse = find_widget<button>(&window, "browse", false);
 	connect_signal_mouse_left_click(browse,
@@ -110,7 +106,7 @@ void game_cache_options::update_cache_size_display()
 
 void game_cache_options::copy_to_clipboard_callback()
 {
-	desktop::clipboard::copy_to_clipboard(cache_path_, false);
+	desktop::clipboard::copy_to_clipboard(cache_path_);
 }
 
 void game_cache_options::browse_cache_callback()

--- a/src/gui/dialogs/game_version_dialog.cpp
+++ b/src/gui/dialogs/game_version_dialog.cpp
@@ -152,11 +152,6 @@ void game_version::pre_show(window& window)
 			// open_object().
 			browse_w.set_visible(widget::visibility::invisible);
 		}
-
-		if(!desktop::clipboard::available()) {
-			copy_w.set_active(false);
-			copy_w.set_tooltip(_("Clipboard support not found, contact your packager"));
-		}
 	}
 
 	button& stderr_button = find_widget<button>(&window, "open_stderr", false);
@@ -250,7 +245,7 @@ void game_version::run_migrator()
 
 void game_version::copy_to_clipboard_callback(const std::string& path, const std::string btn_id)
 {
-	desktop::clipboard::copy_to_clipboard(path, false);
+	desktop::clipboard::copy_to_clipboard(path);
 
 	button& copy_w = find_widget<button>(get_window(), btn_id, false);
 	copy_w.set_success(true);
@@ -258,7 +253,7 @@ void game_version::copy_to_clipboard_callback(const std::string& path, const std
 
 void game_version::report_copy_callback()
 {
-	desktop::clipboard::copy_to_clipboard(report_, false);
+	desktop::clipboard::copy_to_clipboard(report_);
 
 	button& copy_all = find_widget<button>(get_window(), "copy_all", false);
 	copy_all.set_success(true);

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -328,7 +328,7 @@ public:
 
 	void handle_copy_button_clicked()
 	{
-		desktop::clipboard::copy_to_clipboard(model_.get_data_full(), false);
+		desktop::clipboard::copy_to_clipboard(model_.get_data_full());
 	}
 
 	void handle_lua_button_clicked(window& window)
@@ -409,12 +409,6 @@ public:
 
 		left_button->set_visible(widget::visibility::invisible);
 		right_button->set_visible(widget::visibility::invisible);
-
-		if (!desktop::clipboard::available()) {
-			copy_button->set_active(false);
-			copy_button->set_tooltip(_("Clipboard support not found, contact your packager"));
-		}
-
 		build_stuff_list(window);
 	}
 

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -441,11 +441,6 @@ void lua_interpreter::controller::bind(window& window)
 						this,
 						std::ref(window)));
 
-	if (!desktop::clipboard::available()) {
-		copy_button->set_active(false);
-		copy_button->set_tooltip(_("Clipboard support not found, contact your packager"));
-	}
-
 	LOG_LUA << "Exiting lua_interpreter::controller::bind";
 }
 
@@ -453,7 +448,7 @@ void lua_interpreter::controller::bind(window& window)
 void lua_interpreter::controller::handle_copy_button_clicked(window & /*window*/)
 {
 	assert(lua_model_);
-	desktop::clipboard::copy_to_clipboard(lua_model_->get_raw_log(), false);
+	desktop::clipboard::copy_to_clipboard(lua_model_->get_raw_log());
 }
 
 /** Clear the text */

--- a/src/gui/dialogs/screenshot_notification.cpp
+++ b/src/gui/dialogs/screenshot_notification.cpp
@@ -63,12 +63,8 @@ void screenshot_notification::pre_show(window& window)
 
 	button& copy_b = find_widget<button>(&window, "copy", false);
 	connect_signal_mouse_left_click(
-		copy_b, std::bind(&desktop::clipboard::copy_to_clipboard, std::ref(path_), false));
+		copy_b, std::bind(&desktop::clipboard::copy_to_clipboard, std::ref(path_)));
 	copy_b.set_active(false);
-
-	if (!desktop::clipboard::available()) {
-		copy_b.set_tooltip(_("Clipboard support not found, contact your packager"));
-	}
 
 	button& open_b = find_widget<button>(&window, "open", false);
 	connect_signal_mouse_left_click(
@@ -108,10 +104,7 @@ void screenshot_notification::save_screenshot()
 		path_box.set_active(false);
 		find_widget<button>(get_window(), "open", false).set_active(true);
 		find_widget<button>(get_window(), "save", false).set_active(false);
-
-		if(desktop::clipboard::available()) {
-			find_widget<button>(get_window(), "copy", false).set_active(true);
-		}
+		find_widget<button>(get_window(), "copy", false).set_active(true);
 
 		const int filesize = filesystem::file_size(path_);
 		const std::string sizetext = utils::si_string(filesize, true, _("unit_byte^B"));

--- a/src/gui/dialogs/wml_error.cpp
+++ b/src/gui/dialogs/wml_error.cpp
@@ -183,16 +183,11 @@ void wml_error::pre_show(window& window)
 
 	connect_signal_mouse_left_click(
 			copy_button, std::bind(&wml_error::copy_report_callback, this));
-
-	if (!desktop::clipboard::available()) {
-		copy_button.set_active(false);
-		copy_button.set_tooltip(_("Clipboard support not found, contact your packager"));
-	}
 }
 
 void wml_error::copy_report_callback()
 {
-	desktop::clipboard::copy_to_clipboard(report_, false);
+	desktop::clipboard::copy_to_clipboard(report_);
 }
 
 } // end namespace dialogs

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -22,7 +22,7 @@
 #include "gui/widgets/image.hpp"
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/multi_page.hpp"
-#include "gui/widgets/scroll_label.hpp"
+#include "gui/widgets/scroll_text.hpp"
 #include "gui/widgets/text_box.hpp"
 #include "gui/widgets/window.hpp"
 
@@ -214,16 +214,16 @@ void chatbox::append_to_chatbox(const std::string& text, std::size_t id, const b
 {
 	grid& grid = chat_log_container_->page_grid(id);
 
-	scroll_label& log = find_widget<scroll_label>(&grid, "log_text", false);
+	scroll_text& log = find_widget<scroll_text>(&grid, "log_text", false);
 	const bool chatbox_at_end = log.vertical_scrollbar_at_end();
 	const unsigned chatbox_position = log.get_vertical_scrollbar_item_position();
 
-	const std::string before_message = log.get_label().empty() ? "" : "\n";
+	const std::string before_message = log.get_value().empty() ? "" : "\n";
 	const std::string new_text = formatter()
-		<< log.get_label() << before_message << "<span color='#bcb088'>" << prefs::get().get_chat_timestamp(std::time(0)) << text << "</span>";
+		<< log.get_value() << before_message << "<span color='#bcb088'>" << prefs::get().get_chat_timestamp(std::time(0)) << text << "</span>";
 
 	log.set_use_markup(true);
-	log.set_label(new_text);
+	log.set_value(new_text);
 
 	if(log_ != nullptr) {
 		try {
@@ -252,8 +252,8 @@ void chatbox::clear_messages()
 {
 	const auto id = active_window_;
 	grid& grid = chat_log_container_->page_grid(id);
-	scroll_label& log = find_widget<scroll_label>(&grid, "log_text", false);
-	log.set_label("");
+	scroll_text& log = find_widget<scroll_text>(&grid, "log_text", false);
+	log.set_value("");
 }
 
 void chatbox::user_relation_changed(const std::string& /*name*/)

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -167,7 +167,7 @@ void label::signal_handler_right_button_click(bool& handled)
 
 	DBG_GUI_E << "Right Clicked Link:\"" << link << "\"";
 
-	desktop::clipboard::copy_to_clipboard(link, false);
+	desktop::clipboard::copy_to_clipboard(link);
 
 	(void) show_message("", _("Copied link!"), dialogs::message::auto_close);
 

--- a/src/gui/widgets/multiline_text.cpp
+++ b/src/gui/widgets/multiline_text.cpp
@@ -428,7 +428,7 @@ void multiline_text::signal_handler_left_button_down(const event::ui_event event
 					desktop::open_object(link);
 				}
 			} else {
-				desktop::clipboard::copy_to_clipboard(link, true);
+				desktop::clipboard::copy_to_clipboard(link);
 				show_message("", _("Opening links is not supported, contact your packager. Link URL has been copied to the clipboard."), dialogs::message::auto_close);
 			}
 		} else {

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -153,9 +153,9 @@ public:
 
 private:
 	/** Inherited from text_box_base. */
-	void paste_selection(const bool mouse) override
+	void paste_selection() override
 	{
-		text_box_base::paste_selection(mouse);
+		text_box_base::paste_selection();
 		update_layout();
 	}
 

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -33,7 +33,7 @@ class multiline_text : public text_box_base
 	friend struct implementation::builder_multiline_text;
 
 public:
-	explicit multiline_text(const implementation::builder_styled_widget& builder);
+	explicit multiline_text(const implementation::builder_multiline_text& builder);
 
 	/** See @ref widget::can_wrap. */
 	bool can_wrap() const override
@@ -143,6 +143,14 @@ public:
 		update_layout();
 	}
 
+	/** See @ref styled_widget::get_link_aware. */
+	virtual bool get_link_aware() const override
+	{
+		return link_aware_;
+	}
+
+	void set_link_aware(bool l);
+
 private:
 	/** Inherited from text_box_base. */
 	void paste_selection(const bool mouse) override
@@ -193,6 +201,12 @@ private:
 
 	/** Is the mouse in dragging mode, this affects selection in mouse move */
 	bool dragging_;
+
+	/**
+	 * Whether the text area is link aware, rendering links with special formatting
+	 * and handling click events.
+	 */
+	bool link_aware_;
 
 	/** Helper text to display (such as "Search") if the text box is empty. */
 	std::string hint_text_;
@@ -351,6 +365,7 @@ public:
 
 	bool editable;
 	bool wrap;
+	bool link_aware;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/password_box.cpp
+++ b/src/gui/widgets/password_box.cpp
@@ -89,9 +89,9 @@ void password_box::insert_char(const std::string& unicode)
 	utf8::insert(real_value_, sel, unicode);
 }
 
-void password_box::paste_selection(const bool mouse)
+void password_box::paste_selection()
 {
-	const std::string& text = desktop::clipboard::copy_from_clipboard(mouse);
+	const std::string& text = desktop::clipboard::copy_from_clipboard();
 	if(text.empty()) {
 		return;
 	}

--- a/src/gui/widgets/password_box.hpp
+++ b/src/gui/widgets/password_box.hpp
@@ -49,7 +49,7 @@ public:
 
 protected:
 	void insert_char(const std::string& unicode) override;
-	void paste_selection(const bool mouse) override;
+	void paste_selection() override;
 	void delete_selection() override;
 
 	// We do not override copy_selection because we

--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -1,6 +1,6 @@
 /*
 	Copyright (C) 2023 - 2024
-	by babaissarkar(Subhraman Sarkar) <suvrax@gmail.com>
+	by Subhraman Sarkar (babaissarkar) <suvrax@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify
@@ -41,8 +41,9 @@ scroll_text::scroll_text(const implementation::builder_scroll_text& builder)
 	, state_(ENABLED)
 	, wrap_on_(false)
 	, text_alignment_(builder.text_alignment)
-	, editable_(true)
+	, editable_(builder.editable)
 	, max_size_(point(0,0))
+	, link_aware_(builder.link_aware)
 {
 	connect_signal<event::LEFT_BUTTON_DOWN>(
 		std::bind(&scroll_text::signal_handler_left_button_down, this, std::placeholders::_2),
@@ -81,6 +82,15 @@ std::string scroll_text::get_value()
 	}
 }
 
+void scroll_text::set_link_aware(bool l)
+{
+	link_aware_ = l;
+
+	if(multiline_text* widget = get_internal_text_box()) {
+		widget->set_link_aware(l);
+	}
+}
+
 void scroll_text::set_text_alignment(const PangoAlignment text_alignment)
 {
 	// Inherit.
@@ -90,16 +100,6 @@ void scroll_text::set_text_alignment(const PangoAlignment text_alignment)
 
 	if(multiline_text* widget = get_internal_text_box()) {
 		widget->set_text_alignment(text_alignment_);
-	}
-}
-
-void scroll_text::set_use_markup(bool use_markup)
-{
-	// Inherit.
-	styled_widget::set_use_markup(use_markup);
-
-	if(multiline_text* widget = get_internal_text_box()) {
-		widget->set_use_markup(use_markup);
 	}
 }
 
@@ -126,6 +126,7 @@ void scroll_text::finalize_subclass()
 	text->set_editable(is_editable());
 	text->set_label(get_label());
 	text->set_text_alignment(text_alignment_);
+	text->set_link_aware(link_aware_);
 	text->set_use_markup(get_use_markup());
 }
 
@@ -244,6 +245,7 @@ builder_scroll_text::builder_scroll_text(const config& cfg)
 	, horizontal_scrollbar_mode(get_scrollbar_mode(cfg["horizontal_scrollbar_mode"]))
 	, text_alignment(decode_text_alignment(cfg["text_alignment"]))
 	, editable(cfg["editable"].to_bool(true))
+	, link_aware(cfg["link_aware"].to_bool(false))
 {
 	// Scrollbar default to auto. AUTO_VISIBLE_FIRST_RUN doesn't work.
 	if (horizontal_scrollbar_mode == scrollbar_container::AUTO_VISIBLE_FIRST_RUN) {
@@ -261,8 +263,6 @@ std::unique_ptr<widget> builder_scroll_text::build() const
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);
-	widget->set_editable(editable);
-	widget->set_text_alignment(text_alignment);
 
 	const auto conf = widget->cast_config_to<scroll_text_definition>();
 	assert(conf);

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -1,6 +1,6 @@
 /*
 	Copyright (C) 2023 - 2024
-	by babaissarkar(Subhraman Sarkar) <suvrax@gmail.com>
+	by Subhraman Sarkar (babaissarkar) <suvrax@gmail.com>
 	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
 
 	This program is free software; you can redistribute it and/or modify
@@ -53,9 +53,6 @@ public:
 	/** See @ref styled_widget::set_text_alignment. */
 	virtual void set_text_alignment(const PangoAlignment text_alignment) override;
 
-	/** See @ref styled_widget::set_use_markup. */
-	virtual void set_use_markup(bool use_markup) override;
-
 	/** See @ref container_base::set_self_active. */
 	virtual void set_self_active(const bool active) override;
 
@@ -69,6 +66,14 @@ public:
 
 	bool can_wrap() const override;
 	void set_can_wrap(bool can_wrap);
+
+	void set_link_aware(bool l);
+
+	/** See @ref styled_widget::get_link_aware. */
+	virtual bool get_link_aware() const override
+	{
+		return link_aware_;
+	}
 
 	void set_editable(bool editable)
 	{
@@ -109,6 +114,8 @@ private:
 	bool editable_;
 
 	point max_size_;
+
+	bool link_aware_;
 
 	void finalize_subclass() override;
 
@@ -183,6 +190,7 @@ struct builder_scroll_text : public builder_styled_widget
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
 	const PangoAlignment text_alignment;
 	bool editable;
+	bool link_aware;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -487,7 +487,7 @@ point styled_widget::get_best_text_size(point minimum_size, point maximum_size) 
 		<< "Status:\n"
 		<< "minimum_size: " << minimum_size << "\n"
 		<< "maximum_size: " << maximum_size << "\n"
-		<< "text_maximum_width_: " << text_maximum_width_ << "\n"
+		<< "maximum width of text: " << text_maximum_width_ << "\n"
 		<< "can_wrap: " << can_wrap() << "\n"
 		<< "characters_per_line: " << get_characters_per_line() << "\n"
 		<< "truncated: " << renderer_.is_truncated() << "\n"

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -139,10 +139,6 @@ void text_box_base::set_cursor(const std::size_t offset, const bool select)
 
 	if(select) {
 		selection_length_ = (selection_start_ == offset) ? 0 : -static_cast<int>(selection_start_ - offset);
-#ifdef __unix__
-		// selecting copies on UNIX systems.
-		copy_selection(true);
-#endif
 	} else {
 		selection_start_ = (offset <= text_.get_length()) ? offset : 0;
 		selection_length_ = 0;
@@ -197,7 +193,7 @@ void text_box_base::interrupt_composition()
 	SDL_StartTextInput();
 }
 
-void text_box_base::copy_selection(const bool mouse)
+void text_box_base::copy_selection()
 {
 	if(selection_length_ == 0) {
 		return;
@@ -214,17 +210,17 @@ void text_box_base::copy_selection(const bool mouse)
 		end = utf8::index(txt, start);
 		start = utf8::index(txt, start + selection_length_);
 	}
-	desktop::clipboard::copy_to_clipboard(txt.substr(start, end - start), mouse);
+	desktop::clipboard::copy_to_clipboard(txt.substr(start, end - start));
 }
 
-void text_box_base::paste_selection(const bool mouse)
+void text_box_base::paste_selection()
 {
 	if(!editable_)
 	{
 		return;
 	}
 
-	const std::string& text = desktop::clipboard::copy_from_clipboard(mouse);
+	const std::string& text = desktop::clipboard::copy_from_clipboard();
 	if(text.empty()) {
 		return;
 	}
@@ -515,7 +511,7 @@ void text_box_base::signal_handler_middle_button_click(const event::ui_event eve
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
 
-	paste_selection(true);
+	paste_selection();
 
 	handled = true;
 }
@@ -620,7 +616,7 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 
 			// atm we don't care whether there is something to copy or paste
 			// if nothing is there we still don't want to be chained.
-			copy_selection(false);
+			copy_selection();
 			handled = true;
 			break;
 
@@ -629,7 +625,7 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 				return;
 			}
 
-			copy_selection(false);
+			copy_selection();
 
 			if ( is_editable() ) {
 				delete_selection();
@@ -642,7 +638,7 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 				return;
 			}
 
-			paste_selection(false);
+			paste_selection();
 			handled = true;
 			break;
 

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -123,7 +123,7 @@ void text_box_base::set_maximum_length(const std::size_t maximum_length)
 void text_box_base::set_value(const std::string& text)
 {
 	if(text != text_.text()) {
-		text_.set_text(text, false);
+		text_.set_text(text, get_use_markup());
 
 		// default to put the cursor at the end of the buffer.
 		selection_start_ = text_.get_length();
@@ -138,31 +138,18 @@ void text_box_base::set_cursor(const std::size_t offset, const bool select)
 	reset_cursor_state();
 
 	if(select) {
-
-		if(selection_start_ == offset) {
-			selection_length_ = 0;
-		} else {
-			selection_length_ = -static_cast<int>(selection_start_ - offset);
-		}
-
+		selection_length_ = (selection_start_ == offset) ? 0 : -static_cast<int>(selection_start_ - offset);
 #ifdef __unix__
 		// selecting copies on UNIX systems.
 		copy_selection(true);
 #endif
-		update_canvas();
-		queue_redraw();
-
 	} else {
-		if (offset <= text_.get_length()) {
-			selection_start_ = offset;
-		} else {
-			selection_start_ = 0;
-		}
+		selection_start_ = (offset <= text_.get_length()) ? offset : 0;
 		selection_length_ = 0;
-
-		update_canvas();
-		queue_redraw();
 	}
+
+	update_canvas();
+	queue_redraw();
 }
 
 void text_box_base::insert_char(const std::string& unicode)
@@ -174,10 +161,14 @@ void text_box_base::insert_char(const std::string& unicode)
 
 	delete_selection();
 
-	if(text_.insert_text(selection_start_, unicode)) {
-
+	if(text_.insert_text(selection_start_, unicode, get_use_markup())) {
 		// Update status
-		set_cursor(selection_start_ + utf8::size(unicode), false);
+		size_t plain_text_len = utf8::size(plain_text());
+		size_t cursor_pos = selection_start_ + utf8::size(unicode);
+		if (get_use_markup() && (selection_start_ + utf8::size(unicode) > plain_text_len + 1)) {
+			cursor_pos = plain_text_len;
+		}
+		set_cursor(cursor_pos, false);
 		update_canvas();
 		queue_redraw();
 	}
@@ -213,7 +204,7 @@ void text_box_base::copy_selection(const bool mouse)
 	}
 
 	unsigned end, start = selection_start_;
-	const std::string txt = text_.text();
+	const std::string txt = get_use_markup() ? plain_text() : text_.text();
 
 	if(selection_length_ > 0) {
 		end = utf8::index(txt, start + selection_length_);
@@ -240,7 +231,7 @@ void text_box_base::paste_selection(const bool mouse)
 
 	delete_selection();
 
-	selection_start_ += text_.insert_text(selection_start_, text);
+	selection_start_ += text_.insert_text(selection_start_, text, get_use_markup());
 
 	update_canvas();
 	queue_redraw();
@@ -383,7 +374,7 @@ void text_box_base::handle_key_right_arrow(SDL_Keymod modifier, bool& handled)
 
 	handled = true;
 	const std::size_t offset = selection_start_ + 1 + selection_length_;
-	if(offset <= text_.get_length()) {
+	if(offset <= (get_use_markup() ? utf8::size(plain_text()) : text_.get_length())) {
 		set_cursor(offset, (modifier & KMOD_SHIFT) != 0);
 	}
 }
@@ -498,13 +489,13 @@ void text_box_base::handle_editing(bool& handled, const std::string& unicode, in
 		// SDL_TextEditingEvent.
 		// start is start position of the separated event in entire composition text
 		if(start == 0) {
-			text_.set_text(text_cached_, false);
+			text_.set_text(text_cached_, get_use_markup());
 		}
-		text_.insert_text(ime_start_point_ + start, unicode);
+		text_.insert_text(ime_start_point_ + start, unicode, get_use_markup());
 #else
 		std::string new_text(text_cached_);
 		utf8::insert(new_text, ime_start_point_, unicode);
-		text_.set_text(new_text, false);
+		text_.set_text(new_text, get_use_markup());
 
 #endif
 		int maximum_length = text_.get_length();

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -284,10 +284,10 @@ protected:
 	virtual void delete_selection() = 0;
 
 	/** Copies the current selection. */
-	virtual void copy_selection(const bool mouse);
+	virtual void copy_selection();
 
 	/** Pastes the current selection. */
-	virtual void paste_selection(const bool mouse);
+	virtual void paste_selection();
 
 	/***** ***** ***** ***** expose some functions ***** ***** ***** *****/
 

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -147,6 +147,13 @@ public:
 		return text_.text();
 	}
 
+	std::string plain_text()
+	{
+		char* plain_text = nullptr;
+		pango_parse_markup(text().c_str(), text().size(), 0, nullptr, &plain_text, nullptr, nullptr);
+		return plain_text ? std::string(plain_text) : std::string();
+	}
+
 	/** Set the text_changed callback. */
 	void set_text_changed_callback(
 			std::function<void(text_box_base* textbox, const std::string text)> cb)

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -553,7 +553,7 @@ bool textbox::handle_key_down(const SDL_Event &event)
 				if(is_selection())
 					erase_selection();
 
-				std::string str = desktop::clipboard::copy_from_clipboard(false);
+				std::string str = desktop::clipboard::copy_from_clipboard();
 
 				//cut off anything after the first newline
 				str.erase(std::find_if(str.begin(),str.end(),utils::isnewline),str.end());
@@ -581,7 +581,7 @@ bool textbox::handle_key_down(const SDL_Event &event)
 
 					std::u32string ws(text_.begin() + beg, text_.begin() + end);
 					std::string s = unicode_cast<std::string>(ws);
-					desktop::clipboard::copy_to_clipboard(s, false);
+					desktop::clipboard::copy_to_clipboard(s);
 				}
 			}
 			break;
@@ -595,7 +595,7 @@ bool textbox::handle_key_down(const SDL_Event &event)
 
 					std::u32string ws(text_.begin() + beg, text_.begin() + end);
 					std::string s = unicode_cast<std::string>(ws);
-					desktop::clipboard::copy_to_clipboard(s, false);
+					desktop::clipboard::copy_to_clipboard(s);
 					erase_selection();
 				}
 				break;


### PR DESCRIPTION
Resolves #1206.

![Screenshot from 2024-09-19 07-14-36](https://github.com/user-attachments/assets/1f827cde-ba4d-46ae-80c5-947a66118f0e)

This allows text to be selected from the MP lobby chat log area.

Introduces the following two keys in `multiline_text` and `scroll_text`: `use_markup` and `link_aware`. Markup support only works for non-editable text areas only ATM, which is relevant to the usecase of #1206. Editable text areas with formatted text are outside the scope of this PR, but may be done in future (that essentially makes `multiline_text` a pango rich text editor).