### PR TITLE
fix malformed markup in unit_list and unit_recall

### DIFF
--- a/src/gui/dialogs/unit_list.cpp
+++ b/src/gui/dialogs/unit_list.cpp
@@ -53,7 +53,7 @@ static std::string format_level_string(const int level)
 	} else if(level == 2) {
 		return markup::bold(level);
 	} else { // level must be > 2
-		return markup::bold(markup::span_color("#ffffff", level));
+		return markup::span_color("#ffffff", markup::bold(level));
 	}
 
 }

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -99,7 +99,7 @@ static std::string format_level_string(const int level, bool recallable)
 	} else if(level == 2) {
 		return markup::bold(level);
 	} else {
-		return markup::bold(markup::span_color("#ffffff", level));
+		return markup::span_color("#ffffff", markup::bold(level));
 	}
 }
 


### PR DESCRIPTION
error cause to show text of color code instead of use for color level number(same fix what for https://github.com/wesnoth/wesnoth/commit/37b7a83ce08f34f3fcc5036b9e16f824d234355f#diff-010538c81e10d3e4eeadfb49808ab52a6fe1becc787cb247c6a854b8f4c1900aL104)