### PR TITLE
Move Cry from Elensefar to Core

### DIFF
--- a/copyrights.csv
+++ b/copyrights.csv
@@ -1,6 +1,5 @@
 Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes,Needs Update,MD5
 2009/04/10,data/campaigns/Delfadors_Memoirs/sounds/rumble.wav,GNU GPL v2+,Fabian Müller(fabi/fendrin);Eric S. Raymond(esr),,,ba2422ca12aeebe50955c8f44b52243d
-2023/09/15,data/campaigns/Eastern_Invasion/music/cry_from_elensefar.ogg,CC BY-SA 4.0,(pluft),,,3b32d7970ab520b2d488559b69b2ac68
 2023/09/15,data/campaigns/Eastern_Invasion/music/heavens-remix.ogg,CC BY-SA 4.0,(gabriel silver);(dalas),,,158c80c11e2d2cdb5f1ab5cc0298a8fe
 2023/09/15,data/campaigns/Eastern_Invasion/music/journeys_end_faststart.ogg,GNU GPL v2+,Mattias Westlund(West);(dalas),,,3f6b2c8be4e6e30087b7a3cc5969831b
 2021/03/20,data/campaigns/Eastern_Invasion/sounds/gate-fall.ogg,GNU GPL v2+,unknown,,,15d08eb898db8684f18de206a6cbd1a5
@@ -25,6 +24,7 @@ Date,File,License,Author - Real Name(other name);Real Name(other name);etc,Notes
 2013/12/08,data/core/music/battle.ogg,GNU GPL v2+,Aleksi Aubry-Carlson(Aleksi),,,93b53db9e81c0d8879cf4ca51cd246bd
 2013/12/08,data/core/music/breaking_the_chains.ogg,GNU GPL v2+,Mattias Westlund(West),,,fe599b1e02f41846a6e2afeb7d6df76e
 2013/12/08,data/core/music/casualties_of_war.ogg,GNU GPL v2+,Tyler Johnson,,,f0c69501a222afd01218ed783fef7b14
+2023/09/15,data/core/music/cry_from_elensefar.ogg,CC BY-SA 4.0,(pluft),,,3b32d7970ab520b2d488559b69b2ac68
 2013/12/08,data/core/music/defeat.ogg,GNU GPL v2+,Timothy Pinkham(TimothyP),,,8cb8eb9871292ad288f5c703f0679460
 2013/12/08,data/core/music/defeat2.ogg,GNU GPL v2+,Ryan Reilly(Rain),,,9775634e4a20c10844c823d5d79f824f
 2013/12/08,data/core/music/elf-land.ogg,GNU GPL v2+,Aleksi Aubry-Carlson(Aleksi),,,addc5393092c23f2789a028d94f4212e


### PR DESCRIPTION
This music would be useful in core. I don't have to change any WML as I'm not actually changing any playlists. It's still specific to EI. The difference here is UMC creators can more easily use them without copying unnecessary files.

Edit: Failed copyright checks. Is music still using copyrights.csv?

Eidt 2: Looks like it is. I thought it was replaced with a metadata system.