### PR TITLE
EI S01 story: Fix outposts locations accorting to campaign map

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
@@ -54,7 +54,7 @@
             #po: The River Guard posts had been built in 470 YW; they were abandoned in 544 YW.
             #po: The wave of colonization had begun around 530 YW.
             #po: This intro starts in 625 YW; the king's forces arrive at the outposts in 626 YW.
-            story= _ "In the days of King Garard I, two strong points had been built along the near bank of the River Weldyn, south of Soradoc, to stop bandits and orcish raiders out of the Estmarks from entering Wesnoth. In later years, the river guard posts had been abandoned as colonists spread into the Estmarks and the orcs were driven in retreat north of the Great River."
+            story= _ "In the days of King Garard I, two strong points had been built along the far bank of the River Weldyn, south of Soradoc, to stop bandits and orcish raiders out of the Estmarks from entering Wesnoth. In later years, the river guard posts had been abandoned as colonists spread into the Estmarks and the orcs were driven in retreat north of the Great River."
             {EI_BIGMAP}
         [/part]
         [part]


### PR DESCRIPTION
The outposts are east of River Weldyn in the campaign map. Also, in scenario 1, the castle is east of the river. The heartland of Wesnoth country is west of that river, so the  eastern bank is the "far" one.
These words date back to the original campaign design by Eric S. Raymond. Back then, the campaign map had the outposts on the western bank of Weldyn.
But in aeb9ec7 the map was replaced with a newer one, with outpost on the eastern bank, which persists to this day with some minor changes (like the southern outpost was moved futher south).