### PR TITLE
Fix the attack_end event in Liberty S5

### DIFF
--- a/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
+++ b/data/campaigns/Liberty/scenarios/05_Hide_and_Seek.cfg
@@ -574,13 +574,13 @@ Been a tough few days since we left Elensefar with all them patrols running arou
     [event]
         name=attack_end
         [filter]
-            side=2
+            side=3
         [/filter]
         [filter_second]
             side=1
         [/filter_second]
 
-        {IF_VAR $second_unit.hitpoints greater_than 0 (
+        {IF_VAR second_unit.hitpoints greater_than 0 (
             [then]
                 [message]
                     speaker=Baldras


### PR DESCRIPTION
The event never fired because it has to use side 3 (side 2 is idle). After fixing that, the event fires, but the IF_VAR statement is always false unless you remove the dollar sign.