### PR TITLE
Fixes #7992

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -32,6 +32,7 @@
 #include "terrain/filter.hpp"
 #include "units/unit.hpp"
 #include "units/abilities.hpp"
+#include "units/ability_tags.hpp"
 #include "units/filter.hpp"
 #include "units/map.hpp"
 #include "utils/config_filters.hpp"
@@ -1849,29 +1850,52 @@ bool attack_type::has_special_or_ability(const std::string& special, bool specia
 
 namespace
 {
+	bool exclude_ability_attributes(const std::string& tag_name, const config & filter)
+	{
+		using namespace utils::config_filters;
+		///check what filter attributes used can be used in type of ability checked.
+		bool abilities_check = abilities_list::ability_value_tags().count(tag_name) != 0 || abilities_list::ability_no_value_tags().count(tag_name) != 0;
+		if(filter.has_attribute("active_on") && tag_name != "resistance" && abilities_check)
+			return false;
+		if(filter.has_attribute("apply_to")  && tag_name != "resistance" && abilities_check)
+			return false;
+
+		if(filter.has_attribute("overwrite_specials") && abilities_list::weapon_number_tags().count(tag_name) == 0)
+			return false;
+
+		bool no_value_weapon_abilities_check =  abilities_list::no_weapon_number_tags().count(tag_name) != 0 || abilities_list::ability_no_value_tags().count(tag_name) != 0;
+		if(filter.has_attribute("value") && no_value_weapon_abilities_check)
+			return false;
+		if(filter.has_attribute("add") && no_value_weapon_abilities_check)
+			return false;
+		if(filter.has_attribute("sub") && no_value_weapon_abilities_check)
+			return false;
+		if(filter.has_attribute("multiply") && no_value_weapon_abilities_check)
+			return false;
+		if(filter.has_attribute("divide") && no_value_weapon_abilities_check)
+			return false;
+
+		bool all_engine =  abilities_list::no_weapon_number_tags().count(tag_name) != 0 || abilities_list::weapon_number_tags().count(tag_name) != 0 || abilities_list::ability_value_tags().count(tag_name) != 0 || abilities_list::ability_no_value_tags().count(tag_name) != 0;
+		if(filter.has_attribute("replacement_type") && tag_name != "damage_type" && all_engine)
+			return false;
+		if(filter.has_attribute("alternative_type") && tag_name != "damage_type" && all_engine)
+			return false;
+		if(filter.has_attribute("type") && tag_name != "plague" && all_engine)
+			return false;
+
+		return true;
+	}
+
 	bool matches_ability_filter(const config & cfg, const std::string& tag_name, const config & filter)
 	{
 		using namespace utils::config_filters;
 
-		if(!filter["affect_adjacent"].empty()){
-			bool adjacent = cfg.has_child("affect_adjacent");
-			if(filter["affect_adjacent"].to_bool() != adjacent){
-				return false;
-			}
-		}
-
-		if(!bool_matches_if_present(filter, cfg, "affect_self", true))
+		//check if attributes have right to be in type of ability checked
+		if(!exclude_ability_attributes(tag_name, filter))
 			return false;
 
-		if(!bool_or_empty(filter, cfg, "affect_allies"))
-			return false;
-
-		if(!bool_matches_if_present(filter, cfg, "affect_enemies", false))
-			return false;
-
-		if(!bool_matches_if_present(filter, cfg, "cumulative", false))
-			return false;
-
+		// tag_name and id are equivalent of ability ability_type and ability_id/type_active filters
+		//can be extent to special_id/type_active. If tag_name or id matche if present in list.
 		const std::vector<std::string> filter_type = utils::split(filter["tag_name"]);
 		if ( !filter_type.empty() && std::find(filter_type.begin(), filter_type.end(), tag_name) == filter_type.end() )
 			return false;
@@ -1879,15 +1903,33 @@ namespace
 		if(!string_matches_if_present(filter, cfg, "id", ""))
 			return false;
 
-		if(tag_name == "resistance"){
-			if(!set_includes_if_present(filter, cfg, "apply_to")){
-				return false;
-			}
-		} else {
-			if(!string_matches_if_present(filter, cfg, "apply_to", "self")){
+		//when affect_adjacent=yes detect presence of [affect_adjacent] in abilities, if no
+		//then matches when tag not present.
+		if(!filter["affect_adjacent"].empty()){
+			bool adjacent = cfg.has_child("affect_adjacent");
+			if(filter["affect_adjacent"].to_bool() != adjacent){
 				return false;
 			}
 		}
+
+		//these attributs below filter attribute used in all engine abilities.
+		//matches if filter attribute have same boolean value what attribute
+		if(!bool_matches_if_present(filter, cfg, "affect_self", true))
+			return false;
+
+		//here if value of affect_allies but also his presence who is checked because
+		//when affect_allies not specified, ability affect unit of same side what owner only.
+		if(!bool_or_empty(filter, cfg, "affect_allies"))
+			return false;
+
+		if(!bool_matches_if_present(filter, cfg, "affect_enemies", false))
+			return false;
+
+
+		//cumulative, overwrite_specials and active_on check attributes used in all abilities
+		//who return a numerical value.
+		if(!bool_matches_if_present(filter, cfg, "cumulative", false))
+			return false;
 
 		if(!string_matches_if_present(filter, cfg, "overwrite_specials", "none"))
 			return false;
@@ -1895,17 +1937,8 @@ namespace
 		if(!string_matches_if_present(filter, cfg, "active_on", "both"))
 			return false;
 
-		//for damage only
-		if(!string_matches_if_present(filter, cfg, "replacement_type", ""))
-			return false;
-
-		if(!string_matches_if_present(filter, cfg, "alternative_type", ""))
-			return false;
-
-		//for plague only
-		if(!string_matches_if_present(filter, cfg, "type", ""))
-			return false;
-
+		//value, add, sub multiply and divide check values of attribute used in engines abilities(default value of 'value' can be checked when not specified)
+		//who return numericals value but can also check in non-engine abilities(in last case if 'value' not specified none value can matches)
 		if(!filter["value"].empty()){
 			if(tag_name == "drains"){
 				if(!int_matches_if_present(filter, cfg, "value", 50)){
@@ -1936,6 +1969,35 @@ namespace
 			return false;
 
 		if(!double_matches_if_present(filter, cfg, "divide"))
+			return false;
+
+
+		//apply_to is a special case, in resistance ability, it check a list of damage type used by [resistance]
+		//but in weapon specials, check identity of unit affected by special(self, opponent tc...)
+		if(tag_name == "resistance"){
+			if(!set_includes_if_present(filter, cfg, "apply_to")){
+				return false;
+			}
+		} else {
+			if(!string_matches_if_present(filter, cfg, "apply_to", "self")){
+				return false;
+			}
+		}
+
+		//the three attribute below are used for check in specifics abilitie:
+		//replacement_type and alternative_type are present in [damage_type] only for engine abilities
+		//and type for [plague], but if someone want use this in non-engine abilities, these attribute can be checked outside type mentioned.
+		//
+
+		//for damage_type only(in engine cases)
+		if(!string_matches_if_present(filter, cfg, "replacement_type", ""))
+			return false;
+
+		if(!string_matches_if_present(filter, cfg, "alternative_type", ""))
+			return false;
+
+		//for plague only(in engine cases)
+		if(!string_matches_if_present(filter, cfg, "type", ""))
 			return false;
 
 		//the wml_filter is used in cases where the attribute we are looking for is not

--- a/src/units/ability_tags.hpp
+++ b/src/units/ability_tags.hpp
@@ -1,0 +1,75 @@
+/*
+	Copyright (C) 2024 - 2024
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "enum_base.hpp"
+
+#include <set>
+
+struct ability_list_defines
+{
+    // abilities
+    static constexpr const char* const heals = "heals";
+    static constexpr const char* const regenerate = "regenerate";
+    static constexpr const char* const resistance = "resistance";
+    static constexpr const char* const leadership = "leadership";
+    static constexpr const char* const skirmisher = "skirmisher";
+    static constexpr const char* const illuminates = "illuminates";
+    static constexpr const char* const teleport = "teleport";
+    static constexpr const char* const hides = "hides";
+    static constexpr const char* const dummy = "dummy";
+    // weapon specials
+    static constexpr const char* const attacks = "attacks";
+    static constexpr const char* const berserk = "berserk";
+    static constexpr const char* const chance_to_hit = "chance_to_hit";
+    static constexpr const char* const damage = "damage";
+    static constexpr const char* const damage_type = "damage_type";
+    static constexpr const char* const disable = "disable";
+    static constexpr const char* const drains = "drains";
+    static constexpr const char* const firststrike = "firststrike";
+    static constexpr const char* const heal_on_hit = "heal_on_hit";
+    static constexpr const char* const petrifies = "petrifies";
+    static constexpr const char* const plague = "plague";
+    static constexpr const char* const poison = "poison";
+    static constexpr const char* const slow = "slow";
+    static constexpr const char* const swarm = "swarm";
+
+    ENUM_AND_ARRAY(heals, regenerate, resistance, leadership, skirmisher, illuminates, teleport, hides, dummy, attacks, berserk, chance_to_hit, damage, damage_type, disable, drains, firststrike, heal_on_hit, petrifies, plague, poison, slow, swarm)
+
+    static const std::set<std::string> weapon_number_tags()
+    {
+        static std::set<std::string> tags{attacks, damage, chance_to_hit, berserk, swarm, drains, heal_on_hit};
+        return tags;
+    }
+
+    static const std::set<std::string> no_weapon_number_tags()
+    {
+        static std::set<std::string> tags{disable, plague, slow, petrifies, firststrike, poison, damage_type};
+        return tags;
+    }
+
+    static const std::set<std::string> ability_value_tags()
+    {
+        static std::set<std::string> tags{resistance, leadership, heals, regenerate, illuminates};
+        return tags;
+    }
+
+    static const std::set<std::string> ability_no_value_tags()
+    {
+        static std::set<std::string> tags{teleport, hides, skirmisher};
+        return tags;
+    }
+};
+using abilities_list = string_enums::enum_base<ability_list_defines>;

--- a/src/utils/config_filters.cpp
+++ b/src/utils/config_filters.cpp
@@ -38,18 +38,13 @@ bool utils::config_filters::string_matches_if_present(
 	}
 
 	const std::vector<std::string> filter_attribute = utils::split(filter[attribute]);
-	return (
-		std::find(filter_attribute.begin(), filter_attribute.end(), cfg[attribute].str(def)) != filter_attribute.end());
+	return std::find(filter_attribute.begin(), filter_attribute.end(), cfg[attribute].str(def)) != filter_attribute.end();
 }
 
 bool utils::config_filters::set_includes_if_present(const config& filter, const config& cfg, const std::string& attribute)
 {
 	if(!filter.has_attribute(attribute)) {
 		return true;
-	}
-
-	if(!cfg.has_attribute(attribute)) {
-		return false;
 	}
 
 	const std::set<std::string> filter_attribute = utils::split_set(filter[attribute].str());
@@ -67,9 +62,6 @@ bool utils::config_filters::unsigned_matches_if_present(const config& filter, co
 	if(!filter.has_attribute(attribute)) {
 		return true;
 	}
-	if(!cfg.has_attribute(attribute)) {
-		return false;
-	}
 
 	return in_ranges<int>(cfg[attribute].to_int(0), utils::parse_ranges_unsigned(filter[attribute].str()));
 }
@@ -79,7 +71,7 @@ bool utils::config_filters::int_matches_if_present(const config& filter, const c
 	if(!filter.has_attribute(attribute)) {
 		return true;
 	}
-	if(!cfg.has_attribute(attribute) && !def) {
+	if(!def) {
 		return false;
 	}
 
@@ -120,7 +112,7 @@ bool utils::config_filters::double_matches_if_present(const config& filter, cons
 	if(!filter.has_attribute(attribute)) {
 		return true;
 	}
-	if(!cfg.has_attribute(attribute) && !def) {
+	if(!def) {
 		return false;
 	}
 


### PR DESCRIPTION
abilities.cpp changes taken from #9361 by newfrenchy

---

Removing the `cfg` checks from `config_filters.cpp` currently breaks the WML unit tests, so that still needs to be fixed. Supercedes #9361.