### PR TITLE
Better description for absorb.

### DIFF
--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -145,17 +145,30 @@
     [/damage]
 #enddef
 
-#define WEAPON_SPECIAL_ABSORB AMT
+#define WEAPON_SPECIAL_ABSORB_40
     # Canned definition of the Absorb ability to be included in a
     # [specials] clause.
     [damage]
-        id=absorb
-        name= _ "absorb"
-        description= _ "This attack puts the unit in good defensive position, and it absorbs some of the damage dealt by an enemy strike."
+        id=absorb_40
+        name= _ "absorb 40%"
+        description= _ "This attack puts the unit in good defensive position, and it absorbs 40% of the damage dealt by an enemy strike."
         special_note= _ "This unit can block enemy strikes, so that it takes reduced damage when hit."
-        multiply={AMT}
+        multiply=0.6
         apply_to=opponent
     [/damage]
+#enddef
+
+#define WEAPON_SPECIAL_ABSORB_25
+# Canned definition of the Absorb ability to be included in a
+# [specials] clause.
+[damage]
+    id=absorb_25
+    name= _ "absorb 25%"
+    description= _ "This attack puts the unit in good defensive position, and it absorbs 25% of the damage dealt by an enemy strike."
+    special_note= _ "This unit can block enemy strikes, so that it takes reduced damage when hit."
+    multiply=0.75
+    apply_to=opponent
+[/damage]
 #enddef
 
 #define WEAPON_SPECIAL_DRAIN

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -159,16 +159,16 @@
 #enddef
 
 #define WEAPON_SPECIAL_ABSORB_25
-# Canned definition of the Absorb ability to be included in a
-# [specials] clause.
-[damage]
-    id=absorb_25
-    name= _ "absorb 25%"
-    description= _ "This attack puts the unit in good defensive position, and it absorbs 25% of the damage dealt by an enemy strike."
-    special_note= _ "This unit can block enemy strikes, so that it takes reduced damage when hit."
-    multiply=0.75
-    apply_to=opponent
-[/damage]
+    # Canned definition of the Absorb ability to be included in a
+    # [specials] clause.
+    [damage]
+        id=absorb_25
+        name= _ "absorb 25%"
+        description= _ "This attack puts the unit in good defensive position, and it absorbs 25% of the damage dealt by an enemy strike."
+        special_note= _ "This unit can block enemy strikes, so that it takes reduced damage when hit."
+        multiply=0.75
+        apply_to=opponent
+    [/damage]
 #enddef
 
 #define WEAPON_SPECIAL_DRAIN

--- a/data/core/units/nagas/Guard_High.cfg
+++ b/data/core/units/nagas/Guard_High.cfg
@@ -48,7 +48,7 @@
         damage=10
         number=1
         [specials]
-            {WEAPON_SPECIAL_ABSORB 0.6}
+            {WEAPON_SPECIAL_ABSORB_40}
         [/specials]
         icon=icons/shield_steel.png
     [/attack]

--- a/data/core/units/nagas/Guard_Shield.cfg
+++ b/data/core/units/nagas/Guard_Shield.cfg
@@ -46,7 +46,7 @@
         damage=8
         number=1
         [specials]
-            {WEAPON_SPECIAL_ABSORB 0.75}
+            {WEAPON_SPECIAL_ABSORB_25}
         [/specials]
         icon=attacks/heater-shield.png
     [/attack]


### PR DESCRIPTION
Absorb special is currently the only variable special of mainline.
Because of that its current description is confusion, not stating the value of prevented damages. 
This PR solve the problem by making two separate specials "absorb 40%" and "absorb 25%" and changing the two units that are using them accordingly.
Another option was to change the description to take into account the amount but that would introduce a variable value inside a translatable string. 
Absorb could be kept as deprecated for a few version if needed. 