### PR TITLE
Enable clang-tidy and refactor NULL to nullptr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          '-*,modernize-use-nullptr'
+WarningsAsErrors: true
+...

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -104,7 +104,7 @@ jobs:
                 cmake "$@" -DCMAKE_BUILD_TYPE="$CFG" -DCXX_STD="$CXX_STD" \
                   -DEXTRA_FLAGS_CONFIG="-pipe" -DENABLE_MYSQL=true \
                   -DENABLE_NLS=false -DENABLE_LTO="$LTO" -DFORCE_COLOR_OUTPUT=true -DLTO_JOBS=2 \
-                  -DENABLE_SYSTEM_LUA="$SYS_LUA" .
+                  -DENABLE_SYSTEM_LUA="$SYS_LUA -DCLANG_TIDY=true" .
               }
               rm -R /usr/local/lib/cmake
               rm /usr/local/lib/libboost*

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -90,9 +90,14 @@ jobs:
                 scons "$@" build="$CFG" ctool="$CC" cxxtool="$CXX" cxx_std="$CXX_STD" \
                   extra_flags_config="-pipe" forum_user_handler=true \
                   nls=false enable_lto="$LTO" system_lua="$SYS_LUA" force_color=true \
-                  jobs=2 --debug=time glibcxx_debug=true glibcxx_assertions=true
+                  jobs=2 --debug=time glibcxx_debug=true glibcxx_assertions=true compile_db=true
               }
               build strict=true wesnoth boost_unit_tests
+
+              build cdb
+              # disable all warnings since we have coverage on them in a standard build, and clang-tidy
+              # triggers false positive compiler warnings that clang itself won't
+              run-clang-tidy -use-color -j 2 -extra-arg="-w" '^(?!.*src/modules/|.*build/)'
 
               apt remove -y -qq libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ wesnoth.plg
 *.exe
 *.dll
 *.so
+compile_commands.json
 
 # library files
 .libs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ option(GLIBCXX_ASSERTIONS "Whether to define _GLIBCXX_ASSERTIONS" OFF)
 option(GLIBCXX_DEBUG "Whether to define _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC. Requires a version of Boost's program_options that's compiled with __GLIBCXX_DEBUG too." OFF)
 option(ENABLE_POT_UPDATE_TARGET "Enables the tools to update the pot files and manuals. This target has extra dependencies." OFF)
 option(FORCE_COLOR_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." FALSE)
+option(CLANG_TIDY "Enable clang-tidy linter checks." OFF)
 
 if(UNIX AND NOT APPLE AND NOT CYGWIN)
 	option(ENABLE_NOTIFICATIONS "Enable Window manager notification messages" ON)
@@ -253,6 +254,11 @@ if(NOT MSVC)
 		elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 			set(COMPILER_FLAGS "${COMPILER_FLAGS} -fcolor-diagnostics")
 		endif()
+	endif()
+
+### Enable clang-tidy linting
+	if (CLANG_TIDY)
+		set(CMAKE_CXX_CLANG_TIDY "clang-tidy -Wno-unknown-warning-option")
 	endif()
 
 ### Set the final compiler flags.

--- a/SConstruct
+++ b/SConstruct
@@ -120,6 +120,7 @@ opts.AddVariables(
     BoolVariable("OS_ENV", "Forward the entire OS environment to scons", False),
     BoolVariable("history", "Clear to disable GNU history support in lua console", True),
     BoolVariable('force_color', 'Always produce ANSI-colored output (GNU/Clang only).', False),
+    BoolVariable('compile_db', 'Produce a compile_commands.json file.', False),
     )
 
 #
@@ -188,6 +189,11 @@ if env['distcc']:
     env.Tool('distcc')
 
 if env['ccache']: env.Tool('ccache')
+
+if env['compile_db']:
+    env.Tool('compilation_db')
+    cdb = env.CompilationDatabase()
+    Alias('cdb', cdb) 
 
 boost_version = "1.67"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,14 @@
 # store the specified sources list in the specified variable
 function(GetSources source_list store_in_var)
-	file(STRINGS "../source_lists/${source_list}" sources)
-	set(${store_in_var} ${sources} PARENT_SCOPE)
+	file(STRINGS "${CMAKE_SOURCE_DIR}/source_lists/${source_list}" sources)
+	foreach(source IN LISTS sources)
+	    list(APPEND loaded_sources "${CMAKE_SOURCE_DIR}/src/${source}")
+		set(${store_in_var} ${loaded_sources} PARENT_SCOPE)
+	endforeach()
 endfunction()
 
-if(ENABLE_MYSQL)
-	execute_process(COMMAND mysql_config --cflags OUTPUT_VARIABLE MYSQL_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-	string(REGEX REPLACE "-I" "" MYSQL_CFLAGS "${MYSQL_CFLAGS}")
-	string(REGEX REPLACE "-DNDEBUG" "" MYSQL_CFLAGS "${MYSQL_CFLAGS}")
-	execute_process(COMMAND mysql_config --libs OUTPUT_VARIABLE MYSQL_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
-	add_subdirectory("modules/mariadbpp/")
-endif()
+# external git submodules
+add_subdirectory("modules")
 
 ## some includes ##
 include_directories(SYSTEM ${PANGOCAIRO_INCLUDE_DIRS})
@@ -79,32 +77,6 @@ GetSources("libwesnoth_widgets" wesnoth_widget-sources)
 GetSources("libwesnoth" wesnoth_game_sources)
 GetSources("libwesnoth_core" wesnoth_core_sources)
 GetSources("wesnoth" wesnoth_sources)
-if(NOT ENABLE_SYSTEM_LUA)
-	GetSources("lua" lua_sources)
-
-	# Inject a header into the Lua sources for Wesnoth-specific changes
-	# makedepend won't see it so we have to specifically add it as a dependency.
-	file(GLOB wesnoth_lua_config wesnoth_lua_config.h)
-	set_source_files_properties(${lua_sources} PROPERTIES OBJECT_DEPENDS ${wesnoth_lua_config})
-
-	set_source_files_properties(${lua_sources} PROPERTIES LANGUAGE CXX)
-
-	# We explicitly want lua compiled as C++ version
-	if(MSVC)
-		set_source_files_properties(${lua_sources} PROPERTIES COMPILE_FLAGS "/FI\"${wesnoth_lua_config}\"")
-		# silence an implicit bitshift conversion warning
-		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " /wd4334 /TP")
-	else()
-		set_source_files_properties(${lua_sources} PROPERTIES COMPILE_FLAGS "-include \"${wesnoth_lua_config}\" -x c++ -Wno-old-style-cast -Wno-useless-cast -Wno-stringop-overflow")
-	endif()
-
-	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-		# silence a Clang specific warning due to extra parenthesis in if statements
-		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-parentheses-equality")
-		# silence a Clang specific warning when compiling the lua code
-		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-string-plus-int")
-	endif()
-endif()
 
 if(WIN32)
 	set(wesnoth_core_sources ${wesnoth_core_sources} log_windows.cpp)
@@ -211,8 +183,10 @@ endif()
 
 add_library(wesnoth-common STATIC ${wesnoth_core_sources})
 if(ENABLE_GAME OR ENABLE_TESTS)
-	add_library(wesnoth-client STATIC ${wesnoth_sources} ${lua_sources} ${wesnoth_game_sources} ${wesnoth_sdl_sources})
-
+	add_library(wesnoth-client STATIC ${wesnoth_sources} ${wesnoth_game_sources} ${wesnoth_sdl_sources})
+	if(NOT ENABLE_SYSTEM_LUA)
+    	target_link_libraries(wesnoth-client lua)
+	endif()
 	# widgets need special handling since otherwise the way they're registered causes the linker to remove them since it incorrectly thinks they're unused
 	add_library(wesnoth-widgets STATIC ${wesnoth_widget-sources})
 	if(APPLE)

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -408,7 +408,7 @@ bool config_cache::delete_cache_files(const std::vector<std::string>& paths,
 }
 
 config_cache_transaction::state config_cache_transaction::state_ = FREE;
-config_cache_transaction* config_cache_transaction::active_ = 0;
+config_cache_transaction* config_cache_transaction::active_ = nullptr;
 
 config_cache_transaction::config_cache_transaction()
 	: define_filenames_()
@@ -422,7 +422,7 @@ config_cache_transaction::config_cache_transaction()
 config_cache_transaction::~config_cache_transaction()
 {
 	state_ = FREE;
-	active_ = 0;
+	active_ = nullptr;
 }
 
 void config_cache_transaction::lock()

--- a/src/conftests/sdl2_audio.cpp
+++ b/src/conftests/sdl2_audio.cpp
@@ -37,7 +37,7 @@ int main(int, char** argv)
     }
 
     Mix_Music* music = Mix_LoadMUS(argv[1]);
-    if (music == NULL) {
+    if (music == nullptr) {
         fprintf(stdout, "Cannot load music file: %s\\n", Mix_GetError());
         Mix_CloseAudio();
         return (EXIT_FAILURE);

--- a/src/conftests/sdl2_jpg.cpp
+++ b/src/conftests/sdl2_jpg.cpp
@@ -18,7 +18,7 @@
 int main(int, char** argv)
 {
     SDL_RWops *src = SDL_RWFromFile(argv[1], "rb");
-    if (src == NULL) {
+    if (src == nullptr) {
         exit(2);
     }
     exit(!IMG_isJPG(src));

--- a/src/conftests/sdl2_png.cpp
+++ b/src/conftests/sdl2_png.cpp
@@ -18,7 +18,7 @@
 int main(int, char** argv)
 {
     SDL_RWops *src = SDL_RWFromFile(argv[1], "rb");
-    if (src == NULL) {
+    if (src == nullptr) {
         exit(2);
     }
     exit(!IMG_isPNG(src));

--- a/src/conftests/sdl2_webp.cpp
+++ b/src/conftests/sdl2_webp.cpp
@@ -18,7 +18,7 @@
 int main(int, char** argv)
 {
     SDL_RWops *src = SDL_RWFromFile(argv[1], "rb");
-    if (src == NULL) {
+    if (src == nullptr) {
         exit(2);
     }
     exit(!IMG_isWEBP(src));

--- a/src/crypt_blowfish/.clang-tidy
+++ b/src/crypt_blowfish/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          '-*,bugprone-use-after-move'
+WarningsAsErrors: true
+...

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -437,7 +437,7 @@ void mouse_button<I>::initialize_state(int32_t button_state)
 {
 	last_click_stamp_ = {};
 	last_clicked_widget_ = nullptr;
-	focus_ = 0;
+	focus_ = nullptr;
 	// SDL_BUTTON_LEFT, SDL_BUTTON_MIDDLE, and SDL_BUTTON_RIGHT correspond to 1,2,3
 	is_down_ = button_state & SDL_BUTTON(I + 1);
 }

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -220,7 +220,7 @@ void chatbox::append_to_chatbox(const std::string& text, std::size_t id, const b
 
 	const std::string before_message = log.get_value().empty() ? "" : "\n";
 	const std::string new_text = formatter()
-		<< log.get_value() << before_message << markup::span_color("#bcb088", prefs::get().get_chat_timestamp(std::time(0)), text);
+		<< log.get_value() << before_message << markup::span_color("#bcb088", prefs::get().get_chat_timestamp(std::time(nullptr)), text);
 
 	log.set_use_markup(true);
 	log.set_value(new_text);

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -70,7 +70,7 @@ md5::md5(const std::string& input) {
 	assert(utils::md5::DIGEST_SIZE == md5_digest_len);
 
 	// MD5_Init
-	EVP_DigestInit_ex(mdctx, EVP_md5(), NULL);
+	EVP_DigestInit_ex(mdctx, EVP_md5(), nullptr);
 
 	// MD5_Update
 	EVP_DigestUpdate(mdctx, input.c_str(), input.size());

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -269,7 +269,7 @@ void set_log_to_file()
 
 		// make stdout unbuffered - otherwise some output might be lost
 		// in practice shouldn't make much difference either way, given how little output goes through stdout/std::cout
-		if(setvbuf(stdout, NULL, _IONBF, 2) == -1) {
+		if(setvbuf(stdout, nullptr, _IONBF, 2) == -1) {
 			std::cerr << "Failed to set stdout to be unbuffered";
 		}
 

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Disable clang-tidy for all git submodules, since we can't fix these issues
+# in the wesnoth repo
+set(CMAKE_CXX_CLANG_TIDY "")
+if(ENABLE_MYSQL)
+	execute_process(COMMAND mysql_config --cflags OUTPUT_VARIABLE MYSQL_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+	string(REGEX REPLACE "-I" "" MYSQL_CFLAGS "${MYSQL_CFLAGS}")
+	string(REGEX REPLACE "-DNDEBUG" "" MYSQL_CFLAGS "${MYSQL_CFLAGS}")
+	execute_process(COMMAND mysql_config --libs OUTPUT_VARIABLE MYSQL_LIBS OUTPUT_STRIP_TRAILING_WHITESPACE)
+	add_subdirectory("mariadbpp/")
+endif()
+
+if(NOT ENABLE_SYSTEM_LUA)
+	GetSources("lua" lua_sources)
+
+	# Inject a header into the Lua sources for Wesnoth-specific changes
+	# makedepend won't see it so we have to specifically add it as a dependency.
+	file(GLOB wesnoth_lua_config ../wesnoth_lua_config.h)
+	set_source_files_properties(${lua_sources} PROPERTIES OBJECT_DEPENDS ${wesnoth_lua_config})
+
+	set_source_files_properties(${lua_sources} PROPERTIES LANGUAGE CXX)
+
+	# We explicitly want lua compiled as C++ version
+	if(MSVC)
+		set_source_files_properties(${lua_sources} PROPERTIES COMPILE_FLAGS "/FI\"${wesnoth_lua_config}\"")
+		# silence an implicit bitshift conversion warning
+		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " /wd4334 /TP")
+	else()
+		set_source_files_properties(${lua_sources} PROPERTIES COMPILE_FLAGS "-include \"${wesnoth_lua_config}\" -x c++ -Wno-old-style-cast -Wno-useless-cast -Wno-stringop-overflow")
+	endif()
+
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		# silence a Clang specific warning due to extra parenthesis in if statements
+		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-parentheses-equality")
+		# silence a Clang specific warning when compiling the lua code
+		set_property(SOURCE SOURCE ${lua_sources} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-string-plus-int")
+	endif()
+
+    add_library(lua STATIC ${lua_sources})
+endif()

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -325,7 +325,7 @@ static void add_localized_overlay(const std::string& ovr_file, surface& orig_sur
 
 	SDL_Rect area {0, 0, ovr_surf->w, ovr_surf->h};
 
-	sdl_blit(ovr_surf, 0, orig_surf, &area);
+	sdl_blit(ovr_surf, nullptr, orig_surf, &area);
 }
 
 static surface load_image_file(const image::locator& loc)

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -855,7 +855,7 @@ bool playsingle_controller::should_return_to_play_side() const
 		return true;
 	} else if(gamestate().in_phase(game_data::TURN_ENDED)) {
 		return true;
-	} else if((gamestate().in_phase(game_data::TURN_STARTING_WAITING) || end_turn_requested_) && replay_controller_.get() == 0 && current_team().is_local() && !current_team().is_idle()) {
+	} else if((gamestate().in_phase(game_data::TURN_STARTING_WAITING) || end_turn_requested_) && replay_controller_.get() == nullptr && current_team().is_local() && !current_team().is_idle()) {
 		// When we are a locally controlled side and havent done init_side yet also return to play_side
 		return true;
 	} else {

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -1933,15 +1933,15 @@ preferences::secure_buffer prefs::aes_encrypt(const preferences::secure_buffer& 
 	if(!ctx)
 	{
 		ERR_CFG << "AES EVP_CIPHER_CTX_new failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		return preferences::secure_buffer();
 	}
 
 	// TODO: use EVP_EncryptInit_ex2 once openssl 3.0 is more widespread
-	if(EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key.data(), iv) != 1)
+	if(EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr, key.data(), iv) != 1)
 	{
 		ERR_CFG << "AES EVP_EncryptInit_ex failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		EVP_CIPHER_CTX_free(ctx);
 		return preferences::secure_buffer();
 	}
@@ -1949,7 +1949,7 @@ preferences::secure_buffer prefs::aes_encrypt(const preferences::secure_buffer& 
 	if(EVP_EncryptUpdate(ctx, encrypted_buffer, &update_length, plaintext.data(), plaintext.size()) != 1)
 	{
 		ERR_CFG << "AES EVP_EncryptUpdate failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		EVP_CIPHER_CTX_free(ctx);
 		return preferences::secure_buffer();
 	}
@@ -1958,7 +1958,7 @@ preferences::secure_buffer prefs::aes_encrypt(const preferences::secure_buffer& 
 	if(EVP_EncryptFinal_ex(ctx, encrypted_buffer + update_length, &extra_length) != 1)
 	{
 		ERR_CFG << "AES EVP_EncryptFinal failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		EVP_CIPHER_CTX_free(ctx);
 		return preferences::secure_buffer();
 	}
@@ -2021,15 +2021,15 @@ preferences::secure_buffer prefs::aes_decrypt(const preferences::secure_buffer& 
 	if(!ctx)
 	{
 		ERR_CFG << "AES EVP_CIPHER_CTX_new failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		return preferences::secure_buffer();
 	}
 
 	// TODO: use EVP_DecryptInit_ex2 once openssl 3.0 is more widespread
-	if(EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key.data(), iv) != 1)
+	if(EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr, key.data(), iv) != 1)
 	{
 		ERR_CFG << "AES EVP_DecryptInit_ex failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		EVP_CIPHER_CTX_free(ctx);
 		return preferences::secure_buffer();
 	}
@@ -2037,7 +2037,7 @@ preferences::secure_buffer prefs::aes_decrypt(const preferences::secure_buffer& 
 	if(EVP_DecryptUpdate(ctx, plaintext_buffer, &update_length, encrypted.data(), encrypted.size()) != 1)
 	{
 		ERR_CFG << "AES EVP_DecryptUpdate failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		EVP_CIPHER_CTX_free(ctx);
 		return preferences::secure_buffer();
 	}
@@ -2046,7 +2046,7 @@ preferences::secure_buffer prefs::aes_decrypt(const preferences::secure_buffer& 
 	if(EVP_DecryptFinal_ex(ctx, plaintext_buffer + update_length, &extra_length) != 1)
 	{
 		ERR_CFG << "AES EVP_DecryptFinal failed with error:";
-		ERR_CFG << ERR_error_string(ERR_get_error(), NULL);
+		ERR_CFG << ERR_error_string(ERR_get_error(), nullptr);
 		EVP_CIPHER_CTX_free(ctx);
 		return preferences::secure_buffer();
 	}

--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -134,7 +134,7 @@ bool application_lua_kernel::thread::is_running() {
 	return started_ ? (lua_status(T_) == LUA_YIELD) : (lua_status(T_) == LUA_OK);
 }
 
-static char * v_threadtableKey = 0;
+static char * v_threadtableKey = nullptr;
 static void * const threadtableKey = static_cast<void *> (& v_threadtableKey);
 
 static lua_State * get_new_thread(lua_State * L)

--- a/src/scripting/lua_terrainfilter.cpp
+++ b/src/scripting/lua_terrainfilter.cpp
@@ -63,7 +63,7 @@ namespace {
 			return 0;
 		}
 
-		char** end = 0;
+		char** end = nullptr;
 		int res = strtol(&s[0], end, 10);
 		return res;
 	}

--- a/src/server/campaignd/auth.cpp
+++ b/src/server/campaignd/auth.cpp
@@ -33,7 +33,7 @@ namespace
 
 std::string generate_salt(std::size_t len)
 {
-	boost::mt19937 mt(std::time(0));
+	boost::mt19937 mt(std::time(nullptr));
 	auto salt = std::string(len, '0');
 	boost::uniform_int<> from_str(0, 63); // 64 possible values for base64
 	boost::variate_generator< boost::mt19937, boost::uniform_int<>> get_char(mt, from_str);

--- a/src/tests/utils/fake_display.cpp
+++ b/src/tests/utils/fake_display.cpp
@@ -50,7 +50,7 @@ public:
 	//		~fake_display_manager();
 };
 
-fake_display_manager* fake_display_manager::manager_ = 0;
+fake_display_manager* fake_display_manager::manager_ = nullptr;
 
 fake_display_manager* fake_display_manager::get_manager()
 {

--- a/src/utils/general.cpp
+++ b/src/utils/general.cpp
@@ -25,7 +25,7 @@ std::string get_unknown_exception_type()
 #if defined(__clang__) || defined(__GNUG__)
 	std::string to_demangle = __cxxabiv1::__cxa_current_exception_type()->name();
 	int status = 0;
-	char* buff = __cxxabiv1::__cxa_demangle(to_demangle.c_str(), NULL, NULL, &status);
+	char* buff = __cxxabiv1::__cxa_demangle(to_demangle.c_str(), nullptr, nullptr, &status);
 	if(status == 0)
 	{
 		std::string demangled = buff;


### PR DESCRIPTION
clang-tidy is a linter tool that automatically checks for common code quality issues. This PR adds a cmake option `DCLANG_TIDY` that when set with `DCLANG_TIDY=ON` will automatically lint Wesnoth's code for the issues specified in `src/.clang-tidy`

As a representative example, the `NULL` macro is an implementation-defined keyword that is typically the integer 0. This causes issues because it is not actually a pointer type, and so will trigger integer overloads of methods preferentially to pointer overloads. In C++11, the keyword `nullptr` was introduced which is actually a pointer type and doesn't have this problem. This PR removes the last remaining usages of `NULL` or `0` from the codebase and enables `clang-tidy` to check for usage of `NULL` automatically.

Git submodules not owned by `wesnoth` are excluded from linting.

To use clang-tidy with an in-tree build:

1. Install `clang` and tooling
2. `cmake . -DCLANG_TIDY=ON && make`