### PR TITLE
Display: simplify add_overlay interface

### DIFF
--- a/src/display.hpp
+++ b/src/display.hpp
@@ -167,9 +167,7 @@ public:
 	 * An overlay is an image that is displayed on top of the tile.
 	 * One tile may have multiple overlays.
 	 */
-	void add_overlay(const map_location& loc, const std::string& image,
-		const std::string& halo="", const std::string& team_name="",const std::string& item_id="",
-		bool visible_under_fog = true, float submerge = 0.0f, float z_order = 0);
+	void add_overlay(const map_location& loc, overlay&& ov);
 
 	/** remove_overlay will remove all overlays on a tile. */
 	void remove_overlay(const map_location& loc);

--- a/src/editor/action/mouse/mouse_action_item.cpp
+++ b/src/editor/action/mouse/mouse_action_item.cpp
@@ -50,8 +50,8 @@ std::unique_ptr<editor_action> mouse_action_item::click_left(editor_display& dis
 		return nullptr;
 	}
 
-	const overlay& item = item_palette_.selected_fg_item();
-	disp.add_overlay(start_hex_, item.image, item.halo, "", "", item.visible_in_fog, item.submerge);
+	overlay item = item_palette_.selected_fg_item();
+	disp.add_overlay(start_hex_, std::move(item));
 
 	click_ = true;
 	return nullptr;

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -22,7 +22,6 @@ struct overlay
 
 	overlay(const std::string& img,
 			const std::string& halo_img,
-			halo::handle handle,
 			const std::string& overlay_team_name,
 			const std::string& item_id,
 			const bool fogged,
@@ -31,8 +30,9 @@ struct overlay
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
+		, name()
 		, id(item_id)
-		, halo_handle(handle)
+		, halo_handle()
 		, visible_in_fog(fogged)
 		, submerge(submerge)
 		, z_order(item_z_order)

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4113,7 +4113,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 	}
 
 	if (game_display_) {
-		game_display_->add_overlay(loc, overlay{
+		game_display_->add_overlay(loc, overlay(
 			cfg["image"],
 			cfg["halo"],
 			team_name,
@@ -4121,7 +4121,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["visible_in_fog"].to_bool(true),
 			cfg["submerge"].to_double(0),
 			cfg["z_order"].to_double(0)
-		});
+		));
 	}
 	return 0;
 }

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -64,6 +64,7 @@
 #include "map/location.hpp"             // for map_location
 #include "mouse_events.hpp"             // for mouse_handler
 #include "mp_game_settings.hpp"         // for mp_game_settings
+#include "overlay.hpp"
 #include "pathfind/pathfind.hpp"        // for full_cost_map, plain_route, etc
 #include "pathfind/teleport.hpp"        // for get_teleport_locations, etc
 #include "play_controller.hpp"          // for play_controller
@@ -4112,9 +4113,15 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 	}
 
 	if (game_display_) {
-		game_display_->add_overlay(loc, cfg["image"], cfg["halo"],
-			team_name, cfg["name"], cfg["visible_in_fog"].to_bool(true),
-			cfg["submerge"].to_double(0), cfg["z_order"].to_double(0));
+		game_display_->add_overlay(loc, overlay{
+			cfg["image"],
+			cfg["halo"],
+			team_name,
+			cfg["name"], // Name is treated as the ID
+			cfg["visible_in_fog"].to_bool(true),
+			cfg["submerge"].to_double(0),
+			cfg["z_order"].to_double(0)
+		});
 	}
 	return 0;
 }


### PR DESCRIPTION
Instead of passing all the arguments for an overlay to display::add_overlay, just take an rvalue-reference to an existing overlay object.

The overlay ctor was adjusted. It no longer takes a halo::handle argument, and the display class sets that manually.