### PR TITLE
campaign selection: opening add-ons manager entry

### DIFF
--- a/data/gui/themes/default/window/campaign_dialog.cfg
+++ b/data/gui/themes/default/window/campaign_dialog.cfg
@@ -519,7 +519,7 @@ Example: if you strike three times with 50% accuracy, you will always hit at lea
 								border_size = 5
 
 								[button]
-									id = "ok"
+									id = "proceed"
 									definition = "really_large"
 									label = _ "game^Play"
 								[/button]

--- a/src/game_initialization/singleplayer.cpp
+++ b/src/game_initialization/singleplayer.cpp
@@ -14,6 +14,7 @@
 
 #include "game_initialization/singleplayer.hpp"
 
+#include "addon/manager_ui.hpp"
 #include "config.hpp"
 #include "game_initialization/configure_engine.hpp"
 #include "game_initialization/connect_engine.hpp"
@@ -57,23 +58,26 @@ bool select_campaign(saved_game& state, jump_to_campaign_info jump_to_campaign)
 				return false;
 			}
 
-			if(dlg.get_retval() != gui2::retval::OK) {
+			if(dlg.get_retval() == gui2::retval::OK) {
+				switch(dlg.get_rng_mode()) {
+					case gui2::dialogs::campaign_selection::RNG_DEFAULT:
+						random_mode = "";
+						break;
+					case gui2::dialogs::campaign_selection::RNG_SAVE_SEED:
+						random_mode = "deterministic";
+						break;
+					case gui2::dialogs::campaign_selection::RNG_BIASED:
+						random_mode = "biased";
+						break;
+				}
+				difficulty = dlg.get_difficulty();
+			} else {
+				if (dlg.get_retval() == gui2::dialogs::campaign_selection::OPEN_ADDON_MANAGER) {
+					manage_addons();
+				}
 				return false;
 			}
 
-			switch(dlg.get_rng_mode()) {
-				case gui2::dialogs::campaign_selection::RNG_DEFAULT:
-					random_mode = "";
-					break;
-				case gui2::dialogs::campaign_selection::RNG_SAVE_SEED:
-					random_mode = "deterministic";
-					break;
-				case gui2::dialogs::campaign_selection::RNG_BIASED:
-					random_mode = "biased";
-					break;
-			}
-
-			difficulty = dlg.get_difficulty();
 		} else {
 			// Don't reset the campaign_id_ so we can know
 			// if we should quit the game or return to the main menu

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -754,12 +754,11 @@ std::string game_launcher::jump_to_campaign_id() const
 bool game_launcher::goto_campaign()
 {
 	if(jump_to_campaign_.jump) {
+		jump_to_campaign_.jump = false;
 		if(new_campaign()) {
 			state_.set_skip_story(jump_to_campaign_.skip_story);
-			jump_to_campaign_.jump = false;
 			launch_game(reload_mode::NO_RELOAD_DATA);
 		} else {
-			jump_to_campaign_.jump = false;
 			return false;
 		}
 	}
@@ -769,16 +768,12 @@ bool game_launcher::goto_campaign()
 
 bool game_launcher::goto_multiplayer()
 {
-	if(jump_to_multiplayer_) {
-		jump_to_multiplayer_ = false;
-		if(play_multiplayer(mp_mode::CONNECT)) {
-			;
-		} else {
-			return false;
-		}
+	if(!jump_to_multiplayer_) {
+		return true;
 	}
 
-	return true;
+	jump_to_multiplayer_ = false;
+	return play_multiplayer(mp_mode::CONNECT);
 }
 
 bool game_launcher::goto_editor()

--- a/src/gui/dialogs/campaign_selection.cpp
+++ b/src/gui/dialogs/campaign_selection.cpp
@@ -18,7 +18,6 @@
 #include "gui/dialogs/campaign_selection.hpp"
 
 #include "filesystem.hpp"
-#include "serialization/markup.hpp"
 #include "gui/dialogs/campaign_difficulty.hpp"
 #include "gui/widgets/button.hpp"
 #include "gui/widgets/menu_button.hpp"
@@ -30,9 +29,10 @@
 #include "gui/widgets/tree_view_node.hpp"
 #include "gui/widgets/window.hpp"
 #include "preferences/preferences.hpp"
+#include "serialization/markup.hpp"
+#include "utils/irdya_datetime.hpp"
 
 #include <functional>
-#include "utils/irdya_datetime.hpp"
 
 namespace gui2::dialogs
 {
@@ -48,10 +48,14 @@ void campaign_selection::campaign_selected()
 
 	assert(tree.selected_item());
 
-	if(!tree.selected_item()->id().empty()) {
-		auto iter = std::find(page_ids_.begin(), page_ids_.end(), tree.selected_item()->id());
+	const std::string& campaign_id = tree.selected_item()->id();
 
-		find_widget<button>("ok").set_active(tree.selected_item()->id() != missing_campaign_);
+	if(!campaign_id.empty()) {
+		auto iter = std::find(page_ids_.begin(), page_ids_.end(), campaign_id);
+
+		button& ok_button = find_widget<button>("proceed");
+		ok_button.set_active(campaign_id != missing_campaign_);
+		ok_button.set_label((campaign_id == addons_) ? _("game^Get Add-ons") : _("game^Play"));
 
 		const int choice = std::distance(page_ids_.begin(), iter);
 		if(iter == page_ids_.end()) {
@@ -85,7 +89,7 @@ void campaign_selection::campaign_selected()
 				entry["label"] = cfg["label"].str() + " (" + cfg["description"].str() + ")";
 				entry["image"] = cfg["image"].str("misc/blank-hex.png");
 
-				if(prefs::get().is_campaign_completed(tree.selected_item()->id(), cfg["define"])) {
+				if(prefs::get().is_campaign_completed(campaign_id, cfg["define"])) {
 					std::string laurel;
 
 					if(n + 1 >= max_n) {
@@ -202,9 +206,9 @@ void campaign_selection::sort_campaigns(campaign_selection::CAMPAIGN_ORDER order
 			for(const auto& word : last_search_words_) {
 				found = translation::ci_search(levels[i]->name(), word) ||
 						translation::ci_search(levels[i]->data()["name"].t_str().base_str(), word) ||
-				        translation::ci_search(levels[i]->description(), word) ||
+						translation::ci_search(levels[i]->description(), word) ||
 						translation::ci_search(levels[i]->data()["description"].t_str().base_str(), word) ||
-				        translation::ci_search(levels[i]->data()["abbrev"], word) ||
+						translation::ci_search(levels[i]->data()["abbrev"], word) ||
 						translation::ci_search(levels[i]->data()["abbrev"].t_str().base_str(), word);
 
 				if(!found) {
@@ -321,12 +325,16 @@ void campaign_selection::pre_show()
 	connect_signal_notify_modified(sort_time,
 		std::bind(&campaign_selection::toggle_sorting_selection, this, DATE));
 
+	connect_signal_mouse_left_click(find_widget<button>("proceed"),
+		std::bind(&campaign_selection::proceed, this));
+
 	keyboard_capture(filter);
 	add_to_keyboard_chain(&tree);
 
 	/***** Setup campaign details. *****/
 	multi_page& pages = find_widget<multi_page>("campaign_details");
 
+	// Setup completion filter
 	multimenu_button& filter_comp = find_widget<multimenu_button>("filter_completion");
 	connect_signal_notify_modified(filter_comp,
 		std::bind(&campaign_selection::sort_campaigns, this, RANK, 1));
@@ -334,6 +342,7 @@ void campaign_selection::pre_show()
 		filter_comp.select_option(j);
 	}
 
+	// Add campaigns to the list
 	for(const auto& level : engine_.get_levels_by_type_unfiltered(level_type::type::sp_campaign)) {
 		const config& campaign = level->data();
 
@@ -359,6 +368,25 @@ void campaign_selection::pre_show()
 		pages.add_page(data);
 		page_ids_.push_back(campaign["id"]);
 	}
+
+	//
+	// Addon Manager link
+	//
+	config addons;
+	addons["icon"] = "icons/icon-game.png~BLIT(icons/icon-addon-publish.png)";
+	addons["name"] = _("More campaigns...");
+	addons["completed"] = false;
+	addons["id"] = addons_;
+
+	add_campaign_to_tree(addons);
+
+	widget_data data;
+	widget_item item;
+
+	item["label"] = _("In addition to the mainline campaigns, Wesnoth also has an ever-growing list of add-on content created by other players available via the Add-ons server, included but not limited to more single and multiplayer campaigns, multiplayer maps, additional media and various other content! Be sure to give it a try!");
+	data.emplace("description", item);
+	pages.add_page(data);
+	page_ids_.push_back(addons_);
 
 	std::vector<std::string> dirs;
 	filesystem::get_files_in_dir(game_config::path + "/data/campaigns", nullptr, &dirs);
@@ -468,7 +496,7 @@ void campaign_selection::add_campaign_to_tree(const config& campaign)
 	tree.add_node("campaign", data).set_id(campaign["id"]);
 }
 
-void campaign_selection::post_show()
+void campaign_selection::proceed()
 {
 	tree_view& tree = find_widget<tree_view>("campaign_tree");
 
@@ -477,10 +505,16 @@ void campaign_selection::post_show()
 	}
 
 	assert(tree.selected_item());
-	if(!tree.selected_item()->id().empty()) {
-		auto iter = std::find(page_ids_.begin(), page_ids_.end(), tree.selected_item()->id());
-		if(iter != page_ids_.end()) {
-			choice_ = std::distance(page_ids_.begin(), iter);
+	const std::string& campaign_id = tree.selected_item()->id();
+	if(!campaign_id.empty()) {
+		if (campaign_id == addons_) {
+			set_retval(OPEN_ADDON_MANAGER);
+		} else {
+			auto iter = std::find(page_ids_.begin(), page_ids_.end(), campaign_id);
+			if(iter != page_ids_.end()) {
+				choice_ = std::distance(page_ids_.begin(), iter);
+			}
+			set_retval(retval::OK);
 		}
 	}
 

--- a/src/gui/dialogs/campaign_selection.hpp
+++ b/src/gui/dialogs/campaign_selection.hpp
@@ -41,6 +41,9 @@ public:
 		RNG_BIASED,
 	};
 
+	//return value for opening addon manager
+	const static int OPEN_ADDON_MANAGER = 3;
+
 	explicit campaign_selection(ng::create_engine& eng)
 		: modal_dialog(window_id())
 		, engine_(eng)
@@ -84,7 +87,7 @@ private:
 
 	virtual void pre_show() override;
 
-	virtual void post_show() override;
+	void proceed();
 
 	void sort_campaigns(CAMPAIGN_ORDER order, bool ascending);
 
@@ -119,6 +122,7 @@ private:
 	std::vector<std::string> last_search_words_;
 
 	inline const static std::string missing_campaign_ = "////missing-campaign////";
+	inline const static std::string addons_ = "////addons////";
 
 	std::vector<std::string> mod_ids_;
 };


### PR DESCRIPTION
Resolves #8478 by adding an entry to open the Add-ons manager in the campaign list.

![Screenshot from 2024-10-13 09-22-59](https://github.com/user-attachments/assets/74795725-63ab-4b05-a125-f43915068874)
