### PR TITLE
Fixed an error in [filter_special] encoding

### DIFF
--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_filter_ability.cfg
@@ -417,20 +417,76 @@
     [/event]
 ) TIME=AFTERNOON}
 
+#undef FILTER_ABILITY_TEST
+
 #####
 # API(s) being tested: [event][filter_attack][filter_special]
 ##
 # Actions:
-# Use the common setup from FILTER_ABILITY_TEST.
-# Add an event with a filter matching Alice's drains ability.
+# Give to alice drains special.
+# Add an event with a filter matching Alice's drains special.
 # Time of day for test is lawful,  which makes it the wrong time of day for her drains ability.
-# The events in FILTER_ABILITY_TEST make Alice attacks Bob and then Bob attack Alice.
+# The start events make Alice attacks Bob and then Bob attack Alice.
 ##
 # Expected end state:
 # The filtered event is triggered exactly once.
 #####
 {COMMON_KEEP_A_B_UNIT_TEST event_test_filter_special_simple_check (
-    {FILTER_ABILITY_TEST}
+    [event]
+        name=start
+        # Make sure the attacks hit
+        {FORCE_CHANCE_TO_HIT (id=bob) (id=alice) 100 ()}
+        {FORCE_CHANCE_TO_HIT (id=alice) (id=bob) 100 ()}
+        [modify_unit]
+            [filter]
+            [/filter]
+            # Make sure they don't die during the attacks
+            [status]
+                invulnerable=yes
+            [/status]
+        [/modify_unit]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [drains]
+                        value=25
+                        [filter_self]
+                            [filter_location]
+                                time_of_day=neutral
+                            [/filter_location]
+                        [/filter_self]
+                    [/drains]
+                [/set_specials]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+        {VARIABLE triggers 0}
+    [/event]
+
+    [event]
+        name=side 1 turn 1
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
+
+    [event]
+        name=side 2 turn
+        [test_do_attack_by_id]
+            attacker=bob
+            defender=alice
+            weapon=0
+        [/test_do_attack_by_id]
+        [end_turn][/end_turn]
+    [/event]
 
     [event]
         name=attack
@@ -450,8 +506,6 @@
         {RETURN ({VARIABLE_CONDITIONAL triggers equals 1})}
     [/event]
 ) TIME=AFTERNOON}
-
-#undef FILTER_ABILITY_TEST
 
 ##
 # Common code for the tests in this file.

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -2127,22 +2127,17 @@ bool attack_type::has_special_with_filter(const config & filter) const
 
 bool attack_type::has_ability_with_filter(const config & filter) const
 {
-	bool check_if_active = filter["active"].to_bool();
+	if(!filter["active"].to_bool()){
+		return false;
+	}
 	const unit_map& units = get_unit_map();
 	if(self_){
 		for(const auto [key, cfg] : (*self_).abilities().all_children_view()) {
 			if(self_->ability_matches_filter(cfg, key, filter)){
-				if(!check_if_active){
-					return true;
-				}
 				if(check_self_abilities(cfg, key)){
 					return true;
 				}
 			}
-		}
-
-		if(!check_if_active){
-			return false;
 		}
 
 		const auto adjacent = get_adjacent_tiles(self_loc_);


### PR DESCRIPTION
In special_id/type without the _'active' suffix only the encoding of the special in the attack is checked, and therefore the specials encoded in the [abilities] tags are de facto excluded, except that I forgot this logic in [filter_special] and I have to fix my error before updating the wikia.