### PR TITLE
GUI2 stacked_widget - add length operator

### DIFF
--- a/src/scripting/lua_widget.cpp
+++ b/src/scripting/lua_widget.cpp
@@ -18,6 +18,7 @@
 
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/multi_page.hpp"
+#include "gui/widgets/stacked_widget.hpp"
 #include "gui/widgets/tree_view.hpp"
 #include "gui/widgets/tree_view_node.hpp"
 #include "gui/widgets/widget.hpp"
@@ -194,6 +195,8 @@ static int impl_widget_length(lua_State* L)
 		lua_pushinteger(L, list->get_item_count());
 	} else if(gui2::multi_page* multi_page = dynamic_cast<gui2::multi_page*>(&w)) {
 		lua_pushinteger(L, multi_page->get_page_count());
+	} else if(gui2::stacked_widget* stacked_widget = dynamic_cast<gui2::stacked_widget*>(&w)) {
+		lua_pushinteger(L, stacked_widget->get_layer_count());
 	} else if(gui2::tree_view* tree_view = dynamic_cast<gui2::tree_view*>(&w)) {
 		lua_pushinteger(L, tree_view->get_root_node().count_children());
 	} else if(gui2::tree_view_node* tree_view_node = dynamic_cast<gui2::tree_view_node*>(&w)) {


### PR DESCRIPTION
Simply adds the ability to do something like `#dialog.my_stacked_widget`.

I started out wanting to make the sw more like other container widgets, where you could add and remove layers, etc.  Removing is simple, adding not so much.  I really can't think of any good use cases for adding layers, other than perhaps removing and adding layers as a way of changing the order of layers.

Along the way I found that the stacked_widget seems to be a little odd, particularly from the Lua API.  FWIW....

WML/LUA:
Initially, all layers are visible, selected_index returns 0, and events go to last (highest index) child.  Widgets may be made in/visible using sw[3].id3.visible (this is acting on the child widget, NOT the stacked_widget).

If you set selected_index (say =2), that widget becomes the only visible widget (irrespective of, for example, sw[3].id3.visible).  While you can still set sw[3].id3.visible, you won't actually see it, sw:find("id3") now fails (for any but the selected widget), etc.  You can set selected_index to 0 to make all children visible/"active" (active in the stacked_widget sense) again.  I do not believe you can make 1 < N < #sw children visible/active, though this appears to be possible in cpp via `select_layers(const boost::dynamic_bitset<>& mask)`.

So it appears in Lua, a stacked_widget has two "modes".  1) one active/visible layer - basically a multi_page (or perhaps a MP + size_lock).  2) All layers visible (though you could manually set individual children to invisible).  I'm almost okay with this, except that you can't choose the layer to receive events.

At least that's what it looks like to me.