### PR TITLE
Lint for unnecessary pass by values and lack of std::move usage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks:          '-*,modernize-use-nullptr'
+Checks:          '-*,modernize-use-nullptr,performance-unnecessary-value-param'
 WarningsAsErrors: true
 ...

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -77,7 +77,7 @@ battle_context_unit_stats::battle_context_unit_stats(nonempty_unit_const_ptr up,
 		bool attacking,
 		nonempty_unit_const_ptr oppp,
 		const map_location& opp_loc,
-		const_attack_ptr opp_weapon)
+		const const_attack_ptr& opp_weapon)
 	: weapon(nullptr)
 	, attack_num(u_attack_num)
 	, is_attacker(attacking)
@@ -229,7 +229,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		const_attack_ptr att_weapon,
 		bool attacking,
 		const unit_type* opp_type,
-		const_attack_ptr opp_weapon,
+		const const_attack_ptr& opp_weapon,
 		unsigned int opp_terrain_defense,
 		int lawful_bonus)
 	: weapon(att_weapon)
@@ -523,7 +523,7 @@ bool battle_context::better_combat(const combatant& us_a,
 }
 
 battle_context battle_context::choose_attacker_weapon(nonempty_unit_const_ptr attacker,
-		nonempty_unit_const_ptr defender,
+		const nonempty_unit_const_ptr& defender,
 		const map_location& attacker_loc,
 		const map_location& defender_loc,
 		double harm_weight,

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -20,6 +20,8 @@
 
 #include "actions/attack.hpp"
 
+#include <utility>
+
 #include "actions/advancement.hpp"
 #include "actions/vision.hpp"
 
@@ -232,7 +234,7 @@ battle_context_unit_stats::battle_context_unit_stats(const unit_type* u_type,
 		const const_attack_ptr& opp_weapon,
 		unsigned int opp_terrain_defense,
 		int lawful_bonus)
-	: weapon(att_weapon)
+	: weapon(std::move(att_weapon))
 	, attack_num(-2) // This is and stays invalid. Always use weapon when using this constructor.
 	, is_attacker(attacking)
 	, is_poisoned(false)
@@ -1590,7 +1592,7 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	unit_ability_list abil = u.get_abilities_weapons("leadership", loc, weapon, opp_weapon);
+	unit_ability_list abil = u.get_abilities_weapons("leadership", loc, std::move(weapon), std::move(opp_weapon));
 	unit_abilities::effect leader_effect(abil, 0, nullptr, unit_abilities::EFFECT_CUMULABLE);
 	return leader_effect.get_composite_value();
 }

--- a/src/actions/attack.hpp
+++ b/src/actions/attack.hpp
@@ -85,14 +85,14 @@ struct battle_context_unit_stats
 			bool attacking,
 			nonempty_unit_const_ptr opp,
 			const map_location& opp_loc,
-			const_attack_ptr opp_weapon);
+			const const_attack_ptr& opp_weapon);
 
 	/** Used by AI for combat analysis, and by statistics_dialog */
 	battle_context_unit_stats(const unit_type* u_type,
 			const_attack_ptr att_weapon,
 			bool attacking,
 			const unit_type* opp_type,
-			const_attack_ptr opp_weapon,
+			const const_attack_ptr& opp_weapon,
 			unsigned int opp_terrain_defense,
 			int lawful_bonus = 0);
 
@@ -227,7 +227,7 @@ private:
 			int defender_weapon);
 
 	static battle_context choose_attacker_weapon(nonempty_unit_const_ptr attacker,
-			nonempty_unit_const_ptr defender,
+			const nonempty_unit_const_ptr& defender,
 			const map_location& attacker_loc,
 			const map_location& defender_loc,
 			double harm_weight,

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -127,7 +127,7 @@ namespace { // Helpers for get_recalls()
 	 * that can be skipped (because they are already in @a result), and the
 	 * underlying ID of units added to @a result will be added to @a already_added.
 	 */
-	void add_leader_filtered_recalls(const unit_const_ptr leader,
+	void add_leader_filtered_recalls(const unit_const_ptr& leader,
 	                                 std::vector< unit_const_ptr > & result,
 	                                 std::set<std::size_t> * already_added = nullptr)
 	{
@@ -617,7 +617,7 @@ namespace { // Helpers for place_recruit()
 	}
 }// anonymous namespace
 //Used by recalls and recruits
-place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_location, const map_location& recruited_from,
+place_recruit_result place_recruit(const unit_ptr& u, const map_location &recruit_location, const map_location& recruited_from,
 	int cost, bool is_recall, map_location::direction facing, bool show, bool fire_event, bool full_movement,
 	bool wml_triggered)
 {

--- a/src/actions/create.hpp
+++ b/src/actions/create.hpp
@@ -158,7 +158,7 @@ typedef std::tuple<bool /*event modified*/, int /*previous village owner side*/,
  * @param wml_triggered whether this was triggered via WML.
  * @returns true if an event (or fog clearing) has mutated the game state.
  */
-place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_location, const map_location& recruited_from,
+place_recruit_result place_recruit(const unit_ptr& u, const map_location &recruit_location, const map_location& recruited_from,
 	int cost, bool is_recall, map_location::direction facing = map_location::direction::indeterminate, bool show = false, bool fire_event = true, bool full_movement = false, bool wml_triggered = false);
 
 /**

--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -85,7 +85,7 @@ void undo_list::add_auto_shroud(bool turned_on)
 /**
  * Adds a dismissal to the undo stack.
  */
-void undo_list::add_dismissal(const unit_const_ptr u)
+void undo_list::add_dismissal(const unit_const_ptr& u)
 {
 	add(std::make_unique<undo::dismiss_action>(u));
 }
@@ -93,7 +93,7 @@ void undo_list::add_dismissal(const unit_const_ptr u)
 /**
  * Adds a move to the undo stack.
  */
-void undo_list::add_move(const unit_const_ptr u,
+void undo_list::add_move(const unit_const_ptr& u,
                          const std::vector<map_location>::const_iterator & begin,
                          const std::vector<map_location>::const_iterator & end,
                          int start_moves,
@@ -105,7 +105,7 @@ void undo_list::add_move(const unit_const_ptr u,
 /**
  * Adds a recall to the undo stack.
  */
-void undo_list::add_recall(const unit_const_ptr u, const map_location& loc,
+void undo_list::add_recall(const unit_const_ptr& u, const map_location& loc,
                            const map_location& from)
 {
 	add(std::make_unique<undo::recall_action>(u, loc, from));
@@ -114,7 +114,7 @@ void undo_list::add_recall(const unit_const_ptr u, const map_location& loc,
 /**
  * Adds a recruit to the undo stack.
  */
-void undo_list::add_recruit(const unit_const_ptr u, const map_location& loc,
+void undo_list::add_recruit(const unit_const_ptr& u, const map_location& loc,
                             const map_location& from)
 {
 	add(std::make_unique<undo::recruit_action>(u, loc, from));

--- a/src/actions/undo.hpp
+++ b/src/actions/undo.hpp
@@ -49,18 +49,18 @@ public:
 	/** Adds an auto-shroud toggle to the undo stack. */
 	void add_auto_shroud(bool turned_on);
 	/** Adds a dismissal to the undo stack. */
-	void add_dismissal(const unit_const_ptr u);
+	void add_dismissal(const unit_const_ptr& u);
 	/** Adds a move to the undo stack. */
-	void add_move(const unit_const_ptr u,
+	void add_move(const unit_const_ptr& u,
 	              const std::vector<map_location>::const_iterator & begin,
 	              const std::vector<map_location>::const_iterator & end,
 	              int start_moves,
 	              const map_location::direction dir=map_location::direction::indeterminate);
 	/** Adds a recall to the undo stack. */
-	void add_recall(const unit_const_ptr u, const map_location& loc,
+	void add_recall(const unit_const_ptr& u, const map_location& loc,
 	                const map_location& from);
 	/** Adds a recruit to the undo stack. */
-	void add_recruit(const unit_const_ptr u, const map_location& loc,
+	void add_recruit(const unit_const_ptr& u, const map_location& loc,
 	                 const map_location& from);
 
 	template<class T, class... Args>

--- a/src/actions/undo_dismiss_action.cpp
+++ b/src/actions/undo_dismiss_action.cpp
@@ -20,7 +20,7 @@
 
 namespace actions::undo
 {
-dismiss_action::dismiss_action(const unit_const_ptr dismissed)
+dismiss_action::dismiss_action(const unit_const_ptr& dismissed)
 	: undo_action()
 	, dismissed_unit(dismissed->clone())
 {

--- a/src/actions/undo_dismiss_action.hpp
+++ b/src/actions/undo_dismiss_action.hpp
@@ -22,7 +22,7 @@ struct dismiss_action : undo_action
 {
 	unit_ptr dismissed_unit;
 
-	explicit dismiss_action(const unit_const_ptr dismissed);
+	explicit dismiss_action(const unit_const_ptr& dismissed);
 	explicit dismiss_action(const config& cfg);
 
 	static const char* get_type_impl() { return "dismiss"; }

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -29,7 +29,7 @@ static lg::log_domain log_engine("engine");
 
 namespace actions::undo
 {
-move_action::move_action(const unit_const_ptr moved,
+move_action::move_action(const unit_const_ptr& moved,
 			const std::vector<map_location>::const_iterator & begin,
 			const std::vector<map_location>::const_iterator & end,
 			int sm, const map_location::direction dir)

--- a/src/actions/undo_move_action.hpp
+++ b/src/actions/undo_move_action.hpp
@@ -27,7 +27,7 @@ struct move_action : undo_action, shroud_clearing_action
 	map_location goto_hex;
 
 
-	move_action(const unit_const_ptr moved,
+	move_action(const unit_const_ptr& moved,
 	            const std::vector<map_location>::const_iterator & begin,
 	            const std::vector<map_location>::const_iterator & end,
 	            int sm, const map_location::direction dir);

--- a/src/actions/undo_recall_action.cpp
+++ b/src/actions/undo_recall_action.cpp
@@ -32,7 +32,7 @@ static lg::log_domain log_engine("engine");
 
 namespace actions::undo
 {
-recall_action::recall_action(const unit_const_ptr recalled, const map_location& loc,
+recall_action::recall_action(const unit_const_ptr& recalled, const map_location& loc,
 			  const map_location& from)
 	: undo_action()
 	, shroud_clearing_action(recalled, loc)

--- a/src/actions/undo_recall_action.hpp
+++ b/src/actions/undo_recall_action.hpp
@@ -26,7 +26,7 @@ struct recall_action : undo_action, shroud_clearing_action
 	map_location recall_from;
 
 
-	recall_action(const unit_const_ptr recalled, const map_location& loc,
+	recall_action(const unit_const_ptr& recalled, const map_location& loc,
 				  const map_location& from);
 	recall_action(const config & cfg);
 

--- a/src/actions/undo_recruit_action.cpp
+++ b/src/actions/undo_recruit_action.cpp
@@ -31,7 +31,7 @@ static lg::log_domain log_engine("engine");
 
 namespace actions::undo
 {
-recruit_action::recruit_action(const unit_const_ptr recruited, const map_location& loc,
+recruit_action::recruit_action(const unit_const_ptr& recruited, const map_location& loc,
 			   const map_location& from)
 	: undo_action()
 	, shroud_clearing_action(recruited, loc)

--- a/src/actions/undo_recruit_action.hpp
+++ b/src/actions/undo_recruit_action.hpp
@@ -30,7 +30,7 @@ struct recruit_action : undo_action, shroud_clearing_action
 	map_location recruit_from;
 
 
-	recruit_action(const unit_const_ptr recruited, const map_location& loc,
+	recruit_action(const unit_const_ptr& recruited, const map_location& loc,
 	               const map_location& from);
 	recruit_action(const config & cfg);
 

--- a/src/addon/manager.cpp
+++ b/src/addon/manager.cpp
@@ -306,7 +306,7 @@ static void unarchive_file(const std::string& path, const config& cfg)
 	filesystem::write_file(path + '/' + cfg["name"].str(), unencode_binary(cfg["contents"]));
 }
 
-static void unarchive_dir(const std::string& path, const config& cfg, std::function<void()> file_callback = {})
+static void unarchive_dir(const std::string& path, const config& cfg, const std::function<void()>& file_callback = {})
 {
 	std::string dir;
 	if (cfg["name"].empty())

--- a/src/ai/composite/ai.cpp
+++ b/src/ai/composite/ai.cpp
@@ -102,7 +102,7 @@ void ai_composite::create_engine(std::vector<engine_ptr> &engines, const config 
 	engine::parse_engine_from_config(*this,cfg,std::back_inserter(engines));
 }
 
-void ai_composite::replace_aspect(std::map<std::string,aspect_ptr> &aspects, const config &cfg, std::string id)
+void ai_composite::replace_aspect(std::map<std::string,aspect_ptr> &aspects, const config &cfg, const std::string& id)
 {
 	std::vector<aspect_ptr> temp_aspects;
 	engine::parse_aspect_from_config(*this,cfg,id,std::back_inserter(temp_aspects));

--- a/src/ai/composite/ai.hpp
+++ b/src/ai/composite/ai.hpp
@@ -75,7 +75,7 @@ public:
 
 	void create_engine(std::vector<engine_ptr> &engines, const config &cfg);
 
-	void replace_aspect(std::map<std::string,aspect_ptr> &aspects, const config &cfg, std::string id);
+	void replace_aspect(std::map<std::string,aspect_ptr> &aspects, const config &cfg, const std::string& id);
 
 	void on_create();
 

--- a/src/ai/composite/goal.cpp
+++ b/src/ai/composite/goal.cpp
@@ -53,6 +53,8 @@ void goal::on_create()
 	LOG_AI_GOAL << "side " << get_side() << " : " << " created goal with name=[" << cfg_["name"] << "]";
 }
 
+// In this case, the API is intended to cause an error with this specific type.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void goal::on_create(std::shared_ptr<ai::lua_ai_context>)
 {
 	unrecognized();

--- a/src/ai/default/attack.cpp
+++ b/src/ai/default/attack.cpp
@@ -40,7 +40,7 @@ static lg::log_domain log_ai("ai/attack");
 
 namespace ai {
 
-extern ai_context& get_ai_context(wfl::const_formula_callable_ptr for_fai);
+extern ai_context& get_ai_context(const wfl::const_formula_callable_ptr& for_fai);
 
 void attack_analysis::analyze(const gamemap& map, unit_map& units,
                               const readonly_context& ai_obj,

--- a/src/ai/default/recruitment.cpp
+++ b/src/ai/default/recruitment.cpp
@@ -1093,7 +1093,7 @@ struct attack_simulation {
 
 	attack_simulation(const unit_type* attacker, const unit_type* defender,
 			double attacker_defense, double defender_defense,
-			const_attack_ptr att_weapon, const_attack_ptr def_weapon,
+			const const_attack_ptr& att_weapon, const const_attack_ptr& def_weapon,
 			int average_lawful_bonus) :
 			attacker_type(attacker),
 			defender_type(defender),

--- a/src/ai/formula/ai.cpp
+++ b/src/ai/formula/ai.cpp
@@ -173,7 +173,7 @@ std::string formula_ai::evaluate(const std::string& formula_str)
 	}
 }
 
-wfl::variant formula_ai::make_action(wfl::const_formula_ptr formula_, const wfl::formula_callable& variables)
+wfl::variant formula_ai::make_action(const wfl::const_formula_ptr& formula_, const wfl::formula_callable& variables)
 {
 	if (!formula_) {
 		throw formula_error("null formula passed to make_action","","formula",0);
@@ -250,7 +250,7 @@ pathfind::teleport_map formula_ai::get_allowed_teleports(unit_map::iterator& uni
 	return pathfind::get_teleport_locations(*unit_it, current_team(), true);
 }
 
-void formula_ai::add_formula_function(const std::string& name, const_formula_ptr formula, const_formula_ptr precondition, const std::vector<std::string>& args)
+void formula_ai::add_formula_function(const std::string& name, const const_formula_ptr& formula, const const_formula_ptr& precondition, const std::vector<std::string>& args)
 {
 	function_table_.add_function(name, std::make_shared<user_formula_function>(name, formula, precondition, args));
 }
@@ -655,13 +655,13 @@ void formula_ai::on_create(){
 
 }
 
-void formula_ai::evaluate_candidate_action(ca_ptr fai_ca)
+void formula_ai::evaluate_candidate_action(const ca_ptr& fai_ca)
 {
 	fai_ca->evaluate(this,resources::gameboard->units());
 
 }
 
-bool formula_ai::execute_candidate_action(ca_ptr fai_ca)
+bool formula_ai::execute_candidate_action(const ca_ptr& fai_ca)
 {
 	map_formula_callable callable(fake_ptr());
 	fai_ca->update_callable_map( callable );

--- a/src/ai/formula/ai.hpp
+++ b/src/ai/formula/ai.hpp
@@ -77,7 +77,7 @@ public:
 
 	std::string evaluate(const std::string& formula_str);
 
-	virtual void add_formula_function(const std::string& name, wfl::const_formula_ptr formula, wfl::const_formula_ptr precondition, const std::vector<std::string>& args);
+	virtual void add_formula_function(const std::string& name, const wfl::const_formula_ptr& formula, const wfl::const_formula_ptr& precondition, const std::vector<std::string>& args);
 
 #if 0
 	//class responsible for looking for possible infinite loops when calling set_var or set_unit_var
@@ -133,18 +133,18 @@ public:
 	wfl::candidate_action_ptr load_candidate_action_from_config(const config& cfg);
 
 	/** Evaluate the fai candidate action */
-	void evaluate_candidate_action(wfl::candidate_action_ptr fai_ca);
+	void evaluate_candidate_action(const wfl::candidate_action_ptr& fai_ca);
 
 	/**
 	 * Execute the fai candidate action
 	 * @return true if game state was changed
 	 * @return false if game state was not changed
 	 */
-	bool execute_candidate_action(wfl::candidate_action_ptr fai_ca);
+	bool execute_candidate_action(const wfl::candidate_action_ptr& fai_ca);
 
 	void set_ai_context(ai_context *context);
 
-	wfl::variant make_action(wfl::const_formula_ptr formula_, const wfl::formula_callable& variables);
+	wfl::variant make_action(const wfl::const_formula_ptr& formula_, const wfl::formula_callable& variables);
 
 private:
 	ai_context *ai_ptr_;
@@ -165,7 +165,7 @@ private:
 	mutable wfl::ai_function_symbol_table function_table_;
 
 	friend class ai_default;
-	friend ai_context& get_ai_context(wfl::const_formula_callable_ptr for_fai);
+	friend ai_context& get_ai_context(const wfl::const_formula_callable_ptr& for_fai);
 };
 
 } //end of namespace ai

--- a/src/ai/formula/callable_objects.cpp
+++ b/src/ai/formula/callable_objects.cpp
@@ -34,7 +34,7 @@ static lg::log_domain log_formula_ai("ai/engine/fai");
 
 namespace ai {
 
-ai_context& get_ai_context(wfl::const_formula_callable_ptr for_fai) {
+ai_context& get_ai_context(const wfl::const_formula_callable_ptr& for_fai) {
 	auto fai = std::dynamic_pointer_cast<const formula_ai>(for_fai);
 	assert(fai != nullptr);
 	return *std::const_pointer_cast<formula_ai>(fai)->ai_ptr_;

--- a/src/ai/formula/candidates.cpp
+++ b/src/ai/formula/candidates.cpp
@@ -75,7 +75,7 @@ candidate_action_with_filters::candidate_action_with_filters(
 	}
 }
 
-variant candidate_action_with_filters::do_filtering(ai::formula_ai* ai, variant& input, const_formula_ptr formula)
+variant candidate_action_with_filters::do_filtering(ai::formula_ai* ai, variant& input, const const_formula_ptr& formula)
 {
 	map_formula_callable callable(ai->fake_ptr());
 	callable.add("input", input);

--- a/src/ai/formula/candidates.hpp
+++ b/src/ai/formula/candidates.hpp
@@ -72,7 +72,7 @@ class candidate_action_with_filters : public base_candidate_action {
 public:
 	candidate_action_with_filters(const std::string& name, const std::string& type,const config& cfg, function_symbol_table* function_table);
 protected:
-	variant do_filtering(ai::formula_ai* ai, variant& input, const_formula_ptr formula);
+	variant do_filtering(ai::formula_ai* ai, variant& input, const const_formula_ptr& formula);
 
 	candidate_action_filters filter_map_;
 };

--- a/src/ai/formula/engine_fai.cpp
+++ b/src/ai/formula/engine_fai.cpp
@@ -20,11 +20,13 @@
 
 #include "ai/formula/ai.hpp"
 #include "ai/formula/engine_fai.hpp"
+
 #include "ai/composite/rca.hpp"
 #include "ai/formula/candidates.hpp"
 #include "ai/formula/stage_side_formulas.hpp"
 #include "ai/formula/stage_unit_formulas.hpp"
 #include "log.hpp"
+#include <utility>
 
 namespace ai {
 
@@ -36,7 +38,7 @@ static lg::log_domain log_ai_engine_fai("ai/engine/fai");
 class fai_candidate_action_wrapper : public candidate_action {
 public:
 	fai_candidate_action_wrapper( rca_context &context, const config &cfg, wfl::candidate_action_ptr fai_ca, formula_ai &_formula_ai )
-		: candidate_action(context,cfg),fai_ca_(fai_ca),formula_ai_(_formula_ai),cfg_(cfg)
+		: candidate_action(context,cfg),fai_ca_(std::move(fai_ca)),formula_ai_(_formula_ai),cfg_(cfg)
 	{
 
 }

--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -125,7 +125,7 @@ void lua_ai_context::push_ai_table()
 	lua_ai_load ctx(*this, false);
 }
 
-static int transform_ai_action(lua_State *L, ai::action_result_ptr action_result)
+static int transform_ai_action(lua_State *L, const ai::action_result_ptr& action_result)
 {
 	lua_newtable(L);
 	lua_pushboolean(L,action_result->is_ok());
@@ -1098,7 +1098,7 @@ lua_ai_context::~lua_ai_context()
 	lua_pop(L, 1);
 }
 
-void lua_ai_action_handler::handle(const config &cfg, const config &filter_own, bool read_only, lua_object_ptr l_obj)
+void lua_ai_action_handler::handle(const config &cfg, const config &filter_own, bool read_only, const lua_object_ptr& l_obj)
 {
 	int initial_top = lua_gettop(L);//get the old stack size
 

--- a/src/ai/lua/core.hpp
+++ b/src/ai/lua/core.hpp
@@ -80,7 +80,7 @@ private:
 public:
 	~lua_ai_action_handler();
 	//void handle(const config &cfg, bool read_only, lua_object_ptr l_obj);
-	void handle(const config &cfg, const config &filter_own, bool read_only, lua_object_ptr l_obj);
+	void handle(const config &cfg, const config &filter_own, bool read_only, const lua_object_ptr& l_obj);
 	friend class ::game_lua_kernel;
 };
 

--- a/src/ai/testing.cpp
+++ b/src/ai/testing.cpp
@@ -78,7 +78,7 @@ void ai_testing::log_draw()
 	resources::recorder->add_log_data("ai_log","result","draw");
 }
 
-void ai_testing::log_victory(std::set<unsigned int> winners)
+void ai_testing::log_victory(const std::set<unsigned int>& winners)
 {
 	resources::recorder->add_log_data("ai_log","result","victory");
 	for(std::set<unsigned int>::const_iterator w = winners.begin(); w != winners.end(); ++w) {

--- a/src/ai/testing.hpp
+++ b/src/ai/testing.hpp
@@ -42,7 +42,7 @@ public:
 	 * Log in case of victory
 	 * teams vector of winner teams
 	 */
-	static void log_victory( std::set<unsigned int> teams );
+	static void log_victory( const std::set<unsigned int>& teams );
 
 	/*
 	 * Log at game start

--- a/src/attack_prediction.cpp
+++ b/src/attack_prediction.cpp
@@ -2053,8 +2053,8 @@ void complex_fight(attack_prediction_mode mode,
 		double& self_not_hit,
 		double& opp_not_hit,
 		bool levelup_considered,
-		std::vector<combat_slice> split,
-		std::vector<combat_slice> opp_split,
+		const std::vector<combat_slice>& split,
+		const std::vector<combat_slice>& opp_split,
 		double initially_slowed_chance,
 		double opp_initially_slowed_chance)
 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -651,7 +651,7 @@ void config::remove_child(config_key_type key, std::size_t index)
 	remove_child(i, index);
 }
 
-void config::remove_children(config_key_type key, std::function<bool(const config&)> p)
+void config::remove_children(config_key_type key, const std::function<bool(const config&)>& p)
 {
 	child_map::iterator pos = children_.find(key);
 	if(pos == children_.end()) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -626,7 +626,7 @@ public:
 	 * Removes all children with tag @a key for which @a p returns true.
 	 * If no predicate is provided, all @a key tags will be removed.
 	 */
-	void remove_children(config_key_type key, std::function<bool(const config&)> p = {});
+	void remove_children(config_key_type key, const std::function<bool(const config&)>& p = {});
 
 	void recursive_clear_value(config_key_type key);
 

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -94,14 +94,14 @@ void config_cache::get_config(const std::string& file_path, config& cfg, abstrac
 	load_configs(file_path, cfg, validator);
 }
 
-void config_cache::write_file(std::string file_path, const config& cfg)
+void config_cache::write_file(const std::string& file_path, const config& cfg)
 {
 	filesystem::scoped_ostream stream = filesystem::ostream_file(file_path);
 	config_writer writer(*stream, true, game_config::cache_compression_level);
 	writer.write(cfg);
 }
 
-void config_cache::write_file(std::string file_path, const preproc_map& defines)
+void config_cache::write_file(const std::string& file_path, const preproc_map& defines)
 {
 	if(defines.empty()) {
 		if(filesystem::file_exists(file_path)) {

--- a/src/config_cache.hpp
+++ b/src/config_cache.hpp
@@ -160,8 +160,8 @@ private:
 	std::string cache_file_prefix_;
 
 	void read_file(const std::string& file, config& cfg);
-	void write_file(std::string file, const config& cfg);
-	void write_file(std::string file, const preproc_map& defines);
+	void write_file(const std::string& file, const config& cfg);
+	void write_file(const std::string& file, const preproc_map& defines);
 
 	void read_cache(const std::string& path, config& cfg, abstract_validator* validator = nullptr);
 

--- a/src/desktop/paths.cpp
+++ b/src/desktop/paths.cpp
@@ -197,7 +197,7 @@ std::ostream& operator<<(std::ostream& os, const path_info& pinf)
 	return os << pinf.name << " [" << pinf.label << "] - " << pinf.path;
 }
 
-std::vector<path_info> game_paths(std::set<GAME_PATH_TYPES> paths)
+std::vector<path_info> game_paths(const std::set<GAME_PATH_TYPES>& paths)
 {
 	static const std::string& game_bin_dir = pretty_path(filesystem::get_exe_dir());
 	static const std::string& game_data_dir = pretty_path(game_config::path);
@@ -225,7 +225,7 @@ std::vector<path_info> game_paths(std::set<GAME_PATH_TYPES> paths)
 	return res;
 }
 
-std::vector<path_info> system_paths(std::set<SYSTEM_PATH_TYPES> paths)
+std::vector<path_info> system_paths(const std::set<SYSTEM_PATH_TYPES>& paths)
 {
 	static const std::string& home_dir = user_profile_dir();
 

--- a/src/desktop/paths.hpp
+++ b/src/desktop/paths.hpp
@@ -74,7 +74,7 @@ enum SYSTEM_PATH_TYPES
  * These paths are guaranteed to be their canonical forms (with links and dot
  * entries resolved) and using the platform's preferred path delimiter.
  */
-std::vector<path_info> game_paths(std::set<GAME_PATH_TYPES> paths);
+std::vector<path_info> game_paths(const std::set<GAME_PATH_TYPES>& paths);
 
 /**
  * Returns a list of system-defined paths.
@@ -87,7 +87,7 @@ std::vector<path_info> game_paths(std::set<GAME_PATH_TYPES> paths);
  * These paths are guaranteed to be their canonical forms (with links and dot
  * entries resolved) and using the platform's preferred path delimiter.
  */
-std::vector<path_info> system_paths(std::set<SYSTEM_PATH_TYPES> paths);
+std::vector<path_info> system_paths(const std::set<SYSTEM_PATH_TYPES>& paths);
 
 struct bookmark_info
 {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -149,7 +149,7 @@ display::display(const display_context* dc,
 		const config& level)
 	: dc_(dc)
 	, halo_man_()
-	, wb_(wb)
+	, wb_(std::move(wb))
 	, exclusive_unit_draw_requests_()
 	, viewing_team_index_(0)
 	, dont_show_all_(false)
@@ -1257,7 +1257,7 @@ uint32_t generate_hex_key(const drawing_layer layer, const map_location& loc)
 
 void display::drawing_buffer_add(const drawing_layer layer, const map_location& loc, decltype(draw_helper::do_draw) draw_func)
 {
-	drawing_buffer_.AGGREGATE_EMPLACE(generate_hex_key(layer, loc), draw_func, get_location_rect(loc));
+	drawing_buffer_.AGGREGATE_EMPLACE(generate_hex_key(layer, loc), std::move(draw_func), get_location_rect(loc));
 }
 
 void display::drawing_buffer_commit()

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2317,7 +2317,7 @@ void display::queue_repaint()
 	draw_manager::invalidate_all();
 }
 
-void display::add_redraw_observer(std::function<void(display&)> f)
+void display::add_redraw_observer(const std::function<void(display&)>& f)
 {
 	redraw_observers_.push_back(f);
 }

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -382,7 +382,7 @@ public:
 
 	/** Adds a redraw observer, a function object to be called when a
 	  * full rerender is queued. */
-	void add_redraw_observer(std::function<void(display&)> f);
+	void add_redraw_observer(const std::function<void(display&)>& f);
 
 	/** Clear the redraw observers */
 	void clear_redraw_observers();

--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -297,7 +297,7 @@ void editor_controller::custom_tods_dialog()
 	}
 }
 
-void editor_controller::update_map_schedule(std::vector<time_of_day> schedule)
+void editor_controller::update_map_schedule(const std::vector<time_of_day>& schedule)
 {
 	get_current_map_context().replace_schedule(schedule);
 	gui_->update_tod();

--- a/src/editor/controller/editor_controller.hpp
+++ b/src/editor/controller/editor_controller.hpp
@@ -87,7 +87,7 @@ class editor_controller : public controller_base,
 		void custom_tods_dialog();
 
 		/** Updates schedule and the map display */
-		void update_map_schedule(std::vector<time_of_day> schedule);
+		void update_map_schedule(const std::vector<time_of_day>& schedule);
 
 		/** Save the map, open dialog if not named yet. */
 		void save_map() override {context_manager_->save_map();}

--- a/src/editor/toolkit/editor_toolkit.cpp
+++ b/src/editor/toolkit/editor_toolkit.cpp
@@ -146,7 +146,7 @@ void editor_toolkit::clear_mouseover_overlay()
 	gui_.clear_mouseover_hex_overlay();
 }
 
-void editor_toolkit::set_brush(std::string id) {
+void editor_toolkit::set_brush(const std::string& id) {
 
 	for (brush& i : brushes_) {
 		if (i.id() == id) {

--- a/src/editor/toolkit/editor_toolkit.hpp
+++ b/src/editor/toolkit/editor_toolkit.hpp
@@ -74,7 +74,7 @@ public:
 	/** Cycle to the next brush. */
 	void cycle_brush();
 
-	void set_brush(std::string id);
+	void set_brush(const std::string& id);
 
 	bool is_active_brush(std::string id) const { return brush_->id() == id; }
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1395,7 +1395,7 @@ std::string normalize_path(const std::string& fpath, bool normalize_separators, 
 	}
 }
 
-bool to_asset_path(std::string& path, std::string addon_id, std::string asset_type)
+bool to_asset_path(std::string& path, const std::string& addon_id, const std::string& asset_type)
 {
 	std::string rel_path = "";
 	std::string core_asset_dir = get_dir(game_config::path + "/data/core/" + asset_type);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -59,6 +59,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <set>
+#include <utility>
 
 // Copied from boost::predef, as it's there only since 1.55.
 #if defined(__APPLE__) && defined(__MACH__) && defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__)
@@ -807,7 +808,7 @@ bool rename_dir(const std::string& old_dir, const std::string& new_dir)
 
 static void set_cache_path(bfs::path newcache)
 {
-	cache_dir = newcache;
+	cache_dir = std::move(newcache);
 	if(!create_directory_if_missing_recursive(cache_dir)) {
 		ERR_FS << "could not open or create cache directory at " << cache_dir.string() << '\n';
 	}

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -378,8 +378,8 @@ std::string normalize_path(const std::string& path,
 
 /** Helper function to convert absolute path to wesnoth relative path */
 bool to_asset_path(std::string& abs_path,
-                   std::string addon_id,
-                   std::string asset_type);
+                   const std::string& addon_id,
+                   const std::string& asset_type);
 
 /**
  * Sanitizes a path to remove references to the user's name.

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -436,7 +436,7 @@ void pango_text::add_attribute_fg_color(const unsigned start_offset, const unsig
 	}
 }
 
-void pango_text::add_attribute_font_family(const unsigned start_offset, const unsigned end_offset, std::string family)
+void pango_text::add_attribute_font_family(const unsigned start_offset, const unsigned end_offset, const std::string& family)
 {
 	attribute_start_offset_ = start_offset;
 	attribute_end_offset_ = end_offset;

--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -382,7 +382,7 @@ public:
  	 * @param end_offset          Byte index of the cursor where size change ends
  	 * @param family              The font family
 	 */
-	void add_attribute_font_family(const unsigned start_offset, const unsigned end_offset, std::string family);
+	void add_attribute_font_family(const unsigned start_offset, const unsigned end_offset, const std::string& family);
 
 	/** Clears all attributes from the global attribute list */
 	void clear_attribute_list();

--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -1198,7 +1198,7 @@ static void parse_set_args(const tk::token* i1, const tk::token* i2,
 	}
 }
 
-static void parse_where_clauses(const tk::token* i1, const tk::token* i2, expr_table_ptr res, function_symbol_table* symbols)
+static void parse_where_clauses(const tk::token* i1, const tk::token* i2, const expr_table_ptr& res, function_symbol_table* symbols)
 {
 	int parens = 0;
 	const tk::token* original_i1_cached = i1;

--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <set>
 #include <sstream>
+#include <utility>
 
 // This is here only for the below initialization code.
 // If other logging is required in this file, it should use a different logdomain
@@ -405,7 +406,7 @@ class unary_operator_expression : public formula_expression
 public:
 	unary_operator_expression(const std::string& op, expression_ptr arg)
 		: op_(),op_str_(op)
-		, operand_(arg)
+		, operand_(std::move(arg))
 	{
 		if(op == "not") {
 			op_ = NOT;
@@ -620,7 +621,7 @@ class dot_expression : public formula_expression
 {
 public:
 	dot_expression(expression_ptr left, expression_ptr right)
-		: left_(left), right_(right)
+		: left_(std::move(left)), right_(std::move(right))
 	{}
 
 	std::string str() const
@@ -667,7 +668,7 @@ class square_bracket_expression : public formula_expression
 {
 public:
 	square_bracket_expression(expression_ptr left, expression_ptr key)
-		: left_(left), key_(key)
+		: left_(std::move(left)), key_(std::move(key))
 	{}
 
 	std::string str() const
@@ -696,7 +697,7 @@ class operator_expression : public formula_expression
 {
 public:
 	operator_expression(const std::string& op, expression_ptr left, expression_ptr right)
-		: op_(OP(op[0])), op_str_(op), left_(left), right_(right)
+		: op_(OP(op[0])), op_str_(op), left_(std::move(left)), right_(std::move(right))
 	{
 		if(op == ">=") {
 			op_ = GTE;
@@ -812,7 +813,7 @@ public:
 	where_variables(const formula_callable &base, expr_table_ptr table, formula_debugger* fdb)
 		: formula_callable(false)
 		, base_(base)
-		, table_(table)
+		, table_(std::move(table))
 		, evaluated_table_()
 		, debugger_(fdb)
 	{
@@ -853,7 +854,7 @@ class where_expression: public formula_expression
 {
 public:
 	where_expression(expression_ptr body, expr_table_ptr clauses)
-		: body_(body), clauses_(clauses)
+		: body_(std::move(body)), clauses_(std::move(clauses))
 	{}
 
 	std::string str() const

--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -1542,7 +1542,7 @@ function_expression_ptr user_formula_function::generate_function_expression(
 	return std::make_shared<formula_function_expression>(name_, args, formula_, precondition_, args_);
 }
 
-function_symbol_table::function_symbol_table(std::shared_ptr<function_symbol_table> parent)
+function_symbol_table::function_symbol_table(const std::shared_ptr<function_symbol_table>& parent)
 	: parent(parent ? parent : get_builtins())
 {
 }
@@ -1670,7 +1670,7 @@ std::shared_ptr<function_symbol_table> function_symbol_table::get_builtins()
 	return std::shared_ptr<function_symbol_table>(&functions_table, [](function_symbol_table*) {});
 }
 
-action_function_symbol_table::action_function_symbol_table(std::shared_ptr<function_symbol_table> parent)
+action_function_symbol_table::action_function_symbol_table(const std::shared_ptr<function_symbol_table>& parent)
 	: function_symbol_table(parent)
 {
 	using namespace actions;

--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -28,6 +28,7 @@
 #include <cctype>
 #include <chrono>
 #include <deque>
+#include <utility>
 
 using namespace boost::math::constants;
 
@@ -1483,8 +1484,8 @@ formula_function_expression::formula_function_expression(const std::string& name
 		const_formula_ptr precondition,
 		const std::vector<std::string>& arg_names)
 	: function_expression(name, args, arg_names.size(), arg_names.size())
-	, formula_(formula)
-	, precondition_(precondition)
+	, formula_(std::move(formula))
+	, precondition_(std::move(precondition))
 	, arg_names_(arg_names)
 	, star_arg_(-1)
 {

--- a/src/formula/function.hpp
+++ b/src/formula/function.hpp
@@ -232,7 +232,7 @@ typedef std::map<std::string, formula_function_ptr> functions_map;
 class function_symbol_table
 {
 public:
-	explicit function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
+	explicit function_symbol_table(const std::shared_ptr<function_symbol_table>& parent = nullptr);
 
 	void add_function(const std::string& name, formula_function_ptr&& fcn);
 
@@ -260,7 +260,7 @@ private:
 class action_function_symbol_table : public function_symbol_table
 {
 public:
-	action_function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
+	action_function_symbol_table(const std::shared_ptr<function_symbol_table>& parent = nullptr);
 };
 
 class wrapper_formula : public formula_expression

--- a/src/formula/function_gamestate.cpp
+++ b/src/formula/function_gamestate.cpp
@@ -443,7 +443,7 @@ DEFINE_WFL_FUNCTION(base_tod_bonus, 0, 2)
 
 } // namespace gamestate
 
-gamestate_function_symbol_table::gamestate_function_symbol_table(std::shared_ptr<function_symbol_table> parent) : function_symbol_table(parent) {
+gamestate_function_symbol_table::gamestate_function_symbol_table(const std::shared_ptr<function_symbol_table>& parent) : function_symbol_table(parent) {
 	using namespace gamestate;
 	function_symbol_table& functions_table = *this;
 	DECLARE_WFL_FUNCTION(get_unit_type);

--- a/src/formula/function_gamestate.cpp
+++ b/src/formula/function_gamestate.cpp
@@ -14,7 +14,9 @@
 */
 
 #include "formula/function_gamestate.hpp"
+
 #include "formula/callable_objects.hpp"
+#include <utility>
 
 #include "resources.hpp"
 #include "game_board.hpp"

--- a/src/formula/function_gamestate.hpp
+++ b/src/formula/function_gamestate.hpp
@@ -19,7 +19,7 @@ namespace wfl {
 
 class gamestate_function_symbol_table : public function_symbol_table {
 public:
-	gamestate_function_symbol_table(std::shared_ptr<function_symbol_table> parent = nullptr);
+	gamestate_function_symbol_table(const std::shared_ptr<function_symbol_table>& parent = nullptr);
 };
 
 }

--- a/src/formula/tokenizer.cpp
+++ b/src/formula/tokenizer.cpp
@@ -25,7 +25,7 @@ namespace tokenizer
 
 namespace {
 
-[[noreturn]] void raise_exception(iterator& i1, iterator i2, std::string str) {
+[[noreturn]] void raise_exception(iterator& i1, iterator i2, const std::string& str) {
 	std::ostringstream expr;
 	while( (i1 != i2) && (*i1 != '\n') ) {
 		if( (*i1 != '\t') )

--- a/src/formula/variant_value.cpp
+++ b/src/formula/variant_value.cpp
@@ -15,6 +15,8 @@
 #include "formula/variant.hpp"
 #include "formula/variant_value.hpp"
 
+#include <utility>
+
 #include "formula/callable.hpp"
 #include "formula/function.hpp"
 
@@ -77,7 +79,7 @@ std::string variant_decimal::to_string_impl(const bool sign_value) const
 }
 
 variant_callable::variant_callable(const_formula_callable_ptr callable)
-	: callable_(callable)
+	: callable_(std::move(callable))
 {
 	if(callable_) {
 		callable_->subscribe_dtor(this);
@@ -298,7 +300,7 @@ variant_list::variant_list(const variant_vector& vec)
 
 variant variant_list::list_op(value_base_ptr second, const std::function<variant(variant&, variant&)>& op_func)
 {
-	const auto& other_list = value_cast<variant_list>(second);
+	const auto& other_list = value_cast<variant_list>(std::move(second));
 
 	if(num_elements() != other_list->num_elements()) {
 		throw type_error("List op requires two lists of the same length");

--- a/src/formula/variant_value.cpp
+++ b/src/formula/variant_value.cpp
@@ -296,7 +296,7 @@ variant_list::variant_list(const variant_vector& vec)
 {
 }
 
-variant variant_list::list_op(value_base_ptr second, std::function<variant(variant&, variant&)> op_func)
+variant variant_list::list_op(value_base_ptr second, const std::function<variant(variant&, variant&)>& op_func)
 {
 	const auto& other_list = value_cast<variant_list>(second);
 

--- a/src/formula/variant_value.hpp
+++ b/src/formula/variant_value.hpp
@@ -493,7 +493,7 @@ public:
 	/**
 	 * Applies the provided function to the corresponding variants in this and another list.
 	 */
-	variant list_op(value_base_ptr second, std::function<variant(variant&, variant&)> op_func);
+	variant list_op(value_base_ptr second, const std::function<variant(variant&, variant&)>& op_func);
 
 	virtual bool equals(variant_value_base& other) const override;
 	virtual bool less_than(variant_value_base& other) const override;

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -283,7 +283,7 @@ bool game_board::team_is_defeated(const team& t) const
 	}
 }
 
-bool game_board::try_add_unit_to_recall_list(const map_location&, const unit_ptr u)
+bool game_board::try_add_unit_to_recall_list(const map_location&, const unit_ptr& u)
 {
 	get_team(u->side()).recall_list().add(u);
 	return true;

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -152,7 +152,7 @@ public:
 
 	// Manipulator from actionwml
 
-	bool try_add_unit_to_recall_list(const map_location& loc, const unit_ptr u);
+	bool try_add_unit_to_recall_list(const map_location& loc, const unit_ptr& u);
 	utils::optional<std::string> replace_map(const gamemap & r);
 
 	bool change_terrain(const map_location &loc, const std::string &t, const std::string & mode, bool replace_if_failed); //used only by lua and debug commands

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -278,7 +278,7 @@ void load_config(const config &v)
 	std::vector<std::string> zoom_levels_str = utils::split(v["zoom_levels"]);
 	if(!zoom_levels_str.empty()) {
 		zoom_levels.clear();
-		std::transform(zoom_levels_str.begin(), zoom_levels_str.end(), std::back_inserter(zoom_levels), [](const std::string zoom) {
+		std::transform(zoom_levels_str.begin(), zoom_levels_str.end(), std::back_inserter(zoom_levels), [](const std::string& zoom) {
 			int z = std::stoi(zoom);
 			if((z / 4) * 4 != z) {
 				ERR_NG << "zoom level " << z << " is not divisible by 4."

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -756,7 +756,7 @@ void game_config_manager::load_game_config_for_create(bool is_mp, bool is_test)
 	}
 }
 
-void game_config_manager::set_enabled_addon(std::set<std::string> addon_ids)
+void game_config_manager::set_enabled_addon(const std::set<std::string>& addon_ids)
 {
 	auto& vec = game_config_view_.data();
 	vec.clear();

--- a/src/game_config_manager.hpp
+++ b/src/game_config_manager.hpp
@@ -60,7 +60,7 @@ public:
 	static game_config_manager * get();
 
 private:
-	void set_enabled_addon(std::set<std::string> addon_ids);
+	void set_enabled_addon(const std::set<std::string>& addon_ids);
 	void set_enabled_addon_all();
 
 	void load_game_config(bool reload_everything, const game_classification* classification, const std::string& scenario_id);

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -20,6 +20,8 @@
 
 #include "game_display.hpp"
 
+#include <utility>
+
 
 #include "cursor.hpp"
 #include "display_chat_manager.hpp"
@@ -63,7 +65,7 @@ game_display::game_display(game_board& board,
 		reports& reports_object,
 		const std::string& theme_id,
 		const config& level)
-	: display(&board, wb, reports_object, theme_id, level)
+	: display(&board, std::move(wb), reports_object, theme_id, level)
 	, overlay_map_()
 	, attack_indicator_src_()
 	, attack_indicator_dst_()

--- a/src/game_events/manager.cpp
+++ b/src/game_events/manager.cpp
@@ -202,7 +202,7 @@ void manager::write_events(config& cfg, bool include_nonserializable) const
 	wml_menu_items_.to_config(cfg);
 }
 
-void manager::execute_on_events(const std::string& event_id, manager::event_func_t func)
+void manager::execute_on_events(const std::string& event_id, const manager::event_func_t& func)
 {
 	const std::string standardized_event_id = event_handlers::standardize_name(event_id);
 	const game_data* gd = resources::gamedata;

--- a/src/game_events/manager.hpp
+++ b/src/game_events/manager.hpp
@@ -77,7 +77,7 @@ public:
 	void write_events(config& cfg, bool include_nonserializable=false) const;
 
 	using event_func_t = std::function<void(game_events::manager&, handler_ptr&)>;
-	void execute_on_events(const std::string& event_id, event_func_t func);
+	void execute_on_events(const std::string& event_id, const event_func_t& func);
 
 	bool is_event_running() const;
 

--- a/src/game_events/manager_impl.cpp
+++ b/src/game_events/manager_impl.cpp
@@ -76,7 +76,7 @@ std::string event_handlers::standardize_name(const std::string& name)
 	return retval;
 }
 
-bool event_handlers::cmp(const handler_ptr lhs, const handler_ptr rhs)
+bool event_handlers::cmp(const handler_ptr& lhs, const handler_ptr& rhs)
 {
 	return lhs->priority() < rhs->priority();
 }
@@ -117,7 +117,7 @@ pending_event_handler event_handlers::add_event_handler(const std::string& name,
 	return {*this, handler};
 }
 
-void event_handlers::finish_adding_event_handler(handler_ptr handler)
+void event_handlers::finish_adding_event_handler(const handler_ptr& handler)
 {
 	// Someone decided to register an empty event... bail.
 	if(handler->empty()) {
@@ -204,7 +204,7 @@ void event_handlers::clean_up_expired_handlers(const std::string& event_name)
 
 	// And finally remove any now-unlockable weak_ptrs from the with-variables name list.
 	dynamic_.remove_if(
-		[](weak_handler_ptr ptr) { return ptr.expired(); }
+		[](const weak_handler_ptr& ptr) { return ptr.expired(); }
 	);
 }
 

--- a/src/game_events/manager_impl.hpp
+++ b/src/game_events/manager_impl.hpp
@@ -78,14 +78,14 @@ private:
 	void log_handlers();
 
 	friend pending_event_handler;
-	void finish_adding_event_handler(handler_ptr new_handler);
+	void finish_adding_event_handler(const handler_ptr& new_handler);
 
 public:
 	/** Utility to standardize the event names used in by_name_. */
 	static std::string standardize_name(const std::string& name);
 
 	/** Compare function to sort event handlers by priority. */
-	static bool cmp(const handler_ptr lhs, const handler_ptr rhs);
+	static bool cmp(const handler_ptr& lhs, const handler_ptr& rhs);
 
 	event_handlers()
 		: active_()

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -369,7 +369,7 @@ std::multimap<std::string, config> side_engine::get_side_children()
 	return children;
 }
 
-void side_engine::set_side_children(std::multimap<std::string, config> children)
+void side_engine::set_side_children(const std::multimap<std::string, config>& children)
 {
 	for(const std::string& children_to_remove : children_to_swap) {
 		cfg_.clear_children(children_to_remove);

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -196,7 +196,7 @@ public:
 	unsigned team() const { return team_; }
 	void set_team(unsigned team) { team_ = team; }
 	std::multimap<std::string, config> get_side_children();
-	void set_side_children(std::multimap<std::string, config> children);
+	void set_side_children(const std::multimap<std::string, config>& children);
 	int color() const { return color_; }
 	void set_color(int color) { color_ = color; color_id_ = color_options_[color]; }
 	int gold() const { return gold_; }

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -617,7 +617,7 @@ std::vector<create_engine::extras_metadata_ptr> create_engine::active_mods_data(
 	const std::vector<extras_metadata_ptr>& mods = get_const_extras_by_type(MP_EXTRA::MOD);
 
 	std::vector<extras_metadata_ptr> data_vec;
-	std::copy_if(mods.begin(), mods.end(), std::back_inserter(data_vec), [this](extras_metadata_ptr mod) {
+	std::copy_if(mods.begin(), mods.end(), std::back_inserter(data_vec), [this](const extras_metadata_ptr& mod) {
 		return dependency_manager_->is_modification_active(mod->id);
 	});
 

--- a/src/game_initialization/depcheck.cpp
+++ b/src/game_initialization/depcheck.cpp
@@ -430,7 +430,7 @@ bool manager::is_modification_active(int index) const
 	return std::find(mods_.begin(), mods_.end(), id) != mods_.end();
 }
 
-bool manager::is_modification_active(const std::string id) const
+bool manager::is_modification_active(const std::string& id) const
 {
 	return std::find(mods_.begin(), mods_.end(), id) != mods_.end();
 }

--- a/src/game_initialization/depcheck.hpp
+++ b/src/game_initialization/depcheck.hpp
@@ -138,7 +138,7 @@ public:
 	 *
 	 * @return true if activated, false is not
 	 */
-	bool is_modification_active(const std::string id) const;
+	bool is_modification_active(const std::string& id) const;
 
 	/**
 	 * Returns the selected era

--- a/src/game_initialization/multiplayer.cpp
+++ b/src/game_initialization/multiplayer.cpp
@@ -113,7 +113,7 @@ private:
 	};
 
 	/** Opens a new server connection and prompts the client for login credentials, if necessary. */
-	std::unique_ptr<wesnothd_connection> open_connection(std::string host);
+	std::unique_ptr<wesnothd_connection> open_connection(const std::string& host);
 
 	/** Opens the MP lobby. */
 	bool enter_lobby_mode();
@@ -152,7 +152,7 @@ public:
 		return session_info;
 	}
 
-	auto add_network_handler(decltype(process_handlers)::value_type func)
+	auto add_network_handler(const decltype(process_handlers)::value_type& func)
 	{
 		return [this, iter = process_handlers.insert(process_handlers.end(), func)]() { process_handlers.erase(iter); };
 	}
@@ -216,7 +216,7 @@ mp_manager::mp_manager(const utils::optional<std::string> host)
 	manager = this;
 }
 
-std::unique_ptr<wesnothd_connection> mp_manager::open_connection(std::string host)
+std::unique_ptr<wesnothd_connection> mp_manager::open_connection(const std::string& host)
 {
 	DBG_MP << "opening connection";
 
@@ -832,7 +832,7 @@ void send_to_server(const config& data)
 	}
 }
 
-network_registrar::network_registrar(handler func)
+network_registrar::network_registrar(const handler& func)
 {
 	if(manager /*&& manager->connection*/) {
 		remove_handler = manager->add_network_handler(func);

--- a/src/game_initialization/multiplayer.hpp
+++ b/src/game_initialization/multiplayer.hpp
@@ -80,7 +80,7 @@ class network_registrar
 public:
 	using handler = std::function<void(const config&)>;
 
-	network_registrar(handler func);
+	network_registrar(const handler& func);
 	~network_registrar();
 
 private:

--- a/src/game_initialization/singleplayer.cpp
+++ b/src/game_initialization/singleplayer.cpp
@@ -83,7 +83,7 @@ bool select_campaign(saved_game& state, jump_to_campaign_info jump_to_campaign)
 			// if we should quit the game or return to the main menu
 
 			// Checking for valid campaign name
-			const auto campaign = std::find_if(campaigns.begin(), campaigns.end(), [&jump_to_campaign](ng::create_engine::level_ptr level) {
+			const auto campaign = std::find_if(campaigns.begin(), campaigns.end(), [&jump_to_campaign](const ng::create_engine::level_ptr& level) {
 				return level->data()["id"] == jump_to_campaign.campaign_id;
 			});
 

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -80,7 +80,7 @@ namespace
 	class wesnoth_message_format : public bl::message_format<char>
 	{
 	public:
-		wesnoth_message_format(std::locale base, const std::set<std::string>& domains, const std::set<std::string>& paths)
+		wesnoth_message_format(const std::locale& base, const std::set<std::string>& domains, const std::set<std::string>& paths)
 			: base_loc_(base)
 		{
 			const bl::info& inf = std::use_facet<bl::info>(base);

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -278,7 +278,7 @@ private:
 	 *                            which to execute the hotkey callback, false
 	 *                            otherwise.
 	 */
-	bool hotkey_pressed(const hotkey::hotkey_ptr key);
+	bool hotkey_pressed(const hotkey::hotkey_ptr& key);
 
 	/**
 	 * Fires a key down event.
@@ -786,7 +786,7 @@ void sdl_event_handler::text_editing(const std::string& unicode, int32_t start, 
 	}
 }
 
-bool sdl_event_handler::hotkey_pressed(const hotkey::hotkey_ptr key)
+bool sdl_event_handler::hotkey_pressed(const hotkey::hotkey_ptr& key)
 {
 	if(dispatcher* dispatcher = keyboard_dispatcher()) {
 		return dispatcher->execute_hotkey(hotkey::get_hotkey_command(key->get_command()).command);

--- a/src/gui/core/static_registry.cpp
+++ b/src/gui/core/static_registry.cpp
@@ -21,6 +21,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <utility>
 
 namespace gui2
 {
@@ -48,7 +49,7 @@ std::map<std::string, registered_widget_parser>& registered_widget_types()
 
 void register_widget(const std::string& type, widget_parser_t f, const char* key)
 {
-	registered_widget_types()[type] = {f, key};
+	registered_widget_types()[type] = {std::move(f), key};
 }
 
 std::map<std::string, widget_builder_func_t>& widget_builder_lookup()

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -599,7 +599,7 @@ void addon_manager::load_addon_list()
 	apply_filters();
 }
 
-void addon_manager::reload_list_and_reselect_item(const std::string id)
+void addon_manager::reload_list_and_reselect_item(const std::string& id)
 {
 	load_addon_list();
 

--- a/src/gui/dialogs/addon/manager.hpp
+++ b/src/gui/dialogs/addon/manager.hpp
@@ -72,7 +72,7 @@ private:
 	void fetch_addons_list();
 	void load_addon_list();
 
-	void reload_list_and_reselect_item(const std::string id);
+	void reload_list_and_reselect_item(const std::string& id);
 
 	/** Config which contains the list with the campaigns. */
 	config cfg_;

--- a/src/gui/dialogs/attack_predictions.cpp
+++ b/src/gui/dialogs/attack_predictions.cpp
@@ -34,6 +34,7 @@
 #include "units/unit.hpp"
 
 #include <iomanip>
+#include <utility>
 
 namespace gui2::dialogs
 {
@@ -46,8 +47,8 @@ const unsigned int attack_predictions::graph_max_rows = 10;
 
 attack_predictions::attack_predictions(battle_context& bc, unit_const_ptr attacker, unit_const_ptr defender)
 	: modal_dialog(window_id())
-	, attacker_data_(attacker, bc.get_attacker_combatant(), bc.get_attacker_stats())
-	, defender_data_(defender, bc.get_defender_combatant(), bc.get_defender_stats())
+	, attacker_data_(std::move(attacker), bc.get_attacker_combatant(), bc.get_attacker_stats())
+	, defender_data_(std::move(defender), bc.get_defender_combatant(), bc.get_defender_stats())
 {
 }
 

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -58,7 +58,7 @@ static custom_tod::string_pair tod_getter_sound(const time_of_day& tod)
 
 REGISTER_DIALOG(custom_tod)
 
-custom_tod::custom_tod(const std::vector<time_of_day>& times, int current_time, const std::string addon_id)
+custom_tod::custom_tod(const std::vector<time_of_day>& times, int current_time, const std::string& addon_id)
 	: modal_dialog(window_id())
 	, addon_id_(addon_id)
 	, times_(times)
@@ -323,7 +323,7 @@ void custom_tod::update_selected_tod_info()
 	update_tod_display();
 }
 
-void custom_tod::copy_to_clipboard_callback(std::pair<std::string, tod_attribute_getter> data)
+void custom_tod::copy_to_clipboard_callback(const std::pair<std::string, tod_attribute_getter>& data)
 {
 	auto& [type, getter] = data;
 	button& copy_w = find_widget<button>("copy_" + type);

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -32,8 +32,9 @@
 #include "gui/widgets/text_box.hpp"
 #include "sound.hpp"
 
-#include <functional>
 #include <boost/filesystem.hpp>
+#include <functional>
+#include <utility>
 
 namespace gui2::dialogs
 {
@@ -363,7 +364,7 @@ const std::vector<time_of_day> custom_tod::get_schedule()
 
 void custom_tod::register_callback(std::function<void(std::vector<time_of_day>)> update_func)
 {
-	update_map_and_schedule_ = update_func;
+	update_map_and_schedule_ = std::move(update_func);
 }
 
 void custom_tod::post_show()

--- a/src/gui/dialogs/editor/custom_tod.hpp
+++ b/src/gui/dialogs/editor/custom_tod.hpp
@@ -30,7 +30,7 @@ namespace dialogs
 class custom_tod : public modal_dialog
 {
 public:
-	custom_tod(const std::vector<time_of_day>& times, int current_time, const std::string addon_id = "");
+	custom_tod(const std::vector<time_of_day>& times, int current_time, const std::string& addon_id = "");
 
 	/** The execute function. See @ref modal_dialog for more information. */
 	DEFINE_SIMPLE_EXECUTE_WRAPPER(custom_tod)
@@ -82,7 +82,7 @@ private:
 
 	void update_selected_tod_info();
 
-	void copy_to_clipboard_callback(std::pair<std::string, tod_attribute_getter> data);
+	void copy_to_clipboard_callback(const std::pair<std::string, tod_attribute_getter>& data);
 
 	/** Update current TOD with values from the GUI */
 	void update_schedule();

--- a/src/gui/dialogs/editor/edit_label.cpp
+++ b/src/gui/dialogs/editor/edit_label.cpp
@@ -52,7 +52,7 @@ void editor_edit_label::pre_show()
 	add_to_tab_order(find_widget<text_box>("category", false, true));
 }
 
-void editor_edit_label::register_color_component(std::string widget_id, uint8_t color_t::* component) {
+void editor_edit_label::register_color_component(const std::string& widget_id, uint8_t color_t::* component) {
 	register_integer(widget_id, true,
 					 std::bind(&editor_edit_label::load_color_component, this, component),
 					 std::bind(&editor_edit_label::save_color_component, this, component, std::placeholders::_1));

--- a/src/gui/dialogs/editor/edit_label.hpp
+++ b/src/gui/dialogs/editor/edit_label.hpp
@@ -51,7 +51,7 @@ private:
 	color_t& color_store;
 	int load_color_component(uint8_t color_t::* component);
 	void save_color_component(uint8_t color_t::* component, const int value);
-	void register_color_component(std::string widget_id, uint8_t color_t::* component);
+	void register_color_component(const std::string& widget_id, uint8_t color_t::* component);
 	virtual const std::string& window_id() const override;
 	virtual void pre_show() override;
 };

--- a/src/gui/dialogs/editor/edit_unit.cpp
+++ b/src/gui/dialogs/editor/edit_unit.cpp
@@ -844,7 +844,7 @@ void editor_edit_unit::load_movetype() {
 	tabs.select_tab(prev_tab);
 }
 
-void editor_edit_unit::write_macro(std::ostream& out, unsigned level, const std::string macro_name)
+void editor_edit_unit::write_macro(std::ostream& out, unsigned level, const std::string& macro_name)
 {
 	for(unsigned i = 0; i < level; i++)
 	{
@@ -1006,7 +1006,7 @@ void editor_edit_unit::update_image(const std::string& id_stem) {
 	queue_redraw();
 }
 
-bool editor_edit_unit::check_id(std::string id) {
+bool editor_edit_unit::check_id(const std::string& id) {
 	for(char c : id) {
 		if (!(std::isalnum(c) || c == '_' || c == ' ')) {
 			// One bad char means entire id string is invalid

--- a/src/gui/dialogs/editor/edit_unit.hpp
+++ b/src/gui/dialogs/editor/edit_unit.hpp
@@ -83,7 +83,7 @@ private:
 	void save_unit_type();
 
 	/** Write macro to a stream at specified tab level */
-	void write_macro(std::ostream& out, unsigned level, const std::string macro_name);
+	void write_macro(std::ostream& out, unsigned level, const std::string& macro_name);
 
 	/** Update wml preview */
 	void update_wml_view();
@@ -132,7 +132,7 @@ private:
 	void quit_confirmation();
 
 	/** Utility method to check if ID contains any invalid characters */
-	bool check_id(std::string id);
+	bool check_id(const std::string& id);
 
 	void set_selected_from_string(menu_button& list, std::vector<config> values, std::string item) {
 		for (unsigned i = 0; i < values.size(); ++i) {

--- a/src/gui/dialogs/editor/resize_map.cpp
+++ b/src/gui/dialogs/editor/resize_map.cpp
@@ -84,7 +84,7 @@ static int resize_grid_xy_to_idx(const int x, const int y)
 	}
 }
 
-void editor_resize_map::set_direction_icon(int index, std::string icon)
+void editor_resize_map::set_direction_icon(int index, const std::string& icon)
 {
 	if(index < 9) {
 		direction_buttons_[index]->set_icon_name("icons/arrows/arrows_blank_"

--- a/src/gui/dialogs/editor/resize_map.hpp
+++ b/src/gui/dialogs/editor/resize_map.hpp
@@ -102,7 +102,7 @@ private:
 
 	void update_expand_direction();
 
-	void set_direction_icon(int index, std::string icon);
+	void set_direction_icon(int index, const std::string& icon);
 
 	virtual void pre_show() override;
 

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -53,7 +53,7 @@ inline std::string config_to_string(const config& cfg)
 	return s.str();
 }
 
-inline std::string config_to_string(const config& cfg, std::string only_children)
+inline std::string config_to_string(const config& cfg, const std::string& only_children)
 {
 	config filtered;
 	for(const config& child : cfg.child_range(only_children)) {

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -32,6 +32,7 @@
 
 #include <chrono>
 #include <functional>
+#include <utility>
 
 static lg::log_domain log_loadscreen("loadscreen");
 #define LOG_LS LOG_STREAM(info, log_loadscreen)
@@ -77,7 +78,7 @@ loading_screen* loading_screen::singleton_ = nullptr;
 
 loading_screen::loading_screen(std::function<void()> f)
 	: modal_dialog(window_id())
-	, load_funcs_{f}
+	, load_funcs_{std::move(f)}
 	, worker_result_()
 	, cursor_setter_()
 	, progress_stage_label_(nullptr)

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -212,7 +212,7 @@ loading_screen::~loading_screen()
 	singleton_ = nullptr;
 }
 
-void loading_screen::display(std::function<void()> f)
+void loading_screen::display(const std::function<void()>& f)
 {
 	if(singleton_ || video::headless()) {
 		LOG_LS << "Directly executing loading function.";

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -78,7 +78,7 @@ public:
 
 	~loading_screen();
 
-	static void display(std::function<void()> f);
+	static void display(const std::function<void()>& f);
 	static bool displaying() { return singleton_ != nullptr; }
 
 	/**

--- a/src/gui/dialogs/log_settings.cpp
+++ b/src/gui/dialogs/log_settings.cpp
@@ -136,7 +136,7 @@ void log_settings::post_show()
 	}
 }
 
-void log_settings::set_logger(const std::string log_domain)
+void log_settings::set_logger(const std::string& log_domain)
 {
 	std::string active_value = groups_[log_domain].get_active_member_value();
 

--- a/src/gui/dialogs/log_settings.hpp
+++ b/src/gui/dialogs/log_settings.hpp
@@ -38,7 +38,7 @@ public:
 	DEFINE_SIMPLE_DISPLAY_WRAPPER(log_settings)
 
 private:
-	void set_logger(const std::basic_string<char> log_domain);
+	void set_logger(const std::basic_string<char>& log_domain);
 
 	std::map<std::string, group<std::string>> groups_;
 	std::vector<std::string> domain_list_, widget_id_;

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -162,7 +162,7 @@ field_integer* modal_dialog::register_integer(
 		const std::string& id,
 		const bool mandatory,
 		const std::function<int()>& callback_load_value,
-		const std::function<void(const int)>& callback_save_value)
+		const std::function<void(int)>& callback_save_value)
 {
 	field_integer* field = new field_integer(
 			id, mandatory, callback_load_value, callback_save_value);

--- a/src/gui/dialogs/modal_dialog.cpp
+++ b/src/gui/dialogs/modal_dialog.cpp
@@ -73,8 +73,8 @@ bool modal_dialog::show(const unsigned auto_close_time)
 		if (pm && pm->any_running())
 		{
 			plugins_context pc("Dialog");
-			pc.set_callback("skip_dialog", [this](config) { retval_ = retval::OK; }, false);
-			pc.set_callback("quit", [](config) {}, false);
+			pc.set_callback("skip_dialog", [this](const config&) { retval_ = retval::OK; }, false);
+			pc.set_callback("quit", [](const config&) {}, false);
 			pc.play_slice();
 		}
 
@@ -128,9 +128,9 @@ T* modal_dialog::register_field(Args&&... args)
 field_bool* modal_dialog::register_bool(
 		const std::string& id,
 		const bool mandatory,
-		const std::function<bool()> callback_load_value,
-		const std::function<void(bool)> callback_save_value,
-		const std::function<void(widget&)> callback_change,
+		const std::function<bool()>& callback_load_value,
+		const std::function<void(bool)>& callback_save_value,
+		const std::function<void(widget&)>& callback_change,
 		const bool initial_fire)
 {
 	field_bool* field = new field_bool(id,
@@ -148,7 +148,7 @@ field_bool*
 modal_dialog::register_bool(const std::string& id,
 					   const bool mandatory,
 					   bool& linked_variable,
-					   const std::function<void(widget&)> callback_change,
+					   const std::function<void(widget&)>& callback_change,
 					   const bool initial_fire)
 {
 	field_bool* field
@@ -161,8 +161,8 @@ modal_dialog::register_bool(const std::string& id,
 field_integer* modal_dialog::register_integer(
 		const std::string& id,
 		const bool mandatory,
-		const std::function<int()> callback_load_value,
-		const std::function<void(const int)> callback_save_value)
+		const std::function<int()>& callback_load_value,
+		const std::function<void(const int)>& callback_save_value)
 {
 	field_integer* field = new field_integer(
 			id, mandatory, callback_load_value, callback_save_value);
@@ -184,8 +184,8 @@ field_integer* modal_dialog::register_integer(const std::string& id,
 field_text* modal_dialog::register_text(
 		const std::string& id,
 		const bool mandatory,
-		const std::function<std::string()> callback_load_value,
-		const std::function<void(const std::string&)> callback_save_value,
+		const std::function<std::string()>& callback_load_value,
+		const std::function<void(const std::string&)>& callback_save_value,
 		const bool capture_focus)
 {
 	field_text* field = new field_text(

--- a/src/gui/dialogs/modal_dialog.hpp
+++ b/src/gui/dialogs/modal_dialog.hpp
@@ -228,9 +228,9 @@ protected:
 	field_bool*
 	register_bool(const std::string& id,
 				  const bool mandatory,
-				  const std::function<bool()> callback_load_value = nullptr,
-				  const std::function<void(bool)> callback_save_value = nullptr,
-				  const std::function<void(widget&)> callback_change = nullptr,
+				  const std::function<bool()>& callback_load_value = nullptr,
+				  const std::function<void(bool)>& callback_save_value = nullptr,
+				  const std::function<void(widget&)>& callback_change = nullptr,
 				  const bool initial_fire = false);
 
 	/**
@@ -253,7 +253,7 @@ protected:
 	register_bool(const std::string& id,
 				  const bool mandatory,
 				  bool& linked_variable,
-				  const std::function<void(widget&)> callback_change = nullptr,
+				  const std::function<void(widget&)>& callback_change = nullptr,
 				  const bool initial_fire = false);
 
 	/**
@@ -264,8 +264,8 @@ protected:
 	field_integer*
 	register_integer(const std::string& id,
 					 const bool mandatory,
-					 const std::function<int()> callback_load_value = nullptr,
-					 const std::function<void(int)> callback_save_value = nullptr);
+					 const std::function<int()>& callback_load_value = nullptr,
+					 const std::function<void(int)>& callback_save_value = nullptr);
 
 	/**
 	 * Creates a new integer field.
@@ -283,8 +283,8 @@ protected:
 	field_text* register_text(
 			const std::string& id,
 			const bool mandatory,
-			const std::function<std::string()> callback_load_value = nullptr,
-			const std::function<void(const std::string&)> callback_save_value = nullptr,
+			const std::function<std::string()>& callback_load_value = nullptr,
+			const std::function<void(const std::string&)>& callback_save_value = nullptr,
 			const bool capture_focus = false);
 
 	/**

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -190,7 +190,7 @@ void faction_select::profile_button_callback()
 	}
 }
 
-void faction_select::on_gender_select(const std::string val)
+void faction_select::on_gender_select(const std::string& val)
 {
 	flg_manager_.set_current_gender(val);
 

--- a/src/gui/dialogs/multiplayer/faction_select.hpp
+++ b/src/gui/dialogs/multiplayer/faction_select.hpp
@@ -55,7 +55,7 @@ private:
 
 	void profile_button_callback();
 
-	void on_gender_select(const std::string val);
+	void on_gender_select(const std::string& val);
 
 	void update_leader_image();
 };

--- a/src/gui/dialogs/multiplayer/mp_connect.cpp
+++ b/src/gui/dialogs/multiplayer/mp_connect.cpp
@@ -66,7 +66,7 @@ mp_connect::mp_connect()
 	, host_name_(register_text("host_name",
 							   true,
 							   []() {return prefs::get().network_host();},
-							   [](std::string v) {prefs::get().set_network_host(v);},
+							   [](const std::string& v) {prefs::get().set_network_host(v);},
 							   true))
 	, builtin_servers_(prefs::get().builtin_servers_list())
 	, user_servers_(prefs::get().user_servers_list())

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -543,7 +543,7 @@ void mp_create_game::on_tab_select()
 	find_widget<stacked_widget>("pager").select_layer(i);
 }
 
-void mp_create_game::on_mod_toggle(const std::string id, toggle_button* sender)
+void mp_create_game::on_mod_toggle(const std::string& id, toggle_button* sender)
 {
 	if(sender && (sender->get_value_bool() == create_engine_.dependency_manager().is_modification_active(id))) {
 		ERR_MP << "ignoring on_mod_toggle that is already set";

--- a/src/gui/dialogs/multiplayer/mp_create_game.hpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.hpp
@@ -99,7 +99,7 @@ private:
 	void on_game_select();
 	void on_tab_select();
 	void on_era_select();
-	void on_mod_toggle(const std::string id, toggle_button* sender);
+	void on_mod_toggle(const std::string& id, toggle_button* sender);
 	void on_random_faction_mode_select();
 
 	std::vector<std::string> get_active_mods();

--- a/src/gui/dialogs/multiplayer/mp_login.cpp
+++ b/src/gui/dialogs/multiplayer/mp_login.cpp
@@ -35,7 +35,7 @@ mp_login::mp_login(const std::string& host, const std::string& label, const bool
 	register_label("login_label", false, label);
 	username_ = register_text("user_name", true,
 		[]() {return prefs::get().login();},
-		[](std::string v) {prefs::get().set_login(v);},
+		[](const std::string& v) {prefs::get().set_login(v);},
 		!focus_password);
 
 	register_bool("remember_password", false,

--- a/src/gui/dialogs/multiplayer/mp_staging.cpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.cpp
@@ -128,7 +128,7 @@ void mp_staging::pre_show()
 	plugins_context_->set_callback("chat",   [&chat](const config& cfg) { chat.send_chat_message(cfg["message"], false); }, true);
 }
 
-int mp_staging::get_side_node_position(ng::side_engine_ptr side) const
+int mp_staging::get_side_node_position(const ng::side_engine_ptr& side) const
 {
 	int position = 0;
 	for(const auto& side_engine : connect_engine_.side_engines()) {
@@ -141,7 +141,7 @@ int mp_staging::get_side_node_position(ng::side_engine_ptr side) const
 }
 
 template<typename... T>
-tree_view_node& mp_staging::add_side_to_team_node(ng::side_engine_ptr side, T&&... params)
+tree_view_node& mp_staging::add_side_to_team_node(const ng::side_engine_ptr& side, T&&... params)
 {
 	static const widget_data empty_map;
 
@@ -168,7 +168,7 @@ tree_view_node& mp_staging::add_side_to_team_node(ng::side_engine_ptr side, T&&.
 	return team_node->add_child(std::forward<T>(params)...);
 }
 
-void mp_staging::add_side_node(ng::side_engine_ptr side)
+void mp_staging::add_side_node(const ng::side_engine_ptr& side)
 {
 	widget_data data;
 	widget_item item;
@@ -373,7 +373,7 @@ void mp_staging::add_side_node(ng::side_engine_ptr side)
 	}
 }
 
-void mp_staging::on_controller_select(ng::side_engine_ptr side, grid& row_grid)
+void mp_staging::on_controller_select(const ng::side_engine_ptr& side, grid& row_grid)
 {
 	menu_button& ai_selection         = row_grid.find_widget<menu_button>("ai_controller");
 	menu_button& controller_selection = row_grid.find_widget<menu_button>("controller");
@@ -385,7 +385,7 @@ void mp_staging::on_controller_select(ng::side_engine_ptr side, grid& row_grid)
 	}
 }
 
-void mp_staging::on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu, const bool saved_game)
+void mp_staging::on_ai_select(const ng::side_engine_ptr& side, menu_button& ai_menu, const bool saved_game)
 {
 	// If this is a saved game, we need to reduce the index by one, to account for
 	// the "Keep saved AI" option having been added to the computer player menu
@@ -403,7 +403,7 @@ void mp_staging::on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu, co
 	set_state_changed();
 }
 
-void mp_staging::on_color_select(ng::side_engine_ptr side, grid& row_grid)
+void mp_staging::on_color_select(const ng::side_engine_ptr& side, grid& row_grid)
 {
 	side->set_color(row_grid.find_widget<menu_button>("side_color").get_value());
 
@@ -412,7 +412,7 @@ void mp_staging::on_color_select(ng::side_engine_ptr side, grid& row_grid)
 	set_state_changed();
 }
 
-void mp_staging::on_team_select(ng::side_engine_ptr side, menu_button& team_menu)
+void mp_staging::on_team_select(const ng::side_engine_ptr& side, menu_button& team_menu)
 {
 	// Since we're not necessarily displaying every every team in the menu, we can't just
 	// use the selected index to set a side's team. Instead, we grab the index we stored
@@ -451,7 +451,7 @@ void mp_staging::on_team_select(ng::side_engine_ptr side, menu_button& team_menu
 	set_state_changed();
 }
 
-void mp_staging::select_leader_callback(ng::side_engine_ptr side, grid& row_grid)
+void mp_staging::select_leader_callback(const ng::side_engine_ptr& side, grid& row_grid)
 {
 	if(gui2::dialogs::faction_select::execute(side->flg(), side->color_id(), side->index() + 1)) {
 		update_leader_display(side, row_grid);
@@ -461,14 +461,14 @@ void mp_staging::select_leader_callback(ng::side_engine_ptr side, grid& row_grid
 }
 
 template<void(ng::side_engine::*fptr)(int)>
-void mp_staging::on_side_slider_change(ng::side_engine_ptr side, slider& slider)
+void mp_staging::on_side_slider_change(const ng::side_engine_ptr& side, slider& slider)
 {
 	std::invoke(fptr, side, slider.get_value());
 
 	set_state_changed();
 }
 
-void mp_staging::update_leader_display(ng::side_engine_ptr side, grid& row_grid)
+void mp_staging::update_leader_display(const ng::side_engine_ptr& side, grid& row_grid)
 {
 	// BIG FAT TODO: get rid of this shitty "null" string value in the FLG manager
 	std::string current_leader = side->flg().current_leader() != "null" ? side->flg().current_leader() : font::unicode_em_dash;

--- a/src/gui/dialogs/multiplayer/mp_staging.hpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.hpp
@@ -52,9 +52,9 @@ private:
 	virtual void post_show() override;
 
 	template<typename... T>
-	tree_view_node& add_side_to_team_node(ng::side_engine_ptr side, T&&... params);
+	tree_view_node& add_side_to_team_node(const ng::side_engine_ptr& side, T&&... params);
 
-	void add_side_node(ng::side_engine_ptr side);
+	void add_side_node(const ng::side_engine_ptr& side);
 
 	/**
 	 * Find an appropriate position to insert a side node.
@@ -62,19 +62,19 @@ private:
 	 * This ensures the side nodes are always arranged by descending index order
 	 * in each team group.
 	 */
-	int get_side_node_position(ng::side_engine_ptr side) const;
+	int get_side_node_position(const ng::side_engine_ptr& side) const;
 
-	void on_controller_select(ng::side_engine_ptr side, grid& row_grid);
-	void on_ai_select(ng::side_engine_ptr side, menu_button& ai_menu, const bool saved_game);
-	void on_color_select(ng::side_engine_ptr side, grid& row_grid);
-	void on_team_select(ng::side_engine_ptr side, menu_button& team_menu);
+	void on_controller_select(const ng::side_engine_ptr& side, grid& row_grid);
+	void on_ai_select(const ng::side_engine_ptr& side, menu_button& ai_menu, const bool saved_game);
+	void on_color_select(const ng::side_engine_ptr& side, grid& row_grid);
+	void on_team_select(const ng::side_engine_ptr& side, menu_button& team_menu);
 
 	template<void(ng::side_engine::*fptr)(int)>
-	void on_side_slider_change(ng::side_engine_ptr side, slider& slider);
+	void on_side_slider_change(const ng::side_engine_ptr& side, slider& slider);
 
-	void select_leader_callback(ng::side_engine_ptr side, grid& row_grid);
+	void select_leader_callback(const ng::side_engine_ptr& side, grid& row_grid);
 
-	void update_leader_display(ng::side_engine_ptr side, grid& row_grid);
+	void update_leader_display(const ng::side_engine_ptr& side, grid& row_grid);
 	void update_status_label_and_buttons();
 
 	void network_handler();

--- a/src/gui/dialogs/screenshot_notification.cpp
+++ b/src/gui/dialogs/screenshot_notification.cpp
@@ -33,6 +33,7 @@
 
 #include <functional>
 #include <stdexcept>
+#include <utility>
 
 namespace gui2::dialogs
 {
@@ -43,7 +44,7 @@ screenshot_notification::screenshot_notification(const std::string& path, surfac
 	: modal_dialog(window_id())
 	, path_(path)
 	, screenshots_dir_path_(filesystem::get_screenshot_dir())
-	, screenshot_(screenshot)
+	, screenshot_(std::move(screenshot))
 {
 }
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -86,7 +86,7 @@ title_screen::~title_screen()
 {
 }
 
-void title_screen::register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, std::function<void()> callback)
+void title_screen::register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, const std::function<void()>& callback)
 {
 	if(hk != hotkey::HOTKEY_NULL) {
 		register_hotkey(hk, std::bind(callback));

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -71,7 +71,7 @@ private:
 
 	void init_callbacks();
 
-	void register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, std::function<void()> callback);
+	void register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, const std::function<void()>& callback);
 
 	/***** ***** ***** ***** Callbacks ***** ***** ****** *****/
 

--- a/src/gui/dialogs/unit_list.cpp
+++ b/src/gui/dialogs/unit_list.cpp
@@ -58,12 +58,12 @@ static std::string format_level_string(const int level)
 
 }
 
-static std::string format_if_leader(unit_const_ptr u, const std::string& str)
+static std::string format_if_leader(const unit_const_ptr& u, const std::string& str)
 {
 	return u->can_recruit() ? markup::span_color("#cdad00", str) : str;
 }
 
-static std::string format_movement_string(unit_const_ptr u)
+static std::string format_movement_string(const unit_const_ptr& u)
 {
 	const int moves_left = u->movement_left();
 	const int moves_max  = u->total_movement();

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -385,7 +385,7 @@ void addon_list::finalize_setup()
 	list.set_active_sorting_option(order);
 }
 
-void addon_list::set_addon_order(addon_sort_func func)
+void addon_list::set_addon_order(const addon_sort_func& func)
 {
 	listbox& list = get_listbox();
 

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -109,7 +109,7 @@ public:
 		get_listbox().set_row_shown(shown);
 	}
 
-	void set_addon_order(addon_sort_func func);
+	void set_addon_order(const addon_sort_func& func);
 
 	/**
 	 * Changes the color of an add-on state string (installed, outdated, etc.) according to the state itself.

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -45,7 +45,7 @@ REGISTER_WIDGET3(listbox_definition, grid_listbox, nullptr)
 
 listbox::listbox(const implementation::builder_styled_widget& builder,
 		const generator_base::placement placement,
-		builder_grid_ptr list_builder)
+		const builder_grid_ptr& list_builder)
 	: scrollbar_container(builder, type())
 	, generator_(nullptr)
 	, is_horizontal_(placement == generator_base::horizontal_list)
@@ -518,8 +518,8 @@ void listbox::handle_key_right_arrow(SDL_Keymod modifier, bool& handled)
 }
 
 void listbox::finalize(std::unique_ptr<generator_base> generator,
-		builder_grid_const_ptr header,
-		builder_grid_const_ptr footer,
+		const builder_grid_const_ptr& header,
+		const builder_grid_const_ptr& footer,
 		const std::vector<widget_data>& list_data)
 {
 	// "Inherited."
@@ -609,7 +609,7 @@ void listbox::set_column_order(unsigned col, const generator_sort_array& func)
 	orders_[col].second = func;
 }
 
-void listbox::register_translatable_sorting_option(const int col, translatable_sorter_func_t f)
+void listbox::register_translatable_sorting_option(const int col, const translatable_sorter_func_t& f)
 {
 	set_column_order(col, {{
 		[f](int lhs, int rhs) { return translation::icompare(f(lhs), f(rhs)) < 0; },

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -57,7 +57,7 @@ public:
 	 */
 	listbox(const implementation::builder_styled_widget& builder,
 			const generator_base::placement placement,
-			builder_grid_ptr list_builder);
+			const builder_grid_ptr& list_builder);
 
 	/***** ***** ***** ***** Row handling. ***** ***** ****** *****/
 
@@ -268,7 +268,7 @@ public:
 	using translatable_sorter_func_t = std::function<std::string(const int)>;
 
 	/** Registers a special sorting function specifically for translatable values. */
-	void register_translatable_sorting_option(const int col, translatable_sorter_func_t f);
+	void register_translatable_sorting_option(const int col, const translatable_sorter_func_t& f);
 
 	using order_pair = std::pair<int, sort_order::type>;
 
@@ -343,8 +343,8 @@ private:
 	 * @param list_data           The initial data to fill the listbox with.
 	 */
 	void finalize(std::unique_ptr<generator_base> generator,
-			builder_grid_const_ptr header,
-			builder_grid_const_ptr footer,
+			const builder_grid_const_ptr& header,
+			const builder_grid_const_ptr& footer,
 			const std::vector<widget_data>& list_data);
 
 	/**

--- a/src/gui/widgets/multimenu_button.cpp
+++ b/src/gui/widgets/multimenu_button.cpp
@@ -214,7 +214,7 @@ void multimenu_button::select_option(const unsigned option, const bool selected)
 	update_label();
 }
 
-void multimenu_button::select_options(boost::dynamic_bitset<> states)
+void multimenu_button::select_options(const boost::dynamic_bitset<>& states)
 {
 	assert(states.size() == values_.size());
 	toggle_states_ = states;

--- a/src/gui/widgets/multimenu_button.hpp
+++ b/src/gui/widgets/multimenu_button.hpp
@@ -94,7 +94,7 @@ public:
 	 *
 	 * @param states   A mask specifying which options to select and deselect
 	 */
-	void select_options(boost::dynamic_bitset<> states);
+	void select_options(const boost::dynamic_bitset<>& states);
 
 	/**
 	 * Set the available menu options.

--- a/src/gui/widgets/rich_label.cpp
+++ b/src/gui/widgets/rich_label.cpp
@@ -38,9 +38,10 @@
 #include "video.hpp"
 #include "wml_exception.hpp"
 
+#include <boost/format.hpp>
 #include <functional>
 #include <string>
-#include <boost/format.hpp>
+#include <utility>
 
 static lg::log_domain log_rich_label("gui/widget/rich_label");
 #define DBG_GUI_RL LOG_STREAM(debug, log_rich_label)
@@ -823,7 +824,7 @@ void rich_label::register_link_callback(std::function<void(std::string)> link_ha
 		std::bind(&rich_label::signal_handler_mouse_motion, this, std::placeholders::_3, std::placeholders::_5));
 	connect_signal<event::MOUSE_LEAVE>(
 		std::bind(&rich_label::signal_handler_mouse_leave, this, std::placeholders::_3));
-	link_handler_ = link_handler;
+	link_handler_ = std::move(link_handler);
 }
 
 

--- a/src/gui/widgets/rich_label.cpp
+++ b/src/gui/widgets/rich_label.cpp
@@ -108,7 +108,7 @@ point rich_label::get_image_size(config& img_cfg) const {
 	};
 }
 
-std::pair<size_t, size_t> rich_label::add_text(config& curr_item, std::string text) {
+std::pair<size_t, size_t> rich_label::add_text(config& curr_item, const std::string& text) {
 	auto& attr = curr_item["text"];
 	size_t start = attr.str().size();
 	attr = attr.str() + std::move(text);
@@ -116,7 +116,7 @@ std::pair<size_t, size_t> rich_label::add_text(config& curr_item, std::string te
 	return { start, end };
 }
 
-void rich_label::add_attribute(config& curr_item, std::string attr_name, size_t start, size_t end, std::string extra_data) {
+void rich_label::add_attribute(config& curr_item, const std::string& attr_name, size_t start, size_t end, const std::string& extra_data) {
 	curr_item.add_child("attribute", config{
 		"name"  , attr_name,
 		"start" , start,
@@ -125,13 +125,13 @@ void rich_label::add_attribute(config& curr_item, std::string attr_name, size_t 
 	});
 }
 
-std::pair<size_t, size_t> rich_label::add_text_with_attribute(config& curr_item, std::string text, std::string attr_name, std::string extra_data) {
+std::pair<size_t, size_t> rich_label::add_text_with_attribute(config& curr_item, const std::string& text, const std::string& attr_name, const std::string& extra_data) {
 	const auto [start, end] = add_text(curr_item, std::move(text));
 	add_attribute(curr_item, attr_name, start, end, extra_data);
 	return { start, end };
 }
 
-void rich_label::add_image(config& curr_item, std::string name, std::string align, bool has_prev_image, bool floating) {
+void rich_label::add_image(config& curr_item, const std::string& name, std::string align, bool has_prev_image, bool floating) {
 	// TODO: still doesn't cover the case where consecutive inline images have different heights
 	curr_item["name"] = name;
 
@@ -174,7 +174,7 @@ void rich_label::add_image(config& curr_item, std::string name, std::string alig
 	actions.str("");
 }
 
-void rich_label::add_link(config& curr_item, std::string name, std::string dest, const point& origin, int img_width) {
+void rich_label::add_link(config& curr_item, const std::string& name, const std::string& dest, const point& origin, int img_width) {
 	// TODO algorithm needs to be text_alignment independent
 
 	DBG_GUI_RL << "add_link: " << name << "->" << dest;
@@ -731,7 +731,7 @@ std::pair<config, point> rich_label::get_parsed_text(
 	return { text_dom, point(w, h - origin.y) };
 } // function ends
 
-void rich_label::default_text_config(config* txt_ptr, t_string text) {
+void rich_label::default_text_config(config* txt_ptr, const t_string& text) {
 	if (txt_ptr != nullptr) {
 		(*txt_ptr)["text"] = text;
 		(*txt_ptr)["color"] = text_color_enabled_.to_rgba_string();

--- a/src/gui/widgets/rich_label.hpp
+++ b/src/gui/widgets/rich_label.hpp
@@ -248,14 +248,14 @@ private:
 	unsigned padding_;
 
 	/** Create template for text config that can be shown in canvas */
-	void default_text_config(config* txt_ptr, t_string text = "");
+	void default_text_config(config* txt_ptr, const t_string& text = "");
 
-	std::pair<size_t, size_t> add_text(config& curr_item, std::string text);
-	void add_attribute(config& curr_item, std::string attr_name, size_t start = 0, size_t end = 0, std::string extra_data = "");
-	std::pair<size_t, size_t> add_text_with_attribute(config& curr_item, std::string text, std::string attr_name = "", std::string extra_data = "");
+	std::pair<size_t, size_t> add_text(config& curr_item, const std::string& text);
+	void add_attribute(config& curr_item, const std::string& attr_name, size_t start = 0, size_t end = 0, const std::string& extra_data = "");
+	std::pair<size_t, size_t> add_text_with_attribute(config& curr_item, const std::string& text, const std::string& attr_name = "", const std::string& extra_data = "");
 
-	void add_image(config& curr_item, std::string name, std::string align, bool has_prev_image, bool floating);
-	void add_link(config& curr_item, std::string name, std::string dest, const point& origin, int img_width);
+	void add_image(config& curr_item, const std::string& name, std::string align, bool has_prev_image, bool floating);
+	void add_link(config& curr_item, const std::string& name, const std::string& dest, const point& origin, int img_width);
 
 	/** size calculation functions */
 	point get_text_size(config& text_cfg, unsigned width = 0) const;

--- a/src/gui/widgets/stacked_widget.cpp
+++ b/src/gui/widgets/stacked_widget.cpp
@@ -104,7 +104,7 @@ void stacked_widget::set_self_active(const bool /*active*/)
 	/* DO NOTHING */
 }
 
-void stacked_widget::select_layer_impl(std::function<bool(unsigned int i)> display_condition)
+void stacked_widget::select_layer_impl(const std::function<bool(unsigned int i)>& display_condition)
 {
 	const unsigned int num_layers = get_layer_count();
 

--- a/src/gui/widgets/stacked_widget.hpp
+++ b/src/gui/widgets/stacked_widget.hpp
@@ -159,7 +159,7 @@ private:
 	void update_selected_layer_index(const int i);
 
 	/** Internal implementation detail for selecting layers. */
-	void select_layer_impl(std::function<bool(unsigned int i)> display_condition);
+	void select_layer_impl(const std::function<bool(unsigned int i)>& display_condition);
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */

--- a/src/gui/widgets/tab_container.cpp
+++ b/src/gui/widgets/tab_container.cpp
@@ -98,7 +98,7 @@ void tab_container::finalize_listbox() {
 	get_internal_list().connect_signal<event::NOTIFY_MODIFIED>(std::bind(&tab_container::change_selection, this));
 };
 
-void tab_container::add_tab_entry(const widget_data row)
+void tab_container::add_tab_entry(const widget_data& row)
 {
 	listbox& list = get_internal_list();
 	list.add_row(row);

--- a/src/gui/widgets/tab_container.hpp
+++ b/src/gui/widgets/tab_container.hpp
@@ -106,7 +106,7 @@ private:
 	/** Get the listbox inside which the tabs are shown */
 	listbox& get_internal_list();
 
-	void add_tab_entry(const widget_data row);
+	void add_tab_entry(const widget_data& row);
 
 	void change_selection();
 

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -145,7 +145,7 @@ static inline std::string get_hp_tooltip(
 	return tooltip.str();
 }
 
-static inline std::string get_mp_tooltip(int total_movement, std::function<int (t_translation::terrain_code)> get)
+static inline std::string get_mp_tooltip(int total_movement, const std::function<int (t_translation::terrain_code)>& get)
 {
 	std::set<terrain_movement> terrain_moves;
 	std::ostringstream tooltip;

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -44,12 +44,13 @@
 #include "units/types.hpp"              // for unit_type, unit_type_data, etc
 #include "utils/general.hpp"            // for contains
 
+#include <algorithm>                    // for sort, find, transform, etc
 #include <boost/algorithm/string.hpp>
 #include <cassert>                     // for assert
-#include <algorithm>                    // for sort, find, transform, etc
 #include <iterator>                     // for back_insert_iterator, etc
 #include <map>                          // for map, etc
 #include <set>
+#include <utility>
 
 static lg::log_domain log_help("help");
 #define WRN_HP LOG_STREAM(warn, log_help)
@@ -372,7 +373,7 @@ std::string generate_topic_text(const std::string &generator, const config *help
 
 topic_text& topic_text::operator=(std::shared_ptr<topic_generator> g)
 {
-	generator_ = g;
+	generator_ = std::move(g);
 	return *this;
 }
 

--- a/src/hotkey/hotkey_handler_sp.cpp
+++ b/src/hotkey/hotkey_handler_sp.cpp
@@ -319,7 +319,7 @@ void playsingle_controller::hotkey_handler::load_autosave(const std::string& fil
 	if(!start_replay) {
 		play_controller::hotkey_handler::load_autosave(filename);
 	}
-	auto invalid_save_file = [this, filename](std::string msg){
+	auto invalid_save_file = [this, filename](const std::string& msg){
 		if(playsingle_controller_.is_networked_mp()) {
 			gui2::show_error_message(msg);
 		} else {

--- a/src/hotkey/hotkey_item.cpp
+++ b/src/hotkey/hotkey_item.cpp
@@ -81,7 +81,7 @@ const std::string hotkey_base::get_name() const
 	return ret += get_name_helper();
 }
 
-bool hotkey_base::bindings_equal(hotkey_ptr other)
+bool hotkey_base::bindings_equal(const hotkey_ptr& other)
 {
 	if(other == nullptr) {
 		return false;
@@ -325,7 +325,7 @@ bool hotkey_keyboard::bindings_equal_helper(hotkey_ptr other) const
 	return text_ == other_k->text_;
 }
 
-void del_hotkey(hotkey_ptr item)
+void del_hotkey(const hotkey_ptr& item)
 {
 	if(!hotkeys_.empty()) {
 		utils::erase(hotkeys_, item);

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -173,7 +173,7 @@ public:
 	 * @param other the hokey bindings to compare against.
 	 * @return true if %other has same scope and bindings.
 	 */
-	virtual bool bindings_equal(hotkey_ptr other);
+	virtual bool bindings_equal(const hotkey_ptr& other);
 
 	virtual ~hotkey_base()
 	{}
@@ -356,7 +356,7 @@ void add_hotkey(hotkey_ptr item);
  * Remove a hotkey from the list of hotkeys
  * @todo unusued?
  */
-void del_hotkey(const hotkey_ptr item);
+void del_hotkey(const hotkey_ptr& item);
 
 /**
  * Create a new hotkey item for a command from an SDL_Event.

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -15,6 +15,8 @@
 
 #include "image_modifications.hpp"
 
+#include <utility>
+
 #include "color.hpp"
 #include "config.hpp"
 #include "game_config.hpp"
@@ -537,7 +539,7 @@ struct parse_mod_registration
 {
 	parse_mod_registration(const char* name, mod_parser parser)
 	{
-		mod_parsers[name] = parser;
+		mod_parsers[name] = std::move(parser);
 	}
 };
 

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -1312,7 +1312,7 @@ void mouse_handler::save_whiteboard_attack(
 }
 
 int mouse_handler::fill_weapon_choices(
-		std::vector<battle_context>& bc_vector, unit_map::iterator attacker, unit_map::iterator defender)
+		std::vector<battle_context>& bc_vector, const unit_map::iterator& attacker, const unit_map::iterator& defender)
 {
 	int best = 0;
 	for(unsigned int i = 0; i < attacker->attacks().size(); i++) {
@@ -1504,7 +1504,7 @@ void mouse_handler::show_attack_options(const unit_map::const_iterator& u)
 	}
 }
 
-bool mouse_handler::unit_in_cycle(unit_map::const_iterator it)
+bool mouse_handler::unit_in_cycle(const unit_map::const_iterator& it)
 {
 	game_board& board = pc_.gamestate().board_;
 

--- a/src/mouse_events.hpp
+++ b/src/mouse_events.hpp
@@ -141,7 +141,7 @@ protected:
 
 	// fill weapon choices into bc_vector
 	// return the best weapon choice
-	int fill_weapon_choices(std::vector<battle_context>& bc_vector, unit_map::iterator attacker, unit_map::iterator defender);
+	int fill_weapon_choices(std::vector<battle_context>& bc_vector, const unit_map::iterator& attacker, const unit_map::iterator& defender);
 	// the real function but can throw bad_alloc
 	// choice is the attack chosen in the attack dialog
 	void attack_enemy_(const map_location& attacker_loc
@@ -157,7 +157,7 @@ protected:
 	 */
 	unit* find_unit_nonowning(const map_location& hex);
 	const unit* find_unit_nonowning(const map_location& hex) const;
-	bool unit_in_cycle(unit_map::const_iterator it);
+	bool unit_in_cycle(const unit_map::const_iterator& it);
 private:
 	team &current_team();
 

--- a/src/network_asio.cpp
+++ b/src/network_asio.cpp
@@ -103,7 +103,7 @@ connection::~connection()
 	}
 }
 
-void connection::handle_resolve(const boost::system::error_code& ec, results_type results)
+void connection::handle_resolve(const boost::system::error_code& ec, const results_type& results)
 {
 	if(ec) {
 		throw system_error(ec);

--- a/src/network_asio.hpp
+++ b/src/network_asio.hpp
@@ -150,7 +150,7 @@ private:
 	using results_type = resolver::results_type;
 	using endpoint = const boost::asio::ip::tcp::endpoint&;
 
-	void handle_resolve(const boost::system::error_code& ec, results_type results);
+	void handle_resolve(const boost::system::error_code& ec, const results_type& results);
 	void handle_connect(const boost::system::error_code& ec, endpoint endpoint);
 
 	void handshake();

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -280,7 +280,7 @@ void play_controller::init(const config& level)
 		plugins_context_->set_callback("save_game", [this](const config& cfg) { save_game_auto(cfg["filename"]); }, true);
 		plugins_context_->set_callback("save_replay", [this](const config& cfg) { save_replay_auto(cfg["filename"]); }, true);
 		plugins_context_->set_callback("quit", [](const config&) { throw_quit_game_exception(); }, false);
-		plugins_context_->set_accessor_string("scenario_name", [this](config) { return get_scenario_name(); });
+		plugins_context_->set_accessor_string("scenario_name", [this](const config&) { return get_scenario_name(); });
 	});
 }
 

--- a/src/playturn_network_adapter.cpp
+++ b/src/playturn_network_adapter.cpp
@@ -16,8 +16,9 @@
 #include "log.hpp"
 #include "utils/general.hpp"
 
-#include <functional>
 #include <cassert>
+#include <functional>
+#include <utility>
 
 
 static lg::log_domain log_network("network");
@@ -128,7 +129,7 @@ bool playturn_network_adapter::read(config& dst)
 }
 
 playturn_network_adapter::playturn_network_adapter(source_type source)
-	: network_reader_(source)
+	: network_reader_(std::move(source))
 	, data_({config()})
 	, data_front_()
 	, next_(data_.front().ordered_end())
@@ -151,7 +152,7 @@ playturn_network_adapter::~playturn_network_adapter()
 
 void playturn_network_adapter::set_source(source_type source)
 {
-	network_reader_ = source;
+	network_reader_ = std::move(source);
 }
 
 

--- a/src/random_synced.cpp
+++ b/src/random_synced.cpp
@@ -14,7 +14,9 @@
 */
 
 #include "random_synced.hpp"
+
 #include "log.hpp"
+#include <utility>
 
 static lg::log_domain log_random("random");
 #define DBG_RND LOG_STREAM(debug, log_random)
@@ -25,7 +27,7 @@ static lg::log_domain log_random("random");
 namespace randomness
 {
 	synced_rng::synced_rng(std::function<std::string()> seed_generator)
-		: has_valid_seed_(false), seed_generator_(seed_generator), gen_()
+		: has_valid_seed_(false), seed_generator_(std::move(seed_generator)), gen_()
 	{
 	}
 	uint32_t synced_rng::next_random_impl()

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1050,7 +1050,7 @@ static std::string format_hp(unsigned hp)
 	return res.str();
 }
 
-static config unit_weapons(const reports::context& rc, unit_const_ptr attacker, const map_location &attacker_pos, const unit *defender, bool show_attacker)
+static config unit_weapons(const reports::context& rc, const unit_const_ptr& attacker, const map_location &attacker_pos, const unit *defender, bool show_attacker)
 {
 	if (!attacker || !defender) return config();
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -39,9 +39,10 @@
 #include "units/unit_alignments.hpp"
 #include "whiteboard/manager.hpp"
 
+#include <boost/format.hpp>
 #include <ctime>
 #include <iomanip>
-#include <boost/format.hpp>
+#include <utility>
 
 #ifdef __cpp_lib_format
 #include <format>
@@ -117,7 +118,7 @@ static static_report_generators static_generators;
 
 struct report_generator_helper
 {
-	report_generator_helper(const char *name, reports::generator_function g)
+	report_generator_helper(const char *name, const reports::generator_function& g)
 	{
 		static_generators.insert(static_report_generators::value_type(name, g));
 	}
@@ -993,7 +994,7 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		//If we have a second unit, do the 2-unit specials_context
 		bool attacking = (u.side() == rc.screen().playing_team().side());
 		auto ctx = (sec_u == nullptr) ? at.specials_context_for_listing(attacking) :
-						at.specials_context(u.shared_from_this(), sec_u->shared_from_this(), hex, sec_u->get_location(), attacking, sec_u_weapon);
+						at.specials_context(u.shared_from_this(), sec_u->shared_from_this(), hex, sec_u->get_location(), attacking, std::move(sec_u_weapon));
 
 		boost::dynamic_bitset<> active;
 		const std::vector<std::pair<t_string, t_string>> &specials = at.special_tooltips(&active);

--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -223,7 +223,7 @@ struct lua_context_backend {
 	{}
 };
 
-static int impl_context_backend(lua_State * L, std::shared_ptr<lua_context_backend> backend, std::string req_name)
+static int impl_context_backend(lua_State * L, const std::shared_ptr<lua_context_backend>& backend, std::string req_name)
 {
 	if (!backend->valid) {
 		luaL_error(L , "Error, you tried to use an invalid context object in a lua thread");
@@ -237,7 +237,7 @@ static int impl_context_backend(lua_State * L, std::shared_ptr<lua_context_backe
 	return 0;
 }
 
-static int impl_context_accessor(lua_State * L, std::shared_ptr<lua_context_backend> backend, plugins_context::accessor_function func)
+static int impl_context_accessor(lua_State * L, const std::shared_ptr<lua_context_backend>& backend, const plugins_context::accessor_function& func)
 {
 	if (!backend->valid) {
 		luaL_error(L , "Error, you tried to use an invalid context object in a lua thread");

--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -230,7 +230,7 @@ static int impl_context_backend(lua_State * L, const std::shared_ptr<lua_context
 	}
 
 	plugins_manager::event evt;
-	evt.name = req_name;
+	evt.name = std::move(req_name);
 	evt.data = luaW_checkconfig(L, -1);
 
 	backend->requests.push_back(evt);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4901,7 +4901,7 @@ namespace {
 /**
  * Executes its upvalue as a theme item generator.
  */
-int game_lua_kernel::impl_theme_item(lua_State *L, std::string m)
+int game_lua_kernel::impl_theme_item(lua_State *L, const std::string& m)
 {
 	reports::context temp_context = reports::context(board(), *game_display_, tod_man(), play_controller_.get_whiteboard(), play_controller_.get_mouse_handler_base());
 	luaW_pushconfig(L, reports_.generate_report(m.c_str(), temp_context , true));

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -178,7 +178,7 @@ class game_lua_kernel : public lua_kernel_base
 	int impl_schedule_dir(lua_State *L);
 	int intf_scroll(lua_State *L);
 	int intf_get_all_vars(lua_State *L);
-	int impl_theme_item(lua_State *L, std::string name);
+	int impl_theme_item(lua_State *L, const std::string& name);
 	int impl_theme_items_get(lua_State *L);
 	int impl_theme_items_set(lua_State *L);
 	int impl_theme_items_dir(lua_State *L);

--- a/src/scripting/lua_audio.cpp
+++ b/src/scripting/lua_audio.cpp
@@ -15,14 +15,15 @@
 #include "lua_audio.hpp"
 
 #include "log.hpp"
+#include "preferences/preferences.hpp"
+#include "resources.hpp"
 #include "scripting/lua_common.hpp"
 #include "scripting/push_check.hpp"
 #include "sound.hpp"
 #include "sound_music_track.hpp"
-#include "preferences/preferences.hpp"
-#include "resources.hpp"
 #include "soundsource.hpp"
 #include <set>
+#include <utility>
 
 static lg::log_domain log_audio("audio");
 #define DBG_AUDIO LOG_STREAM(debug, log_audio)
@@ -36,7 +37,7 @@ class lua_music_track {
 	std::shared_ptr<sound::music_track> track;
 public:
 	explicit lua_music_track(int i) : track(sound::get_track(i)) {}
-	explicit lua_music_track(std::shared_ptr<sound::music_track> new_track) : track(new_track) {}
+	explicit lua_music_track(std::shared_ptr<sound::music_track> new_track) : track(std::move(new_track)) {}
 	bool valid() const {
 		return track && track->valid();
 	}
@@ -61,7 +62,7 @@ static lua_music_track* push_track(lua_State* L, int i) {
 }
 
 static lua_music_track* push_track(lua_State* L, std::shared_ptr<sound::music_track> new_track) {
-	lua_music_track* trk = new(L) lua_music_track(new_track);
+	lua_music_track* trk = new(L) lua_music_track(std::move(new_track));
 	luaL_setmetatable(L, Track);
 	return trk;
 }

--- a/src/scripting/lua_formula_bridge.cpp
+++ b/src/scripting/lua_formula_bridge.cpp
@@ -33,7 +33,7 @@ static const char formulaKey[] = "formula";
 
 using namespace wfl;
 
-void luaW_pushfaivariant(lua_State* L, variant val);
+void luaW_pushfaivariant(lua_State* L, const variant& val);
 variant luaW_tofaivariant(lua_State* L, int i);
 
 class lua_callable : public formula_callable {
@@ -119,7 +119,7 @@ public:
 	}
 };
 
-void luaW_pushfaivariant(lua_State* L, variant val) {
+void luaW_pushfaivariant(lua_State* L, const variant& val) {
 	if(val.is_int()) {
 		lua_pushinteger(L, val.as_int());
 	} else if(val.is_decimal()) {

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -1027,12 +1027,12 @@ bool lua_kernel_base::load_string(char const * prog, const std::string& name)
 	return this->load_string(prog, name, eh);
 }
 
-bool lua_kernel_base::protected_call(int nArgs, int nRets, error_handler e_h)
+bool lua_kernel_base::protected_call(int nArgs, int nRets, const error_handler& e_h)
 {
 	return this->protected_call(mState, nArgs, nRets, e_h);
 }
 
-bool lua_kernel_base::protected_call(lua_State * L, int nArgs, int nRets, error_handler e_h)
+bool lua_kernel_base::protected_call(lua_State * L, int nArgs, int nRets, const error_handler& e_h)
 {
 	int errcode = luaW_pcall_internal(L, nArgs, nRets);
 
@@ -1065,7 +1065,7 @@ bool lua_kernel_base::protected_call(lua_State * L, int nArgs, int nRets, error_
 	return true;
 }
 
-bool lua_kernel_base::load_string(char const * prog, const std::string& name, error_handler e_h)
+bool lua_kernel_base::load_string(char const * prog, const std::string& name, const error_handler& e_h)
 {
 	// pass 't' to prevent loading bytecode which is unsafe and can be used to escape the sandbox.
 	int errcode = luaL_loadbufferx(mState, prog, strlen(prog), name.empty() ? prog : name.c_str(), "t");

--- a/src/scripting/lua_kernel_base.hpp
+++ b/src/scripting/lua_kernel_base.hpp
@@ -121,11 +121,11 @@ public:
 	int intf_show_lua_console(lua_State * L);
 protected:
 	// Execute a protected call. Error handler is called in case of an error, using syntax for log_error and throw_exception above. Returns true if successful.
-	bool protected_call(int nArgs, int nRets, error_handler);
+	bool protected_call(int nArgs, int nRets, const error_handler&);
 	// Execute a protected call, taking a lua_State as argument. For functions pushed into the lua environment, this version should be used, or the function cannot be used by coroutines without segfaulting (since they have a different lua_State pointer). This version is called by the above version.
-	static bool protected_call(lua_State * L, int nArgs, int nRets, error_handler);
+	static bool protected_call(lua_State * L, int nArgs, int nRets, const error_handler&);
 	// Load a string onto the stack as a function. Returns true if successful, error handler is called if not.
-	bool load_string(char const * prog, const std::string& name, error_handler);
+	bool load_string(char const * prog, const std::string& name, const error_handler&);
 
 	virtual bool protected_call(int nArgs, int nRets); 	// select default error handler polymorphically
 	virtual bool load_string(char const * prog, const std::string& name);		// select default error handler polymorphically

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -26,6 +26,7 @@
 
 
 #include <type_traits>
+#include <utility>
 
 static const char uattacksKey[] = "unit attacks table";
 static const char uattackKey[] = "unit attack";
@@ -34,7 +35,7 @@ struct attack_ref {
 	attack_ptr attack;
 	const_attack_ptr cattack;
 	attack_ref(const attack_ptr& atk) : attack(atk), cattack(atk) {}
-	attack_ref(const_attack_ptr atk) : cattack(atk) {}
+	attack_ref(const_attack_ptr atk) : cattack(std::move(atk)) {}
 };
 
 void push_unit_attacks_table(lua_State* L, int idx)

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -33,7 +33,7 @@ static const char uattackKey[] = "unit attack";
 struct attack_ref {
 	attack_ptr attack;
 	const_attack_ptr cattack;
-	attack_ref(attack_ptr atk) : attack(atk), cattack(atk) {}
+	attack_ref(const attack_ptr& atk) : attack(atk), cattack(atk) {}
 	attack_ref(const_attack_ptr atk) : cattack(atk) {}
 };
 
@@ -47,7 +47,7 @@ void push_unit_attacks_table(lua_State* L, int idx)
 	luaL_setmetatable(L, uattacksKey);
 }
 
-void luaW_pushweapon(lua_State* L, attack_ptr weapon)
+void luaW_pushweapon(lua_State* L, const attack_ptr& weapon)
 {
 	if(weapon != nullptr) {
 		new(L) attack_ref(weapon);
@@ -57,7 +57,7 @@ void luaW_pushweapon(lua_State* L, attack_ptr weapon)
 	}
 }
 
-void luaW_pushweapon(lua_State* L, const_attack_ptr weapon)
+void luaW_pushweapon(lua_State* L, const const_attack_ptr& weapon)
 {
 	if(weapon != nullptr) {
 		new(L) attack_ref(weapon);

--- a/src/scripting/lua_unit_attacks.hpp
+++ b/src/scripting/lua_unit_attacks.hpp
@@ -27,8 +27,8 @@ namespace lua_units {
 	std::string register_attacks_metatables(lua_State* L);
 }
 
-void luaW_pushweapon(lua_State* L, attack_ptr weapon);
-void luaW_pushweapon(lua_State* L, const_attack_ptr weapon);
+void luaW_pushweapon(lua_State* L, const attack_ptr& weapon);
+void luaW_pushweapon(lua_State* L, const const_attack_ptr& weapon);
 const_attack_ptr luaW_toweapon(lua_State* L, int idx);
 attack_type& luaW_checkweapon(lua_State* L, int idx);
 int intf_create_attack(lua_State* L);

--- a/src/scripting/plugins/context.cpp
+++ b/src/scripting/plugins/context.cpp
@@ -19,6 +19,7 @@
 
 #include <cassert>
 #include <functional>
+#include <utility>
 
 plugins_context::plugins_context(const std::string & name)
 	: callbacks_()
@@ -50,7 +51,7 @@ void plugins_context::initialize(const reg_vec& callbacks, const areg_vec& acces
 
 void plugins_context::set_callback(const std::string & name, callback_function func)
 {
-	callbacks_[name] = func;
+	callbacks_[name] = std::move(func);
 }
 
 std::size_t plugins_context::erase_callback(const std::string & name)
@@ -67,7 +68,7 @@ std::size_t plugins_context::clear_callbacks()
 
 void plugins_context::set_accessor(const std::string & name, accessor_function func)
 {
-	accessors_[name] = func;
+	accessors_[name] = std::move(func);
 }
 
 void plugins_context::set_accessor_string(const std::string & name, const std::function<std::string(config)>& func)
@@ -101,5 +102,5 @@ void plugins_context::play_slice()
 
 void plugins_context::set_callback(const std::string & name, const std::function<void(config)>& func, bool preserves_context)
 {
-	set_callback(name, [func, preserves_context](config cfg) { func(cfg); return preserves_context; });
+	set_callback(name, [func, preserves_context](config cfg) { func(std::move(cfg)); return preserves_context; });
 }

--- a/src/scripting/plugins/context.cpp
+++ b/src/scripting/plugins/context.cpp
@@ -70,12 +70,12 @@ void plugins_context::set_accessor(const std::string & name, accessor_function f
 	accessors_[name] = func;
 }
 
-void plugins_context::set_accessor_string(const std::string & name, std::function<std::string(config)> func)
+void plugins_context::set_accessor_string(const std::string & name, const std::function<std::string(config)>& func)
 {
 	set_accessor(name, [func, name](const config& cfg) { return config {name, func(cfg)}; });
 }
 
-void plugins_context::set_accessor_int(const std::string & name, std::function<int(config)> func)
+void plugins_context::set_accessor_int(const std::string & name, const std::function<int(config)>& func)
 {
 	set_accessor(name, [func, name](const config& cfg) { return config {name, func(cfg)}; });
 }
@@ -99,7 +99,7 @@ void plugins_context::play_slice()
 	plugins_manager::get()->play_slice(*this);
 }
 
-void plugins_context::set_callback(const std::string & name, std::function<void(config)> func, bool preserves_context)
+void plugins_context::set_callback(const std::string & name, const std::function<void(config)>& func, bool preserves_context)
 {
 	set_callback(name, [func, preserves_context](config cfg) { func(cfg); return preserves_context; });
 }

--- a/src/scripting/plugins/context.hpp
+++ b/src/scripting/plugins/context.hpp
@@ -46,13 +46,13 @@ public:
 	void play_slice();
 
 	void set_callback(const std::string & name, callback_function);
-	void set_callback(const std::string & name, std::function<void(config)> function, bool preserves_context);
+	void set_callback(const std::string & name, const std::function<void(config)>& function, bool preserves_context);
 	std::size_t erase_callback(const std::string & name);
 	std::size_t clear_callbacks();
 
 	void set_accessor(const std::string & name, accessor_function);
-	void set_accessor_string(const std::string & name, std::function<std::string(config)>);	//helpers which create a config from a simple type
-	void set_accessor_int(const std::string & name, std::function<int(config)>);
+	void set_accessor_string(const std::string & name, const std::function<std::string(config)>&);	//helpers which create a config from a simple type
+	void set_accessor_int(const std::string & name, const std::function<int(config)>&);
 	std::size_t erase_accessor(const std::string & name);
 	std::size_t clear_accessors();
 

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -51,6 +51,7 @@
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <utility>
 
 // the fork execute is unix specific only tested on Linux quite sure it won't
 // work on Windows not sure which other platforms have a problem with it.
@@ -491,7 +492,7 @@ std::ostream& operator<<(std::ostream& o, const server::request& r)
 void server::handle_new_client(tls_socket_ptr socket)
 {
 	boost::asio::spawn(
-		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, yield); }
+		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, std::move(yield)); }
 #if BOOST_VERSION >= 108000
 		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
@@ -501,9 +502,9 @@ void server::handle_new_client(tls_socket_ptr socket)
 void server::handle_new_client(socket_ptr socket)
 {
 	boost::asio::spawn(
-		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, yield); }
+		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, std::move(yield)); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 }

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -493,7 +493,7 @@ void server::handle_new_client(tls_socket_ptr socket)
 	boost::asio::spawn(
 		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, yield); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 }

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -40,9 +40,10 @@
 #include <boost/asio/read_until.hpp>
 #endif
 
+#include <iostream>
 #include <queue>
 #include <string>
-#include <iostream>
+#include <utility>
 
 
 static lg::log_domain log_server("server");
@@ -378,7 +379,7 @@ void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filen
 {
 	// We fallback to userspace if using TLS socket because sendfile is not aware of TLS state
 	// TODO: keep in mind possibility of using KTLS instead. This seem to be available only in openssl3 branch for now
-	coro_send_file_userspace(socket, filename, yield);
+	coro_send_file_userspace(std::move(socket), filename, std::move(yield));
 }
 
 void server_base::coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -74,16 +74,16 @@ server_base::server_base(unsigned short port, bool keep_alive)
 void server_base::start_server()
 {
 	boost::asio::ip::tcp::endpoint endpoint_v6(boost::asio::ip::tcp::v6(), port_);
-	boost::asio::spawn(io_service_, [this, endpoint_v6](boost::asio::yield_context yield) { serve(yield, acceptor_v6_, endpoint_v6); }
+	boost::asio::spawn(io_service_, [this, endpoint_v6](const boost::asio::yield_context& yield) { serve(yield, acceptor_v6_, endpoint_v6); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 
 	boost::asio::ip::tcp::endpoint endpoint_v4(boost::asio::ip::tcp::v4(), port_);
-	boost::asio::spawn(io_service_, [this, endpoint_v4](boost::asio::yield_context yield) { serve(yield, acceptor_v4_, endpoint_v4); }
+	boost::asio::spawn(io_service_, [this, endpoint_v4](const boost::asio::yield_context& yield) { serve(yield, acceptor_v4_, endpoint_v4); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 
@@ -96,7 +96,7 @@ void server_base::start_server()
 #endif
 }
 
-void server_base::serve(boost::asio::yield_context yield, boost::asio::ip::tcp::acceptor& acceptor, boost::asio::ip::tcp::endpoint endpoint)
+void server_base::serve(const boost::asio::yield_context& yield, boost::asio::ip::tcp::acceptor& acceptor, const boost::asio::ip::tcp::endpoint& endpoint)
 {
 	try {
 		if(!acceptor.is_open()) {
@@ -123,9 +123,9 @@ void server_base::serve(boost::asio::yield_context yield, boost::asio::ip::tcp::
 	}
 
 	if(accepting_connections()) {
-		boost::asio::spawn(io_service_, [this, &acceptor, endpoint](boost::asio::yield_context yield) { serve(yield, acceptor, endpoint); }
+		boost::asio::spawn(io_service_, [this, &acceptor, endpoint](const boost::asio::yield_context& yield) { serve(yield, acceptor, endpoint); }
 #if BOOST_VERSION >= 108000
-			, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+			, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 		);
 	} else {
@@ -307,7 +307,7 @@ void info_table_into_simple_wml(simple_wml::document& doc, const std::string& pa
  * @param doc
  * @param yield The function will suspend on write operation using this yield context
  */
-template<class SocketPtr> void server_base::coro_send_doc(SocketPtr socket, simple_wml::document& doc, boost::asio::yield_context yield)
+template<class SocketPtr> void server_base::coro_send_doc(SocketPtr socket, simple_wml::document& doc, const boost::asio::yield_context& yield)
 {
 	if(dump_wml) {
 		std::cout << "Sending WML to " << log_address(socket) << ": \n" << doc.output() << std::endl;
@@ -339,10 +339,10 @@ template<class SocketPtr> void server_base::coro_send_doc(SocketPtr socket, simp
 		throw;
 	}
 }
-template void server_base::coro_send_doc<socket_ptr>(socket_ptr socket, simple_wml::document& doc, boost::asio::yield_context yield);
-template void server_base::coro_send_doc<tls_socket_ptr>(tls_socket_ptr socket, simple_wml::document& doc, boost::asio::yield_context yield);
+template void server_base::coro_send_doc<socket_ptr>(socket_ptr socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
+template void server_base::coro_send_doc<tls_socket_ptr>(tls_socket_ptr socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
 
-template<class SocketPtr> void coro_send_file_userspace(SocketPtr socket, const std::string& filename, boost::asio::yield_context yield)
+template<class SocketPtr> void coro_send_file_userspace(SocketPtr socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	std::size_t filesize { std::size_t(filesystem::file_size(filename)) };
 	union DataSize
@@ -374,14 +374,14 @@ template<class SocketPtr> void coro_send_file_userspace(SocketPtr socket, const 
 
 #ifdef HAVE_SENDFILE
 
-void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, boost::asio::yield_context yield)
+void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	// We fallback to userspace if using TLS socket because sendfile is not aware of TLS state
 	// TODO: keep in mind possibility of using KTLS instead. This seem to be available only in openssl3 branch for now
 	coro_send_file_userspace(socket, filename, yield);
 }
 
-void server_base::coro_send_file(socket_ptr socket, const std::string& filename, boost::asio::yield_context yield)
+void server_base::coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	std::size_t filesize { std::size_t(filesystem::file_size(filename)) };
 	int in_file { open(filename.c_str(), O_RDONLY) };
@@ -442,12 +442,12 @@ void server_base::coro_send_file(socket_ptr socket, const std::string& filename,
 
 #elif defined(_WIN32)
 
-void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, boost::asio::yield_context yield)
+void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	coro_send_file_userspace(socket, filename, yield);
 }
 
-void server_base::coro_send_file(socket_ptr socket, const std::string& filename, boost::asio::yield_context yield)
+void server_base::coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	OVERLAPPED overlap;
 	std::vector<boost::asio::const_buffer> buffers;
@@ -507,19 +507,19 @@ void server_base::coro_send_file(socket_ptr socket, const std::string& filename,
 
 #else
 
-void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, boost::asio::yield_context yield)
+void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	coro_send_file_userspace(socket, filename, yield);
 }
 
-void server_base::coro_send_file(socket_ptr socket, const std::string& filename, boost::asio::yield_context yield)
+void server_base::coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	coro_send_file_userspace(socket, filename, yield);
 }
 
 #endif
 
-template<class SocketPtr> std::unique_ptr<simple_wml::document> server_base::coro_receive_doc(SocketPtr socket, boost::asio::yield_context yield)
+template<class SocketPtr> std::unique_ptr<simple_wml::document> server_base::coro_receive_doc(SocketPtr socket, const boost::asio::yield_context& yield)
 {
 	union DataSize
 	{
@@ -559,8 +559,8 @@ template<class SocketPtr> std::unique_ptr<simple_wml::document> server_base::cor
 		return {};
 	}
 }
-template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<socket_ptr>(socket_ptr socket, boost::asio::yield_context yield);
-template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<tls_socket_ptr>(tls_socket_ptr socket, boost::asio::yield_context yield);
+template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<socket_ptr>(socket_ptr socket, const boost::asio::yield_context& yield);
+template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<tls_socket_ptr>(tls_socket_ptr socket, const boost::asio::yield_context& yield);
 
 template<class SocketPtr> void server_base::send_doc_queued(SocketPtr socket, std::unique_ptr<simple_wml::document>& doc_ptr, boost::asio::yield_context yield)
 {
@@ -586,7 +586,7 @@ template<class SocketPtr> void server_base::async_send_doc_queued(SocketPtr sock
 			send_doc_queued(socket, doc_ptr, yield);
 		}
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 }

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -92,22 +92,22 @@ public:
 	 * @param doc
 	 * @param yield The function will suspend on write operation using this yield context
 	 */
-	template<class SocketPtr> void coro_send_doc(SocketPtr socket, simple_wml::document& doc, boost::asio::yield_context yield);
+	template<class SocketPtr> void coro_send_doc(SocketPtr socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
 	/**
 	 * Send contents of entire file directly to socket from within a coroutine
 	 * @param socket
 	 * @param filename
 	 * @param yield The function will suspend on write operations using this yield context
 	 */
-	void coro_send_file(socket_ptr socket, const std::string& filename, boost::asio::yield_context yield);
-	void coro_send_file(tls_socket_ptr socket, const std::string& filename, boost::asio::yield_context yield);
+	void coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield);
+	void coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield);
 	/**
 	 * Receive WML document from a coroutine
 	 * @param socket
 	 * @param yield The function will suspend on read operation using this yield context
 	 * @return unique_ptr with doc deceived. In case of error empty unique_ptr
 	 */
-	template<class SocketPtr> std::unique_ptr<simple_wml::document> coro_receive_doc(SocketPtr socket, boost::asio::yield_context yield);
+	template<class SocketPtr> std::unique_ptr<simple_wml::document> coro_receive_doc(SocketPtr socket, const boost::asio::yield_context& yield);
 
 	/**
 	 * High level wrapper for sending a WML document
@@ -145,7 +145,7 @@ protected:
 	void load_tls_config(const config& cfg);
 
 	void start_server();
-	void serve(boost::asio::yield_context yield, boost::asio::ip::tcp::acceptor& acceptor, boost::asio::ip::tcp::endpoint endpoint);
+	void serve(const boost::asio::yield_context& yield, boost::asio::ip::tcp::acceptor& acceptor, const boost::asio::ip::tcp::endpoint& endpoint);
 
 	uint32_t handshake_response_;
 

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -176,7 +176,7 @@ std::string game::username(player_iterator iter) const
 	return iter->info().name();
 }
 
-std::string game::list_users(user_vector users) const
+std::string game::list_users(const user_vector& users) const
 {
 	std::string list;
 

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -773,7 +773,7 @@ private:
 	 * @param users The users to create a comma separated list from.
 	 * @return A comma separated list of user names.
 	 */
-	std::string list_users(user_vector users) const;
+	std::string list_users(const user_vector& users) const;
 
 	/** calculates the initial value for sides_, side_controllerds_, nsides_*/
 	void reset_sides();

--- a/src/server/wesnothd/player_connection.cpp
+++ b/src/server/wesnothd/player_connection.cpp
@@ -15,6 +15,8 @@
 
 #include "server/wesnothd/player_connection.hpp"
 
+#include <utility>
+
 #include "server/wesnothd/game.hpp"
 
 namespace wesnothd
@@ -36,7 +38,7 @@ int player_record::game_id() const
 
 void player_record::set_game(std::shared_ptr<game> new_game)
 {
-	game_ = new_game;
+	game_ = std::move(new_game);
 }
 
 void player_record::enter_lobby()

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -56,6 +56,7 @@
 #include <map>
 #include <set>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 static lg::log_domain log_server("server");
@@ -680,7 +681,7 @@ void server::refresh_tournaments(const boost::system::error_code& ec)
 
 void server::handle_new_client(socket_ptr socket)
 {
-	boost::asio::spawn(io_service_, [socket, this](boost::asio::yield_context yield) { login_client(yield, socket); }
+	boost::asio::spawn(io_service_, [socket, this](boost::asio::yield_context yield) { login_client(std::move(yield), socket); }
 #if BOOST_VERSION >= 108000
 		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
@@ -689,7 +690,7 @@ void server::handle_new_client(socket_ptr socket)
 
 void server::handle_new_client(tls_socket_ptr socket)
 {
-	boost::asio::spawn(io_service_, [socket, this](boost::asio::yield_context yield) { login_client(yield, socket); }
+	boost::asio::spawn(io_service_, [socket, this](boost::asio::yield_context yield) { login_client(std::move(yield), socket); }
 #if BOOST_VERSION >= 108000
 		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
@@ -800,7 +801,7 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 	boost::asio::spawn(io_service_,
 		[this, socket, new_player](boost::asio::yield_context yield) { handle_player(yield, socket, new_player); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -682,7 +682,7 @@ void server::handle_new_client(socket_ptr socket)
 {
 	boost::asio::spawn(io_service_, [socket, this](boost::asio::yield_context yield) { login_client(yield, socket); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 }
@@ -691,7 +691,7 @@ void server::handle_new_client(tls_socket_ptr socket)
 {
 	boost::asio::spawn(io_service_, [socket, this](boost::asio::yield_context yield) { login_client(yield, socket); }
 #if BOOST_VERSION >= 108000
-		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif
 	);
 }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -27,6 +27,7 @@
 
 #include <list>
 #include <string>
+#include <utility>
 
 static lg::log_domain log_audio("audio");
 #define DBG_AUDIO LOG_STREAM(debug, log_audio)
@@ -215,7 +216,7 @@ std::shared_ptr<music_track> get_previous_music_track()
 }
 void set_previous_track(std::shared_ptr<music_track> track)
 {
-	previous_track = track;
+	previous_track = std::move(track);
 }
 
 unsigned int get_num_tracks()

--- a/src/statistics_record.cpp
+++ b/src/statistics_record.cpp
@@ -50,7 +50,7 @@ static void write_str_int_map(config_writer& out, const stats_t::str_int_map& m)
 	using reverse_map = std::multimap<int, std::string>;
 	reverse_map rev;
 	std::transform(m.begin(), m.end(), std::inserter(rev, rev.begin()),
-		[](const stats_t::str_int_map::value_type p) { return std::pair(p.second, p.first); });
+		[](const stats_t::str_int_map::value_type& p) { return std::pair(p.second, p.first); });
 	reverse_map::const_iterator i = rev.begin(), j;
 	while(i != rev.end()) {
 		j = rev.upper_bound(i->first);

--- a/src/tests/test_map_location.cpp
+++ b/src/tests/test_map_location.cpp
@@ -126,8 +126,8 @@ static void characterization_distance_direction (const std::vector<map_location>
 	BOOST_CHECK_MESSAGE( int_it == int_answers.end(), "Did not exhaust answers list.");
 }
 
-static std::size_t get_first (std::pair<std::size_t, std::string> arg) {return arg.first; }
-static map_location::direction get_second (std::pair<std::size_t, std::string> arg) {return map_location::parse_direction(arg.second); }
+static std::size_t get_first (const std::pair<std::size_t, std::string>& arg) {return arg.first; }
+static map_location::direction get_second (const std::pair<std::size_t, std::string>& arg) {return map_location::parse_direction(arg.second); }
 
 /* This has to be recomputed, I'm commenting out the test so that it doesn't fail in the meantime. --iceiceice
 

--- a/src/tests/test_rng.cpp
+++ b/src/tests/test_rng.cpp
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE( test_mt_rng_reproducibility5 )
 
 namespace {
 
-void validate_seed_string(std::string seed_str)
+void validate_seed_string(const std::string& seed_str)
 {
 	config cfg;
 	cfg["random_seed"] = seed_str;

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -401,7 +401,7 @@ void theme::object::modify_location(const _rect& rect)
 	location_modified_ = true;
 }
 
-void theme::object::modify_location(std::string rect_str, SDL_Rect location_ref_rect)
+void theme::object::modify_location(const std::string& rect_str, SDL_Rect location_ref_rect)
 {
 	_rect rect {0, 0, 0, 0};
 	const std::vector<std::string> items = utils::split(rect_str.c_str());
@@ -802,7 +802,7 @@ void theme::remove_object(const std::string& id)
 	throw config::error(stream.str());
 }
 
-void theme::set_object_location(theme::object& element, std::string rect_str, std::string ref_id)
+void theme::set_object_location(theme::object& element, const std::string& rect_str, std::string ref_id)
 {
 	theme::object ref_element = element;
 	if(ref_id.empty()) {

--- a/src/theme.hpp
+++ b/src/theme.hpp
@@ -57,7 +57,7 @@ class theme
 		// This supports relocating of theme elements ingame.
 		// It is needed for [change] tags in theme WML.
 		void modify_location(const _rect& rect);
-		void modify_location(std::string rect_str, SDL_Rect rect_ref);
+		void modify_location(const std::string& rect_str, SDL_Rect rect_ref);
 
 		// All on-screen objects have 'anchoring' in the x and y dimensions.
 		// 'fixed' means that they have fixed co-ordinates and don't move.
@@ -288,7 +288,7 @@ private:
 	theme::object& find_element(const std::string& id);
 	void add_object(std::size_t sw, std::size_t sh, const config& cfg);
 	void remove_object(const std::string& id);
-	void set_object_location(theme::object& element, std::string rect_str, std::string ref_id);
+	void set_object_location(theme::object& element, const std::string& rect_str, std::string ref_id);
 
 	//notify observers that the theme has been rebuilt completely
 	//atm this is used for replay_controller to add replay controls to the standard theme

--- a/src/time_of_day.cpp
+++ b/src/time_of_day.cpp
@@ -50,7 +50,7 @@ time_of_day::time_of_day()
 {
 }
 
-void time_of_day::write(config& cfg, std::string textdomain) const
+void time_of_day::write(config& cfg, const std::string& textdomain) const
 {
 	cfg["lawful_bonus"] = lawful_bonus;
 	cfg["red"] = color.r;

--- a/src/time_of_day.hpp
+++ b/src/time_of_day.hpp
@@ -77,7 +77,7 @@ struct time_of_day
 			&& sounds == o.sounds;
 	}
 
-	void write(config& cfg, std::string textdomain = "") const;
+	void write(config& cfg, const std::string& textdomain = "") const;
 
 	/** The % bonus lawful units receive. Chaotics receive -lawful_bonus. */
 	int lawful_bonus;

--- a/src/tod_manager.cpp
+++ b/src/tod_manager.cpp
@@ -93,7 +93,7 @@ void tod_manager::resolve_random(randomness::rng& r)
 	random_tod_ = false;
 }
 
-config tod_manager::to_config(std::string textdomain) const
+config tod_manager::to_config(const std::string& textdomain) const
 {
 	config cfg;
 	cfg["turn_at"] = turn_;

--- a/src/tod_manager.hpp
+++ b/src/tod_manager.hpp
@@ -36,7 +36,7 @@ class tod_manager
 		~tod_manager() {}
 		tod_manager& operator=(const tod_manager& manager) = default;
 
-		config to_config(std::string textdomain = "") const;
+		config to_config(const std::string& textdomain = "") const;
 		/**
 			handles random_start_time, should be called before the game starts.
 		*/

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -56,7 +56,7 @@ namespace {
 		map_location::direction save_dir_;
 		unit_const_ptr u_;
 	public:
-		temporary_facing(unit_const_ptr u, map_location::direction new_dir)
+		temporary_facing(const unit_const_ptr& u, map_location::direction new_dir)
 			: save_dir_(u ? u->facing() : map_location::direction::indeterminate)
 			, u_(u)
 		{
@@ -534,7 +534,7 @@ bool unit::ability_affects_self(const std::string& ability,const config& cfg,con
 	return unit_filter(vconfig(*filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
 }
 
-bool unit::ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const
+bool unit::ability_affects_weapon(const config& cfg, const const_attack_ptr& weapon, bool is_opp) const
 {
 	const std::string filter_tag_name = is_opp ? "filter_second_weapon" : "filter_weapon";
 	if(!cfg.has_child(filter_tag_name)) {
@@ -651,7 +651,7 @@ private:
 };
 
 template<typename T, typename TFuncFormula>
-T get_single_ability_value(const config::attribute_value& v, T def, const unit_ability& ability_info, const map_location& receiver_loc, const_attack_ptr att, const TFuncFormula& formula_handler)
+T get_single_ability_value(const config::attribute_value& v, T def, const unit_ability& ability_info, const map_location& receiver_loc, const const_attack_ptr& att, const TFuncFormula& formula_handler)
 {
 	return v.apply_visitor(get_ability_value_visitor(def, [&](const std::string& s) {
 
@@ -974,7 +974,7 @@ std::vector<std::pair<t_string, t_string>> attack_type::special_tooltips(
  * @param[in] name string who must be or not added
  * @param[in,out] checking_name the reference for checking if @name already added
  */
-static void add_name(std::string& temp_string, bool active, const std::string name, std::set<std::string>& checking_name)
+static void add_name(std::string& temp_string, bool active, const std::string& name, std::set<std::string>& checking_name)
 {
 	if (active) {
 		if (!name.empty() && checking_name.count(name) == 0) {
@@ -1029,7 +1029,7 @@ std::string attack_type::weapon_specials() const
 	return res;
 }
 
-static void add_name_list(std::string& temp_string, std::string& weapon_abilities, std::set<std::string>& checking_name, const std::string from_str)
+static void add_name_list(std::string& temp_string, std::string& weapon_abilities, std::set<std::string>& checking_name, const std::string& from_str)
 {
 	if(!temp_string.empty()){
 		temp_string = from_str.c_str() + temp_string;
@@ -1040,7 +1040,7 @@ static void add_name_list(std::string& temp_string, std::string& weapon_abilitie
 	}
 }
 
-std::string attack_type::weapon_specials_value(const std::set<std::string> checking_tags) const
+std::string attack_type::weapon_specials_value(const std::set<std::string>& checking_tags) const
 {
 	//log_scope("weapon_specials_value");
 	std::string temp_string, weapon_abilities;
@@ -1082,9 +1082,9 @@ std::string attack_type::weapon_specials_value(const std::set<std::string> check
 
 void attack_type::weapon_specials_impl_self(
 	std::string& temp_string,
-	unit_const_ptr self,
-	const_attack_ptr self_attack,
-	const_attack_ptr other_attack,
+	const unit_const_ptr& self,
+	const const_attack_ptr& self_attack,
+	const const_attack_ptr& other_attack,
 	const map_location& self_loc,
 	AFFECTS whom,
 	std::set<std::string>& checking_name,
@@ -1102,9 +1102,9 @@ void attack_type::weapon_specials_impl_self(
 
 void attack_type::weapon_specials_impl_adj(
 	std::string& temp_string,
-	unit_const_ptr self,
-	const_attack_ptr self_attack,
-	const_attack_ptr other_attack,
+	const unit_const_ptr& self,
+	const const_attack_ptr& self_attack,
+	const const_attack_ptr& other_attack,
 	const map_location& self_loc,
 	AFFECTS whom,
 	std::set<std::string>& checking_name,
@@ -1285,7 +1285,7 @@ static std::string select_replacement_type(const unit_ability_list& damage_type_
 	return type_list.front();
 }
 
-static std::string select_alternative_type(const unit_ability_list& damage_type_list, unit_ability_list resistance_list, const unit& u)
+static std::string select_alternative_type(const unit_ability_list& damage_type_list, const unit_ability_list& resistance_list, const unit& u)
 {
 	std::map<std::string, int> type_res;
 	int max_res = std::numeric_limits<int>::min();
@@ -1313,7 +1313,7 @@ static std::string select_alternative_type(const unit_ability_list& damage_type_
 	return type_list.front();
 }
 
-std::string attack_type::select_damage_type(const unit_ability_list& damage_type_list, const std::string& key_name, unit_ability_list resistance_list) const
+std::string attack_type::select_damage_type(const unit_ability_list& damage_type_list, const std::string& key_name, const unit_ability_list& resistance_list) const
 {
 	bool is_alternative = (key_name == "alternative_type");
 	if(is_alternative && other_){
@@ -1429,7 +1429,7 @@ namespace { // Helpers for attack_type::special_active()
 	 * Print "Recursion limit reached" log messages, including deduplication if the same problem has
 	 * already been logged.
 	 */
-	void show_recursion_warning(const_attack_ptr& attack, const config& filter) {
+	void show_recursion_warning(const const_attack_ptr& attack, const config& filter) {
 		// This function is only called when a special is checked for the second time
 		// filter has already been parsed multiple times, so I'm not trying to optimize the performance
 		// of this; it's merely to prevent the logs getting spammed. For example, each of
@@ -1470,7 +1470,7 @@ namespace { // Helpers for attack_type::special_active()
 	static bool special_unit_matches(unit_const_ptr & u,
 		                             unit_const_ptr & u2,
 		                             const map_location & loc,
-		                             const_attack_ptr& weapon,
+		                             const const_attack_ptr& weapon,
 		                             const config & filter,
 									 const bool for_listing,
 		                             const std::string & child_tag, const std::string& check_if_recursion)
@@ -1733,12 +1733,12 @@ bool unit::get_adj_ability_bool(const config& cfg, const std::string& ability, i
 	return (affects_side(cfg, side(), from.side()) && from.ability_active_impl(ability, cfg, adjacent[dir]) && ability_affects_adjacent(ability, cfg, dir, loc, from));
 }
 
-bool unit::get_self_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon) const
+bool unit::get_self_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
 {
 	return (get_self_ability_bool(special, tag_name, loc) && ability_affects_weapon(special, weapon, false) && ability_affects_weapon(special, opp_weapon, true));
 }
 
-bool unit::get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const_attack_ptr weapon, const_attack_ptr opp_weapon) const
+bool unit::get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
 {
 	return (get_adj_ability_bool(special, tag_name, dir, loc, from) && ability_affects_weapon(special, weapon, false) && ability_affects_weapon(special, opp_weapon, true));
 }
@@ -1748,7 +1748,7 @@ bool attack_type::check_self_abilities(const config& cfg, const std::string& spe
 	return check_self_abilities_impl(shared_from_this(), other_attack_, cfg, self_, self_loc_, AFFECT_SELF, special, true);
 }
 
-bool attack_type::check_self_abilities_impl(const_attack_ptr self_attack, const_attack_ptr other_attack, const config& special, unit_const_ptr u, const map_location& loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
+bool attack_type::check_self_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const config& special, const unit_const_ptr& u, const map_location& loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
 {
 	if(tag_name == "leadership" && leader_bool){
 		if((*u).get_self_ability_bool_weapon(special, tag_name, loc, self_attack, other_attack)) {
@@ -1768,7 +1768,7 @@ bool attack_type::check_adj_abilities(const config& cfg, const std::string& spec
 	return check_adj_abilities_impl(shared_from_this(), other_attack_, cfg, self_, from, dir, self_loc_, AFFECT_SELF, special, true);
 }
 
-bool attack_type::check_adj_abilities_impl(const_attack_ptr self_attack, const_attack_ptr other_attack, const config& special, unit_const_ptr u, const unit& from, int dir, const map_location& loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
+bool attack_type::check_adj_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const config& special, const unit_const_ptr& u, const unit& from, int dir, const map_location& loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
 {
 	if(tag_name == "leadership" && leader_bool){
 		if((*u).get_adj_ability_bool_weapon(special, tag_name, dir, loc, from, self_attack, other_attack)) {
@@ -2212,8 +2212,8 @@ bool attack_type::special_active(const config& special, AFFECTS whom, const std:
  *  @param filter_self      the filter to use
  */
 bool attack_type::special_active_impl(
-	const_attack_ptr self_attack,
-	const_attack_ptr other_attack,
+	const const_attack_ptr& self_attack,
+	const const_attack_ptr& other_attack,
 	const config& special,
 	AFFECTS whom,
 	const std::string& tag_name,
@@ -2302,8 +2302,8 @@ bool attack_type::special_active_impl(
 	unit_const_ptr & def = is_attacker ? other : self;
 	const map_location & att_loc   = is_attacker ? self_loc : other_loc;
 	const map_location & def_loc   = is_attacker ? other_loc : self_loc;
-	const_attack_ptr& att_weapon = is_attacker ? self_attack : other_attack;
-	const_attack_ptr& def_weapon = is_attacker ? other_attack : self_attack;
+	const const_attack_ptr& att_weapon = is_attacker ? self_attack : other_attack;
+	const const_attack_ptr& def_weapon = is_attacker ? other_attack : self_attack;
 
 	// Filter firststrike here, if both units have first strike then the effects cancel out. Only check
 	// the opponent if "whom" is the defender, otherwise this leads to infinite recursion.
@@ -2425,7 +2425,7 @@ bool filter_base_matches(const config& cfg, int def)
 	return true;
 }
 
-effect::effect(const unit_ability_list& list, int def, const_attack_ptr att, EFFECTS wham) :
+effect::effect(const unit_ability_list& list, int def, const const_attack_ptr& att, EFFECTS wham) :
 	effect_list_(),
 	composite_value_(0)
 {

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -40,7 +40,9 @@
 #include "formula/callable_objects.hpp"
 #include "formula/formula.hpp"
 #include "formula/function_gamestate.hpp"
+#include "units/filter.hpp"
 #include "deprecation.hpp"
+#include <utility>
 
 
 
@@ -1154,12 +1156,12 @@ attack_type::specials_context_t::specials_context_t(
 	bool attacking)
 	: parent(weapon.shared_from_this())
 {
-	weapon.self_ = self;
-	weapon.other_ = other;
+	weapon.self_ = std::move(self);
+	weapon.other_ = std::move(other);
 	weapon.self_loc_ = unit_loc;
 	weapon.other_loc_ = other_loc;
 	weapon.is_attacker_ = attacking;
-	weapon.other_attack_ = other_attack;
+	weapon.other_attack_ = std::move(other_attack);
 	weapon.is_for_listing_ = false;
 }
 
@@ -1174,7 +1176,7 @@ attack_type::specials_context_t::specials_context_t(
 attack_type::specials_context_t::specials_context_t(const attack_type& weapon, unit_const_ptr self, const map_location& loc, bool attacking)
 	: parent(weapon.shared_from_this())
 {
-	weapon.self_ = self;
+	weapon.self_ = std::move(self);
 	weapon.other_ = unit_ptr();
 	weapon.self_loc_ = loc;
 	weapon.other_loc_ = map_location::null_location();

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -41,7 +41,7 @@ struct individual_effect
 class effect
 {
 	public:
-		effect(const unit_ability_list& list, int def, const_attack_ptr attacker = const_attack_ptr(), EFFECTS wham = EFFECT_DEFAULT);
+		effect(const unit_ability_list& list, int def, const const_attack_ptr& attacker = const_attack_ptr(), EFFECTS wham = EFFECT_DEFAULT);
 		// Provide read-only access to the effect list:
 		typedef std::vector<individual_effect>::const_iterator iterator;
 		typedef std::vector<individual_effect>::const_iterator const_iterator;

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -375,8 +375,8 @@ unit_animation::unit_animation(const config& cfg,const std::string& frame_string
 }
 
 int unit_animation::matches(const map_location& loc, const map_location& second_loc,
-		unit_const_ptr my_unit, const std::string& event, const int value, strike_result::type hit, const_attack_ptr attack,
-		const_attack_ptr second_attack, int value2) const
+		const unit_const_ptr& my_unit, const std::string& event, const int value, strike_result::type hit, const const_attack_ptr& attack,
+		const const_attack_ptr& second_attack, int value2) const
 {
 	int result = base_score_;
 	const display& disp = *display::get_singleton();
@@ -1302,8 +1302,8 @@ void unit_animator::add_animation(unit_const_ptr animated_unit
 		, const std::string& text
 		, const color_t text_color
 		, const strike_result::type hit_type
-		, const_attack_ptr attack
-		, const_attack_ptr second_attack
+		, const const_attack_ptr& attack
+		, const const_attack_ptr& second_attack
 		, int value2)
 {
 	if(!animated_unit) return;
@@ -1329,20 +1329,20 @@ void unit_animator::add_animation(unit_const_ptr animated_unit
 	animated_units_.AGGREGATE_EMPLACE(std::move(animated_unit), anim, text, text_color, src, with_bars);
 }
 
-bool unit_animator::has_animation(unit_const_ptr animated_unit
+bool unit_animator::has_animation(const unit_const_ptr& animated_unit
 		, const std::string& event
 		, const map_location &src
 		, const map_location &dst
 		, const int value
 		, const strike_result::type hit_type
-		, const_attack_ptr attack
-		, const_attack_ptr second_attack
+		, const const_attack_ptr& attack
+		, const const_attack_ptr& second_attack
 		, int value2) const
 {
 	return (animated_unit && animated_unit->anim_comp().choose_animation(src, event, dst, value, hit_type, attack, second_attack, value2));
 }
 
-void unit_animator::replace_anim_if_invalid(unit_const_ptr animated_unit
+void unit_animator::replace_anim_if_invalid(const unit_const_ptr& animated_unit
 	, const std::string& event
 	, const map_location &src
 	, const map_location & dst
@@ -1351,8 +1351,8 @@ void unit_animator::replace_anim_if_invalid(unit_const_ptr animated_unit
 	, const std::string& text
 	, const color_t text_color
 	, const strike_result::type hit_type
-	, const_attack_ptr attack
-	, const_attack_ptr second_attack
+	, const const_attack_ptr& attack
+	, const const_attack_ptr& second_attack
 	, int value2)
 {
 	if(!animated_unit) return;

--- a/src/units/animation.hpp
+++ b/src/units/animation.hpp
@@ -34,8 +34,8 @@ public:
 	static void fill_initial_animations(std::vector<unit_animation>& animations, const config& cfg);
 	static void add_anims(std::vector<unit_animation>& animations, const config& cfg);
 
-	int matches(const map_location& loc, const map_location& second_loc, unit_const_ptr my_unit, const std::string& event = "",
-		const int value = 0, strike_result::type hit = strike_result::type::invalid, const_attack_ptr attack = nullptr, const_attack_ptr second_attack = nullptr,
+	int matches(const map_location& loc, const map_location& second_loc, const unit_const_ptr& my_unit, const std::string& event = "",
+		const int value = 0, strike_result::type hit = strike_result::type::invalid, const const_attack_ptr& attack = nullptr, const const_attack_ptr& second_attack = nullptr,
 		int value2 = 0) const;
 
 	const unit_frame& get_last_frame() const
@@ -204,8 +204,8 @@ public:
 		, const std::string& text = ""
 		, const color_t text_color = {0,0,0}
 		, const strike_result::type hit_type = strike_result::type::invalid
-		, const_attack_ptr attack = nullptr
-		, const_attack_ptr second_attack = nullptr
+		, const const_attack_ptr& attack = nullptr
+		, const const_attack_ptr& second_attack = nullptr
 		, int value2 = 0);
 
 	/** has_animation : return an boolean value if animated unit present and have animation specified, used for verify prensence of [leading_anim] or [resistance_anim] for playability of [teaching_anim]
@@ -220,17 +220,17 @@ public:
 	 * @param second_attack weapon used by opponent.
 	 * @param value2 i don't understand myself.but this value is used in choose_animation.
 	 */
-	bool has_animation(unit_const_ptr animated_unit
+	bool has_animation(const unit_const_ptr& animated_unit
 		, const std::string& event
 		, const map_location& src = map_location::null_location()
 		, const map_location& dst = map_location::null_location()
 		, const int value = 0
 		, const strike_result::type hit_type = strike_result::type::invalid
-		, const_attack_ptr attack = nullptr
-		, const_attack_ptr second_attack = nullptr
+		, const const_attack_ptr& attack = nullptr
+		, const const_attack_ptr& second_attack = nullptr
 		, int value2 = 0) const;
 
-	void replace_anim_if_invalid(unit_const_ptr animated_unit
+	void replace_anim_if_invalid(const unit_const_ptr& animated_unit
 		, const std::string& event
 		, const map_location& src = map_location::null_location()
 		, const map_location& dst = map_location::null_location()
@@ -239,8 +239,8 @@ public:
 		, const std::string& text = ""
 		, const color_t text_color = {0,0,0}
 		, const strike_result::type hit_type = strike_result::type::invalid
-		, const_attack_ptr attack = nullptr
-		, const_attack_ptr second_attack = nullptr
+		, const const_attack_ptr& attack = nullptr
+		, const const_attack_ptr& second_attack = nullptr
 		, int value2 = 0);
 	void start_animations();
 	void pause_animation();

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -43,7 +43,7 @@ std::chrono::steady_clock::time_point get_next_idle_tick()
 
 const unit_animation* unit_animation_component::choose_animation(const map_location& loc,const std::string& event,
 		const map_location& second_loc,const int value,const strike_result::type hit,
-		const_attack_ptr attack, const_attack_ptr second_attack, int swing_num)
+		const const_attack_ptr& attack, const const_attack_ptr& second_attack, int swing_num)
 {
 	// Select one of the matching animations at random
 	std::vector<const unit_animation*> options;
@@ -213,7 +213,7 @@ std::vector<std::string> unit_animation_component::get_flags() {
 	std::set<std::string> result;
 	for(const auto& anim : animations_) {
 		const std::vector<std::string>& flags = anim.get_flags();
-		std::copy_if(flags.begin(), flags.end(), std::inserter(result, result.begin()), [](const std::string flag) {
+		std::copy_if(flags.begin(), flags.end(), std::inserter(result, result.begin()), [](const std::string& flag) {
 			return !(flag.empty() || (flag.front() == '_' && flag.back() == '_'));
 		});
 	}

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -71,7 +71,7 @@ public:
 			const map_location& second_loc = map_location::null_location(),
 			const int damage=0,
 			const strike_result::type hit_type = strike_result::type::invalid,
-			const_attack_ptr attack=nullptr,const_attack_ptr second_attack = nullptr,
+			const const_attack_ptr& attack=nullptr,const const_attack_ptr& second_attack = nullptr,
 			int swing_num =0);
 
 	/** Sets the animation state to standing. */

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -85,7 +85,7 @@ public:
 	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials() const;
-	std::string weapon_specials_value(const std::set<std::string> checking_tags) const;
+	std::string weapon_specials_value(const std::set<std::string>& checking_tags) const;
 
 	/** Returns alignment specified by alignment_ variable.
 	 */
@@ -105,7 +105,7 @@ public:
 	 * @param key_name name of attribute checked 'alternative_type' or 'replacement_type'.
 	 * @param resistance_list list of "resistance" abilities to check for each type of damage checked.
 	 */
-	std::string select_damage_type(const unit_ability_list& damage_type_list, const std::string& key_name, unit_ability_list resistance_list) const;
+	std::string select_damage_type(const unit_ability_list& damage_type_list, const std::string& key_name, const unit_ability_list& resistance_list) const;
 	/** return a modified damage type and/or add a secondary_type for hybrid use if special is active. */
 	std::pair<std::string, std::string> damage_type() const;
 	/** @return A list of alternative_type damage types. */
@@ -282,9 +282,9 @@ private:
 	 */
 	static void weapon_specials_impl_self(
 		std::string& temp_string,
-		unit_const_ptr self,
-		const_attack_ptr self_attack,
-		const_attack_ptr other_attack,
+		const unit_const_ptr& self,
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
 		const map_location& self_loc,
 		AFFECTS whom,
 		std::set<std::string>& checking_name,
@@ -294,9 +294,9 @@ private:
 
 	static void weapon_specials_impl_adj(
 		std::string& temp_string,
-		unit_const_ptr self,
-		const_attack_ptr self_attack,
-		const_attack_ptr other_attack,
+		const unit_const_ptr& self,
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
 		const map_location& self_loc,
 		AFFECTS whom,
 		std::set<std::string>& checking_name,
@@ -316,10 +316,10 @@ private:
 	 * @param leader_bool If true, [leadership] abilities are checked.
 	 */
 	static bool check_self_abilities_impl(
-		const_attack_ptr self_attack,
-		const_attack_ptr other_attack,
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
 		const config& special,
-		unit_const_ptr u,
+		const unit_const_ptr& u,
 		const map_location& loc,
 		AFFECTS whom,
 		const std::string& tag_name,
@@ -341,10 +341,10 @@ private:
 	 * @param leader_bool If true, [leadership] abilities are checked.
 	 */
 	static bool check_adj_abilities_impl(
-		const_attack_ptr self_attack,
-		const_attack_ptr other_attack,
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
 		const config& special,
-		unit_const_ptr u,
+		const unit_const_ptr& u,
 		const unit& from,
 		int dir,
 		const map_location& loc,
@@ -354,8 +354,8 @@ private:
 	);
 
 	static bool special_active_impl(
-		const_attack_ptr self_attack,
-		const_attack_ptr other_attack,
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
 		const config& special,
 		AFFECTS whom,
 		const std::string& tag_name,

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -47,7 +47,7 @@ static lg::log_domain log_wml("wml");
 
 using namespace unit_filter_impl;
 
-unit_filter::unit_filter(vconfig cfg)
+unit_filter::unit_filter(const vconfig& cfg)
 	: cfg_(cfg)
 	, fc_(resources::filter_con)
 	, use_flat_tod_(false)
@@ -222,7 +222,7 @@ public:
 }
 
 
-unit_filter_compound::unit_filter_compound(vconfig cfg)
+unit_filter_compound::unit_filter_compound(const vconfig& cfg)
 	: children_()
 	, cond_children_()
 {
@@ -313,7 +313,7 @@ namespace {
 	}
 }
 
-void unit_filter_compound::fill(vconfig cfg)
+void unit_filter_compound::fill(const vconfig& cfg)
 	{
 		const config& literal = cfg.get_config();
 

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -81,14 +81,14 @@ namespace unit_filter_impl
 
 	struct unit_filter_compound : public unit_filter_base
 	{
-		unit_filter_compound(vconfig cfg);
+		unit_filter_compound(const vconfig& cfg);
 
 		template<typename C, typename F>
 		void create_attribute(const config::attribute_value c, C conv, F func);
 		template<typename F>
 		void create_child(const vconfig& c, F func);
 
-		void fill(vconfig cfg);
+		void fill(const vconfig& cfg);
 
 		virtual bool matches(const unit_filter_args& u) const override;
 		bool filter_impl(const unit_filter_args& u) const;
@@ -102,7 +102,7 @@ namespace unit_filter_impl
 class unit_filter
 {
 public:
-	explicit unit_filter(vconfig cfg);
+	explicit unit_filter(const vconfig& cfg);
 
 	unit_filter(const unit_filter&) = default;
 	unit_filter& operator=(const unit_filter&) = default;

--- a/src/units/formula_manager.cpp
+++ b/src/units/formula_manager.cpp
@@ -18,7 +18,7 @@
 #include "config.hpp"
 #include "deprecation.hpp"
 
-void unit_formula_manager::add_formula_var(std::string str,wfl:: variant var)
+void unit_formula_manager::add_formula_var(const std::string& str,const wfl:: variant& var)
 {
 	if(!formula_vars_) formula_vars_ = std::make_shared<wfl::map_formula_callable>();
 	formula_vars_->add(str, var);

--- a/src/units/formula_manager.hpp
+++ b/src/units/formula_manager.hpp
@@ -32,7 +32,7 @@ public:
 	{}
 
 	const wfl::map_formula_callable_ptr& formula_vars() const { return formula_vars_; }
-	void add_formula_var(std::string str, wfl::variant var);
+	void add_formula_var(const std::string& str, const wfl::variant& var);
 	bool has_formula() const { return !unit_formula_.empty(); }
 	bool has_loop_formula() const { return !unit_loop_formula_.empty(); }
 	bool has_priority_formula() const { return !unit_priority_formula_.empty(); }

--- a/src/units/map.cpp
+++ b/src/units/map.cpp
@@ -132,7 +132,7 @@ unit_map::umap_retval_pair_t unit_map::move(const map_location& src, const map_l
 	return std::pair(make_unit_iterator(uit), true);
 }
 
-unit_map::umap_retval_pair_t unit_map::insert(unit_ptr p)
+unit_map::umap_retval_pair_t unit_map::insert(const unit_ptr& p)
 {
 	// 1. Construct a unit_pod.
 	// 2. Try insertion into the umap.
@@ -213,7 +213,7 @@ unit_map::umap_retval_pair_t unit_map::insert(unit_ptr p)
 	return std::pair(make_unit_iterator(uinsert.first), true);
 }
 
-unit_map::umap_retval_pair_t unit_map::replace(const map_location& l, unit_ptr p)
+unit_map::umap_retval_pair_t unit_map::replace(const map_location& l, const unit_ptr& p)
 {
 	self_check();
 	p->set_location(l);

--- a/src/units/map.hpp
+++ b/src/units/map.hpp
@@ -481,7 +481,7 @@ public:
 	 * @note            If the unit::underlying_id is already in use, a new one will be generated.
 	 * @note            The map takes ownership of the pointed object only if the operation succeeds.
 	 */
-	umap_retval_pair_t insert(unit_ptr p);
+	umap_retval_pair_t insert(const unit_ptr& p);
 
 	/**
 	 * Moves a unit from location @a src to location @a dst.
@@ -501,7 +501,7 @@ public:
 	 * @returns         A pair consisting of an iterator pointing to the new unit (or the unit
 	 *                  already occupying that location) and a bool indicating success.
 	 */
-	umap_retval_pair_t replace(const map_location& l, unit_ptr p);
+	umap_retval_pair_t replace(const map_location& l, const unit_ptr& p);
 
 	/**
 	 * Erases the unit at location @a l, if any.

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -452,7 +452,7 @@ void unit_type::build(BUILD_STATUS status,
 	}
 }
 
-const unit_type& unit_type::get_gender_unit_type(std::string gender) const
+const unit_type& unit_type::get_gender_unit_type(const std::string& gender) const
 {
 	if(gender == unit_race::s_female) {
 		return get_gender_unit_type(unit_race::FEMALE);
@@ -506,7 +506,7 @@ static void append_special_note(std::vector<t_string>& notes, const t_string& ne
 	notes.push_back(new_note);
 }
 
-std::vector<t_string> combine_special_notes(const std::vector<t_string> direct, const config& abilities, const_attack_itors attacks, const movetype& mt)
+std::vector<t_string> combine_special_notes(const std::vector<t_string>& direct, const config& abilities, const_attack_itors attacks, const movetype& mt)
 {
 	std::vector<t_string> notes;
 	for(const auto& note : direct) {

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -124,7 +124,7 @@ public:
 	 * Returns a gendered variant of this unit_type.
 	 * @param gender "male" or "female".
 	 */
-	const unit_type& get_gender_unit_type(std::string gender) const;
+	const unit_type& get_gender_unit_type(const std::string& gender) const;
 	/** Returns a gendered variant of this unit_type based on the given parameter. */
 	const unit_type& get_gender_unit_type(unit_race::GENDER gender) const;
 
@@ -455,4 +455,4 @@ private:
  *
  * @return the special notes for a unit or unit_type.
  */
-std::vector<t_string> combine_special_notes(const std::vector<t_string> direct, const config& abilities, const_attack_itors attacks, const movetype& mt);
+std::vector<t_string> combine_special_notes(const std::vector<t_string>& direct, const config& abilities, const_attack_itors attacks, const movetype& mt);

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -128,7 +128,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
  */
 std::chrono::milliseconds move_unit_between(const map_location& a,
 		const map_location& b,
-		unit_ptr temp_unit,
+		const unit_ptr& temp_unit,
 		unsigned int step_num,
 		unsigned int step_left,
 		unit_animator& animator,
@@ -213,7 +213,7 @@ unit_mover::~unit_mover()
 /* Note: Hide the unit in its current location; do not actually remove it.
  * Otherwise the status displays will be wrong during the movement.
  */
-void unit_mover::replace_temporary(unit_ptr u)
+void unit_mover::replace_temporary(const unit_ptr& u)
 {
 	if ( disp_ == nullptr )
 		// No point in creating a temp unit with no way to display it.
@@ -254,7 +254,7 @@ void unit_mover::update_shown_unit()
  * Initiates the display of movement for the supplied unit.
  * This should be called before attempting to display moving to a new hex.
  */
-void unit_mover::start(unit_ptr u)
+void unit_mover::start(const unit_ptr& u)
 {
 	// Nothing to do here if there is nothing to animate.
 	if ( !can_draw_ )
@@ -311,7 +311,7 @@ void unit_mover::start(unit_ptr u)
  * wait (another call to proceed_to() or finish() will implicitly wait). The
  * unit must remain valid until the wait is finished.
  */
-void unit_mover::proceed_to(unit_ptr u, std::size_t path_index, bool update, bool wait)
+void unit_mover::proceed_to(const unit_ptr& u, std::size_t path_index, bool update, bool wait)
 {
 	// Nothing to do here if animations cannot be shown.
 	if ( !can_draw_ || !animate_ )
@@ -430,7 +430,7 @@ void unit_mover::wait_for_anims()
  * If @a dir is not supplied, the final direction will be determined by (the
  * last two traversed hexes of) the path.
  */
-void unit_mover::finish(unit_ptr u, map_location::direction dir)
+void unit_mover::finish(const unit_ptr& u, map_location::direction dir)
 {
 	// Nothing to do here if the display is not valid.
 	if ( !can_draw_ ) {
@@ -502,7 +502,7 @@ void unit_mover::finish(unit_ptr u, map_location::direction dir)
  * so that while the unit is moving status etc.
  * will still display the correct number of units.
  */
-void move_unit(const std::vector<map_location>& path, unit_ptr u,
+void move_unit(const std::vector<map_location>& path, const unit_ptr& u,
                bool animate, map_location::direction dir,
                bool force_scroll)
 {
@@ -517,7 +517,7 @@ void move_unit(const std::vector<map_location>& path, unit_ptr u,
 void reset_helpers(const unit *attacker,const unit *defender);
 
 void unit_draw_weapon(const map_location& loc, unit& attacker,
-		const_attack_ptr attack,const_attack_ptr secondary_attack, const map_location& defender_loc, unit_ptr defender)
+		const const_attack_ptr& attack,const const_attack_ptr& secondary_attack, const map_location& defender_loc, const unit_ptr& defender)
 {
 	display* disp = display::get_singleton();
 	if(do_not_show_anims(disp) || disp->fogged(loc) || !prefs::get().show_combat()) {
@@ -536,8 +536,8 @@ void unit_draw_weapon(const map_location& loc, unit& attacker,
 }
 
 
-void unit_sheath_weapon(const map_location& primary_loc, unit_ptr primary_unit,
-		const_attack_ptr primary_attack,const_attack_ptr secondary_attack, const map_location& secondary_loc,unit_ptr secondary_unit)
+void unit_sheath_weapon(const map_location& primary_loc, const unit_ptr& primary_unit,
+		const const_attack_ptr& primary_attack,const const_attack_ptr& secondary_attack, const map_location& secondary_loc,const unit_ptr& secondary_unit)
 {
 	display* disp = display::get_singleton();
 	if(do_not_show_anims(disp) || disp->fogged(primary_loc) || !prefs::get().show_combat()) {
@@ -567,7 +567,7 @@ void unit_sheath_weapon(const map_location& primary_loc, unit_ptr primary_unit,
 
 
 void unit_die(const map_location& loc, unit& loser,
-		const_attack_ptr attack,const_attack_ptr secondary_attack, const map_location& winner_loc, unit_ptr winner)
+		const const_attack_ptr& attack,const const_attack_ptr& secondary_attack, const map_location& winner_loc, const unit_ptr& winner)
 {
 	display* disp = display::get_singleton();
 	if(do_not_show_anims(disp) || disp->fogged(loc) || !prefs::get().show_combat()) {
@@ -594,7 +594,7 @@ void unit_die(const map_location& loc, unit& loser,
 
 void unit_attack(display * disp, game_board & board,
                  const map_location& a, const map_location& b, int damage,
-                 const attack_type& attack, const_attack_ptr secondary_attack,
+                 const attack_type& attack, const const_attack_ptr& secondary_attack,
                  int swing, const std::string& hit_text, int drain_amount,
                  const std::string& att_text,
                  const std::vector<std::string>* extra_hit_sounds,

--- a/src/units/udisplay.hpp
+++ b/src/units/udisplay.hpp
@@ -50,13 +50,13 @@ public:
 	explicit unit_mover(const std::vector<map_location>& path, bool animate=true, bool force_scroll=false);
 	~unit_mover();
 
-	void start(unit_ptr u);
-	void proceed_to(unit_ptr u, std::size_t path_index, bool update=false, bool wait=true);
+	void start(const unit_ptr& u);
+	void proceed_to(const unit_ptr& u, std::size_t path_index, bool update=false, bool wait=true);
 	void wait_for_anims();
-	void finish(unit_ptr u, map_location::direction dir = map_location::direction::indeterminate);
+	void finish(const unit_ptr& u, map_location::direction dir = map_location::direction::indeterminate);
 
 private: // functions
-	void replace_temporary(unit_ptr u);
+	void replace_temporary(const unit_ptr& u);
 	void update_shown_unit();
 
 private: // data
@@ -80,7 +80,7 @@ private: // data
 /**
  * Display a unit moving along a given path.
  */
-void move_unit(const std::vector<map_location>& path, unit_ptr u,
+void move_unit(const std::vector<map_location>& path, const unit_ptr& u,
 	bool animate=true,
 	map_location::direction dir=map_location::direction::indeterminate,
 	bool force_scroll=false);
@@ -89,13 +89,13 @@ void move_unit(const std::vector<map_location>& path, unit_ptr u,
  * Play a pre-fight animation
  * First unit is the attacker, second unit the defender
  */
-void unit_draw_weapon( const map_location& loc, unit& u, const_attack_ptr attack=nullptr, const_attack_ptr secondary_attack=nullptr,const map_location& defender_loc = map_location::null_location(), unit_ptr defender=unit_ptr());
+void unit_draw_weapon( const map_location& loc, unit& u, const const_attack_ptr& attack=nullptr, const const_attack_ptr& secondary_attack=nullptr,const map_location& defender_loc = map_location::null_location(), const unit_ptr& defender=unit_ptr());
 
 /**
  * Play a post-fight animation
  * Both unit can be set to null, only valid units will play their animation
  */
-void unit_sheath_weapon( const map_location& loc, unit_ptr u=unit_ptr(), const_attack_ptr attack=nullptr, const_attack_ptr secondary_attack=nullptr,const map_location& defender_loc = map_location::null_location(), unit_ptr defender=unit_ptr());
+void unit_sheath_weapon( const map_location& loc, const unit_ptr& u=unit_ptr(), const const_attack_ptr& attack=nullptr, const const_attack_ptr& secondary_attack=nullptr,const map_location& defender_loc = map_location::null_location(), const unit_ptr& defender=unit_ptr());
 
 /**
  * Show a unit fading out.
@@ -103,9 +103,9 @@ void unit_sheath_weapon( const map_location& loc, unit_ptr u=unit_ptr(), const_a
  * Note: this only shows the effect, it doesn't actually kill the unit.
  */
  void unit_die( const map_location& loc, unit& u,
-	const_attack_ptr attack=nullptr, const_attack_ptr secondary_attack=nullptr,
+	const const_attack_ptr& attack=nullptr, const const_attack_ptr& secondary_attack=nullptr,
 	const map_location& winner_loc=map_location::null_location(),
-	unit_ptr winner = unit_ptr());
+	const unit_ptr& winner = unit_ptr());
 
 
 /**
@@ -116,7 +116,7 @@ void unit_sheath_weapon( const map_location& loc, unit_ptr u=unit_ptr(), const_a
  */
 void unit_attack(display * disp, game_board & board, //TODO: Would be nice if this could be purely a display function and defer damage dealing to its caller
 	const map_location& a, const map_location& b, int damage,
-	const attack_type& attack, const_attack_ptr secondary_attack,
+	const attack_type& attack, const const_attack_ptr& secondary_attack,
 	int swing, const std::string& hit_text, int drain_amount, const std::string& att_text, const std::vector<std::string>* extra_hit_sounds=nullptr,
 	bool attacking=true);
 

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1777,7 +1777,7 @@ static bool resistance_filter_matches_base(const config& cfg, bool attacker)
 	return true;
 }
 
-int unit::resistance_against(const std::string& damage_name, bool attacker, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon) const
+int unit::resistance_against(const std::string& damage_name, bool attacker, const map_location& loc, const_attack_ptr weapon, const const_attack_ptr& opp_weapon) const
 {
 	unit_ability_list resistance_list = get_abilities_weapons("resistance",loc, weapon, opp_weapon);
 	utils::erase_if(resistance_list, [&](const unit_ability& i) {
@@ -1967,7 +1967,7 @@ const std::set<std::string> unit::builtin_effects {
 	"status", "type", "variation", "vision", "vision_costs", "zoc"
 };
 
-std::string unit::describe_builtin_effect(std::string apply_to, const config& effect)
+std::string unit::describe_builtin_effect(const std::string& apply_to, const config& effect)
 {
 	if(apply_to == "attack") {
 		std::vector<t_string> attack_names;
@@ -2032,7 +2032,7 @@ std::string unit::describe_builtin_effect(std::string apply_to, const config& ef
 	return "";
 }
 
-void unit::apply_builtin_effect(std::string apply_to, const config& effect)
+void unit::apply_builtin_effect(const std::string& apply_to, const config& effect)
 {
 	config events;
 	appearance_changed_ = true;
@@ -2079,7 +2079,7 @@ void unit::apply_builtin_effect(std::string apply_to, const config& effect)
 		}
 	} else if(apply_to == "remove_attacks") {
 		set_attr_changed(UA_ATTACKS);
-		utils::erase_if(attacks_, [&effect](attack_ptr a) { return a->matches_filter(effect); });
+		utils::erase_if(attacks_, [&effect](const attack_ptr& a) { return a->matches_filter(effect); });
 	} else if(apply_to == "attack") {
 		set_attr_changed(UA_ATTACKS);
 		for(attack_ptr a : attacks_) {
@@ -2744,7 +2744,7 @@ std::string unit::image_mods() const
 }
 
 // Called by the Lua API after resetting an attack pointer.
-bool unit::remove_attack(attack_ptr atk)
+bool unit::remove_attack(const attack_ptr& atk)
 {
 	set_attr_changed(UA_ATTACKS);
 	auto iter = std::find(attacks_.begin(), attacks_.end(), atk);

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -55,6 +55,7 @@
 #include <exception>                    // for exception
 #include <iterator>                     // for back_insert_iterator, etc
 #include <string_view>
+#include <utility>
 
 namespace t_translation { struct terrain_code; }
 
@@ -1779,7 +1780,7 @@ static bool resistance_filter_matches_base(const config& cfg, bool attacker)
 
 int unit::resistance_against(const std::string& damage_name, bool attacker, const map_location& loc, const_attack_ptr weapon, const const_attack_ptr& opp_weapon) const
 {
-	unit_ability_list resistance_list = get_abilities_weapons("resistance",loc, weapon, opp_weapon);
+	unit_ability_list resistance_list = get_abilities_weapons("resistance",loc, std::move(weapon), opp_weapon);
 	utils::erase_if(resistance_list, [&](const unit_ability& i) {
 		return !resistance_filter_matches_base(*i.ability_cfg, attacker);
 	});
@@ -1926,7 +1927,7 @@ std::vector<config> unit::get_modification_advances() const
 void unit::set_advancements(std::vector<config> advancements)
 {
 	set_attr_changed(UA_ADVANCEMENTS);
-	advancements_ = advancements;
+	advancements_ = std::move(advancements);
 }
 
 const std::string& unit::type_id() const

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -958,7 +958,7 @@ public:
 	 * @param atk A pointer to the attack to remove
 	 * @return true if the attack was removed, false if it didn't exist on the unit
 	 */
-	bool remove_attack(attack_ptr atk);
+	bool remove_attack(const attack_ptr& atk);
 
 	/**
 	 * Set the unit to have no attacks left for this turn.
@@ -1046,7 +1046,7 @@ public:
 	 * @param weapon The weapon to check for any abilities or weapon specials
 	 * @param opp_weapon The opponent's weapon to check for any abilities or weapon specials
 	 */
-	int resistance_against(const std::string& damage_name, bool attacker, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const;
+	int resistance_against(const std::string& damage_name, bool attacker, const map_location& loc, const_attack_ptr weapon = nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 
 	/**
 	 * The unit's resistance against a given attack
@@ -1591,14 +1591,14 @@ public:
 	 * @param type The effect to apply. Must be one of the effects in @ref builtin_effects.
 	 * @param effect The details of the effect
 	 */
-	void apply_builtin_effect(std::string type, const config& effect);
+	void apply_builtin_effect(const std::string& type, const config& effect);
 
 	/**
 	 * Construct a string describing a built-in effect.
 	 * @param type The effect to describe. Must be one of the effects in @ref builtin_effects.
 	 * @param effect The details of the effect
 	 */
-	std::string describe_builtin_effect(std::string type, const config& effect);
+	std::string describe_builtin_effect(const std::string& type, const config& effect);
 
 	/** Re-apply all saved modifications. */
 	void apply_modifications();
@@ -1757,7 +1757,7 @@ public:
 	 * @param weapon the attack used by unit checked in this function.
 	 * @param opp_weapon the attack used by opponent to unit checked.
 	 */
-	bool get_self_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const_attack_ptr weapon = nullptr, const_attack_ptr opp_weapon = nullptr) const;
+	bool get_self_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const const_attack_ptr& weapon = nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 	/** Checks whether this unit is affected by a given ability, and that that ability is active.
 	 * @return True if the ability @a tag_name is active.
 	 * @param cfg the const config to one of abilities @a ability checked.
@@ -1777,7 +1777,7 @@ public:
 	 * @param weapon the attack used by unit checked in this function.
 	 * @param opp_weapon the attack used by opponent to unit checked.
 	 */
-	bool get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const_attack_ptr weapon=nullptr, const_attack_ptr opp_weapon = nullptr) const;
+	bool get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const const_attack_ptr& weapon=nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 
 	/**
 	 * Gets the unit's active abilities of a particular type if it were on a specified location.
@@ -1950,7 +1950,7 @@ private:
 	 * filters the weapons that condition the use of abilities for combat ([resistance],[leadership] or abilities used like specials
 	 * (deprecated in two last cases)
 	 */
-	bool ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bool is_opp) const;
+	bool ability_affects_weapon(const config& cfg, const const_attack_ptr& weapon, bool is_opp) const;
 
 public:
 	/** Get the unit formula manager. */

--- a/src/utils/name_generator_factory.cpp
+++ b/src/utils/name_generator_factory.cpp
@@ -35,7 +35,7 @@ name_generator_factory::name_generator_factory(const config& config, std::vector
 	}
 }
 
-void name_generator_factory::add_name_generator_from_config(const config& config, const std::string id, const std::string prefix) {
+void name_generator_factory::add_name_generator_from_config(const config& config, const std::string& id, const std::string& prefix) {
 	std::string cfg_name 	= prefix + "name_generator";
 	std::string markov_name = prefix + "names";
 
@@ -69,7 +69,7 @@ std::shared_ptr<name_generator> name_generator_factory::get_name_generator() {
 	return it->second;
 }
 
-std::shared_ptr<name_generator> name_generator_factory::get_name_generator(const std::string id) {
+std::shared_ptr<name_generator> name_generator_factory::get_name_generator(const std::string& id) {
 	std::map<std::string, std::shared_ptr<name_generator>>::const_iterator it = name_generators_.find(id);
 	if(it == name_generators_.end()) {
 		return get_name_generator();

--- a/src/utils/name_generator_factory.hpp
+++ b/src/utils/name_generator_factory.hpp
@@ -42,7 +42,7 @@ public:
 	 * @param name generator id, e.g. a gender or a terrain type
 	 * @returns a name generator
 	 */
-	std::shared_ptr<name_generator> get_name_generator(const std::string name);
+	std::shared_ptr<name_generator> get_name_generator(const std::string& name);
 
 private:
 	std::map<std::string, std::shared_ptr<name_generator>> name_generators_;
@@ -54,5 +54,5 @@ private:
 	 * @param id the generator id to use
 	 * @param prefix the prefix to look for
 	 */
-	void add_name_generator_from_config(const config& config, const std::string id, const std::string prefix);
+	void add_name_generator_from_config(const config& config, const std::string& id, const std::string& prefix);
 };

--- a/src/wesnothd_connection.cpp
+++ b/src/wesnothd_connection.cpp
@@ -135,7 +135,7 @@ wesnothd_connection::~wesnothd_connection()
 }
 
 // worker thread
-void wesnothd_connection::handle_resolve(const error_code& ec, results_type results)
+void wesnothd_connection::handle_resolve(const error_code& ec, const results_type& results)
 {
 	MPTEST_LOG;
 	if(ec) {

--- a/src/wesnothd_connection.hpp
+++ b/src/wesnothd_connection.hpp
@@ -161,7 +161,7 @@ private:
 	using results_type = resolver::results_type;
 	using endpoint = const boost::asio::ip::tcp::endpoint&;
 
-	void handle_resolve(const boost::system::error_code& ec, results_type results);
+	void handle_resolve(const boost::system::error_code& ec, const results_type& results);
 	void handle_connect(const boost::system::error_code& ec, endpoint endpoint);
 
 	void handshake();

--- a/src/whiteboard/action.cpp
+++ b/src/whiteboard/action.cpp
@@ -31,13 +31,13 @@
 
 namespace wb {
 
-std::ostream& operator<<(std::ostream& s, action_ptr action)
+std::ostream& operator<<(std::ostream& s, const action_ptr& action)
 {
 	assert(action);
 	return action->print(s);
 }
 
-std::ostream& operator<<(std::ostream& s, action_const_ptr action)
+std::ostream& operator<<(std::ostream& s, const action_const_ptr& action)
 {
 	assert(action);
 	return action->print(s);

--- a/src/whiteboard/action.hpp
+++ b/src/whiteboard/action.hpp
@@ -143,7 +143,7 @@ private:
 	bool hidden_;
 };
 
-std::ostream& operator<<(std::ostream& s, action_ptr action);
-std::ostream& operator<<(std::ostream& s, action_const_ptr action);
+std::ostream& operator<<(std::ostream& s, const action_ptr& action);
+std::ostream& operator<<(std::ostream& s, const action_const_ptr& action);
 
 } // end namespace wb

--- a/src/whiteboard/attack.cpp
+++ b/src/whiteboard/attack.cpp
@@ -33,13 +33,13 @@
 namespace wb
 {
 
-std::ostream &operator<<(std::ostream &s, attack_ptr attack)
+std::ostream &operator<<(std::ostream &s, const attack_ptr& attack)
 {
 	assert(attack);
 	return attack->print(s);
 }
 
-std::ostream &operator<<(std::ostream &s, attack_const_ptr attack)
+std::ostream &operator<<(std::ostream &s, const attack_const_ptr& attack)
 {
 	assert(attack);
 	return attack->print(s);

--- a/src/whiteboard/attack.cpp
+++ b/src/whiteboard/attack.cpp
@@ -19,6 +19,8 @@
 
 #include "whiteboard/attack.hpp"
 
+#include <utility>
+
 #include "whiteboard/visitor.hpp"
 
 #include "config.hpp"
@@ -54,7 +56,7 @@ std::ostream& attack::print(std::ostream& s) const
 
 attack::attack(std::size_t team_index, bool hidden, unit& u, const map_location& target_hex, int weapon_choice, const pathfind::marked_route& route,
 		arrow_ptr arrow, fake_unit_ptr fake_unit)
-	: move(team_index, hidden, u, route, arrow, std::move(fake_unit)),
+	: move(team_index, hidden, u, route, std::move(arrow), std::move(fake_unit)),
 	target_hex_(target_hex),
 	weapon_choice_(weapon_choice),
 	attack_movement_cost_(u.attacks()[weapon_choice_].movement_used()),

--- a/src/whiteboard/attack.hpp
+++ b/src/whiteboard/attack.hpp
@@ -87,7 +87,7 @@ private:
 };
 
 /** Dumps an attack on a stream, for debug purposes. */
-std::ostream& operator<<(std::ostream &s, attack_ptr attack);
-std::ostream& operator<<(std::ostream &s, attack_const_ptr attack);
+std::ostream& operator<<(std::ostream &s, const attack_ptr& attack);
+std::ostream& operator<<(std::ostream &s, const attack_const_ptr& attack);
 
 } // end namespace wb

--- a/src/whiteboard/highlighter.cpp
+++ b/src/whiteboard/highlighter.cpp
@@ -179,7 +179,7 @@ void highlighter::unhighlight()
 	exclusive_display_hexes_.clear();
 }
 
-void highlighter::last_action_redraw(move_ptr move)
+void highlighter::last_action_redraw(const move_ptr& move)
 {
 	//Last action with a fake unit always gets normal appearance
 	if(move->get_fake_unit()) {

--- a/src/whiteboard/highlighter.cpp
+++ b/src/whiteboard/highlighter.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <utility>
 
 #include "whiteboard/highlighter.hpp"
 
@@ -52,7 +53,7 @@ highlighter::highlighter(side_actions_ptr side_actions)
 	, selected_action_()
 	, main_highlight_()
 	, secondary_highlights_()
-	, side_actions_(side_actions)
+	, side_actions_(std::move(side_actions))
 {
 }
 

--- a/src/whiteboard/highlighter.hpp
+++ b/src/whiteboard/highlighter.hpp
@@ -77,7 +77,7 @@ private:
 	void find_secondary_highlights();
 
 	/** Redraw the given move action when needed. */
-	void last_action_redraw(move_ptr);
+	void last_action_redraw(const move_ptr&);
 
 	map_location mouseover_hex_;
 	std::set<map_location> exclusive_display_hexes_;

--- a/src/whiteboard/manager.cpp
+++ b/src/whiteboard/manager.cpp
@@ -333,11 +333,11 @@ void manager::on_finish_side_turn(int side)
 	LOG_WB << "on_finish_side_turn()";
 }
 
-void manager::pre_delete_action(action_ptr)
+void manager::pre_delete_action(const action_ptr&)
 {
 }
 
-void manager::post_delete_action(action_ptr action)
+void manager::post_delete_action(const action_ptr& action)
 {
 	// The fake unit representing the destination of a chain of planned moves should have the regular animation.
 	// If the last remaining action of the unit that owned this move is a move as well,

--- a/src/whiteboard/manager.hpp
+++ b/src/whiteboard/manager.hpp
@@ -95,9 +95,9 @@ public:
 	void on_change_controller(int side, const team& t);
 	void on_kill_unit();
 	/** Handles various cleanup right before removing an action from the queue */
-	void pre_delete_action(action_ptr action);
+	void pre_delete_action(const action_ptr& action);
 	/** Handles various cleanup right after removing an action from the queue */
-	void post_delete_action(action_ptr action);
+	void post_delete_action(const action_ptr& action);
 
 	/** Called by replay_network_sender to add whiteboard data to the outgoing network packets */
 	void send_network_data();

--- a/src/whiteboard/move.cpp
+++ b/src/whiteboard/move.cpp
@@ -41,13 +41,13 @@
 
 namespace wb {
 
-std::ostream& operator<<(std::ostream &s, move_ptr move)
+std::ostream& operator<<(std::ostream &s, const move_ptr& move)
 {
 	assert(move);
 	return move->print(s);
 }
 
-std::ostream& operator<<(std::ostream &s, move_const_ptr move)
+std::ostream& operator<<(std::ostream &s, const move_const_ptr& move)
 {
 	assert(move);
 	return move->print(s);

--- a/src/whiteboard/move.cpp
+++ b/src/whiteboard/move.cpp
@@ -19,6 +19,8 @@
 
 #include "whiteboard/move.hpp"
 
+#include <utility>
+
 #include "whiteboard/visitor.hpp"
 #include "whiteboard/side_actions.hpp"
 #include "whiteboard/utility.hpp"
@@ -73,7 +75,7 @@ move::move(std::size_t team_index, bool hidden, unit& u, const pathfind::marked_
   route_(new pathfind::marked_route(route)),
   movement_cost_(0),
   turn_number_(0),
-  arrow_(arrow),
+  arrow_(std::move(arrow)),
   fake_unit_(std::move(fake_unit)),
   arrow_brightness_(),
   arrow_texture_(),

--- a/src/whiteboard/move.hpp
+++ b/src/whiteboard/move.hpp
@@ -134,7 +134,7 @@ private:
 };
 
 /** Dumps an move on a stream, for debug purposes. */
-std::ostream &operator<<(std::ostream &s, move_ptr move);
-std::ostream &operator<<(std::ostream &s, move_const_ptr move);
+std::ostream &operator<<(std::ostream &s, const move_ptr& move);
+std::ostream &operator<<(std::ostream &s, const move_const_ptr& move);
 
 } // end namespace wb

--- a/src/whiteboard/recall.cpp
+++ b/src/whiteboard/recall.cpp
@@ -38,12 +38,12 @@
 namespace wb
 {
 
-std::ostream& operator<<(std::ostream& s, recall_ptr recall)
+std::ostream& operator<<(std::ostream& s, const recall_ptr& recall)
 {
 	assert(recall);
 	return recall->print(s);
 }
-std::ostream& operator<<(std::ostream& s, recall_const_ptr recall)
+std::ostream& operator<<(std::ostream& s, const recall_const_ptr& recall)
 {
 	assert(recall);
 	return recall->print(s);

--- a/src/whiteboard/recall.hpp
+++ b/src/whiteboard/recall.hpp
@@ -93,7 +93,7 @@ private:
 	int original_recall_pos_;
 };
 
-std::ostream& operator<<(std::ostream& s, recall_ptr recall);
-std::ostream& operator<<(std::ostream& s, recall_const_ptr recall);
+std::ostream& operator<<(std::ostream& s, const recall_ptr& recall);
+std::ostream& operator<<(std::ostream& s, const recall_const_ptr& recall);
 
 }

--- a/src/whiteboard/recruit.cpp
+++ b/src/whiteboard/recruit.cpp
@@ -35,12 +35,12 @@
 namespace wb
 {
 
-std::ostream& operator<<(std::ostream& s, recruit_ptr recruit)
+std::ostream& operator<<(std::ostream& s, const recruit_ptr& recruit)
 {
 	assert(recruit);
 	return recruit->print(s);
 }
-std::ostream& operator<<(std::ostream& s, recruit_const_ptr recruit)
+std::ostream& operator<<(std::ostream& s, const recruit_const_ptr& recruit)
 {
 	assert(recruit);
 	return recruit->print(s);

--- a/src/whiteboard/recruit.hpp
+++ b/src/whiteboard/recruit.hpp
@@ -98,7 +98,7 @@ private:
 	unit_ptr create_corresponding_unit();
 };
 
-std::ostream& operator<<(std::ostream& s, recruit_ptr recruit);
-std::ostream& operator<<(std::ostream& s, recruit_const_ptr recruit);
+std::ostream& operator<<(std::ostream& s, const recruit_ptr& recruit);
+std::ostream& operator<<(std::ostream& s, const recruit_const_ptr& recruit);
 
 }

--- a/src/whiteboard/side_actions.cpp
+++ b/src/whiteboard/side_actions.cpp
@@ -19,6 +19,7 @@
 
 #include <set>
 #include <sstream>
+#include <utility>
 
 #include "whiteboard/side_actions.hpp"
 
@@ -439,7 +440,7 @@ namespace
 	struct swapable_with_move: public visitor
 	{
 	public:
-		swapable_with_move(side_actions &sa, side_actions::iterator position, move_ptr second): sa_(sa), valid_(false), position_(position), second_(second) {}
+		swapable_with_move(side_actions &sa, side_actions::iterator position, move_ptr second): sa_(sa), valid_(false), position_(position), second_(std::move(second)) {}
 		bool valid() const { return valid_; }
 
 		void visit(move_ptr first) {

--- a/src/whiteboard/side_actions.cpp
+++ b/src/whiteboard/side_actions.cpp
@@ -120,7 +120,7 @@ side_actions_container::const_iterator side_actions_container::turn_begin(std::s
 	}
 }
 
-side_actions_container::iterator side_actions_container::push_front(std::size_t turn, action_ptr action){
+side_actions_container::iterator side_actions_container::push_front(std::size_t turn, const action_ptr& action){
 	if(turn_size(turn) == 0) {
 		return queue(turn, action);
 	}
@@ -137,7 +137,7 @@ side_actions_container::iterator side_actions_container::push_front(std::size_t 
 	return res;
 }
 
-side_actions_container::iterator side_actions_container::insert(iterator position, action_ptr action)
+side_actions_container::iterator side_actions_container::insert(iterator position, const action_ptr& action)
 {
 	assert(position <= end());
 
@@ -154,7 +154,7 @@ side_actions_container::iterator side_actions_container::insert(iterator positio
 	return res.first;
 }
 
-side_actions_container::iterator side_actions_container::queue(std::size_t turn_num, action_ptr action)
+side_actions_container::iterator side_actions_container::queue(std::size_t turn_num, const action_ptr& action)
 {
 	// Are we inserting an action in the future while the current turn is empty?
 	// That is, are we in the sole case where an empty turn can be followed by a non-empty one.
@@ -408,7 +408,7 @@ void side_actions::show()
 	}
 }
 
-side_actions::iterator side_actions::insert_action(iterator position, action_ptr action)
+side_actions::iterator side_actions::insert_action(iterator position, const action_ptr& action)
 {
 	if(resources::whiteboard->has_planned_unit_map()) {
 		ERR_WB << "Modifying action queue while temp modifiers are applied!!!";
@@ -420,7 +420,7 @@ side_actions::iterator side_actions::insert_action(iterator position, action_ptr
 	return valid_position;
 }
 
-side_actions::iterator side_actions::queue_action(std::size_t turn_num, action_ptr action)
+side_actions::iterator side_actions::queue_action(std::size_t turn_num, const action_ptr& action)
 {
 	if(resources::whiteboard->has_planned_unit_map()) {
 		ERR_WB << "Modifying action queue while temp modifiers are applied!!!";
@@ -701,7 +701,7 @@ void side_actions::update_recruited_unit(std::size_t old_id, unit& new_unit)
 	}
 }
 
-side_actions::iterator side_actions::safe_insert(std::size_t turn, std::size_t pos, action_ptr act)
+side_actions::iterator side_actions::safe_insert(std::size_t turn, std::size_t pos, const action_ptr& act)
 {
 	assert(act);
 	if(pos == 0) {
@@ -717,13 +717,13 @@ side_actions::iterator side_actions::synced_erase(iterator itor)
 	return safe_erase(itor);
 }
 
-side_actions::iterator side_actions::synced_insert(iterator itor, action_ptr act)
+side_actions::iterator side_actions::synced_insert(iterator itor, const action_ptr& act)
 {
 	resources::whiteboard->queue_net_cmd(team_index_, make_net_cmd_insert(itor, act));
 	return actions_.insert(itor, act);
 }
 
-side_actions::iterator side_actions::synced_enqueue(std::size_t turn_num, action_ptr act)
+side_actions::iterator side_actions::synced_enqueue(std::size_t turn_num, const action_ptr& act)
 {
 	//raw_enqueue() creates actions_[turn_num] if it doesn't exist already, so we
 	//have to do it first -- before subsequently calling actions_[turn_num].size().
@@ -743,13 +743,13 @@ side_actions::iterator side_actions::safe_erase(const iterator& itor)
 	resources::whiteboard->post_delete_action(action);
 	return return_itor;
 }
-side_actions::iterator side_actions::queue_move(std::size_t turn, unit& mover, const pathfind::marked_route& route, arrow_ptr arrow, fake_unit_ptr fake_unit)
+side_actions::iterator side_actions::queue_move(std::size_t turn, unit& mover, const pathfind::marked_route& route, const arrow_ptr& arrow, fake_unit_ptr fake_unit)
 {
 	move_ptr new_move(std::make_shared<move>(team_index(), hidden_, std::ref(mover), route, arrow, std::move(fake_unit)));
 	return queue_action(turn, new_move);
 }
 
-side_actions::iterator side_actions::queue_attack(std::size_t turn, unit& mover, const map_location& target_hex, int weapon_choice, const pathfind::marked_route& route, arrow_ptr arrow, fake_unit_ptr fake_unit)
+side_actions::iterator side_actions::queue_attack(std::size_t turn, unit& mover, const map_location& target_hex, int weapon_choice, const pathfind::marked_route& route, const arrow_ptr& arrow, fake_unit_ptr fake_unit)
 {
 	attack_ptr new_attack(std::make_shared<attack>(team_index(), hidden_, std::ref(mover), target_hex, weapon_choice, route, arrow, std::move(fake_unit)));
 	return queue_action(turn, new_attack);
@@ -873,7 +873,7 @@ void side_actions::execute_net_cmd(const net_cmd& cmd)
 	resources::whiteboard->validate_viewer_actions();
 }
 
-side_actions::net_cmd side_actions::make_net_cmd_insert(std::size_t turn_num, std::size_t pos, action_const_ptr act) const
+side_actions::net_cmd side_actions::make_net_cmd_insert(std::size_t turn_num, std::size_t pos, const action_const_ptr& act) const
 {
 	net_cmd result;
 	result["type"] = "insert";
@@ -882,7 +882,7 @@ side_actions::net_cmd side_actions::make_net_cmd_insert(std::size_t turn_num, st
 	result.add_child("action", act->to_config());
 	return result;
 }
-side_actions::net_cmd side_actions::make_net_cmd_insert(const const_iterator& pos, action_const_ptr act) const
+side_actions::net_cmd side_actions::make_net_cmd_insert(const const_iterator& pos, const action_const_ptr& act) const
 {
 	if(pos == begin()) {
 		return make_net_cmd_insert(0,0,act);
@@ -891,7 +891,7 @@ side_actions::net_cmd side_actions::make_net_cmd_insert(const const_iterator& po
 		return make_net_cmd_insert(get_turn(prec), actions_.position_in_turn(prec)+1, act);
 	}
 }
-side_actions::net_cmd side_actions::make_net_cmd_replace(const const_iterator& pos, action_const_ptr act) const
+side_actions::net_cmd side_actions::make_net_cmd_replace(const const_iterator& pos, const action_const_ptr& act) const
 {
 	net_cmd result;
 	result["type"] = "replace";

--- a/src/whiteboard/side_actions.hpp
+++ b/src/whiteboard/side_actions.hpp
@@ -93,20 +93,20 @@ public:
 	 * @return           The inserted action's position.
 	 * @retval end()     When the action can't be inserted.
 	 */
-	iterator insert(iterator position, action_ptr action);
+	iterator insert(iterator position, const action_ptr& action);
 
 	/**
 	 * Queues an action to be executed last
 	 * @return The queued action's position
 	 * @retval end() when the action can't be inserted
 	 */
-	iterator queue(std::size_t turn_num, action_ptr action);
+	iterator queue(std::size_t turn_num, const action_ptr& action);
 
 	/**
 	 * Pushes an action in front of a given turn.
 	 * @return The inserted action's position
 	 */
-	iterator push_front(std::size_t turn, action_ptr action);
+	iterator push_front(std::size_t turn, const action_ptr& action);
 
 	/**
 	 * Moves an action earlier in the execution order.
@@ -365,13 +365,13 @@ public:
 	 * Inserts an action at the specified position. The begin() and end() functions might prove useful here.
 	 * @return The inserted action's position.
 	 */
-	iterator insert_action(iterator position, action_ptr action);
+	iterator insert_action(iterator position, const action_ptr& action);
 
 	/**
 	 * Queues an action to be executed last
 	 * @return The queued action's position
 	 */
-	iterator queue_action(std::size_t turn_num, action_ptr action);
+	iterator queue_action(std::size_t turn_num, const action_ptr& action);
 
 	/**
 	 * Moves an action earlier in the execution order.
@@ -517,14 +517,14 @@ public:
 	 * @return The queued move's position
 	 */
 	iterator queue_move(std::size_t turn_num, unit& mover, const pathfind::marked_route& route,
-			arrow_ptr arrow, fake_unit_ptr fake_unit);
+			const arrow_ptr& arrow, fake_unit_ptr fake_unit);
 
 	/**
 	 * Queues an attack or attack-move to be executed last
 	 * @return The queued attack's position
 	 */
 	iterator queue_attack(std::size_t turn_num, unit& mover, const map_location& target_hex, int weapon_choice, const pathfind::marked_route& route,
-			arrow_ptr arrow, fake_unit_ptr fake_unit);
+			const arrow_ptr& arrow, fake_unit_ptr fake_unit);
 
 	/**
 	 * Queues a recruit to be executed last
@@ -552,19 +552,19 @@ public:
 	 */
 	typedef config net_cmd;
 	void execute_net_cmd(const net_cmd&);
-	net_cmd make_net_cmd_insert(std::size_t turn_num, std::size_t pos, action_const_ptr) const;
-	net_cmd make_net_cmd_insert(const const_iterator& pos, action_const_ptr) const;
-	net_cmd make_net_cmd_replace(const const_iterator& pos, action_const_ptr) const;
+	net_cmd make_net_cmd_insert(std::size_t turn_num, std::size_t pos, const action_const_ptr&) const;
+	net_cmd make_net_cmd_insert(const const_iterator& pos, const action_const_ptr&) const;
+	net_cmd make_net_cmd_replace(const const_iterator& pos, const action_const_ptr&) const;
 	net_cmd make_net_cmd_remove(const const_iterator& pos) const;
 	net_cmd make_net_cmd_bump_later(const const_iterator& pos) const;
 	net_cmd make_net_cmd_clear() const;
 	net_cmd make_net_cmd_refresh() const;
 
 private:
-	iterator safe_insert(std::size_t turn_num, std::size_t pos, action_ptr to_insert);
+	iterator safe_insert(std::size_t turn_num, std::size_t pos, const action_ptr& to_insert);
 	iterator synced_erase(iterator itor);
-	iterator synced_insert(iterator itor, action_ptr to_insert);
-	iterator synced_enqueue(std::size_t turn_num, action_ptr to_insert);
+	iterator synced_insert(iterator itor, const action_ptr& to_insert);
+	iterator synced_enqueue(std::size_t turn_num, const action_ptr& to_insert);
 	iterator safe_erase(const iterator& itor);
 
 	container actions_;

--- a/src/whiteboard/suppose_dead.cpp
+++ b/src/whiteboard/suppose_dead.cpp
@@ -32,13 +32,13 @@
 namespace wb
 {
 
-std::ostream& operator<<(std::ostream &s, suppose_dead_ptr sup_d)
+std::ostream& operator<<(std::ostream &s, const suppose_dead_ptr& sup_d)
 {
 	assert(sup_d);
 	return sup_d->print(s);
 }
 
-std::ostream& operator<<(std::ostream &s, suppose_dead_const_ptr sup_d)
+std::ostream& operator<<(std::ostream &s, const suppose_dead_const_ptr& sup_d)
 {
 	assert(sup_d);
 	return sup_d->print(s);

--- a/src/whiteboard/suppose_dead.hpp
+++ b/src/whiteboard/suppose_dead.hpp
@@ -84,6 +84,6 @@ private:
 };
 
 /** Dumps a suppose_dead on a stream, for debug purposes. */
-std::ostream &operator<<(std::ostream &s, suppose_dead_ptr sup_d);
-std::ostream &operator<<(std::ostream &s, suppose_dead_const_ptr sup_d);
+std::ostream &operator<<(std::ostream &s, const suppose_dead_ptr& sup_d);
+std::ostream &operator<<(std::ostream &s, const suppose_dead_const_ptr& sup_d);
 } // end namespace wb

--- a/src/whiteboard/utility.cpp
+++ b/src/whiteboard/utility.cpp
@@ -80,7 +80,7 @@ unit* find_recruiter(std::size_t team_index, const map_location& hex)
 	return nullptr;
 }
 
-bool any_recruiter(int team_num, const map_location& loc, std::function<bool(unit&)> func)
+bool any_recruiter(int team_num, const map_location& loc, const std::function<bool(unit&)>& func)
 {
 	if ( !resources::gameboard->map().is_castle(loc) ) {
 		return false;
@@ -173,7 +173,7 @@ bool team_has_visible_plan(team &t)
 	return !t.get_side_actions()->hidden();
 }
 
-void for_each_action(std::function<void(action*)> function, team_filter team_filter)
+void for_each_action(const std::function<void(action*)>& function, const team_filter& team_filter)
 {
 	bool end = false;
 	for(std::size_t turn=0; !end; ++turn) {
@@ -190,7 +190,7 @@ void for_each_action(std::function<void(action*)> function, team_filter team_fil
 	}
 }
 
-action_ptr find_action_at(map_location hex, team_filter team_filter)
+action_ptr find_action_at(map_location hex, const team_filter& team_filter)
 {
 	action_ptr result;
 	std::size_t result_turn = std::numeric_limits<std::size_t>::max();

--- a/src/whiteboard/utility.hpp
+++ b/src/whiteboard/utility.hpp
@@ -55,7 +55,7 @@ unit* find_recruiter(std::size_t team_index, const map_location&);
  * executes @a func for each unti of side of @a side_num that can recruit on @a loc.
  * @a func takes the leader unit and can return true to 'break' the loop
  */
-bool any_recruiter(int side_num, const map_location& loc, std::function<bool(unit&)> func);
+bool any_recruiter(int side_num, const map_location& loc, const std::function<bool(unit&)>& func);
 
 /**
  * Applies the future unit map and @return a pointer to the unit at hex
@@ -134,8 +134,8 @@ bool team_has_visible_plan(team&);
  * @param function the function to execute.
  * @param team_filter select whether a team is visited (default to @ref team_has_visible_plan).
  */
-void for_each_action(std::function<void(action*)> function,
-                     team_filter team_filter = team_has_visible_plan);
+void for_each_action(const std::function<void(action*)>& function,
+                     const team_filter& team_filter = team_has_visible_plan);
 
 /**
  * Find the first action occurring on a given hex.
@@ -147,7 +147,7 @@ void for_each_action(std::function<void(action*)> function,
  * @param team_filter select whether a team is visited (default to @ref team_has_visible_plan).
  * @retval action_ptr() when no action verifying the team_filter are present on the given hex.
  */
-action_ptr find_action_at(map_location hex, team_filter team_filter = team_has_visible_plan);
+action_ptr find_action_at(map_location hex, const team_filter& team_filter = team_has_visible_plan);
 
 /**
  * Find the actions of an unit.

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -30,6 +30,7 @@
 #include "wml_separators.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <utility>
 
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
@@ -48,7 +49,7 @@ button::button(const std::string& label, button::TYPE type,
 	  overlayImage_(nullptr), overlayPressedImage_(nullptr), overlayActiveImage_(nullptr),
 	  state_(NORMAL), pressed_(false),
 	  spacing_(spacing), base_height_(0), base_width_(0),
-	  button_image_name_(), button_overlay_image_name_(overlay_image),
+	  button_image_name_(), button_overlay_image_name_(std::move(overlay_image)),
 	  button_image_path_suffix_(),
 	  font_size_(font_size <= 0 ? (type != TYPE_CHECK && type != TYPE_RADIO ? default_font_size : font::SIZE_SMALL) : font_size),
 	  horizontal_padding_(font_size_),

--- a/src/widgets/button.cpp
+++ b/src/widgets/button.cpp
@@ -39,7 +39,7 @@ namespace gui {
 const int default_font_size = font::SIZE_BUTTON;
 
 button::button(const std::string& label, button::TYPE type,
-               std::string button_image_name, SPACE_CONSUMPTION spacing,
+               const std::string& button_image_name, SPACE_CONSUMPTION spacing,
                const bool auto_join, std::string overlay_image, int font_size)
 	: widget(auto_join), type_(type),
 	  label_text_(label),

--- a/src/widgets/button.hpp
+++ b/src/widgets/button.hpp
@@ -32,7 +32,7 @@ public:
 	enum SPACE_CONSUMPTION { DEFAULT_SPACE, MINIMUM_SPACE };
 
 	button(const std::string& label, TYPE type=TYPE_PRESS,
-	       std::string button_image="", SPACE_CONSUMPTION spacing=DEFAULT_SPACE,
+	       const std::string& button_image="", SPACE_CONSUMPTION spacing=DEFAULT_SPACE,
 	       const bool auto_join=true, std::string overlay_image="", int font_size = -1);
 
 


### PR DESCRIPTION
If a function parameter is only ever used in a `const` manner (so only `const` member functions are called or it is `const`), it can be treated as a `const reference` and no copying is required.

Additionally, if a parameter is only copied or moved once and has a non-trivial move constructor (i.e. one different than the copy constructor), it might make sense to `std::move` that parameter.

This PR enables the `clang-tidy` linter check (`performance-unnecessary-value-param`) that recommends doing so, and additionally applies its recommended autofixes to the codebase. This is based on #9358.

edit: The PR itself is split into five commits. The first three commits are mostly formulaic transformations.

The fourth and fifth commits are broken out as they're special cases. `goal::on_create(std::shared_ptr<ai::lua_ai_context>)` is _not_ turned into a const reference, as the goal of that override is to catch calls to `on_create` and cause a runtime error. That's why it's `NOLINT`ed

The fifth commit is because `modal_dialog::register_integer` accepts an argument `callback_save_value` which has slightly different types in `modal_dialog.h` and `modal_dialog.cpp`. Specifically, `callback_save_value` is a `std::function<void(int)>` in the header and `std::function<void(const int)>` in the implementation. I made the implementation match the header before applying the transformation to make the final type a `const std::function<void(int)>&`.