### PR TITLE
EI S14 "Drowned Plains" - rework scenario objective

### DIFF
--- a/changelog_entries/ei-drowned-plains-redesign.md
+++ b/changelog_entries/ei-drowned-plains-redesign.md
@@ -1,0 +1,2 @@
+### Campaigns
+   * Eastern Invasion: "Drowned Plains" drastically shortened in length. Objective now involves gathering gold, not killing enemy leaders.

--- a/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
@@ -797,11 +797,11 @@
         name=prestart
 
         {GOLD_PICKUP 69 43 items/gold-coins-medium.png 105 _"105 gold"}
-        {GOLD_PICKUP 70 41 items/gold-coins-small.png   60 _"60 gold"}
-        {GOLD_PICKUP 18  4 items/gold-coins-medium.png 140 _"140 gold"}
+        {GOLD_PICKUP 70 41 items/gold-coins-small.png   80 _"80 gold"}
+        {GOLD_PICKUP 18  4 items/gold-coins-medium.png 175 _"175 gold"}
         {GOLD_PICKUP  9 50 items/gold-coins-small.png   55 _"55 gold"}
-        {GOLD_PICKUP  8 50 items/gold-coins-medium.png 130 _"130 gold"}
-        {GOLD_PICKUP  5 51 items/gold-coins-small.png   70 _"70 gold"}
+        {GOLD_PICKUP  8 50 items/gold-coins-medium.png 150 _"150 gold"}
+        {GOLD_PICKUP  5 51 items/gold-coins-small.png   80 _"80 gold"}
 
         {SET_LABEL 16 24 _"Lord Alric’s Palace"  }
         {SET_LABEL 17 5  _"Sir Efran’s Castle"   }
@@ -1303,7 +1303,7 @@ Even if we lack the strength to truly reclaim this place, we should still take t
             [/objective]
             [gold_carryover]
                 bonus=no
-                carryover_percentage=100
+                carryover_percentage=80
             [/gold_carryover]
             [note]
                 description= _ "Enemy leaders are idle until first sighted, but will then abandon their keep and attack you."
@@ -2156,7 +2156,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
         [endlevel]
             result=victory
             bonus=no
-            {NEW_GOLD_CARRYOVER 100}
+            {NEW_GOLD_CARRYOVER 80}
         [/endlevel]
     [/event]
 
@@ -2183,7 +2183,7 @@ I offer one final prayer to the Light, that at least my family may be spared and
                 [endlevel]
                     result=victory
                     bonus=yes
-                    {NEW_GOLD_CARRYOVER 100}
+                    {NEW_GOLD_CARRYOVER 80}
                 [/endlevel]
             [/then]
         [/if]

--- a/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
@@ -340,6 +340,40 @@
         name=prestart
 
         #---------------------------
+        # MARK UNTOUCHED HEXES
+        #---------------------------
+        # make it easier for the player to know which hexes they've cleared of undead by marking the untouched ones
+#define PLACE_REEDS TERRAIN IPF
+    [store_locations]
+        x,y=1-99,1-99
+        terrain={TERRAIN}
+        variable=swamp_hexes
+    [/store_locations]
+    [foreach]
+        array=swamp_hexes
+        [do]
+            {VARIABLE_OP variant rand 1..5}
+            {PLACE_IMAGE scenery/swamp-reeds$variant|.png{IPF} $this_item.x $this_item.y}
+            {CLEAR_VARIABLE variant}
+            [event]
+                name=enter hex
+                delayed_variable_substitution=no
+                [filter]
+                    side=1
+                    [filter_location]
+                        x,y=$this_item.x,$this_item.y
+                        radius=1
+                    [/filter_location]
+                [/filter]
+                {REMOVE_IMAGE $this_item.x $this_item.y}
+            [/event]
+        [/do]
+    [/foreach]
+#enddef
+        {PLACE_REEDS Ss,Ss^Qhu "~CS(25,25,25)"}
+        {PLACE_REEDS Sm,Sm^Qhu "~CS(-15,-35,0)"}
+
+        #---------------------------
         # SPAWN AMBUSHERS
         #---------------------------
         [store_locations]

--- a/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
@@ -5,18 +5,13 @@
 # when you stumble upon 1, it awakens some nearby buddies
 # when you sight an enemy leader, they recruit, awaken sleepers, and charge at you
 #
-# the turn limit is very generous. A player with many veterans can finish quickly and have a large bonus for S16
-# alternatively, maybe the player only has a few veterans (maybe they lost everything in S12 Evacuation)
-#    then they can take their time, cap villages, farm XP off the swamp, etc.
-#    and wait as long as possible to activate enemy leaders
-#
 # note that the map is based off of the penultimate HttT scenario, "Test of the Clans"
 #
 
 #define SCENARIO_TURN_LIMIT
-75 #enddef
+25 #enddef
 #define TURNS_LOW_WARNING
-60 #enddef
+20 #enddef
 
 [scenario]
     id=14_The_Drowned_Plains
@@ -343,40 +338,6 @@
     #---------------------------
     [event]
         name=prestart
-
-        #---------------------------
-        # MARK UNTOUCHED HEXES
-        #---------------------------
-        # make it easier for the player to know which hexes they've cleared of undead by marking the untouched ones
-#define PLACE_REEDS TERRAIN IPF
-    [store_locations]
-        x,y=1-99,1-99
-        terrain={TERRAIN}
-        variable=swamp_hexes
-    [/store_locations]
-    [foreach]
-        array=swamp_hexes
-        [do]
-            {VARIABLE_OP variant rand 1..5}
-            {PLACE_IMAGE scenery/swamp-reeds$variant|.png{IPF} $this_item.x $this_item.y}
-            {CLEAR_VARIABLE variant}
-            [event]
-                name=enter hex
-                delayed_variable_substitution=no
-                [filter]
-                    side=1
-                    [filter_location]
-                        x,y=$this_item.x,$this_item.y
-                        radius=1
-                    [/filter_location]
-                [/filter]
-                {REMOVE_IMAGE $this_item.x $this_item.y}
-            [/event]
-        [/do]
-    [/foreach]
-#enddef
-        {PLACE_REEDS Ss,Ss^Qhu "~CS(25,25,25)"}
-        {PLACE_REEDS Sm,Sm^Qhu "~CS(-15,-35,0)"}
 
         #---------------------------
         # SPAWN AMBUSHERS
@@ -779,8 +740,34 @@
         side=1
     [/redraw]
 #enddef
+#define GOLD_PICKUP X Y IMAGE AMOUNT LABEL
+    {PLACE_IMAGE {IMAGE} {X} {Y}}
+    {SET_LABEL {X} {Y} {LABEL}}
+    [event]
+        name=moveto
+        [filter]
+            side=1
+            x,y={X},{Y}
+        [/filter]
+        [sound]
+            name=gold.ogg
+        [/sound]
+        [gold]
+            side,amount=1,{AMOUNT}
+        [/gold]
+        {REMOVE_IMAGE $unit.x $unit.y}
+        {REMOVE_LABEL {X} {Y}}
+    [/event]
+#enddef
     [event]
         name=prestart
+
+        {GOLD_PICKUP 69 43 items/gold-coins-medium.png 105 _"105 gold"}
+        {GOLD_PICKUP 70 41 items/gold-coins-small.png   60 _"60 gold"}
+        {GOLD_PICKUP 18  4 items/gold-coins-medium.png 140 _"140 gold"}
+        {GOLD_PICKUP  9 50 items/gold-coins-small.png   55 _"55 gold"}
+        {GOLD_PICKUP  8 50 items/gold-coins-medium.png 130 _"130 gold"}
+        {GOLD_PICKUP  5 51 items/gold-coins-small.png   70 _"70 gold"}
 
         {SET_LABEL 16 24 _"Lord Alric’s Palace"  }
         {SET_LABEL 17 5  _"Sir Efran’s Castle"   }
@@ -1257,13 +1244,15 @@
         [/message]
         [message]
             speaker=Gweddry
-            message= _ "I agree, yet all is strangely quiet. Perhaps the remaining undead lie dormant? If we take time to capture villages and rebuild our forces, we may yet be able to reclaim this place."
+            message= _ "I agree, yet all is strangely quiet. Perhaps the remaining undead lie dormant?
+
+Even if we lack the strength to truly reclaim this place, we should still take the opportunity to gather what supplies remain. When finally we meet the shambling hordes responsible for all this destruction, we must not find our armories wanting."
         [/message]
 
         [objectives]
             side=1
             [objective]
-                description= _ "Defeat all enemy leaders"
+                description= _ "Gather as much gold as you can before turns run out."
                 condition=win
             [/objective]
             [objective]
@@ -1278,16 +1267,12 @@
                 description= _ "Death of Gweddry, Dacyn, or Owaec"
                 condition=lose
             [/objective]
-            {TURNS_RUN_OUT}
             [gold_carryover]
-                bonus=yes
-                carryover_percentage=40
+                bonus=no
+                carryover_percentage=100
             [/gold_carryover]
             [note]
                 description= _ "Enemy leaders are idle until first sighted, but will then abandon their keep and attack you."
-            [/note]
-            [note]
-                description= _ "It may be wise to capture villages and build up an army before attacking."
             [/note]
         [/objectives]
 
@@ -1744,19 +1729,44 @@ I offer one final prayer to the Light, that at least my family may be spared and
             [filter]
                 id=Khrakrahs
             [/filter]
-
             [effect]
                 apply_to=new_ability
                 [abilities]
                     {ABILITY_TERROR}
                 [/abilities]
             [/effect]
-
             [effect]
                 apply_to=movement
-                set=3
+                set=3 # needs to be slow, or else his escort can't keep up
             [/effect]
-            # needs to be slow, or else his escort can't keep up
+            [effect]
+                apply_to=hitpoints
+                increase_total={ON_DIFFICULTY 0 25 50}
+                heal_full=yes
+            [/effect]
+            [effect]
+                apply_to=new_attack
+                name=tail
+                description= _"tail"
+                icon=attacks/tail-dragon.png~GS()
+                type=impact
+                range=melee
+                damage=41 # not quite enough to 1-shot a Heavy Infantryman, unless at night and non-illuminated. This makes the difference between a HI and a Shock Trooper less extreme
+                number=1
+            [/effect]
+            [effect]
+                apply_to=new_animation
+                [attack_anim]
+                    [filter_attack]
+                        name=tail
+                    [/filter_attack]
+                    start_time=-200
+                    [frame]
+                        image="units/monsters/skeletal-dragon/skeletal-dragon.png:400"
+                    [/frame]
+                    {SOUND:HIT_AND_MISS mace.ogg mace-miss.ogg -75}
+                [/attack_anim]
+            [/effect]
         [/object]
         [fire_event]
             name=moveto
@@ -2049,53 +2059,42 @@ I offer one final prayer to the Light, that at least my family may be spared and
     # FLAVOR
     #--------------------
     [event]
-        name=last breath
-
-        [filter]
-            id=Sir Seoraery,Sir Efran,Khrakrahs
-        [/filter]
-
-        [event]
-            name=new turn
-            [event]
-                name=new turn
-                [message]
-                    speaker=Gweddry
-                    #po: spoken at the start of a new turn after killing the first undead leader
-                    message= _ "Dacyn, I’ve been thinking. This artifact has had such a draining effect on you. Perhaps you should rest and take a moment to regain your strength? I could carry the Amulet for a while, or we could store it away."
-                [/message]
-                [message]
-                    speaker=Dacyn
-                    message= _ "Hmm... I suppose there would be no harm in locking it up somewhere safe."
-                [/message]
-                [message]
-                    caption= _ "Unknown"
-                    image=units/unknown-unit1.png
-                    #po: voices from the amulet talking to Dacyn
-                    message= _ "<span size='small' font-style='italic'>You have a great weapon... and you would simply lock it away?</span>"
-                [/message]
-                [message]
-                    caption= _ "Unknown 2"
-                    image=units/unknown-unit2.png
-                    #po: voices from the amulet talking to Dacyn, speaking of Gweddry
-                    message= _ "<span size='small' font-style='italic'>His intent is good, but his spirit is weak... he would be corrupted...</span>"
-                [/message]
-                [message]
-                    caption= _ "Unknown"
-                    image=units/unknown-unit1.png
-                    #po: voices from the amulet talking to Dacyn
-                    message= _ "<span size='small' font-style='italic'>Only you can be trusted with this responsibility.</span>"
-                [/message]
-                [message]
-                    speaker=Dacyn
-                    message= _ "But on the other hand... this is a dangerous artifact. I fear that only I can withstand its energies."
-                [/message]
-                [message]
-                    speaker=Gweddry
-                    message= _ "Well, you’re the magic expert."
-                [/message]
-            [/event]
-        [/event]
+        name=turn 16
+        [message]
+            speaker=Gweddry
+            #po: spoken at the start of a new turn after killing the first undead leader
+            message= _ "Dacyn, I’ve been thinking. This artifact has had such a draining effect on you. Perhaps you should rest and take a moment to regain your strength? I could carry the Amulet for a while, or we could store it away."
+        [/message]
+        [message]
+            speaker=Dacyn
+            message= _ "Hmm... I suppose there would be no harm in locking it up somewhere safe."
+        [/message]
+        [message]
+            caption= _ "Unknown"
+            image=units/unknown-unit1.png
+            #po: voices from the amulet talking to Dacyn
+            message= _ "<span size='small' font-style='italic'>You have a great weapon... and you would simply lock it away?</span>"
+        [/message]
+        [message]
+            caption= _ "Unknown 2"
+            image=units/unknown-unit2.png
+            #po: voices from the amulet talking to Dacyn, speaking of Gweddry
+            message= _ "<span size='small' font-style='italic'>His intent is good, but his spirit is weak... he would be corrupted...</span>"
+        [/message]
+        [message]
+            caption= _ "Unknown"
+            image=units/unknown-unit1.png
+            #po: voices from the amulet talking to Dacyn
+            message= _ "<span size='small' font-style='italic'>Only you can be trusted with this responsibility.</span>"
+        [/message]
+        [message]
+            speaker=Dacyn
+            message= _ "But on the other hand... this is a dangerous artifact. I fear that only I can withstand its energies."
+        [/message]
+        [message]
+            speaker=Gweddry
+            message= _ "Well, you’re the magic expert."
+        [/message]
     [/event]
 
     #--------------------
@@ -2106,32 +2105,24 @@ I offer one final prayer to the Light, that at least my family may be spared and
         name=side 1 turn {TURNS_LOW_WARNING}
         [message]
             speaker=Gweddry
-            message= _ "We must finish here and hurry on from this dead place! If the Horse Clans have fallen so completely, I fear for Weldyn and the rest of Wesnoth."
-        [/message]
-        [message]
-            speaker=Dacyn
-            message= _ "Why are we here at all? We should be advancing towards Weldyn, not humoring Owaec’s lust for vengeance. The Plains are already drowned."
+            message= _ "If the Horse Clans have fallen so completely, I fear for Weldyn and the rest of Wesnoth. We must make the most of our time here; we cannot afford to tarry too long."
         [/message]
     [/event]
     # time over
     [event]
-        name=side 1 turn {SCENARIO_TURN_LIMIT} end
+        name=time over # not side 1 turn end, so the AI gets a chance to attack
         [message]
-            speaker=Dacyn
-            #po: time over, talking to Owaec
-            message= _ "Enough of this. We have wasted too much time here already; give up your foolish quest of vengeance and travel on."
+             speaker=Owaec
+             message= _ "So much death. So many of my kinsmen left unavenged. If only we had more time..."
         [/message]
         [message]
-            speaker=Owaec
-            #po: time over, talking to Dacyn
-            message= _ "Your search for foul magic has caused enough harm already, and now you would leave my countrymen’s bodies defiled by undeath? I will slay everything that moves in this swamp, and once I am done, perhaps my hammer will find you next!"
-        [/message]
-        [message]
-            speaker=Dacyn
-            message= _ "You fools are welcome to linger here clearing this swamp, but I intend to travel on alone and defeat Mal-Ravanal. Go as you wish on your own. I have a task to complete."
+            speaker=Gweddry
+            message= _ "We have done all we could here."
         [/message]
         [endlevel]
-            result=defeat
+            result=victory
+            bonus=no
+            {NEW_GOLD_CARRYOVER 100}
         [/endlevel]
     [/event]
 
@@ -2139,40 +2130,35 @@ I offer one final prayer to the Light, that at least my family may be spared and
     [event]
         name=die
         first_time_only=no
-
         [filter]
             id=Sir Seoraery,Sir Efran,Khrakrahs
         [/filter]
-
         [if]
             [not]
                 [have_unit]
                     id=Sir Seoraery,Sir Efran,Khrakrahs
                 [/have_unit]
             [/not]
-
             [then]
+                [message]
+                    speaker=Owaec
+                    message= _ "It is done. My kinsmen have been avenged."
+                [/message]
+                {KILL_COUNT 4 side=2,3,4,6,8 ANIMATE=yes}
+                {KILL side=2,3,4,5,6,7,8}
                 [endlevel]
                     result=victory
                     bonus=yes
-                    {NEW_GOLD_CARRYOVER 40}
+                    {NEW_GOLD_CARRYOVER 100}
                 [/endlevel]
             [/then]
         [/if]
     [/event]
     [event]
         name=victory
-        {KILL_COUNT 4 side=2,3,4,6,8 ANIMATE=yes}
-        {KILL side=2,3,4,5,6,7,8}
-        [message]
-            speaker=Owaec
-            message= _ "It is done. My kinsmen have been avenged."
-        [/message]
-
         [delay]
             time=1000
         [/delay]
-
         [message]
             speaker=Owaec
             message= _ "Mage... I owe you an apology. This destruction... even had we journeyed here instead of questing north, we would most assuredly have made no difference. Of that I am now certain.
@@ -2183,11 +2169,9 @@ The fates may yet reveal that our journey north was necessary, even at such a st
             speaker=Dacyn
             message= _ "Apology accepted."
         [/message]
-
         [delay]
             time=2000
         [/delay]
-
         [message]
             speaker=Dacyn
             message= _ "And I too must admit, I underestimated the power in this Amulet. Even now, voices gnaw at the edges of my mind..."

--- a/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/14_The_Drowned_Plains.cfg
@@ -2146,8 +2146,8 @@ I offer one final prayer to the Light, that at least my family may be spared and
     [event]
         name=time over # not side 1 turn end, so the AI gets a chance to attack
         [message]
-             speaker=Owaec
-             message= _ "So much death. So many of my kinsmen left unavenged. If only we had more time..."
+            speaker=Owaec
+            message= _ "So much death. So many of my kinsmen left unavenged. If only we had more time..."
         [/message]
         [message]
             speaker=Gweddry

--- a/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/16_Eleventh_Hour.cfg
@@ -37,7 +37,7 @@
         controller=human
         team_name=good
         user_team_name=_"Wesnothians"
-        {GOLD 100 75 50} # you're expected to have a large early finish bonus from S14; maybe 300-600 gold
+        {GOLD 0 0 0} # you're expected to have a large early finish bonus from S14; maybe 300-600 gold
         # you get a lot of income, so even with no carryover you can still recruit enough to defend the central island
         {FLAG_VARIANT loyalist}
     [/side]


### PR DESCRIPTION
Drowned Plains is one of the most-criticized EI scenarios. It has a 75 turn limit, and involves trudging across swamp while enduring ambushes to kill 3 enemy leaders.

This revision drastically shortens the scenario to only 25 turns, and changes the objective to _'Gather as much gold as you can before turns run out'_. Enemy leaders have piles of gold nearby, to reward killing them (or luring/stealing from them).

I played through this once to verify the balance was at least plausible and that nothing was completely broken, but it's possible I missed something. Please let me know if anything looks incorrect.