### PR TITLE
Status table team name fix

### DIFF
--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -1070,42 +1070,6 @@ config side_engine::new_config() const
 
 		res["team_name"] = parent_.team_data_[team_].team_name;
 
-		// TODO: Fix this mess!
-		//
-		// There is a fundamental disconnect, here. One the one hand we have the idea of
-		// 'teams' (which don't actually exist). A 'team' has a name (internal key:
-		// team_name) and a translatable display name (internal key: user_team_name). But
-		// what we actually have are sides. Sides relate to each other by 'team' (internal
-		// key: team_name) and each side has it's own name for the team (internal key:
-		// user_team_name).
-		//
-		// The confusion is that the keys from the side have names which one might expect
-		// always refer to the 'team' concept. THEY DO NOT! They are simply named in such
-		// a way to confuse the unwary.
-		//
-		// There is no simple, clean way to clear up the confusion. So, I'm applying the
-		// Principle of Least Surprise. The user can see the user_team_name, and it should
-		// not change. So if the side already has a user_team_name, use it.
-		//
-		// In the rare and unlikely (like, probably never happens) case that the side does
-		// not have a user_team_name, but an (nebulous and non-deterministic term here)
-		// EARLIER side has the same team_name and that side gives a user_team_name, we'll
-		// use it.
-		//
-		// The effect of this mess, and my lame fix for it, is probably only visible when
-		// randomizing the sides on a team for multi-player games. But the effect when it's
-		// not fixed is an obvious mistake on the player's screen when playing a campaign
-		// in single-player mode.
-		//
-		// At some level, all this is probably wrong, but it is the least breakage from the
-		// mess I found; so deal with it, or fix it.
-		//
-		// If, by now, you get the impression this is a kludged-together mess which cries
-		// out for an honest design and a thoughtful implementation, you're correct! But
-		// I'm tired, and I'm cranky from wasting a over day on this, and so I'm exercising
-		// my prerogative as a grey-beard and leaving this for someone else to clean up.
-		//
-		// Now should be fixed for single player
 		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings || team_changed_) {
 			res["user_team_name"] = parent_.team_data_[team_].user_team_name;
 		}

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -828,7 +828,6 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine, const
 	, controller_lock_(cfg["controller_lock"].to_bool(parent_.force_lock_settings_) && parent_.params_.use_map_settings)
 	, index_(index)
 	, team_(0)
-	, team_changed_(false)
 	, color_(std::min(index, gamemap::MAX_PLAYERS - 1))
 	, gold_(cfg["gold"].to_int(100))
 	, income_(cfg["income"])
@@ -900,7 +899,6 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine, const
 	if(team_name_index >= parent_.team_data_.size()) {
 		assert(!parent_.team_data_.empty());
 		team_ = 0;
-		team_changed_ = true;
 		WRN_MP << "In side_engine constructor: Could not find my team_name " << cfg["team_name"] << " among the mp connect engine's list of team names. I am being assigned to the first team. This may indicate a bug!";
 	} else {
 		team_ = team_name_index;
@@ -1068,9 +1066,10 @@ config side_engine::new_config() const
 			(*leader)["gender"] = "null";
 		}
 
-		res["team_name"] = parent_.team_data_[team_].team_name;
+		std::string& new_team_name = parent_.team_data_[team_].team_name;
 
-		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings || team_changed_) {
+		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings || res["team_name"] != new_team_name) {
+			res["team_name"] = new_team_name;
 			res["user_team_name"] = parent_.team_data_[team_].user_team_name;
 		}
 

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -1104,6 +1104,8 @@ config side_engine::new_config() const
 		// out for an honest design and a thoughtful implementation, you're correct! But
 		// I'm tired, and I'm cranky from wasting a over day on this, and so I'm exercising
 		// my prerogative as a grey-beard and leaving this for someone else to clean up.
+		//
+		// Now should be fixed for single player
 		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings || team_changed_) {
 			res["user_team_name"] = parent_.team_data_[team_].user_team_name;
 		}

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -828,6 +828,7 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine, const
 	, controller_lock_(cfg["controller_lock"].to_bool(parent_.force_lock_settings_) && parent_.params_.use_map_settings)
 	, index_(index)
 	, team_(0)
+	, team_changed_(false)
 	, color_(std::min(index, gamemap::MAX_PLAYERS - 1))
 	, gold_(cfg["gold"].to_int(100))
 	, income_(cfg["income"])
@@ -899,6 +900,7 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine, const
 	if(team_name_index >= parent_.team_data_.size()) {
 		assert(!parent_.team_data_.empty());
 		team_ = 0;
+		team_changed_ = true;
 		WRN_MP << "In side_engine constructor: Could not find my team_name " << cfg["team_name"] << " among the mp connect engine's list of team names. I am being assigned to the first team. This may indicate a bug!";
 	} else {
 		team_ = team_name_index;
@@ -1102,7 +1104,7 @@ config side_engine::new_config() const
 		// out for an honest design and a thoughtful implementation, you're correct! But
 		// I'm tired, and I'm cranky from wasting a over day on this, and so I'm exercising
 		// my prerogative as a grey-beard and leaving this for someone else to clean up.
-		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings) {
+		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings || team_changed_) {
 			res["user_team_name"] = parent_.team_data_[team_].user_team_name;
 		}
 

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -1066,7 +1066,7 @@ config side_engine::new_config() const
 			(*leader)["gender"] = "null";
 		}
 
-		std::string& new_team_name = parent_.team_data_[team_].team_name;
+		const std::string& new_team_name = parent_.team_data_[team_].team_name;
 
 		if(res["user_team_name"].empty() || !parent_.params_.use_map_settings || res["team_name"] != new_team_name) {
 			res["team_name"] = new_team_name;

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -194,7 +194,7 @@ public:
 	int index() const { return index_; }
 	void set_index(int index) { index_ = index; }
 	unsigned team() const { return team_; }
-	void set_team(unsigned team) { team_ = team; team_changed_ = true; }
+	void set_team(unsigned team) { team_ = team; }
 	std::multimap<std::string, config> get_side_children();
 	void set_side_children(std::multimap<std::string, config> children);
 	int color() const { return color_; }
@@ -251,7 +251,6 @@ private:
 
 	int index_;
 	unsigned team_;
-	bool team_changed_;
 	int color_;
 	int gold_;
 	int income_;

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -194,7 +194,7 @@ public:
 	int index() const { return index_; }
 	void set_index(int index) { index_ = index; }
 	unsigned team() const { return team_; }
-	void set_team(unsigned team) { team_ = team; }
+	void set_team(unsigned team) { team_ = team; team_changed_ = true; }
 	std::multimap<std::string, config> get_side_children();
 	void set_side_children(std::multimap<std::string, config> children);
 	int color() const { return color_; }
@@ -251,6 +251,7 @@ private:
 
 	int index_;
 	unsigned team_;
+	bool team_changed_;
 	int color_;
 	int gold_;
 	int income_;


### PR DESCRIPTION
Resolves #9407 where status dialog team names are not changed, when changed at game start.