### PR TITLE
Set UtBS date to 600 AF to prevent lore conflicts with IfTU

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/_main.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/_main.cfg
@@ -13,7 +13,7 @@
     image="data/campaigns/Under_the_Burning_Suns/images/campaign_image.png"
     abbrev= _ "UtBS"
     rank=205
-    year="1000 AF"
+    year="600 AF"
     define=CAMPAIGN_UNDER_THE_BURNING_SUNS
     first_scenario=01_The_Morning_After
 


### PR DESCRIPTION
Sorry about this second PR! This is a follow-up on #9404 Apparently my previsouly proposed date of 1000 AF contradicts certain UMC such as IfTU so I’m going for 600 AF, which is still more reasonable than the previous 300.