### PR TITLE
Properly capitalize Young Ogre description

### DIFF
--- a/data/core/units/ogres/Young_Ogre.cfg
+++ b/data/core/units/ogres/Young_Ogre.cfg
@@ -20,7 +20,7 @@
     advances_to=Ogre
     cost=13
     usage=fighter
-    description= _ "When still young, Ogres are sometimes captured and taken into armies to be trained. They cannot manage weapons skillfully, but they compensate for that lack with great strength."
+    description= _ "When still young, ogres are sometimes captured and taken into armies to be trained. They cannot manage weapons skillfully, but they compensate for that lack with great strength."
     die_sound={SOUND_LIST:OGRE_DIE}
     [attack]
         name=cleaver


### PR DESCRIPTION
According to the typography style guide (https://wiki.wesnoth.org/Typography_Style_Guide#Race_Names) race names should not be capitalized in Wesnoth. While ogres are a unit, in the context of the young ogre description this probably to reffers to the race and not the unit.