### PR TITLE
More config stuff

### DIFF
--- a/src/config_attribute_value.cpp
+++ b/src/config_attribute_value.cpp
@@ -129,11 +129,11 @@ bool from_string_verify(const std::string& source, To& res)
 }
 } // end anon namespace
 
-config_attribute_value& config_attribute_value::operator=(const std::string& v)
+config_attribute_value& config_attribute_value::operator=(std::string&& v)
 {
 	// Handle some special strings.
 	if(v.empty()) {
-		value_ = v;
+		value_ = std::move(v);
 		return *this;
 	}
 
@@ -190,8 +190,13 @@ config_attribute_value& config_attribute_value::operator=(const std::string& v)
 	}
 
 	// No conversion possible. Store the string.
-	value_ = v;
+	value_ = std::move(v);
 	return *this;
+}
+
+config_attribute_value& config_attribute_value::operator=(const std::string& v)
+{
+	return operator=(std::string(v));
 }
 
 config_attribute_value& config_attribute_value::operator=(const std::string_view& v)
@@ -199,8 +204,8 @@ config_attribute_value& config_attribute_value::operator=(const std::string_view
 	// TODO: Currently this acts just like std::string assignment.
 	// Perhaps the underlying variant should take a string_view directly?
 	return operator=(std::string(v));
-
 }
+
 config_attribute_value& config_attribute_value::operator=(const t_string& v)
 {
 	if(!v.translatable()) {

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -122,6 +122,7 @@ public:
 
 	// String assignments:
 	config_attribute_value& operator=(const char *v) { return operator=(std::string(v)); }
+	config_attribute_value& operator=(std::string&& v);
 	config_attribute_value& operator=(const std::string &v);
 	config_attribute_value& operator=(const std::string_view &v);
 	config_attribute_value& operator=(const t_string &v);


### PR DESCRIPTION
Fixes:
* `cfg["foo"] = std::move(value)` is now allowed
* `config { key, value }` will no longer fail if `value` is a const config reference (it worked with a non-const reference)

`config::all_children_view` is meant to replace `all_children_range` for the vast majority of cases in which you just need the iterate over tags without saving the iterator. It's easier to read, code-wise, it fixes the issue of `any_child` always holding a mutable reference even when the owning config was const, and intellisense now properly shows key/value types as references when destructuring (rather than value as with `all_children_range`).