### PR TITLE
give 'neutral' alignment' to scepter of fire and rod of justice

### DIFF
--- a/changelog_entries/give_neutral_to_scepter_of_fire_rod_of_justive.md
+++ b/changelog_entries/give_neutral_to_scepter_of_fire_rod_of_justive.md
@@ -1,0 +1,12 @@
+### Campaigns
+  * Heir to the Throne
+    * Fighter, Commander and Lord have neutral alignment to the Scepter of Fire and make damage equals to Princess and Battle Princess Scepter of fire.
+  * Eastern Invasion
+    * Scepter of Fire have damage increased from 15 to 16 for be equals to level 3 user of Httt campaign and greater what Ruby of fire of TRoW 
+    * Scepter of Fire alignment remain neutral regardless of unit alignment of user.
+  * Northern Rebirth
+    * The attack given by Rod of Justice have neutral alignment.
+  * The Rise of Wesnoth
+    * Ruby of fire become neutral and damage increased from 14 to 15 for compensate lack of Tod bonus/malus.
+
+

--- a/data/campaigns/Heir_To_The_Throne/units/Commander.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Commander.cfg
@@ -109,11 +109,12 @@
             description= _"sceptre of fire"
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
             icon=attacks/fireball.png
-            damage=16
+            damage=14
             number=4
         [/attack]
         {DEFENSE_ANIM_FILTERED "units/konrad-commander-scepter-defend.png" "units/konrad-commander-scepter.png" {SOUND_LIST:HUMAN_HIT} (

--- a/data/campaigns/Heir_To_The_Throne/units/Fighter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Fighter.cfg
@@ -65,6 +65,7 @@
             description= _"sceptre of fire"
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]

--- a/data/campaigns/Heir_To_The_Throne/units/Lord.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Lord.cfg
@@ -132,11 +132,12 @@
             description= _"sceptre of fire"
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
             icon=attacks/fireball.png
-            damage=18
+            damage=16
             number=4
         [/attack]
         [attack_anim]

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_01_The_Pursuit.cfg
@@ -1439,6 +1439,7 @@
                             description= _ "rod of justice"
                             type=fire
                             range=ranged
+                            alignment=neutral
                             damage=16
                             number=4
                             icon=attacks/lightning.png

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/12_A_Final_Spring.cfg
@@ -346,10 +346,11 @@
                 icon=attacks/fireball.png
                 type=fire
                 range=ranged
+                alignment=neutral
                 [specials]
                     {WEAPON_SPECIAL_MAGICAL}
                 [/specials]
-                damage=14
+                damage=15
                 number=4
             [/effect]
 

--- a/data/core/macros/items.cfg
+++ b/data/core/macros/items.cfg
@@ -584,10 +584,11 @@
         icon=attacks/fireball.png
         type=fire
         range=ranged
+        alignment=neutral
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=15
+        damage=16
         number=4
     [/effect]
 


### PR DESCRIPTION
This item have great power of their own, is should not depend of alignment of user.