### PR TITLE
Unit strange number manipulation fix

### DIFF
--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -527,7 +527,7 @@ struct fai_variant_visitor
 	variant operator()(bool b) const               { return variant(b ? 1 : 0); }
 	variant operator()(int i) const                { return variant(i); }
 	variant operator()(unsigned long long i) const { return variant(i); }
-	variant operator()(double i) const             { return variant(i * 1000, variant::DECIMAL_VARIANT); }
+	variant operator()(double i) const             { return variant(i, variant::DECIMAL_VARIANT); }
 	// TODO: Should comma-separated lists of stuff be returned as a list?
 	// The challenge is to distinguish them from ordinary strings that happen to contain a comma
 	// (or should we assume that such strings will be translatable?).

--- a/src/formula/variant.cpp
+++ b/src/formula/variant.cpp
@@ -305,6 +305,18 @@ int variant::as_decimal() const
 		return value_cast<variant_int>()->get_numeric_value() * 1000;
 	} else if(is_null()) {
 		return 0;
+	} else if(is_string()) {
+		const std::string& s = value_cast<variant_string>()->get_string();
+
+		try {
+			float f = std::stof(s);
+
+			if(f == floor(f)) {
+				return f;
+			}
+
+			return f * 1000;
+		} catch (std::invalid_argument&) { }
 	}
 
 	throw type_error(was_expecting("an integer or a decimal", *this));

--- a/src/formula/variant.cpp
+++ b/src/formula/variant.cpp
@@ -306,16 +306,8 @@ int variant::as_decimal() const
 	} else if(is_null()) {
 		return 0;
 	} else if(is_string()) {
-		const std::string& s = value_cast<variant_string>()->get_string();
-
 		try {
-			float f = std::stof(s);
-
-			if(f == floor(f)) {
-				return f;
-			}
-
-			return f * 1000;
+			return std::stof(value_cast<variant_string>()->get_string()) * 1000;
 		} catch (std::invalid_argument&) { }
 	}
 


### PR DESCRIPTION
Resolves  #8917. The cause of one of the bugs was that when converting config_attribute_value to formula variant it is unnecessarily multiplied by 1000. This is already done inside the constructor. The cause of the other bug was that the value becomes string when using certain syntax. To solve this now the variant to_decimal function attempts to convert string to number.