### PR TITLE
Change Human Ranger and Huntsman

### DIFF
--- a/changelog_entries/change_huntsman_ranger
+++ b/changelog_entries/change_huntsman_ranger
@@ -1,7 +1,0 @@
-### Units 
-* Huntsman:
-** HP 57 > 53, bow 9-4(marksman) > 10-4(marksman), cost 43g > 50g
-** new ability: Swamp Lurk (invisibility in swamps)
-* Ranger:
-** HP 60 > 64, bow 7-4 > 8-4, cost 43g > 50g
-** Defense: castle 60% > 50%, frozen 20% > 30%, reef 30% > 50%, sand 30% > 40%

--- a/changelog_entries/change_huntsman_ranger
+++ b/changelog_entries/change_huntsman_ranger
@@ -1,0 +1,7 @@
+### Units 
+* Huntsman:
+** HP 57 > 53, bow 9-4(marksman) > 10-4(marksman), cost 43g > 50g
+** new ability: Swamp Lurk (invisibility in swamps)
+* Ranger:
+** HP 60 > 64, bow 7-4 > 8-4, cost 43g > 50g
+** Defense: castle 60% > 50%, frozen 20% > 30%, reef 30% > 50%, sand 30% > 40%

--- a/changelog_entries/change_huntsman_ranger.md
+++ b/changelog_entries/change_huntsman_ranger.md
@@ -1,0 +1,7 @@
+### Units 
+* Huntsman:
+  - HP 57 > 53, bow 9-4(marksman) > 10-4(marksman), cost 43g > 50g
+  - new ability: Swamp Lurk (invisibility in swamps)
+* Ranger:
+  - HP 60 > 64, bow 7-4 > 8-4, cost 43g > 50g
+  - Defense: castle 60% > 50%, frozen 20% > 30%, reef 30% > 50%, sand 30% > 40%

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -380,6 +380,25 @@ Enemy units cannot see this unit while it is in deep water, except if they have 
     [/hides]
 #enddef
 
+#define ABILITY_SWAMP_LURK
+    # Canned definition of the Swamp Lurk ability to be included in an
+    # [abilities] clause.
+    [hides]
+        id=swamp_lurk
+        name= _ "swamp lurk"
+        female_name= _ "female^swamp lurk"
+        description= _ "This unit can hide in swamp, and remain undetected by its enemies.
+
+Enemy units cannot see this unit while it is in swamp, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
+        affect_self=yes
+        [filter]
+            [filter_location]
+                terrain=S*^*
+            [/filter_location]
+        [/filter]
+    [/hides]
+#enddef
+
 #define ABILITY_FEEDING
     # Canned definition of the Feeding ability to be included in an
     # [abilities] clause.

--- a/data/core/units/humans/Woodsman_Huntsman.cfg
+++ b/data/core/units/humans/Woodsman_Huntsman.cfg
@@ -16,7 +16,7 @@
     {AMLA_DEFAULT}
     cost=50
     usage=archer
-    description= _ "Hunting is a popular sport of noblemen, but it can also be a livelihood for commoners. Like any other craft, it has men of masterful skill in its practice. Huntsmen know all the tricks of their trade, and are skilled at navigating the wilderness, at tracking, and at the use of the bow. They are a fair shot at moving targets, and targets hiding under brush and cover; a skill wrought from years of practice at shooting game, and one which garrisoned bowmen often lack.
+    description= _ "Hunting is a popular sport of noblemen, but it can also be a livelihood for commoners. Like any other craft, it has men of masterful skill in its practice. Huntsmen know all the tricks of their trade, and are skilled at tracking, the use of the bow, and at disguising their silhouette and scent among the marshy wilds. They are a fair shot at moving targets, and targets hiding under brush and cover; a skill wrought from years of practice at shooting game, and one which garrisoned bowmen often lack.
 
 Master hunters are employed by any group living in or passing through wild country, be they men of the law, or those working against it. Even nature itself can have deadly surprises, and any commander who fails to hire a such a guide can lose his men to nothing more than terrain. Good woodsmen can save lives, ease travel, provide food, and their skill with a bow is capitally useful in a fight."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/humans/Woodsman_Huntsman.cfg
+++ b/data/core/units/humans/Woodsman_Huntsman.cfg
@@ -6,7 +6,7 @@
     race=human
     image="units/human-outlaws/huntsman.png"
     profile=portraits/humans/huntsman.webp
-    hitpoints=57
+    hitpoints=53
     movement_type=smallfoot
     movement=5
     experience=150
@@ -14,7 +14,7 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=50
     usage=archer
     description= _ "Hunting is a popular sport of noblemen, but it can also be a livelihood for commoners. Like any other craft, it has men of masterful skill in its practice. Huntsmen know all the tricks of their trade, and are skilled at navigating the wilderness, at tracking, and at the use of the bow. They are a fair shot at moving targets, and targets hiding under brush and cover; a skill wrought from years of practice at shooting game, and one which garrisoned bowmen often lack.
 
@@ -31,6 +31,9 @@ Master hunters are employed by any group living in or passing through wild count
         forest=40
         swamp_water=40
     [/defense]
+    [abilities]
+        {ABILITY_SWAMP_LURK}
+    [/abilities]
     [attack]
         name=dagger
         description= _ "dagger"
@@ -46,8 +49,8 @@ Master hunters are employed by any group living in or passing through wild count
         icon=attacks/bow.png
         type=pierce
         range=ranged
-        damage=9
-        number=4
+        damage=8
+        number=5
         [specials]
             {WEAPON_SPECIAL_MARKSMAN}
         [/specials]

--- a/data/core/units/humans/Woodsman_Huntsman.cfg
+++ b/data/core/units/humans/Woodsman_Huntsman.cfg
@@ -49,8 +49,8 @@ Master hunters are employed by any group living in or passing through wild count
         icon=attacks/bow.png
         type=pierce
         range=ranged
-        damage=8
-        number=5
+        damage=10
+        number=4
         [specials]
             {WEAPON_SPECIAL_MARKSMAN}
         [/specials]

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -16,7 +16,7 @@
     {AMLA_DEFAULT}
     cost=50
     usage=mixed fighter
-"Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. Unused to places of civilization, they have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
+    description= _ "Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. Unused to places of civilization, they have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
 
 The presence of these men troubles the more authoritarian of rulers; they are an element that knights and landed armies cannot control. They are men of dubious motives, and are the first to scoff at any royal decree, if they even hear of it at all. Rangers can be hired, but they are just as likely to be in the employ of bandits, as they are to be in the king’s service."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -25,7 +25,7 @@ The presence of these men troubles the more authoritarian of rulers; they are an
 
     # Rangers are almost like human elves
     # same frozen/sand defense as the Elvish Avenger
-    # reduced castle/village defense, reflecting their "wild-ness"
+    # reduced castle defense reflecting their "wild-ness"
     [defense]
         castle=50
         forest=40

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -6,7 +6,7 @@
     race=human
     image="units/human-outlaws/ranger.png"
     profile=portraits/humans/ranger.webp
-    hitpoints=60
+    hitpoints=67 # same hitpoints as the Master Bowman
     movement_type=smallfoot
     movement=6
     experience=150
@@ -14,9 +14,9 @@
     alignment=chaotic
     advances_to=null
     {AMLA_DEFAULT}
-    cost=43
+    cost=50
     usage=mixed fighter
-    description= _ "Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. They have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
+"Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. Unused to places of civilization, they have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
 
 The presence of these men troubles the more authoritarian of rulers; they are an element that knights and landed armies cannot control. They are men of dubious motives, and are the first to scoff at any royal decree, if they even hear of it at all. Rangers can be hired, but they are just as likely to be in the employ of bandits, as they are to be in the king’s service."
     die_sound={SOUND_LIST:HUMAN_DIE}
@@ -24,20 +24,25 @@ The presence of these men troubles the more authoritarian of rulers; they are an
     {DEFENSE_ANIM_RANGE "units/human-outlaws/ranger-bow-defend.png" "units/human-outlaws/ranger-bow.png" {SOUND_LIST:HUMAN_HIT} ranged }
 
     # Rangers are almost like human elves
+    # same frozen/sand defense as the Elvish Avenger
+    # reduced castle/village defense, reflecting their "wild-ness"
     [defense]
-        swamp_water=40
+        castle=50
         forest=40
+        frozen=70
         hills=40
+        sand=60
         shallow_water=60
+        swamp_water=40
+        village=50
     [/defense]
     [movement_costs]
-        shallow_water=2
-        swamp_water=2
         forest=1
+        frozen=2
         hills=1
         mountains=2
-        cave=2
-        frozen=2
+        shallow_water=2
+        swamp_water=2
     [/movement_costs]
     [attack]
         name=sword
@@ -45,7 +50,7 @@ The presence of these men troubles the more authoritarian of rulers; they are an
         icon=attacks/sword-human.png
         type=blade
         range=melee
-        damage=7
+        damage=8
         number=4
     [/attack]
     [attack]

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -50,7 +50,7 @@ The presence of these men troubles the more authoritarian of rulers; they are an
         icon=attacks/sword-human.png
         type=blade
         range=melee
-        damage=8
+        damage=7
         number=4
     [/attack]
     [attack]
@@ -59,7 +59,7 @@ The presence of these men troubles the more authoritarian of rulers; they are an
         icon=attacks/bow.png
         type=pierce
         range=ranged
-        damage=7
+        damage=8
         number=4
     [/attack]
     [attack_anim]

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -6,7 +6,7 @@
     race=human
     image="units/human-outlaws/ranger.png"
     profile=portraits/humans/ranger.webp
-    hitpoints=67 # same hitpoints as the Master Bowman
+    hitpoints=64
     movement_type=smallfoot
     movement=6
     experience=150
@@ -31,10 +31,10 @@ The presence of these men troubles the more authoritarian of rulers; they are an
         forest=40
         frozen=70
         hills=40
+        reef=50
         sand=60
         shallow_water=60
         swamp_water=40
-        village=50
     [/defense]
     [movement_costs]
         forest=1

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -16,7 +16,7 @@
     {AMLA_DEFAULT}
     cost=50
     usage=mixed fighter
-    description= _ "Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. Unused to places of civilization, they have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
+    description= _ "Rangers are wild men and wanderers, who have chosen to shun the company of their fellow men for myriad reasons. Unaccustomed to places of civilization, they have spent the better part of their lives in the thick of nature, and know many of its secrets. They are excellent pathfinders and explorers, and can find food and shelter where other men would find only sticks and stones.
 
 The presence of these men troubles the more authoritarian of rulers; they are an element that knights and landed armies cannot control. They are men of dubious motives, and are the first to scoff at any royal decree, if they even hear of it at all. Rangers can be hired, but they are just as likely to be in the employ of bandits, as they are to be in the king’s service."
     die_sound={SOUND_LIST:HUMAN_DIE}

--- a/data/core/units/monsters/Crocodile.cfg
+++ b/data/core/units/monsters/Crocodile.cfg
@@ -139,20 +139,7 @@
         {CROC_TERRAIN_FILTER_TEMP}
     )}
     [abilities]
-        [hides]
-            id=swamp_lurk
-            name= _ "swamp lurk"
-            female_name= _ "female^swamp lurk"
-            description= _ "This unit can hide in swamp, and remain undetected by its enemies.
-
-Enemy units cannot see this unit while it is in swamp, except if they have units next to it. Any enemy unit that first discovers this unit immediately loses all its remaining movement."
-            affect_self=yes
-            [filter]
-                [filter_location]
-                    terrain=S*^*
-                [/filter_location]
-            [/filter]
-        [/hides]
+        {ABILITY_SWAMP_LURK}
     [/abilities]
     [attack]
         name=bite


### PR DESCRIPTION
These Ranger changes are an attempt to raise his power closer to the Master Bowman or Elvish Avenger, while also cementing his role as a wilderness rover - powerful in the wild but vulnerable in castle/village.

These Huntsman changes are an attempt to help him better-fill the role of a frail mage-equivalent for the bandits (who otherwise lack Marksman/Magical), while adding some hunting flavor and a useful niche with "swamp lurk".

