### PR TITLE
GUI2: Fix broken tab order

### DIFF
--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -319,12 +319,13 @@ window::window(const builder_window::window_resolution& definition)
 						SDL_BUTTON_RMASK),
 			event::dispatcher::front_child);
 
+	// FIXME investigate why this handler is being called twice and if this is actually needed
 	connect_signal<event::SDL_KEY_DOWN>(
 			std::bind(
-					&window::signal_handler_sdl_key_down, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_5, std::placeholders::_6, true),
+					&window::signal_handler_sdl_key_down, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_5, std::placeholders::_6, false),
 			event::dispatcher::back_post_child);
 	connect_signal<event::SDL_KEY_DOWN>(std::bind(
-			&window::signal_handler_sdl_key_down, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_5, std::placeholders::_6, false));
+			&window::signal_handler_sdl_key_down, this, std::placeholders::_2, std::placeholders::_3, std::placeholders::_5, std::placeholders::_6, true));
 
 	connect_signal<event::MESSAGE_SHOW_TOOLTIP>(
 			std::bind(&window::signal_handler_message_show_tooltip,


### PR DESCRIPTION
Resolves #9443 and partially deals with #1239.
The first SDL_KEY_DOWN handler is being called twice, while the second one is being called once. The tab order handling is done by the first handler, which caused the focus to move *twice*, resulting in the erratic behavior when tab was pressed. Moving the tab handling to the second one stops this and now focus moves only once when Tab is pressed.

Original code:
https://github.com/wesnoth/wesnoth/blob/1ca69e1ecaf8fe387f3ea6220671c842c250cc3b/src/gui/widgets/window.cpp#L322-L327

