### PR TITLE
EI: update Dacyn arcane resistance to be consistent with the arcane rework

### DIFF
--- a/data/campaigns/Eastern_Invasion/units/Human_Dacyn_Fallen_Mage.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Dacyn_Fallen_Mage.cfg
@@ -26,7 +26,7 @@
     die_sound=lich-die.ogg
     {DEFENSE_ANIM "units/dacyn/dacyn-L5-defend1.png" "units/dacyn/dacyn-L5-defend2.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [resistance]
-        arcane=130
+        arcane=120
         cold=70
     [/resistance]
 

--- a/data/campaigns/Eastern_Invasion/units/Human_Dacyn_Twilight_Mage.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Dacyn_Twilight_Mage.cfg
@@ -20,7 +20,7 @@
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
     {DEFENSE_ANIM "units/dacyn/dacyn-L3-defend1.png" "units/dacyn/dacyn-L3-defend2.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [resistance]
-        arcane=110
+        arcane=80
         cold=80
     [/resistance]
 

--- a/data/campaigns/Eastern_Invasion/units/Human_Dacyn_Twilight_Mage.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Dacyn_Twilight_Mage.cfg
@@ -20,7 +20,7 @@
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
     {DEFENSE_ANIM "units/dacyn/dacyn-L3-defend1.png" "units/dacyn/dacyn-L3-defend2.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [resistance]
-        arcane=90
+        arcane=110
         cold=80
     [/resistance]
 


### PR DESCRIPTION
In EI, Dacyn transforms into a Twilight Mage and then Fallen Mage, meant to foreshadow his transition towards undeath.

The original arcane resistances for these forms were set before the 1.18 arcane rework. In particular, it's odd that Fallen Mage Dacyn (who's still visibly human) has worse arcane resist than a lich or a skeleton.

Even if the arcane changes proposed in #9392 go through, these proposed Dacyn stats should still be reasonable.