### PR TITLE
Increased text size for UMC Author note in terrain elevation help page

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -201,7 +201,7 @@ An example use case would be:
 
 The graphics used to represent the ledge borders are determined by the base terrain.
 " +
-        _ "editor^<format>text='Note for UMC authors: The flood-filled tiles do not have their terrain codes changed, or any other properties affected, so filtering a location by elevation is not simple.' italic='yes' font_size=10 </format>"
+        _ "editor^<format>text='Note for UMC authors: The flood-filled tiles do not have their terrain codes changed, or any other properties affected, so filtering a location by elevation is not simple.' italic='yes' font_size=15 </format>"
 [/topic]
 # wmllint: markcheck on
 


### PR DESCRIPTION
This note was previously borderline unreadable on my screen. This makes it slightly large. Still not as large as the other text, but it should be a bit easier to read.