### PR TITLE
Save game: text correction

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -428,7 +428,7 @@ bool savegame::check_overwrite()
 bool savegame::check_filename(const std::string& filename)
 {
 	if(filesystem::is_compressed_file(filename)) {
-		gui2::show_error_message(_("Save names should not end on ‘.gz’ or ‘.bz2’. Please remove the extension."));
+		gui2::show_error_message(_("Save names should not end with ‘.gz’ or ‘.bz2’. Please remove the extension."));
 		return false;
 	} else if(!filesystem::is_legal_user_file_name(filename)) {
 		// This message is not all-inclusive. This is on purpose. Few people


### PR DESCRIPTION
I'll grant this is really old text, introduced in 2007 (1.3.13) in 22ad729bccab7d52f06e71a02fbcd6816a36da9e, but the text as it stands really doesn't read right to me.

This also aligns better with the line immediately below it:
https://github.com/wesnoth/wesnoth/blob/c284a080e3d7c93652598bb71b1bad95620263f6/src/savegame.cpp#L436