### PR TITLE
Remove fallback logic from alignment_str() to work the same as alignment()

### DIFF
--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -59,7 +59,7 @@ attack_type::attack_type(const config& cfg)
 	, range_(cfg["range"])
 	, min_range_(cfg["min_range"].to_int(1))
 	, max_range_(cfg["max_range"].to_int(1))
-	, alignment_str_(cfg["alignment"].str())
+	, alignment_(unit_alignments::get_enum(cfg["alignment"].str()))
 	, damage_(cfg["damage"].to_int())
 	, num_attacks_(cfg["number"].to_int())
 	, attack_weight_(cfg["attack_weight"].to_double(1.0))
@@ -84,11 +84,7 @@ attack_type::attack_type(const config& cfg)
 
 std::string attack_type::alignment_str() const
 {
-	if (alignment()){
-		return unit_alignments::get_string(*alignment());
-	}
-	//if not alignment() fallback to unit alignment or return empty string if not available.
-	return (self_ ? unit_alignments::get_string(self_->alignment()) : "");
+	return alignment_ ? unit_alignments::get_string(*alignment()) : "";
 }
 
 std::string attack_type::accuracy_parry_description() const
@@ -364,7 +360,7 @@ bool attack_type::apply_modification(const config& cfg)
 	}
 
 	if(set_attack_alignment.empty() == false) {
-		alignment_str_ = set_attack_alignment;
+		alignment_ = unit_alignments::get_enum(set_attack_alignment);
 	}
 
 	if(set_icon.empty() == false) {
@@ -710,7 +706,7 @@ void attack_type::write(config& cfg) const
 	cfg["range"] = range_;
 	cfg["min_range"] = min_range_;
 	cfg["max_range"] = max_range_;
-	cfg["alignment"] = alignment_str_;
+	cfg["alignment"] = alignment_str();
 	cfg["damage"] = damage_;
 	cfg["number"] = num_attacks_;
 	cfg["attack_weight"] = attack_weight_;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -62,7 +62,7 @@ public:
 	void set_range(const std::string& value) { range_ = value; set_changed(true); }
 	void set_min_range(int value) { min_range_ = value; set_changed(true); }
 	void set_max_range(int value) { max_range_ = value; set_changed(true); }
-	void set_attack_alignment(const std::string& value) { alignment_str_ = value; set_changed(true); }
+	void set_attack_alignment(const std::string& value) { alignment_ = unit_alignments::get_enum(value); set_changed(true); }
 	void set_accuracy(int value) { accuracy_ = value; set_changed(true); }
 	void set_parry(int value) { parry_ = value; set_changed(true); }
 	void set_damage(int value) { damage_ = value; set_changed(true); }
@@ -89,7 +89,7 @@ public:
 
 	/** Returns alignment specified by alignment_str_ variable If empty or not valid returns the unit's alignment or neutral if self_ variable empty.
 	 */
-	utils::optional<unit_alignments::type> alignment() const {return unit_alignments::get_enum(alignment_str_);}
+	utils::optional<unit_alignments::type> alignment() const { return alignment_; }
 	/** Returns alignment specified by alignment() for filtering when exist.
 	 */
 	std::string alignment_str() const;
@@ -414,7 +414,7 @@ private:
 	std::string icon_;
 	std::string range_;
 	int min_range_, max_range_;
-	std::string alignment_str_;
+	utils::optional<unit_alignments::type> alignment_;
 	int damage_;
 	int num_attacks_;
 	double attack_weight_;


### PR DESCRIPTION
No caller was adjusted since IMO this is the correct behavior.