### PR TITLE
Use XMP metadata for PNG files

### DIFF
--- a/.github/workflows/image_metadata.yml
+++ b/.github/workflows/image_metadata.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: check image metadata
+      - name: check image EXIF metadata
         run: |
-          mapfile -t image_files < <(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" | grep -E '\.(webp|png|je?pg)$')
+          mapfile -t image_files < <(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" | grep -E '\.(webp|je?pg)$')
           # cycle through the changed image files, make sure they have the right fields
           for file in "${image_files[@]}"; do
             # check Artist tag, fail if missing
@@ -52,6 +52,36 @@ jobs:
                 ;;
               *)
                 printf 'Copyright tag %s in file %s is not an accepted license! Must be one of: "GNU GPL v2+", "CC BY-SA 4.0", "CC0"\n' "$copyright" "$file"
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: check png XMP metadata
+        run: |
+          mapfile -t image_files < <(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" | grep -E '\.png$')
+          # cycle through the changed image files, make sure they have the right fields
+          for file in "${image_files[@]}"; do
+            # check Creator tag, fail if missing
+            artist="$(exiftool -p '$XMP:Creator' "$file")"
+            if [ "$artist" ]; then
+              printf 'Creator tag in %s is %s\n' "$file" "$artist"
+            else
+              printf 'no Creator XMP tag in %s\n' "$file"
+              exit 1
+            fi
+            # check Rights tag, fail if missing or wrong type
+            copyright="$(exiftool -p '$XMP:Rights' "$file")"
+            case $copyright in
+              'GNU GPL v2+'|'CC BY-SA 4.0'|CC0)
+                printf 'Rights tag in %s is %s\n' "$file" "$copyright"
+                ;;
+              '')
+                printf 'no Rights XMP tag in %s\n' "$file"
+                exit 1
+                ;;
+              *)
+                printf 'Rights tag %s in file %s is not an accepted license! Must be one of: "GNU GPL v2+", "CC BY-SA 4.0", "CC0"\n' "$copyright" "$file"
                 exit 1
                 ;;
             esac


### PR DESCRIPTION
GIMP can read/write Creator and Rights XMP tags in PNGs, unlike the tags in the PNG or EXIF chunks.   Fixes #9312 

Maybe XMP should be used for everything, but at least for Dolphin, I can see the Artist & Copyright under PNG or EXIF, and nothing for XMP.  Is that just Dolphin weirdness, or is it a similar case for Windows and Mac?  If XMP isn't as visible, it would make sense to just use that for PNG files, while leaving the larger WebP and JPEG files with EXIF, since those are more likely to be "browsed" and shouldn't need "small fixes".

This is to change the CI.  A follow-up to migrate the data in existing PNGs will be a separate PR.