### PR TITLE
GUI2 LuaAPI: expand widget attr support

### DIFF
--- a/src/gui/widgets/combobox.hpp
+++ b/src/gui/widgets/combobox.hpp
@@ -45,6 +45,34 @@ public:
 		max_input_length_ = length;
 	}
 
+    std::size_t get_max_input_length() const
+    {
+        return max_input_length_;
+    }
+
+    void set_hint_text(const std::string& text)
+    {
+        hint_text_ = text;
+        update_canvas();
+    }
+
+    std::string get_hint_text() const
+    {
+        return hint_text_;
+    }
+
+    void set_hint_image(const std::string& image)
+    {
+        hint_image_ = image;
+        update_canvas();
+    }
+
+    std::string get_hint_image() const
+    {
+        return hint_image_;
+    }
+
+
 	void set_hint_data(const std::string& text, const std::string& image)
 	{
 		hint_text_ = text;
@@ -56,6 +84,11 @@ public:
 	void clear()
 	{
 		set_value("");
+	}
+
+	int get_item_count() const
+	{
+		return values_.size();
 	}
 
 	void set_values(const std::vector<::config>& values, unsigned selected = 0);

--- a/src/gui/widgets/scroll_label.hpp
+++ b/src/gui/widgets/scroll_label.hpp
@@ -66,6 +66,12 @@ public:
 
 	void set_text_alpha(unsigned short alpha);
 
+    /** See @ref styled_widget::get_link_aware. */
+    virtual bool get_link_aware() const override
+    {
+        return link_aware_;
+    }
+
 	void set_link_aware(bool l);
 
 	void set_text_max_width(int max_width) {

--- a/src/gui/widgets/scroll_text.hpp
+++ b/src/gui/widgets/scroll_text.hpp
@@ -80,7 +80,7 @@ public:
 		editable_ = editable;
 	}
 
-	bool is_editable()
+	bool is_editable() const
 	{
 		return editable_;
 	}

--- a/src/gui/widgets/slider.hpp
+++ b/src/gui/widgets/slider.hpp
@@ -87,6 +87,11 @@ public:
 		queue_redraw(); // TODO: draw_manager - does the above change the size?
 	}
 
+	unsigned get_best_slider_length() const
+	{
+		return best_slider_length_;
+	}
+
 	void set_value_range(int min_value, int max_value);
 
 	void set_minimum_value_label(const t_string& minimum_value_label)
@@ -94,9 +99,19 @@ public:
 		minimum_value_label_ = minimum_value_label;
 	}
 
+	t_string get_minimum_value_label() const
+	{
+		return minimum_value_label_;
+	}
+
 	void set_maximum_value_label(const t_string& maximum_value_label)
 	{
 		maximum_value_label_ = maximum_value_label;
+	}
+
+	t_string get_maximum_value_label() const
+	{
+		return maximum_value_label_;
 	}
 
 	void set_value_labels(const std::vector<t_string>& value_labels);

--- a/src/gui/widgets/text_box.hpp
+++ b/src/gui/widgets/text_box.hpp
@@ -146,6 +146,33 @@ public:
 		max_input_length_ = length;
 	}
 
+	std::size_t get_max_input_length() const
+	{
+		return max_input_length_;
+	}
+
+	void set_hint_text(const std::string& text)
+	{
+		hint_text_ = text;
+		update_canvas();
+	}
+
+	std::string get_hint_text() const
+	{
+		return hint_text_;
+	}
+
+	void set_hint_image(const std::string& image)
+	{
+		hint_image_ = image;
+		update_canvas();
+	}
+
+	std::string get_hint_image() const
+	{
+		return hint_image_;
+	}
+
 	void set_hint_data(const std::string& text, const std::string& image)
 	{
 		hint_text_ = text;

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -196,7 +196,7 @@ public:
 	/**
 	 * Check whether text can be edited or not
 	 */
-	bool is_editable()
+	bool is_editable() const
 	{
 		return editable_;
 	}

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -50,6 +50,11 @@ public:
 
 	using scrollbar_container::finalize_setup;
 
+	const tree_view_node& get_root_node() const
+	{
+		return *root_node_;
+	}
+
 	tree_view_node& get_root_node()
 	{
 		return *root_node_;
@@ -83,6 +88,11 @@ public:
 	void set_indentation_step_size(const unsigned indentation_step_size)
 	{
 		indentation_step_size_ = indentation_step_size;
+	}
+
+	unsigned get_indentation_step_size() const
+	{
+		return indentation_step_size_;
 	}
 
 	tree_view_node* selected_item()

--- a/src/gui/widgets/widget.hpp
+++ b/src/gui/widgets/widget.hpp
@@ -461,6 +461,11 @@ protected:
 public:
 	void set_linked_group(const std::string& linked_group);
 
+	std::string get_linked_group() const
+	{
+		return linked_group_;
+	}
+
 	/*** *** *** *** *** *** *** *** Members. *** *** *** *** *** *** *** ***/
 
 private:

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -55,13 +55,7 @@
 static lg::log_domain log_scripting_lua("scripting/lua");
 #define ERR_LUA LOG_STREAM(err, log_scripting_lua)
 
-#define INVALIDATE_LAYOUT() \
-do { \
-	gui2::window* window = w.get_window(); \
-	if(window) { \
-		window->invalidate_layout(); \
-	} \
-} while(false)
+#define INVALIDATE_LAYOUT() if(auto window = w.get_window()) { window->invalidate_layout(); }
 
 static gui2::widget* find_child_by_index(gui2::widget& w, int i)
 {

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -16,6 +16,7 @@
 #include "gui/auxiliary/iterator/iterator.hpp"
 #include "gui/widgets/clickable_item.hpp"
 #include "gui/widgets/styled_widget.hpp"
+#include "gui/widgets/label.hpp"
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/multi_page.hpp"
 #include "gui/widgets/progress_bar.hpp"
@@ -327,6 +328,11 @@ WIDGET_GETTER("item_count", int, gui2::listbox)
 	return w.get_item_count();
 }
 
+WIDGET_GETTER("use_markup", bool, gui2::styled_widget)
+{
+	return w.get_use_markup();
+}
+
 WIDGET_SETTER("use_markup", bool, gui2::styled_widget)
 {
 	w.set_use_markup(value);
@@ -342,9 +348,29 @@ WIDGET_SETTER("marked_up_text", t_string, gui2::styled_widget)
 	w.set_label(value);
 }
 
+WIDGET_GETTER("enabled", bool, gui2::styled_widget)
+{
+	return w.get_active();
+}
+
 WIDGET_SETTER("enabled", bool, gui2::styled_widget)
 {
 	w.set_active(value);
+}
+
+WIDGET_GETTER("help", t_string, gui2::styled_widget)
+{
+	return w.help_message();
+}
+
+WIDGET_SETTER("help", t_string, gui2::styled_widget)
+{
+	w.set_help_message(value);
+}
+
+WIDGET_GETTER("tooltip", t_string, gui2::styled_widget)
+{
+	return w.tooltip();
 }
 
 WIDGET_SETTER("tooltip", t_string, gui2::styled_widget)
@@ -352,6 +378,15 @@ WIDGET_SETTER("tooltip", t_string, gui2::styled_widget)
 	w.set_tooltip(value);
 }
 
+WIDGET_GETTER("wrap", bool, gui2::label)
+{
+	return w.can_wrap();
+}
+
+WIDGET_SETTER("wrap", bool, gui2::label)
+{
+	w.set_can_wrap(value);
+}
 
 WIDGET_SETTER("callback", lua_index_raw, gui2::widget)
 {
@@ -404,6 +439,11 @@ WIDGET_SETTER("visible", lua_index_raw, gui2::styled_widget)
 			window->invalidate_layout();
 		}
 	}
+}
+
+WIDGET_GETTER("value_compat,label", t_string, gui2::styled_widget)
+{
+	return w.get_label();
 }
 
 //must be last

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -621,21 +621,9 @@ WIDGET_GETTER("link_color", std::string, gui2::label)
 	return w.get_link_color().to_hex_string();
 }
 
-WIDGET_SETTER("link_color", std::string, gui2::label)
-{
-	w.set_link_color(color_t::from_hex_string(value));
-	INVALIDATE_LAYOUT();
-}
-
 WIDGET_GETTER("link_color", std::string, gui2::rich_label)
 {
 	return w.get_link_color().to_hex_string();
-}
-
-WIDGET_SETTER("link_color", std::string, gui2::rich_label)
-{
-	w.set_link_color(color_t::from_hex_string(value));
-	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("max_input_length", int, gui2::combobox)

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -344,6 +344,20 @@ WIDGET_GETTER("path", std::vector<int>, gui2::tree_view_node)
 	return res;
 }
 
+WIDGET_GETTER("unfolded", bool, gui2::tree_view)
+{
+	return !w.get_root_node().is_folded();
+}
+
+WIDGET_SETTER("value_compat,unfolded", bool, gui2::tree_view)
+{
+	if(value) {
+		w.get_root_node().unfold();
+	} else {
+		w.get_root_node().fold();
+	}
+}
+
 WIDGET_GETTER("unfolded", bool, gui2::tree_view_node)
 {
 	return !w.is_folded();

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -55,6 +55,14 @@
 static lg::log_domain log_scripting_lua("scripting/lua");
 #define ERR_LUA LOG_STREAM(err, log_scripting_lua)
 
+#define INVALIDATE_LAYOUT \
+do { \
+	gui2::window* window = w.get_window(); \
+	if(window) { \
+		window->invalidate_layout(); \
+	} \
+} while(false)
+
 static gui2::widget* find_child_by_index(gui2::widget& w, int i)
 {
 	assert(i > 0);
@@ -620,16 +628,6 @@ WIDGET_SETTER("link_color", std::string, gui2::rich_label)
 {
 	w.set_link_color(color_t::from_hex_string(value));
 	INVALIDATE_LAYOUT;
-}
-
-WIDGET_GETTER("linked_group", std::string, gui2::widget)
-{
-	return w.get_linked_group();
-}
-
-WIDGET_SETTER("linked_group", std::string, gui2::widget)
-{
-	w.set_linked_group(value);
 }
 
 WIDGET_GETTER("max_input_length", int, gui2::combobox)

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -55,7 +55,7 @@
 static lg::log_domain log_scripting_lua("scripting/lua");
 #define ERR_LUA LOG_STREAM(err, log_scripting_lua)
 
-#define INVALIDATE_LAYOUT \
+#define INVALIDATE_LAYOUT() \
 do { \
 	gui2::window* window = w.get_window(); \
 	if(window) { \
@@ -296,7 +296,7 @@ WIDGET_GETTER("maximum_value_label", t_string, gui2::slider)
 WIDGET_SETTER("maximum_value_label", t_string, gui2::slider)
 {
 	w.set_maximum_value_label(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("min_value", int, gui2::slider)
@@ -317,7 +317,7 @@ WIDGET_GETTER("minimum_value_label", t_string, gui2::slider)
 WIDGET_SETTER("minimum_value_label", t_string, gui2::slider)
 {
 	w.set_minimum_value_label(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("value_compat,percentage", int, gui2::progress_bar)
@@ -431,7 +431,7 @@ WIDGET_SETTER("characters_per_line", int, gui2::label)
 		throw std::invalid_argument("characters_per_line must be >= 0");
 	}
 	w.set_characters_per_line(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("editable", bool, gui2::text_box)
@@ -444,7 +444,7 @@ WIDGET_SETTER("editable", bool, gui2::text_box)
 	w.set_editable(value);
 }
 
-WIDGET_GETTER("ellipse_mode", std::string, gui2::styled_widget)
+WIDGET_GETTER("ellipsize_mode", std::string, gui2::styled_widget)
 {
 	std::string s;
 
@@ -465,7 +465,7 @@ WIDGET_GETTER("ellipse_mode", std::string, gui2::styled_widget)
 	return s;
 }
 
-WIDGET_SETTER("ellipse_mode", std::string, gui2::styled_widget)
+WIDGET_SETTER("ellipsize_mode", std::string, gui2::styled_widget)
 {
 	if(value == "none") {
 		w.set_text_ellipse_mode(PangoEllipsizeMode::PANGO_ELLIPSIZE_NONE);
@@ -476,9 +476,9 @@ WIDGET_SETTER("ellipse_mode", std::string, gui2::styled_widget)
 	} else if(value == "end") {
 		w.set_text_ellipse_mode(PangoEllipsizeMode::PANGO_ELLIPSIZE_END);
 	} else {
-		throw std::invalid_argument("ellipse_mode must be one of <none,start,middle,end>");
+		throw std::invalid_argument("ellipsize_mode must be one of <none,start,middle,end>");
 	}
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("enabled", bool, gui2::styled_widget)
@@ -509,7 +509,7 @@ WIDGET_GETTER("hint_image", std::string, gui2::combobox)
 WIDGET_SETTER("hint_image", std::string, gui2::combobox)
 {
 	w.set_hint_image(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("hint_text", t_string, gui2::combobox)
@@ -520,7 +520,7 @@ WIDGET_GETTER("hint_text", t_string, gui2::combobox)
 WIDGET_SETTER("hint_text", t_string, gui2::combobox)
 {
 	w.set_hint_text(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("hint_image", std::string, gui2::text_box)
@@ -531,7 +531,7 @@ WIDGET_GETTER("hint_image", std::string, gui2::text_box)
 WIDGET_SETTER("hint_image", std::string, gui2::text_box)
 {
 	w.set_hint_image(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("hint_text", t_string, gui2::text_box)
@@ -542,7 +542,7 @@ WIDGET_GETTER("hint_text", t_string, gui2::text_box)
 WIDGET_SETTER("hint_text", t_string, gui2::text_box)
 {
 	w.set_hint_text(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_SETTER("history", std::string, gui2::text_box)
@@ -561,7 +561,7 @@ WIDGET_SETTER("indentation_step_size", int, gui2::tree_view)
 		throw std::invalid_argument("indentation_step_size must be >= 0");
 	}
 	w.set_indentation_step_size(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("link_aware", bool, gui2::label)
@@ -572,7 +572,7 @@ WIDGET_GETTER("link_aware", bool, gui2::label)
 WIDGET_SETTER("link_aware", bool, gui2::label)
 {
 	w.set_link_aware(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("link_aware", bool, gui2::rich_label)
@@ -583,7 +583,7 @@ WIDGET_GETTER("link_aware", bool, gui2::rich_label)
 WIDGET_SETTER("link_aware", bool, gui2::rich_label)
 {
 	w.set_link_aware(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("link_aware", bool, gui2::scroll_label)
@@ -594,7 +594,7 @@ WIDGET_GETTER("link_aware", bool, gui2::scroll_label)
 WIDGET_SETTER("link_aware", bool, gui2::scroll_label)
 {
 	w.set_link_aware(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("link_aware", bool, gui2::scroll_text)
@@ -605,7 +605,7 @@ WIDGET_GETTER("link_aware", bool, gui2::scroll_text)
 WIDGET_SETTER("link_aware", bool, gui2::scroll_text)
 {
 	w.set_link_aware(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("link_color", std::string, gui2::label)
@@ -616,7 +616,7 @@ WIDGET_GETTER("link_color", std::string, gui2::label)
 WIDGET_SETTER("link_color", std::string, gui2::label)
 {
 	w.set_link_color(color_t::from_hex_string(value));
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("link_color", std::string, gui2::rich_label)
@@ -627,7 +627,7 @@ WIDGET_GETTER("link_color", std::string, gui2::rich_label)
 WIDGET_SETTER("link_color", std::string, gui2::rich_label)
 {
 	w.set_link_color(color_t::from_hex_string(value));
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("max_input_length", int, gui2::combobox)
@@ -641,7 +641,7 @@ WIDGET_SETTER("max_input_length", int, gui2::combobox)
 		throw std::invalid_argument("max_input_length must be >= 0");
 	}
 	w.set_max_input_length(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("max_input_length", int, gui2::text_box)
@@ -655,7 +655,7 @@ WIDGET_SETTER("max_input_length", int, gui2::text_box)
 		throw std::invalid_argument("max_input_length must be >= 0");
 	}
 	w.set_max_input_length(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("step_size", int, gui2::slider)
@@ -712,15 +712,15 @@ WIDGET_SETTER("tooltip", t_string, gui2::styled_widget)
 	w.set_tooltip(value);
 }
 
-WIDGET_GETTER("use_tooltip_on_label_overflow", bool, gui2::styled_widget)
+WIDGET_GETTER("overflow_to_tooltip", bool, gui2::styled_widget)
 {
 	return w.get_use_tooltip_on_label_overflow();
 }
 
-WIDGET_SETTER("use_tooltip_on_label_overflow", bool, gui2::styled_widget)
+WIDGET_SETTER("overflow_to_tooltip", bool, gui2::styled_widget)
 {
 	w.set_use_tooltip_on_label_overflow(value);
-	INVALIDATE_LAYOUT;
+	INVALIDATE_LAYOUT();
 }
 
 WIDGET_GETTER("wrap", bool, gui2::label)

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -16,10 +16,14 @@
 #include "gui/auxiliary/iterator/iterator.hpp"
 #include "gui/widgets/clickable_item.hpp"
 #include "gui/widgets/styled_widget.hpp"
+#include "gui/widgets/combobox.hpp"
 #include "gui/widgets/label.hpp"
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/multi_page.hpp"
 #include "gui/widgets/progress_bar.hpp"
+#include "gui/widgets/rich_label.hpp"
+#include "gui/widgets/scroll_label.hpp"
+#include "gui/widgets/scroll_text.hpp"
 #include "gui/widgets/selectable_item.hpp"
 #include "gui/widgets/slider.hpp"
 #include "gui/widgets/stacked_widget.hpp"
@@ -47,7 +51,6 @@
 #include <map>
 #include <utility>
 #include <vector>
-
 
 static lg::log_domain log_scripting_lua("scripting/lua");
 #define ERR_LUA LOG_STREAM(err, log_scripting_lua)
@@ -254,6 +257,19 @@ WIDGET_SETTER("value_compat,value", int, gui2::slider)
 	w.set_value(value);
 }
 
+WIDGET_GETTER("best_slider_length", int, gui2::slider)
+{
+	return w.get_best_slider_length();
+}
+
+WIDGET_SETTER("best_slider_length", int, gui2::slider)
+{
+	if(value < 0) {
+		throw std::invalid_argument("best_slider_length must be >= 0");
+	}
+	w.set_best_slider_length(value);
+}
+
 WIDGET_GETTER("max_value", int, gui2::slider)
 {
 	return w.get_maximum_value();
@@ -264,6 +280,17 @@ WIDGET_SETTER("max_value", int, gui2::slider)
 	w.set_value_range(w.get_minimum_value(), value);
 }
 
+WIDGET_GETTER("maximum_value_label", t_string, gui2::slider)
+{
+	return w.get_maximum_value_label();
+}
+
+WIDGET_SETTER("maximum_value_label", t_string, gui2::slider)
+{
+	w.set_maximum_value_label(value);
+	INVALIDATE_LAYOUT;
+}
+
 WIDGET_GETTER("min_value", int, gui2::slider)
 {
 	return w.get_minimum_value();
@@ -272,6 +299,17 @@ WIDGET_GETTER("min_value", int, gui2::slider)
 WIDGET_SETTER("min_value", int, gui2::slider)
 {
 	w.set_value_range(value, w.get_maximum_value());
+}
+
+WIDGET_GETTER("minimum_value_label", t_string, gui2::slider)
+{
+	return w.get_minimum_value_label();
+}
+
+WIDGET_SETTER("minimum_value_label", t_string, gui2::slider)
+{
+	w.set_minimum_value_label(value);
+	INVALIDATE_LAYOUT;
 }
 
 WIDGET_GETTER("value_compat,percentage", int, gui2::progress_bar)
@@ -298,6 +336,11 @@ WIDGET_GETTER("path", std::vector<int>, gui2::tree_view_node)
 	return res;
 }
 
+WIDGET_GETTER("unfolded", bool, gui2::tree_view_node)
+{
+	return !w.is_folded();
+}
+
 WIDGET_SETTER("value_compat,unfolded", bool, gui2::tree_view_node)
 {
 	if(value) {
@@ -318,14 +361,35 @@ WIDGET_SETTER("value_compat,unit", lua_index_raw, gui2::unit_preview_pane)
 	}
 }
 
-WIDGET_GETTER("item_count", int, gui2::multi_page)
+WIDGET_GETTER("item_count", int, gui2::combobox)
 {
-	return w.get_page_count();
+	return w.get_item_count();
 }
 
 WIDGET_GETTER("item_count", int, gui2::listbox)
 {
 	return w.get_item_count();
+}
+
+WIDGET_GETTER("item_count", int, gui2::multi_page)
+{
+	return w.get_page_count();
+}
+
+WIDGET_GETTER("item_count", int, gui2::stacked_widget)
+{
+	return w.get_layer_count();
+}
+
+WIDGET_GETTER("item_count", int, gui2::tree_view)
+{
+	const gui2::tree_view_node& tvn = w.get_root_node();
+	return tvn.count_children();
+}
+
+WIDGET_GETTER("item_count", int, gui2::tree_view_node)
+{
+	return w.count_children();
 }
 
 WIDGET_GETTER("use_markup", bool, gui2::styled_widget)
@@ -348,6 +412,67 @@ WIDGET_SETTER("marked_up_text", t_string, gui2::styled_widget)
 	w.set_label(value);
 }
 
+WIDGET_GETTER("characters_per_line", int, gui2::label)
+{
+	return w.get_characters_per_line();
+}
+
+WIDGET_SETTER("characters_per_line", int, gui2::label)
+{
+	if(value < 0) {
+		throw std::invalid_argument("characters_per_line must be >= 0");
+	}
+	w.set_characters_per_line(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("editable", bool, gui2::text_box)
+{
+	return w.is_editable();
+}
+
+WIDGET_SETTER("editable", bool, gui2::text_box)
+{
+	w.set_editable(value);
+}
+
+WIDGET_GETTER("ellipse_mode", std::string, gui2::styled_widget)
+{
+	std::string s;
+
+	switch(w.get_text_ellipse_mode()) {
+		case(PangoEllipsizeMode::PANGO_ELLIPSIZE_NONE):
+			s = "none";
+			break;
+		case(PangoEllipsizeMode::PANGO_ELLIPSIZE_START):
+			s = "start";
+			break;
+		case(PangoEllipsizeMode::PANGO_ELLIPSIZE_MIDDLE):
+			s = "middle";
+			break;
+		case(PangoEllipsizeMode::PANGO_ELLIPSIZE_END):
+			s = "end";
+	}
+
+	return s;
+}
+
+WIDGET_SETTER("ellipse_mode", std::string, gui2::styled_widget)
+{
+	if(value == "none") {
+		w.set_text_ellipse_mode(PangoEllipsizeMode::PANGO_ELLIPSIZE_NONE);
+	} else if(value == "start") {
+		w.set_text_ellipse_mode(PangoEllipsizeMode::PANGO_ELLIPSIZE_START);
+	} else if(value == "middle") {
+		w.set_text_ellipse_mode(PangoEllipsizeMode::PANGO_ELLIPSIZE_MIDDLE);
+	} else if(value == "end") {
+		w.set_text_ellipse_mode(PangoEllipsizeMode::PANGO_ELLIPSIZE_END);
+	} else {
+		throw std::invalid_argument("ellipse_mode must be one of <none,start,middle,end>");
+	}
+	INVALIDATE_LAYOUT;
+}
+
 WIDGET_GETTER("enabled", bool, gui2::styled_widget)
 {
 	return w.get_active();
@@ -368,6 +493,217 @@ WIDGET_SETTER("help", t_string, gui2::styled_widget)
 	w.set_help_message(value);
 }
 
+WIDGET_GETTER("hint_image", std::string, gui2::combobox)
+{
+	return w.get_hint_image();
+}
+
+WIDGET_SETTER("hint_image", std::string, gui2::combobox)
+{
+	w.set_hint_image(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("hint_text", t_string, gui2::combobox)
+{
+	return w.get_hint_text();
+}
+
+WIDGET_SETTER("hint_text", t_string, gui2::combobox)
+{
+	w.set_hint_text(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("hint_image", std::string, gui2::text_box)
+{
+	return w.get_hint_image();
+}
+
+WIDGET_SETTER("hint_image", std::string, gui2::text_box)
+{
+	w.set_hint_image(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("hint_text", t_string, gui2::text_box)
+{
+	return w.get_hint_text();
+}
+
+WIDGET_SETTER("hint_text", t_string, gui2::text_box)
+{
+	w.set_hint_text(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_SETTER("history", std::string, gui2::text_box)
+{
+	w.set_history(value);
+}
+
+WIDGET_GETTER("indentation_step_size", int, gui2::tree_view)
+{
+	return w.get_indentation_step_size();
+}
+
+WIDGET_SETTER("indentation_step_size", int, gui2::tree_view)
+{
+	if(value < 0) {
+		throw std::invalid_argument("indentation_step_size must be >= 0");
+	}
+	w.set_indentation_step_size(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("link_aware", bool, gui2::label)
+{
+	return w.get_link_aware();
+}
+
+WIDGET_SETTER("link_aware", bool, gui2::label)
+{
+	w.set_link_aware(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("link_aware", bool, gui2::rich_label)
+{
+	return w.get_link_aware();
+}
+
+WIDGET_SETTER("link_aware", bool, gui2::rich_label)
+{
+	w.set_link_aware(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("link_aware", bool, gui2::scroll_label)
+{
+	return w.get_link_aware();
+}
+
+WIDGET_SETTER("link_aware", bool, gui2::scroll_label)
+{
+	w.set_link_aware(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("link_aware", bool, gui2::scroll_text)
+{
+	return w.get_link_aware();
+}
+
+WIDGET_SETTER("link_aware", bool, gui2::scroll_text)
+{
+	w.set_link_aware(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("link_color", std::string, gui2::label)
+{
+	return w.get_link_color().to_hex_string();
+}
+
+WIDGET_SETTER("link_color", std::string, gui2::label)
+{
+	w.set_link_color(color_t::from_hex_string(value));
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("link_color", std::string, gui2::rich_label)
+{
+	return w.get_link_color().to_hex_string();
+}
+
+WIDGET_SETTER("link_color", std::string, gui2::rich_label)
+{
+	w.set_link_color(color_t::from_hex_string(value));
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("linked_group", std::string, gui2::widget)
+{
+	return w.get_linked_group();
+}
+
+WIDGET_SETTER("linked_group", std::string, gui2::widget)
+{
+	w.set_linked_group(value);
+}
+
+WIDGET_GETTER("max_input_length", int, gui2::combobox)
+{
+	return w.get_max_input_length();
+}
+
+WIDGET_SETTER("max_input_length", int, gui2::combobox)
+{
+	if(value < 0) {
+		throw std::invalid_argument("max_input_length must be >= 0");
+	}
+	w.set_max_input_length(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("max_input_length", int, gui2::text_box)
+{
+	return w.get_max_input_length();
+}
+
+WIDGET_SETTER("max_input_length", int, gui2::text_box)
+{
+	if(value < 0) {
+		throw std::invalid_argument("max_input_length must be >= 0");
+	}
+	w.set_max_input_length(value);
+	INVALIDATE_LAYOUT;
+}
+
+WIDGET_GETTER("step_size", int, gui2::slider)
+{
+	return w.get_step_size();
+}
+
+WIDGET_SETTER("step_size", int, gui2::slider)
+{
+	if(value < 0) {
+		throw std::invalid_argument("step_size must be >= 0");
+	}
+	w.set_step_size(value);
+}
+
+WIDGET_GETTER("text_alignment", std::string, gui2::styled_widget)
+{
+	std::string s;
+
+	switch(w.get_text_alignment()) {
+		case(PangoAlignment::PANGO_ALIGN_LEFT):
+			s = "left";
+			break;
+		case(PangoAlignment::PANGO_ALIGN_RIGHT):
+			s = "right";
+			break;
+		case(PangoAlignment::PANGO_ALIGN_CENTER):
+			s = "center";
+	}
+
+	return s;
+}
+
+WIDGET_SETTER("text_alignment", std::string, gui2::styled_widget)
+{
+	if(value == "left") {
+		w.set_text_alignment(PangoAlignment::PANGO_ALIGN_LEFT);
+	} else if(value == "right") {
+		w.set_text_alignment(PangoAlignment::PANGO_ALIGN_RIGHT);
+	} else if(value == "center") {
+		w.set_text_alignment(PangoAlignment::PANGO_ALIGN_CENTER);
+	} else {
+		throw std::invalid_argument("text_alignment must be one of <left,center,right>");
+	}
+}
+
 WIDGET_GETTER("tooltip", t_string, gui2::styled_widget)
 {
 	return w.tooltip();
@@ -378,12 +714,33 @@ WIDGET_SETTER("tooltip", t_string, gui2::styled_widget)
 	w.set_tooltip(value);
 }
 
+WIDGET_GETTER("use_tooltip_on_label_overflow", bool, gui2::styled_widget)
+{
+	return w.get_use_tooltip_on_label_overflow();
+}
+
+WIDGET_SETTER("use_tooltip_on_label_overflow", bool, gui2::styled_widget)
+{
+	w.set_use_tooltip_on_label_overflow(value);
+	INVALIDATE_LAYOUT;
+}
+
 WIDGET_GETTER("wrap", bool, gui2::label)
 {
 	return w.can_wrap();
 }
 
 WIDGET_SETTER("wrap", bool, gui2::label)
+{
+	w.set_can_wrap(value);
+}
+
+WIDGET_GETTER("wrap", bool, gui2::rich_label)
+{
+	return w.can_wrap();
+}
+
+WIDGET_SETTER("wrap", bool, gui2::rich_label)
 {
 	w.set_can_wrap(value);
 }
@@ -397,6 +754,24 @@ WIDGET_SETTER("callback", lua_index_raw, gui2::widget)
 	lua_pushvalue(L, value.index);
 	lua_call(L, 2, 0);
 }
+
+WIDGET_GETTER("visible", std::string, gui2::styled_widget)
+{
+	std::string s;
+	switch(w.get_visible()) {
+		case gui2::styled_widget::visibility::visible:
+			s = "visible";
+			break;
+		case gui2::styled_widget::visibility::hidden:
+			s = "hidden";
+			break;
+		case gui2::styled_widget::visibility::invisible:
+			s = "invisible";
+	}
+
+	return s;
+}
+
 
 WIDGET_SETTER("visible", lua_index_raw, gui2::styled_widget)
 {

--- a/src/scripting/lua_widget_attributes.hpp
+++ b/src/scripting/lua_widget_attributes.hpp
@@ -22,4 +22,14 @@ int impl_widget_get(lua_State* L);
 int impl_widget_set(lua_State* L);
 int impl_widget_dir(lua_State* L);
 
-} // end namespace lua_gui2
+} // end namespace lua_widget
+
+#define INVALIDATE_LAYOUT \
+do { \
+    gui2::window* window = w.get_window(); \
+    if(window) { \
+        window->invalidate_layout(); \
+    } \
+} while(false)
+
+

--- a/src/scripting/lua_widget_attributes.hpp
+++ b/src/scripting/lua_widget_attributes.hpp
@@ -24,12 +24,3 @@ int impl_widget_dir(lua_State* L);
 
 } // end namespace lua_widget
 
-#define INVALIDATE_LAYOUT \
-do { \
-    gui2::window* window = w.get_window(); \
-    if(window) { \
-        window->invalidate_layout(); \
-    } \
-} while(false)
-
-

--- a/utils/emmylua/README.md
+++ b/utils/emmylua/README.md
@@ -1,5 +1,5 @@
 
-These files can be used to allow Lua linting tools to understand Wesnoth types and functions that are defined in C++. Documentation of the annotations format can be found [here](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations).
+These files can be used to allow Lua linting tools to understand Wesnoth types and functions that are defined in C++. Documentation of the annotations format can be found [here](https://luals.github.io/wiki/annotations/).
 
 
 To enable in Visual Studio Code, install [this Lua plugin](https://marketplace.visualstudio.com/items?itemName=sumneko.lua) and add the following settings to your settings.json:

--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -153,7 +153,7 @@ function gui.add_widget_definition(type, id, content) end
 ---@field on_modified fun()
 
 ---A button that produces a dropdown menu when clicked in addition to supporting text input
----@class menu_button : combobox
+---@class combobox : widget
 ---@field hint_image string
 ---@field hint_text tstring
 ---@field item_count integer
@@ -198,12 +198,12 @@ function gui.add_widget_definition(type, id, content) end
 ---@class treeview : widget
 ---@field selected_item_path integer[]
 ---@field item_count integer
+---@field unfolded boolean
 ---@field on_modified fun()
 
 ---A single node in a tree view
 ---@class tree_view_node : widget
 ---@field path integer[]
----@field item_count integer
 ---@field item_count integer
 ---@field unfolded boolean
 

--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -101,9 +101,13 @@ function gui.add_widget_definition(type, id, content) end
 ---A reference to a widget in a custom dialog box
 ---@class widget : gui.widget
 ---@field enabled boolean
+---@field help tstring
 ---@field tooltip tstring
 ---@field visible boolean|"'visible'"|"'hidden'"|"'invisible'"
 ---@field type string
+---@field text_alignment "'left'"|"'right'"|"'center'"
+---@field ellipsize_mode "'none'"|"'start'"|"'middle'"|"'end'"
+---@field overflow_to_tooltip boolean
 ---@field on_left_click fun()
 
 ---The window widget is a container that contains all other widgets in the dialog
@@ -141,22 +145,49 @@ function gui.add_widget_definition(type, id, content) end
 ---A container widget whose children all occupy the same space, overlayed on top of each other
 ---@class stacked_widget : widget
 ---@field selected_index integer
+---@field item_count integer
 
 ---A button that produces a dropdown menu when clicked
 ---@class menu_button : widget
 ---@field selected_index integer
 ---@field on_modified fun()
 
+---A button that produces a dropdown menu when clicked in addition to supporting text input
+---@class menu_button : combobox
+---@field hint_image string
+---@field hint_text tstring
+---@field item_count integer
+---@field max_input_length integer
+---@field selected_index integer
+---@field on_modified fun()
+
 ---An editable text box
 ---@class text_box : widget
 ---@field text string
+---@field editable boolean
+---@field hint_image string
+---@field hint_text tstring
+---@field history string
+---@field max_input_length integer
 ---@field on_modified fun()
+
+---A label that wraps its text and also has a vertical scrollbar
+---@class scroll_label : widget
+---@field link_aware boolean
+
+---A multiline text area that shows a scrollbar if the text gets too long
+---@class scroll_text : widget
+---@field link_aware boolean
 
 ---A slider
 ---@class slider : widget
 ---@field value integer
 ---@field min_value integer
 ---@field max_value integer
+---@field best_slider_length integer
+---@field maximum_value_label tstring
+---@field minimum_value_label tstring
+---@field step_size integer
 ---@field on_modified fun()
 
 ---A progress bar
@@ -166,11 +197,14 @@ function gui.add_widget_definition(type, id, content) end
 ---A dynamic, hierarchical list of items, shown with a scrollbar
 ---@class treeview : widget
 ---@field selected_item_path integer[]
+---@field item_count integer
 ---@field on_modified fun()
 
 ---A single node in a tree view
 ---@class tree_view_node : widget
 ---@field path integer[]
+---@field item_count integer
+---@field item_count integer
 ---@field unfolded boolean
 
 ---A panel that shows details on a given unit or unit type
@@ -183,6 +217,16 @@ function gui.add_widget_definition(type, id, content) end
 
 ---A static text label
 ---@class label : simple_widget
+---@field characters_per_line integer
+---@field link_aware boolean
+---@field link_color string
+---@field wrap boolean
+
+---A label that shows formatted text marked up with Help markup
+---@class rich_label : simple_widget
+---@field link_color string
+---@field wrap boolean
+
 ---A simple image
 ---@class image : simple_widget
 ---A simple button that triggers repeatedly if the mouse is held down


### PR DESCRIPTION
Obviously, the Lua API is missing a lot of stuff, for example you can set a styled_widget enabled (active), but you can't check whether it is enabled.  Some of these are pretty obvious, others I'm not sure what, if anything, to do with.

The attached spreadsheet contains a bunch of "attributes" I've found, whether because they can be set in WML, or just have a public member function, or whatever.  It's a complete mess atm, but it seems like it would be useful to have the data in one place.

No real reason to push at this point, except that I know I'm going to have a lot of questions.  For example...

**visible**
- current can be set (not get) for styled_widget, though the function is a member of widget
- Currently, from lua you can set via string (visible,invisible,hidden) or bool (true=visible,false=invisible), but if I add get the only thing that seems to make sense is to return a string.  This is kind of weird, if you foo.visible=true and the print foo.visible you get back "visible" not true.  Not really a problem IMO, but a little odd.

**text_maximum_width**
- I don't know what this is or when I'd actually use it, so I probably won't touch it, but I noticed that set_text_maximum_width is public, while get_text_maximum_width is protected (another reason to leave it alone?).

**wrap**
- usually seems to be referred to as "can_wrap", but "wrap" is what's used in WML
- in cpp, you can get_can_wrap on any widget, but only set_can_wrap on label/rich_label/scroll_label/scroll_text.  I'm not sure how get wrap should work in lua, but I'm leaning toward only being able to get on widgets you can set, it seems like maybe less confusing that way?


[attrs.ods](https://github.com/user-attachments/files/17611403/attrs.ods)

