### PR TITLE
Scenario editor, unit facing, game crash fix

### DIFF
--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -770,6 +770,7 @@ bool editor_controller::do_execute_command(const hotkey::ui_command& cmd, bool p
 					assert(un != get_current_map_context().units().end());
 					un->set_facing(map_location::DIRECTION(index));
 					un->anim_comp().set_standing();
+					active_menu_ = MAP;
 					return true;
 				}
 			}


### PR DESCRIPTION
Resolves #9226. Game no longer crashes when clicking menu bar after setting unit facing.