### PR TITLE
Events stuff

### DIFF
--- a/src/countdown_clock.cpp
+++ b/src/countdown_clock.cpp
@@ -17,11 +17,11 @@
 #include "team.hpp"
 #include "preferences/preferences.hpp"
 #include "sound.hpp"
+#include "utils/rate_counter.hpp"
 
 namespace {
 	const int WARNTIME = 20000; //start beeping when 20 seconds are left (20,000ms)
-	unsigned timer_refresh = 0;
-	const unsigned timer_refresh_rate = 50; // prevents calling SDL_GetTicks() too frequently
+	utils::rate_counter timer_refresh_rate{50}; // prevents calling SDL_GetTicks() too frequently
 }
 
 
@@ -57,7 +57,7 @@ void countdown_clock::update_team(int new_timestamp)
 //make sure we think about countdown even while dialogs are open
 void countdown_clock::process(events::pump_info &info)
 {
-	if(info.ticks(&timer_refresh, timer_refresh_rate)) {
+	if(timer_refresh_rate.poll()) {
 		update(info.ticks());
 	}
 }

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -778,9 +778,9 @@ void process_tooltip_strings(int mousex, int mousey)
 	}
 }
 
-int pump_info::ticks(unsigned* refresh_counter, unsigned refresh_rate)
+int pump_info::ticks()
 {
-	if(!ticks_ && !(refresh_counter && ++*refresh_counter % refresh_rate)) {
+	if(!ticks_) {
 		ticks_ = ::SDL_GetTicks();
 	}
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -618,8 +618,6 @@ void pump()
 			case SDL_WINDOWEVENT_RESIZED:
 				LOG_DP << "events/RESIZED "
 					<< event.window.data1 << 'x' << event.window.data2;
-				info.resize_dimensions.first = event.window.data1;
-				info.resize_dimensions.second = event.window.data2;
 				prefs::get().set_resolution(video::window_size());
 				break;
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -485,10 +485,6 @@ void pump()
 
 	pump_info info;
 
-	// Used to keep track of double click events
-	static int last_mouse_down = -1;
-	static int last_click_x = -1, last_click_y = -1;
-
 	SDL_Event temp_event;
 	int poll_count = 0;
 	int begin_ignoring = 0;
@@ -658,24 +654,10 @@ void pump()
 			// Always make sure a cursor is displayed if the mouse moves or if the user clicks
 			cursor::set_focus(true);
 			if(event.button.button == SDL_BUTTON_LEFT || event.button.which == SDL_TOUCH_MOUSEID) {
-				static const int DoubleClickTime = 500;
-#ifdef __IPHONEOS__
-				static const int DoubleClickMaxMove = 15;
-#else
-				static const int DoubleClickMaxMove = 3;
-#endif
-
-				if(last_mouse_down >= 0 && info.ticks() - last_mouse_down < DoubleClickTime
-						&& std::abs(event.button.x - last_click_x) < DoubleClickMaxMove
-						&& std::abs(event.button.y - last_click_y) < DoubleClickMaxMove
-				) {
+				if(event.button.clicks == 2) {
 					sdl::UserEvent user_event(DOUBLE_CLICK_EVENT, event.button.which, event.button.x, event.button.y);
 					::SDL_PushEvent(reinterpret_cast<SDL_Event*>(&user_event));
 				}
-
-				last_mouse_down = info.ticks();
-				last_click_x = event.button.x;
-				last_click_y = event.button.y;
 			}
 			break;
 		}

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -151,8 +151,7 @@ inline void pump_and_draw() { pump(); draw(); }
 // TODO: draw_manager - should this also raise_process_event? Some things do some don't
 
 struct pump_info {
-	pump_info() : resize_dimensions(), ticks_(0) {}
-	std::pair<int,int> resize_dimensions;
+	pump_info() : ticks_(0) {}
 	int ticks();
 private:
 	int ticks_; //0 if not calculated

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -153,7 +153,7 @@ inline void pump_and_draw() { pump(); draw(); }
 struct pump_info {
 	pump_info() : resize_dimensions(), ticks_(0) {}
 	std::pair<int,int> resize_dimensions;
-	int ticks(unsigned *refresh_counter=nullptr, unsigned refresh_rate=1);
+	int ticks();
 private:
 	int ticks_; //0 if not calculated
 };

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -20,6 +20,7 @@
 #include "random.hpp"
 #include "serialization/string_utils.hpp"
 #include "sound_music_track.hpp"
+#include "utils/rate_counter.hpp"
 
 #include <SDL2/SDL.h> // Travis doesn't like this, although it works on my machine -> '#include <SDL2/SDL_sound.h>
 #include <SDL2/SDL_mixer.h>
@@ -50,8 +51,7 @@ namespace
 {
 bool mix_ok = false;
 int music_start_time = 0;
-unsigned music_refresh = 0;
-unsigned music_refresh_rate = 20;
+utils::rate_counter music_refresh_rate{20};
 bool want_new_music = false;
 int fadingout_time = 5000;
 bool no_fading = false;
@@ -790,8 +790,8 @@ void music_thinker::process(events::pump_info& info)
 			fadingout_time = 0;
 		}
 
-		if(music_start_time && info.ticks(&music_refresh, music_refresh_rate) >= music_start_time - fadingout_time) {
-			want_new_music = true;
+		if(music_start_time && music_refresh_rate.poll()) {
+			want_new_music = info.ticks() >= music_start_time - fadingout_time;
 		}
 
 		if(want_new_music) {

--- a/src/utils/rate_counter.hpp
+++ b/src/utils/rate_counter.hpp
@@ -1,0 +1,32 @@
+/*
+	Copyright (C) 2003 - 2024
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+namespace utils
+{
+class rate_counter
+{
+public:
+	explicit rate_counter(unsigned rate) : rate_(rate) {}
+
+	/** Increments the counter by one and checks whether it is now a multiple of the chosen rate. */
+	bool poll() { return (++counter_ % rate_) == 0; }
+
+private:
+	unsigned counter_ = 0;
+	unsigned rate_ = 1;
+};
+
+} // end namespace utils


### PR DESCRIPTION
Probably going to add more to this. Main functional change is using native SDL handling for double clicks, which means the click radius has bumped to 32px. Double click time remains unchanged (500ms), though I think SDL queries it from the OS on Windows (https://github.com/libsdl-org/SDL/blob/SDL2/src/events/SDL_mouse.c#L49-L75). Shouldn't be an issue though.