### PR TITLE
Editor terrain button click fix

### DIFF
--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -308,14 +308,14 @@ void tristate_button::mouse_down(const SDL_MouseButtonEvent& event) {
 		return;
 
 	if (event.button == SDL_BUTTON_RIGHT) {
-		if (state_ == ACTIVE)
+		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_RIGHT;
 		if (state_ == PRESSED_ACTIVE_LEFT)
 			state_ = TOUCHED_BOTH_LEFT;
 	}
 
 	if (event.button == SDL_BUTTON_LEFT) {
-		if (state_ == ACTIVE)
+		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_LEFT;
 		if (state_ == PRESSED_ACTIVE_RIGHT)
 			state_ = TOUCHED_BOTH_RIGHT;

--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -310,14 +310,14 @@ void tristate_button::mouse_down(const SDL_MouseButtonEvent& event) {
 	if (event.button == SDL_BUTTON_RIGHT) {
 		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_RIGHT;
-		if (state_ == PRESSED_ACTIVE_LEFT)
+		if (state_ == PRESSED_ACTIVE_LEFT || state_ == PRESSED_LEFT)
 			state_ = TOUCHED_BOTH_LEFT;
 	}
 
 	if (event.button == SDL_BUTTON_LEFT) {
 		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_LEFT;
-		if (state_ == PRESSED_ACTIVE_RIGHT)
+		if (state_ == PRESSED_ACTIVE_RIGHT || state_ == PRESSED_RIGHT)
 			state_ = TOUCHED_BOTH_RIGHT;
 	}
 

--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -307,6 +307,7 @@ void tristate_button::mouse_down(const SDL_MouseButtonEvent& event) {
 	if (!hit(event.x, event.y))
 		return;
 
+	//The widget is expected to be in one of the "active" states when the mouse cursor is hovering over it, but that currently doesn't happen if the widget is moved under the cursor by scrolling the palette.
 	if (event.button == SDL_BUTTON_RIGHT) {
 		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_RIGHT;


### PR DESCRIPTION
Fixed palette button not being clickable after scrolling in palette widget without moving the cursor. Resolves #1335. The cause of the bug was that scrolling doesnt change the highlighted state of the palette buttons and not highlighted buttons didnt process being clicked. Solved the bug by making not highlighted buttons process being clicked.