### PR TITLE
Create in [filter_ability] an attribute 'active' to replace _active suffix in [filter_ability_active]

### DIFF
--- a/data/schema/filters/unit.cfg
+++ b/data/schema/filters/unit.cfg
@@ -47,8 +47,7 @@
 	{FILTER_TAG "filter_adjacent" adjacent ()}
 	{FILTER_TAG "filter_location" location ()}
 	{FILTER_TAG "filter_side" side ()}
-	{FILTER_TAG "experimental_filter_ability" abilities ()}
-	{FILTER_TAG "experimental_filter_ability_active" abilities ()}
+	{FILTER_TAG "experimental_filter_ability" abilities {SIMPLE_KEY active s_bool}}
 	{FILTER_BOOLEAN_OPS unit}
 [/tag]
 

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -297,7 +297,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability_active]
+# API(s) being tested: [event][filter][experimental_filter_ability]active=yes
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -313,10 +313,11 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability_active]
+            [experimental_filter_ability]
+                active=yes
                 tag_name=drains
                 value=25
-            [/experimental_filter_ability_active]
+            [/experimental_filter_ability]
         [/filter]
         {ASSERT ({VARIABLE_CONDITIONAL side_number equals 1})}
         {ASSERT ({VARIABLE_CONDITIONAL triggers equals 0})}
@@ -329,7 +330,7 @@
 )}
 
 #####
-# API(s) being tested: [event][filter][experimental_filter_ability_active]
+# API(s) being tested: [event][filter][experimental_filter_ability]active=yes
 ##
 # Actions:
 # Use the common setup from FILTER_ABILITY_TEST.
@@ -362,10 +363,11 @@
         name=attack
         first_time_only=no
         [filter]
-            [experimental_filter_ability_active]
+            [experimental_filter_ability]
+                active=yes
                 tag_name=drains
                 value=25
-            [/experimental_filter_ability_active]
+            [/experimental_filter_ability]
         [/filter]
         {FAIL}
     [/event]

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -776,40 +776,38 @@ void unit_filter_compound::fill(vconfig cfg)
 			}
 			else if (child.first == "experimental_filter_ability") {
 				create_child(child.second, [](const vconfig& c, const unit_filter_args& args) {
-					for(const auto [key, cfg] : args.u.abilities().all_children_range()) {
-						if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
-							return true;
-						}
-					}
-					return false;
-				});
-			}
-			else if (child.first == "experimental_filter_ability_active") {
-				create_child(child.second, [](const vconfig& c, const unit_filter_args& args) {
-					if(!display::get_singleton()){
-						return false;
-					}
-					const unit_map& units = display::get_singleton()->get_units();
-					for(const auto [key, cfg] : args.u.abilities().all_children_range()) {
-						if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
-							if (args.u.get_self_ability_bool(cfg, key, args.loc)) {
+					if(!(c.get_parsed_config())["active"].to_bool()){
+						for(const auto [key, cfg] : args.u.abilities().all_children_range()) {
+							if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
 								return true;
 							}
 						}
-					}
-
-					const auto adjacent = get_adjacent_tiles(args.loc);
-					for(unsigned i = 0; i < adjacent.size(); ++i) {
-						const unit_map::const_iterator it = units.find(adjacent[i]);
-						if (it == units.end() || it->incapacitated())
-							continue;
-						if (&*it == (args.u.shared_from_this()).get())
-							continue;
-
-						for(const auto [key, cfg] : it->abilities().all_children_range()) {
-							if(it->ability_matches_filter(cfg, key, c.get_parsed_config())) {
-								if (args.u.get_adj_ability_bool(cfg, key, i, args.loc, *it)) {
+					} else {
+						if(!display::get_singleton()){
+							return false;
+						}
+						const unit_map& units = display::get_singleton()->get_units();
+						for(const auto [key, cfg] : args.u.abilities().all_children_range()) {
+							if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
+								if (args.u.get_self_ability_bool(cfg, key, args.loc)) {
 									return true;
+								}
+							}
+						}
+
+						const auto adjacent = get_adjacent_tiles(args.loc);
+						for(unsigned i = 0; i < adjacent.size(); ++i) {
+							const unit_map::const_iterator it = units.find(adjacent[i]);
+							if (it == units.end() || it->incapacitated())
+								continue;
+							if (&*it == (args.u.shared_from_this()).get())
+								continue;
+
+							for(const auto [key, cfg] : it->abilities().all_children_range()) {
+								if(it->ability_matches_filter(cfg, key, c.get_parsed_config())) {
+									if (args.u.get_adj_ability_bool(cfg, key, i, args.loc, *it)) {
+										return true;
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Resolves https://github.com/wesnoth/wesnoth/issues/7926

Under pressure from @soliton-, I agree to merge [filter_ability] and [filter_ability_active] into a single filter equipped with the 'active' attribute which when the value is 'true' checks the units affected by the sought ability and when the value is 'false' will check the units carrying the ability even if they are not affected by it.

Because of the attribute strategy, I'm afraid that the developer will be mistaken about its function and that's why I'm not at all keen on it. (is it so bad to keep two tags like for ability_type and ability_type_active? there it would be clearer for those who manipulate these attributes because of the resemblance)