### PR TITLE
Fix invalid WFL crashes Wesnoth

### DIFF
--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -1329,9 +1329,14 @@ expression_ptr parse_expression(const tk::token* i1, const tk::token* i2, functi
 	}
 
 	if(op == nullptr) {
-		if(i1->type == tk::token_type::lparens && (i2-1)->type == tk::token_type::rparens) {
+		// There's a situation when i1+1 equals i2-1 (meanwhile iter length is 2, like `()`)
+		// Resulting in empty expression.
+		if(i1->type == tk::token_type::lparens && (i2 - 1)->type == tk::token_type::rparens) {
+			if(i1 + 1 == i2 - 1) {
+				throw formula_error("Syntax error: no expression between brackets", "()", *i1->filename, i1->line_number);
+			}
 			return parse_expression(i1+1,i2-1,symbols);
-		} else if((i2-1)->type == tk::token_type::rsquare) { //check if there is [ ] : either a list/map definition, or a operator
+		} else if((i2 - 1)->type == tk::token_type::rsquare) { // check if there is [ ] : either a list/map definition, or a operator
 			// First, a special case for an empty map
 			if(i2 - i1 == 3 && i1->type == tk::token_type::lsquare && (i1+1)->type == tk::token_type::pointer) {
 				return std::make_shared<map_expression>(std::vector<expression_ptr>());

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -666,8 +666,15 @@ void unit_filter_compound::fill(vconfig cfg)
 		create_attribute(literal["formula"],
 			[](const config::attribute_value& c)
 			{
-				//TODO: catch syntax error.
-				return wfl::formula(c, new wfl::gamestate_function_symbol_table());
+				try {
+					return wfl::formula(c, new wfl::gamestate_function_symbol_table());
+				} catch(const wfl::formula_error& e) {
+					lg::log_to_chat() << "Formula error while evaluating formula in unit filter: " << e.type << " at "
+									  << e.filename << ':' << e.line << ")\n";
+					ERR_WML << "Formula error while evaluating formula in unit filter: " << e.type << " at "
+							<< e.filename << ':' << e.line << ")";
+					return wfl::formula("", new wfl::gamestate_function_symbol_table());
+				}
 			},
 			[](const wfl::formula& form, const unit_filter_args& args)
 			{

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -673,7 +673,7 @@ void unit_filter_compound::fill(vconfig cfg)
 									  << e.filename << ':' << e.line << ")\n";
 					ERR_WML << "Formula error while evaluating formula in unit filter: " << e.type << " at "
 							<< e.filename << ':' << e.line << ")";
-					return wfl::formula("", new wfl::gamestate_function_symbol_table());
+					return wfl::formula("");
 				}
 			},
 			[](const wfl::formula& form, const unit_filter_args& args)


### PR DESCRIPTION
### Goal of the PR
- Resolves #9249.
### How does the PR work?
- By adding try-catch to finish a todo in filter.cpp, it catches formula error when evaluating formula.
### Does it resolve any reported issue?
- #9249
### If not a bug fix, why is this PR needed? What use cases does it solve?
- This is a bug fix. Also, there's a case in formula evaluating that the formula will undoubtly be an empty expression and don't need to call itself again to find out the error, the pr also makes changes on it.

## To do

Adjust possibly missed related method, delete some redundant description.

This PR is Ready for Review.

## How to test
Compile and run, see the test video I might be uploading soon, or see changes in the src. (personally have tested it and it works)