### PR TITLE
Change UtBS date from 300 to 1000 AF

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -13,7 +13,7 @@
     image="data/campaigns/Under_the_Burning_Suns/images/campaign_image.png"
     abbrev= _ "UtBS"
     rank=205
-    year="300 AF"
+    year="1000 AF"
     define=CAMPAIGN_UNDER_THE_BURNING_SUNS
     first_scenario=01_The_Morning_After
 


### PR DESCRIPTION
This makes a lot more sense given how forgotten everything before the fall is by the time of UtBS. 300 AF is small enough for a few elves to remember the times before. 1000 AF is more sensible in my opinion. This a change I proposed in #9398 but decide to split into another PR.