### PR TITLE
campaignd: Use completion token overload

### DIFF
--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -488,16 +488,22 @@ std::ostream& operator<<(std::ostream& o, const server::request& r)
 
 void server::handle_new_client(tls_socket_ptr socket)
 {
-	boost::asio::spawn(io_service_, [this, socket](boost::asio::yield_context yield) {
-		serve_requests(socket, yield);
-	});
+	boost::asio::spawn(
+		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, yield); }
+#if BOOST_VERSION >= 108000
+		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+#endif
+	);
 }
 
 void server::handle_new_client(socket_ptr socket)
 {
-	boost::asio::spawn(io_service_, [this, socket](boost::asio::yield_context yield) {
-		serve_requests(socket, yield);
-	});
+	boost::asio::spawn(
+		io_service_, [this, socket](boost::asio::yield_context yield) { serve_requests(socket, yield); }
+#if BOOST_VERSION >= 108000
+		, [](std::exception_ptr e) { if (e) std::rethrow_exception(e); }
+#endif
+	);
 }
 
 template<class Socket>


### PR DESCRIPTION
... to fix compile issues with boost 1.86.

Commit 9c665ae3c4684f8826f4b7d8e0a75b9a986e8617 does the same for wesnothd, but campaignd still fails to compile with overload resolution failure.

References  #9284