### PR TITLE
[Units][Skeletal Dragon] Adjust Stats to a more moderate amount

### DIFF
--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -6,7 +6,7 @@
     race=undead
     image="units/monsters/skeletal-dragon/skeletal-dragon.png"
     image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(0,0,160,160)"
-    hitpoints=171
+    hitpoints=98
     movement_type=undeadfly
     movement=5
     experience=200
@@ -14,13 +14,13 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=288
+    cost=160
     usage=fighter
     [resistance]
         blade=60
         pierce=40
         impact=120
-        fire=120
+        fire=80#since it is the bones of a dragon, retain some fire resistance
         arcane=120
     [/resistance]
     description= _ "Long ago one of the mightiest living creatures, the feared Dragon has become only bones and dark sinew. Long after its death, it was raised through the dark powers of necromancy, which it now serves. The Skeletal Dragon may look like nothing more than a pile of bones, but few people who thought that way lived long enough to change their minds."
@@ -34,16 +34,16 @@
         [specials]
             {WEAPON_SPECIAL_DRAIN}
         [/specials]
-        damage=17
-        number=4
+        damage=15
+        number=3
     [/attack]
     [attack]
         name=claws
         description= _"claws"
         type=blade
         range=melee
-        damage=24
-        number=3
+        damage=27
+        number=2
     [/attack]
     {DEFENSE_ANIM "units/monsters/skeletal-dragon/skeletal-dragon.png" "units/monsters/skeletal-dragon/skeletal-dragon.png" {SOUND_LIST:SKELETON_BIG_HIT} }
     [attack_anim]


### PR DESCRIPTION
Although I support making the skeletal dragon stronger than in 1.18, I believe that PR #8541 was too extreme of a change in that direction, nearly doubling the unit's jaw damage and more than doubling the healthbar. After discussing the matter with some other players, modders and Dalas, I decided to propose a more moderate improvement over the 1.18 stats, and a major nerf over the current 1.19 dev build stats which seem very overtuned.

HP: 171 > 98 (or 86 > 98 if comparing to 1.18)

jaw attack: 17x4 > 15x3 (or 10-4 > 15-3 when comparing to 1.18). More damage per hit than 1.18 and more total damage, but 1 fewer strike, making it feel more weighty.

claws: 24-3 > 27-2 (or 25-2 > 27-3 when comparing to 1.18).

Fire Resistance: -20% > 20% (slightly more moderate version of Dalas's idea. Since the unit is the bones of a dead dragon, it's fitting that it is more fire-resistant than normal skeletons. Also makes the unit less weak to the Mage line)