### PR TITLE
Increase Fire Resistances of Fire Guardian Line

### DIFF
--- a/changelog_entries/fire_guardian_resistances.md
+++ b/changelog_entries/fire_guardian_resistances.md
@@ -1,0 +1,3 @@
+ ### Units
+   * Fire Wisps and Guardian - Fire Resistance changed from 50% to 70%
+   * Fire Wraith - Fire Resistance changed from 50% to 80%

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -1507,6 +1507,37 @@ The life span of the wose is unknown, although the most ancient members of this 
     [/movetype]
 
     [movetype]
+        name=flamefly
+        flying=yes
+        {DRAKEFLY_MOVE}
+        [defense]
+            deep_water=80
+            shallow_water=80
+            reef=70
+            swamp_water=70
+            flat=70
+            sand=60
+            forest=60
+            hills=60
+            mountains=60
+            village=60
+            castle=60
+            cave=70
+            fungus=60
+            frozen=80
+            unwalkable=60
+        [/defense]
+        [resistance]
+            blade=100
+            pierce=100
+            impact=100
+            fire=30
+            cold=150
+            arcane=110
+        [/resistance]
+    [/movetype]
+
+    [movetype]
         name=dunefoot
         [movement_costs]
             shallow_water=3

--- a/data/core/units/monsters/Fire_Guardian.cfg
+++ b/data/core/units/monsters/Fire_Guardian.cfg
@@ -8,12 +8,7 @@
     profile="portraits/monsters/fire_guardian.webp"
     {DEFENSE_ANIM "units/monsters/fireghost-defend.png" "units/monsters/fireghost.png" {SOUND_LIST:DRAKE_HIT} }
     hitpoints=25
-    movement_type=drakefly
-    [resistance]
-        blade=100
-        pierce=100
-        impact=100
-    [/resistance]
+    movement_type=flamefly
     movement=6
     experience=24
     level=1

--- a/data/core/units/monsters/Fire_Wisp.cfg
+++ b/data/core/units/monsters/Fire_Wisp.cfg
@@ -7,12 +7,7 @@
     image="units/monsters/firewisp.png"
     profile="portraits/monsters/fire_guardian.webp" # temporary portrait
     hitpoints=13
-    movement_type=drakefly
-    [resistance]
-        blade=100
-        pierce=100
-        impact=100
-    [/resistance]
+    movement_type=flamefly
     movement=6
     experience=18
     level=0

--- a/data/core/units/monsters/Fire_Wraith.cfg
+++ b/data/core/units/monsters/Fire_Wraith.cfg
@@ -29,11 +29,12 @@ units/monsters/firewraith#enddef
         [/frame]
     [/movement_anim]
     hitpoints=41
-    movement_type=drakefly
+    movement_type=flamefly
     [resistance]
         blade=90
         pierce=90
         impact=90
+        fire=20
     [/resistance]
     movement=6
     experience=100


### PR DESCRIPTION
Fire Wisps and Guardian fire resistances increased from 50% to 70%, whereas the more powerful level 2 Fire Wraiths have increased to 80%. The previous 50% made little sense for a unit made of flames and smoke, so this is a bit more reasonable while still not requiring changes to existing scenarios or much rebalancing of UMC.