### PR TITLE
Make sure Elvish Race Description doesn't contradict WoF

### DIFF
--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -122,7 +122,7 @@ Dwarves are of small stature by human measure, but they are by no means fragile.
 
 Most elves share an intense affection for unspoiled nature and find themselves uncomfortable in open, unvegetated places. They live primarily in the forests of the Great Continent, the Aethenwood in the southwest, Wesmere in the northwest, and the great northern woods of which the Lintanir Forest is the southernmost edge.
 
-Elves are the eldest race of the continent, with the possible exception of trolls. Many of their settlements cannot be reliably dated, undoubtedly having existed for several millennia.
+Elves are among the eldest races of the continent. Many of their settlements cannot be reliably dated, undoubtedly having existed for several millennia.
 
 <header>text='Magic'</header>
 While elves are fundamentally different creatures than the fabled fair folk, their magic has some connection to the faerie and is the source of their unusually keen senses as well as their long lives. Elven magic is split between two different paths, one focused on manipulation of the mundane or natural world, and one focused on divination into the arcane plane. More common is the the way of corporeal alteration, which has more tangible effects than its antithesis in the arcane. Though elven nature magic is ill-suited toward combat, its potent ability to harness earthly energies to nurture and protect is the primary reason for the effectiveness of elven healing as well as the beauty and vitality of their forests.


### PR DESCRIPTION
https://github.com/wesnoth/wesnoth/blob/master/data/campaigns/Winds_of_Fate/story/Past_and_Future_Drake_History_(Spoilers).txt

This contradicts the unused drake history file in WoF, which shows the elves appeared after many other races, like drakes, trolls and many others.

CC: @Dalas121