### PR TITLE
Rect: add grow_by, point_at, and subrect

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2789,7 +2789,7 @@ void display::draw_hex(const map_location& loc)
 			const rect text_dest { dest.center() - tex.draw_size() / 2, tex.draw_size() };
 
 			// Add a little padding to the bg
-			const rect bg_dest = text_dest.grow_by(3);
+			const rect bg_dest = text_dest.padded_by(3);
 
 			draw::fill(bg_dest, 0, 0, 0, 170);
 			draw::blit(tex, text_dest);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1486,13 +1486,8 @@ void display::draw_text_in_hex(const map_location& loc,
 	renderer.set_foreground_color(color);
 	renderer.set_add_outline(true);
 
-	drawing_buffer_add(layer, loc, [x_in_hex, y_in_hex, res = renderer.render_and_get_texture()](const rect& dest) {
-		draw::blit(res, {
-			dest.x - (res.w() / 2) + static_cast<int>(x_in_hex * dest.w),
-			dest.y - (res.h() / 2) + static_cast<int>(y_in_hex * dest.h),
-			res.w(),
-			res.h()
-		});
+	drawing_buffer_add(layer, loc, [x_in_hex, y_in_hex, tex = renderer.render_and_get_texture()](const rect& dest) {
+		draw::blit(tex, rect{ dest.point_at(x_in_hex, y_in_hex) - tex.draw_size() / 2, tex.draw_size() });
 	});
 }
 
@@ -2075,12 +2070,8 @@ void display::scroll_to_tiles(const std::vector<map_location>& locs,
 	if(!valid) return;
 
 	if (scroll_type == ONSCREEN || scroll_type == ONSCREEN_WARP) {
-		rect r = map_area();
 		int spacing = std::round(add_spacing * hex_size());
-		r.x += spacing;
-		r.y += spacing;
-		r.w -= 2*spacing;
-		r.h -= 2*spacing;
+		rect r = map_area().grow_by(-spacing); // Shrink
 		if (!outside_area(r, minx,miny) && !outside_area(r, maxx,maxy)) {
 			return;
 		}
@@ -2094,14 +2085,12 @@ void display::scroll_to_tiles(const std::vector<map_location>& locs,
 	locs_bbox.h = maxy - miny + hex_size();
 
 	// target the center
-	int target_x = locs_bbox.x + locs_bbox.w/2;
-	int target_y = locs_bbox.y + locs_bbox.h/2;
+	auto [target_x, target_y] = locs_bbox.center();
 
 	if (scroll_type == ONSCREEN || scroll_type == ONSCREEN_WARP) {
 		// when doing an ONSCREEN scroll we do not center the target unless needed
 		rect r = map_area();
-		int map_center_x = r.x + r.w/2;
-		int map_center_y = r.y + r.h/2;
+		auto [map_center_x, map_center_y] = r.center();
 
 		int h = r.h;
 		int w = r.w;
@@ -2796,22 +2785,13 @@ void display::draw_hex(const map_location& loc)
 		renderer.set_maximum_width(-1);
 
 		drawing_buffer_add(drawing_layer::fog_shroud, loc, [tex = renderer.render_and_get_texture()](const rect& dest) {
-			const rect text_dest {
-				(dest.x + dest.w / 2) - (tex.w() / 2),
-				(dest.y + dest.h / 2) - (tex.h() / 2),
-				tex.w(),
-				tex.h()
-			};
+			// Center text in dest rect
+			const rect text_dest { dest.center() - tex.draw_size() / 2, tex.draw_size() };
 
-			// Add a little horizontal padding to the bg
-			const rect bg_dest {
-				text_dest.x - 3,
-				text_dest.y - 3,
-				text_dest.w + 6,
-				text_dest.h + 6
-			};
+			// Add a little padding to the bg
+			const rect bg_dest = text_dest.grow_by(3);
 
-			draw::fill(bg_dest, {0, 0, 0, 0xaa});
+			draw::fill(bg_dest, 0, 0, 0, 170);
 			draw::blit(tex, text_dest);
 		});
 	}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2071,7 +2071,7 @@ void display::scroll_to_tiles(const std::vector<map_location>& locs,
 
 	if (scroll_type == ONSCREEN || scroll_type == ONSCREEN_WARP) {
 		int spacing = std::round(add_spacing * hex_size());
-		rect r = map_area().grow_by(-spacing); // Shrink
+		rect r = map_area().padded_by(-spacing); // Shrink
 		if (!outside_area(r, minx,miny) && !outside_area(r, maxx,maxy)) {
 			return;
 		}

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -93,7 +93,7 @@ int floating_label::xpos(std::size_t width) const
 
 rect floating_label::get_bg_rect(const rect& text_rect) const
 {
-	return text_rect.grow_by(border_);
+	return text_rect.padded_by(border_);
 }
 
 void floating_label::clear_texture()

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -93,12 +93,7 @@ int floating_label::xpos(std::size_t width) const
 
 rect floating_label::get_bg_rect(const rect& text_rect) const
 {
-	return {
-		text_rect.x -  border_,
-		text_rect.y -  border_,
-		text_rect.w + (border_ * 2),
-		text_rect.h + (border_ * 2)
-	};
+	return text_rect.grow_by(border_);
 }
 
 void floating_label::clear_texture()

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -117,7 +117,7 @@ void rectangle_shape::draw(wfl::map_formula_callable& variables)
 	if(!fill_color.null()) {
 		DBG_GUI_D << "fill " << fill_color;
 		draw::set_color(fill_color);
-		draw::fill(area.grow_by(-border_thickness_));
+		draw::fill(area.padded_by(-border_thickness_));
 	}
 
 	const color_t border_color = border_color_(variables);
@@ -126,7 +126,7 @@ void rectangle_shape::draw(wfl::map_formula_callable& variables)
 	draw::set_color(border_color);
 	DBG_GUI_D << "border thickness " << border_thickness_ << ", colour " << border_color;
 	for(int i = 0; i < border_thickness_; ++i) {
-		draw::rect(area.grow_by(-i));
+		draw::rect(area.padded_by(-i));
 	}
 }
 

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -104,10 +104,12 @@ rectangle_shape::rectangle_shape(const config& cfg)
 
 void rectangle_shape::draw(wfl::map_formula_callable& variables)
 {
-	const int x = x_(variables);
-	const int y = y_(variables);
-	const int w = w_(variables);
-	const int h = h_(variables);
+	const rect area {
+		x_(variables),
+		y_(variables),
+		w_(variables),
+		h_(variables)
+	};
 
 	const color_t fill_color = fill_color_(variables);
 
@@ -115,32 +117,16 @@ void rectangle_shape::draw(wfl::map_formula_callable& variables)
 	if(!fill_color.null()) {
 		DBG_GUI_D << "fill " << fill_color;
 		draw::set_color(fill_color);
-
-		const SDL_Rect area {
-			x +  border_thickness_,
-			y +  border_thickness_,
-			w - (border_thickness_ * 2),
-			h - (border_thickness_ * 2)
-		};
-
-		draw::fill(area);
+		draw::fill(area.grow_by(-border_thickness_));
 	}
 
 	const color_t border_color = border_color_(variables);
 
 	// Draw the border
 	draw::set_color(border_color);
-	DBG_GUI_D << "border thickness " << border_thickness_
-		<< ", colour " << border_color;
+	DBG_GUI_D << "border thickness " << border_thickness_ << ", colour " << border_color;
 	for(int i = 0; i < border_thickness_; ++i) {
-		const SDL_Rect dimensions {
-			x + i,
-			y + i,
-			w - (i * 2),
-			h - (i * 2)
-		};
-
-		draw::rect(dimensions);
+		draw::rect(area.grow_by(-i));
 	}
 }
 

--- a/src/sdl/rect.cpp
+++ b/src/sdl/rect.cpp
@@ -16,6 +16,7 @@
 #include "sdl/point.hpp"
 #include "sdl/rect.hpp"
 
+#include <algorithm>
 #include <ostream>
 
 bool operator==(const SDL_Rect& a, const SDL_Rect& b)
@@ -118,6 +119,21 @@ rect rect::shifted_by(int x, int y) const
 rect rect::shifted_by(const point& other) const
 {
 	return shifted_by(other.x, other.y);
+}
+
+point rect::point_at(double x, double y) const
+{
+	return {
+		static_cast<int>(this->x + this->w * std::clamp(x, 0.0, 1.0)),
+		static_cast<int>(this->y + this->h * std::clamp(y, 0.0, 1.0))
+	};
+}
+
+rect rect::subrect(const SDL_FPoint& tl, const SDL_FPoint& br) const
+{
+	point p1 = point_at(tl.x, tl.y);
+	point p2 = point_at(br.x, br.y);
+	return { p1, p2 - p1 };
 }
 
 std::ostream& operator<<(std::ostream& s, const rect& r)

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -151,6 +151,24 @@ public:
 	/** Returns a new rectangle shifted by the given relative position. */
 	rect shifted_by(int x, int y) const;
 	rect shifted_by(const point& p) const;
+
+	/** Returns a new rectangle with @a dx horizontal padding and @a dy vertical padding. */
+	constexpr rect grow_by(int dx, int dy) const
+	{
+		return { x - dx, y - dy, w + dx * 2, h + dy * 2 };
+	}
+
+	/** Returns a new rectangle with equal @a amount horizontal and vertical padding. */
+	constexpr rect grow_by(int amount) const
+	{
+		return grow_by(amount, amount);
+	}
+
+	/** Returns the proper point that corresponds to the given [0.0, 1.0] coordinates. */
+	point point_at(double x, double y) const;
+
+	/** Returns the sub-rect bounded to the top left and bottom right by the given [0.0, 1.0] coordinates. */
+	rect subrect(const SDL_FPoint& top_left, const SDL_FPoint& bottom_right) const;
 };
 
 std::ostream& operator<<(std::ostream&, const rect&);

--- a/src/sdl/rect.hpp
+++ b/src/sdl/rect.hpp
@@ -153,15 +153,15 @@ public:
 	rect shifted_by(const point& p) const;
 
 	/** Returns a new rectangle with @a dx horizontal padding and @a dy vertical padding. */
-	constexpr rect grow_by(int dx, int dy) const
+	constexpr rect padded_by(int dx, int dy) const
 	{
 		return { x - dx, y - dy, w + dx * 2, h + dy * 2 };
 	}
 
 	/** Returns a new rectangle with equal @a amount horizontal and vertical padding. */
-	constexpr rect grow_by(int amount) const
+	constexpr rect padded_by(int amount) const
 	{
-		return grow_by(amount, amount);
+		return padded_by(amount, amount);
 	}
 
 	/** Returns the proper point that corresponds to the given [0.0, 1.0] coordinates. */


### PR DESCRIPTION
Unsure if I should add a `shrink_by` function or keep the current `grow_by(-amount)` approach. Also, `grow_by` is a little inconsistent with the other const helper functions (`shifted_by`, for instance). Considering `adjusted_by`?