### PR TITLE
Fix weapon special unexpected behaviour

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1261,7 +1261,7 @@ void attack_type::modified_attacks(unsigned & min_attacks,
 	int attacks_value = composite_value(get_specials_and_abilities("attacks"), num_attacks());
 
 	if ( attacks_value < 0 ) {
-		attacks_value = num_attacks();
+		attacks_value = 0;
 		ERR_NG << "negative number of strikes after applying weapon specials";
 	}
 


### PR DESCRIPTION
### Goal of the PR
- Resolves #9366
### How does the PR work?
- By setting the bouncing back logic of strike times to only happen when attributes are used incorrectly(meaning sub is non-negative at the same time)
### Does it resolve any reported issue?
- #9366
### If not a bug fix, why is this PR needed? What use cases does it solve?
- This is a bug fix.

## To do

Adjust possibly missed related method.

This PR is a Work In Progress.

## How to test
see changes in the src.
