### PR TITLE
[Units] Adjust Forest Lion Stats

### DIFF
--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -203,6 +203,8 @@
 #enddef
 
 #define WEAPON_SPECIAL_ARCANE
+    # Canned definition of the Arcane ability to be included in a
+    # [specials] clause.
     [damage_type]
         id=arcane_damage
         name= _ "arcane"
@@ -210,4 +212,15 @@
         special_note=_ "This unit can use the arcane type when the opponent is particularly sensitive to it in relation to the weapon on which it is applied."
         alternative_type=arcane
     [/damage_type]
+#enddef
+
+#define WEAPON_SPECIAL_UNWIELDY
+    # Canned definition of the Unwieldy ability to be included in a
+    # [specials] clause.
+    [disable]
+        id=unwieldy
+        name=_"unwieldy"
+        description=_"This attack can only be used offensively."
+        active_on=defense
+    [/disable]
 #enddef

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -213,14 +213,3 @@
         alternative_type=arcane
     [/damage_type]
 #enddef
-
-#define WEAPON_SPECIAL_UNWIELDY
-    # Canned definition of the Unwieldy ability to be included in a
-    # [specials] clause.
-    [disable]
-        id=unwieldy
-        name=_"unwieldy"
-        description=_"This attack can only be used offensively."
-        active_on=defense
-    [/disable]
-#enddef

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -94,6 +94,8 @@
         range=melee
         damage=13
         number=2
+        #TODO: when there is a proper attack-only special in core, use that instead of defense_weight!
+        defense_weight=0
     [/attack]
     ###########################################################
     # this does not work, attacks are not defined at this point

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -19,14 +19,14 @@
         mountains=2
     [/movement_costs]
     [resistance]
-        arcane=80
+        arcane=90
     [/resistance]
     experience=100
     {AMLA_DEFAULT}
     level=2
     alignment=neutral
     advances_to=null
-    cost=21
+    cost=27
     usage=scout
     description=_ "Forest Lions are light-brown cats, roughly the same size as a wolf, that hunt the woods and hills at dusk and dawn. Their most distinctive feature is their odd, triply branched tail, which they seem to use for camouflage and disruptive patterning."
     # To Do: Get big cat sounds, maybe we can use the WoF leopard sounds?
@@ -82,10 +82,9 @@
         description=_"claws"
         range=melee
         type=blade
-        damage=5
+        damage=6
         number=4
         icon=attacks/claws-animal.png
-        attack_weight=0
     [/attack]
     [attack]
         name=fangs
@@ -93,9 +92,8 @@
         icon=attacks/fangs-animal.png
         type=blade
         range=melee
-        damage=15
+        damage=13
         number=2
-        defense_weight=0
     [/attack]
     ###########################################################
     # this does not work, attacks are not defined at this point

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -26,7 +26,7 @@
     level=2
     alignment=neutral
     advances_to=null
-    cost=24
+    cost=30
     usage=scout
     description=_ "Forest Lions are light-brown cats, roughly the same size as a wolf, that hunt the woods and hills at dusk and dawn. Their most distinctive feature is their odd, triply branched tail, which they seem to use for camouflage and disruptive patterning."
     # To Do: Get big cat sounds, maybe we can use the WoF leopard sounds?

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -94,8 +94,9 @@
         range=melee
         damage=13
         number=2
-        #TODO: when there is a proper attack-only special in core, use that instead of defense_weight!
-        defense_weight=0
+        [specials]
+            {WEAPON_SPECIAL_UNWIELDY}
+        [/specials]
     [/attack]
     ###########################################################
     # this does not work, attacks are not defined at this point

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -26,7 +26,7 @@
     level=2
     alignment=neutral
     advances_to=null
-    cost=27
+    cost=24
     usage=scout
     description=_ "Forest Lions are light-brown cats, roughly the same size as a wolf, that hunt the woods and hills at dusk and dawn. Their most distinctive feature is their odd, triply branched tail, which they seem to use for camouflage and disruptive patterning."
     # To Do: Get big cat sounds, maybe we can use the WoF leopard sounds?

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -7,7 +7,7 @@
     image="units/monsters/cat/tritail-sitting.png"
     profile="portraits/monsters/tritail-cat.webp"
     hitpoints=42
-    movement=9
+    movement=7
     # similar to elves, but not as bad in caves, and not magical
     movement_type=woodland
     [defense]
@@ -82,7 +82,7 @@
         description=_"claws"
         range=melee
         type=blade
-        damage=6
+        damage=5
         number=4
         icon=attacks/claws-animal.png
     [/attack]
@@ -92,7 +92,7 @@
         icon=attacks/fangs-animal.png
         type=blade
         range=melee
-        damage=13
+        damage=15
         number=2
         [specials]
             {WEAPON_SPECIAL_UNWIELDY}

--- a/data/core/units/monsters/Cat_Forest.cfg
+++ b/data/core/units/monsters/Cat_Forest.cfg
@@ -6,7 +6,7 @@
     generate_name=no
     image="units/monsters/cat/tritail-sitting.png"
     profile="portraits/monsters/tritail-cat.webp"
-    hitpoints=42
+    hitpoints=48
     movement=7
     # similar to elves, but not as bad in caves, and not magical
     movement_type=woodland
@@ -82,7 +82,7 @@
         description=_"claws"
         range=melee
         type=blade
-        damage=5
+        damage=6
         number=4
         icon=attacks/claws-animal.png
     [/attack]
@@ -92,10 +92,10 @@
         icon=attacks/fangs-animal.png
         type=blade
         range=melee
-        damage=15
+        damage=9
         number=2
         [specials]
-            {WEAPON_SPECIAL_UNWIELDY}
+            {WEAPON_SPECIAL_CHARGE}
         [/specials]
     [/attack]
     ###########################################################


### PR DESCRIPTION
Looking at the brand-new 1.19 cat stats. The concept is neat but I believe the unit is a bit overtuned (and Jump Cat is very overtuned, but I will get to that one in another PR) with 9mp, 15-2 attack and 21 cost a once. Though on the other hand, using attack/defense weights seems a bit too not-user-friendly since that mechanic is not visible in-game, so I propose the following changes with my PR

arcane resistance from 20% to 10%
claws from 5-4 to 6-4 now usable on offense
bite from 15-2 to 9-2 charge, now usable in defense
price from 21 to ~~27~~ 30

MP from 9 to 7
HP from 42 to 48

EDIT: reduced price to 24

EDIT2: reverted damage numbers but nerfed MP to 7 as suggested by Dalas

EDIT3: another rebalance around making it a charge unit

EDIT4: increased price to 30