### PR TITLE
EI S02: Avoid creating unit with same id twice

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/02_The_Escape_Tunnel.cfg
@@ -133,6 +133,8 @@
             [/modifications]
         [/unit]
 
+#endif
+#ifdef NORMAL
         {NAMED_NOTRAIT_UNIT 3 (Troll Whelp) 23 8 "Hur" (_"Hur")} {GUARDIAN}
         [+unit]
             [modifications]


### PR DESCRIPTION
In the existing code, on HARD difficulty, creating a unit with id="Hur" is done twice, first as a Troll Whelp, then as a Troll Rocklobber. As a result, the former unit is replaced with the latter one. As they are created at the same coordinates, I believe this is the intended behavior.

But according to https://wiki.wesnoth.org/SingleUnitWML , reusing the id "may produce unpredictable results in many cases". For example, (I tested it) if you create the new unit at the different coordinates, it instead appears at the former unit's coordinates.

I've added another preprocessor directive, so the unit with this id is created only once on both NORMAL and HARD.