### PR TITLE
Fix assertion error on [allow_undo] misuse

### DIFF
--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -406,6 +406,10 @@ void undo_list::redo()
 	redos_list temp;
 	temp.swap(redos_);
 	synced_context::run(commandname, data, /*use_undo*/ true, /*show*/ true, error_handler);
+	if(!resources::recorder->at_end()) {
+		error_handler(_"Unhandled choices while redoing");
+		resources::recorder->set_to_end();
+	}
 	temp.swap(redos_);
 
 	// Screen updates.


### PR DESCRIPTION
Previously it could happen that the replay recorder was not at end after redoing if redo() pushed additional user choices to the recorderwhihc were not used by the actual code (this can happen if the game is out of sync)