### PR TITLE
Tweak some Elvish units stats

### DIFF
--- a/data/core/units/elves/Avenger.cfg
+++ b/data/core/units/elves/Avenger.cfg
@@ -7,7 +7,7 @@
     image="units/elves-wood/avenger.png"
     small_profile="portraits/elves/ranger.webp~CROP(20,20,400,400)"
     profile="portraits/elves/ranger.webp"
-    hitpoints=59
+    hitpoints=55
     movement_type=woodland
     movement=6
     experience=150

--- a/data/core/units/elves/Marshal.cfg
+++ b/data/core/units/elves/Marshal.cfg
@@ -12,7 +12,7 @@
             image="units/elves-wood/marshal-leading.png:300"
         [/frame]
     [/leading_anim]
-    hitpoints=68
+    hitpoints=62
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}

--- a/data/core/units/elves/Outrider.cfg
+++ b/data/core/units/elves/Outrider.cfg
@@ -46,7 +46,7 @@ The truth of this tale, one can only surmise, but doubtless, Outriders the faste
         icon=attacks/sword-elven.png
         type=blade
         range=melee
-        damage=8
+        damage=7
         number=4
     [/attack]
     [attack]
@@ -55,7 +55,7 @@ The truth of this tale, one can only surmise, but doubtless, Outriders the faste
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=11
+        damage=9
         number=3
     [/attack]
     {DEFENSE_ANIM "units/elves-wood/outrider/outrider-defend2.png" "units/elves-wood/outrider/outrider-defend1.png" {SOUND_LIST:HORSE_HIT} }

--- a/data/core/units/elves/Rider.cfg
+++ b/data/core/units/elves/Rider.cfg
@@ -42,7 +42,7 @@
         icon=attacks/bow-elven.png
         type=pierce
         range=ranged
-        damage=11
+        damage=9
         number=2
     [/attack]
     {DEFENSE_ANIM "units/elves-wood/rider/rider-defend2.png" "units/elves-wood/rider/rider-defend1.png" {SOUND_LIST:HORSE_HIT} }

--- a/data/core/units/elves/Scout.cfg
+++ b/data/core/units/elves/Scout.cfg
@@ -11,7 +11,7 @@
     #are bad at defending in villages
     #they are weak against piercing attacks
     movement=9
-    experience=42
+    experience=32
     level=1
     alignment=neutral
     advances_to=Elvish Rider


### PR DESCRIPTION
In version 1.18, outrider/avenger/marshall were buffed alongside 1.18's 16-5 sylphs, 14-3 shydes and 12-5 sharpshooter in an unpopular attempt to make elves more "elite" while Yumi was still in charge of SP. Now that most of those units got reverted to be closer to 1.16 stats, I think it no longer makes sense to overbuff the remaining elf units, so I propose the following:

Elvish Scout: exp 42 -> 32 (revert to 1.16 value)
Elvish Rider: bow 11-2 -> 9-2 (to compensate the lvl2 being easier to obtain, nerfing the bow back to 9-2)
Elvish Outrider: sword 8-4 -> 7-4, bow 11-3 -> 9-3 (the unit is too deadly for a 11mp scout)
Elvish Avenger: HP 59 -> 55 (sharpshooter got fully nerfed to 1.16 stats, so avenger keeping the hp bonus would be unfair advantage over sharpshooter)
Elvish Marshal: HP 68 -> 62 (with 10-4 melee damage, 1.18 marshall feels too similar to 72 hp 8-5 10 accuracy champion in overall melee power while he is supposed to be the weaker support branch)

