### PR TITLE
wesnothd: handle bans and IP spam instead of the base class

### DIFF
--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -167,8 +167,6 @@ protected:
 	virtual void handle_new_client(tls_socket_ptr socket) = 0;
 
 	virtual bool accepting_connections() const { return true; }
-	virtual std::string is_ip_banned(const std::string&) { return std::string(); }
-	virtual bool ip_exceeds_connection_limit(const std::string&) const { return false; }
 
 #ifndef _WIN32
 	boost::asio::posix::stream_descriptor input_;


### PR DESCRIPTION
These methods were only implemented for wesnothd anyway, and would do nothing for the addon server (campaignd). If we want bans for the latter, it would be better to do it with forum auth.

This also moves the handling for both internal and forum bans for the same place.