### PR TITLE
Fix issues with hero deaths in EI S03

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/03_An_Unexpected_Appearance.cfg
@@ -321,9 +321,6 @@
             #po: star wars reference
             message= _ "We will watch your career with great interest..."
         [/message]
-        [endlevel]
-            result=defeat
-        [/endlevel]
     [/event]
     [event]
         name=last breath
@@ -335,10 +332,6 @@
             speaker=Mal-Tar
             message= _ "Wait, please, not like this!"
         [/message]
-
-        # add in the herodeaths. Don't do these before, since we want special behavior for the achievement
-        {HERODEATH_GWEDDRY}
-        {HERODEATH_DACYN}
     [/event]
     [event]
         name=die


### PR DESCRIPTION
This scenario aims to have a custom dialogue if Gweddry or Dacyn are killed by Mal-Tar's side (event on line 294). The comment on line 339 suggests that their normal "last breath" events (HERODEATH macros) are added only after Mal-Tar is dead. However, these macros are also added at the bottom of the file (line 438). This leads to a couple of minor bugs:
* If Gweddry or Dacyn are killed by Mal-Tar, a chat message "\<Lua\> Repeated [endlevel] execution, ignoring" appears in the top left corner of the screen. That's because it is executed in both this scenario's "die" event, and the "last breath" included by the macro.
* If Mal-Tar is killed, the "last breath" events for both Gweddry and Dacyn are duplicated. So, if one of them is killed afterwards, you need to press the space button twice to skip the message; also, the same chat message about repeated [endlevel] appears.

The proposed changes fix both of these bugs. Notes:
* First I tried to remove the HERODEATH macros in the bottom of the file (as the aforementioned comment suggests), but that's an incorrect solution: if Mal-Tar is alive and Dacyn is killed by Mal-Kallat's or Mal-Skraat's side, you can continue playing without him. (With Gweddry it's still defeat because he's the leader.)
* The proposed code relies on the fact that if the "last breath" event executes the [endlevel] tag, the corresponding "die" event will still run before the "defeat" event. It works like this with my 1.18.3 executables, but I didn't test this on the master branch, and I didn't find this explicitly mentioned in the documentation like https://wiki.wesnoth.org/EventWML or https://wiki.wesnoth.org/DirectActionsWML