### PR TITLE
Switch default Pango/Cairo render backend to Fontconfig on macOS

### DIFF
--- a/changelog_entries/macos-font-render-backend.md
+++ b/changelog_entries/macos-font-render-backend.md
@@ -1,0 +1,2 @@
+### User interface
+   * Switched default Pango/Cairo backend from CoreText to Fontconfig on macOS to fix issues with certain fonts such as Oldania ADF Std being unrecognized on current OS versions (issue #8488).

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -920,6 +920,11 @@ int main(int argc, char** argv)
 	_putenv("PANGOCAIRO_BACKEND=fontconfig");
 	_putenv("FONTCONFIG_PATH=fonts");
 #endif
+#ifdef __APPLE__
+	// Using setenv with overwrite disabled so we can override this in the
+	// original process environment for research/testing purposes.
+	setenv("PANGOCAIRO_BACKEND", "fontconfig", 0);
+#endif
 
 	try {
 		commandline_options cmdline_opts = commandline_options(args);


### PR DESCRIPTION
Fixes #8488 based on my first suggestion there since there doesn't seem to be any particular interest around here in pursuing the second path — the issue has been dormant for months with multiple stable and development releases tagged in the meantime and a wholesale refresh of the main menu making it even more visible to users.

Ideally we would instead figure out how to fix Oldania ADF Std to work on newer macOS, but since we know the Fontconfig backend works for us on Windows and Linux, we may as well stick to it and hope there will never be a situation where CoreText would prove superior somehow.

This patch is equivalent to invoking Wesnoth with `PANGOCAIRO_BACKEND=fontconfig wesnoth`, with the difference being that we don't overwrite the environment variable if it already exists (e.g. because someone wanted to test CoreText again with `PANGOCAIRO_BACKEND=coretext wesnoth`). Worth noting that `fontconfig` and `fc` are synonymous values in Pango (see the [source](https://github.com/GNOME/pango/blob/5d23702cc822ddf4c0e9c144e384c46be92f1e8b/pango/pangocairo-fontmap.c#L89) of `pango_cairo_font_map_new()`).

(Side note: I feel like the Windows-specific hack right above it should adopt the same approach and let the environment overrule the devs — currently it uses `putenv`, which is a forced overwrite of the existing environment. Not sure who to tag to gauge their opinion on this.)

### Backport plan

In my opinion, this should be backported to 1.18 after there's been a development release shipping it that hasn't caused any reported regressions for a couple of weeks. Preferably, of course, I'd hear from people on different macOS versions testing this before merging, but that might be hoping for too much since nobody else in the dev team seems to actively run dev builds on macOS — for a very flexible definition of "actively" on my part, anyway.