### PR TITLE
Delete the obsolete comment about Dune Piercer

### DIFF
--- a/data/campaigns/World_Conquest/era/factions/The_Hand.cfg
+++ b/data/campaigns/World_Conquest/era/factions/The_Hand.cfg
@@ -12,7 +12,6 @@
         [world_conquest_data]
             commanders=Loyalists,Northerners,Young Ogre
             heroes=Undead_All,Rebels_All
-            # TODO: this contained 'Dune Piercer' in 1.14
             deserters=Knalgans,Drakes
             deserters_names=_ "Dune Rider, Knalgan Alliance and Drakes"
             {WC_II_PAIR "Spearman" "Orcish Grunt"}


### PR DESCRIPTION
I believe this comment is no longer relevant, Dune Piercer is no longer used by WC