### PR TITLE
[1.18] Map Editor terrain button click fix (#1335)

### DIFF
--- a/src/editor/palette/tristate_button.cpp
+++ b/src/editor/palette/tristate_button.cpp
@@ -307,17 +307,18 @@ void tristate_button::mouse_down(const SDL_MouseButtonEvent& event) {
 	if (!hit(event.x, event.y))
 		return;
 
+	//The widget is expected to be in one of the "active" states when the mouse cursor is hovering over it, but that currently doesn't happen if the widget is moved under the cursor by scrolling the palette.
 	if (event.button == SDL_BUTTON_RIGHT) {
-		if (state_ == ACTIVE)
+		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_RIGHT;
-		if (state_ == PRESSED_ACTIVE_LEFT)
+		if (state_ == PRESSED_ACTIVE_LEFT || state_ == PRESSED_LEFT)
 			state_ = TOUCHED_BOTH_LEFT;
 	}
 
 	if (event.button == SDL_BUTTON_LEFT) {
-		if (state_ == ACTIVE)
+		if (state_ == ACTIVE || state_ == NORMAL)
 			state_ = TOUCHED_LEFT;
-		if (state_ == PRESSED_ACTIVE_RIGHT)
+		if (state_ == PRESSED_ACTIVE_RIGHT || state_ == PRESSED_RIGHT)
 			state_ = TOUCHED_BOTH_RIGHT;
 	}
 


### PR DESCRIPTION
Backport of #9560, opening a PR to run the CI.

Fixed palette button not being clickable after scrolling in palette widget without moving the cursor. Resolves #1335. The cause of the bug was that scrolling doesnt change the highlighted state of the palette buttons and not highlighted buttons didnt process being clicked. Solved the bug by making not highlighted buttons process being clicked.

(cherry picked from commit 484116ea09ab3bf0ac6cddd5340458dd91ea8730)