### PR TITLE
Add support for UI Theme addon type

### DIFF
--- a/data/schema/pbl.cfg
+++ b/data/schema/pbl.cfg
@@ -8,7 +8,7 @@
 	[/type]
 	[type]
 		name="addon_type"
-		value="core|campaign|scenario|campaign_sp_mp|era|faction|map_pack|campaign_mp|scenario_mp|mod_mp|media|other"
+		value="core|campaign|scenario|campaign_sp_mp|era|faction|map_pack|campaign_mp|scenario_mp|mod_mp|media|theme|other"
 	[/type]
 	[type]
 		# This is a very loose definition of an email, but it should be sufficient for our purposes.

--- a/src/addon/validation.cpp
+++ b/src/addon/validation.cpp
@@ -32,7 +32,7 @@ namespace
 const std::array<std::string, ADDON_TYPES_COUNT> addon_type_strings {{
 	"unknown", "core", "campaign", "scenario", "campaign_sp_mp", "campaign_mp",
 	"scenario_mp", "map_pack", "era", "faction", "mod_mp", /*"gui", */ "media",
-	"other"
+	"theme", "other"
 }};
 
 struct addon_name_char_illegal

--- a/src/addon/validation.hpp
+++ b/src/addon/validation.hpp
@@ -114,6 +114,7 @@ enum ADDON_TYPE {
 	//ADDON_GUI,			// GUI add-ons/themes.
 	ADDON_MEDIA,		/**< Miscellaneous content/media (unit packs, terrain packs, music packs, etc.). */
 	ADDON_OTHER,		/**< an add-on that fits in no other category */
+	ADDON_THEME,		/** GUI2 Themes */
 	ADDON_TYPES_COUNT
 };
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -159,6 +159,7 @@ const std::vector<std::pair<ADDON_TYPE, std::string>> addon_manager::type_filter
 	{ADDON_MP_FACTION,     N_("addons_of_type^MP factions")},
 	{ADDON_MOD,            N_("addons_of_type^Modifications")},
 	{ADDON_CORE,           N_("addons_of_type^Cores")},
+	{ADDON_THEME,          N_("addons_of_type^UI Themes")},
 	{ADDON_MEDIA,          N_("addons_of_type^Resources")},
 	// FIXME: (also in WML) should this and Unknown be a single option in the UI?
 	{ADDON_OTHER,          N_("addons_of_type^Other")},

--- a/src/gui/dialogs/editor/edit_pbl.cpp
+++ b/src/gui/dialogs/editor/edit_pbl.cpp
@@ -55,6 +55,7 @@ const std::array type_values = {
 	"map_pack",
 	"mod_mp",
 	"media",
+	"theme",
 	"other",
 };
 
@@ -178,6 +179,7 @@ void editor_edit_pbl::pre_show()
 	type_list.emplace_back("label", _("Map Pack"));
 	type_list.emplace_back("label", _("Modification"));
 	type_list.emplace_back("label", _("Media"));
+	type_list.emplace_back("label", _("UI Theme"));
 	type_list.emplace_back("label", _("Other"));
 	types.set_values(type_list);
 	types.set_selected(selected);


### PR DESCRIPTION
With custom gui2 theme support in #9057, it is now possible to create addons that supply UI Themes or Skins. This adds support so such addons are properly recognized and validated.
A new addon type, `theme` is now recognized in the PBL file as well as the Addons Manager and PBL Editor.