### PR TITLE
[Units][Jumpcat] Rebalance Stats

### DIFF
--- a/data/core/units/monsters/Cat_Jump.cfg
+++ b/data/core/units/monsters/Cat_Jump.cfg
@@ -80,7 +80,7 @@
         description=_"claws"
         range=melee
         type=blade
-        damage=6
+        damage=5
         number=3
         icon=attacks/claws-animal.png
         [specials]

--- a/data/core/units/monsters/Cat_Jump.cfg
+++ b/data/core/units/monsters/Cat_Jump.cfg
@@ -6,7 +6,7 @@
     generate_name=no
     image="units/monsters/cat/jumpcat.png"
     profile="portraits/monsters/jumpcat.webp"
-    hitpoints=32
+    hitpoints=40
     movement=9
     movement_type=elusivefoot
     [defense]
@@ -18,14 +18,14 @@
     [/movement_costs]
     # nothing arcane here, all animal
     [resistance]
-        arcane=80
+        arcane=90
     [/resistance]
     experience=100
     {AMLA_DEFAULT}
-    level=1
+    level=2
     alignment=chaotic
     advances_to=null
-    cost=15
+    cost=28
     usage=scout
     description=_ "Jumpcats are opportunistic predators with keen senses and fast reflexes, but very little bulk, so they are easily dispatched if they can be hit, and easily scared off if they can’t. One of the most distinctive features of these odd creatures is the hard clump of twigs, clay, and rocks they carry on their tail, which is their primary offensive weapon. Their actions are mostly driven by instinct, but they are sometimes used as assassins by more sophisticated handlers."
     # To Do: Get smaller cat sounds
@@ -83,7 +83,9 @@
         damage=6
         number=3
         icon=attacks/claws-animal.png
-        parry=10
+        [specials]
+            {WEAPON_SPECIAL_BACKSTAB}
+        [/specials]
     [/attack]
     [attack]
         name=tail

--- a/data/core/units/monsters/Cat_Jump.cfg
+++ b/data/core/units/monsters/Cat_Jump.cfg
@@ -6,7 +6,7 @@
     generate_name=no
     image="units/monsters/cat/jumpcat.png"
     profile="portraits/monsters/jumpcat.webp"
-    hitpoints=42
+    hitpoints=40
     movement=7
     movement_type=elusivefoot
     [defense]
@@ -25,7 +25,7 @@
     level=2
     alignment=chaotic
     advances_to=null
-    cost=28
+    cost=26
     usage=scout
     description=_ "Jumpcats are opportunistic predators with keen senses and fast reflexes, but very little bulk, so they are easily dispatched if they can be hit, and easily scared off if they can’t. One of the most distinctive features of these odd creatures is the hard clump of twigs, clay, and rocks they carry on their tail, which is their primary offensive weapon. Their actions are mostly driven by instinct, but they are sometimes used as assassins by more sophisticated handlers."
     # To Do: Get smaller cat sounds

--- a/data/core/units/monsters/Cat_Jump.cfg
+++ b/data/core/units/monsters/Cat_Jump.cfg
@@ -6,8 +6,8 @@
     generate_name=no
     image="units/monsters/cat/jumpcat.png"
     profile="portraits/monsters/jumpcat.webp"
-    hitpoints=40
-    movement=9
+    hitpoints=42
+    movement=7
     movement_type=elusivefoot
     [defense]
         frozen=50
@@ -93,9 +93,8 @@
         icon=attacks/tail-jumpcat.png
         type=impact
         range=melee
-        damage=12
+        damage=13
         number=2
-        accuracy=10
     [/attack]
     [attack_anim]
         [filter_attack]


### PR DESCRIPTION
Alongside PR #9420, I also noticed that the new Jumpcat's current stats have some glaring problems:

1. first and most important, despite being a lvl1 unit it, he has, all at the same time: 9mp, a 12-2 attack that also has 10 accuracy bonus, nightstalk, parry on melee, and all this while only costing 15 gold
2. on the subject of parry, I believe using parry on an elusivefoot unit is too much, as the jumpcat will have 80% dodge chance on many types of terrain, while normally dodge chance is pretty much never above 70% in wesnoth.

I think heavily nerfing the unit to the point of being on par with other lvl1 would take away the unit's uniqueness, and it's cool to have a powerful non-undead nightstalk unit, so instead I propose rebalancing the unit into a lvl2:


level from 1 to 2 (massive change, but it is still a new unit in a dev build so I think such big changes are justifiable at this point)
hp from 32 to 40
claws parry removed
claws become 5-3 backstab (I was originally considering making the claws 8-3, but then after thinking decided that 5-3 backstab would give the claws a more useful niche while keeping tail as the main attack when not backstabbing)
arcane resistance from 20% to 10% (same as with the forest lion PR)
price from 15 to ~~28~~ 26

mp from 9 to 7
tail from 12-2 10 accuracy, to 13-2 no specials

EDIT: changed 6-3 backstab to 5-3 backstab after seeing that cats are not traitless unlike the monster race

EDIT2: implemented the 42hp, 7mp and 13-2 no specials tail ideas