### PR TITLE
Fix location_palette's override of supports_swap

### DIFF
--- a/src/editor/palette/common_palette.hpp
+++ b/src/editor/palette/common_palette.hpp
@@ -80,7 +80,16 @@ public:
 	virtual std::size_t start_num() = 0;
 	virtual void set_start_item(std::size_t index) = 0;
 
+	/** Whether the hotkey system should the enable GUI button connected to swap(). */
 	virtual bool supports_swap() { return true; }
+	/**
+	 * For tools which support fg and bg items, exchange the two items. Typically, fg and bg mean
+	 * that they're placed by left or right mouse clicks, respectively.
+	 *
+	 * There's a mismatch between class structure and responsibilities here, as part of the UX isn't
+	 * part of the palette. The tool decides what right-click does. Even for the scenery item tool,
+	 * where right-click deletes an item, fg and bg provide a way to switch between two items.
+	 */
 	virtual void swap() = 0;
 
 	virtual std::vector<std::string> action_pressed() const { return std::vector<std::string>(); }

--- a/src/editor/palette/location_palette.hpp
+++ b/src/editor/palette/location_palette.hpp
@@ -70,8 +70,8 @@ public:
 	virtual bool scroll_down() override;
 	virtual bool can_scroll_down() override;
 
-	void swap() override {}
-	bool can_swap() { return false; }
+	virtual void swap() override {}
+	virtual bool supports_swap() override { return false; }
 
 	std::string get_help_string() const { return ""; }
 

--- a/src/editor/palette/unit_palette.hpp
+++ b/src/editor/palette/unit_palette.hpp
@@ -39,7 +39,7 @@ public:
 
 	virtual std::string get_help_string() const override;
 
-	bool supports_swap() { return false; }
+	virtual bool supports_swap() override { return false; }
 
 	const std::set<std::string>& get_selected_bg_items() { return selected_bg_items_; }
 
@@ -56,7 +56,6 @@ private:
 	virtual bool is_selected_bg_item(const std::string& id) override;
 
 	virtual void select_bg_item(const std::string& item_id) override;
-//	virtual void update_report();
 
 	std::set<std::string> selected_bg_items_;
 


### PR DESCRIPTION
Rename location_palette::can_swap() to the correct name so that it overrides as intended, thus making the UI disable the "swap fg and bg items" button.

The class structure doesn't match the responsibilities here, as part of UX isn't part of the palette, rather it's part of the tool that decides whether there are fg and bg items - alternatively, the tool decides whether right-click is "place bg item", "delete items", or "show unit tool options". However, this change seems to be enough to make the UX correct.

The "virtual" is redundant, but add it for consistency with the other code in these classes.