### PR TITLE
GUI2/Widgets: use unique_ptr for builder ptrs

### DIFF
--- a/src/gui/core/window_builder.cpp
+++ b/src/gui/core/window_builder.cpp
@@ -80,7 +80,7 @@ builder_widget_ptr create_widget_builder(const config& cfg)
 	auto [widget_key, widget_cfg] = *cfg.ordered_begin();
 
 	if(widget_key == "grid") {
-		return std::make_shared<builder_grid>(widget_cfg);
+		return std::make_unique<builder_grid>(widget_cfg);
 	}
 
 	if(widget_key == "instance") {
@@ -165,7 +165,7 @@ builder_window::window_resolution::window_resolution(const config& cfg)
 
 	VALIDATE(c, _("No grid defined."));
 
-	grid = std::make_shared<builder_grid>(*c);
+	grid = std::make_unique<builder_grid>(*c);
 
 	if(!automatic_placement) {
 		VALIDATE(width.has_formula() || width(), missing_mandatory_wml_key("resolution", "width"));
@@ -240,14 +240,14 @@ builder_grid::builder_grid(const config& cfg)
 	DBG_GUI_P << "Window builder: grid has " << rows << " rows and " << cols << " columns.";
 }
 
-std::unique_ptr<widget> builder_grid::build() const
+std::unique_ptr<widget> builder_grid::build()
 {
 	auto result = std::make_unique<grid>();
 	build(*result);
 	return result;
 }
 
-std::unique_ptr<widget> builder_grid::build(const replacements_map& replacements) const
+std::unique_ptr<widget> builder_grid::build(const replacements_map& replacements)
 {
 	auto result = std::make_unique<grid>();
 	build(*result, replacements);

--- a/src/gui/core/window_builder.hpp
+++ b/src/gui/core/window_builder.hpp
@@ -53,9 +53,9 @@ struct builder_widget
 	{
 	}
 
-	virtual std::unique_ptr<widget> build() const = 0;
+	virtual std::unique_ptr<widget> build() = 0;
 
-	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const = 0;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) = 0;
 
 	/** Parameters for the widget. */
 	std::string id;
@@ -135,16 +135,16 @@ struct builder_grid : public builder_widget
 	std::vector<builder_widget_ptr> widgets;
 
 	/** Inherited from @ref builder_widget. */
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	/** Inherited from @ref builder_widget. */
-	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) override;
 
 	void build(grid& grid, optional_replacements replacements = utils::nullopt) const;
 };
 
-using builder_grid_ptr = std::shared_ptr<builder_grid>;
-using builder_grid_const_ptr = std::shared_ptr<const builder_grid>;
+using builder_grid_ptr = std::unique_ptr<builder_grid>;
+using builder_grid_const_ptr = std::unique_ptr<const builder_grid>;
 using builder_grid_map = std::map<std::string, builder_grid_const_ptr>;
 
 class builder_window

--- a/src/gui/core/window_builder/instance.cpp
+++ b/src/gui/core/window_builder/instance.cpp
@@ -30,12 +30,12 @@ builder_instance::builder_instance(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_instance::build() const
+std::unique_ptr<widget> builder_instance::build()
 {
 	return build(replacements_map());
 }
 
-std::unique_ptr<widget> builder_instance::build(const replacements_map& replacements) const
+std::unique_ptr<widget> builder_instance::build(const replacements_map& replacements)
 {
 	const replacements_map::const_iterator itor = replacements.find(id);
 	if(itor != replacements.end()) {

--- a/src/gui/core/window_builder/instance.hpp
+++ b/src/gui/core/window_builder/instance.hpp
@@ -29,9 +29,9 @@ struct builder_instance : public builder_widget
 {
 	explicit builder_instance(const config& cfg);
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
-	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) override;
 
 	/**
 	 * Holds a copy of the cfg parameter in the constructor.

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -428,7 +428,7 @@ addon_list_definition::resolution::resolution(const config& cfg)
 	auto child = cfg.optional_child("grid");
 	VALIDATE(child, _("No grid defined."));
 
-	grid = std::make_shared<builder_grid>(*child);
+	grid = std::make_unique<builder_grid>(*child);
 }
 
 namespace implementation
@@ -461,7 +461,7 @@ builder_addon_list::builder_addon_list(const config& cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_addon_list::build() const
+std::unique_ptr<widget> builder_addon_list::build()
 {
 	auto widget = std::make_unique<addon_list>(*this);
 

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -215,7 +215,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	widget::visibility install_status_visibility_;

--- a/src/gui/widgets/button.cpp
+++ b/src/gui/widgets/button.cpp
@@ -194,7 +194,7 @@ builder_button::builder_button(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_button::build() const
+std::unique_ptr<widget> builder_button::build()
 {
 	auto widget = std::make_unique<button>(*this);
 

--- a/src/gui/widgets/button.hpp
+++ b/src/gui/widgets/button.hpp
@@ -153,7 +153,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	std::string retval_id_;

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -652,7 +652,7 @@ chatbox_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "foreground", missing_mandatory_wml_tag("chatbox_definition][resolution", "foreground")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("chatbox_definition][resolution", "grid"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 // }---------- BUILDER -----------{
 
@@ -664,7 +664,7 @@ builder_chatbox::builder_chatbox(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_chatbox::build() const
+std::unique_ptr<widget> builder_chatbox::build()
 {
 	auto widget = std::make_unique<chatbox>(*this);
 

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -263,7 +263,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 };

--- a/src/gui/widgets/combobox.cpp
+++ b/src/gui/widgets/combobox.cpp
@@ -430,7 +430,7 @@ builder_combobox::builder_combobox(const config& cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_combobox::build() const
+std::unique_ptr<widget> builder_combobox::build()
 {
 	auto widget = std::make_unique<combobox>(*this);
 

--- a/src/gui/widgets/combobox.hpp
+++ b/src/gui/widgets/combobox.hpp
@@ -214,7 +214,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	std::size_t max_input_length;
 

--- a/src/gui/widgets/drawing.cpp
+++ b/src/gui/widgets/drawing.cpp
@@ -114,7 +114,7 @@ builder_drawing::builder_drawing(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_drawing::build() const
+std::unique_ptr<widget> builder_drawing::build()
 {
 	auto widget = std::make_unique<drawing>(*this);
 

--- a/src/gui/widgets/drawing.hpp
+++ b/src/gui/widgets/drawing.hpp
@@ -126,7 +126,7 @@ struct builder_drawing : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	/** The width of the widget. */
 	typed_formula<unsigned> width;

--- a/src/gui/widgets/horizontal_scrollbar.cpp
+++ b/src/gui/widgets/horizontal_scrollbar.cpp
@@ -140,7 +140,7 @@ builder_horizontal_scrollbar::builder_horizontal_scrollbar(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_horizontal_scrollbar::build() const
+std::unique_ptr<widget> builder_horizontal_scrollbar::build()
 {
 	auto widget = std::make_unique<horizontal_scrollbar>(*this);
 

--- a/src/gui/widgets/horizontal_scrollbar.hpp
+++ b/src/gui/widgets/horizontal_scrollbar.hpp
@@ -107,7 +107,7 @@ struct builder_horizontal_scrollbar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/image.cpp
+++ b/src/gui/widgets/image.cpp
@@ -120,7 +120,7 @@ builder_image::builder_image(const config& cfg) : builder_styled_widget(cfg)
 {
 }
 
-std::unique_ptr<widget> builder_image::build() const
+std::unique_ptr<widget> builder_image::build()
 {
 	auto widget = std::make_unique<image>(*this);
 

--- a/src/gui/widgets/image.hpp
+++ b/src/gui/widgets/image.hpp
@@ -125,7 +125,7 @@ struct builder_image : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -253,7 +253,7 @@ builder_label::builder_label(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_label::build() const
+std::unique_ptr<widget> builder_label::build()
 {
 	auto lbl = std::make_unique<label>(*this);
 

--- a/src/gui/widgets/label.hpp
+++ b/src/gui/widgets/label.hpp
@@ -226,7 +226,7 @@ struct builder_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	bool wrap;
 

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -518,15 +518,15 @@ void listbox::handle_key_right_arrow(SDL_Keymod modifier, bool& handled)
 }
 
 void listbox::finalize(std::unique_ptr<generator_base> generator,
-		std::unique_ptr<widget>&& header,
-		std::unique_ptr<widget>&& footer,
+		builder_grid_ptr header,
+		builder_grid_ptr footer,
 		const std::vector<widget_data>& list_data)
 {
 	// "Inherited."
 	scrollbar_container::finalize_setup();
 
 	if(header) {
-		swap_grid(&get_grid(), content_grid(), std::move(header), "_header_grid");
+		swap_grid(&get_grid(), content_grid(), header->build(), "_header_grid");
 	}
 
 	grid& p = find_widget<grid>("_header_grid");
@@ -552,7 +552,7 @@ void listbox::finalize(std::unique_ptr<generator_base> generator,
 	}
 
 	if(footer) {
-		swap_grid(&get_grid(), content_grid(), std::move(footer), "_footer_grid");
+		swap_grid(&get_grid(), content_grid(), footer->build(), "_footer_grid");
 	}
 
 	// Save our *non-owning* pointer before this gets moved into the grid.
@@ -793,7 +793,7 @@ std::unique_ptr<widget> builder_listbox::build()
 	widget->init_grid(*conf->grid);
 
 	auto generator = generator_base::build(has_minimum_, has_maximum_, generator_base::vertical_list, allow_selection_);
-	widget->finalize(std::move(generator), header->build(), footer->build(), list_data);
+	widget->finalize(std::move(generator), std::move(header), std::move(footer), list_data);
 
 	return widget;
 }

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -338,13 +338,13 @@ private:
 	 * Finishes the building initialization of the widget.
 	 *
 	 * @param generator           Generator for the list
-	 * @param header              Builder for the header.
-	 * @param footer              Builder for the footer.
+	 * @param header              Builder output for the header.
+	 * @param footer              Builder output for the footer.
 	 * @param list_data           The initial data to fill the listbox with.
 	 */
 	void finalize(std::unique_ptr<generator_base> generator,
-			builder_grid_const_ptr header,
-			builder_grid_const_ptr footer,
+			std::unique_ptr<widget>&& header,
+			std::unique_ptr<widget>&& footer,
 			const std::vector<widget_data>& list_data);
 
 	/**
@@ -438,7 +438,7 @@ struct builder_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
@@ -465,7 +465,7 @@ struct builder_horizontal_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;
@@ -489,7 +489,7 @@ struct builder_grid_listbox : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -343,8 +343,8 @@ private:
 	 * @param list_data           The initial data to fill the listbox with.
 	 */
 	void finalize(std::unique_ptr<generator_base> generator,
-			std::unique_ptr<widget>&& header,
-			std::unique_ptr<widget>&& footer,
+			builder_grid_ptr header,
+			builder_grid_ptr footer,
 			const std::vector<widget_data>& list_data);
 
 	/**

--- a/src/gui/widgets/matrix.cpp
+++ b/src/gui/widgets/matrix.cpp
@@ -57,28 +57,28 @@ unsigned state_default::get_state() const
 	return state_;
 }
 
-matrix::matrix(const implementation::builder_matrix& builder)
+matrix::matrix(implementation::builder_matrix& builder)
 	: tbase(builder, "matrix"), content_(), pane_(nullptr)
 {
 	const auto cfg = cast_config_to<matrix_definition>();
 
 	builder_widget::replacements_map replacements;
-	replacements.emplace("_main", builder.builder_main);
+	replacements.emplace("_main", std::move(builder.builder_main));
 
 	if(builder.builder_top) {
-		replacements.emplace("_top", builder.builder_top);
+		replacements.emplace("_top", std::move(builder.builder_top));
 	}
 
 	if(builder.builder_left) {
-		replacements.emplace("_left", builder.builder_left);
+		replacements.emplace("_left", std::move(builder.builder_left));
 	}
 
 	if(builder.builder_right) {
-		replacements.emplace("_right", builder.builder_right);
+		replacements.emplace("_right", std::move(builder.builder_right));
 	}
 
 	if(builder.builder_bottom) {
-		replacements.emplace("_bottom", builder.builder_bottom);
+		replacements.emplace("_bottom", std::move(builder.builder_bottom));
 	}
 
 	cfg->content->build(content_, replacements);
@@ -207,23 +207,23 @@ builder_matrix::builder_matrix(const config& cfg)
 	, builder_main(create_widget_builder(VALIDATE_WML_CHILD(cfg, "main", missing_mandatory_wml_tag("matrix", "main"))))
 {
 	if(auto top = cfg.optional_child("top")) {
-		builder_top = std::make_shared<builder_grid>(*top);
+		builder_top = std::make_unique<builder_grid>(*top);
 	}
 
 	if(auto bottom = cfg.optional_child("bottom")) {
-		builder_bottom = std::make_shared<builder_grid>(*bottom);
+		builder_bottom = std::make_unique<builder_grid>(*bottom);
 	}
 
 	if(auto left = cfg.optional_child("left")) {
-		builder_left = std::make_shared<builder_grid>(*left);
+		builder_left = std::make_unique<builder_grid>(*left);
 	}
 
 	if(auto right = cfg.optional_child("right")) {
-		builder_right = std::make_shared<builder_grid>(*right);
+		builder_right = std::make_unique<builder_grid>(*right);
 	}
 }
 
-std::unique_ptr<widget> builder_matrix::build() const
+std::unique_ptr<widget> builder_matrix::build()
 {
 	return std::make_unique<matrix>(*this);
 }

--- a/src/gui/widgets/matrix.hpp
+++ b/src/gui/widgets/matrix.hpp
@@ -100,7 +100,7 @@ class matrix : public tbase
 	friend class debug_layout_graph;
 
 public:
-	explicit matrix(const implementation::builder_matrix& builder);
+	explicit matrix(implementation::builder_matrix& builder);
 
 	/***** ***** ***** ***** Item handling. ***** ***** ****** *****/
 
@@ -248,7 +248,7 @@ struct builder_matrix : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/menu_button.cpp
+++ b/src/gui/widgets/menu_button.cpp
@@ -248,7 +248,7 @@ builder_menu_button::builder_menu_button(const config& cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_menu_button::build() const
+std::unique_ptr<widget> builder_menu_button::build()
 {
 	auto widget = std::make_unique<menu_button>(*this);
 

--- a/src/gui/widgets/menu_button.hpp
+++ b/src/gui/widgets/menu_button.hpp
@@ -155,7 +155,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	std::vector<::config> options_;

--- a/src/gui/widgets/minimap.cpp
+++ b/src/gui/widgets/minimap.cpp
@@ -120,7 +120,7 @@ builder_minimap::builder_minimap(const config& cfg) : builder_styled_widget(cfg)
 {
 }
 
-std::unique_ptr<widget> builder_minimap::build() const
+std::unique_ptr<widget> builder_minimap::build()
 {
 	auto widget = std::make_unique<minimap>(*this);
 

--- a/src/gui/widgets/minimap.hpp
+++ b/src/gui/widgets/minimap.hpp
@@ -93,7 +93,7 @@ struct builder_minimap : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/multi_page.hpp
+++ b/src/gui/widgets/multi_page.hpp
@@ -38,7 +38,7 @@ class multi_page : public container_base
 	friend class debug_layout_graph;
 
 public:
-	explicit multi_page(const implementation::builder_multi_page& builder);
+	explicit multi_page(implementation::builder_multi_page& builder);
 
 	/***** ***** ***** ***** Page handling. ***** ***** ****** *****/
 
@@ -177,12 +177,6 @@ public:
 private:
 	/***** ***** ***** setters / getters for members ***** ****** *****/
 
-	void set_page_builders(const builder_grid_map& page_builders)
-	{
-		assert(!page_builders.empty());
-		page_builders_ = page_builders;
-	}
-
 	/**
 	 * Finishes the building initialization of the widget.
 	 *
@@ -242,7 +236,7 @@ struct builder_multi_page : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	builder_grid_map builders;
 

--- a/src/gui/widgets/multiline_text.cpp
+++ b/src/gui/widgets/multiline_text.cpp
@@ -499,7 +499,7 @@ builder_multiline_text::builder_multiline_text(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_multiline_text::build() const
+std::unique_ptr<widget> builder_multiline_text::build()
 {
 	auto widget = std::make_unique<multiline_text>(*this);
 

--- a/src/gui/widgets/multiline_text.hpp
+++ b/src/gui/widgets/multiline_text.hpp
@@ -354,7 +354,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	std::string history;
 

--- a/src/gui/widgets/multimenu_button.cpp
+++ b/src/gui/widgets/multimenu_button.cpp
@@ -268,7 +268,7 @@ builder_multimenu_button::builder_multimenu_button(const config& cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_multimenu_button::build() const
+std::unique_ptr<widget> builder_multimenu_button::build()
 {
 	auto widget = std::make_unique<multimenu_button>(*this);
 

--- a/src/gui/widgets/multimenu_button.hpp
+++ b/src/gui/widgets/multimenu_button.hpp
@@ -203,7 +203,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	unsigned max_shown_;

--- a/src/gui/widgets/pane.cpp
+++ b/src/gui/widgets/pane.cpp
@@ -101,10 +101,10 @@ struct pane_implementation
 	}
 };
 
-pane::pane(const implementation::builder_pane& builder)
+pane::pane(implementation::builder_pane& builder)
 	: widget(builder)
 	, items_()
-	, item_builder_(builder.item_definition)
+	, item_builder_(std::move(builder.item_definition))
 	, item_id_generator_(0)
 	, placer_(placer_base::build(builder.grow_dir, builder.parallel_items))
 {
@@ -361,12 +361,12 @@ builder_pane::builder_pane(const config& cfg)
 	VALIDATE(parallel_items > 0, _("Need at least 1 parallel item."));
 }
 
-std::unique_ptr<widget> builder_pane::build() const
+std::unique_ptr<widget> builder_pane::build()
 {
 	return build(replacements_map());
 }
 
-std::unique_ptr<widget> builder_pane::build(const replacements_map& /*replacements*/) const
+std::unique_ptr<widget> builder_pane::build(const replacements_map& /*replacements*/)
 {
 	return std::make_unique<pane>(*this);
 }

--- a/src/gui/widgets/pane.hpp
+++ b/src/gui/widgets/pane.hpp
@@ -55,7 +55,7 @@ public:
 	typedef std::function<bool(const item&)> filter_functor_t;
 
 public:
-	explicit pane(const implementation::builder_pane& builder);
+	explicit pane(implementation::builder_pane& builder);
 
 	/**
 	 * Creates a new item.
@@ -191,9 +191,9 @@ struct builder_pane : public builder_widget
 {
 	explicit builder_pane(const config& cfg);
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
-	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) override;
 
 	grow_direction::type grow_dir;
 

--- a/src/gui/widgets/panel.cpp
+++ b/src/gui/widgets/panel.cpp
@@ -130,10 +130,10 @@ builder_panel::builder_panel(const config& cfg)
 
 	VALIDATE(c, _("No grid defined."));
 
-	grid = std::make_shared<builder_grid>(*c);
+	grid = std::make_unique<builder_grid>(*c);
 }
 
-std::unique_ptr<widget> builder_panel::build() const
+std::unique_ptr<widget> builder_panel::build()
 {
 	auto widget = std::make_unique<panel>(*this);
 

--- a/src/gui/widgets/panel.hpp
+++ b/src/gui/widgets/panel.hpp
@@ -93,7 +93,7 @@ struct builder_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	builder_grid_ptr grid;
 };

--- a/src/gui/widgets/password_box.cpp
+++ b/src/gui/widgets/password_box.cpp
@@ -119,7 +119,7 @@ builder_password_box::builder_password_box(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_password_box::build() const
+std::unique_ptr<widget> builder_password_box::build()
 {
 	auto widget = std::make_unique<password_box>(*this);
 

--- a/src/gui/widgets/password_box.hpp
+++ b/src/gui/widgets/password_box.hpp
@@ -82,7 +82,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	std::string history_;

--- a/src/gui/widgets/progress_bar.cpp
+++ b/src/gui/widgets/progress_bar.cpp
@@ -103,7 +103,7 @@ builder_progress_bar::builder_progress_bar(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_progress_bar::build() const
+std::unique_ptr<widget> builder_progress_bar::build()
 {
 	auto widget = std::make_unique<progress_bar>(*this);
 

--- a/src/gui/widgets/progress_bar.hpp
+++ b/src/gui/widgets/progress_bar.hpp
@@ -102,7 +102,7 @@ struct builder_progress_bar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/repeating_button.cpp
+++ b/src/gui/widgets/repeating_button.cpp
@@ -196,7 +196,7 @@ builder_repeating_button::builder_repeating_button(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_repeating_button::build() const
+std::unique_ptr<widget> builder_repeating_button::build()
 {
 	auto widget = std::make_unique<repeating_button>(*this);
 

--- a/src/gui/widgets/repeating_button.hpp
+++ b/src/gui/widgets/repeating_button.hpp
@@ -147,7 +147,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/rich_label.cpp
+++ b/src/gui/widgets/rich_label.cpp
@@ -907,7 +907,7 @@ builder_rich_label::builder_rich_label(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_rich_label::build() const
+std::unique_ptr<widget> builder_rich_label::build()
 {
 	auto lbl = std::make_unique<rich_label>(*this);
 

--- a/src/gui/widgets/rich_label.hpp
+++ b/src/gui/widgets/rich_label.hpp
@@ -299,7 +299,7 @@ struct builder_rich_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	PangoAlignment text_alignment;
 	bool link_aware;

--- a/src/gui/widgets/scroll_label.cpp
+++ b/src/gui/widgets/scroll_label.cpp
@@ -177,7 +177,7 @@ scroll_label_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", missing_mandatory_wml_tag("scroll_label_definition][resolution", "state_disabled")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("scroll_label_definition][resolution", "grid"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -195,7 +195,7 @@ builder_scroll_label::builder_scroll_label(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_scroll_label::build() const
+std::unique_ptr<widget> builder_scroll_label::build()
 {
 	auto widget = std::make_unique<scroll_label>(*this);
 

--- a/src/gui/widgets/scroll_label.hpp
+++ b/src/gui/widgets/scroll_label.hpp
@@ -147,7 +147,7 @@ struct builder_scroll_label : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/scroll_text.cpp
+++ b/src/gui/widgets/scroll_text.cpp
@@ -231,7 +231,7 @@ scroll_text_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", missing_mandatory_wml_tag("scroll_text", "state_disabled")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("scroll_text", "grid"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -257,7 +257,7 @@ builder_scroll_text::builder_scroll_text(const config& cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_scroll_text::build() const
+std::unique_ptr<widget> builder_scroll_text::build()
 {
 	auto widget = std::make_unique<scroll_text>(*this);
 

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -184,7 +184,7 @@ struct builder_scroll_text : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/scrollbar_panel.cpp
+++ b/src/gui/widgets/scrollbar_panel.cpp
@@ -69,7 +69,7 @@ scrollbar_panel_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "foreground", missing_mandatory_wml_tag("scrollbar_panel_definition][resolution", "foreground")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("scrollbar_panel][definition", "grid"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -88,11 +88,11 @@ builder_scrollbar_panel::builder_scrollbar_panel(const config& cfg)
 	auto grid_definition = cfg.optional_child("definition");
 
 	VALIDATE(grid_definition, _("No list defined."));
-	grid_ = std::make_shared<builder_grid>(*grid_definition);
+	grid_ = std::make_unique<builder_grid>(*grid_definition);
 	assert(grid_);
 }
 
-std::unique_ptr<widget> builder_scrollbar_panel::build() const
+std::unique_ptr<widget> builder_scrollbar_panel::build()
 {
 	auto panel = std::make_unique<scrollbar_panel>(*this);
 

--- a/src/gui/widgets/scrollbar_panel.hpp
+++ b/src/gui/widgets/scrollbar_panel.hpp
@@ -83,7 +83,7 @@ struct builder_scrollbar_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/size_lock.cpp
+++ b/src/gui/widgets/size_lock.cpp
@@ -68,13 +68,10 @@ void size_lock::layout_children()
 	widget_->layout_children();
 }
 
-void size_lock::finalize(const builder_widget& widget_builder)
+void size_lock::finalize(std::unique_ptr<widget>&& widget)
 {
 	set_rows_cols(1u, 1u);
-
-	auto widget = widget_builder.build();
 	widget_ = widget.get();
-
 	set_child(std::move(widget), 0u, 0u, grid::VERTICAL_GROW_SEND_TO_CLIENT | grid::HORIZONTAL_GROW_SEND_TO_CLIENT, 0u);
 }
 
@@ -109,7 +106,7 @@ size_lock_definition::resolution::resolution(const config& cfg)
 	auto child = cfg.optional_child("grid");
 	VALIDATE(child, _("No grid defined."));
 
-	grid = std::make_shared<builder_grid>(*child);
+	grid = std::make_unique<builder_grid>(*child);
 }
 
 namespace implementation
@@ -124,7 +121,7 @@ builder_size_lock::builder_size_lock(const config& cfg)
 	content_ = create_widget_builder(cfg.mandatory_child("widget"));
 }
 
-std::unique_ptr<widget> builder_size_lock::build() const
+std::unique_ptr<widget> builder_size_lock::build()
 {
 	auto widget = std::make_unique<size_lock>(*this);
 
@@ -134,7 +131,7 @@ std::unique_ptr<widget> builder_size_lock::build() const
 	assert(conf != nullptr);
 
 	widget->init_grid(*conf->grid);
-	widget->finalize(*content_);
+	widget->finalize(content_->build());
 
 	return widget;
 }

--- a/src/gui/widgets/size_lock.hpp
+++ b/src/gui/widgets/size_lock.hpp
@@ -69,10 +69,9 @@ private:
 	/**
 	 * Finishes the building initialization of the widget.
 	 *
-	 * @param widget_builder      The builder to build the contents of the
-	 *                            widget.
+	 * @param widget      The widget to place in this widget.
 	 */
-	void finalize(const builder_widget& widget_builder);
+	void finalize(std::unique_ptr<widget>&& widget);
 
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
@@ -110,13 +109,13 @@ struct builder_size_lock : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	typed_formula<unsigned> width_;
 	typed_formula<unsigned> height_;
 
 private:
-	builder_widget_const_ptr content_;
+	builder_widget_ptr content_;
 };
 }
 }

--- a/src/gui/widgets/slider.cpp
+++ b/src/gui/widgets/slider.cpp
@@ -340,7 +340,7 @@ builder_slider::builder_slider(const config& cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_slider::build() const
+std::unique_ptr<widget> builder_slider::build()
 {
 	auto widget = std::make_unique<slider>(*this);
 

--- a/src/gui/widgets/slider.hpp
+++ b/src/gui/widgets/slider.hpp
@@ -248,7 +248,7 @@ struct builder_slider : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	unsigned best_slider_length_;

--- a/src/gui/widgets/spacer.cpp
+++ b/src/gui/widgets/spacer.cpp
@@ -126,7 +126,7 @@ builder_spacer::builder_spacer(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_spacer::build() const
+std::unique_ptr<widget> builder_spacer::build()
 {
 	auto widget = std::make_unique<spacer>(*this, width_, height_);
 

--- a/src/gui/widgets/spacer.hpp
+++ b/src/gui/widgets/spacer.hpp
@@ -104,7 +104,7 @@ struct builder_spacer : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	// We store these as strings since they could contain formulas.

--- a/src/gui/widgets/spinner.cpp
+++ b/src/gui/widgets/spinner.cpp
@@ -141,7 +141,7 @@ spinner_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", missing_mandatory_wml_tag("spinner", "state_disabled")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("spinner", "grid"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -154,7 +154,7 @@ builder_spinner::builder_spinner(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_spinner::build() const
+std::unique_ptr<widget> builder_spinner::build()
 {
 	auto widget = std::make_unique<spinner>(*this);
 

--- a/src/gui/widgets/spinner.hpp
+++ b/src/gui/widgets/spinner.hpp
@@ -155,7 +155,7 @@ struct builder_spinner : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/stacked_widget.cpp
+++ b/src/gui/widgets/stacked_widget.cpp
@@ -223,7 +223,7 @@ stacked_widget_definition::resolution::resolution(const config& cfg)
 	auto child = cfg.optional_child("grid");
 	VALIDATE(child, _("No grid defined."));
 
-	grid = std::make_shared<builder_grid>(*child);
+	grid = std::make_unique<builder_grid>(*child);
 }
 
 // }---------- BUILDER -----------{
@@ -246,7 +246,7 @@ builder_stacked_widget::builder_stacked_widget(const config& real_cfg)
 	}
 }
 
-std::unique_ptr<widget> builder_stacked_widget::build() const
+std::unique_ptr<widget> builder_stacked_widget::build()
 {
 	auto widget = std::make_unique<stacked_widget>(*this);
 

--- a/src/gui/widgets/stacked_widget.hpp
+++ b/src/gui/widgets/stacked_widget.hpp
@@ -205,7 +205,7 @@ struct builder_stacked_widget : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	/** The builders for all layers of the stack .*/
 	std::vector<builder_grid> stack;

--- a/src/gui/widgets/styled_widget.cpp
+++ b/src/gui/widgets/styled_widget.cpp
@@ -612,7 +612,7 @@ builder_styled_widget::builder_styled_widget(const config& cfg)
 			  << "' and definition '" << definition << "'.";
 }
 
-std::unique_ptr<widget> builder_styled_widget::build(const replacements_map& /*replacements*/) const
+std::unique_ptr<widget> builder_styled_widget::build(const replacements_map& /*replacements*/)
 {
 	return build();
 }

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -537,7 +537,7 @@ public:
 
 	using builder_widget::build;
 
-	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) override;
 
 	/** Parameters for the styled_widget. */
 	std::string definition;

--- a/src/gui/widgets/tab_container.cpp
+++ b/src/gui/widgets/tab_container.cpp
@@ -38,10 +38,10 @@ namespace gui2
 
 REGISTER_WIDGET(tab_container)
 
-tab_container::tab_container(const implementation::builder_tab_container& builder)
+tab_container::tab_container(implementation::builder_tab_container& builder)
 	: container_base(builder, type())
 	, state_(ENABLED)
-	, builders_(builder.builders)
+	, builders_(std::move(builder.builders))
 	, list_items_(builder.list_items)
 {
 }
@@ -138,7 +138,7 @@ tab_container_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "state_disabled", missing_mandatory_wml_tag("tab_container_definition][resolution", "state_disabled")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", _("No grid defined for tab container control"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -163,14 +163,13 @@ builder_tab_container::builder_tab_container(const config& cfg)
 			list_items.emplace_back(list_row);
 
 			if (tab.has_child("data")) {
-				auto builder = std::make_shared<builder_grid>(tab.mandatory_child("data"));
-				builders.push_back(builder);
+				builders.emplace_back(std::make_unique<builder_grid>(tab.mandatory_child("data")));
 			}
 		}
 	}
 }
 
-std::unique_ptr<widget> builder_tab_container::build() const
+std::unique_ptr<widget> builder_tab_container::build()
 {
 	auto widget = std::make_unique<tab_container>(*this);
 

--- a/src/gui/widgets/tab_container.hpp
+++ b/src/gui/widgets/tab_container.hpp
@@ -36,7 +36,7 @@ class tab_container : public container_base
 	friend struct implementation::builder_tab_container;
 
 public:
-	explicit tab_container(const implementation::builder_tab_container& builder);
+	explicit tab_container(implementation::builder_tab_container& builder);
 
 	virtual void set_self_active(const bool active) override;
 
@@ -88,7 +88,7 @@ private:
 	 */
 	state_t state_;
 
-	std::vector<std::shared_ptr<builder_grid>> builders_;
+	std::vector<builder_grid_ptr> builders_;
 	std::vector<widget_data> list_items_;
 
 	/**
@@ -149,9 +149,9 @@ struct builder_tab_container : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
-	std::vector<std::shared_ptr<builder_grid>> builders;
+	std::vector<builder_grid_ptr> builders;
 
 	std::vector<widget_data> list_items;
 };

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -427,7 +427,7 @@ builder_text_box::builder_text_box(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_text_box::build() const
+std::unique_ptr<widget> builder_text_box::build()
 {
 	auto widget = std::make_unique<text_box>(*this);
 

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -326,7 +326,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	std::string history;
 

--- a/src/gui/widgets/toggle_button.cpp
+++ b/src/gui/widgets/toggle_button.cpp
@@ -229,7 +229,7 @@ builder_toggle_button::builder_toggle_button(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_toggle_button::build() const
+std::unique_ptr<widget> builder_toggle_button::build()
 {
 	auto widget = std::make_unique<toggle_button>(*this);
 

--- a/src/gui/widgets/toggle_button.hpp
+++ b/src/gui/widgets/toggle_button.hpp
@@ -164,7 +164,7 @@ struct builder_toggle_button : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	std::string icon_name_;

--- a/src/gui/widgets/toggle_panel.cpp
+++ b/src/gui/widgets/toggle_panel.cpp
@@ -320,10 +320,10 @@ builder_toggle_panel::builder_toggle_panel(const config& cfg)
 
 	VALIDATE(c, _("No grid defined."));
 
-	grid = std::make_shared<builder_grid>(*c);
+	grid = std::make_unique<builder_grid>(*c);
 }
 
-std::unique_ptr<widget> builder_toggle_panel::build() const
+std::unique_ptr<widget> builder_toggle_panel::build()
 {
 	auto widget = std::make_unique<toggle_panel>(*this);
 

--- a/src/gui/widgets/toggle_panel.hpp
+++ b/src/gui/widgets/toggle_panel.hpp
@@ -197,7 +197,7 @@ struct builder_toggle_panel : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	builder_grid_ptr grid;
 

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -34,10 +34,10 @@ namespace gui2
 
 REGISTER_WIDGET(tree_view)
 
-tree_view::tree_view(const implementation::builder_tree_view& builder)
+tree_view::tree_view(implementation::builder_tree_view& builder)
 	: scrollbar_container(builder, type())
-	, node_definitions_(builder.nodes)
-	, indentation_step_size_(0)
+	, node_definitions_(std::move(builder.nodes))
+	, indentation_step_size_(builder.indentation_step_size)
 	, need_layout_(false)
 	, root_node_(nullptr)
 	, selected_item_(nullptr)
@@ -269,7 +269,7 @@ tree_view_definition::resolution::resolution(const config& cfg)
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("tree_view_definition][resolution", "grid"));
 
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -290,7 +290,7 @@ builder_tree_view::builder_tree_view(const config& cfg)
 	VALIDATE(!nodes.empty(), _("No nodes defined for a tree view."));
 }
 
-std::unique_ptr<widget> builder_tree_view::build() const
+std::unique_ptr<widget> builder_tree_view::build()
 {
 	/*
 	 *  TODO see how much we can move in the constructor instead of
@@ -300,8 +300,6 @@ std::unique_ptr<widget> builder_tree_view::build() const
 
 	widget->set_vertical_scrollbar_mode(vertical_scrollbar_mode);
 	widget->set_horizontal_scrollbar_mode(horizontal_scrollbar_mode);
-
-	widget->set_indentation_step_size(indentation_step_size);
 
 	DBG_GUI_G << "Window builder: placed tree_view '" << id << "' with definition '" << definition << "'.";
 
@@ -325,7 +323,7 @@ tree_node::tree_node(const config& cfg)
 	VALIDATE(id != tree_view::root_node_id, _("[node]id 'root' is reserved for the implementation."));
 
 	auto node_definition = VALIDATE_WML_CHILD(cfg, "node_definition", missing_mandatory_wml_tag("node", "node_definition"));
-	builder = std::make_shared<builder_grid>(node_definition);
+	builder = std::make_unique<builder_grid>(node_definition);
 }
 
 } // namespace implementation

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -44,7 +44,7 @@ class tree_view : public scrollbar_container
 public:
 	typedef implementation::tree_node node_definition;
 
-	explicit tree_view(const implementation::builder_tree_view& builder);
+	explicit tree_view(implementation::builder_tree_view& builder);
 
 	~tree_view();
 
@@ -215,7 +215,7 @@ struct builder_tree_view : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 	scrollbar_container::scrollbar_mode vertical_scrollbar_mode;
 	scrollbar_container::scrollbar_mode horizontal_scrollbar_mode;

--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -609,7 +609,7 @@ unit_preview_pane_definition::resolution::resolution(const config& cfg)
 	state.emplace_back(VALIDATE_WML_CHILD(cfg, "foreground", missing_mandatory_wml_tag("unit_preview_pane_definition][resolution", "foreground")));
 
 	auto child = VALIDATE_WML_CHILD(cfg, "grid", missing_mandatory_wml_tag("unit_preview_pane_definition][resolution", "grid"));
-	grid = std::make_shared<builder_grid>(child);
+	grid = std::make_unique<builder_grid>(child);
 }
 
 // }---------- BUILDER -----------{
@@ -623,7 +623,7 @@ builder_unit_preview_pane::builder_unit_preview_pane(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_unit_preview_pane::build() const
+std::unique_ptr<widget> builder_unit_preview_pane::build()
 {
 	auto widget = std::make_unique<unit_preview_pane>(*this);
 

--- a/src/gui/widgets/unit_preview_pane.hpp
+++ b/src/gui/widgets/unit_preview_pane.hpp
@@ -140,7 +140,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
 private:
 	const std::string image_mods_;

--- a/src/gui/widgets/vertical_scrollbar.cpp
+++ b/src/gui/widgets/vertical_scrollbar.cpp
@@ -133,7 +133,7 @@ builder_vertical_scrollbar::builder_vertical_scrollbar(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_vertical_scrollbar::build() const
+std::unique_ptr<widget> builder_vertical_scrollbar::build()
 {
 	auto widget = std::make_unique<vertical_scrollbar>(*this);
 

--- a/src/gui/widgets/vertical_scrollbar.hpp
+++ b/src/gui/widgets/vertical_scrollbar.hpp
@@ -105,7 +105,7 @@ struct builder_vertical_scrollbar : public builder_styled_widget
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 };
 
 } // namespace implementation

--- a/src/gui/widgets/viewport.cpp
+++ b/src/gui/widgets/viewport.cpp
@@ -171,12 +171,12 @@ builder_viewport::builder_viewport(const config& cfg)
 {
 }
 
-std::unique_ptr<widget> builder_viewport::build() const
+std::unique_ptr<widget> builder_viewport::build()
 {
 	return build(replacements_map());
 }
 
-std::unique_ptr<widget> builder_viewport::build(const replacements_map& replacements) const
+std::unique_ptr<widget> builder_viewport::build(const replacements_map& replacements)
 {
 	return std::make_unique<viewport>(*this, replacements);
 }

--- a/src/gui/widgets/viewport.hpp
+++ b/src/gui/widgets/viewport.hpp
@@ -89,9 +89,9 @@ struct builder_viewport : public builder_widget
 {
 	explicit builder_viewport(const config& cfg);
 
-	virtual std::unique_ptr<widget> build() const override;
+	virtual std::unique_ptr<widget> build() override;
 
-	virtual std::unique_ptr<widget> build(const replacements_map& replacements) const override;
+	virtual std::unique_ptr<widget> build(const replacements_map& replacements) override;
 
 	builder_widget_ptr widget_;
 };

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -98,7 +98,7 @@ public:
 
 	using builder_styled_widget::build;
 
-	virtual std::unique_ptr<widget> build() const override
+	virtual std::unique_ptr<widget> build() override
 	{
 		return nullptr;
 	}
@@ -433,7 +433,7 @@ void window::finish_build(const builder_window::window_resolution& definition)
 
 	if(conf->grid) {
 		init_grid(*conf->grid);
-		finalize(*definition.grid);
+		finalize(definition.grid->build());
 	} else {
 		init_grid(*definition.grid);
 	}
@@ -1106,11 +1106,8 @@ bool window::click_dismiss(const int mouse_button_mask)
 	return false;
 }
 
-void window::finalize(const builder_grid& content_grid)
+void window::finalize(std::unique_ptr<widget>&& widget)
 {
-	auto widget = content_grid.build();
-	assert(widget);
-
 	static const std::string id = "_window_content_grid";
 
 	// Make sure the new child has same id.
@@ -1411,7 +1408,7 @@ window_definition::resolution::resolution(const config& cfg)
 
 	/** @todo Evaluate whether the grid should become mandatory. */
 	if(child) {
-		grid = std::make_shared<builder_grid>(*child);
+		grid = std::make_unique<builder_grid>(*child);
 	}
 }
 

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -665,9 +665,9 @@ private:
 	/**
 	 * Finishes the initialization of the grid.
 	 *
-	 * @param content_grid        The new contents for the content grid.
+	 * @param widget        The new contents for the content grid.
 	 */
-	void finalize(const builder_grid& content_grid);
+	void finalize(std::unique_ptr<widget>&& widget);
 
 #ifdef DEBUG_WINDOW_LAYOUT_GRAPHS
 	debug_layout_graph* debug_layout_;


### PR DESCRIPTION
They really didn't need to be shared_ptrs, except it was easier to copy things around (especially when builders held containers of builder ptrs).

This makes all widget_builder::build overrides non-const to facilitate move semantics from builders to widgets, if desired.