### PR TITLE
Define core units without [base_unit] tag (Horse, Scorpion, Ant Egg)

### DIFF
--- a/data/core/units/monsters/Horse_Dark.cfg
+++ b/data/core/units/monsters/Horse_Dark.cfg
@@ -12,17 +12,30 @@
 [unit_type]
     id=Dark Horse
     name= _ "Dark Horse"
-    [base_unit]
-        id=Bay Horse
-    [/base_unit]
-    profile="portraits/monsters/dark-horse.webp"
+    race=horse
+    generate_name=no
     image="units/monsters/horse/horse.png{HORSE_BLACK_IPF}"
+    profile="portraits/monsters/dark-horse.webp"
+    hitpoints=30
+    movement_type=mounted
+    movement=8
     experience=24
+    level=1
+    alignment=chaotic
+    advances_to=Black Horse
+    cost=16
+    usage=scout
     gender=male,female
     ignore_race_traits=yes
     {TRAIT_INTELLIGENT}
     {TRAIT_RESILIENT}
     {TRAIT_QUICK}
+    description=_ "Dark Horses are wild animals, but they seem to take an odd interest in the civilized races. They leave no signs of their passage, but they have been noticed scouting camps and outposts during the night."
+    die_sound=horse-die.ogg
+    [defense]
+        forest=50
+        hills=50
+    [/defense]
     [resistance]
         blade=100
         pierce=120
@@ -30,14 +43,6 @@
         cold=90
         arcane=100
     [/resistance]
-    [defense]
-        forest=50
-        hills=50
-    [/defense]
-    advances_to=Black Horse
-    alignment=chaotic
-    movement=8
-    description=_ "Dark Horses are wild animals, but they seem to take an odd interest in the civilized races. They leave no signs of their passage, but they have been noticed scouting camps and outposts during the night."
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]
         name=hooves

--- a/data/core/units/monsters/Horse_White.cfg
+++ b/data/core/units/monsters/Horse_White.cfg
@@ -12,19 +12,22 @@
 [unit_type]
     id=White Horse
     name= _ "White Horse"
-    [base_unit]
-        id=Bay Horse
-    [/base_unit]
+    race=horse
+    generate_name=no
     image="units/monsters/horse/horse.png{HORSE_WHITE_IPF}"
     profile="portraits/monsters/white-horse.webp"
     hitpoints=31
-    experience=50
-    advances_to=null
-    {AMLA_DEFAULT}
     movement_type=woodland
     movement=9
+    experience=50
+    level=1
+    alignment=neutral
+    advances_to=null
+    {AMLA_DEFAULT}
+    cost=16
+    usage=scout
     description=_ "Some horses have a white color, and they are merely white horses. But there exist a special breed, found only in the wild woods, that are White Horses. As if blessed by the faerie world, they have a grace and agility not found in their more common relatives."
-    {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_WHITE_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_WHITE_IPF}" {SOUND_LIST:HORSE_HIT} }
+    die_sound=horse-die.ogg
     [defense]
         forest=40
         village=60
@@ -34,6 +37,7 @@
         impact=100
         arcane=100
     [/resistance]
+    {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_WHITE_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_WHITE_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]
         name=hooves
         description=_"hooves"

--- a/data/core/units/monsters/Sand_Scamperer.cfg
+++ b/data/core/units/monsters/Sand_Scamperer.cfg
@@ -5,16 +5,13 @@
 
 [unit_type]
     id=Sand Scamperer
-    [base_unit]
-        id=Giant Scorpling
-    [/base_unit]
     name= _ "Sand Scamperer"
+    race=monster
+    image="units/monsters/scorpion/scorpling.png{SAND_SCAMPERER_IPF}"
     small_profile="portraits/monsters/scamperer.webp~FL()~CROP(0,82,400,318)"
     profile="portraits/monsters/scamperer.webp~RIGHT()"
-    image="units/monsters/scorpion/scorpling.png{SAND_SCAMPERER_IPF}"
-    undead_variation=sand_scorpion
-    description= _ "This impressive creature swiftly moves through the scorching desert sand. Its body is covered in a thick, sand-colored exoskeleton absorbing any impact damage. However, it is also highly flammable and vulnerable to arcane energy, making fire and magic-based attacks the most effective way to take this venomous critter down."
     hitpoints=27
+    movement_type=scuttlefoot
     [resistance]
         blade=90
         pierce=90
@@ -23,9 +20,38 @@
         cold=120
         arcane=150
     [/resistance]
+    movement=6
+    experience=20
+    level=0
+    alignment=neutral
     advances_to=Sand Scuttler
+    cost=12
+    usage=fighter
+    undead_variation=sand_scorpion
+    description= _ "This impressive creature swiftly moves through the scorching desert sand. Its body is covered in a thick, sand-colored exoskeleton absorbing any impact damage. However, it is also highly flammable and vulnerable to arcane energy, making fire and magic-based attacks the most effective way to take this venomous critter down."
+    die_sound=hiss-big.wav
     {DEFENSE_ANIM "units/monsters/scorpion/scorpling-defend2.png{SAND_SCAMPERER_IPF}" "units/monsters/scorpion/scorpling-defend1.png{SAND_SCAMPERER_IPF}" hiss.wav }
 
+    [attack]
+        name=sting
+        description=_"sting"
+        type=pierce
+        range=melee
+        [specials]
+            {WEAPON_SPECIAL_POISON}
+        [/specials]
+        damage=5
+        defense_weight=4.0
+        number=1
+    [/attack]
+    [attack]
+        name=pincers
+        description=_"pincers"
+        type=impact
+        range=melee
+        damage=2
+        number=4
+    [/attack]
     [attack_anim]
         [filter_attack]
             name=pincers

--- a/data/core/units/monsters/Sand_Scuttler.cfg
+++ b/data/core/units/monsters/Sand_Scuttler.cfg
@@ -2,15 +2,11 @@
 
 [unit_type]
     id=Sand Scuttler
-    [base_unit]
-        id=Giant Scorpion
-    [/base_unit]
     name= _ "Sand Scuttler"
+    race=monster
+    image="units/monsters/scorpion/sand-scuttler.png"
     small_profile="portraits/monsters/scuttler.webp~FL()"
     profile="portraits/monsters/scuttler.webp~RIGHT()"
-    image="units/monsters/scorpion/sand-scuttler.png"
-    undead_variation=sand_scorpion
-    description= _ "Making their homes in sandy dunes, these critters are an odd mix of mundane creature and elemental beast. Though usually timid, Sand Scuttlers sometimes attack unwary travelers, especially when startled."
     [standing_anim]
         start_time=0
         direction=s,sw,se
@@ -26,6 +22,7 @@
         [/frame]
     [/standing_anim]
     hitpoints=40
+    movement_type=scuttlefoot
     [resistance]
         blade=90
         pierce=90
@@ -34,8 +31,39 @@
         cold=120
         arcane=150
     [/resistance]
+    movement=8
+    experience=50
+    level=1
+    alignment=neutral
+    advances_to=null
+    {AMLA_DEFAULT}
+    cost=17
+    undead_variation=sand_scorpion
+    usage=fighter
+    description= _ "Making their homes in sandy dunes, these critters are an odd mix of mundane creature and elemental beast. Though usually timid, Sand Scuttlers sometimes attack unwary travelers, especially when startled."
+    die_sound=hiss-big.wav
     {DEFENSE_ANIM_DIRECTIONAL "units/monsters/scorpion/sand-scuttler-defend2.png" "units/monsters/scorpion/sand-scuttler-defend1.png" "units/monsters/scorpion/sand-scuttler-ne-defend2.png" "units/monsters/scorpion/sand-scuttler-ne-defend1.png" hiss.wav }
 
+    [attack]
+        name=sting
+        description=_"sting"
+        type=pierce
+        range=melee
+        [specials]
+            {WEAPON_SPECIAL_POISON}
+        [/specials]
+        damage=9
+        defense_weight=4.0
+        number=1
+    [/attack]
+    [attack]
+        name=pincers
+        description=_"pincers"
+        type=impact
+        range=melee
+        damage=4
+        number=4
+    [/attack]
     [attack_anim]
         [filter_attack]
             name=pincers


### PR DESCRIPTION
Out of all 311 core units, only 5 relatively newly added units use `[base_unit]` tag as a part of their definition (Dark Horse, White Horse, Sand Scamperer, Sand Scuttler, and Fire Ant Egg).
To keep the consistency, and to prevent the potential nested structure of `[base_unit]` of `[base_unit]` in modified units, it is probably better to define core units without the tag.

1. Dark Horse, White Horse, Sand Scamperer, and Sand Scuttler are now defined without `[base_unit]` by copy-pasting data from respective base units.
2. The deprecated variation of Giant Scorpion (moved to Sand Scuttler) is untouched just in case, but it should be removed in the future.
3. Ant_Egg.cfg is the only file that defines 2 units (Giant Ant Egg and Fire Ant Egg) within a single file. They should be separate in my opinion, but I don’t know if separating causes any problem, especially when Giant Ant Egg (level 0) advances to Giant Ant (level 0) and it doesn’t appear in [the unit database](https://units.wesnoth.org/1.19/mainline/en_US/mainline.html). Therefore, Fire Ant Egg whose base unit is Giant Ant Egg is untouched for now.

I would like people to double-check the changes, and give opinions on Ant Eggs.