### PR TITLE
Nerf of Orcish Crossbowman

### DIFF
--- a/changelog_entries/orcish_xbowman_nerf.md
+++ b/changelog_entries/orcish_xbowman_nerf.md
@@ -1,0 +1,2 @@
+### Units
+   * Orcish Crossbowman: melee 6-3 -> 4-3, experience to level 43 -> 57

--- a/data/core/units/orcs/Crossbowman.cfg
+++ b/data/core/units/orcs/Crossbowman.cfg
@@ -8,11 +8,11 @@
     hitpoints=46
     movement_type=orcishfoot
     movement=5
-    experience=43
+    experience=57
     level=2
     alignment=chaotic
     advances_to=Orcish Slurbow
-    cost=22
+    cost=21
     usage=archer
     description= _ "Despite the heavy importance placed on combat prowess by most orcs, very few tribes have any semblance of formal training in any of the warring arts. Because of this, orcish bowmen are rather ineffective at wielding longbows pilfered from human or elven archers, instead preferring to arm themselves with more easily handled crossbows. Simplistic but potent, these weapons can still be deadly even when handled roughly by inexperienced warriors."
     die_sound={SOUND_LIST:ORC_DIE}
@@ -33,7 +33,7 @@
         icon=attacks/sword-orcish.png
         type=blade
         range=melee
-        damage=6
+        damage=4
         number=3
     [/attack]
     [attack]

--- a/data/core/units/orcs/Crossbowman.cfg
+++ b/data/core/units/orcs/Crossbowman.cfg
@@ -12,7 +12,7 @@
     level=2
     alignment=chaotic
     advances_to=Orcish Slurbow
-    cost=21
+    cost=22
     usage=archer
     description= _ "Despite the heavy importance placed on combat prowess by most orcs, very few tribes have any semblance of formal training in any of the warring arts. Because of this, orcish bowmen are rather ineffective at wielding longbows pilfered from human or elven archers, instead preferring to arm themselves with more easily handled crossbows. Simplistic but potent, these weapons can still be deadly even when handled roughly by inexperienced warriors."
     die_sound={SOUND_LIST:ORC_DIE}


### PR DESCRIPTION
The changes of Orcish Crossbowman made in 1.18 increased the power of this unit disproportionately. When advancing lvl 1 Orcish Archer, his melee damage rises extremely fast (3 times, from 3-2 of Orcish Archer to 6-3 of Orcish Crossbowman, which is unprecedented).

Also, the new xp requirement for advancing to level 3 is 43 (compared to 80 in 1.16), which is very close to lvl1-to-lvl-2 values. It becomes near-advancement after just several kills, which makes fighting him extremely troublesome.

My proposal is to set leveling XP to 57 (-10 xp compared to Orcish Warrior's 67 xp, like Orcish Archer-Orcish Grunt xp reqs) and to return 4-3 melee attack as it was in 1.16. I keep 1.18's increased hp (46 compared to 1.16's 43) and increased ranged pierce attack (9-3 vs 1.16's 8-3) because I believe those two were enough to make Orcish Crossbowman stronger without breaking things.

Regarding gold cost: in 1.16 he cost 21 gold, and after 1.18's buffs his price became 22 gold. I find just +1 gold completely unreasonable and weird for such substantial buffs. But after my nerf I think 22 gold becomes a reasonable price, so I let it stay unchanged.