### PR TITLE
Map editor segmentation fault fix

### DIFF
--- a/src/ai/manager.cpp
+++ b/src/ai/manager.cpp
@@ -23,6 +23,7 @@
 #include "config.hpp"             // for config, etc
 #include "game_events/pump.hpp"
 #include "log.hpp"
+#include "manager.hpp"
 #include "map/location.hpp"       // for map_location
 #include "resources.hpp"
 #include "serialization/string_utils.hpp"
@@ -346,6 +347,13 @@ manager::manager()
 {
 	registry::init();
 	singleton_ = this;
+}
+
+manager::~manager() {
+	ai_map_.clear();
+	if(singleton_ == this) {
+		singleton_ = nullptr;
+	}
 }
 
 manager* manager::singleton_ = nullptr;

--- a/src/ai/manager.cpp
+++ b/src/ai/manager.cpp
@@ -23,7 +23,6 @@
 #include "config.hpp"             // for config, etc
 #include "game_events/pump.hpp"
 #include "log.hpp"
-#include "manager.hpp"
 #include "map/location.hpp"       // for map_location
 #include "resources.hpp"
 #include "serialization/string_utils.hpp"

--- a/src/ai/manager.hpp
+++ b/src/ai/manager.hpp
@@ -131,9 +131,7 @@ public:
 
 	manager();
 
-	/* The singleton can't be set to null in the destructor because member objects
-	(which access the singleton) are destroyed *after* the destructor has been run. */
-	~manager() = default;
+	~manager();
 
 	// =======================================================================
 	// ACCESS TO MANAGER


### PR DESCRIPTION
Fixed map editor crashing when creating or opening scenario after played local scenario before opening map editor. Resolves #9563. The cause of the bug was that the ai manager singleton pointer was not set to nullptr after it was destructed. Fixed this by making ai manager destructor set singleton to nullptr. Before this the ai_map_ map member has to be cleared in destructor because it might try to access the singleton when destructed.