### PR TITLE
Chrono type refactor

### DIFF
--- a/data/gui/themes/default/window/preferences/03_display.cfg
+++ b/data/gui/themes/default/window/preferences/03_display.cfg
@@ -133,22 +133,6 @@
 
 		{GUI_FILLER}
 	[/row]
-
-	[row]
-		[column]
-			border = "all"
-			border_size = 5
-			horizontal_alignment = "left"
-
-			[toggle_button]
-				id = "fps_limiter"
-				label = _ "Limit FPS"
-				tooltip = _ "Disabling this increases CPU usage, but may slightly improve performance (requires restart to take effect)"
-			[/toggle_button]
-		[/column]
-
-		{GUI_FILLER}
-	[/row]
 #enddef
 
 #define _GUI_PREFERENCES_DISPLAY_UI_GRID

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -20,6 +20,7 @@
 #include "gettext.hpp"
 #include "picture.hpp"
 #include "log.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/string_utils.hpp"
 
 static lg::log_domain log_addons_client("addons-client");
@@ -102,8 +103,8 @@ void addon_info::read(const config& cfg)
 	tags = utils::split(cfg["tags"].str());
 	feedback_url = cfg["feedback_url"].str();
 
-	updated = cfg["timestamp"].to_time_t();
-	created = cfg["original_timestamp"].to_time_t();
+	updated = chrono::parse_timestamp(cfg["timestamp"]);
+	created = chrono::parse_timestamp(cfg["original_timestamp"]);
 
 	local_only = cfg["local_only"].to_bool();
 }
@@ -137,8 +138,8 @@ void addon_info::write(config& cfg) const
 	cfg["tags"] = utils::join(tags);
 	cfg["feedback_url"] = feedback_url;
 
-	cfg["timestamp"] = updated;
-	cfg["original_timestamp"] = created;
+	cfg["timestamp"] = chrono::serialize_timestamp(updated);
+	cfg["original_timestamp"] = chrono::serialize_timestamp(created);
 }
 
 void addon_info::write_minimal(config& cfg) const

--- a/src/addon/info.hpp
+++ b/src/addon/info.hpp
@@ -19,7 +19,7 @@
 
 #include "addon/validation.hpp"
 
-#include <ctime>
+#include <chrono>
 #include <set>
 #include <map>
 
@@ -99,8 +99,8 @@ struct addon_info
 
 	std::string feedback_url;
 
-	std::time_t updated;
-	std::time_t created;
+	std::chrono::system_clock::time_point updated;
+	std::chrono::system_clock::time_point created;
 
 	// Flag to indicate whether this object was generaled from pbl info for an addon
 	// not previously published.

--- a/src/ai/manager.hpp
+++ b/src/ai/manager.hpp
@@ -431,7 +431,7 @@ private:
 	events::generic_event tod_changed_;
 	events::generic_event gamestate_changed_;
 	events::generic_event turn_started_;
-	int last_interact_;
+	std::chrono::steady_clock::time_point last_interact_;
 	int num_interact_;
 
 	AI_map_of_stacks ai_map_;

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -31,6 +31,7 @@
 #include "tstring.hpp"
 #include "utils/variant.hpp"
 
+#include <chrono>
 #include <climits>
 #include <ctime>
 #include <iosfwd>
@@ -127,6 +128,12 @@ public:
 	config_attribute_value& operator=(const std::string_view &v);
 	config_attribute_value& operator=(const t_string &v);
 
+	template<typename... Args>
+	config_attribute_value& operator=(const std::chrono::duration<Args...>& v)
+	{
+		return this->operator=(v.count());
+	}
+
 	/** Calls @ref operator=(const std::string&) if @a v is not empty. */
 	void write_if_not_empty(const std::string& v);
 	void write_if_not_empty(const t_string& v);
@@ -142,11 +149,20 @@ public:
 	std::string str(const std::string& fallback = "") const;
 	t_string t_str() const;
 
+	template<typename Duration>
+	auto to_duration(const Duration& def = Duration{0}) const
+	{
+		return Duration{to_long_long(def.count())};
+	}
+
 	bool to(const bool def) const { return to_bool(def); }
 	int to(int def) const { return to_int(def); }
 	unsigned to(unsigned def) const { return to_unsigned(def); }
 	double to(double def) const { return to_double(def); }
 	std::string to(const std::string& def) const { return str(def); }
+
+	template<typename... Args>
+	auto to(const std::chrono::duration<Args...>& def) const { return to_duration(def); }
 
 	// Implicit conversions:
 	operator std::string() const { return str(); }

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -149,20 +149,11 @@ public:
 	std::string str(const std::string& fallback = "") const;
 	t_string t_str() const;
 
-	template<typename Duration>
-	auto to_duration(const Duration& def = Duration{0}) const
-	{
-		return Duration{to_long_long(def.count())};
-	}
-
 	bool to(const bool def) const { return to_bool(def); }
 	int to(int def) const { return to_int(def); }
 	unsigned to(unsigned def) const { return to_unsigned(def); }
 	double to(double def) const { return to_double(def); }
 	std::string to(const std::string& def) const { return str(def); }
-
-	template<typename... Args>
-	auto to(const std::chrono::duration<Args...>& def) const { return to_duration(def); }
 
 	// Implicit conversions:
 	operator std::string() const { return str(); }

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -33,7 +33,8 @@
 static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
 
-static const int long_touch_duration_ms = 800;
+using namespace std::chrono_literals;
+static constexpr auto long_touch_duration = 800ms;
 
 controller_base::controller_base()
 	: game_config_(game_config_manager::get()->game_config())
@@ -43,7 +44,7 @@ controller_base::controller_base()
 	, scroll_down_(false)
 	, scroll_left_(false)
 	, scroll_right_(false)
-	, last_scroll_tick_(0)
+	, last_scroll_tick_()
 	, scroll_carry_x_(0.0)
 	, scroll_carry_y_(0.0)
 	, key_release_listener_(*this)
@@ -181,7 +182,7 @@ void controller_base::handle_event(const SDL_Event& event)
 
 		if(last_mouse_is_touch_ && long_touch_timer_ == 0) {
 			long_touch_timer_ = gui2::add_timer(
-					long_touch_duration_ms,
+					long_touch_duration,
 					std::bind(&controller_base::long_touch_callback, this, event.button.x, event.button.y));
 		}
 
@@ -314,16 +315,18 @@ bool controller_base::handle_scroll(int mousex, int mousey, int mouse_flags)
 	}
 
 	// Scale scroll distance according to time passed
-	uint32_t tick_now = SDL_GetTicks();
+	auto tick_now = std::chrono::steady_clock::now();
+
 	// If we weren't previously scrolling, start small.
-	int dt = 1;
+	auto dt = 1ms;
 	if (scrolling_) {
-		dt = tick_now - last_scroll_tick_;
+		dt = std::chrono::duration_cast<std::chrono::milliseconds>(tick_now - last_scroll_tick_);
 	}
+
 	// scroll_speed is in percent. Ticks are in milliseconds.
 	// Let's assume the maximum speed (100) moves 50 hexes per second,
 	// i.e. 3600 pixels per 1000 ticks.
-	double scroll_amount = double(dt) * 0.036 * double(scroll_speed);
+	double scroll_amount = dt.count() * 0.036 * double(scroll_speed);
 	last_scroll_tick_ = tick_now;
 
 	// Apply keyboard scrolling

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -274,7 +274,7 @@ void controller_base::handle_event(const SDL_Event& event)
 	}
 }
 
-void controller_base::process(events::pump_info&)
+void controller_base::process()
 {
 	if(gui2::is_in_dialog()) {
 		return;

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -156,7 +156,7 @@ protected:
 		// No action by default
 	}
 
-	virtual void process(events::pump_info&) override;
+	virtual void process() override;
 
 	/** Process keydown (always). Overridden in derived classes */
 	virtual void process_keydown_event(const SDL_Event& /*event*/)

--- a/src/controller_base.hpp
+++ b/src/controller_base.hpp
@@ -41,6 +41,8 @@
 #include "key.hpp"
 #include "quit_confirmation.hpp"
 
+#include <chrono>
+
 class game_config_view;
 class display;
 class plugins_context;
@@ -185,7 +187,7 @@ protected:
 	bool scroll_left_;
 	bool scroll_right_;
 	/* When the last scroll tick was processed */
-	uint32_t last_scroll_tick_;
+	std::chrono::steady_clock::time_point last_scroll_tick_;
 	/* Sub-pixel movement left over from a previous scroll tick.
 	 * This is added to the next scroll tick, if scrolling continues. */
 	double scroll_carry_x_;

--- a/src/countdown_clock.cpp
+++ b/src/countdown_clock.cpp
@@ -19,19 +19,20 @@
 #include "sound.hpp"
 #include "utils/rate_counter.hpp"
 
-namespace {
-	const int WARNTIME = 20000; //start beeping when 20 seconds are left (20,000ms)
-	utils::rate_counter timer_refresh_rate{50}; // prevents calling SDL_GetTicks() too frequently
-}
+using namespace std::chrono_literals;
 
+namespace {
+	constexpr auto warn_threshold = 20s; // start beeping when 20 seconds are left
+	constexpr auto fade_end = warn_threshold / 2;
+	utils::rate_counter timer_refresh_rate{50};
+}
 
 countdown_clock::countdown_clock(team& team)
 	: team_(team)
-	, last_timestamp_(SDL_GetTicks())
+	, last_timestamp_(clock::now())
 	, playing_sound_(false)
 {
 }
-
 
 countdown_clock::~countdown_clock()
 {
@@ -41,42 +42,42 @@ countdown_clock::~countdown_clock()
 	}
 }
 
-int countdown_clock::update_timestamp(int new_timestamp)
+std::chrono::milliseconds countdown_clock::update_timestamp()
 {
-	int res = std::max<int>(0, new_timestamp - last_timestamp_);
-	last_timestamp_ = new_timestamp;
-	return res;
+	auto now = clock::now();
+	auto prev_time = std::exchange(last_timestamp_, now);
+	return std::chrono::duration_cast<std::chrono::milliseconds>(now - prev_time);
 }
 
-void countdown_clock::update_team(int new_timestamp)
+void countdown_clock::update_team()
 {
-	int time_passed = update_timestamp(new_timestamp);
-	team_.set_countdown_time(std::max<int>(0, team_.countdown_time() - time_passed));
+	auto time_passed = update_timestamp();
+	team_.set_countdown_time(std::max(0ms, team_.countdown_time() - time_passed));
 }
 
 //make sure we think about countdown even while dialogs are open
-void countdown_clock::process(events::pump_info &info)
+void countdown_clock::process(events::pump_info&)
 {
 	if(timer_refresh_rate.poll()) {
-		update(info.ticks());
+		update();
 	}
 }
 
-bool countdown_clock::update(int new_timestamp)
+bool countdown_clock::update()
 {
-	update_team(new_timestamp);
+	update_team();
 	maybe_play_sound();
-	return team_.countdown_time() > 0;
+	return team_.countdown_time() > 0ms;
 }
 
 void countdown_clock::maybe_play_sound()
 {
-	if(!playing_sound_ && team_.countdown_time() < WARNTIME )
+	if(!playing_sound_ && team_.countdown_time() < warn_threshold )
 	{
 		if(prefs::get().turn_bell() || prefs::get().sound() || prefs::get().ui_sound_on())
 		{
-			const int loop_ticks = team_.countdown_time();
-			const int fadein_ticks = (loop_ticks > WARNTIME / 2) ? loop_ticks - WARNTIME / 2 : 0;
+			const auto loop_ticks = team_.countdown_time();
+			const auto fadein_ticks = std::max(loop_ticks - fade_end, 0ms);
 			sound::play_timer(game_config::sounds::timer_bell, loop_ticks, fadein_ticks);
 			playing_sound_ = true;
 		}

--- a/src/countdown_clock.cpp
+++ b/src/countdown_clock.cpp
@@ -56,7 +56,7 @@ void countdown_clock::update_team()
 }
 
 //make sure we think about countdown even while dialogs are open
-void countdown_clock::process(events::pump_info&)
+void countdown_clock::process()
 {
 	if(timer_refresh_rate.poll()) {
 		update();

--- a/src/countdown_clock.hpp
+++ b/src/countdown_clock.hpp
@@ -13,31 +13,34 @@
 */
 
 #pragma once
+
 #include "events.hpp"
-#include <SDL2/SDL_timer.h>
+#include <chrono>
 
 class team;
 class countdown_clock : public events::pump_monitor
 {
+	using clock = std::chrono::steady_clock;
+
 public:
 	countdown_clock(team& team);
 	~countdown_clock();
-	/**
-	 * @returns ticks passed since last update
-	 * @param new_timestamp latest result of SDL_GetTicks()
-	 */
-	int update_timestamp(int new_timestamp);
-	/** @param new_timestamp latest result of SDL_GetTicks() */
-	void update_team(int new_timestamp);
-	void process(events::pump_info &info);
-	/**
-	 * @return whether there is time left
-	 * @param new_timestamp latest result of SDL_GetTicks()
-	 */
-	bool update(int new_timestamp = SDL_GetTicks());
+
+	/** @returns ticks passed since last update */
+	std::chrono::milliseconds update_timestamp();
+
+	void update_team();
+
+	/** Inherited from pump_monitor */
+	virtual void process(events::pump_info& info) override;
+
+	/** @returns whether there is time left */
+	bool update();
+
 	void maybe_play_sound();
+
 private:
 	team& team_;
-	int last_timestamp_;
+	clock::time_point last_timestamp_;
 	bool playing_sound_;
 };

--- a/src/countdown_clock.hpp
+++ b/src/countdown_clock.hpp
@@ -32,7 +32,7 @@ public:
 	void update_team();
 
 	/** Inherited from pump_monitor */
-	virtual void process(events::pump_info& info) override;
+	virtual void process() override;
 
 	/** @returns whether there is time left */
 	bool update();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1510,22 +1510,17 @@ void display::set_diagnostic(const std::string& msg)
 
 void display::update_fps_count()
 {
-	using std::chrono::duration_cast;
-	using std::chrono::steady_clock;
-
-	auto now = steady_clock::now();
+	auto now = std::chrono::steady_clock::now();
 	if(last_frame_finished_) {
-		frametimes_.push_back(duration_cast<std::chrono::milliseconds>(now - *last_frame_finished_));
+		frametimes_.push_back(std::chrono::duration_cast<std::chrono::milliseconds>(now - *last_frame_finished_));
 	}
 
 	last_frame_finished_ = now;
 	++fps_counter_;
 
-	const auto current_second = duration_cast<std::chrono::seconds>(now.time_since_epoch());
-	if(current_second != fps_start_) {
-		fps_start_ = current_second;
-		fps_actual_ = fps_counter_;
-		fps_counter_ = 0;
+	if(now - fps_start_ >= 1s) {
+		fps_start_ = now;
+		fps_actual_ = std::exchange(fps_counter_, 0);
 	}
 }
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -72,6 +72,7 @@
 #include <windows.h>
 #endif
 
+using namespace std::chrono_literals;
 // Includes for bug #17573
 
 static lg::log_domain log_display("display");
@@ -1289,7 +1290,6 @@ void display::drawing_buffer_commit()
 
 static unsigned calculate_fps(std::chrono::milliseconds frametime)
 {
-	using namespace std::chrono_literals;
 	return frametime > 0ms ? 1s / frametime : 999u;
 }
 
@@ -1306,7 +1306,6 @@ void display::update_fps_label()
 
 	const auto [min_iter, max_iter] = std::minmax_element(frametimes_.begin(), frametimes_.end());
 
-	using namespace std::chrono_literals;
 	const std::chrono::milliseconds render_avg = std::accumulate(frametimes_.begin(), frametimes_.end(), 0ms) / frametimes_.size();
 
 	// NOTE: max FPS corresponds to the *shortest* time between frames (that is, min_iter)
@@ -1926,20 +1925,21 @@ void display::scroll_to_xy(const point& screen_coordinates, SCROLL_TYPE scroll_t
 	const double dist_total = std::hypot(move.x, move.y);
 	double dist_moved = 0.0;
 
-	int t_prev = SDL_GetTicks();
+	using fractional_seconds = std::chrono::duration<double>;
+	auto prev_time = std::chrono::steady_clock::now();
 
 	double velocity = 0.0;
 	while (dist_moved < dist_total) {
 		events::pump();
 
-		int t = SDL_GetTicks();
-		double dt = (t - t_prev) / 1000.0;
-		if (dt > 0.200) {
-			// Do not skip too many frames on slow PCs
-			dt = 0.200;
-		}
-		t_prev = t;
+		auto time = std::chrono::steady_clock::now();
+		auto dt = std::chrono::duration_cast<fractional_seconds>(time - prev_time);
 
+		// Do not skip too many frames on slow PCs
+		dt = std::min<fractional_seconds>(dt, 200ms);
+		prev_time = time;
+
+		const double dt_as_double = dt.count();
 		const double accel_time = 0.3 / turbo_speed(); // seconds until full speed is reached
 		const double decel_time = 0.4 / turbo_speed(); // seconds from full speed to stop
 
@@ -1952,14 +1952,14 @@ void display::scroll_to_xy(const point& screen_coordinates, SCROLL_TYPE scroll_t
 		double stop_time = velocity / decel;
 		double dist_stop = dist_moved + velocity*stop_time - 0.5*decel*stop_time*stop_time;
 		if (dist_stop > dist_total || velocity > velocity_max) {
-			velocity -= decel * dt;
+			velocity -= decel * dt_as_double;
 			if (velocity < 1.0) velocity = 1.0;
 		} else {
-			velocity += accel * dt;
+			velocity += accel * dt_as_double;
 			if (velocity > velocity_max) velocity = velocity_max;
 		}
 
-		dist_moved += velocity * dt;
+		dist_moved += velocity * dt_as_double;
 		if (dist_moved > dist_total) dist_moved = dist_total;
 
 		point next_pos(
@@ -2209,10 +2209,10 @@ void display::fade_tod_mask(
 	tod_hex_mask1 = image::get_texture(old_mask, image::HEXED);
 	tod_hex_mask2 = image::get_texture(new_mask, image::HEXED);
 
-	int duration = 300 / turbo_speed();
-	int start = SDL_GetTicks();
-	for(int now = start; now < start + duration; now = SDL_GetTicks()) {
-		float prop_f = float(now - start) / float(duration);
+	auto duration = 300ms / turbo_speed();
+	auto start = std::chrono::steady_clock::now();
+	for(auto now = start; now < start + duration; now = std::chrono::steady_clock::now()) {
+		float prop_f = float((now - start).count()) / float(duration.count());
 		uint8_t p = float_to_color(prop_f);
 		tod_hex_alpha2 = p;
 		tod_hex_alpha1 = ~p;
@@ -2224,9 +2224,9 @@ void display::fade_tod_mask(
 	tod_hex_mask2.reset();
 }
 
-void display::fade_to(const color_t& c, int duration)
+void display::fade_to(const color_t& c, const std::chrono::milliseconds& duration)
 {
-	uint32_t start = SDL_GetTicks();
+	auto start = std::chrono::steady_clock::now();
 	color_t fade_start = fade_color_;
 	color_t fade_end = c;
 
@@ -2245,8 +2245,8 @@ void display::fade_to(const color_t& c, int duration)
 	}
 
 	// Smoothly blend and display
-	for(uint32_t now = start; now < start + duration; now = SDL_GetTicks()) {
-		float prop_f = float(now - start) / float(duration);
+	for(auto now = start; now < start + duration; now = std::chrono::steady_clock::now()) {
+		float prop_f = float((now - start).count()) / float(duration.count());
 		uint8_t p = float_to_color(prop_f);
 		fade_color_ = fade_start.smooth_blend(fade_end, p);
 		draw_manager::invalidate_region(map_outside_area());

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -566,7 +566,7 @@ public:
 	void fade_tod_mask(const std::string& old, const std::string& new_);
 
 	/** Screen fade */
-	void fade_to(const color_t& color, int duration);
+	void fade_to(const color_t& color, const std::chrono::milliseconds& duration);
 	void set_fade(const color_t& color);
 
 private:
@@ -615,7 +615,7 @@ public:
 	struct announce_options
 	{
 		/** Lifetime measured in milliseconds. */
-		int lifetime;
+		std::chrono::milliseconds lifetime;
 
 		/**
 		 * An announcement according these options should replace the

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -760,7 +760,7 @@ protected:
 	boost::circular_buffer<std::chrono::milliseconds> frametimes_;
 	int current_frame_sample_ = 0;
 	unsigned int fps_counter_;
-	std::chrono::seconds fps_start_;
+	std::chrono::steady_clock::time_point fps_start_;
 	unsigned int fps_actual_;
 	utils::optional<std::chrono::steady_clock::time_point> last_frame_finished_ = {};
 

--- a/src/display_chat_manager.hpp
+++ b/src/display_chat_manager.hpp
@@ -18,7 +18,7 @@
 #include "chat_events.hpp"
 
 #include <cstdint>
-#include <ctime>
+#include <chrono>
 #include <set>
 #include <string>
 #include <vector>
@@ -52,7 +52,7 @@ private:
 
 		int speaker_handle;
 		int handle;
-		uint32_t created_at;
+		std::chrono::steady_clock::time_point created_at;
 	};
 
 	void prune_chat_messages(bool remove_all=false);

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -18,7 +18,6 @@
 #include "exceptions.hpp"
 #include "log.hpp"
 #include "gui/core/top_level_drawable.hpp"
-#include "preferences/preferences.hpp"
 #include "sdl/rect.hpp"
 #include "utils/general.hpp"
 #include "video.hpp"
@@ -186,8 +185,7 @@ std::chrono::milliseconds get_frame_length()
 	}
 	// allow 1ms for general processing
 	auto vsync_delay = (1000ms / rr) - 1ms;
-	// if there's a preferred limit, limit to that
-	return std::clamp(vsync_delay, std::chrono::milliseconds{prefs::get().draw_delay()}, 1000ms);
+	return std::min(vsync_delay, 1000ms);
 }
 
 static void wait_for_vsync()

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -23,8 +23,7 @@
 #include "utils/general.hpp"
 #include "video.hpp"
 
-#include <SDL2/SDL_timer.h>
-
+#include <thread>
 #include <algorithm>
 #include <vector>
 
@@ -35,6 +34,8 @@ static lg::log_domain log_draw_man("draw/manager");
 #define DBG_DM LOG_STREAM(debug, log_draw_man)
 
 using gui2::top_level_drawable;
+using std::chrono::steady_clock;
+using namespace std::chrono_literals;
 
 // This is not publically exposed, because nobody else should be using it.
 // Implementation is in video.cpp.
@@ -45,7 +46,7 @@ std::vector<top_level_drawable*> top_level_drawables_;
 std::vector<rect> invalidated_regions_;
 bool drawing_ = false;
 bool tlds_need_tidying_ = false;
-uint32_t last_sparkle_ = 0;
+steady_clock::time_point last_sparkle_;
 bool extra_pass_requested_ = false;
 } // namespace
 
@@ -173,10 +174,10 @@ void sparkle()
 		wait_for_vsync();
 	}
 
-	last_sparkle_ = SDL_GetTicks();
+	last_sparkle_ = steady_clock::now();
 }
 
-int get_frame_length()
+std::chrono::milliseconds get_frame_length()
 {
 	int rr = video::current_refresh_rate();
 	if (rr <= 0) {
@@ -184,17 +185,18 @@ int get_frame_length()
 		rr = 60;
 	}
 	// allow 1ms for general processing
-	int vsync_delay = (1000 / rr) - 1;
+	auto vsync_delay = (1000ms / rr) - 1ms;
 	// if there's a preferred limit, limit to that
-	return std::clamp(vsync_delay, prefs::get().draw_delay(), 1000);
+	return std::clamp(vsync_delay, std::chrono::milliseconds{prefs::get().draw_delay()}, 1000ms);
 }
 
 static void wait_for_vsync()
 {
-	int time_to_wait = last_sparkle_ + get_frame_length() - SDL_GetTicks();
-	if (time_to_wait > 0) {
+	auto now = steady_clock::now();
+	auto next_frame = last_sparkle_ + get_frame_length();
+	if (now < next_frame) {
 		// delay a maximum of 1 second in case something crazy happens
-		SDL_Delay(std::min(time_to_wait, 1000));
+		std::this_thread::sleep_for(std::min<steady_clock::duration>(next_frame - now, 1s));
 	}
 }
 

--- a/src/draw_manager.hpp
+++ b/src/draw_manager.hpp
@@ -16,6 +16,8 @@
 
 #include "sdl/rect.hpp"
 
+#include <chrono>
+
 namespace gui2 { class top_level_drawable; }
 
 /**
@@ -121,7 +123,7 @@ void sparkle();
  *
  * This will usually be determined by the active monitor's refresh rate.
  */
-int get_frame_length();
+std::chrono::milliseconds get_frame_length();
 
 /** Register a top-level drawable.
  *

--- a/src/editor/editor_display.cpp
+++ b/src/editor/editor_display.cpp
@@ -172,12 +172,13 @@ void editor_display::set_status(const std::string& str, const bool is_success)
 		formatted_str = VGETTEXT("<span color='red'><span face='DejaVuSans'>✘</span> $msg</span>", {{"msg", str}});
 	}
 
+	using namespace std::chrono_literals;
 	font::floating_label flabel(formatted_str);
 	flabel.set_font_size(size);
 	flabel.set_position(0, canvas_size.y);
 	flabel.set_bg_color(color);
 	flabel.set_border_size(border);
-	flabel.set_lifetime(1000, 10);
+	flabel.set_lifetime(1000ms, 10ms);
 	flabel.use_markup(true);
 
 	const int f_handle = font::add_floating_label(flabel);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -483,8 +483,6 @@ void pump()
 		return;
 	}
 
-	pump_info info;
-
 	SDL_Event temp_event;
 	int poll_count = 0;
 	int begin_ignoring = 0;
@@ -716,7 +714,7 @@ void pump()
 
 	// Inform the pump monitors that an events::pump() has occurred
 	for(auto monitor : pump_monitors) {
-		monitor->process(info);
+		monitor->process();
 	}
 }
 
@@ -756,15 +754,6 @@ void process_tooltip_strings(int mousex, int mousey)
 			handler->process_tooltip_string(mousex, mousey);
 		}
 	}
-}
-
-int pump_info::ticks()
-{
-	if(!ticks_) {
-		ticks_ = ::SDL_GetTicks();
-	}
-
-	return ticks_;
 }
 
 /* The constants for the minimum and maximum are picked from the headers. */

--- a/src/events.hpp
+++ b/src/events.hpp
@@ -150,19 +150,12 @@ void draw();
 inline void pump_and_draw() { pump(); draw(); }
 // TODO: draw_manager - should this also raise_process_event? Some things do some don't
 
-struct pump_info {
-	pump_info() : ticks_(0) {}
-	int ticks();
-private:
-	int ticks_; //0 if not calculated
-};
-
 class pump_monitor {
 //pump_monitors receive notification after an events::pump() occurs
 public:
 	pump_monitor();
 	virtual ~pump_monitor();
-	virtual void process(pump_info& info) = 0;
+	virtual void process() = 0;
 };
 
 void raise_process_event();

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -20,6 +20,8 @@
 #include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
+
+#include <chrono>
 #include <string>
 
 namespace font {
@@ -40,6 +42,8 @@ enum LABEL_SCROLL_MODE { ANCHOR_LABEL_SCREEN, ANCHOR_LABEL_MAP };
 
 class floating_label
 {
+	using clock = std::chrono::steady_clock;
+
 public:
 	floating_label(const std::string& text);
 
@@ -56,7 +60,7 @@ public:
 		ymove_ = ymove;
 	}
 	// set the number of frames to display the text for, or -1 to display until removed
-	void set_lifetime(int lifetime, int fadeout = 100);
+	void set_lifetime(const std::chrono::milliseconds& lifetime, const std::chrono::milliseconds& fadeout = std::chrono::milliseconds{100});
 	void set_color(const color_t& color) {color_ = color;}
 	void set_bg_color(const color_t& bg_color) {
 		bgcolor_ = bg_color;
@@ -75,7 +79,7 @@ public:
 	/** Change the floating label's position. */
 	void move(double xmove, double ymove);
 	/** Finalize draw position and alpha, and queue redrawing if changed. */
-	void update(int time);
+	void update(const clock::time_point& time);
 	/** Draw the label to the screen. */
 	void draw();
 
@@ -94,32 +98,35 @@ public:
 		return get_bg_rect({0, 0, tex_.w(), tex_.h()}).size();
 	}
 
-	bool expired(int time) const { return lifetime_ >= 0 && get_time_alive(time) > lifetime_ + fadeout_; }
+	bool expired(const clock::time_point& time) const
+	{
+		return lifetime_ >= std::chrono::milliseconds{0} && get_time_alive(time) > lifetime_ + fadeout_;
+	}
 
 	void show(const bool value) { visible_ = value; }
 
 	LABEL_SCROLL_MODE scroll() const { return scroll_; }
 
 	// TODO: Might be good to have more getters, right?
-	int get_fade_time() const { return fadeout_; }
+	auto get_fade_time() const { return fadeout_; }
 
 private:
 
-	int get_time_alive(int current_time) const { return current_time - time_start_; }
+	std::chrono::milliseconds get_time_alive(const clock::time_point& current_time) const;
 	int xpos(std::size_t width) const;
-	point get_pos(int time);
-	uint8_t get_alpha(int time);
+	point get_pos(const clock::time_point& time);
+	uint8_t get_alpha(const clock::time_point& time);
 	rect get_bg_rect(const rect& text_rect) const;
 	texture tex_;
 	rect screen_loc_;
 	uint8_t alpha_;
-	int fadeout_;
-	int time_start_;
+	std::chrono::milliseconds fadeout_;
+	clock::time_point time_start_;
 	std::string text_;
 	int font_size_;
 	color_t color_, bgcolor_;
 	double xpos_, ypos_, xmove_, ymove_;
-	int lifetime_;
+	std::chrono::milliseconds lifetime_;
 	int width_, height_;
 	SDL_Rect clip_rect_;
 	bool visible_;
@@ -146,7 +153,7 @@ void scroll_floating_labels(double xmove, double ymove);
 /** removes the floating label given by 'handle' from the screen */
 /** if fadeout is given, the label fades out over that duration */
 /** if fadeout is less than 0, it uses the fadeout setting from the label */
-void remove_floating_label(int handle, int fadeout = 0);
+void remove_floating_label(int handle, const std::chrono::milliseconds& fadeout = std::chrono::milliseconds{0});
 
 /** hides or shows a floating label */
 void show_floating_label(int handle, bool show);

--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -18,6 +18,7 @@
 #include "config.hpp"
 #include "log.hpp"
 #include "preferences/preferences.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/string_utils.hpp"
 #include "game_version.hpp"
 #include "game_config_manager.hpp"
@@ -51,7 +52,7 @@ game_classification::game_classification(const config& cfg)
 	, abbrev(cfg["abbrev"])
 	, end_credits(cfg["end_credits"].to_bool(true))
 	, end_text(cfg["end_text"])
-	, end_text_duration(std::clamp(cfg["end_text_duration"].to_duration(0ms), 0ms, 5000ms))
+	, end_text_duration(std::clamp(chrono::parse_duration(cfg["end_text_duration"], 0ms), 0ms, 5000ms))
 	, difficulty(cfg["difficulty"].empty() ? DEFAULT_DIFFICULTY : cfg["difficulty"].str())
 	, random_mode(cfg["random_mode"])
 	, oos_debug(cfg["oos_debug"].to_bool(false))

--- a/src/game_classification.cpp
+++ b/src/game_classification.cpp
@@ -30,6 +30,8 @@ static lg::log_domain log_engine("engine");
 #define LOG_NG LOG_STREAM(info, log_engine)
 #define DBG_NG LOG_STREAM(debug, log_engine)
 
+using namespace std::chrono_literals;
+
 /** The default difficulty setting for campaigns. */
 const std::string DEFAULT_DIFFICULTY("NORMAL");
 
@@ -49,7 +51,7 @@ game_classification::game_classification(const config& cfg)
 	, abbrev(cfg["abbrev"])
 	, end_credits(cfg["end_credits"].to_bool(true))
 	, end_text(cfg["end_text"])
-	, end_text_duration(std::clamp<unsigned>(cfg["end_text_duration"].to_unsigned(0), 0, 5000))
+	, end_text_duration(std::clamp(cfg["end_text_duration"].to_duration(0ms), 0ms, 5000ms))
 	, difficulty(cfg["difficulty"].empty() ? DEFAULT_DIFFICULTY : cfg["difficulty"].str())
 	, random_mode(cfg["random_mode"])
 	, oos_debug(cfg["oos_debug"].to_bool(false))
@@ -74,7 +76,7 @@ config game_classification::to_config() const
 	cfg["abbrev"] = abbrev;
 	cfg["end_credits"] = end_credits;
 	cfg["end_text"] = end_text;
-	cfg["end_text_duration"] = std::to_string(end_text_duration);
+	cfg["end_text_duration"] = end_text_duration;
 	cfg["difficulty"] = difficulty;
 	cfg["random_mode"] = random_mode;
 	cfg["oos_debug"] = oos_debug;

--- a/src/game_classification.hpp
+++ b/src/game_classification.hpp
@@ -17,6 +17,7 @@
 
 #include "campaign_type.hpp"
 
+#include <chrono>
 #include <vector>
 #include <set>
 
@@ -50,7 +51,7 @@ public:
 	std::string abbrev;                              /**< the campaign abbreviation */
 	bool end_credits = true;                                /**< whether to show the standard credits at the end */
 	std::string end_text;                            /**< end-of-campaign text */
-	unsigned int end_text_duration;                  /**< for how long the end-of-campaign text is shown */
+	std::chrono::milliseconds end_text_duration;     /**< for how long the end-of-campaign text is shown */
 	std::string difficulty = DEFAULT_DIFFICULTY; /**< The difficulty level the game is being played on. */
 	std::string random_mode = "";
 	bool oos_debug = false;

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -20,6 +20,7 @@
 #include "gettext.hpp"
 #include "log.hpp"
 #include "game_version.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/string_utils.hpp"
 
 #include <cmath>
@@ -271,7 +272,7 @@ void load_config(const config &v)
 	recall_cost      = v["recall_cost"].to_int(20);
 	kill_experience  = v["kill_experience"].to_int(8);
 	combat_experience= v["combat_experience"].to_int(1);
-	lobby_refresh    = v["lobby_refresh"].to_duration(2000ms);
+	lobby_refresh    = chrono::parse_duration(v["lobby_refresh"], 2000ms);
 	default_terrain  = v["default_terrain"].str();
 	tile_size        = v["tile_size"].to_int(72);
 

--- a/src/game_config.cpp
+++ b/src/game_config.cpp
@@ -29,6 +29,8 @@ static lg::log_domain log_engine("engine");
 #define LOG_NG LOG_STREAM(info, log_engine)
 #define ERR_NG LOG_STREAM(err, log_engine)
 
+using namespace std::chrono_literals;
+
 namespace game_config
 {
 //
@@ -65,8 +67,8 @@ double xp_bar_scaling  = 0.5;
 //
 // Misc
 //
-unsigned lobby_network_timer  = 100;
-unsigned lobby_refresh        = 4000;
+std::chrono::milliseconds lobby_network_timer  = 100ms;
+std::chrono::milliseconds lobby_refresh        = 4000ms;
 
 const std::size_t max_loop = 65536;
 
@@ -269,7 +271,7 @@ void load_config(const config &v)
 	recall_cost      = v["recall_cost"].to_int(20);
 	kill_experience  = v["kill_experience"].to_int(8);
 	combat_experience= v["combat_experience"].to_int(1);
-	lobby_refresh    = v["lobby_refresh"].to_int(2000);
+	lobby_refresh    = v["lobby_refresh"].to_duration(2000ms);
 	default_terrain  = v["default_terrain"].str();
 	tile_size        = v["tile_size"].to_int(72);
 

--- a/src/game_config.hpp
+++ b/src/game_config.hpp
@@ -22,6 +22,7 @@ class color_range;
 #include "tstring.hpp"
 #include "game_config_view.hpp"
 
+#include <chrono>
 #include <vector>
 #include <map>
 
@@ -37,8 +38,8 @@ namespace game_config
 	extern int kill_experience;
 	extern int combat_experience;
 	extern unsigned int tile_size;
-	extern unsigned lobby_network_timer;
-	extern unsigned lobby_refresh;
+	extern std::chrono::milliseconds lobby_network_timer;
+	extern std::chrono::milliseconds lobby_refresh;
 	extern const std::string default_title_string;
 	extern std::string default_terrain;
 

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -586,7 +586,7 @@ void game_display::float_label(const map_location& loc, const std::string& text,
 	flabel.set_color(color);
 	flabel.set_position(loc_rect.center().x, loc_rect.y); // middle of top edge
 	flabel.set_move(0, -0.1 * turbo_speed() * get_zoom_factor());
-	flabel.set_lifetime(1000/turbo_speed());
+	flabel.set_lifetime(std::chrono::milliseconds{static_cast<int>(1000 / turbo_speed())});
 	flabel.set_scroll_mode(font::ANCHOR_LABEL_MAP);
 
 	font::add_floating_label(flabel);

--- a/src/game_initialization/configure_engine.cpp
+++ b/src/game_initialization/configure_engine.cpp
@@ -87,22 +87,22 @@ int configure_engine::xp_modifier_default() const
 		: prefs::get().xp_modifier();
 }
 
-int configure_engine::mp_countdown_init_time_default() const
+std::chrono::seconds configure_engine::mp_countdown_init_time_default() const
 {
 	return prefs::get().countdown_init_time();
 }
 
-int configure_engine::mp_countdown_reservoir_time_default() const
+std::chrono::seconds configure_engine::mp_countdown_reservoir_time_default() const
 {
 	return prefs::get().countdown_reservoir_time();
 }
 
-int configure_engine::mp_countdown_turn_bonus_default() const
+std::chrono::seconds configure_engine::mp_countdown_turn_bonus_default() const
 {
 	return prefs::get().countdown_turn_bonus();
 }
 
-int configure_engine::mp_countdown_action_bonus_default() const
+std::chrono::seconds configure_engine::mp_countdown_action_bonus_default() const
 {
 	return prefs::get().countdown_action_bonus();
 }

--- a/src/game_initialization/configure_engine.hpp
+++ b/src/game_initialization/configure_engine.hpp
@@ -18,6 +18,8 @@
 #include "mp_game_settings.hpp"
 #include "saved_game.hpp"
 
+#include <chrono>
+
 namespace ng
 {
 /**
@@ -66,22 +68,22 @@ public:
 		return parameters_.xp_modifier;
 	}
 
-	int mp_countdown_init_time() const
+	auto mp_countdown_init_time() const
 	{
 		return parameters_.mp_countdown_init_time;
 	}
 
-	int mp_countdown_reservoir_time() const
+	auto mp_countdown_reservoir_time() const
 	{
 		return parameters_.mp_countdown_reservoir_time;
 	}
 
-	int mp_countdown_turn_bonus() const
+	auto mp_countdown_turn_bonus() const
 	{
 		return parameters_.mp_countdown_turn_bonus;
 	}
 
-	int mp_countdown_action_bonus() const
+	auto mp_countdown_action_bonus() const
 	{
 		return parameters_.mp_countdown_action_bonus;
 	}
@@ -165,22 +167,22 @@ public:
 		parameters_.xp_modifier = val;
 	}
 
-	void set_mp_countdown_init_time(int val)
+	void set_mp_countdown_init_time(const std::chrono::seconds& val)
 	{
 		parameters_.mp_countdown_init_time = val;
 	}
 
-	void set_mp_countdown_reservoir_time(int val)
+	void set_mp_countdown_reservoir_time(const std::chrono::seconds& val)
 	{
 		parameters_.mp_countdown_reservoir_time = val;
 	}
 
-	void set_mp_countdown_turn_bonus(int val)
+	void set_mp_countdown_turn_bonus(const std::chrono::seconds& val)
 	{
 		parameters_.mp_countdown_turn_bonus = val;
 	}
 
-	void set_mp_countdown_action_bonus(int val)
+	void set_mp_countdown_action_bonus(const std::chrono::seconds& val)
 	{
 		parameters_.mp_countdown_action_bonus = val;
 	}
@@ -246,10 +248,10 @@ public:
 	int village_gold_default() const;
 	int village_support_default() const;
 	int xp_modifier_default() const;
-	int mp_countdown_init_time_default() const;
-	int mp_countdown_reservoir_time_default() const;
-	int mp_countdown_turn_bonus_default() const;
-	int mp_countdown_action_bonus_default() const;
+	std::chrono::seconds mp_countdown_init_time_default() const;
+	std::chrono::seconds mp_countdown_reservoir_time_default() const;
+	std::chrono::seconds mp_countdown_turn_bonus_default() const;
+	std::chrono::seconds mp_countdown_action_bonus_default() const;
 	bool mp_countdown_default() const;
 	bool use_map_settings_default() const;
 	bool random_start_time_default() const;

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -28,6 +28,7 @@
 #include "side_controller.hpp"
 #include "wml_exception.hpp"
 
+#include "serialization/chrono.hpp"
 #include "serialization/preprocessor.hpp"
 #include "serialization/parser.hpp"
 
@@ -405,7 +406,7 @@ void create_engine::prepare_for_campaign(const std::string& difficulty)
 	state_.classification().abbrev = current_level_data["abbrev"].str();
 
 	state_.classification().end_text = current_level_data["end_text"].str();
-	state_.classification().end_text_duration = current_level_data["end_text_duration"].to_duration<std::chrono::milliseconds>();
+	state_.classification().end_text_duration = chrono::parse_duration<std::chrono::milliseconds>(current_level_data["end_text_duration"]);
 	state_.classification().end_credits = current_level_data["end_credits"].to_bool(true);
 
 	state_.classification().campaign_define = current_level_data["define"].str();

--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -405,7 +405,7 @@ void create_engine::prepare_for_campaign(const std::string& difficulty)
 	state_.classification().abbrev = current_level_data["abbrev"].str();
 
 	state_.classification().end_text = current_level_data["end_text"].str();
-	state_.classification().end_text_duration = current_level_data["end_text_duration"].to_unsigned();
+	state_.classification().end_text_duration = current_level_data["end_text_duration"].to_duration<std::chrono::milliseconds>();
 	state_.classification().end_credits = current_level_data["end_credits"].to_bool(true);
 
 	state_.classification().campaign_define = current_level_data["define"].str();

--- a/src/game_initialization/playcampaign.cpp
+++ b/src/game_initialization/playcampaign.cpp
@@ -59,7 +59,7 @@ level_result::type campaign_controller::playsingle_scenario(end_level_data &end_
 
 	playsingle_controller playcontroller(starting_point, state_);
 
-	LOG_NG << "created objects... " << (SDL_GetTicks() - playcontroller.ticks());
+	LOG_NG << "created objects... " << playcontroller.timer();
 	if(is_replay_) {
 		playcontroller.enable_replay(is_unit_test_);
 	}

--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -161,13 +161,7 @@ game_launcher::game_launcher(const commandline_options& cmdline_opts)
 		load_data_ = savegame::load_game_metadata{
 			savegame::save_index_class::default_saves_dir(), *cmdline_opts_.load};
 	if(cmdline_opts_.max_fps) {
-		int fps = std::clamp(*cmdline_opts_.max_fps, 1, 1000);
-		fps = 1000 / fps;
-		// increase the delay to avoid going above the maximum
-		if(1000 % fps != 0) {
-			++fps;
-		}
-		prefs::get().set_draw_delay(fps);
+		prefs::get().set_refresh_rate(std::clamp(*cmdline_opts_.max_fps, 1, 1000));
 	}
 	if(cmdline_opts_.nogui || cmdline_opts_.headless_unit_test) {
 		no_sound = true;

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -34,8 +34,6 @@
 #include "gui/dialogs/loading_screen.hpp"
 #include "side_controller.hpp"
 
-#include <SDL2/SDL_timer.h>
-
 #include <algorithm>
 #include <set>
 
@@ -152,12 +150,12 @@ void game_state::init(const config& level, play_controller & pc)
 		place_sides_in_preferred_locations(level);
 	}
 
-	LOG_NG << "initialized time of day regions... "    << (SDL_GetTicks() - pc.ticks());
+	LOG_NG << "initialized time of day regions... " << pc.timer();
 	for (const config &t : level.child_range("time_area")) {
 		tod_manager_.add_time_area(board_.map(),t);
 	}
 
-	LOG_NG << "initialized teams... "    << (SDL_GetTicks() - pc.ticks());
+	LOG_NG << "initialized teams... " << pc.timer();
 
 	board_.teams().resize(level.child_count("side"));
 	if (player_number_ != 1 && player_number_ > static_cast<int>(board_.teams().size())) {

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -328,7 +328,8 @@ void mouse_motion::start_hover_timer(widget* widget, const point& coordinate)
 	DBG_GUI_E << LOG_HEADER << "Start hover timer for widget '" << widget->id()
 			  << "' at address " << widget << ".";
 
-	hover_timer_ = add_timer(50, std::bind(&mouse_motion::show_tooltip, this));
+	using namespace std::chrono_literals;
+	hover_timer_ = add_timer(50ms, std::bind(&mouse_motion::show_tooltip, this));
 
 	if(hover_timer_) {
 		hover_widget_ = widget;
@@ -405,7 +406,7 @@ constexpr std::array mouse_data{
 template<std::size_t I>
 mouse_button<I>::mouse_button(widget& owner, const dispatcher::queue_position queue_position)
 	: mouse_motion(owner, queue_position)
-	, last_click_stamp_(0)
+	, last_click_stamp_()
 	, last_clicked_widget_(nullptr)
 	, focus_(nullptr)
 	, is_down_(false)
@@ -434,7 +435,7 @@ mouse_button<I>::mouse_button(widget& owner, const dispatcher::queue_position qu
 template<std::size_t I>
 void mouse_button<I>::initialize_state(int32_t button_state)
 {
-	last_click_stamp_ = 0;
+	last_click_stamp_ = {};
 	last_clicked_widget_ = nullptr;
 	focus_ = 0;
 	// SDL_BUTTON_LEFT, SDL_BUTTON_MIDDLE, and SDL_BUTTON_RIGHT correspond to 1,2,3
@@ -551,12 +552,12 @@ void mouse_button<I>::signal_handler_sdl_button_up(
 template<std::size_t I>
 void mouse_button<I>::mouse_button_click(widget* widget)
 {
-	uint32_t stamp = SDL_GetTicks();
+	auto stamp = std::chrono::steady_clock::now();
 	if(last_click_stamp_ + settings::double_click_time >= stamp && last_clicked_widget_ == widget) {
 		DBG_GUI_E << LOG_HEADER << "Firing: " << mouse_data[I].button_double_click_event << ".";
 
 		owner_.fire(mouse_data[I].button_double_click_event, *widget);
-		last_click_stamp_ = 0;
+		last_click_stamp_ = {};
 		last_clicked_widget_ = nullptr;
 
 	} else {

--- a/src/gui/core/event/distributor.hpp
+++ b/src/gui/core/event/distributor.hpp
@@ -42,6 +42,7 @@
 #include "gui/core/event/handler.hpp"
 #include "sdl/point.hpp"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -160,7 +161,7 @@ public:
 
 protected:
 	/** The time of the last click used for double clicking. */
-	uint32_t last_click_stamp_;
+	std::chrono::steady_clock::time_point last_click_stamp_;
 
 	/** The widget the last click was on, used for double clicking. */
 	widget* last_clicked_widget_;

--- a/src/gui/core/gui_definition.cpp
+++ b/src/gui/core/gui_definition.cpp
@@ -124,14 +124,15 @@ gui_definition::gui_definition(const config& cfg)
 	 */
 	const config& settings = cfg.mandatory_child("settings");
 
-	popup_show_delay_ = settings["popup_show_delay"].to_unsigned();
-	popup_show_time_ = settings["popup_show_time"].to_unsigned();
-	help_show_time_ = settings["help_show_time"].to_unsigned();
-	double_click_time_ = settings["double_click_time"].to_unsigned();
+	using namespace std::chrono_literals;
+	popup_show_delay_ = settings["popup_show_delay"].to_duration(0ms);
+	popup_show_time_ = settings["popup_show_time"].to_duration(0ms);
+	help_show_time_ = settings["help_show_time"].to_duration(0ms);
+	double_click_time_ = settings["double_click_time"].to_duration(0ms);
 
-	repeat_button_repeat_time_ = settings["repeat_button_repeat_time"].to_unsigned();
+	repeat_button_repeat_time_ = settings["repeat_button_repeat_time"].to_duration(0ms);
 
-	VALIDATE(double_click_time_, missing_mandatory_wml_key("settings", "double_click_time"));
+	VALIDATE(!settings["double_click_time"].blank(), missing_mandatory_wml_key("settings", "double_click_time"));
 
 	sound_button_click_ = settings["sound_button_click"].str();
 	sound_toggle_button_click_ = settings["sound_toggle_button_click"].str();

--- a/src/gui/core/gui_definition.cpp
+++ b/src/gui/core/gui_definition.cpp
@@ -22,6 +22,7 @@
 #include "gui/core/log.hpp"
 #include "gui/core/static_registry.hpp"
 #include "gui/widgets/settings.hpp"
+#include "serialization/chrono.hpp"
 #include "wml_exception.hpp"
 
 namespace gui2
@@ -125,12 +126,12 @@ gui_definition::gui_definition(const config& cfg)
 	const config& settings = cfg.mandatory_child("settings");
 
 	using namespace std::chrono_literals;
-	popup_show_delay_ = settings["popup_show_delay"].to_duration(0ms);
-	popup_show_time_ = settings["popup_show_time"].to_duration(0ms);
-	help_show_time_ = settings["help_show_time"].to_duration(0ms);
-	double_click_time_ = settings["double_click_time"].to_duration(0ms);
+	popup_show_delay_ = chrono::parse_duration(settings["popup_show_delay"], 0ms);
+	popup_show_time_ = chrono::parse_duration(settings["popup_show_time"], 0ms);
+	help_show_time_ = chrono::parse_duration(settings["help_show_time"], 0ms);
+	double_click_time_ = chrono::parse_duration(settings["double_click_time"], 0ms);
 
-	repeat_button_repeat_time_ = settings["repeat_button_repeat_time"].to_duration(0ms);
+	repeat_button_repeat_time_ = chrono::parse_duration(settings["repeat_button_repeat_time"], 0ms);
 
 	VALIDATE(!settings["double_click_time"].blank(), missing_mandatory_wml_key("settings", "double_click_time"));
 

--- a/src/gui/core/gui_definition.hpp
+++ b/src/gui/core/gui_definition.hpp
@@ -69,11 +69,11 @@ private:
 
 	t_string description_;
 
-	unsigned popup_show_delay_;
-	unsigned popup_show_time_;
-	unsigned help_show_time_;
-	unsigned double_click_time_;
-	unsigned repeat_button_repeat_time_;
+	std::chrono::milliseconds popup_show_delay_;
+	std::chrono::milliseconds popup_show_time_;
+	std::chrono::milliseconds help_show_time_;
+	std::chrono::milliseconds double_click_time_;
+	std::chrono::milliseconds repeat_button_repeat_time_;
 
 	std::string sound_button_click_;
 	std::string sound_toggle_button_click_;

--- a/src/gui/core/timer.hpp
+++ b/src/gui/core/timer.hpp
@@ -30,9 +30,8 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
-
-#include <SDL2/SDL_types.h>
 
 namespace gui2
 {
@@ -50,7 +49,7 @@ namespace gui2
  * @returns                       The id of the timer.
  * @retval [0]                    Failed to create a timer.
  */
-std::size_t add_timer(const uint32_t interval,
+std::size_t add_timer(const std::chrono::milliseconds& interval,
 				 const std::function<void(std::size_t id)>& callback,
 				 const bool repeat = false);
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -1022,25 +1022,22 @@ void addon_manager::show_help()
 	help::show_help("installing_addons");
 }
 
-static std::string format_addon_time(std::time_t time)
+static std::string format_addon_time(const std::chrono::system_clock::time_point& time)
 {
-	if(time) {
-		std::ostringstream ss;
-
-		const std::string format = prefs::get().use_twelve_hour_clock_format()
-			// TRANSLATORS: Month + day of month + year + 12-hour time, eg 'November 02 2021, 1:59 PM'. Format for your locale.
-			// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
-			? _("%B %d %Y, %I:%M %p")
-			// TRANSLATORS: Month + day of month + year + 24-hour time, eg 'November 02 2021, 13:59'. Format for your locale.
-			// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
-			: _("%B %d %Y, %H:%M");
-
-		ss << translation::strftime(format, std::localtime(&time));
-
-		return ss.str();
+	if(time == std::chrono::system_clock::time_point{}) {
+		return font::unicode_em_dash;
 	}
 
-	return font::unicode_em_dash;
+	const std::string format = prefs::get().use_twelve_hour_clock_format()
+		// TRANSLATORS: Month + day of month + year + 12-hour time, eg 'November 02 2021, 1:59 PM'. Format for your locale.
+		// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
+		? _("%B %d %Y, %I:%M %p")
+		// TRANSLATORS: Month + day of month + year + 24-hour time, eg 'November 02 2021, 13:59'. Format for your locale.
+		// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
+		: _("%B %d %Y, %H:%M");
+
+	auto as_time_t = std::chrono::system_clock::to_time_t(time);
+	return translation::strftime(format, std::localtime(&as_time_t));
 }
 
 void addon_manager::on_addon_select()

--- a/src/gui/dialogs/file_progress.cpp
+++ b/src/gui/dialogs/file_progress.cpp
@@ -55,15 +55,11 @@ file_progress::file_progress(const std::string& title, const std::string& messag
 
 void file_progress::update_progress(unsigned value)
 {
-	using std::chrono::duration_cast;
-	using std::chrono::milliseconds;
-	using namespace std::chrono_literals;
-
 	auto now = clock::now();
-	auto elapsed = duration_cast<milliseconds>(now - update_time_);
+	auto elapsed = now - update_time_;
 
 	// Update at most once per vsync.
-	if(elapsed < milliseconds(draw_manager::get_frame_length())) {
+	if(elapsed < draw_manager::get_frame_length()) {
 		return;
 	}
 

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -150,7 +150,7 @@ void loading_screen::raise()
 }
 
 // This will be run inside the window::show() loop.
-void loading_screen::process(events::pump_info&)
+void loading_screen::process()
 {
 	if (load_funcs_.empty()) {
 		return;

--- a/src/gui/dialogs/loading_screen.cpp
+++ b/src/gui/dialogs/loading_screen.cpp
@@ -30,6 +30,7 @@
 #include "log.hpp"
 #include "video.hpp"
 
+#include <chrono>
 #include <functional>
 
 static lg::log_domain log_loadscreen("loadscreen");
@@ -66,7 +67,7 @@ static const std::map<loading_stage, std::string> stage_names {
 	{ loading_stage::download_lobby_data, N_("Downloading lobby data") },
 };
 
-namespace { int last_spin_ = 0; }
+namespace { std::chrono::steady_clock::time_point last_spin; }
 
 namespace gui2::dialogs
 {
@@ -133,9 +134,10 @@ void loading_screen::spin()
 	}
 
 	// Restrict actual update rate.
-	int elapsed = SDL_GetTicks() - last_spin_;
-	if (elapsed > draw_manager::get_frame_length() || elapsed < 0) {
-		last_spin_ = SDL_GetTicks();
+	auto now = std::chrono::steady_clock::now();
+	auto elapsed = now - last_spin;
+	if (elapsed > draw_manager::get_frame_length()) {
+		last_spin = now;
 		events::pump_and_draw();
 	}
 }

--- a/src/gui/dialogs/loading_screen.hpp
+++ b/src/gui/dialogs/loading_screen.hpp
@@ -123,7 +123,7 @@ private:
 	virtual void post_show() override;
 
 	/** Inherited from events::pump_monitor. */
-	virtual void process(events::pump_info&) override;
+	virtual void process() override;
 
 	/** Called by draw_manager to assign concrete layout. */
 	virtual void layout() override;

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -97,7 +97,7 @@ mp_lobby::mp_lobby(mp::lobby_info& info, wesnothd_connection& connection, int& j
 	, player_list_(std::bind(&mp_lobby::user_dialog_callback, this, std::placeholders::_1))
 	, player_list_dirty_(true)
 	, gamelist_dirty_(true)
-	, last_lobby_update_(0)
+	, last_lobby_update_()
 	, gamelist_diff_update_(true)
 	, network_connection_(connection)
 	, lobby_update_timer_(0)
@@ -249,7 +249,7 @@ void mp_lobby::update_gamelist()
 
 	update_selected_game();
 	gamelist_dirty_ = false;
-	last_lobby_update_ = SDL_GetTicks();
+	last_lobby_update_ = std::chrono::steady_clock::now();
 	finish_state_sync();
 	update_visible_games();
 }
@@ -356,7 +356,7 @@ void mp_lobby::update_gamelist_diff()
 
 	update_selected_game();
 	gamelist_dirty_ = false;
-	last_lobby_update_ = SDL_GetTicks();
+	last_lobby_update_ = std::chrono::steady_clock::now();
 	finish_state_sync();
 	update_visible_games();
 }
@@ -529,7 +529,7 @@ void mp_lobby::update_playerlist()
 	player_list_.update(lobby_info_.users(), selected_game_id_);
 
 	player_list_dirty_ = false;
-	last_lobby_update_ = SDL_GetTicks();
+	last_lobby_update_ = std::chrono::steady_clock::now();
 }
 
 void mp_lobby::update_selected_game()
@@ -721,7 +721,7 @@ void mp_lobby::network_handler()
 		throw;
 	}
 
-	if ((SDL_GetTicks() - last_lobby_update_ < game_config::lobby_refresh)) {
+	if(std::chrono::steady_clock::now() - last_lobby_update_ < game_config::lobby_refresh) {
 		return;
 	}
 

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -159,7 +159,7 @@ private:
 
 	bool gamelist_dirty_;
 
-	unsigned last_lobby_update_;
+	std::chrono::steady_clock::time_point last_lobby_update_;
 
 	bool gamelist_diff_update_;
 

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -103,17 +103,17 @@ mp_create_game::mp_create_game(saved_game& state, bool local_mode)
 		[]() {return prefs::get().xp_modifier();},
 		[](int v) {prefs::get().set_xp_modifier(v);}))
 	, init_turn_limit_(register_integer("init_turn_limit", true,
-		[]() {return prefs::get().countdown_init_time();},
-		[](int v) {prefs::get().set_countdown_init_time(v);}))
+		[]() {return prefs::get().countdown_init_time().count();},
+		[](int v) {prefs::get().set_countdown_init_time(std::chrono::seconds{v});}))
 	, turn_bonus_(register_integer("turn_bonus", true,
-		[]() {return prefs::get().countdown_turn_bonus();},
-		[](int v) {prefs::get().set_countdown_turn_bonus(v);}))
+		[]() {return prefs::get().countdown_turn_bonus().count();},
+		[](int v) {prefs::get().set_countdown_turn_bonus(std::chrono::seconds{v});}))
 	, reservoir_(register_integer("reservoir", true,
-		[]() {return prefs::get().countdown_reservoir_time();},
-		[](int v) {prefs::get().set_countdown_reservoir_time(v);}))
+		[]() {return prefs::get().countdown_reservoir_time().count();},
+		[](int v) {prefs::get().set_countdown_reservoir_time(std::chrono::seconds{v});}))
 	, action_bonus_(register_integer("action_bonus", true,
-		[]() {return prefs::get().countdown_action_bonus();},
-		[](int v) {prefs::get().set_countdown_action_bonus(v);}))
+		[]() {return prefs::get().countdown_action_bonus().count();},
+		[](int v) {prefs::get().set_countdown_action_bonus(std::chrono::seconds{v});}))
 	, mod_list_()
 	, eras_menu_button_()
 	, local_mode_(local_mode)
@@ -834,10 +834,10 @@ void mp_create_game::reset_timer_settings()
 	prefs::get().clear_countdown_turn_bonus();
 	prefs::get().clear_countdown_action_bonus();
 
-	init_turn_limit_->set_widget_value(prefs::get().countdown_init_time());
-	turn_bonus_->set_widget_value(prefs::get().countdown_turn_bonus());
-	reservoir_->set_widget_value(prefs::get().countdown_reservoir_time());
-	action_bonus_->set_widget_value(prefs::get().countdown_action_bonus());
+	init_turn_limit_->set_widget_value(prefs::get().countdown_init_time().count());
+	turn_bonus_->set_widget_value(prefs::get().countdown_turn_bonus().count());
+	reservoir_->set_widget_value(prefs::get().countdown_reservoir_time().count());
+	action_bonus_->set_widget_value(prefs::get().countdown_action_bonus().count());
 }
 
 bool mp_create_game::dialog_exit_hook(window& /*window*/)
@@ -950,10 +950,10 @@ void mp_create_game::post_show()
 		}
 
 		config_engine_->set_mp_countdown(time_limit_->get_widget_value());
-		config_engine_->set_mp_countdown_init_time(init_turn_limit_->get_widget_value());
-		config_engine_->set_mp_countdown_turn_bonus(turn_bonus_->get_widget_value());
-		config_engine_->set_mp_countdown_reservoir_time(reservoir_->get_widget_value());
-		config_engine_->set_mp_countdown_action_bonus(action_bonus_->get_widget_value());
+		config_engine_->set_mp_countdown_init_time(std::chrono::seconds{init_turn_limit_->get_widget_value()});
+		config_engine_->set_mp_countdown_turn_bonus(std::chrono::seconds{turn_bonus_->get_widget_value()});
+		config_engine_->set_mp_countdown_reservoir_time(std::chrono::seconds{reservoir_->get_widget_value()});
+		config_engine_->set_mp_countdown_action_bonus(std::chrono::seconds{action_bonus_->get_widget_value()});
 
 		config_engine_->set_allow_observers(observers_->get_widget_value());
 		config_engine_->set_private_replay(private_replay_->get_widget_value());

--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -29,7 +29,7 @@ using namespace std::chrono_literals;
 
 REGISTER_DIALOG(network_transmission)
 
-void network_transmission::pump_monitor::process(events::pump_info&)
+void network_transmission::pump_monitor::process()
 {
 	if(!window_)
 		return;

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -51,7 +51,7 @@ private:
 	{
 	public:
 		connection_data*& connection_;
-		virtual void process(events::pump_info&);
+		virtual void process();
 
 		pump_monitor(connection_data*& connection)
 			: connection_(connection), window_()

--- a/src/gui/dialogs/outro.cpp
+++ b/src/gui/dialogs/outro.cpp
@@ -27,11 +27,13 @@
 
 #include <cmath>
 
+using namespace std::chrono_literals;
+
 namespace
 {
 
 // How long text fading should take - currently a hardcoded value.
-const unsigned FADE_DURATION_MS = 500;
+const auto fade_duration = 500ms;
 
 } // end unnamed namespace
 
@@ -95,8 +97,8 @@ outro::outro(const game_classification& info)
 
 	current_text_ = text_[0];
 
-	if(!duration_) {
-		duration_ = 3500; // 3.5 seconds
+	if(duration_ == 0ms) {
+		duration_ = 3500ms; // 3.5 seconds
 	}
 }
 
@@ -167,7 +169,7 @@ void outro::update()
 	}
 
 	fade_alpha_ = std::clamp<int>(
-		std::round(255.0 * double(current_ticks - fade_start_) / double(FADE_DURATION_MS)),
+		std::round(255.0 * double(current_ticks - fade_start_) / double(fade_duration.count())),
 		0, 255);
 	if(!fading_in_) {
 		fade_alpha_ = 255 - fade_alpha_;

--- a/src/gui/dialogs/outro.hpp
+++ b/src/gui/dialogs/outro.hpp
@@ -17,6 +17,8 @@
 
 #include "gui/dialogs/modal_dialog.hpp"
 
+#include <chrono>
+
 class game_classification;
 
 namespace gui2::dialogs
@@ -47,7 +49,7 @@ private:
 	std::string current_text_;
 	std::size_t text_index_;
 
-	unsigned int duration_;
+	std::chrono::milliseconds duration_;
 	int fade_alpha_;
 	uint32_t fade_start_;
 

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -575,10 +575,6 @@ void preferences_dialog::initialize_callbacks()
 	//register_integer("scaling_slider", true,
 	//	font_scaling, set_font_scaling);
 
-	/* FPS LIMITER */
-	register_bool("fps_limiter", true,
-		[]() { return prefs::get().draw_delay() != 0; }, [](bool v) { prefs::get().set_draw_delay(v ? -1 : 0); });
-
 	/* VSYNC */
 	register_bool("vsync", true,
 		[]() {return prefs::get().vsync();},

--- a/src/gui/dialogs/story_viewer.cpp
+++ b/src/gui/dialogs/story_viewer.cpp
@@ -378,8 +378,8 @@ void story_viewer::draw_floating_image(floating_image_list::const_iterator image
 		get_window()->queue_redraw();
 
 		// If a delay is specified, schedule the next image draw and break out of the loop.
-		const unsigned int draw_delay = floating_image.display_delay();
-		if(draw_delay != 0) {
+		const auto& draw_delay = floating_image.display_delay();
+		if(draw_delay != std::chrono::milliseconds{0}) {
 			// This must be a non-repeating timer
 			timer_id_ = add_timer(draw_delay, std::bind(&story_viewer::draw_floating_image, this, image_iter, this_part_index), false);
 			return;

--- a/src/gui/widgets/settings.cpp
+++ b/src/gui/widgets/settings.cpp
@@ -39,11 +39,11 @@ unsigned gamemap_x_offset = 0;
 unsigned gamemap_width = 0;
 unsigned gamemap_height = 0;
 
-unsigned popup_show_delay = 0;
-unsigned popup_show_time = 0;
-unsigned help_show_time = 0;
-unsigned double_click_time = 0;
-unsigned repeat_button_repeat_time = 0;
+std::chrono::milliseconds popup_show_delay{0};
+std::chrono::milliseconds popup_show_time{0};
+std::chrono::milliseconds help_show_time{0};
+std::chrono::milliseconds double_click_time{0};
+std::chrono::milliseconds repeat_button_repeat_time{0};
 
 std::string sound_button_click = "";
 std::string sound_toggle_button_click = "";

--- a/src/gui/widgets/settings.hpp
+++ b/src/gui/widgets/settings.hpp
@@ -23,6 +23,7 @@
 #include "gui/auxiliary/tips.hpp"
 #include "tstring.hpp"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -57,11 +58,11 @@ extern unsigned gamemap_width;
 extern unsigned gamemap_height;
 
 /** These are copied from the active gui. */
-extern unsigned popup_show_delay;
-extern unsigned popup_show_time;
-extern unsigned help_show_time;
-extern unsigned double_click_time;
-extern unsigned repeat_button_repeat_time;
+extern std::chrono::milliseconds popup_show_delay;
+extern std::chrono::milliseconds popup_show_time;
+extern std::chrono::milliseconds help_show_time;
+extern std::chrono::milliseconds double_click_time;
+extern std::chrono::milliseconds repeat_button_repeat_time;
 
 extern std::string sound_button_click;
 extern std::string sound_toggle_button_click;

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -30,6 +30,8 @@
 #define LOG_SCOPE_HEADER get_control_type() + " [" + id() + "] " + __func__
 #define LOG_HEADER LOG_SCOPE_HEADER + ':'
 
+using namespace std::chrono_literals;
+
 namespace gui2
 {
 
@@ -44,7 +46,7 @@ text_box_base::text_box_base(const implementation::builder_styled_widget& builde
 	, ime_start_point_(0)
 	, cursor_timer_(0)
 	, cursor_alpha_(0)
-	, cursor_blink_rate_ms_(750)
+	, cursor_blink_rate_(750ms)
 	, text_changed_callback_()
 {
 	auto cfg = get_control(control_type, builder.definition);
@@ -292,7 +294,7 @@ void text_box_base::set_state(const state_t state)
 
 void text_box_base::toggle_cursor_timer(bool enable)
 {
-	if(!cursor_blink_rate_ms_) {
+	if(cursor_blink_rate_ == 0ms) {
 		return;
 	}
 
@@ -301,7 +303,7 @@ void text_box_base::toggle_cursor_timer(bool enable)
 	}
 
 	cursor_timer_ = enable
-			? add_timer(cursor_blink_rate_ms_, std::bind(&text_box_base::cursor_timer_callback, this), true)
+			? add_timer(cursor_blink_rate_, std::bind(&text_box_base::cursor_timer_callback, this), true)
 			: 0;
 }
 
@@ -337,7 +339,7 @@ void text_box_base::cursor_timer_callback()
 
 void text_box_base::reset_cursor_state()
 {
-	if(!cursor_blink_rate_ms_) {
+	if(cursor_blink_rate_ == 0ms) {
 		return;
 	}
 

--- a/src/gui/widgets/text_box_base.hpp
+++ b/src/gui/widgets/text_box_base.hpp
@@ -425,7 +425,7 @@ private:
 	std::size_t cursor_timer_;
 
 	unsigned short cursor_alpha_;
-	unsigned short cursor_blink_rate_ms_;
+	std::chrono::milliseconds cursor_blink_rate_;
 
 	/****** handling of special keys first the pure virtuals *****/
 

--- a/src/mp_game_settings.hpp
+++ b/src/mp_game_settings.hpp
@@ -23,6 +23,8 @@
 
 #include "utils/optional_fwd.hpp"
 
+#include <chrono>
+
 struct mp_game_settings
 {
 	mp_game_settings();
@@ -45,10 +47,10 @@ struct mp_game_settings
 	int village_gold;
 	int village_support;
 	int xp_modifier;
-	int mp_countdown_init_time;
-	int mp_countdown_reservoir_time;
-	int mp_countdown_turn_bonus;
-	int mp_countdown_action_bonus;
+	std::chrono::seconds mp_countdown_init_time;
+	std::chrono::seconds mp_countdown_reservoir_time;
+	std::chrono::seconds mp_countdown_turn_bonus;
+	std::chrono::seconds mp_countdown_action_bonus;
 	bool mp_countdown;
 	bool use_map_settings;
 	bool random_start_time;

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -132,7 +132,7 @@ play_controller::play_controller(const config& level, saved_game& state_of_game)
 	: controller_base()
 	, observer()
 	, quit_confirmation()
-	, ticks_(SDL_GetTicks())
+	, timer_()
 	, gamestate_()
 	, level_()
 	, saved_game_(state_of_game)
@@ -209,7 +209,7 @@ void play_controller::init(const config& level)
 	gui2::dialogs::loading_screen::display([this, &level]() {
 		gui2::dialogs::loading_screen::progress(loading_stage::load_level);
 
-		LOG_NG << "initializing game_state..." << (SDL_GetTicks() - ticks());
+		LOG_NG << "initializing game_state..." << timer();
 		gamestate_.reset(new game_state(level, *this));
 
 		resources::gameboard = &gamestate().board_;
@@ -224,19 +224,19 @@ void play_controller::init(const config& level)
 		gamestate_->init(level, *this);
 		resources::tunnels = gamestate().pathfind_manager_.get();
 
-		LOG_NG << "initializing whiteboard..." << (SDL_GetTicks() - ticks());
+		LOG_NG << "initializing whiteboard..." << timer();
 		gui2::dialogs::loading_screen::progress(loading_stage::init_whiteboard);
 		whiteboard_manager_.reset(new wb::manager());
 		resources::whiteboard = whiteboard_manager_;
 
-		LOG_NG << "loading units..." << (SDL_GetTicks() - ticks());
+		LOG_NG << "loading units..." << timer();
 		gui2::dialogs::loading_screen::progress(loading_stage::load_units);
 		prefs::get().encounter_all_content(gamestate().board_);
 
-		LOG_NG << "initializing theme... " << (SDL_GetTicks() - ticks());
+		LOG_NG << "initializing theme... " << timer();
 		gui2::dialogs::loading_screen::progress(loading_stage::init_theme);
 
-		LOG_NG << "building terrain rules... " << (SDL_GetTicks() - ticks());
+		LOG_NG << "building terrain rules... " << timer();
 		gui2::dialogs::loading_screen::progress(loading_stage::build_terrain);
 
 		gui_.reset(new game_display(gamestate().board_, whiteboard_manager_, *gamestate().reports_, theme(), level));
@@ -261,9 +261,9 @@ void play_controller::init(const config& level)
 		mouse_handler_.set_gui(gui_.get());
 		menu_handler_.set_gui(gui_.get());
 
-		LOG_NG << "done initializing display... " << (SDL_GetTicks() - ticks());
+		LOG_NG << "done initializing display... " << timer();
 
-		LOG_NG << "building gamestate to gui and whiteboard... " << (SDL_GetTicks() - ticks());
+		LOG_NG << "building gamestate to gui and whiteboard... " << timer();
 		// This *needs* to be created before the show_intro and show_map_scene
 		// as that functions use the manager state_of_game
 		// Has to be done before registering any events!
@@ -328,11 +328,11 @@ void play_controller::reset_gamestate(const config& level, int replay_pos)
 
 void play_controller::init_managers()
 {
-	LOG_NG << "initializing managers... " << (SDL_GetTicks() - ticks());
+	LOG_NG << "initializing managers... " << timer();
 	soundsources_manager_.reset(new soundsource::manager(*gui_));
 
 	resources::soundsources = soundsources_manager_.get();
-	LOG_NG << "done initializing managers... " << (SDL_GetTicks() - ticks());
+	LOG_NG << "done initializing managers... " << timer();
 }
 
 void play_controller::fire_preload()
@@ -1137,7 +1137,7 @@ void play_controller::start_game()
 		// Initialize countdown clock.
 		for(const team& t : get_teams()) {
 			if(saved_game_.mp_settings().mp_countdown) {
-				t.set_countdown_time(1000 * saved_game_.mp_settings().mp_countdown_init_time);
+				t.set_countdown_time(saved_game_.mp_settings().mp_countdown_init_time);
 			}
 		}
 		did_autosave_this_turn_ = false;

--- a/src/play_controller.hpp
+++ b/src/play_controller.hpp
@@ -25,6 +25,7 @@
 #include "persist_manager.hpp"
 #include "tod_manager.hpp"
 #include "game_state.hpp"
+#include "utils/optimer.hpp"
 #include "utils/optional_fwd.hpp"
 
 #include <set>
@@ -273,7 +274,7 @@ public:
 
 	bool can_use_synced_wml_menu() const;
 	std::set<std::string> all_players() const;
-	int ticks() const { return ticks_; }
+	const auto& timer() const { return timer_; }
 	game_display& get_display() override;
 
 	void update_savegame_snapshot() const;
@@ -334,7 +335,7 @@ public:
 	/** returns 0 if no such team was found. */
 	virtual int find_viewing_side() const = 0;
 private:
-	const int ticks_;
+	utils::ms_optimer timer_;
 
 protected:
 	//gamestate

--- a/src/playsingle_controller.cpp
+++ b/src/playsingle_controller.cpp
@@ -95,7 +95,7 @@ std::string playsingle_controller::describe_result() const
 
 void playsingle_controller::init_gui()
 {
-	LOG_NG << "Initializing GUI... " << (SDL_GetTicks() - ticks());
+	LOG_NG << "Initializing GUI... " << timer();
 	// If we are retarting replay from linger mode.
 	update_gui_linger();
 	play_controller::init_gui();
@@ -131,7 +131,7 @@ void playsingle_controller::init_gui()
 	gui_->set_prevent_draw(false);
 	gui_->queue_repaint();
 	if(!video::headless() && !video::testing()) {
-		gui_->fade_to({0,0,0,0}, 500);
+		gui_->fade_to({0,0,0,0}, std::chrono::milliseconds{500});
 	} else {
 		gui_->set_fade({0,0,0,0});
 	}
@@ -308,7 +308,7 @@ void playsingle_controller::finish_side_turn()
 
 void playsingle_controller::play_scenario_main_loop()
 {
-	LOG_NG << "starting main loop\n" << (SDL_GetTicks() - ticks());
+	LOG_NG << "starting main loop\n" << timer();
 
 	ai_testing::log_game_start();
 	while(!(gamestate().in_phase(game_data::GAME_ENDED) && end_turn_requested_ )) {

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -1598,13 +1598,12 @@ void prefs::set_options(const config& values)
 
 std::chrono::seconds prefs::countdown_init_time()
 {
-	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_init_time], 240s);
-	return std::clamp(val, 0s, 1500s);
+	return chrono::parse_duration(preferences_[prefs_list::mp_countdown_init_time], 240s);
 }
 
 void prefs::set_countdown_init_time(const std::chrono::seconds& value)
 {
-	preferences_[prefs_list::mp_countdown_init_time] = value;
+	preferences_[prefs_list::mp_countdown_init_time] = std::clamp(value, 0s, 1500s);
 }
 
 void prefs::clear_countdown_init_time()
@@ -1614,13 +1613,12 @@ void prefs::clear_countdown_init_time()
 
 std::chrono::seconds prefs::countdown_reservoir_time()
 {
-	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_reservoir_time], 360s);
-	return std::clamp(val, 30s, 1500s);
+	return chrono::parse_duration(preferences_[prefs_list::mp_countdown_reservoir_time], 360s);
 }
 
 void prefs::set_countdown_reservoir_time(const std::chrono::seconds& value)
 {
-	preferences_[prefs_list::mp_countdown_reservoir_time] = value;
+	preferences_[prefs_list::mp_countdown_reservoir_time] = std::clamp(value, 30s, 1500s);
 }
 
 void prefs::clear_countdown_reservoir_time()
@@ -1630,13 +1628,12 @@ void prefs::clear_countdown_reservoir_time()
 
 std::chrono::seconds prefs::countdown_turn_bonus()
 {
-	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_turn_bonus], 240s);
-	return std::clamp(val, 0s, 300s);
+	return chrono::parse_duration(preferences_[prefs_list::mp_countdown_turn_bonus], 240s);
 }
 
 void prefs::set_countdown_turn_bonus(const std::chrono::seconds& value)
 {
-	preferences_[prefs_list::mp_countdown_turn_bonus] = value;
+	preferences_[prefs_list::mp_countdown_turn_bonus] = std::clamp(value, 0s, 300s);
 }
 
 void prefs::clear_countdown_turn_bonus()
@@ -1646,13 +1643,12 @@ void prefs::clear_countdown_turn_bonus()
 
 std::chrono::seconds prefs::countdown_action_bonus()
 {
-	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_action_bonus], 0s);
-	return std::clamp(val, 0s, 30s);
+	return chrono::parse_duration(preferences_[prefs_list::mp_countdown_action_bonus], 0s);
 }
 
 void prefs::set_countdown_action_bonus(const std::chrono::seconds& value)
 {
-	preferences_[prefs_list::mp_countdown_action_bonus] = value;
+	preferences_[prefs_list::mp_countdown_action_bonus] = std::clamp(value, 0s, 30s);
 }
 
 void prefs::clear_countdown_action_bonus()

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -36,6 +36,7 @@
 #include "map_settings.hpp"
 #include "map/map.hpp"
 #include "resources.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/parser.hpp"
 #include "sound.hpp"
 #include "units/unit.hpp"
@@ -1597,7 +1598,8 @@ void prefs::set_options(const config& values)
 
 std::chrono::seconds prefs::countdown_init_time()
 {
-	return std::clamp(preferences_[prefs_list::mp_countdown_init_time].to_duration(240s), 0s, 1500s);
+	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_init_time], 240s);
+	return std::clamp(val, 0s, 1500s);
 }
 
 void prefs::set_countdown_init_time(const std::chrono::seconds& value)
@@ -1612,7 +1614,8 @@ void prefs::clear_countdown_init_time()
 
 std::chrono::seconds prefs::countdown_reservoir_time()
 {
-	return std::clamp(preferences_[prefs_list::mp_countdown_reservoir_time].to_duration(360s), 30s, 1500s);
+	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_reservoir_time], 360s);
+	return std::clamp(val, 30s, 1500s);
 }
 
 void prefs::set_countdown_reservoir_time(const std::chrono::seconds& value)
@@ -1627,7 +1630,8 @@ void prefs::clear_countdown_reservoir_time()
 
 std::chrono::seconds prefs::countdown_turn_bonus()
 {
-	return std::clamp(preferences_[prefs_list::mp_countdown_turn_bonus].to_duration(240s), 0s, 300s);
+	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_turn_bonus], 240s);
+	return std::clamp(val, 0s, 300s);
 }
 
 void prefs::set_countdown_turn_bonus(const std::chrono::seconds& value)
@@ -1642,7 +1646,8 @@ void prefs::clear_countdown_turn_bonus()
 
 std::chrono::seconds prefs::countdown_action_bonus()
 {
-	return std::clamp(preferences_[prefs_list::mp_countdown_action_bonus].to_duration(0s), 0s, 30s);
+	auto val = chrono::parse_duration(preferences_[prefs_list::mp_countdown_action_bonus], 0s);
+	return std::clamp(val, 0s, 30s);
 }
 
 void prefs::set_countdown_action_bonus(const std::chrono::seconds& value)
@@ -1653,6 +1658,16 @@ void prefs::set_countdown_action_bonus(const std::chrono::seconds& value)
 void prefs::clear_countdown_action_bonus()
 {
 	preferences_.remove_attribute(prefs_list::mp_countdown_action_bonus);
+}
+
+std::chrono::minutes prefs::chat_message_aging()
+{
+	return chrono::parse_duration(preferences_[prefs_list::chat_message_aging], 20min);
+}
+
+void prefs::set_chat_message_aging(const std::chrono::minutes& value)
+{
+	preferences_[prefs_list::chat_message_aging] = value;
 }
 
 int prefs::village_gold()

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -66,6 +66,8 @@ static lg::log_domain log_filesystem("filesystem");
 static lg::log_domain advanced_preferences("advanced_preferences");
 #define ERR_ADV LOG_STREAM(err, advanced_preferences)
 
+using namespace std::chrono_literals;
+
 prefs::prefs()
 : preferences_()
 , fps_(false)
@@ -1593,12 +1595,12 @@ void prefs::set_options(const config& values)
 	options_initialized_ = false;
 }
 
-int prefs::countdown_init_time()
+std::chrono::seconds prefs::countdown_init_time()
 {
-	return std::clamp<int>(preferences_[prefs_list::mp_countdown_init_time].to_int(240), 0, 1500);
+	return std::clamp(preferences_[prefs_list::mp_countdown_init_time].to_duration(240s), 0s, 1500s);
 }
 
-void prefs::set_countdown_init_time(int value)
+void prefs::set_countdown_init_time(const std::chrono::seconds& value)
 {
 	preferences_[prefs_list::mp_countdown_init_time] = value;
 }
@@ -1608,12 +1610,12 @@ void prefs::clear_countdown_init_time()
 	preferences_.remove_attribute(prefs_list::mp_countdown_init_time);
 }
 
-int prefs::countdown_reservoir_time()
+std::chrono::seconds prefs::countdown_reservoir_time()
 {
-	return std::clamp<int>(preferences_[prefs_list::mp_countdown_reservoir_time].to_int(360), 30, 1500);
+	return std::clamp(preferences_[prefs_list::mp_countdown_reservoir_time].to_duration(360s), 30s, 1500s);
 }
 
-void prefs::set_countdown_reservoir_time(int value)
+void prefs::set_countdown_reservoir_time(const std::chrono::seconds& value)
 {
 	preferences_[prefs_list::mp_countdown_reservoir_time] = value;
 }
@@ -1623,12 +1625,12 @@ void prefs::clear_countdown_reservoir_time()
 	preferences_.remove_attribute(prefs_list::mp_countdown_reservoir_time);
 }
 
-int prefs::countdown_turn_bonus()
+std::chrono::seconds prefs::countdown_turn_bonus()
 {
-	return std::clamp<int>(preferences_[prefs_list::mp_countdown_turn_bonus].to_int(240), 0, 300);
+	return std::clamp(preferences_[prefs_list::mp_countdown_turn_bonus].to_duration(240s), 0s, 300s);
 }
 
-void prefs::set_countdown_turn_bonus(int value)
+void prefs::set_countdown_turn_bonus(const std::chrono::seconds& value)
 {
 	preferences_[prefs_list::mp_countdown_turn_bonus] = value;
 }
@@ -1638,12 +1640,12 @@ void prefs::clear_countdown_turn_bonus()
 	preferences_.remove_attribute(prefs_list::mp_countdown_turn_bonus);
 }
 
-int prefs::countdown_action_bonus()
+std::chrono::seconds prefs::countdown_action_bonus()
 {
-	return std::clamp<int>(preferences_[prefs_list::mp_countdown_action_bonus].to_int(), 0, 30);
+	return std::clamp(preferences_[prefs_list::mp_countdown_action_bonus].to_duration(0s), 0s, 30s);
 }
 
-void prefs::set_countdown_action_bonus(int value)
+void prefs::set_countdown_action_bonus(const std::chrono::seconds& value)
 {
 	preferences_[prefs_list::mp_countdown_action_bonus] = value;
 }

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -503,7 +503,7 @@ class prefs
 		PREF_GETTER_SETTER(stop_music_in_background, bool, false)
 		PREF_GETTER_SETTER(tile_size, unsigned, 0)
 		PREF_GETTER_SETTER(mouse_scrolling, bool, true)
-		PREF_GETTER_SETTER(draw_delay, int, -1)
+		PREF_GETTER_SETTER(refresh_rate, int, -1)
 		PREF_GETTER_SETTER(animate_map, bool, true)
 		PREF_GETTER_SETTER(animate_water, bool, true)
 		PREF_GETTER_SETTER(minimap_movement_coding, bool, true)
@@ -819,7 +819,7 @@ class prefs
 		static constexpr std::array unsynced_attributes_{
 			prefs_list::auto_pixel_scale,
 			prefs_list::core,
-			prefs_list::draw_delay,
+			prefs_list::refresh_rate,
 			prefs_list::editor_chosen_addon,
 			prefs_list::gui2_theme,
 			prefs_list::mp_server_program_name,

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -370,20 +370,20 @@ class prefs
 		const config& options();
 		void set_options(const config& values);
 
-		int countdown_init_time();
-		void set_countdown_init_time(int value);
+		std::chrono::seconds countdown_init_time();
+		void set_countdown_init_time(const std::chrono::seconds& value);
 		void clear_countdown_init_time();
 
-		int countdown_turn_bonus();
-		void set_countdown_turn_bonus(int value);
+		std::chrono::seconds countdown_turn_bonus();
+		void set_countdown_turn_bonus(const std::chrono::seconds& value);
 		void clear_countdown_turn_bonus();
 
-		int countdown_reservoir_time();
-		void set_countdown_reservoir_time(int value);
+		std::chrono::seconds countdown_reservoir_time();
+		void set_countdown_reservoir_time(const std::chrono::seconds& value);
 		void clear_countdown_reservoir_time();
 
-		int countdown_action_bonus();
-		void set_countdown_action_bonus(int value);
+		std::chrono::seconds countdown_action_bonus();
+		void set_countdown_action_bonus(const std::chrono::seconds& value);
 		void clear_countdown_action_bonus();
 
 		int village_gold();
@@ -556,7 +556,7 @@ class prefs
 		PREF_GETTER_SETTER(floating_labels, bool, true)
 		PREF_GETTER_SETTER(chat_timestamp, bool, false)
 		PREF_GETTER_SETTER(chat_lines, int, 6)
-		PREF_GETTER_SETTER(chat_message_aging, int, 20)
+		PREF_GETTER_SETTER(chat_message_aging, std::chrono::minutes, std::chrono::minutes{20})
 		PREF_GETTER_SETTER(show_all_units_in_help, bool, false)
 		PREF_GETTER_SETTER(custom_command, std::string, std::string(""))
 		PREF_GETTER_SETTER(player_joins_sound, bool, true)

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -386,6 +386,9 @@ class prefs
 		void set_countdown_action_bonus(const std::chrono::seconds& value);
 		void clear_countdown_action_bonus();
 
+		std::chrono::minutes chat_message_aging();
+		void set_chat_message_aging(const std::chrono::minutes& value);
+
 		int village_gold();
 		void set_village_gold(int value);
 
@@ -556,7 +559,6 @@ class prefs
 		PREF_GETTER_SETTER(floating_labels, bool, true)
 		PREF_GETTER_SETTER(chat_timestamp, bool, false)
 		PREF_GETTER_SETTER(chat_lines, int, 6)
-		PREF_GETTER_SETTER(chat_message_aging, std::chrono::minutes, std::chrono::minutes{20})
 		PREF_GETTER_SETTER(show_all_units_in_help, bool, false)
 		PREF_GETTER_SETTER(custom_command, std::string, std::string(""))
 		PREF_GETTER_SETTER(player_joins_sound, bool, true)

--- a/src/preferences/preferences_list.hpp
+++ b/src/preferences/preferences_list.hpp
@@ -77,8 +77,8 @@ struct preferences_list_defines
 	ADDPREF(dir_bookmarks)
 	/** whether to automatically move units that were previously told to move towards hexes more than one turn away */
 	ADDPREF(disable_auto_moves)
-	/** used to enforce the FPS limit - minimum time between frame updates if the player's PC is capable of updating the screen faster than this */
-	ADDPREF(draw_delay)
+	/** maximum FPS, if set, at which to refresh the screen */
+	ADDPREF(refresh_rate)
 	/** whether to have the editor automatically update terrain transitions when placing terrain immediately, after the mouse click is released, or not at all */
 	ADDPREF(editor_auto_update_transitions)
 	/** the current add-on being used in the editor */
@@ -405,7 +405,7 @@ struct preferences_list_defines
 		delete_saves,
 		dir_bookmarks,
 		disable_auto_moves,
-		draw_delay,
+		refresh_rate,
 		editor_auto_update_transitions,
 		editor_chosen_addon,
 		editor_draw_hex_coordinates,

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -856,13 +856,13 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 		}
 		else if (auto countdown_update = cfg->optional_child("countdown_update"))
 		{
-			int val = countdown_update["value"].to_int();
+			auto val = countdown_update["value"].to_duration<std::chrono::milliseconds>();
 			int tval = countdown_update["team"].to_int();
 			if (tval <= 0  || tval > static_cast<int>(resources::gameboard->teams().size())) {
 				std::stringstream errbuf;
 				errbuf << "Illegal countdown update \n"
 					<< "Received update for :" << tval << " Current user :"
-					<< side_num << "\n" << " Updated value :" << val;
+					<< side_num << "\n" << " Updated value :" << val.count();
 
 				replay::process_error(errbuf.str());
 			} else {

--- a/src/replay.cpp
+++ b/src/replay.cpp
@@ -34,6 +34,7 @@
 #include "preferences/preferences.hpp"
 #include "replay_recorder_base.hpp"
 #include "resources.hpp"
+#include "serialization/chrono.hpp"
 #include "synced_context.hpp"
 #include "units/unit.hpp"
 #include "whiteboard/manager.hpp"
@@ -856,7 +857,7 @@ REPLAY_RETURN do_replay_handle(bool one_move)
 		}
 		else if (auto countdown_update = cfg->optional_child("countdown_update"))
 		{
-			auto val = countdown_update["value"].to_duration<std::chrono::milliseconds>();
+			auto val = chrono::parse_duration<std::chrono::milliseconds>(countdown_update["value"]);
 			int tval = countdown_update["team"].to_int();
 			if (tval <= 0  || tval > static_cast<int>(resources::gameboard->teams().size())) {
 				std::stringstream errbuf;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -39,6 +39,7 @@
 #include "saved_game.hpp"
 #include "serialization/binary_or_text.hpp"
 #include "serialization/utf8_exception.hpp"
+#include "utils/optimer.hpp"
 #include "video.hpp" // only for faked
 
 #include <iomanip>
@@ -452,8 +453,9 @@ void savegame::before_save()
 bool savegame::save_game(const std::string& filename)
 {
 	try {
-		uint32_t start, end;
-		start = SDL_GetTicks();
+		utils::optional<const utils::ms_optimer> timer([this](const auto& timer) {
+			LOG_SAVE << "Milliseconds to save " << filename_ << ": " << timer;
+		});
 
 		if(filename_.empty()) {
 			filename_ = filename;
@@ -476,8 +478,8 @@ bool savegame::save_game(const std::string& filename)
 		// the came campaign, for example).
 		save_index_manager_->rebuild(filename_);
 
-		end = SDL_GetTicks();
-		LOG_SAVE << "Milliseconds to save " << filename_ << ": " << end - start;
+		// Log time before showing the confirmation
+		timer.reset();
 
 		if(show_confirmation_) {
 			gui2::show_transient_message(_("Saved"), _("The game has been saved."));

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -122,10 +122,10 @@
 #include <new>                          // for operator new
 #include <set>                          // for set
 #include <sstream>                      // for operator<<, basic_ostream, etc
+#include <thread>
 #include <utility>                      // for pair
 #include <algorithm>
 #include <vector>                       // for vector, etc
-#include <SDL2/SDL_timer.h>                  // for SDL_GetTicks
 
 #ifdef DEBUG_LUA
 #include "scripting/debug_lua.hpp"
@@ -1507,10 +1507,10 @@ static int impl_mp_settings_get(lua_State* L)
 		return_string_attrib("side_users", utils::join_map(settings.side_users));
 		return_int_attrib("experience_modifier", settings.xp_modifier);
 		return_bool_attrib("mp_countdown", settings.mp_countdown);
-		return_int_attrib("mp_countdown_init_time", settings.mp_countdown_init_time);
-		return_int_attrib("mp_countdown_turn_bonus", settings.mp_countdown_turn_bonus);
-		return_int_attrib("mp_countdown_reservoir_bonus", settings.mp_countdown_reservoir_time);
-		return_int_attrib("mp_countdown_action_bonus", settings.mp_countdown_action_bonus);
+		return_int_attrib("mp_countdown_init_time", settings.mp_countdown_init_time.count());
+		return_int_attrib("mp_countdown_turn_bonus", settings.mp_countdown_turn_bonus.count());
+		return_int_attrib("mp_countdown_reservoir_bonus", settings.mp_countdown_reservoir_time.count());
+		return_int_attrib("mp_countdown_action_bonus", settings.mp_countdown_action_bonus.count());
 		return_int_attrib("mp_num_turns", settings.num_turns);
 		return_int_attrib("mp_village_gold", settings.village_gold);
 		return_int_attrib("mp_village_support", settings.village_support);
@@ -1686,11 +1686,11 @@ SCENARIO_SETTER("end_text", t_string) {
 }
 
 SCENARIO_GETTER("end_text_duration", int) {
-	return k.cls().end_text_duration;
+	return k.cls().end_text_duration.count();
 }
 
 SCENARIO_SETTER("end_text_duration", int) {
-	k.cls().end_text_duration = value;
+	k.cls().end_text_duration = std::chrono::milliseconds{value};
 }
 
 SCENARIO_VALID("campaign") {
@@ -2498,7 +2498,7 @@ static int impl_floating_label_getmethod(lua_State* L)
 int game_lua_kernel::intf_remove_floating_label(lua_State* L)
 {
 	int* handle = luaW_check_floating_label(L, 1);
-	int fade = luaL_optinteger(L, 2, -1);
+	std::chrono::milliseconds fade{luaL_optinteger(L, 2, -1)};
 	if(*handle != 0) {
 		// Passing -1 as the second argument means it uses the fade time that was set when the label was created
 		font::remove_floating_label(*handle, fade);
@@ -2695,13 +2695,14 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			break;
 	}
 
+	using std::chrono::milliseconds;
 	font::floating_label flabel(text);
 	flabel.set_font_size(size);
 	flabel.set_color(color);
 	flabel.set_bg_color(bgcolor);
 	flabel.set_alignment(alignment);
 	flabel.set_position(x, y);
-	flabel.set_lifetime(lifetime, fadeout);
+	flabel.set_lifetime(milliseconds{lifetime}, milliseconds{fadeout});
 	flabel.set_clip_rect(rect);
 
 	*handle = font::add_floating_label(flabel);
@@ -4411,7 +4412,7 @@ int game_lua_kernel::intf_screen_fade(lua_State *L)
 			return luaW_type_error(L, 1, "array of 4 integers");
 		}
 		color_t fade{vec[0], vec[1], vec[2], vec[3]};
-		game_display_->fade_to(fade, luaL_checkinteger(L, 2));
+		game_display_->fade_to(fade, std::chrono::milliseconds{luaL_checkinteger(L, 2)});
 	}
 	return 0;
 }
@@ -4428,19 +4429,20 @@ int game_lua_kernel::intf_delay(lua_State *L)
 		return 0;
 	}
 	events::command_disabler command_disabler;
-	lua_Integer delay = luaL_checkinteger(L, 1);
-	if(delay == 0) {
+	using namespace std::chrono_literals;
+	std::chrono::milliseconds delay{luaL_checkinteger(L, 1)};
+	if(delay == 0ms) {
 		play_controller_.play_slice(false);
 		return 0;
 	}
 	if(luaW_toboolean(L, 2) && game_display_ && game_display_->turbo_speed() > 0) {
 		delay /= game_display_->turbo_speed();
 	}
-	const unsigned final = SDL_GetTicks() + delay;
+	const auto end_time = std::chrono::steady_clock::now() + delay;
 	do {
 		play_controller_.play_slice(false);
-		SDL_Delay(10);
-	} while (static_cast<int>(final - SDL_GetTicks()) > 0);
+		std::this_thread::sleep_for(10ms);
+	} while (std::chrono::steady_clock::now() < end_time);
 	return 0;
 }
 

--- a/src/scripting/lua_audio.cpp
+++ b/src/scripting/lua_audio.cpp
@@ -279,8 +279,8 @@ static int impl_track_get(lua_State* L) {
 	return_bool_attrib("shuffle", (*track)->shuffle());
 	return_bool_attrib("immediate", (*track)->immediate());
 	return_bool_attrib("once", (*track)->play_once());
-	return_int_attrib("ms_before", (*track)->ms_before());
-	return_int_attrib("ms_after", (*track)->ms_after());
+	return_int_attrib("ms_before", (*track)->ms_before().count());
+	return_int_attrib("ms_after", (*track)->ms_after().count());
 	return_string_attrib("name", (*track)->id());
 	return_string_attrib("title", (*track)->title());
 
@@ -305,8 +305,8 @@ static int impl_track_set(lua_State* L) {
 	const char* m = luaL_checkstring(L, 2);
 	modify_bool_attrib("shuffle", (*track)->set_shuffle(value));
 	modify_bool_attrib("once", (*track)->set_play_once(value));
-	modify_int_attrib("ms_before", (*track)->set_ms_before(value));
-	modify_int_attrib("ms_after", (*track)->set_ms_after(value));
+	modify_int_attrib("ms_before", (*track)->set_ms_before(std::chrono::milliseconds{value}));
+	modify_int_attrib("ms_after", (*track)->set_ms_after(std::chrono::milliseconds{value}));
 	modify_string_attrib("title", (*track)->set_title(value));
 	return 0;
 }
@@ -387,7 +387,7 @@ static int impl_source_get(lua_State* L) {
 	const char* m = luaL_checkstring(L, 2);
 	return_string_attrib("id", src->id());
 	return_vector_string_attrib("sounds", utils::split(src->files()));
-	return_int_attrib("delay", src->minimum_delay());
+	return_int_attrib("delay", src->minimum_delay().count());
 	return_int_attrib("chance", src->chance());
 	return_int_attrib("loop", src->loops());
 	return_int_attrib("range", src->full_range());
@@ -411,7 +411,7 @@ static int impl_source_get(lua_State* L) {
 static int impl_source_set(lua_State* L) {
 	lua_sound_source& src = get_source(L, 1);
 	const char* m = luaL_checkstring(L, 2);
-	modify_int_attrib("delay", src->set_minimum_delay(value));
+	modify_int_attrib("delay", src->set_minimum_delay(std::chrono::milliseconds{value}));
 	modify_int_attrib("chance", src->set_chance(value));
 	modify_int_attrib("loop", src->set_loops(value));
 	modify_int_attrib("range", src->set_full_range(value));

--- a/src/serialization/chrono.hpp
+++ b/src/serialization/chrono.hpp
@@ -1,0 +1,32 @@
+/*
+	Copyright (C) 2024
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+#include "config_attribute_value.hpp"
+
+#include <chrono>
+
+namespace chrono
+{
+inline auto parse_timestamp(const config_attribute_value& val)
+{
+	return std::chrono::system_clock::from_time_t(val.to_long_long());
+}
+
+inline auto serialize_timestamp(const std::chrono::system_clock::time_point& time)
+{
+	return std::chrono::system_clock::to_time_t(time);
+}
+} // namespace chrono

--- a/src/serialization/chrono.hpp
+++ b/src/serialization/chrono.hpp
@@ -29,4 +29,11 @@ inline auto serialize_timestamp(const std::chrono::system_clock::time_point& tim
 {
 	return std::chrono::system_clock::to_time_t(time);
 }
+
+template<typename Duration>
+inline auto parse_duration(const config_attribute_value& val, const Duration& def = Duration{0})
+{
+	return Duration{val.to_long_long(def.count())};
+}
+
 } // namespace chrono

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -28,6 +28,7 @@
 #include "log.hpp"
 #include "serialization/base64.hpp"
 #include "serialization/binary_or_text.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/parser.hpp"
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
@@ -344,7 +345,8 @@ void server::load_config()
 	// Seems like compression level above 6 is a waste of CPU cycles.
 	compress_level_ = cfg_["compress_level"].to_int(6);
 	// One month probably will be fine (#TODO: testing needed)
-	update_pack_lifespan_ = cfg_["update_pack_lifespan"].to_time_t(30 * 24 * 60 * 60);
+	constexpr std::chrono::seconds seconds_in_a_month{30 * 24 * 60 * 60};
+	update_pack_lifespan_ = cfg_["update_pack_lifespan"].to_duration(seconds_in_a_month);
 
 	const auto& svinfo_cfg = server_info();
 
@@ -967,26 +969,32 @@ void server::handle_request_campaign_list(const server::request& req)
 {
 	LOG_CS << req << "Sending add-ons list";
 
-	std::time_t epoch = std::time(nullptr);
+	auto now = std::chrono::system_clock::now();
+	const bool relative_to_now = req.cfg["times_relative_to"] == "now";
+
 	config addons_list;
+	addons_list["timestamp"] = chrono::serialize_timestamp(now);
 
-	addons_list["timestamp"] = epoch;
-	if(req.cfg["times_relative_to"] != "now") {
-		epoch = 0;
+	bool before_flag = !req.cfg["before"].empty();
+	std::chrono::system_clock::time_point before;
+	if(before_flag) {
+		if(relative_to_now) {
+			auto time_delta = req.cfg["before"].to_duration<std::chrono::seconds>();
+			before = now + time_delta; // delta may be negative
+		} else {
+			before = chrono::parse_timestamp(req.cfg["before"]);
+		}
 	}
 
-	bool before_flag = false;
-	std::time_t before = epoch;
-	if(!req.cfg["before"].empty()) {
-		before += req.cfg["before"].to_time_t();
-		before_flag = true;
-	}
-
-	bool after_flag = false;
-	std::time_t after = epoch;
-	if(!req.cfg["after"].empty()) {
-		after += req.cfg["after"].to_time_t();
-		after_flag = true;
+	bool after_flag = !req.cfg["after"].empty();
+	std::chrono::system_clock::time_point after;
+	if(after_flag) {
+		if(relative_to_now) {
+			auto time_delta = req.cfg["after"].to_duration<std::chrono::seconds>();
+			after = now + time_delta; // delta may be negative
+		} else {
+			after = chrono::parse_timestamp(req.cfg["after"]);
+		}
 	}
 
 	const std::string& name = req.cfg["name"];
@@ -1006,10 +1014,10 @@ void server::handle_request_campaign_list(const server::request& req)
 
 		const auto& tm = i["timestamp"];
 
-		if(before_flag && (tm.empty() || tm.to_time_t(0) >= before)) {
+		if(before_flag && (tm.empty() || chrono::parse_timestamp(tm) >= before)) {
 			continue;
 		}
-		if(after_flag && (tm.empty() || tm.to_time_t(0) <= after)) {
+		if(after_flag && (tm.empty() || chrono::parse_timestamp(tm) <= after)) {
 			continue;
 		}
 
@@ -1473,7 +1481,7 @@ ADDON_CHECK_STATUS server::validate_addon(const server::request& req, config*& e
 
 void server::handle_upload(const server::request& req)
 {
-	const std::time_t upload_ts = std::time(nullptr);
+	const auto upload_ts = std::chrono::system_clock::now();
 	const config& upload = req.cfg;
 	const auto& name = upload["name"].str();
 
@@ -1501,7 +1509,7 @@ void server::handle_upload(const server::request& req)
 
 	if(!is_existing_upload) {
 		// Create a new add-ons list entry and work with that from now on
-		auto entry = addons_.emplace(name, config("original_timestamp", upload_ts));
+		auto entry = addons_.emplace(name, config("original_timestamp", chrono::serialize_timestamp(upload_ts)));
 		addon_ptr = &(*entry.first).second;
 	}
 
@@ -1530,7 +1538,7 @@ void server::handle_upload(const server::request& req)
 		addon["downloads"] = 0;
 	}
 
-	addon["timestamp"] = upload_ts;
+	addon["timestamp"] = chrono::serialize_timestamp(upload_ts);
 	addon["uploads"] = 1 + addon["uploads"].to_int();
 
 	addon.clear_children("feedback");
@@ -1651,7 +1659,7 @@ void server::handle_upload(const server::request& req)
 
 		pack_info["from"] = prev_version;
 		pack_info["to"] = new_version;
-		pack_info["expire"] = upload_ts + update_pack_lifespan_;
+		pack_info["expire"] = chrono::serialize_timestamp(upload_ts + update_pack_lifespan_);
 		pack_info["filename"] = update_pack_fn;
 
 		// Write the update pack to disk
@@ -1753,7 +1761,7 @@ void server::handle_upload(const server::request& req)
 	std::set<std::string> expire_packs;
 
 	for(const config& pack : addon.child_range("update_pack")) {
-		if(upload_ts > pack["expire"].to_time_t() || pack["from"].str() == new_version || (!is_delta_upload && pack["to"].str() == new_version)) {
+		if(upload_ts > chrono::parse_timestamp(pack["expire"]) || pack["from"].str() == new_version || (!is_delta_upload && pack["to"].str() == new_version)) {
 			LOG_CS << "Expiring upate pack for " << pack["from"].str() << " -> " << pack["to"].str();
 			const auto& pack_filename = pack["filename"].str();
 			filesystem::delete_file(pathstem + '/' + pack_filename);
@@ -1808,7 +1816,7 @@ void server::handle_upload(const server::request& req)
 		config& pack_info = addon.add_child("update_pack");
 		pack_info["from"] = prev_version_name;
 		pack_info["to"] = next_version_name;
-		pack_info["expire"] = upload_ts + update_pack_lifespan_;
+		pack_info["expire"] = chrono::serialize_timestamp(upload_ts + update_pack_lifespan_);
 		pack_info["filename"] = update_pack_fn;
 
 		// Generate the update pack from both full packs

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -346,7 +346,7 @@ void server::load_config()
 	compress_level_ = cfg_["compress_level"].to_int(6);
 	// One month probably will be fine (#TODO: testing needed)
 	constexpr std::chrono::seconds seconds_in_a_month{30 * 24 * 60 * 60};
-	update_pack_lifespan_ = cfg_["update_pack_lifespan"].to_duration(seconds_in_a_month);
+	update_pack_lifespan_ = chrono::parse_duration(cfg_["update_pack_lifespan"], seconds_in_a_month);
 
 	const auto& svinfo_cfg = server_info();
 
@@ -979,7 +979,7 @@ void server::handle_request_campaign_list(const server::request& req)
 	std::chrono::system_clock::time_point before;
 	if(before_flag) {
 		if(relative_to_now) {
-			auto time_delta = req.cfg["before"].to_duration<std::chrono::seconds>();
+			auto time_delta = chrono::parse_duration<std::chrono::seconds>(req.cfg["before"]);
 			before = now + time_delta; // delta may be negative
 		} else {
 			before = chrono::parse_timestamp(req.cfg["before"]);
@@ -990,7 +990,7 @@ void server::handle_request_campaign_list(const server::request& req)
 	std::chrono::system_clock::time_point after;
 	if(after_flag) {
 		if(relative_to_now) {
-			auto time_delta = req.cfg["after"].to_duration<std::chrono::seconds>();
+			auto time_delta = chrono::parse_duration<std::chrono::seconds>(req.cfg["after"]);
 			after = now + time_delta; // delta may be negative
 		} else {
 			after = chrono::parse_timestamp(req.cfg["after"]);

--- a/src/server/campaignd/server.hpp
+++ b/src/server/campaignd/server.hpp
@@ -115,7 +115,7 @@ private:
 
 	bool read_only_;
 	int compress_level_; /**< Used for add-on archives. */
-	time_t update_pack_lifespan_;
+	std::chrono::seconds update_pack_lifespan_;
 
 	bool strict_versions_;
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -775,7 +775,7 @@ void play_music_config(const config& music_node, bool allow_interrupt_current_tr
 	}
 }
 
-void music_thinker::process(events::pump_info&)
+void music_thinker::process()
 {
 	if(Mix_FadingMusic() != MIX_NO_FADING) {
 		// Do not block everything while fading.

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -101,7 +101,7 @@ void play_UI_sound(const std::string& files);
 
 // A class to periodically check for new music that needs to be played
 class music_thinker : public events::pump_monitor {
-	void process(events::pump_info &info);
+	void process();
 };
 
 // A class to mute music when the game is in background

--- a/src/sound.hpp
+++ b/src/sound.hpp
@@ -92,7 +92,9 @@ void play_sound_positioned(const std::string &files, int id, int repeats, unsign
 void play_bell(const std::string& files);
 
 // Play sound, or random one of comma-separated sounds in timer channel
-void play_timer(const std::string& files, int loop_ticks, int fadein_ticks);
+void play_timer(const std::string& files,
+	const std::chrono::milliseconds& loop_ticks,
+	const std::chrono::milliseconds& fadein_ticks);
 
 // Play user-interface sound, or random one of comma-separated sounds.
 void play_UI_sound(const std::string& files);

--- a/src/sound_music_track.hpp
+++ b/src/sound_music_track.hpp
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <memory>
 
@@ -39,8 +40,8 @@ public:
 	bool immediate() const { return immediate_; }
 	bool shuffle() const { return shuffle_; }
 	bool play_once() const { return once_; }
-	int ms_before() const { return ms_before_; }
-	int ms_after()  const { return ms_after_;  }
+	auto ms_before() const { return ms_before_; }
+	auto ms_after()  const { return ms_after_;  }
 
 	const std::string& file_path() const { return file_path_; }
 	const std::string& id() const { return id_; }
@@ -48,8 +49,8 @@ public:
 
 	void set_play_once(bool v) { once_ = v; }
 	void set_shuffle(bool v) { shuffle_ = v; }
-	void set_ms_before(int v) { ms_before_ = v; }
-	void set_ms_after(int v) { ms_after_ = v; }
+	void set_ms_before(const std::chrono::milliseconds& v) { ms_before_ = v; }
+	void set_ms_after(const std::chrono::milliseconds& v) { ms_after_ = v; }
 	void set_title(const std::string& v) { title_ = v; }
 
 private:
@@ -59,7 +60,7 @@ private:
 	std::string file_path_;
 	std::string title_;
 
-	int ms_before_, ms_after_;
+	std::chrono::milliseconds ms_before_, ms_after_;
 
 	bool once_;
 	bool append_;

--- a/src/soundsource.cpp
+++ b/src/soundsource.cpp
@@ -15,6 +15,7 @@
 
 #include "display.hpp"
 #include "random.hpp"
+#include "serialization/chrono.hpp"
 #include "sound.hpp"
 #include "soundsource.hpp"
 
@@ -240,7 +241,7 @@ void sourcespec::write(config& cfg) const
 sourcespec::sourcespec(const config& cfg)
 	: id_(cfg["id"])
 	, files_(cfg["sounds"])
-	, min_delay_(cfg["delay"].to_duration(DEFAULT_DELAY))
+	, min_delay_(chrono::parse_duration(cfg["delay"], DEFAULT_DELAY))
 	, chance_(cfg["chance"].to_int(DEFAULT_CHANCE))
 	, loops_(cfg["loop"].to_int())
 	, range_(cfg["full_range"].to_int(3))

--- a/src/soundsource.hpp
+++ b/src/soundsource.hpp
@@ -33,8 +33,8 @@ class sourcespec;
  * appropriate delays, when sound emitting object is visible on screen.
  */
 class positional_source {
-	unsigned int last_played_;
-	int min_delay_;
+	std::chrono::steady_clock::time_point last_played_;
+	std::chrono::milliseconds min_delay_;
 	int chance_;
 	int loops_;
 	const unsigned int id_;
@@ -61,8 +61,8 @@ public:
 
 	bool is_global() const;
 
-	void update(unsigned int time, const display &disp);
-	void update_positions(unsigned int time, const display &disp);
+	void update(const std::chrono::steady_clock::time_point& time, const display &disp);
+	void update_positions(const std::chrono::steady_clock::time_point& time, const display &disp);
 
 	int calculate_volume(const map_location &loc, const display &disp);
 
@@ -117,7 +117,7 @@ class sourcespec
 	const std::string id_;
 	std::string files_;
 
-	int min_delay_;
+	std::chrono::milliseconds min_delay_;
 	int chance_;
 
 	int loops_;
@@ -130,7 +130,7 @@ class sourcespec
 
 public:
 	/** Parameter-list constructor. */
-	sourcespec(const std::string& id, const std::string& files, int min_delay, int chance) :
+	sourcespec(const std::string& id, const std::string& files, const std::chrono::milliseconds& min_delay, int chance) :
 		id_(id),
 		files_(files),
 		min_delay_(min_delay),
@@ -189,9 +189,9 @@ public:
 		faderange_ = value;
 	}
 
-	int minimum_delay() const { return min_delay_; }
+	auto minimum_delay() const { return min_delay_; }
 
-	void set_minimum_delay(int value) {
+	void set_minimum_delay(const std::chrono::milliseconds& value) {
 		min_delay_ = value;
 	}
 

--- a/src/storyscreen/part.hpp
+++ b/src/storyscreen/part.hpp
@@ -22,6 +22,7 @@
 
 #include "storyscreen/parser.hpp"
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -99,7 +100,7 @@ public:
 	 * Delay after displaying this image and before displaying the next image,
 	 * in milliseconds.
 	 */
-	int display_delay() const
+	const std::chrono::milliseconds& display_delay() const
 	{
 		return delay_;
 	}
@@ -107,7 +108,7 @@ public:
 private:
 	std::string file_;
 	int x_, y_; // referential (non corrected) x,y
-	int delay_;
+	std::chrono::milliseconds delay_;
 	bool resize_with_background_;
 	bool centered_;
 

--- a/src/synced_user_choice.cpp
+++ b/src/synced_user_choice.cpp
@@ -455,7 +455,7 @@ namespace {
 		~ucm_process_scope() { ucm_in_proccess = false; }
 	};
 }
-void user_choice_manager::process(events::pump_info&)
+void user_choice_manager::process()
 {
 	if(!oos_ && !finished() && !ucm_in_proccess)
 	{

--- a/src/synced_user_choice.cpp
+++ b/src/synced_user_choice.cpp
@@ -24,6 +24,7 @@
 #include "replay.hpp"
 #include "resources.hpp"
 #include "gui/dialogs/multiplayer/synced_choice_wait.hpp"
+#include <chrono>
 #include <set>
 #include <map>
 #include "formula/string_utils.hpp"
@@ -37,18 +38,19 @@ static lg::log_domain log_replay("replay");
 
 namespace
 {
+	using namespace std::chrono_literals;
 	class user_choice_notifer_ingame
 	{
 		//the handle for the label on the screen -1 if not shown yet.
 		int label_id_;
 		std::string message_;
-		unsigned int start_show_;
+		std::chrono::steady_clock::time_point start_show_;
 
 	public:
 		user_choice_notifer_ingame()
 			: label_id_(-1)
 			, message_()
-			, start_show_(SDL_GetTicks() + 2000)
+			, start_show_(std::chrono::steady_clock::now() + 2000ms)
 		{
 
 		}
@@ -62,7 +64,7 @@ namespace
 
 		void update(const std::string& message)
 		{
-			if(label_id_ == -1 && SDL_GetTicks() > start_show_)
+			if(label_id_ == -1 && std::chrono::steady_clock::now() > start_show_)
 			{
 				start_show_label();
 			}
@@ -84,7 +86,7 @@ namespace
 			flabel.set_font_size(font::SIZE_LARGE);
 			flabel.set_color(font::NORMAL_COLOR);
 			flabel.set_position(area.w/2, area.h/4);
-			flabel.set_lifetime(-1);
+			flabel.set_lifetime(std::chrono::milliseconds{-1});
 			flabel.set_clip_rect(area);
 			label_id_ = font::add_floating_label(flabel);
 		}

--- a/src/synced_user_choice.hpp
+++ b/src/synced_user_choice.hpp
@@ -119,6 +119,6 @@ public:
 	 */
 	static std::map<int, config> get_user_choice_internal(const std::string &name, const mp_sync::user_choice &uch, const std::set<int>& sides);
 	/** Inherited from events::pump_monitor */
-	void process(events::pump_info&);
+	void process();
 	events::generic_event changed_event_;
 };

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -30,6 +30,7 @@
 #include "play_controller.hpp"
 #include "playsingle_controller.hpp"
 #include "resources.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/string_utils.hpp"
 #include "synced_context.hpp"
 #include "units/types.hpp"
@@ -392,7 +393,7 @@ void team::build(const config& cfg, const gamemap& map, int gold)
 		}
 	}
 
-	countdown_time_ = cfg["countdown_time"].to_duration<std::chrono::milliseconds>();
+	countdown_time_ = chrono::parse_duration<std::chrono::milliseconds>(cfg["countdown_time"]);
 	action_bonus_count_ = cfg["action_bonus_count"].to_int();
 
 	planned_actions_.reset(new wb::side_actions());

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -392,7 +392,7 @@ void team::build(const config& cfg, const gamemap& map, int gold)
 		}
 	}
 
-	countdown_time_ = cfg["countdown_time"].to_int();
+	countdown_time_ = cfg["countdown_time"].to_duration<std::chrono::milliseconds>();
 	action_bonus_count_ = cfg["action_bonus_count"].to_int();
 
 	planned_actions_.reset(new wb::side_actions());

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -26,6 +26,7 @@
 #include "side_proxy_controller.hpp"
 #include "team_shared_vision.hpp"
 
+#include <chrono>
 #include <set>
 
 #include <boost/dynamic_bitset.hpp>
@@ -193,9 +194,8 @@ public:
 	void set_start_gold(const int amount) { info_.start_gold = amount; }
 	void spend_gold(const int amount) { gold_ -= amount; }
 	void set_base_income(int amount) { info_.income = amount - game_config::base_income; }
-	int countdown_time() const {  return countdown_time_; }
-	void set_countdown_time (const int amount) const
-		{ countdown_time_ = amount; }
+	std::chrono::milliseconds countdown_time() const { return countdown_time_; }
+	void set_countdown_time(const std::chrono::milliseconds& amount) const { countdown_time_ = amount; }
 	int action_bonus_count() const { return action_bonus_count_; }
 	void set_action_bonus_count(const int count) { action_bonus_count_ = count; }
 	recall_list_manager& recall_list() {return recall_list_;}
@@ -413,7 +413,7 @@ private:
 
 	team_info info_;
 
-	mutable int countdown_time_;
+	mutable std::chrono::milliseconds countdown_time_;
 	int action_bonus_count_;
 
 	recall_list_manager recall_list_;

--- a/src/tooltips.cpp
+++ b/src/tooltips.cpp
@@ -211,7 +211,7 @@ void manager::layout()
 	}
 	// Update the active tooltip's draw state.
 	// This will trigger redraws if necessary.
-	tips.at(active_tooltip).label.update(SDL_GetTicks());
+	tips.at(active_tooltip).label.update(std::chrono::steady_clock::now());
 }
 
 bool manager::expose(const rect& region)
@@ -333,7 +333,7 @@ static void select_active(int id)
 	LOG_FT << "showing tip " << id << " for " << tip.origin;
 	clear_active();
 	active_tooltip = id;
-	tip.label.update(SDL_GetTicks());
+	tip.label.update(std::chrono::steady_clock::now());
 	raise_to_top();
 }
 

--- a/src/utils/optimer.hpp
+++ b/src/utils/optimer.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <functional>
 #include <iosfwd>
+#include <utility>
 
 namespace utils {
 
@@ -64,10 +65,10 @@ struct optimer
 		}
 	}
 
-	/** Resets the timer back to zero. */
-	void reset()
+	/** Resets the timer back to zero and returns the previous tick value. */
+	point reset()
 	{
-		start_ = clock::now();
+		return std::exchange(start_, clock::now());
 	}
 
 	/** Returns the start time point. */
@@ -80,6 +81,19 @@ struct optimer
 	interval elapsed() const
 	{
 		return clock::now() - start_;
+	}
+
+	/**
+	 * Resets the starting tick and returns the elapsed time.
+	 *
+	 * @note This method is preferred to calling elapsed() followed by reset()
+	 * since it guarantees resetting to the same tick as is used for duration
+	 * (or, in other words, clock::now() is called only once.)
+	 */
+	interval lap()
+	{
+		auto prev_start = reset();
+		return start_ - prev_start;
 	}
 
 private:

--- a/src/utils/spritesheet_generator.cpp
+++ b/src/utils/spritesheet_generator.cpp
@@ -24,6 +24,7 @@
 #include "sdl/surface.hpp"
 #include "sdl/utils.hpp"
 #include "serialization/binary_or_text.hpp"
+#include "utils/optimer.hpp"
 
 #include <SDL2/SDL_image.h>
 
@@ -228,9 +229,9 @@ void handle_dir_contents(const fs::path& path)
 
 void build_spritesheet_from(const std::string& entry_point)
 {
-#ifdef DEBUG_SPRITESHEET_OUTPUT
-	const std::size_t start = SDL_GetTicks();
-#endif
+	const utils::ms_optimer timer([&](const auto& timer) {
+		PLAIN_LOG << "Spritesheet generation of '" << entry_point << "' took: " << timer;
+	});
 
 	if(auto path = filesystem::get_binary_file_location("images", entry_point)) {
 		try {
@@ -241,10 +242,6 @@ void build_spritesheet_from(const std::string& entry_point)
 	} else {
 		PLAIN_LOG << "Cannot find entry point to build spritesheet: " << entry_point;
 	}
-
-#ifdef DEBUG_SPRITESHEET_OUTPUT
-	PLAIN_LOG << "Spritesheet generation of '" << entry_point << "' took: " << (SDL_GetTicks() - start) << "ms\n";
-#endif
 }
 
 } // namespace image

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -486,7 +486,7 @@ int get_pixel_scale()
 int current_refresh_rate()
 {
 	// TODO: this should be more clever, depending on usage
-	return refresh_rate_;
+	return std::min(prefs::get().refresh_rate(), refresh_rate_);
 }
 
 void force_render_target(const texture& t)

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -46,6 +46,7 @@
 #include "serialization/preprocessor.hpp"   // for preproc_define, etc
 #include "serialization/schema_validator.hpp" // for strict_validation_enabled and schema_validator
 #include "sound.hpp"                   // for commit_music_changes, etc
+#include "utils/optimer.hpp"
 #include "formula/string_utils.hpp" // VGETTEXT
 #include <functional>
 #include "game_version.hpp"        // for version_info
@@ -133,7 +134,7 @@ static void handle_preprocess_command(const commandline_options& cmdline_opts)
 			return;
 		}
 
-		PLAIN_LOG << SDL_GetTicks() << " Reading cached defines from: " << file;
+		PLAIN_LOG << "Reading cached defines from: " << file;
 
 		config cfg;
 
@@ -153,13 +154,14 @@ static void handle_preprocess_command(const commandline_options& cmdline_opts)
 			++read;
 		}
 
-		PLAIN_LOG << SDL_GetTicks() << " Read " << read << " defines.";
+		PLAIN_LOG << "Read " << read << " defines.";
 	}
 
 	const std::string resourceToProcess(*cmdline_opts.preprocess_path);
 	const std::string targetDir(*cmdline_opts.preprocess_target);
 
-	uint32_t startTime = SDL_GetTicks();
+	const utils::ms_optimer timer(
+		[](const auto& timer) { PLAIN_LOG << "preprocessing finished. Took " << timer << " ticks."; });
 
 	// If the users add the SKIP_CORE define we won't preprocess data/core
 	bool skipCore = false;
@@ -237,8 +239,6 @@ static void handle_preprocess_command(const commandline_options& cmdline_opts)
 			PLAIN_LOG << "couldn't open the file.";
 		}
 	}
-
-	PLAIN_LOG << "preprocessing finished. Took " << SDL_GetTicks() - startTime << " ticks.";
 }
 
 static int handle_validate_command(const std::string& file, abstract_validator& validator, const std::vector<std::string>& defines) {
@@ -670,7 +670,6 @@ static int do_gameloop(commandline_options& cmdline_opts)
 	srand(std::time(nullptr));
 
 	const auto game = std::make_unique<game_launcher>(cmdline_opts);
-	const int start_ticks = SDL_GetTicks();
 
 	init_locale();
 
@@ -755,8 +754,6 @@ static int do_gameloop(commandline_options& cmdline_opts)
 	if(res == false) {
 		return 1;
 	}
-
-	LOG_CONFIG << "time elapsed: " << (SDL_GetTicks() - start_ticks) << " ms";
 
 	plugins_manager plugins_man(new application_lua_kernel);
 


### PR DESCRIPTION
Initially, this was just going to affect events::pump_monitor, but in order to convert that, I had to convert the places using pump_monitor::ticks(), and it spiraled out from there.

In terms of behavior, everything should be the same, save that pump_monitor::ticks() now records a steady_clock value when created instead of being lazily initialized on first call.