### PR TITLE
give active_on and special filters to leadership

### DIFF
--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -89,7 +89,7 @@
 [tag]
 	name="leadership"
 	max=infinite
-	super="units/unit_type/abilities/~value~"
+	super="units/unit_type/abilities/~value~,units/unit_type/attack/specials/~generic~"
 	{FILTER_TAG "filter_weapon" weapon ()}
 	{FILTER_TAG "filter_second_weapon" weapon ()}
 [/tag]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_active_on_defense.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_active_on_defense.cfg
@@ -8,9 +8,9 @@
 # Attack each other
 ##
 # Expected end state:
-# active_on does nothing
-# The damage from the attack is increased by 50% for the attacker
-# The damage from the attack is increased by 50% for the defender
+# active_on for defender
+# The damage from the attack is not increased for the attacker
+# The damage from the attack is increased by 50% forthe defender
 #####
 #ifndef SCHEMA_VALIDATION
 {COMMON_KEEP_A_B_UNIT_TEST "leadership_active_on_defense" (
@@ -28,7 +28,7 @@
             [/effect]
         [/modify_unit]
 
-        {ATTACK_AND_VALIDATE 150}
+        {ATTACK_AND_VALIDATE 150 DAMAGE2=100}
         {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_active_on_offense.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_active_on_offense.cfg
@@ -8,9 +8,9 @@
 # Attack each other
 ##
 # Expected end state:
-# active_on does nothing
+# active_on for attacker only
 # The damage from the attack is increased by 50% for the attacker
-# The damage from the attack is increased by 50% for the defender
+# The damage from the attack is not increased for the defender
 #####
 #ifndef SCHEMA_VALIDATION
 {COMMON_KEEP_A_B_UNIT_TEST "leadership_active_on_offense" (
@@ -28,7 +28,7 @@
             [/effect]
         [/modify_unit]
 
-        {ATTACK_AND_VALIDATE 150}
+        {ATTACK_AND_VALIDATE 100 DAMAGE2=150}
         {SUCCEED}
     [/event]
 )}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_when_opponent_has_no_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_when_opponent_has_no_special.cfg
@@ -1,0 +1,126 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [leadership][filter_opponent][filter_weapon]special_id_active=
+##
+# Actions:
+# Spawn an Elvish Hero and an Orcish Warrior.
+# Give everyone 100 hitpoints.
+# Give the Orcish Warrior leadership that only triggers when the defending unit has a specific weapon special id.
+# Give alice a weapon special with the wrong id required to trigger the leadership.
+# Have bob and alice attack each other.
+##
+# Expected end state:
+# alice has 82 hp left (9x2, not affected by leadership).
+#####
+{GENERIC_UNIT_TEST "leadership_when_opponent_has_no_special" (
+    [event]
+        name=start
+
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=12,4
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [unit]
+            id=ben
+            name=_"Ben"
+            x,y=14,3
+            type=Orcish Warrior
+            side=2
+        [/unit]
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        affect_self=no
+                        affect_allies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                    [/chance_to_hit]
+                    [leadership]
+                        value=100
+                        cumulative=no
+                        affect_self=no
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=test_cth
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        [affect_adjacent]
+                            [filter]
+                                formula="level < other.level"
+                            [/filter]
+                        [/affect_adjacent]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=ben
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        id=blah
+                        value=100
+                        affect_self=no
+                        affect_allies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alex
+            [/filter]
+        [/object]
+
+        [do_command]
+            [move]
+                x=7,12
+                y=3,3
+            [/move]
+        [/do_command]
+
+        [do_command]
+            [attack]
+                weapon=0
+                [source]
+                    x,y=12,3
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+
+        {ASSERT (
+            [have_unit]
+                id=alice
+                formula="self.hitpoints = 82"
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_when_opponent_has_special.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/leadership/leadership_when_opponent_has_special.cfg
@@ -1,0 +1,126 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: [leadership][filter_opponent][filter_weapon]special_id_active=
+##
+# Actions:
+# Spawn an Elvish Hero and an Orcish Warrior.
+# Give everyone 100 hitpoints.
+# Give the Orcish Warrior leadership that only triggers when the defending unit has a specific weapon special id.
+# Give alice a weapon special with the id required to trigger the leadership.
+# Have bob and alice attack each other.
+##
+# Expected end state:
+# alice has 64 hp left (9x2, double to 18x2 from the leadership).
+#####
+{GENERIC_UNIT_TEST "leadership_when_opponent_has_special" (
+    [event]
+        name=start
+
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=12,4
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [unit]
+            id=ben
+            name=_"Ben"
+            x,y=14,3
+            type=Orcish Warrior
+            side=2
+        [/unit]
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            max_hitpoints=100
+            hitpoints=100
+            attacks_left=1
+        [/modify_unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        value=100
+                        affect_self=no
+                        affect_allies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                    [/chance_to_hit]
+                    [leadership]
+                        value=100
+                        cumulative=no
+                        affect_self=no
+                        [filter_opponent]
+                            [filter_weapon]
+                                special_id_active=test_cth
+                            [/filter_weapon]
+                        [/filter_opponent]
+                        [affect_adjacent]
+                            [filter]
+                                formula="level < other.level"
+                            [/filter]
+                        [/affect_adjacent]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=ben
+            [/filter]
+        [/object]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [chance_to_hit]
+                        id=test_cth
+                        value=100
+                        affect_self=no
+                        affect_allies=yes
+                        [affect_adjacent]
+                        [/affect_adjacent]
+                    [/chance_to_hit]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alex
+            [/filter]
+        [/object]
+
+        [do_command]
+            [move]
+                x=7,12
+                y=3,3
+            [/move]
+        [/do_command]
+
+        [do_command]
+            [attack]
+                weapon=0
+                [source]
+                    x,y=12,3
+                [/source]
+                [destination]
+                    x,y=13,3
+                [/destination]
+            [/attack]
+        [/do_command]
+
+        {ASSERT (
+            [have_unit]
+                id=alice
+                formula="self.hitpoints = 64"
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1590,7 +1590,7 @@ void attack_unit_and_advance(const map_location& attacker,
 
 int under_leadership(const unit &u, const map_location& loc, const_attack_ptr weapon, const_attack_ptr opp_weapon)
 {
-	unit_ability_list abil = u.get_abilities_weapons("leadership", loc, weapon, opp_weapon);
+	unit_ability_list abil = weapon ? weapon->attack_type::get_weapon_ability("leadership") : u.get_abilities_weapons("leadership", loc, weapon, opp_weapon);
 	unit_abilities::effect leader_effect(abil, 0, nullptr, unit_abilities::EFFECT_CUMULABLE);
 	return leader_effect.get_composite_value();
 }

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1552,12 +1552,18 @@ unit_ability_list attack_type::get_weapon_ability(const std::string& ability) co
 	const map_location loc = self_ ? self_->get_location() : self_loc_;
 	unit_ability_list abil_list(loc);
 	if(self_) {
-		abil_list.append_if((*self_).get_abilities(ability, self_loc_), [&](const unit_ability& i) {
-			return special_active(*i.ability_cfg, AFFECT_SELF, ability, "filter_student");
-		});
+		if(ability != "leadership"){
+			abil_list.append_if((*self_).get_abilities(ability, self_loc_), [&](const unit_ability& i) {
+				return special_active(*i.ability_cfg, AFFECT_SELF, ability, "filter_student");
+			});
+		} else {
+			abil_list.append_if((*self_).get_abilities_weapons(ability, self_loc_, shared_from_this(), other_attack_), [&](const unit_ability& i) {
+				return special_active(*i.ability_cfg, AFFECT_SELF, ability, "filter_student");
+			});
+		}
 	}
 
-	if(other_) {
+	if(other_ && (ability != "leadership")) {
 		abil_list.append_if((*other_).get_abilities(ability, other_loc_), [&](const unit_ability& i) {
 			return special_active_impl(other_attack_, shared_from_this(), *i.ability_cfg, AFFECT_OTHER, ability, "filter_student");
 		});
@@ -2226,13 +2232,15 @@ bool attack_type::special_active_impl(
 
 
 	// Does this affect the specified unit?
-	if ( whom == AFFECT_SELF ) {
-		if ( !special_affects_self(special, is_attacker) )
-			return false;
-	}
-	if ( whom == AFFECT_OTHER ) {
-		if ( !special_affects_opponent(special, is_attacker) )
-			return false;
+	if(tag_name != "leadership"){
+		if ( whom == AFFECT_SELF ) {
+			if ( !special_affects_self(special, is_attacker) )
+				return false;
+		}
+		if ( whom == AFFECT_OTHER ) {
+			if ( !special_affects_opponent(special, is_attacker) )
+				return false;
+		}
 	}
 
 	// Is this active on attack/defense?

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -412,6 +412,8 @@
 0 special_id_active_lua_function
 0 leadership_when_other_has_special
 0 leadership_when_other_has_no_special
+0 leadership_when_opponent_has_special
+0 leadership_when_opponent_has_no_special
 0 effect_increase_attacks
 0 opponent_weapon_has_no_special
 0 opponent_weapon_has_special


### PR DESCRIPTION
Here I suggest that [leadership] can use active_on, but also filter opponent characteristics other than the weapon used.