### PR TITLE
Add achievements to THoT

### DIFF
--- a/changelog_entries/thot_achievements.md
+++ b/changelog_entries/thot_achievements.md
@@ -1,0 +1,3 @@
+ ### Campaigns
+   * The Hammer of Thursagan
+     * Added Achievements

--- a/data/campaigns/The_Hammer_of_Thursagan/achievements.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/achievements.cfg
@@ -1,1 +1,28 @@
 #textdomain wesnoth-thot
+
+[achievement_group]
+    display_name=_"The Hammer of Thursagan"
+    content_for=the_hammer_of_thursagan
+    [achievement]
+        id="gryphon_hunter"
+        name=_"Gryphon Hunter"
+        description=_"Kill the Gryphon leader in High Pass"
+        hidden=yes
+        icon="data/core/images/units/monsters/gryphon.png"
+        icon_completed="data/core/images/units/monsters/gryphon.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
+    [/achievement]
+    [achievement]
+        id="conqueror_of_the_forest"
+        name=_"Conqueror of the Forest"
+        description=_"Defeat an enemy leader in Forbidden Forest"
+        icon="data/core/images/units/woses/wose-die-fall-5.png"
+        icon_completed="data/core/images/units/woses/wose-die-fall-5.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-8-grey.png",0,0)"
+    [/achievement]
+    [achievement]
+        id="new_thursagan"
+        name=_"New Thursagan"
+        description=_"Complete The Underlevels on challenging difficulty"
+        icon="data/core/images/items/hammer-runic.png"
+        icon_completed="data/core/images/items/hammer-runic.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
+    [/achievement]
+[/achievement_group]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/04_High_Pass.cfg
@@ -234,6 +234,19 @@
     [/event]
 
     [event]
+        name=die
+
+        [filter]
+            id="Kaara"
+        [/filter]
+
+        [set_achievement]
+            content_for=the_hammer_of_thursagan
+            id="gryphon_hunter"
+        [/set_achievement]
+    [/event]
+
+    [event]
         {QUANTITY name (turn 16) (turn 14) (turn 9)}
 
         [message]

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/06_Forbidden_Forest.cfg
@@ -249,6 +249,25 @@
         [/move_unit_fake]
     [/event]
 
+    #Death of an enemy leader
+    [event]
+        name=die
+        [filter]
+            canrecruit=yes
+            [not]
+                side=1
+            [/not]
+        [/filter]
+        [message]
+            speaker=second_unit
+            message= _ "We shall pass!"
+        [/message]
+        [set_achievement]
+            content_for=the_hammer_of_thursagan
+            id="conqueror_of_the_forest"
+        [/set_achievement]
+    [/event]
+
     # Angarthing and Aiglondur speak when they reach the signpost.
     [event]
         name=moveto

--- a/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/scenarios/09_The_Underlevels.cfg
@@ -1294,6 +1294,13 @@
             result=victory
             carryover_report=no
         [/endlevel]
+
+#ifdef HARD
+        [set_achievement]
+            content_for=the_hammer_of_thursagan
+            id="new_thursagan"
+        [/set_achievement]
+#endif
     [/event]
     #########################################################################################
     ######################################## Deaths #########################################


### PR DESCRIPTION
The following achievements have been added:

- Gryphon Hunter: Kill the Gryphon leader in High Pass

- Conqueror of the Forest: Defeat an enemy leader in Forbidden Forest

- New Thursagan: Complete The Underlevels on challenging difficulty