### PR TITLE
EI: add missing last breath (HERODEATH) events for Addogin

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04a_An_Elven_Interlude.cfg
@@ -485,6 +485,7 @@
                 [/set_achievement]
             [/then]
         [/if]
+        {HERODEATH_ADDOGIN}
     [/event]
 
     [event]

--- a/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/11_Captured.cfg
@@ -1862,5 +1862,6 @@ Your punishment is death."
     {HERODEATH_TERRAENT}
     {HERODEATH_DOLBURRAS}
     {HERODEATH_GRUG}
+    {HERODEATH_ADDOGIN}
     {HERODEATH_HAHID}
 [/scenario]


### PR DESCRIPTION
In S04a, the event is added within his original "last breath" event - the one which switches him to the player's side. Without this additional event, he will die silently if killed by the elves after being "captured".

In S11, it looks like the event for him was simply forgotten (HERODEATH events are added for all other heroes).

His HERODEATH event is also missing in S13, but I think that scenario needs a bit more of (related) changes, so I'll post those later in a separate pull request.