### PR TITLE
Tweak Elvish Marshal Stats

### DIFF
--- a/changelog_entries/tweak_elvish_marshal.md
+++ b/changelog_entries/tweak_elvish_marshal.md
@@ -1,2 +1,2 @@
 ### Units 
-* Elvish Marshal: HP 68 -> 62, MP 5 -> 6
+* Elvish Marshal: HP 68 -> 60, MP 5 -> 6

--- a/changelog_entries/tweak_elvish_marshal.md
+++ b/changelog_entries/tweak_elvish_marshal.md
@@ -1,0 +1,2 @@
+### Units 
+* Elvish Marshal: HP 68 -> 62, MP 5 -> 6

--- a/data/core/units/elves/Marshal.cfg
+++ b/data/core/units/elves/Marshal.cfg
@@ -12,9 +12,9 @@
             image="units/elves-wood/marshal-leading.png:300"
         [/frame]
     [/leading_anim]
-    hitpoints=68
+    hitpoints=62
     movement_type=woodland
-    movement=5
+    movement=6
     {LESS_NIMBLE_ELF}
     experience=150
     level=3

--- a/data/core/units/elves/Marshal.cfg
+++ b/data/core/units/elves/Marshal.cfg
@@ -12,7 +12,7 @@
             image="units/elves-wood/marshal-leading.png:300"
         [/frame]
     [/leading_anim]
-    hitpoints=62
+    hitpoints=60
     movement_type=woodland
     movement=6
     {LESS_NIMBLE_ELF}


### PR DESCRIPTION
Since the 1.18 elf enhancements were deemed excessive and received a rollback of one sort or another, there is no reason to leave Marshal in an over-enhanced form. 

However, a full rollback to 1.16 was found to be controversial. I propose a different solution: 

```
HP: 68 -> 62 
MP: 5 -> 6 
```

This way, Marshal will lose some combat power, but will become stronger as a leader. This will emphasize his differences from the Champion and equalize both options in terms of strength. 