### PR TITLE
[Units] Tweak Elvish Champion Stats

### DIFF
--- a/data/core/units/elves/Champion.cfg
+++ b/data/core/units/elves/Champion.cfg
@@ -5,7 +5,7 @@
     race=elf
     image="units/elves-wood/champion.png"
     profile="portraits/elves/hero.webp"
-    hitpoints=72
+    hitpoints=70
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}
@@ -24,9 +24,8 @@
         icon=attacks/greatsword-elven.png
         type=blade
         range=melee
-        damage=8
+        damage=9
         number=5
-        accuracy=10
     [/attack]
     [attack]
         name=bow


### PR DESCRIPTION
This PR reverts the 1.18 changes to the Elvish Champion:

melee attack: 8-5 10 accuracy > 9-5

Elves already have access to two other chance-to-hit specials (marksman + magical), more than most factions, they don't need a third one, and especially 5-strike attacks with accuracy bonuses (sharpshooter/sylph)

Making the damage 9-5 also ensures the total max damage of champion is higher than Marshal (otherwise it is 40 vs 40 for both)

On top of that, Champion has always been the elf race's tough brute-force unit, and 5 strikes already offers a lot of the advantages that a cth bonus does.

hp 72 > 70

The hp buff in 1.18 was mainly needed to compensate marshal getting buffed from 62 to 68, resulting in a 4-hp gap between the units. now that PR #9512 was merged and nerfed Marshal hp from 68 to 60 in return for +1 MP, 70hp results in a 10-hp gap between the units, making them more than distinct enough.