### PR TITLE
Tweak Cavalryman to use Ladder Era stats

### DIFF
--- a/data/core/units/humans/Loyalist_Cavalryman.cfg
+++ b/data/core/units/humans/Loyalist_Cavalryman.cfg
@@ -13,7 +13,7 @@
     alignment=lawful
     advances_to=Dragoon
     undead_variation=mounted
-    cost=17
+    cost=18
     usage=scout
     #extra resistance for these units
     description= _ "Cavalrymen are distinguished from horsemen by their tactics and equipment. A cavalryman wears heavier armor, and carries a sword and shield, rather than a lance. Their tactics do not include charging; instead they maneuver to slash with a sword, using both horse and rider as an effective tool of melee.
@@ -44,6 +44,7 @@ Cavalrymen are very useful for taking and holding positions on open ground, for 
     [/movement_anim]
     {DEFENSE_ANIM "units/human-loyalists/cavalryman/cavalryman-defend2.png" "units/human-loyalists/cavalryman/cavalryman-defend1.png" {SOUND_LIST:HORSE_HIT} }
     [resistance]
+        blade=70
         impact=60
         cold=80
     [/resistance]


### PR DESCRIPTION
Blade resistance is reverted to its original 30% (back from 20% in 1.18) while cost is increased from 17 to 18 gold.

This restores consistency with its advancements (Dragoon and Cavalier) and its general theme of being well armored cavalry.

Competitive multiplayer will not be affected, as expressed by the skilled competitive players Krogen and Skyend on the forums (and the generally conservative and carefully balanced nature of Ladder Era). But single player game play and lore do benefit from keeping the unit's design unique as the "armored scout" (generally tougher but less agile than the scouts of other factions/races).

As a side benefit, campaigns that were balanced around the cavalryman's traditional resistances will be more balanced again, since a 6% increase in initial recruit cost is negligible, especially when most campaigns revolve around recalls instead.