### PR TITLE
Fix last breath events for Hahid and Grug

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -942,7 +942,6 @@
     {HERODEATH_TERRAENT}
     #     {HERODEATH_GRUG} # don't have Gweddry say "he was not one of us, yet [...]"
     {HERODEATH_DOLBURRAS}
-    {HERODEATH_HAHID}
 [/scenario]
 
 #undef SCENARIO_TURN_LIMIT

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -918,19 +918,6 @@
         [/message]
     [/event]
 
-    [event]
-        name=last breath
-
-        [filter]
-            id=Grug
-        [/filter]
-
-        [message]
-            speaker=Grug
-            message= _ "Hurt... grarrgghh..." # wmllint: no spellcheck
-        [/message]
-    [/event]
-
     {ENEMYDEATHS_SORADOC}
     {FOREIGN_DEFEAT}
 
@@ -940,7 +927,7 @@
     {HERODEATH_ADDOGIN}
     {HERODEATH_HAHID}
     {HERODEATH_TERRAENT}
-    #     {HERODEATH_GRUG} # don't have Gweddry say "he was not one of us, yet [...]"
+    {HERODEATH_GRUG}
     {HERODEATH_DOLBURRAS}
 [/scenario]
 

--- a/data/campaigns/Eastern_Invasion/utils/deaths.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/deaths.cfg
@@ -171,11 +171,13 @@
             message= _ "Alas, my long, storied, and exceedingly profitable career has at last come to an end, so far from home! I only... wish I could have died on the soft sands... instead of among these primitive barbarians..."
         [/message]
         [message]
-            speaker=Grug
+            id=Grug
+            side=$unit.side
             message= _ "Bar... ber... bears? Die why?"
         [/message]
         [message]
-            speaker=Dolburras
+            id=Dolburras
+            side=$unit.side
             message= _ "Aye, ‘tis a sad place for one o’ us foreigners to fall. We’ll miss ye, that’s for sure."
         [/message]
     [/event]

--- a/data/campaigns/Eastern_Invasion/utils/deaths.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/deaths.cfg
@@ -139,7 +139,8 @@
             message= _ "Hurt... grarrgghh..." # wmllint: no spellcheck
         [/message]
         [message]
-            speaker=Gweddry
+            id=Gweddry
+            side=$unit.side
             message= _ "Though he was not one of us, he served bravely alongside Wesnoth’s best. We must carry on the good fight."
         [/message]
     [/event]


### PR DESCRIPTION
When Hahid dies, Grug or Dolburras, if present, say the "eulogy". There were problems in scenarios where they first appear (S06a for Dolburras and S07b for Grug) - they say it even before joining the player's side, which makes no sense. I changed the message tags in utils/deaths.cfg to use "id" and "side" instead of "speaker", so they only say it when they are on the same side as Hahid.
Also in S07b, Hahid's herodeath macro was duplicated, so the dialogue was displayed twice.
Also I changed Grug's herodeath to "id" and "side" and re-included it into S07b, so now Gweddry says the eulogy for Grug after Grug joins, but not before.