### PR TITLE
Demote Dawarf to level 0

### DIFF
--- a/changelog_entries/dawarf-level.md
+++ b/changelog_entries/dawarf-level.md
@@ -1,0 +1,2 @@
+### Units
+   * Dawarf - Decreased Cost from 17 to 12, Decreased Level from 1 to 0, and Decreased XP from 50 to 25

--- a/data/campaigns/Under_the_Burning_Suns/units/monsters/Darawf.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/monsters/Darawf.cfg
@@ -8,12 +8,12 @@
     hitpoints=22
     movement_type=dwarvishfoot
     movement=4
-    experience=50
+    experience=25
     {AMLA_DEFAULT}
     advances_to=null
-    level=1
+    level=0
     alignment=neutral
-    cost=17
+    cost=12
     usage=fighter
     # wmllint: local spelling Dawarf
     description= _ "Don’t ask where the Dawarf came from. You really don’t want to know. It is a secret well guarded by the great lore-masters of Wesnoth. And it isn’t pretty. Hint: it involves lots of sherbet."


### PR DESCRIPTION
This unit far too weak for a level 1, with only 22HP, relatively terrain defenses and resistances and a only 6x2 meele attack. I know it's only a joke unit, but I'd still like it if the stats made sense.

I propose the following changes:

-Decrease level from 1 to 0.
-Decrease XP from 50 to 25 so it makes more sense with the new level.
-Reduce gold from 17 to 12 like in Venomous Sands. They aren't recruited in-game, but I think it's still good to have a cost that is sensible for its level.