### PR TITLE
World Conquest: Remove hard coded trainer indices

### DIFF
--- a/data/campaigns/World_Conquest/Modding.md
+++ b/data/campaigns/World_Conquest/Modding.md
@@ -247,6 +247,7 @@ World Conquest looks for `[world_conquest_data]` tags in the era and every loade
             name= _ "Blood Magic"
             dialogue= "You have found me, mortals? Well...let us show your recruits some blood magic!"
             manual_invest = false #Setting manual_invest to false will hide a trainer from the invest screen. Not specifying this variable at all includes a new trainer by default.
+            [grade]
             [/grade]
             [grade]
                 {WCT_CHANCE_FEEDING 3}

--- a/data/campaigns/World_Conquest/Modding.md
+++ b/data/campaigns/World_Conquest/Modding.md
@@ -246,7 +246,7 @@ World Conquest looks for `[world_conquest_data]` tags in the era and every loade
             image=attacks/wail.png
             name= _ "Blood Magic"
             dialogue= "You have found me, mortals? Well...let us show your recruits some blood magic!"
-            manual_invest = false #Setting manual_invest to false will hide a trainer from the invest screen. Not specifying this variable at all includes a new trainer by default.
+            manual_invest = no #Setting manual_invest to false will hide a trainer from the invest screen. Not specifying this variable at all includes a new trainer by default.
             [grade]
             [/grade]
             [grade]

--- a/data/campaigns/World_Conquest/Modding.md
+++ b/data/campaigns/World_Conquest/Modding.md
@@ -246,8 +246,7 @@ World Conquest looks for `[world_conquest_data]` tags in the era and every loade
             image=attacks/wail.png
             name= _ "Blood Magic"
             dialogue= "You have found me, mortals? Well...let us show your recruits some blood magic!"
-            manual_invest = False #Leaving this blank will allow the training to appear on the invest screen.
-            [grade]
+            manual_invest = false #Setting manual_invest to false will hide a trainer from the invest screen. Not specifying this variable at all includes a new trainer by default.
             [/grade]
             [grade]
                 {WCT_CHANCE_FEEDING 3}

--- a/data/campaigns/World_Conquest/Modding.md
+++ b/data/campaigns/World_Conquest/Modding.md
@@ -246,6 +246,7 @@ World Conquest looks for `[world_conquest_data]` tags in the era and every loade
             image=attacks/wail.png
             name= _ "Blood Magic"
             dialogue= "You have found me, mortals? Well...let us show your recruits some blood magic!"
+            manual_invest = False #Leaving this blank will allow the training to appear on the invest screen.
             [grade]
             [/grade]
             [grade]

--- a/data/campaigns/World_Conquest/lua/game_mechanics/invest/invest.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/invest/invest.lua
@@ -137,7 +137,7 @@ function wc2_invest.invest()
 	local heroes_available = stringx.split(side.variables["wc2.heroes"] or "")
 	local commanders_available = stringx.split(side.variables["wc2.commanders"] or "")
 	local deserters_available = stringx.split(side.variables["wc2.deserters"] or "")
-	local trainings_available = wc2_training.list_available(side_num, {2,3,4,5,6})
+	local trainings_available = wc2_training.list_available(side_num)
 	local gold_available = true
 	for i = 1,2 do
 		local is_local = false

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -85,20 +85,25 @@ function training.has_max_training(side_num, trainer, amount)
 	return training.available(side_num, trainer) == 0
 end
 
-function training.list_available(side_num, among, amount)
-	local av = among or wc2_utils.range(#training.get_list())
-	local res = {}
-	for i,v in ipairs(av) do
-		local j = tonumber(v)
-		if training.available(side_num, j, amount) then
-			table.insert(res, j)
-		end
-	end
-	return res
+function training.list_available(side_num, amount)
+    local av = wc2_utils.range(#training.get_list())
+    local res = {}
+    for i,v in ipairs(av) do
+        local j = tonumber(v)
+        -- Get the trainer's data (assuming get_trainer returns the trainer table or object)
+        local trainer = training.get_trainer(j)
+        -- Check if manual_invest is true, or if manual_invest is nil (assuming default is true)
+        if trainer and (trainer.manual_invest == nil or trainer.manual_invest == true) then
+            if training.available(side_num, j, amount) then
+                table.insert(res, j)
+            end
+        end
+    end
+    return res
 end
 
-function training.find_available(side_num, among, amount)
-	local possible_traintypes = training.list_available(side_num, among, amount)
+function training.find_available(side_num, amount)
+	local possible_traintypes = training.list_available(side_num, amount)
 	if #possible_traintypes == 0 then
 		return
 	else

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -86,18 +86,18 @@ function training.has_max_training(side_num, trainer, amount)
 end
 
 function training.list_available(side_num, amount)
-    local av = wc2_utils.range(#training.get_list())
-    local res = {}
-    for i,v in ipairs(av) do
-        local j = tonumber(v)
-        local trainer = training.get_trainer(j)
-        if trainer and (trainer.manual_invest == nil or trainer.manual_invest == true) then
-            if training.available(side_num, j, amount) then
-                table.insert(res, j)
-            end
-        end
-    end
-    return res
+	local av = wc2_utils.range(#training.get_list())
+	local res = {}
+	for i,v in ipairs(av) do
+		local j = tonumber(v)
+		local trainer = training.get_trainer(j)
+		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == true) then
+			if training.available(side_num, j, amount) then
+				table.insert(res, j)
+			end
+		end
+	end
+	return res
 end
 
 function training.find_available(side_num, amount)

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -91,7 +91,7 @@ function training.list_available(side_num, amount)
 	for i,v in ipairs(av) do
 		local j = tonumber(v)
 		local trainer = training.get_trainer(j)
-		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == false) then
+		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == true) then
 			if training.available(side_num, j, amount) then
 				table.insert(res, j)
 			end

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -91,7 +91,7 @@ function training.list_available(side_num, amount)
 	for i,v in ipairs(av) do
 		local j = tonumber(v)
 		local trainer = training.get_trainer(j)
-		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == yes) then
+		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == false) then
 			if training.available(side_num, j, amount) then
 				table.insert(res, j)
 			end
@@ -195,15 +195,9 @@ end
 
 function training.pick_bonus(side_num)
 	local amount = training.bonus_calculate_amount(side_num)
-	-- dark training reduced chances
-	local traintype_index = training.find_available(side_num, {1,2,3,4,5,6,2,3,4,5,6,2,3,4,5,6}, amount)
+	local traintype_index = training.find_available(side_num, amount)
 	if traintype_index == nil then
 		return nil
-	end
-
-	--dark training increased level.
-	if traintype_index == 1 then
-		amount = math.min(training.trainings_left(side_num, traintype_index), math.max(amount, wc2_scenario.scenario_num() - 1))
 	end
 	return traintype_index, amount
 end

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -91,7 +91,7 @@ function training.list_available(side_num, amount)
 	for i,v in ipairs(av) do
 		local j = tonumber(v)
 		local trainer = training.get_trainer(j)
-		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == true) then
+		if trainer and (trainer.manual_invest == nil or trainer.manual_invest == yes) then
 			if training.available(side_num, j, amount) then
 				table.insert(res, j)
 			end

--- a/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
+++ b/data/campaigns/World_Conquest/lua/game_mechanics/training.lua
@@ -90,9 +90,7 @@ function training.list_available(side_num, amount)
     local res = {}
     for i,v in ipairs(av) do
         local j = tonumber(v)
-        -- Get the trainer's data (assuming get_trainer returns the trainer table or object)
         local trainer = training.get_trainer(j)
-        -- Check if manual_invest is true, or if manual_invest is nil (assuming default is true)
         if trainer and (trainer.manual_invest == nil or trainer.manual_invest == true) then
             if training.available(side_num, j, amount) then
                 table.insert(res, j)

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -9,7 +9,7 @@
         image=attacks/curse.png
         name=_ "Dark"
         dialogue=_ "I haven’t lived centuries fighting others’ battles, but I could combat boredom teaching your men a couple of things about dark techniques."
-        manual_invest = False
+        manual_invest = false
         [grade]
         [/grade]
         [grade]

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -9,6 +9,7 @@
         image=attacks/curse.png
         name=_ "Dark"
         dialogue=_ "I haven’t lived centuries fighting others’ battles, but I could combat boredom teaching your men a couple of things about dark techniques."
+        manual_invest = False
         [grade]
         [/grade]
         [grade]

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -9,7 +9,7 @@
         image=attacks/curse.png
         name=_ "Dark"
         dialogue=_ "I haven’t lived centuries fighting others’ battles, but I could combat boredom teaching your men a couple of things about dark techniques."
-        manual_invest = no
+        manual_invest = false
         [grade]
         [/grade]
         [grade]

--- a/data/campaigns/World_Conquest/resources/data/training.cfg
+++ b/data/campaigns/World_Conquest/resources/data/training.cfg
@@ -9,7 +9,7 @@
         image=attacks/curse.png
         name=_ "Dark"
         dialogue=_ "I haven’t lived centuries fighting others’ battles, but I could combat boredom teaching your men a couple of things about dark techniques."
-        manual_invest = false
+        manual_invest = no
         [grade]
         [/grade]
         [grade]


### PR DESCRIPTION
Intended as a bug fix for: https://github.com/wesnoth/wesnoth/issues/9372

Removed hard-coded indices. Bonus points route through get_trainer so they should work as normal. This primarily updates training.list_available. References to the "Among" list_available parameter were also removed. The dark training was updated to not be visible on the invest screen as is default. The modding readme was updated to include this new functionality.

Edit: I am working on testing this more extensively with friends, locally, in the meantime.