### PR TITLE
add recursion_guard in [filter_(second_)weapon] for [leadership] and [resistance] abilities.

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/ability_cycle_filter_weapon_recursion.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/ability_cycle_filter_weapon_recursion.cfg
@@ -1,0 +1,57 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [filter_self]ability_id_active=
+##
+# Actions:
+# Alice and Bob are both of type Test Melee Quintain.
+# Give Alice a leadership_test_recursion ability, which is active only if it is itself active.
+# Have Alice attack with his weapon.
+##
+# Expected end state:
+# Deterministic end state, without crashing, but BROKE STRICT.
+# All abilities are inactive.
+# Bob takes 10 damage.
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "leadership_filter_weapon_cycle_recursion" (
+    [event]
+        name=start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=leadership_test_recursion
+                        value=50
+                        cumulative=no
+                        affect_self=yes
+                        [filter_weapon]
+                            special_id_active=leadership_test_recursion
+                        [/filter_weapon]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        [store_unit]
+            [filter]
+                id=bob
+            [/filter]
+            variable=bob
+        [/store_unit]
+
+        {ASSERT ({VARIABLE_CONDITIONAL bob.hitpoints equals 90})}
+
+        {SUCCEED}
+    [/event]
+) SIDE1_LEADER="Test Melee Quintain" SIDE2_LEADER="Test Melee Quintain"}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -544,6 +544,12 @@ bool unit::ability_affects_weapon(const config& cfg, const_attack_ptr weapon, bo
 	if(!weapon) {
 		return false;
 	}
+	attack_type::recursion_guard filter_lock;
+	filter_lock  = weapon->update_variables_recursion(cfg);
+	if(!filter_lock) {
+		show_recursion_warning(*this, cfg);
+		return false;
+	}
 	return weapon->matches_filter(filter);
 }
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -399,6 +399,7 @@
 9 ability_cycle_recursion_by_id
 9 filter_self_ability_cycle_recursion_by_id
 9 adjacent_abilities_recursion_by_id
+9 leadership_filter_weapon_cycle_recursion
 0 negative_resistance_with_two_attack_types
 0 positive_resistance_with_two_attack_types
 0 taught_resistance_with_two_attack_types


### PR DESCRIPTION
In moving recursion_guard from matches_filter() to special_unit_matches() i has forgotten what [leadership] abilities called directly matches_filter().