### PR TITLE
Add a red line to the bottom of chat window when entering lobby

### DIFF
--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -91,7 +91,7 @@ void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby
 {
 	const std::string new_tip = formatter()
 		<< "\n"
-		// TRANSLATORS # po: This is the new chat text indicator
+		// TRANSLATORS: This is the new chat text indicator
 		<< markup::span_color("#FF0000", "============", _("NEW"), "============");
 
 	for(auto& l : log) {

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -89,9 +89,10 @@ void chatbox::finalize_setup()
 
 void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby)
 {
-	const std::string new_tip = formatter() << markup::span_color("#FF0000", "\n============NEW============");
+	const std::string new_tip = formatter()
+		<< markup::span_color("#FF0000", "\n============" + translation::dsgettext("wesnoth", "NEW") + "============");
 
-	for(const auto& l : log) {
+	for(auto& l : log) {
 		const bool is_lobby = l.first == "lobby";
 
 		if(!show_lobby && is_lobby && !l.second.whisper) {
@@ -102,8 +103,8 @@ void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby
 
 		if(new_tip_index != std::string::npos) {
 			std::string new_log = l.second.log;
-			new_log.replace(l.second.log.find(new_tip), new_tip.length(), "");
-			log.at(l.first).log = new_log;
+			new_log.replace(new_tip_index, new_tip.length(), "");
+			l.second.log = new_log;
 			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, new_log + new_tip);
 		} else {
 			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, l.second.log + new_tip);

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -92,7 +92,7 @@ void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby
 	const std::string new_tip = formatter()
 		<< "\n"
 		// TRANSLATORS # po: This is the new chat text indicator
-		<< markup::span_color("#FF0000", "============" + _("NEW") + "============");
+		<< markup::span_color("#FF0000", "============", _("NEW"), "============");
 
 	for(auto& l : log) {
 		const bool is_lobby = l.first == "lobby";

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -47,7 +47,6 @@ static lg::log_domain log_lobby("lobby");
 namespace gui2
 {
 
-bool chatbox::should_attach_redline_;
 // ------------ WIDGET -----------{
 
 REGISTER_WIDGET(chatbox)
@@ -87,11 +86,7 @@ void chatbox::finalize_setup()
 	connect_signal_pre_key_press(*chat_input_,
 		std::bind(&chatbox::chat_input_keypress_callback, this, std::placeholders::_5));
 }
-//mark the log should be end with a special red line, with a mark to make sure there's only one of it.
-// first element of <std::string, chatroom_log> indicates the name of window, not just a mark only visible to the program.
-// so only use it as a indicator, when it comes to redline, don't let it processed normally, but delt specially: 
-// not create a new window like usual, but merge into where it belongs, use part of its content to indicate the place
-// after that delete the marked redline.
+
 void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby)
 {
 	const std::string new_tip = formatter() << markup::span_color("#FF0000", "\n============NEW============");
@@ -106,10 +101,10 @@ void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby
 		const std::size_t new_tip_index = l.second.log.find(new_tip);
 
 		if(new_tip_index != std::string::npos) {
-			std::string temp = l.second.log;
-			temp.replace(l.second.log.find(new_tip), new_tip.length(), "");
-			log.at(l.first).log = temp;
-			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, temp + new_tip);
+			std::string new_log = l.second.log;
+			new_log.replace(l.second.log.find(new_tip), new_tip.length(), "");
+			log.at(l.first).log = new_log;
+			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, new_log + new_tip);
 		} else {
 			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, l.second.log + new_tip);
 		}
@@ -225,7 +220,7 @@ void chatbox::append_to_chatbox(const std::string& text, const bool force_scroll
 {
 	append_to_chatbox(text, active_window_, force_scroll);
 }
-//mark red line here
+
 void chatbox::append_to_chatbox(const std::string& text, std::size_t id, const bool force_scroll)
 {
 	grid& grid = chat_log_container_->page_grid(id);
@@ -233,9 +228,7 @@ void chatbox::append_to_chatbox(const std::string& text, std::size_t id, const b
 
 	const bool chatbox_at_end = log.vertical_scrollbar_at_end();
 	const unsigned chatbox_position = log.get_vertical_scrollbar_item_position();
-	//const std::string new_tip = formatter() << markup::span_color("#FF0000", "============NEW============\n");
 
-	//const std::string before_message = log.get_value().empty() ? "" : should_attach_redline_ ? new_tip : "\n";
 	const std::string before_message = log.get_value().empty() ? "" : "\n";
 	const std::string new_text = formatter()
 		<< log.get_value() << before_message << markup::span_color("#bcb088", prefs::get().get_chat_timestamp(std::time(0)), text);
@@ -389,7 +382,7 @@ bool chatbox::room_window_active(const std::string& room)
 	const lobby_chat_window& t = open_windows_[active_window_];
 	return t.name == room && t.whisper == false;
 }
-//mark might be start of the issue
+
 lobby_chat_window* chatbox::room_window_open(const std::string& room, const bool open_new, const bool allow_close)
 {
 	return find_or_create_window(room, false, open_new, allow_close,
@@ -402,7 +395,7 @@ lobby_chat_window* chatbox::whisper_window_open(const std::string& name, bool op
 		VGETTEXT("Started private message with <i>$name</i>. "
 		"If you do not want to receive messages from this player, type <i>/ignore $name</i>", { { "name", name } }));
 }
-//mark add a second-initial_text to impl red line
+
 lobby_chat_window* chatbox::find_or_create_window(const std::string& name,
 	const bool whisper,
 	const bool open_new,

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -90,7 +90,9 @@ void chatbox::finalize_setup()
 void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby)
 {
 	const std::string new_tip = formatter()
-		<< markup::span_color("#FF0000", "\n============" + translation::dsgettext("wesnoth", "NEW") + "============");
+		<< "\n"
+		// TRANSLATORS # po: This is the new chat text indicator
+		<< markup::span_color("#FF0000", "============" + _("NEW") + "============");
 
 	for(auto& l : log) {
 		const bool is_lobby = l.first == "lobby";
@@ -102,13 +104,9 @@ void chatbox::load_log(std::map<std::string, chatroom_log>& log, bool show_lobby
 		const std::size_t new_tip_index = l.second.log.find(new_tip);
 
 		if(new_tip_index != std::string::npos) {
-			std::string new_log = l.second.log;
-			new_log.replace(new_tip_index, new_tip.length(), "");
-			l.second.log = new_log;
-			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, new_log + new_tip);
-		} else {
-			find_or_create_window(l.first, l.second.whisper, true, !is_lobby, l.second.log + new_tip);
+			l.second.log.replace(new_tip_index, new_tip.length(), "");
 		}
+		find_or_create_window(l.first, l.second.whisper, true, !is_lobby, l.second.log + new_tip);
 	}
 
 	log_ = &log;

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -135,6 +135,8 @@ private:
 
 	std::map<std::string, chatroom_log>* log_;
 
+	static bool should_attach_redline_;
+
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
 	static const std::string& type();

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -135,8 +135,6 @@ private:
 
 	std::map<std::string, chatroom_log>* log_;
 
-	static bool should_attach_redline_;
-
 public:
 	/** Static type getter that does not rely on the widget being constructed. */
 	static const std::string& type();


### PR DESCRIPTION
### Goal of the PR
- Add a red line to help distinguish the old msgs (Based on the discussion of adding redlines as referenced in #9211）
### How does the PR work?
- By making sure every time the chat log is loaded, there's a red line at the bottom of chat window. 
### Does it resolve any reported issue?
- It's a feature from discussion in #9211.
### If not a bug fix, why is this PR needed? What use cases does it solve?
- While keeping the old msgs when entering lobby, some UI clarification on what are old messages would be expected according to the related discussion in #9211.

## To do

Adjust possibly missed related method and changes I mistakenly made. 

If there's a better idea about the details of red line content, it's perhaps also okay to replace existed red line content with that.

This PR is Ready for Review.

## How to test
Compile and run, see the test video I might upload later if needed, or see changes in the src.