### PR TITLE
add preprocess_string method and use preprocessed loyal trait

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -253,9 +253,14 @@ Example:
 For details regarding the preprocessor visit:
 https://wiki.wesnoth.org/PreprocessorRef#Command-line_preprocessor.
 .TP
+.BI --preprocess-string \ source-string
+preprocesses a given string and writes the output to stdout.
+.TP
 .BI --preprocess-defines= DEFINE1 , DEFINE2 , ...
 comma separated list of defines to be used by the
 .B --preprocess
+or
+.B --preprocess-string
 command. If
 .B SKIP_CORE
 is in the define list the "data/core" directory won't be preprocessed.
@@ -263,6 +268,8 @@ is in the define list the "data/core" directory won't be preprocessed.
 .BI --preprocess-input-macros \ source-file
 used only by the
 .B --preprocess
+or
+.B --preprocess-string
 command. Specifies a file that contains
 .BR [preproc_define] s
 to be included before preprocessing.
@@ -270,7 +277,9 @@ to be included before preprocessing.
 .BI --preprocess-output-macros[ =target-file ]
 used only by the
 .B --preprocess
-command. Will output all preprocessed macros in the target file. If the file is not specified
+command (But not by the
+.B --preprocess-string
+command). Will output all preprocessed macros in the target file. If the file is not specified
 the output will be file '_MACROS_.cfg' in the target directory of preprocess's command. The
 output file can be passed to
 .BR --preprocess-input-macros .

--- a/src/commandline_options.cpp
+++ b/src/commandline_options.cpp
@@ -29,6 +29,7 @@
 #include <boost/program_options/variables_map.hpp>  // for variables_map, etc
 
 #include <array>
+#include <string>
 
 namespace po = boost::program_options;
 
@@ -291,6 +292,7 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		("output,o", po::value<std::string>(), "output to specified file")
 		("patch,P", po::value<two_strings>()->multitoken(), "apply a patch to a preprocessed WML document." IMPLY_TERMINAL)
 		("preprocess,p", po::value<two_strings>()->multitoken(), "requires two arguments: <file/folder> <target directory>. Preprocesses a specified file/folder. The preprocessed file(s) will be written in the specified target directory: a plain cfg file and a processed cfg file." IMPLY_TERMINAL)
+		("preprocess-string", po::value<std::string>(), "preprocess given string" IMPLY_TERMINAL)
 		("preprocess-defines", po::value<std::string>(), "comma separated list of defines to be used by '--preprocess' command. If 'SKIP_CORE' is in the define list the data/core won't be preprocessed. Example: --preprocess-defines=FOO,BAR")
 		("preprocess-input-macros", po::value<std::string>(), "used only by the '--preprocess' command. Specifies source file <arg> that contains [preproc_define]s to be included before preprocessing.")
 		("preprocess-output-macros", po::value<std::string>()->implicit_value(std::string()), "used only by the '--preprocess' command. Will output all preprocessed macros in the target file <arg>. If the file is not specified the output will be file '_MACROS_.cfg' in the target directory of preprocess's command.")
@@ -412,6 +414,10 @@ commandline_options::commandline_options(const std::vector<std::string>& args)
 		preprocess = true;
 		preprocess_path = vm["preprocess"].as<two_strings>().first;
 		preprocess_target = vm["preprocess"].as<two_strings>().second;
+	}
+	if(vm.count("preprocess-string"))
+	{
+		preprocess_source_string = vm["preprocess-string"].as<std::string>();
 	}
 	if(vm.count("diff"))
 	{

--- a/src/commandline_options.hpp
+++ b/src/commandline_options.hpp
@@ -164,6 +164,8 @@ public:
 	utils::optional<std::string> preprocess_path;
 	/** Target (output) path that was given to the --preprocess option. */
 	utils::optional<std::string> preprocess_target;
+	/** String to preprocess */
+	utils::optional<std::string> preprocess_source_string;
 	/** Pair of AxB values specified after --resolution. Changes Wesnoth resolution. */
 	utils::optional<std::pair<int,int>> resolution;
 	/** RNG seed specified by --rng-seed option. Initializes RNG with given seed. */
@@ -178,7 +180,7 @@ public:
 	utils::optional<std::string> render_image;
 	/** Output file to put rendered image path in. Optional second parameter after --render-image */
 	utils::optional<std::string> render_image_dst;
-  /** Path of which to generate a spritesheet */
+	/** Path of which to generate a spritesheet */
 	utils::optional<std::string> generate_spritesheet;
 	/** True if --screenshot was given on the command line. Starts Wesnoth in screenshot mode. */
 	bool screenshot;

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -732,7 +732,7 @@ config map_context::to_config()
 	// [unit]s
 	config traits;
 	preproc_map traits_map;
-	read(traits, *(preprocess_file(game_config::path+"/data/core/macros/traits.cfg", &traits_map)));
+	read(traits, *(preprocess_file(game_config::path + "/data/core/macros/traits.cfg", &traits_map)));
 
 	for(const auto& unit : units_) {
 		config& u = event.add_child("unit");
@@ -756,10 +756,11 @@ config map_context::to_config()
 			u["unrenamable"] = unit.unrenamable();
 		}
 
+		config& mods = u.add_child("modifications");
 		if(unit.loyal()) {
 			config trait_loyal;
-			read(trait_loyal, traits_map["TRAIT_LOYAL"].value);
-			u.append(trait_loyal);
+			read(trait_loyal, preprocess_string("{TRAIT_LOYAL}", &traits_map, "wesnoth-editor"));
+			mods.append(trait_loyal);
 		}
 		//TODO this entire block could also be replaced by unit.write(u, true)
 		//however, the resultant config is massive and contains many attributes we don't need.

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -759,7 +759,7 @@ config map_context::to_config()
 		config& mods = u.add_child("modifications");
 		if(unit.loyal()) {
 			config trait_loyal;
-			read(trait_loyal, preprocess_string("{TRAIT_LOYAL}", &traits_map, "wesnoth-editor"));
+			read(trait_loyal, preprocess_string("{TRAIT_LOYAL}", &traits_map, "wesnoth-help"));
 			mods.append(trait_loyal);
 		}
 		//TODO this entire block could also be replaced by unit.write(u, true)

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -143,8 +143,24 @@ std::ostream& operator<<(std::ostream& stream, const preproc_map::value_type& de
  */
 filesystem::scoped_istream preprocess_file(const std::string& fname, preproc_map* defines = nullptr);
 
-void preprocess_resource(const std::string& res_name,
-		preproc_map* defines_map,
-		bool write_cfg = false,
-		bool write_plain_cfg = false,
-		const std::string& target_directory = "");
+/**
+ * Function to use the WML preprocessor on a string.
+ *
+ * @param defines                 A map of symbols defined.
+ * @param contents                The string to be preprocessed.
+ * @param textdomain              The textdomain to associate the contents.
+ *                                Default: wesnoth
+ *
+ * @returns                       The resulting preprocessed string.
+ */
+std::string preprocess_string(
+	const std::string& contents,
+	preproc_map* defines,
+	const std::string& textdomain = "wesnoth");
+
+void preprocess_resource(
+	const std::string& res_name,
+	preproc_map* defines_map,
+	bool write_cfg = false,
+	bool write_plain_cfg = false,
+	const std::string& target_directory = "");


### PR DESCRIPTION
Resolves #9580.

Adds a `preprocess_string` method that allows to run the preprocessor on a string. Example:
https://github.com/wesnoth/wesnoth/blob/0088534cd91b4331fe0ed5e9fcf992e93a1b8ea8/src/editor/map/map_context.cpp#L762

Also, the Loyal trait will now be written inside `[modifications]`.

TODO:
- [x] Add a command line option to preprocess a string