### PR TITLE
split undo actions into smaller steps

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -748,15 +748,9 @@ bool recall_unit(const std::string & id, team & current_team,
 	// Place the recall.
 	// We also check to see if a custom unit level recall has been set if not,
 	// we use the team's recall cost otherwise the unit's.
-	place_recruit_result res;
-	if (recall->recall_cost() < 0) {
-		res = place_recruit(recall, loc, from, current_team.recall_cost(),
+	int cost = recall->recall_cost() >= 0 ? recall->recall_cost() : current_team.recall_cost();
+	place_recruit_result res = place_recruit(recall, loc, from, cost,
 	                             true, facing, show);
-	}
-	else {
-		res = place_recruit(recall, loc, from, recall->recall_cost(),
-	                             true, facing, show);
-	}
 	resources::controller->statistics().recall_unit(*recall);
 
 	resources::undo_stack->add_recall(recall, loc, from, std::get<1>(res), std::get<2>(res));

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -626,6 +626,7 @@ place_recruit_result place_recruit(unit_ptr u, const map_location &recruit_locat
 	if (full_movement) {
 		u->set_movement(u->total_movement(), true);
 	} else {
+		//TODO: it looks to me like this change of unit stats is not properly undone yet.
 		u->set_movement(0, true);
 		u->set_attacks(0);
 	}
@@ -721,10 +722,11 @@ void recruit_unit(const unit_type & u_type, int side_num, const map_location & l
 
 
 	// Place the recruit.
-	place_recruit_result res = place_recruit(new_unit, loc, from, u_type.cost(), false, map_location::direction::indeterminate, show);
+	resources::undo_stack->add_recruit(new_unit, loc, from);
+	place_recruit_result res
+		= place_recruit(new_unit, loc, from, u_type.cost(), false, map_location::direction::indeterminate, show);
 	resources::controller->statistics().recruit_unit(*new_unit);
 
-	resources::undo_stack->add_recruit(new_unit, loc, from, std::get<1>(res), std::get<2>(res));
 	// Check for information uncovered or randomness used.
 
 	synced_context::block_undo(std::get<0>(res));
@@ -745,15 +747,16 @@ bool recall_unit(const std::string & id, team & current_team,
 	if ( !recall )
 		return false;
 
+	resources::undo_stack->add_recall(recall, loc, from);
 	// Place the recall.
 	// We also check to see if a custom unit level recall has been set if not,
 	// we use the team's recall cost otherwise the unit's.
 	int cost = recall->recall_cost() >= 0 ? recall->recall_cost() : current_team.recall_cost();
+
 	place_recruit_result res = place_recruit(recall, loc, from, cost,
 	                             true, facing, show);
-	resources::controller->statistics().recall_unit(*recall);
 
-	resources::undo_stack->add_recall(recall, loc, from, std::get<1>(res), std::get<2>(res));
+	resources::controller->statistics().recall_unit(*recall);
 	synced_context::block_undo(std::get<0>(res));
 
 
@@ -764,6 +767,5 @@ bool recall_unit(const std::string & id, team & current_team,
 
 	return true;
 }
-
 
 }//namespace actions

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -1190,7 +1190,6 @@ namespace { // Private helpers for move_unit()
 	 */
 	void unit_mover::post_move()
 	{
-		auto* undo_stack = resources::undo_stack;
 		const map_location & final_loc = final_hex();
 
 		int orig_village_owner = 0;
@@ -1236,15 +1235,17 @@ namespace { // Private helpers for move_unit()
 			spectator_->set_interrupted(interrupted());
 			spectator_->set_tiles_entered(steps_travelled());
 		}
-		if ( undo_stack ) {
-			const bool mover_valid = move_it_.valid();
+
+		const bool mover_valid = move_it_.valid();
 
 
-			if ( !mover_valid  ||  undo_blocked()  ||
-				(resources::whiteboard->is_active() && resources::whiteboard->should_clear_undo()) || synced_context::undo_blocked())
-			{
-				synced_context::block_undo();
-			}
+		if(!mover_valid || undo_blocked()) {
+			synced_context::block_undo();
+		}
+
+		// TODO: this looks wrong, whiteboard shouldn't effect the undo stack during a synced action.
+		if(resources::whiteboard->is_active() && resources::whiteboard->should_clear_undo()) {
+			synced_context::block_undo();
 		}
 
 		// Update the screen.

--- a/src/actions/shroud_clearing_action.cpp
+++ b/src/actions/shroud_clearing_action.cpp
@@ -22,28 +22,4 @@
 #include "play_controller.hpp"
 
 namespace actions {
-void shroud_clearing_action::return_village()
-{
-	team &current_team = resources::controller->current_team();
-	const map_location back = route.back();
-	if(resources::gameboard->map().is_village(back)) {
-		get_village(back, original_village_owner, nullptr, false);
-		//MP_COUNTDOWN take away capture bonus
-		if(take_village_timebonus) {
-			current_team.set_action_bonus_count(current_team.action_bonus_count() - 1);
-		}
-	}
-}
-void shroud_clearing_action::take_village()
-{
-	team &current_team = resources::controller->current_team();
-	const map_location back = route.back();
-	if(resources::gameboard->map().is_village(back)) {
-		get_village(back, current_team.side(), nullptr, false);
-		//MP_COUNTDOWN restore capture bonus
-		if(take_village_timebonus) {
-			current_team.set_action_bonus_count(1 + current_team.action_bonus_count());
-		}
-	}
-}
 }

--- a/src/actions/shroud_clearing_action.hpp
+++ b/src/actions/shroud_clearing_action.hpp
@@ -27,28 +27,22 @@ struct shroud_clearing_action
 	shroud_clearing_action(const config& cfg)
 		: route()
 		, view_info(cfg.child_or_empty("unit"))
-		, original_village_owner(cfg["village_owner"].to_int())
-		, take_village_timebonus(cfg["village_timebonus"].to_bool())
 	{
 		read_locations(cfg, route);
 	}
 
-	shroud_clearing_action(const unit_const_ptr u, const map_location& loc, int village_owner, bool village_bonus)
+	shroud_clearing_action(const unit_const_ptr u, const map_location& loc)
 		: route(1, loc)
 		, view_info(*u)
-		, original_village_owner(village_owner)
-		, take_village_timebonus(village_bonus)
 	{
 
 	}
 
 	typedef std::vector<map_location> route_t;
 
-	shroud_clearing_action(const unit_const_ptr u, const route_t::const_iterator& begin, const route_t::const_iterator& end, int village_owner, bool village_bonus)
+	shroud_clearing_action(const unit_const_ptr u, const route_t::const_iterator& begin, const route_t::const_iterator& end)
 		: route(begin, end)
 		, view_info(*u)
-		, original_village_owner(village_owner)
-		, take_village_timebonus(village_bonus)
 	{
 
 	}
@@ -60,25 +54,11 @@ struct shroud_clearing_action
 	route_t route;
 	/** A record of the affected unit's ability to see. */
 	clearer_info view_info;
-	/**
-	 * The number of the side that preivously owned the village that the unit stepped on
-	 * Note, that recruit/recall actions can also take a village if the unit was recruits/recalled onto a village
-	 */
-	int original_village_owner;
-	/** Whether this actions got a timebonus because it took a village. */
-	bool take_village_timebonus;
-
-	/** Change village owner on undo. */
-	void return_village();
-	/** Change village owner on redo. */
-	void take_village();
 
 	void write(config & cfg) const
 	{
 		write_locations(route, cfg);
 		view_info.write(cfg.add_child("unit"));
-		cfg["village_owner"] = original_village_owner;
-		cfg["village_timebonus"] = take_village_timebonus;
 	}
 
 	virtual ~shroud_clearing_action() {}

--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -196,12 +196,15 @@ void undo_list::new_side_turn(int side)
  * Currently, this is only used when the undo_list is empty, but in theory
  * it could be used to append the config to the current data.
  */
-void undo_list::read(const config & cfg)
+void undo_list::read(const config& cfg, int current_side)
 {
-	// Merge header data.
-	// TODO: remove side parameter, its already stored in [snapshot].
-	side_ = cfg["side"].to_int(side_);
+	side_ = current_side;
 	committed_actions_ = committed_actions_ || cfg["committed"].to_bool();
+
+	//If we have the side parameter this means that this was the old format pre 1.19.7, we ignore this since it's incompatible.
+	if(cfg.has_attribute("side")) {
+		return;
+	}
 
 	// Build the undo stack.
 	try {
@@ -235,7 +238,6 @@ void undo_list::read(const config & cfg)
  */
 void undo_list::write(config & cfg) const
 {
-	cfg["side"] = side_;
 	cfg["committed"] = committed_actions_;
 
 	for ( const auto& action_ptr : undos_)

--- a/src/actions/undo.cpp
+++ b/src/actions/undo.cpp
@@ -96,28 +96,28 @@ void undo_list::add_dismissal(const unit_const_ptr u)
 void undo_list::add_move(const unit_const_ptr u,
                          const std::vector<map_location>::const_iterator & begin,
                          const std::vector<map_location>::const_iterator & end,
-                         int start_moves, int timebonus, int village_owner,
+                         int start_moves,
                          const map_location::direction dir)
 {
-	add(std::make_unique<undo::move_action>(u, begin, end, start_moves, timebonus, village_owner, dir));
+	add(std::make_unique<undo::move_action>(u, begin, end, start_moves, dir));
 }
 
 /**
  * Adds a recall to the undo stack.
  */
 void undo_list::add_recall(const unit_const_ptr u, const map_location& loc,
-                           const map_location& from, int orig_village_owner, bool time_bonus)
+                           const map_location& from)
 {
-	add(std::make_unique<undo::recall_action>(u, loc, from, orig_village_owner, time_bonus));
+	add(std::make_unique<undo::recall_action>(u, loc, from));
 }
 
 /**
  * Adds a recruit to the undo stack.
  */
 void undo_list::add_recruit(const unit_const_ptr u, const map_location& loc,
-                            const map_location& from, int orig_village_owner, bool time_bonus)
+                            const map_location& from)
 {
-	add(std::make_unique<undo::recruit_action>(u, loc, from, orig_village_owner, time_bonus));
+	add(std::make_unique<undo::recruit_action>(u, loc, from));
 }
 
 

--- a/src/actions/undo.hpp
+++ b/src/actions/undo.hpp
@@ -85,7 +85,7 @@ public:
 	/** Returns true if the player has performed any actions this turn. */
 	bool player_acted() const { return committed_actions_ || !undos_.empty(); }
 	/** Read the undo_list from the provided config. */
-	void read(const config & cfg);
+	void read(const config & cfg, int current_side);
 	/** Write the undo_list into the provided config. */
 	void write(config & cfg) const;
 

--- a/src/actions/undo.hpp
+++ b/src/actions/undo.hpp
@@ -54,14 +54,14 @@ public:
 	void add_move(const unit_const_ptr u,
 	              const std::vector<map_location>::const_iterator & begin,
 	              const std::vector<map_location>::const_iterator & end,
-	              int start_moves, int timebonus=0, int village_owner=-1,
+	              int start_moves,
 	              const map_location::direction dir=map_location::direction::indeterminate);
 	/** Adds a recall to the undo stack. */
 	void add_recall(const unit_const_ptr u, const map_location& loc,
-	                const map_location& from, int orig_village_owner, bool time_bonus);
+	                const map_location& from);
 	/** Adds a recruit to the undo stack. */
 	void add_recruit(const unit_const_ptr u, const map_location& loc,
-	                 const map_location& from, int orig_village_owner, bool time_bonus);
+	                 const map_location& from);
 
 	template<class T, class... Args>
 	void add_custom(Args&&... args)

--- a/src/actions/undo.hpp
+++ b/src/actions/undo.hpp
@@ -33,7 +33,7 @@ namespace actions {
 /** Class to store the actions that a player can undo and redo. */
 class undo_list {
 
-	typedef std::unique_ptr<undo_action_base> action_ptr_t;
+	typedef std::unique_ptr<undo_action_container> action_ptr_t;
 	typedef std::vector<action_ptr_t> action_list;
 	typedef std::vector<std::unique_ptr<config>> redos_list;
 
@@ -44,18 +44,10 @@ public:
 	undo_list();
 	~undo_list();
 
-	/**
-	 * Creates an undo_action based on a config.
-	 * Throws bad_lexical_cast or config::error if it cannot parse the config properly.
-	 */
-	static std::unique_ptr<undo_action_base> create_action(const config & cfg);
-
 	// Functions related to managing the undo stack:
 
 	/** Adds an auto-shroud toggle to the undo stack. */
 	void add_auto_shroud(bool turned_on);
-	/** Adds an auto-shroud toggle to the undo stack. */
-	void add_dummy();
 	/** Adds a dismissal to the undo stack. */
 	void add_dismissal(const unit_const_ptr u);
 	/** Adds a move to the undo stack. */
@@ -70,8 +62,12 @@ public:
 	/** Adds a recruit to the undo stack. */
 	void add_recruit(const unit_const_ptr u, const map_location& loc,
 	                 const map_location& from, int orig_village_owner, bool time_bonus);
-	/** Adds a shroud update to the undo stack. */
-	void add_update_shroud();
+
+	template<class T, class... Args>
+	void add_custom(Args&&... args)
+	{
+		add(std::make_unique<T>(std::forward<Args>(args)...));
+	}
 private:
 public:
 	/** Clears the stack of undoable (and redoable) actions. */
@@ -99,19 +95,36 @@ public:
 	bool can_undo() const  { return !undos_.empty(); }
 	/** True if there are actions that can be redone. */
 	bool can_redo() const  { return !redos_.empty(); }
+
+	/** called before a user action, starts collecting undo steps for the new action. */
+	void init_action();
+	/** called after a user action, pushes the collected undo steps on the undo stack. */
+	void finish_action(bool can_undo);
+	/** called after a user action, removes empty actions */
+	void cleanup_action();
 	/** Undoes the top action on the undo stack. */
 	void undo();
 	/** Redoes the top action on the redo stack. */
 	void redo();
 
-private: // functions
-	/** Adds an action to the undo stack. */
-	void add(std::unique_ptr<undo_action_base>&& action)
-	{ undos_.push_back(std::move(action));  redos_.clear(); }
+	undo_action_container* get_current()
+	{
+		return current_.get();
+	}
+
+private:
+	/** Adds an undo step to the current action. */
+	void add(std::unique_ptr<undo_action>&& action)
+	{
+		if(current_) {
+			current_->add(std::move(action));
+		}
+	}
 	/** Applies the pending fog/shroud changes from the undo stack. */
 	bool apply_shroud_changes() const;
 
 private: // data
+	action_ptr_t current_;
 	action_list undos_;
 	redos_list redos_;
 

--- a/src/actions/undo_action.cpp
+++ b/src/actions/undo_action.cpp
@@ -171,15 +171,14 @@ bool undo_event::undo(int)
 	assert(resources::lua_kernel);
 	assert(resources::gamedata);
 
-	config::attribute_value& x1 = resources::gamedata->get_variable("x1");
-	config::attribute_value& y1 = resources::gamedata->get_variable("y1");
-	config::attribute_value& x2 = resources::gamedata->get_variable("x2");
-	config::attribute_value& y2 = resources::gamedata->get_variable("y2");
-	int oldx1 = x1.to_int(), oldy1 = y1.to_int(), oldx2 = x2.to_int(), oldy2 = y2.to_int();
-	x1 = e.filter_loc1.wml_x();
-	y1 = e.filter_loc1.wml_y();
-	x2 = e.filter_loc2.wml_x();
-	y2 = e.filter_loc2.wml_y();
+	config::attribute_value x1 = config::attribute_value::create(e.filter_loc1.wml_x());
+	config::attribute_value y1 = config::attribute_value::create(e.filter_loc1.wml_y());
+	config::attribute_value x2 = config::attribute_value::create(e.filter_loc2.wml_x());
+	config::attribute_value y2 = config::attribute_value::create(e.filter_loc2.wml_y());
+	std::swap(x1, resources::gamedata->get_variable("x1"));
+	std::swap(y1, resources::gamedata->get_variable("y1"));
+	std::swap(x2, resources::gamedata->get_variable("x2"));
+	std::swap(y2, resources::gamedata->get_variable("y2"));
 
 	std::unique_ptr<scoped_xy_unit> u1, u2;
 	if(unit_ptr who = get_unit(e.uid1, e.id1)) {
@@ -200,10 +199,10 @@ bool undo_event::undo(int)
 	}
 	sound::commit_music_changes();
 
-	x1 = oldx1;
-	y1 = oldy1;
-	x2 = oldx2;
-	y2 = oldy2;
+	std::swap(x1, resources::gamedata->get_variable("x1"));
+	std::swap(y1, resources::gamedata->get_variable("y1"));
+	std::swap(x2, resources::gamedata->get_variable("x2"));
+	std::swap(y2, resources::gamedata->get_variable("y2"));
 	return true;
 }
 

--- a/src/actions/undo_action.cpp
+++ b/src/actions/undo_action.cpp
@@ -15,19 +15,77 @@
 
 #include "actions/undo_action.hpp"
 #include "game_board.hpp"
+#include "log.hpp"                   // for LOG_STREAM, logger, etc
 #include "scripting/game_lua_kernel.hpp"
 #include "resources.hpp"
 #include "variable.hpp" // vconfig
 #include "game_data.hpp"
 #include "units/unit.hpp"
+#include "utils/ranges.hpp"
 #include "sound.hpp"
 
 #include <cassert>
 #include <iterator>
 #include <algorithm>
 
+static lg::log_domain log_engine("engine");
+#define ERR_NG LOG_STREAM(err, log_engine)
+#define LOG_NG LOG_STREAM(info, log_engine)
+
+
 namespace actions
 {
+
+
+undo_action_container::undo_action_container()
+	: steps_()
+	, unit_id_diff_(0)
+{
+}
+
+bool undo_action_container::undo(int side)
+{
+	int last_unit_id = resources::gameboard->unit_id_manager().get_save_id();
+	for(auto& p_step : utils::reversed_view(steps_)) {
+		p_step->undo(side);
+	}
+	if(last_unit_id - unit_id_diff_ < 0) {
+		ERR_NG << "Next unit id is below 0 after undoing";
+	}
+	resources::gameboard->unit_id_manager().set_save_id(last_unit_id - unit_id_diff_);
+	return true;
+}
+
+void undo_action_container::add(t_step_ptr&& action)
+{
+	steps_.emplace_back(std::move(action));
+}
+
+
+void undo_action_container::read(const config& cfg)
+{
+	for(const config& step : cfg.child_range("step")) {
+		auto& factory = get_factories()[step["type"]];
+		add(factory(step));
+	}
+}
+void undo_action_container::write(config& cfg)
+{
+	for(auto& p_step : steps_) {
+		p_step->write(cfg.add_child("step"));
+	}
+}
+
+undo_action_container::t_factory_map& undo_action_container::get_factories()
+{
+	static t_factory_map res;
+	return res;
+}
+
+
+
+
+
 
 undo_event::undo_event(int fcn_idx, const config& args, const game_events::queued_event& ctx)
 	: lua_idx(fcn_idx)
@@ -84,125 +142,101 @@ undo_event::undo_event(const config& first, const config& second, const config& 
 {
 }
 
-undo_action::undo_action()
-	: undo_action_base()
-	, unit_id_diff(synced_context::get_unit_id_diff())
+undo_event::undo_event(const config& cfg)
+	: undo_event(cfg.child_or_empty("filter"),
+		cfg.child_or_empty("filter_second"),
+		cfg.child_or_empty("data"),
+		cfg.child_or_empty("command"))
 {
-	auto& undo = synced_context::get_undo_commands();
-	auto command_transformer = [](const synced_context::event_info& p) {
-		if(p.lua_.has_value()) {
-			return undo_event(*p.lua_, p.cmds_, p.evt_);
-		} else {
-			return undo_event(p.cmds_, p.evt_);
-		}
-	};
-	std::transform(undo.begin(), undo.end(), std::back_inserter(umc_commands_undo), command_transformer);
-	undo.clear();
 }
 
-undo_action::undo_action(const config& cfg)
-	: undo_action_base()
-	, unit_id_diff(cfg["unit_id_diff"].to_int())
-{
-	read_event_vector(umc_commands_undo, cfg, "undo_actions");
-}
 
-namespace {
-	unit_ptr get_unit(std::size_t uid, const std::string& id) {
-		assert(resources::gameboard);
-		auto iter = resources::gameboard->units().find(uid);
-		if(!iter.valid() || iter->id() != id) {
-			return nullptr;
-		}
-		return iter.get_shared_ptr();
+namespace
+{
+unit_ptr get_unit(std::size_t uid, const std::string& id)
+{
+	assert(resources::gameboard);
+	auto iter = resources::gameboard->units().find(uid);
+	if(!iter.valid() || iter->id() != id) {
+		return nullptr;
 	}
-	void execute_event(const undo_event& e, std::string tag) {
-		assert(resources::lua_kernel);
-		assert(resources::gamedata);
-
-		config::attribute_value& x1 = resources::gamedata->get_variable("x1");
-		config::attribute_value& y1 = resources::gamedata->get_variable("y1");
-		config::attribute_value& x2 = resources::gamedata->get_variable("x2");
-		config::attribute_value& y2 = resources::gamedata->get_variable("y2");
-		int oldx1 = x1.to_int(), oldy1 = y1.to_int(), oldx2 = x2.to_int(), oldy2 = y2.to_int();
-		x1 = e.filter_loc1.wml_x(); y1 = e.filter_loc1.wml_y();
-		x2 = e.filter_loc2.wml_x(); y2 = e.filter_loc2.wml_y();
-
-		std::unique_ptr<scoped_xy_unit> u1, u2;
-		if(unit_ptr who = get_unit(e.uid1, e.id1)) {
-			u1.reset(new scoped_xy_unit("unit", who->get_location(), resources::gameboard->units()));
-		}
-		if(unit_ptr who = get_unit(e.uid2, e.id2)) {
-			u2.reset(new scoped_xy_unit("unit", who->get_location(), resources::gameboard->units()));
-		}
-
-		scoped_weapon_info w1("weapon", e.data.optional_child("first"));
-		scoped_weapon_info w2("second_weapon", e.data.optional_child("second"));
-
-		game_events::queued_event q(tag, "", map_location(x1, y1, wml_loc()), map_location(x2, y2, wml_loc()), e.data);
-		if(e.lua_idx.has_value()) {
-			resources::lua_kernel->run_wml_event(*e.lua_idx, vconfig(e.commands), q);
-		} else {
-			resources::lua_kernel->run_wml_action("command", vconfig(e.commands), q);
-		}
-		sound::commit_music_changes();
-
-		x1 = oldx1; y1 = oldy1;
-		x2 = oldx2; y2 = oldy2;
-	}
+	return iter.get_shared_ptr();
 }
+} // namespace
 
-void undo_action::execute_undo_umc_wml()
+bool undo_event::undo(int)
 {
-	for(const undo_event& e : umc_commands_undo)
-	{
-		execute_event(e, "undo");
+	undo_event& e = *this;
+	std::string tag = "undo";
+	assert(resources::lua_kernel);
+	assert(resources::gamedata);
+
+	config::attribute_value& x1 = resources::gamedata->get_variable("x1");
+	config::attribute_value& y1 = resources::gamedata->get_variable("y1");
+	config::attribute_value& x2 = resources::gamedata->get_variable("x2");
+	config::attribute_value& y2 = resources::gamedata->get_variable("y2");
+	int oldx1 = x1.to_int(), oldy1 = y1.to_int(), oldx2 = x2.to_int(), oldy2 = y2.to_int();
+	x1 = e.filter_loc1.wml_x();
+	y1 = e.filter_loc1.wml_y();
+	x2 = e.filter_loc2.wml_x();
+	y2 = e.filter_loc2.wml_y();
+
+	std::unique_ptr<scoped_xy_unit> u1, u2;
+	if(unit_ptr who = get_unit(e.uid1, e.id1)) {
+		u1.reset(new scoped_xy_unit("unit", who->get_location(), resources::gameboard->units()));
 	}
-}
-
-
-void undo_action::write(config & cfg) const
-{
-	cfg["unit_id_diff"] = unit_id_diff;
-	write_event_vector(umc_commands_undo, cfg, "undo_actions");
-	undo_action_base::write(cfg);
-}
-
-void undo_action::read_event_vector(event_vector& vec, const config& cfg, const std::string& tag)
-{
-	for(auto c : cfg.child_range(tag)) {
-		vec.emplace_back(c.child_or_empty("filter"), c.child_or_empty("filter_second"), c.child_or_empty("data"), c.child_or_empty("command"));
+	if(unit_ptr who = get_unit(e.uid2, e.id2)) {
+		u2.reset(new scoped_xy_unit("unit", who->get_location(), resources::gameboard->units()));
 	}
-}
 
-void undo_action::write_event_vector(const event_vector& vec, config& cfg, const std::string& tag)
-{
-	for(const auto& evt : vec)
-	{
-		if(evt.lua_idx.has_value()) {
-			// TODO: Log warning that this cannot be serialized
-			continue;
-		}
-		config& entry = cfg.add_child(tag);
-		config& first = entry.add_child("filter");
-		config& second = entry.add_child("filter_second");
-		entry.add_child("data", evt.data);
-		entry.add_child("command", evt.commands);
-		// First location
-		first["filter_x"] = evt.filter_loc1.wml_x();
-		first["filter_y"] = evt.filter_loc1.wml_y();
-		first["underlying_id"] = evt.uid1;
-		first["id"] = evt.id1;
-		first["x"] = evt.loc1.wml_x();
-		first["y"] = evt.loc1.wml_y();
-		// Second location
-		second["filter_x"] = evt.filter_loc2.wml_x();
-		second["filter_y"] = evt.filter_loc2.wml_y();
-		second["underlying_id"] = evt.uid2;
-		second["id"] = evt.id2;
-		second["x"] = evt.loc2.wml_x();
-		second["y"] = evt.loc2.wml_y();
+	scoped_weapon_info w1("weapon", e.data.optional_child("first"));
+	scoped_weapon_info w2("second_weapon", e.data.optional_child("second"));
+
+	game_events::queued_event q(tag, "", map_location(x1, y1, wml_loc()), map_location(x2, y2, wml_loc()), e.data);
+	if(e.lua_idx.has_value()) {
+		resources::lua_kernel->run_wml_event(*e.lua_idx, vconfig(e.commands), q);
+	} else {
+		resources::lua_kernel->run_wml_action("command", vconfig(e.commands), q);
 	}
+	sound::commit_music_changes();
+
+	x1 = oldx1;
+	y1 = oldy1;
+	x2 = oldx2;
+	y2 = oldy2;
+	return true;
 }
 
+void undo_event::write(config& cfg) const
+{
+	undo_action::write(cfg);
+	auto& evt = *this;
+	if(evt.lua_idx.has_value()) {
+		// TODO: Log warning that this cannot be serialized
+		return;
+	}
+	config& entry = cfg;
+	config& first = entry.add_child("filter");
+	config& second = entry.add_child("filter_second");
+	entry.add_child("data", evt.data);
+	entry.add_child("command", evt.commands);
+	// First location
+	first["filter_x"] = evt.filter_loc1.wml_x();
+	first["filter_y"] = evt.filter_loc1.wml_y();
+	first["underlying_id"] = evt.uid1;
+	first["id"] = evt.id1;
+	first["x"] = evt.loc1.wml_x();
+	first["y"] = evt.loc1.wml_y();
+	// Second location
+	second["filter_x"] = evt.filter_loc2.wml_x();
+	second["filter_y"] = evt.filter_loc2.wml_y();
+	second["underlying_id"] = evt.uid2;
+	second["id"] = evt.id2;
+	second["x"] = evt.loc2.wml_x();
+	second["y"] = evt.loc2.wml_y();
 }
+
+
+static auto red_undo_event = undo_action_container::subaction_factory<undo_event>();
+
+} // namespace actions

--- a/src/actions/undo_action.hpp
+++ b/src/actions/undo_action.hpp
@@ -22,99 +22,102 @@
 
 namespace actions {
 
-	struct undo_event {
-		utils::optional<int> lua_idx;
-		config commands, data;
-		map_location loc1, loc2, filter_loc1, filter_loc2;
-		std::size_t uid1, uid2;
-		std::string id1, id2;
-		undo_event(int fcn_idx, const config& args, const game_events::queued_event& ctx);
-		undo_event(const config& cmds, const game_events::queued_event& ctx);
-		undo_event(const config& first, const config& second, const config& weapons, const config& cmds);
+	struct undo_action;
+
+	/*
+	 * Contains all steps that are needed to undo a user action.
+	 */
+	class undo_action_container
+	{
+		using t_step_ptr = std::unique_ptr<undo_action>;
+		using t_steps = std::vector<t_step_ptr>;
+
+		t_steps steps_;
+		int unit_id_diff_;
+
+	public:
+
+		undo_action_container();
+
+		bool empty() const { return steps_.empty(); }
+		t_steps& steps() { return steps_; }
+		bool undo(int side);
+		void write(config& cfg);
+		/**
+		 * Creates the list of undo steps based on a config.
+		 * Throws bad_lexical_cast or config::error if it cannot parse the config properly.
+		 */
+		void read(const config& cfg);
+		void add(t_step_ptr&& action);
+		void set_unit_id_diff(int id_diff)
+		{
+			unit_id_diff_ = id_diff;
+		}
+
+		using t_factory = std::function<t_step_ptr(const config&)>;
+		using t_factory_map = std::map<std::string, t_factory>;
+		static t_factory_map& get_factories();
+
+		template<typename T>
+		struct subaction_factory
+		{
+			subaction_factory()
+			{
+				std::string name = T::get_type_impl();
+				get_factories()[name] = [](const config& cfg) {
+					auto res = std::make_unique<T>(cfg);
+					return res;
+				};
+			}
+		};
 	};
 
 	/**
 	 * Records information to be able to undo an action.
-	 * Each type of action gets its own derived type.
-	 * Base class for all entries in the undo stack, also contains non undoable actions like update_shroud or auto_shroud.
+	 * Each type of step gets its own derived type.
 	 */
-	struct undo_action_base
+	struct undo_action
 	{
-		undo_action_base(const undo_action_base&) = delete;
-		undo_action_base& operator=(const undo_action_base&) = delete;
-
-		/**
-		 * Default constructor.
-		 * This is the only way to get nullptr view_info.
-		 */
-		undo_action_base()
-		{ }
-		// Virtual destructor to support derived classes.
-		virtual ~undo_action_base() {}
-
-		/** Writes this into the provided config. */
-		virtual void write(config & cfg) const
-		{
-			cfg["type"] = this->get_type();
-		}
-
-		virtual const char* get_type() const = 0;
-	};
-
-	/** actions that are undoable (this does not include update_shroud and auto_shroud) */
-	struct undo_action : undo_action_base
-	{
-		/**
-		 * Default constructor.
-		 * It is assumed that undo actions are constructed after the action is performed
-		 * so that the unit id diff does not change after this constructor
-		 */
-		undo_action();
-		undo_action(const config& cfg);
+		undo_action() {}
 		// Virtual destructor to support derived classes.
 		virtual ~undo_action() {}
-
-		/** Writes this into the provided config. */
-		virtual void write(config & cfg) const;
 
 		/**
 		 * Undoes this action.
 		 * @return true on success; false on an error.
 		 */
 		virtual bool undo(int side) = 0;
-		/**
-		 * the difference in the unit ids
-		 * TODO: does it really make sense to allow undoing if the unit id counter has changed?
-		 */
-		int unit_id_diff;
-		/** actions wml (specified by wml) that should be executed when undoing this command. */
-		typedef std::vector<undo_event> event_vector;
-		event_vector umc_commands_undo;
-		void execute_undo_umc_wml();
-
-		static void read_event_vector(event_vector& vec, const config& cfg, const std::string& tag);
-		static void write_event_vector(const event_vector& vec, config& cfg, const std::string& tag);
+		/** Writes this into the provided config. */
+		virtual void write(config& cfg) const
+		{
+			cfg["type"] = this->get_type();
+		}
+		virtual const char* get_type() const = 0;
 	};
 
-	/** entry for player actions that do not need any special code to be performed when undoing such as right-click menu items. */
-	struct undo_dummy_action : undo_action
+	class  undo_event : public undo_action
 	{
-		undo_dummy_action ()
-			: undo_action()
-		{
-		}
-		explicit undo_dummy_action (const config & cfg)
-			: undo_action(cfg)
-		{
-		}
-		virtual const char* get_type() const { return "dummy"; }
-		virtual ~undo_dummy_action () {}
-		/** Undoes this action. */
-		virtual bool undo(int)
-		{
-			execute_undo_umc_wml();
-			return true;
-		}
-	};
+	public:
 
+		undo_event(int fcn_idx, const config& args, const game_events::queued_event& ctx);
+		undo_event(const config& cmds, const game_events::queued_event& ctx);
+
+		undo_event(const config& cfg);
+
+		virtual bool undo(int side);
+		virtual void write(config& cfg) const;
+
+
+		static const char* get_type_impl() { return "event"; }
+		virtual const char* get_type() const { return get_type_impl(); }
+
+	private:
+		undo_event(const config& first, const config& second, const config& weapons, const config& cmds);
+
+		utils::optional<int> lua_idx;
+		config commands, data;
+		map_location loc1, loc2, filter_loc1, filter_loc2;
+		std::size_t uid1, uid2;
+		std::string id1, id2;
+	};
 }

--- a/src/actions/undo_dismiss_action.cpp
+++ b/src/actions/undo_dismiss_action.cpp
@@ -26,9 +26,9 @@ dismiss_action::dismiss_action(const unit_const_ptr dismissed)
 {
 }
 
-dismiss_action::dismiss_action(const config& cfg, const config& unit_cfg)
-	: undo_action(cfg)
-	, dismissed_unit(unit::create(unit_cfg))
+dismiss_action::dismiss_action(const config& cfg)
+	: undo_action()
+	, dismissed_unit(unit::create(cfg.mandatory_child("unit")))
 {
 }
 
@@ -50,8 +50,9 @@ bool dismiss_action::undo(int side)
 	team &current_team = resources::gameboard->get_team(side);
 
 	current_team.recall_list().add(dismissed_unit);
-	execute_undo_umc_wml();
 	return true;
 }
+
+static auto red_undo_dismiss = undo_action_container::subaction_factory<dismiss_action>();
 
 }

--- a/src/actions/undo_dismiss_action.hpp
+++ b/src/actions/undo_dismiss_action.hpp
@@ -23,9 +23,11 @@ struct dismiss_action : undo_action
 	unit_ptr dismissed_unit;
 
 	explicit dismiss_action(const unit_const_ptr dismissed);
-	explicit dismiss_action(const config& cfg, const config& unit_cfg);
+	explicit dismiss_action(const config& cfg);
 
-	virtual const char* get_type() const { return "dismiss"; }
+	static const char* get_type_impl() { return "dismiss"; }
+	virtual const char* get_type() const { return get_type_impl(); }
+
 	virtual ~dismiss_action() {}
 
 	/** Writes this into the provided config. */

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -123,8 +123,8 @@ bool move_action::undo(int)
 	u->anim_comp().set_standing();
 
 	gui.invalidate_unit_after_move(rev_route.front(), rev_route.back());
-	execute_undo_umc_wml();
 	return true;
 }
+static auto reg_undo_move = undo_action_container::subaction_factory<move_action>();
 
 }

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -32,9 +32,9 @@ namespace actions::undo
 move_action::move_action(const unit_const_ptr moved,
 			const std::vector<map_location>::const_iterator & begin,
 			const std::vector<map_location>::const_iterator & end,
-			int sm, int timebonus, int orig, const map_location::direction dir)
+			int sm, const map_location::direction dir)
 	: undo_action()
-	, shroud_clearing_action(moved, begin, end, orig, timebonus != 0)
+	, shroud_clearing_action(moved, begin, end)
 	, starting_moves(sm)
 	, starting_dir(dir == map_location::direction::indeterminate ? moved->facing() : dir)
 	, goto_hex(moved->get_goto())
@@ -91,12 +91,11 @@ bool move_action::undo(int)
 	// Check units.
 	unit_map::iterator u = units.find(rev_route.front());
 	const unit_map::iterator u_end = units.find(rev_route.back());
-	if ( u == units.end()  ||  u_end != units.end() ) {
-		//this can actually happen if the scenario designer has abused the [allow_undo] command
+	if(u == units.end() || u_end != units.end()) {
+		// this can actually happen if the scenario designer has abused the [allow_undo] command
 		ERR_NG << "Illegal 'undo' found. Possible abuse of [allow_undo]?";
 		return false;
 	}
-	this->return_village();
 
 	// Record the unit's current state so it can be redone.
 	starting_moves = u->movement_left();

--- a/src/actions/undo_move_action.hpp
+++ b/src/actions/undo_move_action.hpp
@@ -31,17 +31,20 @@ struct move_action : undo_action, shroud_clearing_action
 	            const std::vector<map_location>::const_iterator & begin,
 	            const std::vector<map_location>::const_iterator & end,
 	            int sm, int timebonus, int orig, const map_location::direction dir);
-	move_action(const config & cfg, const config & unit_cfg,
-	            int sm, const map_location::direction dir)
-		: undo_action(cfg)
+	move_action(const config & cfg)
+		: undo_action()
 		, shroud_clearing_action(cfg)
-		, starting_moves(sm)
-		, starting_dir(dir)
-		, goto_hex(unit_cfg["goto_x"].to_int(-999),
-		         unit_cfg["goto_y"].to_int(-999), wml_loc())
+		, starting_moves(cfg["starting_moves"].to_int())
+		, starting_dir(map_location::parse_direction(cfg["starting_direction"]))
+		, goto_hex(cfg.child_or_empty("unit")["goto_x"].to_int(-999),
+			  cfg.child_or_empty("unit")["goto_y"].to_int(-999),
+			  wml_loc())
 	{
 	}
-	virtual const char* get_type() const { return "move"; }
+
+	static const char* get_type_impl() { return "move"; }
+	virtual const char* get_type() const { return get_type_impl(); }
+
 	virtual ~move_action() {}
 
 	/** Writes this into the provided config. */

--- a/src/actions/undo_move_action.hpp
+++ b/src/actions/undo_move_action.hpp
@@ -30,7 +30,7 @@ struct move_action : undo_action, shroud_clearing_action
 	move_action(const unit_const_ptr moved,
 	            const std::vector<map_location>::const_iterator & begin,
 	            const std::vector<map_location>::const_iterator & end,
-	            int sm, int timebonus, int orig, const map_location::direction dir);
+	            int sm, const map_location::direction dir);
 	move_action(const config & cfg)
 		: undo_action()
 		, shroud_clearing_action(cfg)

--- a/src/actions/undo_recall_action.cpp
+++ b/src/actions/undo_recall_action.cpp
@@ -33,9 +33,9 @@ static lg::log_domain log_engine("engine");
 namespace actions::undo
 {
 recall_action::recall_action(const unit_const_ptr recalled, const map_location& loc,
-			  const map_location& from, int orig_village_owner, bool time_bonus)
+			  const map_location& from)
 	: undo_action()
-	, shroud_clearing_action(recalled, loc, orig_village_owner, time_bonus)
+	, shroud_clearing_action(recalled, loc)
 	, id(recalled->id())
 	, recall_from(from)
 {}
@@ -97,7 +97,6 @@ bool recall_action::undo(int side)
 	units.erase(recall_loc);
 	resources::whiteboard->on_kill_unit();
 	un->anim_comp().clear_haloes();
-	this->return_village();
 	return true;
 }
 static auto reg_undo_recall = undo_action_container::subaction_factory<recall_action>();

--- a/src/actions/undo_recall_action.cpp
+++ b/src/actions/undo_recall_action.cpp
@@ -40,11 +40,11 @@ recall_action::recall_action(const unit_const_ptr recalled, const map_location& 
 	, recall_from(from)
 {}
 
-recall_action::recall_action(const config & cfg, const map_location & from)
-	: undo_action(cfg)
+recall_action::recall_action(const config & cfg)
+	: undo_action()
 	, shroud_clearing_action(cfg)
 	, id(cfg["id"])
-	, recall_from(from)
+	, recall_from(map_location(cfg.child_or_empty("leader"), nullptr))
 {}
 
 /**
@@ -98,8 +98,8 @@ bool recall_action::undo(int side)
 	resources::whiteboard->on_kill_unit();
 	un->anim_comp().clear_haloes();
 	this->return_village();
-	execute_undo_umc_wml();
 	return true;
 }
+static auto reg_undo_recall = undo_action_container::subaction_factory<recall_action>();
 
 }

--- a/src/actions/undo_recall_action.hpp
+++ b/src/actions/undo_recall_action.hpp
@@ -28,8 +28,11 @@ struct recall_action : undo_action, shroud_clearing_action
 
 	recall_action(const unit_const_ptr recalled, const map_location& loc,
 				  const map_location& from, int orig_village_owner, bool time_bonus);
-	recall_action(const config & cfg, const map_location & from);
-	virtual const char* get_type() const { return "recall"; }
+	recall_action(const config & cfg);
+
+	static const char* get_type_impl() { return "recall"; }
+	virtual const char* get_type() const { return get_type_impl(); }
+
 	virtual ~recall_action() {}
 
 	/** Writes this into the provided config. */

--- a/src/actions/undo_recall_action.hpp
+++ b/src/actions/undo_recall_action.hpp
@@ -27,7 +27,7 @@ struct recall_action : undo_action, shroud_clearing_action
 
 
 	recall_action(const unit_const_ptr recalled, const map_location& loc,
-				  const map_location& from, int orig_village_owner, bool time_bonus);
+				  const map_location& from);
 	recall_action(const config & cfg);
 
 	static const char* get_type_impl() { return "recall"; }

--- a/src/actions/undo_recruit_action.cpp
+++ b/src/actions/undo_recruit_action.cpp
@@ -39,12 +39,24 @@ recruit_action::recruit_action(const unit_const_ptr recruited, const map_locatio
 	, recruit_from(from)
 {}
 
-recruit_action::recruit_action(const config & cfg, const unit_type & type, const map_location& from)
-	: undo_action(cfg)
+static const unit_type& get_unit_type(const config& cfg)
+{
+	const config& child = cfg.mandatory_child("unit");
+	const unit_type* u_type = unit_types.find(child["type"]);
+
+	if(!u_type) {
+		// Bad data.
+		throw config::error("Invalid recruit; unit type '" + child["type"].str() + "' was not found.\n");
+	}
+	return *u_type;
+}
+recruit_action::recruit_action(const config & cfg)
+	: undo_action()
 	, shroud_clearing_action(cfg)
-	, u_type(type)
-	, recruit_from(from)
-{}
+	, u_type(get_unit_type(cfg))
+	, recruit_from(map_location(cfg.child_or_empty("leader"), nullptr))
+{
+}
 
 /**
  * Writes this into the provided config.
@@ -87,8 +99,8 @@ bool recruit_action::undo(int side)
 	gui.invalidate(recruit_loc);
 	units.erase(recruit_loc);
 	this->return_village();
-	execute_undo_umc_wml();
 	return true;
 }
+static auto reg_undo_recruit = undo_action_container::subaction_factory<recruit_action>();
 
 }

--- a/src/actions/undo_recruit_action.cpp
+++ b/src/actions/undo_recruit_action.cpp
@@ -32,9 +32,9 @@ static lg::log_domain log_engine("engine");
 namespace actions::undo
 {
 recruit_action::recruit_action(const unit_const_ptr recruited, const map_location& loc,
-			   const map_location& from, int orig_village_owner, bool time_bonus)
+			   const map_location& from)
 	: undo_action()
-	, shroud_clearing_action(recruited, loc, orig_village_owner, time_bonus)
+	, shroud_clearing_action(recruited, loc)
 	, u_type(recruited->type())
 	, recruit_from(from)
 {}
@@ -98,7 +98,6 @@ bool recruit_action::undo(int side)
 	// to also do the overlapped hexes
 	gui.invalidate(recruit_loc);
 	units.erase(recruit_loc);
-	this->return_village();
 	return true;
 }
 static auto reg_undo_recruit = undo_action_container::subaction_factory<recruit_action>();

--- a/src/actions/undo_recruit_action.hpp
+++ b/src/actions/undo_recruit_action.hpp
@@ -31,7 +31,7 @@ struct recruit_action : undo_action, shroud_clearing_action
 
 
 	recruit_action(const unit_const_ptr recruited, const map_location& loc,
-	               const map_location& from, int orig_village_owner, bool time_bonus);
+	               const map_location& from);
 	recruit_action(const config & cfg);
 
 	static const char* get_type_impl() { return "recruit"; }

--- a/src/actions/undo_recruit_action.hpp
+++ b/src/actions/undo_recruit_action.hpp
@@ -32,8 +32,11 @@ struct recruit_action : undo_action, shroud_clearing_action
 
 	recruit_action(const unit_const_ptr recruited, const map_location& loc,
 	               const map_location& from, int orig_village_owner, bool time_bonus);
-	recruit_action(const config & cfg, const unit_type & type, const map_location& from);
-	virtual const char* get_type() const { return "recruit"; }
+	recruit_action(const config & cfg);
+
+	static const char* get_type_impl() { return "recruit"; }
+	virtual const char* get_type() const { return get_type_impl(); }
+
 	virtual ~recruit_action() {}
 
 	/** Writes this into the provided config. */

--- a/src/actions/undo_update_shroud_action.cpp
+++ b/src/actions/undo_update_shroud_action.cpp
@@ -14,6 +14,11 @@
 
 #include "actions/undo_update_shroud_action.hpp"
 
+#include "play_controller.hpp"
+#include "resources.hpp"      // for screen, teams, units, etc
+#include "synced_context.hpp" // for set_scontext_synced
+#include "team.hpp"           // for team
+
 namespace actions::undo
 {
 /**
@@ -21,16 +26,16 @@ namespace actions::undo
  */
 void auto_shroud_action::write(config & cfg) const
 {
-	undo_action_base::write(cfg);
+	undo_action::write(cfg);
 	cfg["active"] = active;
 }
 
-/**
- * Writes this into the provided config.
- */
-void update_shroud_action::write(config & cfg) const
+bool auto_shroud_action::undo(int)
 {
-	undo_action_base::write(cfg);
+	resources::controller->current_team().set_auto_shroud_updates(!active);
+	return true;
 }
+
+static auto reg_auto_shroud = undo_action_container::subaction_factory<auto_shroud_action>();
 
 }

--- a/src/actions/undo_update_shroud_action.hpp
+++ b/src/actions/undo_update_shroud_action.hpp
@@ -18,28 +18,28 @@
 
 namespace actions::undo
 {
-struct auto_shroud_action : undo_action_base {
+struct auto_shroud_action : undo_action {
 	bool active;
 
 	explicit auto_shroud_action(bool turned_on)
-		: undo_action_base()
+		: undo_action()
 		, active(turned_on)
-	{}
-	virtual const char* get_type() const { return "auto_shroud"; }
-	virtual ~auto_shroud_action() {}
+	{
+	}
+	explicit auto_shroud_action(const config& cfg)
+		: undo_action()
+		, active(cfg["active"].to_bool())
+	{
+	}
 
-	/** Writes this into the provided config. */
-	virtual void write(config & cfg) const;
-};
+	static const char* get_type_impl() { return "auto_shroud"; }
+	virtual const char* get_type() const { return get_type_impl(); }
 
-struct update_shroud_action : undo_action_base {
-	// No additional data.
+	virtual bool undo(int);
 
-	update_shroud_action()
-		: undo_action_base()
-	{}
-	virtual const char* get_type() const { return "update_shroud"; }
-	virtual ~update_shroud_action() {}
+	virtual ~auto_shroud_action()
+	{
+	}
 
 	/** Writes this into the provided config. */
 	virtual void write(config & cfg) const;

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -128,6 +128,15 @@ public:
 	config_attribute_value& operator=(const std::string_view &v);
 	config_attribute_value& operator=(const t_string &v);
 
+	//TODO: should this be a normal constructor?
+	template<typename T>
+	static config_attribute_value create(const T val)
+	{
+		config_attribute_value res;
+		res = val;
+		return res;
+	}
+
 	template<typename... Args>
 	config_attribute_value& operator=(const std::chrono::duration<Args...>& v)
 	{

--- a/src/game_state.cpp
+++ b/src/game_state.cpp
@@ -189,7 +189,7 @@ void game_state::init(const config& level, play_controller & pc)
 
 		tod_manager_.resolve_random(*randomness::generator);
 
-		undo_stack_->read(level.child_or_empty("undo_stack"));
+		undo_stack_->read(level.child_or_empty("undo_stack"), player_number_);
 
 		for(team_builder& tb : team_builders) {
 			tb.build_team_stage_two();

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -30,6 +30,8 @@
 #include "actions/advancement.hpp"           // for advance_unit_at, etc
 #include "actions/move.hpp"		// for clear_shroud
 #include "actions/vision.hpp"		// for clear_shroud and create_jamming_map
+#include "actions/undo.hpp"		// for clear_shroud and create_jamming_map
+#include "actions/undo_action.hpp"		// for clear_shroud and create_jamming_map
 #include "ai/composite/ai.hpp"          // for ai_composite
 #include "ai/composite/component.hpp"   // for component, etc
 #include "ai/composite/contexts.hpp"    // for ai_context
@@ -4212,10 +4214,10 @@ int game_lua_kernel::intf_add_undo_actions(lua_State *L)
 {
 	config cfg;
 	if(luaW_toconfig(L, 1, cfg)) {
-		synced_context::add_undo_commands(cfg, get_event_info());
+		game_state_.undo_stack_->add_custom<actions::undo_event>(cfg, get_event_info());
 	} else {
 		luaW_toconfig(L, 2, cfg);
-		synced_context::add_undo_commands(save_wml_event(1), cfg, get_event_info());
+		game_state_.undo_stack_->add_custom<actions::undo_event>(save_wml_event(1), cfg, get_event_info());
 	}
 	return 0;
 }
@@ -4318,7 +4320,7 @@ int game_lua_kernel::cfun_undoable_event(lua_State* L)
 	lua_pushvalue(L, lua_upvalueindex(1));
 	lua_push(L, 1);
 	luaW_pcall(L, 1, 0);
-	synced_context::add_undo_commands(lua_upvalueindex(2), get_event_info());
+	game_state_.undo_stack_->add_custom<actions::undo_event>(lua_upvalueindex(2), config(), get_event_info());
 	return 0;
 }
 

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -321,12 +321,6 @@ SYNCED_COMMAND_HANDLER_FUNCTION(fire_event, child, /*spectator*/)
 		synced_context::block_undo(std::get<0>(resources::game_events->pump().fire(event_name)));
 	}
 
-	// Not clearing the undo stack here causes OOS because we added an entry to the replay but no entry to the undo stack.
-	if(synced_context::undo_blocked()) {
-		synced_context::block_undo();
-	} else {
-		resources::undo_stack->add_dummy();
-	}
 	return true;
 }
 
@@ -335,11 +329,6 @@ SYNCED_COMMAND_HANDLER_FUNCTION(custom_command, child, /*spectator*/)
 	assert(resources::lua_kernel);
 	resources::lua_kernel->custom_command(child["name"], child.child_or_empty("data"));
 
-	if(synced_context::undo_blocked()) {
-		synced_context::block_undo();
-	} else {
-		resources::undo_stack->add_dummy();
-	}
 	return true;
 }
 
@@ -369,7 +358,6 @@ SYNCED_COMMAND_HANDLER_FUNCTION(update_shroud, /*child*/, spectator)
 		spectator.error("Team has DSU disabled but we found an explicit shroud update");
 	}
 	bool res = resources::undo_stack->commit_vision();
-	resources::undo_stack->add_update_shroud();
 	if(res) {
 		synced_context::block_undo();
 	}

--- a/src/synced_context.hpp
+++ b/src/synced_context.hpp
@@ -20,6 +20,7 @@
 #include "random.hpp"
 #include "synced_checkup.hpp"
 #include "synced_commands.hpp"
+#include "actions/undo_action.hpp"
 
 #include <deque>
 
@@ -152,30 +153,6 @@ public:
 	/** If we are in a mp game, ask the server, otherwise generate the answer ourselves. */
 	static config ask_server_choice(const server_choice&);
 
-	struct event_info {
-		config cmds_;
-		utils::optional<int> lua_;
-		game_events::queued_event evt_;
-		event_info(const config& cmds, game_events::queued_event evt) : cmds_(cmds), evt_(evt) {}
-		event_info(int lua, game_events::queued_event evt) : lua_(lua), evt_(evt) {}
-		event_info(int lua, const config& args, game_events::queued_event evt) : cmds_(args), lua_(lua), evt_(evt) {}
-	};
-
-	typedef std::deque<event_info> event_list;
-	static event_list& get_undo_commands()
-	{
-		return undo_commands_;
-	}
-
-	static void add_undo_commands(const config& commands, const game_events::queued_event& ctx);
-	static void add_undo_commands(int fcn_idx, const game_events::queued_event& ctx);
-	static void add_undo_commands(int fcn_idx, const config& args, const game_events::queued_event& ctx);
-
-	static void reset_undo_commands()
-	{
-		undo_commands_.clear();
-	}
-
 	static bool ignore_undo();
 private:
 	/** Weather we are in a synced move, in a user_choice, or none of them. */
@@ -192,9 +169,6 @@ private:
 
 	/** Used to restore the unit id manager when undoing. */
 	static inline int last_unit_id_ = 0;
-
-	/** Actions to be executed when the current action is undone. */
-	static inline event_list undo_commands_ {};
 };
 
 class set_scontext_synced_base

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -440,9 +440,9 @@ game_events::pump_result_t team::get_village(const map_location& loc, const int 
 	game_events::pump_result_t res;
 
 	if(gamedata) {
-		config::attribute_value& var = gamedata->get_variable("owner_side");
-		const config::attribute_value old_value = var;
-		var = owner_side;
+		config::attribute_value var_owner_side;
+		var_owner_side = owner_side;
+		std::swap(var_owner_side, gamedata->get_variable("owner_side"));
 
 		// During team building, game_events pump is not guaranteed to exist yet. (At current revision.) We skip capture
 		// events in this case.
@@ -450,10 +450,10 @@ game_events::pump_result_t team::get_village(const map_location& loc, const int 
 			res = resources::game_events->pump().fire("capture", loc);
 		}
 
-		if(old_value.blank()) {
+		if(var_owner_side.blank()) {
 			gamedata->clear_variable("owner_side");
 		} else {
-			var = old_value;
+			std::swap(var_owner_side, gamedata->get_variable("owner_side"));
 		}
 	}
 

--- a/src/utils/general.hpp
+++ b/src/utils/general.hpp
@@ -126,4 +126,15 @@ void sort_if(Container& container, const Predicate& predicate)
 	std::sort(container.begin(), container.end(), predicate);
 }
 
+/**
+ * Convenience wrapper for using find on a container without needing to comare to end()
+ *
+ */
+template<typename Container, typename Value>
+auto* find(Container& container, const Value& value)
+{
+	auto res = container.find(value);
+	return (res == container.end()) ? nullptr : &*res;
+}
+
 } // namespace utils


### PR DESCRIPTION
This commit splits undo actions into multiple smaller steps. The main advantages:
- Its allows us always undo the parts of an action in the reverse order of which
  they originally happen, preventing bugs that could be caused if the parts
  interact with each other in a way where the order matters (like for example
  an [on_undo] resetting a units moves, when the event happend in a move action
  which would then also reset the units moves on undoing).
- It's easier to add (c++) undo steps for specific steps even if they are used
  from wml, like spending gold.
- [do_command] no longer confuses the undo stack (in fact it's by default now undoable).
- All actions are put onto the undo stack in the same way, previously it was
  often unclear whether the undo stack is empty during a specific step  during
  the execution of an action, in particular when people tried to use
  `undo_stack->empty()` to check whether an action could still be undone.
