### PR TITLE
Enable warnings as errors for scons

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -97,7 +97,7 @@ jobs:
               build cdb
               # disable all warnings since we have coverage on them in a standard build, and clang-tidy
               # triggers false positive compiler warnings that clang itself won't
-              run-clang-tidy -use-color -j 2 -extra-arg="-w" '^(?!.*src/modules/|.*build/)'
+              run-clang-tidy -use-color -j 2 -extra-arg="-w" '^(?!.*src/modules/|.*build/)' -warnings-as-errors='*'
 
               apt remove -y -qq libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
 


### PR DESCRIPTION
I didn't realize I could do this until now. This PR actually makes CI fail when there's a linter issue.