### PR TITLE
Add manual to Wesnoth about section

### DIFF
--- a/data/gui/themes/default/window/game_version.cfg
+++ b/data/gui/themes/default/window/game_version.cfg
@@ -260,6 +260,39 @@
 				[/row]
 				[row]
 					[column]
+						border = "left,bottom"
+						border_size = 5
+						horizontal_alignment = left
+						[grid]
+							[row]
+								[column]
+									horizontal_alignment = left
+									[label]
+										label = _ "<span font_family='DejaVu Sans'>✦</span> <b>Manual:</b>"
+										use_markup = yes
+									[/label]
+								[/column]
+								[column]
+									grow_factor = 0
+									horizontal_alignment = left
+									border = "left"
+									border_size = 5
+									
+									[label]
+										#textdomain wesnoth-test
+                                        #po: Replace with your local version of the Wesnoth Manual found at https://wiki.wesnoth.org/WesnothManual
+										label = _ "<span foreground='yellow'><u>https://www.wesnoth.org/manual/dev/manual.en.html</u></span>"
+										#textdomain wesnoth-lib
+										use_markup = yes
+										link_aware = yes
+									[/label]
+								[/column]
+							[/row]
+						[/grid]
+					[/column]
+				[/row]
+				[row]
+					[column]
 						[spacer]
 							height = 20
 						[/spacer]


### PR DESCRIPTION
Fixes #9369 

I have tested this on both UI themes. This adds the manual just below the wiki when clicking on the about button on the bottom left.