### PR TITLE
unsuccessful whisper no feedback fix

### DIFF
--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -451,7 +451,7 @@ lobby_chat_window* chatbox::find_or_create_window(const std::string& name,
 void chatbox::close_window_button_callback(std::string room_name, bool& handled, bool& halt)
 {
 	const int index = std::distance(open_windows_.begin(), std::find_if(open_windows_.begin(), open_windows_.end(),
-		[&room_name](const lobby_chat_window& room) { return room.name == room_name; }
+		[&room_name](const lobby_chat_window& room) { return room.name == room_name && room.whisper; }
 	));
 
 	close_window(index);
@@ -595,26 +595,10 @@ void chatbox::process_message(const ::config& data, bool whisper /*= false*/)
 
 		if (!prefs::get().parse_should_show_lobby_join(sender, message)) return;
 
-		std::string room = data["room"];
+		std::string room = "lobby";
 
-		// Attempt to send to the currently active room first.
-		if(room.empty()) {
-			LOG_LB << "Message without a room from " << sender << ", falling back to active window";
-			const lobby_chat_window& active_window = open_windows_[active_window_];
-
-			if(!active_window.whisper) {
-				room = active_window.name;
-			}
-		}
-
-		// If we still don't have a name, fall back to lobby.
-		if(room.empty()) {
-			LOG_LB << "Message without a room from " << sender << ", assuming lobby";
-			room = "lobby";
-
-			if(!room_window_open(room, false, false)) {
-				room = "this game";
-			}
+		if(!room_window_open(room, false, false)) {
+			room = "this game";
 		}
 
 		if(log_ != nullptr && data["type"].str() == "motd") {

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -115,6 +115,11 @@ protected:
 	virtual void add_chat_room_message_sent(const std::string& room,
 		const std::string& message) override;
 
+	void add_chat_room_message_received_general(const std::string& room,
+		const std::string& speaker,
+		const std::string& message,
+		bool whisper);
+
 	/** Inherited form @ref chat_handler */
 	virtual void add_chat_room_message_received(const std::string& room,
 		const std::string& speaker,
@@ -159,13 +164,13 @@ private:
 	bool whisper_window_active(const std::string& name);
 
 	/** @returns true if the room window for "room" is the active window. */
-	bool room_window_active(const std::string& room);
+	bool room_window_active(const std::string& room, bool whisper = false);
 
 	/** Mark the whisper window for "name" as having one more pending message. */
 	void increment_waiting_whispers(const std::string& name);
 
 	/** Mark the room window for "room" as having one more pending message. */
-	void increment_waiting_messages(const std::string& room);
+	void increment_waiting_messages(const std::string& room, bool whisper = false);
 
 	/** Add a whisper message to the whisper window. */
 	void add_whisper_window_whisper(const std::string& sender,
@@ -181,7 +186,8 @@ private:
 	/** Add a message to the window for room "room". */
 	void add_room_window_message(const std::string& room,
 		const std::string& sender,
-		const std::string& message);
+		const std::string& message,
+		bool whisper = false);
 
 	/** Add a message to the window for room "room". */
 	void add_active_window_message(const std::string& sender,
@@ -213,7 +219,7 @@ public:
 	 * @return valid ptr if the window was found or added, null otherwise
 	 */
 	lobby_chat_window* room_window_open(const std::string& room,
-		const bool open_new, const bool allow_close = true);
+		const bool open_new, const bool allow_close = true, bool whisper = false);
 
 	/**
 	 * Check if a whisper window for user "name" is open, if open_new is true

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -68,10 +68,10 @@ private:
 	void remove_player(player_iterator player);
 
 public:
-	template<class SocketPtr> void send_server_message(SocketPtr socket, const std::string& message, const std::string& type);
-	void send_server_message(player_iterator player, const std::string& message, const std::string& type) {
+	template<class SocketPtr> void send_server_message(SocketPtr socket, const std::string& message, const std::string& type, const std::string& original_receiver = "");
+	void send_server_message(player_iterator player, const std::string& message, const std::string& type, const std::string& original_receiver = "") {
 		utils::visit(
-			[this, &message, &type](auto&& socket) { send_server_message(socket, message, type); },
+			[this, &message, &type, &original_receiver](auto&& socket) { send_server_message(socket, message, type, original_receiver); },
 			player->socket()
 		);
 	}


### PR DESCRIPTION
Resolves #9049. The source of the error was trying to add message to the current whisper room with the add_chat_room_message_received function which is not meant to be used with whisper rooms. The error was solved by checking if the current room is whisper room and in this case selecting the lobby. There was an other error because during staging there is no lobby. This was solved by checking if the lobby room exists and if it doesnt then sending the message to the 'this game' room. Furthermore when receiving the cant find user message from the server the associated whisper room is closed.