### PR TITLE
Help text review

### DIFF
--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -463,9 +463,9 @@ In scenario mode, the button accesses an editor for individual schedules for <re
 
 There is a filter function to show only a subset of the available items — this is the leftmost of the four buttons at the top of the palette, and the graphic changes depending on what is selected. Examples:" +
         "<table>" +
-        "<row><col><img src=icons/terrain/terrain_group_all_30.png align=left /></col><col>" + _ "Show all kinds of terrain" + "</col></row>"
-        "<row><col><img src=icons/terrain/terrain_group_water_deep_30.png align=left /></col><col>" + _ "Show only water terrains" + "</col></row>"
-        "<row><col><img src=icons/terrain/terrain_group_village_30.png align=left /></col><col>" + _ "Show only villages" + "</col></row>"
+        "<row><col><img src=icons/terrain/terrain_group_all_30.png align=left /></col><col>" + _ "Show all kinds of terrain" + "</col></row>" +
+        "<row><col><img src=icons/terrain/terrain_group_water_deep_30.png align=left /></col><col>" + _ "Show only water terrains" + "</col></row>" +
+        "<row><col><img src=icons/terrain/terrain_group_village_30.png align=left /></col><col>" + _ "Show only villages" + "</col></row>" +
         "</table>"
 [/topic]
 # wmllint: markcheck on

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -358,7 +358,7 @@ The map won’t look exactly the same in the game as it does in the editor, beca
 
 • Event handlers and scripting
 
-The editor is not a tool to help you scripting the scenario’s event handlers.
+The editor is not a tool to help you with scripting the scenario’s event handlers.
 
 • Infinite Backwards Compatibility
 
@@ -436,7 +436,7 @@ If your add-on will only be used on 1.18 and later, it is instead recommended to
 [topic]
     id=editor_masks
     title= _ "Editor Mask Usage"
-    text= _ "Masks can be applied to a base map for reusal in several scenarios playing at the same locations."
+    text= _ "Masks can be applied to a base map for reuse in several scenarios playing at the same locations."
 [/topic]
 # wmllint: markcheck on
 
@@ -483,7 +483,7 @@ There is a filter function to show only a subset of the available items — this
 
 " + _ "<header>Native</header>
 
-A map file consists of rows with comma separated terrain code strings. The only non-terrain information provided by the map syntax is the set of locations created by the <ref dst='editor_tool_starting'>Starting Locations Tool</ref>. The files can be edited with a general purpose text editor like notepad.
+A map file consists of rows with comma-separated terrain code strings. The only non-terrain information provided by the map syntax is the set of locations created by the <ref dst='editor_tool_starting'>Starting Locations Tool</ref>. The files can be edited with a general purpose text editor like Notepad.
 
 These files can be used directly for multiplayer games, the number of players is automatically determined by the number of starting positions. When saved in the default directory, the map can be found in the “Custom Maps” game type of the multiplayer “Create Game” dialog; you may need to refresh the cache (press F5 on the title screen) before a newly-created map appears.
 
@@ -496,7 +496,7 @@ The <italic>map_file</italic> method is preferred over using a preprocessor incl
 
 " + _ "<header>Embedded</header>
 
-The map data can stored as part of a scenario’s .cfg file, directly in the <italic>map_data</italic> attribute. In other words, in the place that the preprocessor would include it when using the preprocessor-include method.
+The map data can be stored as part of a scenario’s .cfg file, directly in the <italic>map_data</italic> attribute. In other words, in the place that the preprocessor would include it when using the preprocessor-include method.
 
 <header>Using Embedded Format in Terrain Mode</header>
 

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -483,7 +483,7 @@ There is a filter function to show only a subset of the available items — this
 
 " + _ "<header>Native</header>
 
-A map file consists of rows with comma-separated terrain code strings. The only non-terrain information provided by the map syntax is the set of locations created by the <ref dst='editor_tool_starting'>Starting Locations Tool</ref>. The files can be edited with a general purpose text editor like Notepad.
+A map file consists of rows with comma-separated terrain code strings. The only non-terrain information provided by the map syntax is the set of locations created by the <ref dst='editor_tool_starting'>Starting Locations Tool</ref>. The files can be edited with a general purpose text editor.
 
 These files can be used directly for multiplayer games, the number of players is automatically determined by the number of starting positions. When saved in the default directory, the map can be found in the “Custom Maps” game type of the multiplayer “Create Game” dialog; you may need to refresh the cache (press F5 on the title screen) before a newly-created map appears.
 

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -463,9 +463,9 @@ In scenario mode, the button accesses an editor for individual schedules for <re
 
 There is a filter function to show only a subset of the available items — this is the leftmost of the four buttons at the top of the palette, and the graphic changes depending on what is selected. Examples:" +
         "<table>" +
-        "<row><col><img src=icons/terrain/terrain_group_all_30.png align=left /></col><col>" + _ "Show all kinds of terrain</col></row>" +
-        "<row><col><img src=icons/terrain/terrain_group_water_deep_30.png align=left /></col><col>" + _ "Show only water terrains</col></row>" +
-        "<row><col><img src=icons/terrain/terrain_group_village_30.png align=left /></col><col>" + _ "Show only villages</col></row>" +
+        "<row><col><img src=icons/terrain/terrain_group_all_30.png align=left /></col><col>" + _ "Show all kinds of terrain" + "</col></row>"
+        "<row><col><img src=icons/terrain/terrain_group_water_deep_30.png align=left /></col><col>" + _ "Show only water terrains" + "</col></row>"
+        "<row><col><img src=icons/terrain/terrain_group_village_30.png align=left /></col><col>" + _ "Show only villages" + "</col></row>"
         "</table>"
 [/topic]
 # wmllint: markcheck on

--- a/data/core/editor/help.cfg
+++ b/data/core/editor/help.cfg
@@ -424,7 +424,7 @@ If your add-on will only be used on 1.18 and later, it is instead recommended to
 • <span face='monospace'>maps/first.map</span>
   ◦ this is the .map file created by the scenario editor when saving in scenario mode
 • <span face='monospace'>scenarios/other.cfg</span>
-  ◦ this is the .cfg file containing everything that the scenario editor doesn't understand
+  ◦ this is the .cfg file containing everything that the scenario editor doesn’t understand
 • <span face='monospace'>scenarios/first.cfg</span>
   ◦ inside the <span face='monospace'>[scenario]</span> element, use <span face='monospace'>map_file=&quot;first.map&quot;</span> to load the map file
   ◦ inside the <span face='monospace'>[scenario]</span> element, use <span face='monospace'>include_file=&quot;other.cfg&quot;</span> to load the additional cfg file"

--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -93,7 +93,7 @@
     [topic]
         id=..introduction
         title= _ "Introduction"
-        text="<img>src=misc/logo-bg.png~BLIT(misc/logo.png) align=middle</img>" + _ "<br/><italic>text='Battle for Wesnoth'</italic> is a turn-based fantasy strategy game somewhat unusual among modern strategy games. While other games strive for complexity, <italic>text='Battle for Wesnoth'</italic> strives for simplicity of both rules and gameplay. This does not make the game simple, however — from these simple rules arises a wealth of strategy, making the game easy to learn but a challenge to master.
+        text="<img>src=misc/logo-bg.png~BLIT(misc/logo.png) align=middle</img><br/>" + _ "<italic>text='Battle for Wesnoth'</italic> is a turn-based fantasy strategy game somewhat unusual among modern strategy games. While other games strive for complexity, <italic>text='Battle for Wesnoth'</italic> strives for simplicity of both rules and gameplay. This does not make the game simple, however — from these simple rules arises a wealth of strategy, making the game easy to learn but a challenge to master.
 
 The following pages outline all you need to know to play Wesnoth. As you play, new information is added to the various categories as you come across new aspects of the game. For more detailed information on special situations and exceptions, follow the included links."
     [/topic]
@@ -575,7 +575,7 @@ Mixed terrain types share the properties of multiple basic terrain types — uni
 
 " + "<img src='terrain/hills/regular.png~BLIT(terrain/forest/pine-tile.png)'/>" + "<img src='terrain/hills/desert.png'/>" + "<img src='terrain/cave/hills-variation.png'/><br/>" + _ "One notable exception is bridge terrains, such as <italic>bridges over shallow water</italic>, <italic>fords</italic>, and <italic>bridges over chasms</italic>. Fords are easily passable to both merfolk and humans — all units moving on a ford enjoy the best defense and best movement out of flat and shallow water, rather than the worse movement of the two. Similarly, bridges over chasms are passable to nonfliers (unsurprisingly).
 
-" + "<img src='terrain/water/coast-tile.png~BLIT(terrain/bridge/wood-se-nw.png)'/>" + "<img src='terrain/water/ford-tile.png'/>" + "<img src='terrain/chasm/regular-tile.png~BLIT(terrain/cave/chasm-stone-bridge-sw-ne-tile.png)'/>" + _ "<br/>Land-based villages generally give the best defense and movement as well. These villages are mixed terrains, based on the village terrain type, together with hill, swamp, and cave, respectively.
+" + "<img src='terrain/water/coast-tile.png~BLIT(terrain/bridge/wood-se-nw.png)'/>" + "<img src='terrain/water/ford-tile.png'/>" + "<img src='terrain/chasm/regular-tile.png~BLIT(terrain/cave/chasm-stone-bridge-sw-ne-tile.png)'/><br/>" + _ "Land-based villages generally give the best defense and movement as well. These villages are mixed terrains, based on the village terrain type, together with hill, swamp, and cave, respectively.
 
 " + "<img src='terrain/hills/regular.png~BLIT(terrain/village/human-hills-tile.png)'/>" + "<img src='terrain/swamp/water-tile.png~BLIT(terrain/village/swampwater-tile.png)'/>" + "<img src='terrain/cave/floor6.png~BLIT(terrain/village/cave-tile.png)'/><br/>" + _ "Finally, water villages are generally inhospitable to land units, and do not give defense or movement benefits associated with the village terrain type. Instead, they count only as water tiles.
 

--- a/data/core/help.cfg
+++ b/data/core/help.cfg
@@ -93,7 +93,7 @@
     [topic]
         id=..introduction
         title= _ "Introduction"
-        text="<img>src=misc/logo-bg.png~BLIT(misc/logo.png) align=middle</img><br/>" + _ "<italic>text='Battle for Wesnoth'</italic> is a turn-based fantasy strategy game somewhat unusual among modern strategy games. While other games strive for complexity, <italic>text='Battle for Wesnoth'</italic> strives for simplicity of both rules and gameplay. This does not make the game simple, however — from these simple rules arises a wealth of strategy, making the game easy to learn but a challenge to master.
+        text="<img src=misc/logo-bg.png~BLIT(misc/logo.png) align=middle /><br/>" + _ "<italic>Battle for Wesnoth</italic> is a turn-based fantasy strategy game somewhat unusual among modern strategy games. While other games strive for complexity, <italic>Battle for Wesnoth</italic> strives for simplicity of both rules and gameplay. This does not make the game simple, however — from these simple rules arises a wealth of strategy, making the game easy to learn but a challenge to master.
 
 The following pages outline all you need to know to play Wesnoth. As you play, new information is added to the various categories as you come across new aspects of the game. For more detailed information on special situations and exceptions, follow the included links."
     [/topic]


### PR DESCRIPTION
#3653 and subsequent related commits prompted a change in translated strings and I found a few more issues. Primarily I want to avoid including mark-up in the translated strings (last commit here), hopefully to reduce the burden on translators if the strings in question haven't already been changed fundamentally. A lot of the strings include mark-up already (part of the problem) but at least we shouldn't be including new mark-up where none existed previously.