### PR TITLE
fix clang-tidy warnings

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -97,7 +97,7 @@ jobs:
               build cdb
               # disable all warnings since we have coverage on them in a standard build, and clang-tidy
               # triggers false positive compiler warnings that clang itself won't
-              run-clang-tidy -use-color -j 2 -extra-arg="-w" '^(?!.*src/modules/|.*build/)' -warnings-as-errors='*'
+              run-clang-tidy -quiet -use-color -j 2 -extra-arg="-w" -warnings-as-errors='*' '^(?!.*src/modules/|.*build/)'
 
               apt remove -y -qq libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
 

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -672,7 +672,7 @@ battle_context battle_context::choose_defender_weapon(nonempty_unit_const_ptr at
 
 namespace
 {
-void refresh_weapon_index(int& weap_index, const std::string& weap_id, attack_itors attacks)
+void refresh_weapon_index(int& weap_index, const std::string& weap_id, const attack_itors& attacks)
 {
 	// No attacks to choose from.
 	if(attacks.empty()) {

--- a/src/ai/configuration.cpp
+++ b/src/ai/configuration.cpp
@@ -42,13 +42,13 @@ static lg::log_domain log_ai_configuration("ai/config");
 static lg::log_domain log_wml("wml");
 #define ERR_WML LOG_STREAM(err, log_wml)
 
-void configuration::init(const game_config_view &game_config)
+void configuration::init(const game_config_view& game_config)
 {
 	ai_configurations_.clear();
 	era_ai_configurations_.clear();
 	mod_ai_configurations_.clear();
 
-	const config &ais = game_config.mandatory_child("ais");
+	const config& ais = game_config.mandatory_child("ais");
 	if (auto default_config = ais.optional_child("default_config")) {
 		default_config_ = *default_config;
 	} else {
@@ -61,8 +61,8 @@ void configuration::init(const game_config_view &game_config)
 	}
 
 
-	for (const config &ai_configuration : ais.child_range("ai")) {
-		const std::string &id = ai_configuration["id"];
+	for (const config& ai_configuration : ais.child_range("ai")) {
+		const std::string& id = ai_configuration["id"];
 		if (id.empty()){
 
 			ERR_AI_CONFIGURATION << "skipped AI config due to missing id" << ". Config contains:"<< std::endl << ai_configuration;
@@ -85,10 +85,10 @@ void configuration::init(const game_config_view &game_config)
 }
 
 namespace {
-void extract_ai_configurations(std::map<std::string, description> &storage, const config &input)
+void extract_ai_configurations(std::map<std::string, description>& storage, const config& input)
 {
-	for (const config &ai_configuration : input.child_range("ai")) {
-		const std::string &id = ai_configuration["id"];
+	for (const config& ai_configuration : input.child_range("ai")) {
+		const std::string& id = ai_configuration["id"];
 		if (id.empty()){
 
 			ERR_AI_CONFIGURATION << "skipped AI config due to missing id" << ". Config contains:"<< std::endl << ai_configuration;
@@ -111,16 +111,16 @@ void extract_ai_configurations(std::map<std::string, description> &storage, cons
 }
 }
 
-void configuration::add_era_ai_from_config(const config &era)
+void configuration::add_era_ai_from_config(const config& era)
 {
 	era_ai_configurations_.clear();
 	extract_ai_configurations(era_ai_configurations_, era);
 }
 
-void configuration::add_mod_ai_from_config(config::const_child_itors mods)
+void configuration::add_mod_ai_from_config(const config::const_child_itors& mods)
 {
 	mod_ai_configurations_.clear();
-	for (const config &mod : mods) {
+	for (const config& mod : mods) {
 		extract_ai_configurations(mod_ai_configurations_, mod);
 	}
 }
@@ -161,7 +161,7 @@ std::vector<description*> configuration::get_available_ais()
 	return ais_list;
 }
 
-const config& configuration::get_ai_config_for(const std::string &id)
+const config& configuration::get_ai_config_for(const std::string& id)
 {
 	description_map::iterator cfg_it = ai_configurations_.find(id);
 	if (cfg_it==ai_configurations_.end()){
@@ -185,7 +185,7 @@ bool configuration::get_side_config_from_file(const std::string& file, config& c
 		filesystem::scoped_istream stream = preprocess_file(filesystem::get_wml_location(file).value());
 		read(cfg, *stream);
 		LOG_AI_CONFIGURATION << "Reading AI configuration from file '" << file  << "'";
-	} catch(const config::error &) {
+	} catch(const config::error&) {
 		ERR_AI_CONFIGURATION << "Error while reading AI configuration from file '" << file  << "'";
 		return false;
 	}
@@ -199,13 +199,13 @@ const config& configuration::get_default_ai_parameters()
 }
 
 
-bool configuration::parse_side_config(side_number side, const config& original_cfg, config &cfg )
+bool configuration::parse_side_config(side_number side, const config& original_cfg, config& cfg )
 {
 	LOG_AI_CONFIGURATION << "side "<< side <<": parsing AI configuration from config";
 
 	//leave only the [ai] children
 	cfg.clear();
-	for (const config &aiparam : original_cfg.child_range("ai")) {
+	for (const config& aiparam : original_cfg.child_range("ai")) {
 		cfg.add_child("ai",aiparam);
 	}
 
@@ -233,7 +233,7 @@ bool configuration::parse_side_config(side_number side, const config& original_c
 	config parsed_cfg = config();
 
 	LOG_AI_CONFIGURATION << "side "<< side <<": merging AI configurations";
-	for (const config &aiparam : cfg.child_range("ai")) {
+	for (const config& aiparam : cfg.child_range("ai")) {
 		parsed_cfg.append(aiparam);
 	}
 
@@ -242,7 +242,7 @@ bool configuration::parse_side_config(side_number side, const config& original_c
 	parsed_cfg.merge_children_by_attribute("aspect","id");
 
 	LOG_AI_CONFIGURATION << "side "<< side <<": removing duplicate [default] tags from aspects";
-	for (config &aspect_cfg : parsed_cfg.child_range("aspect")) {
+	for (config& aspect_cfg : parsed_cfg.child_range("aspect")) {
 		if (aspect_cfg["name"] != "composite_aspect") {
 			// No point in warning about Lua or standard aspects lacking [default]
 			continue;
@@ -272,10 +272,10 @@ static const std::set<std::string> non_aspect_attributes {"turns", "time_of_day"
 static const std::set<std::string> just_copy_tags {"engine", "stage", "aspect", "goal", "modify_ai", "micro_ai"};
 static const std::set<std::string> old_goal_tags {"target", "target_location", "protect_unit", "protect_location"};
 
-void configuration::expand_simplified_aspects(side_number side, config &cfg) {
+void configuration::expand_simplified_aspects(side_number side, config& cfg) {
 	std::string algorithm;
 	config base_config, parsed_config;
-	for (const config &aiparam : cfg.child_range("ai")) {
+	for (const config& aiparam : cfg.child_range("ai")) {
 		std::string turns, time_of_day, engine = "cpp";
 		if (aiparam.has_attribute("turns")) {
 			turns = aiparam["turns"].str();
@@ -364,8 +364,8 @@ void configuration::expand_simplified_aspects(side_number side, config &cfg) {
 		}
 		std::map<std::string, config> aspect_configs;
 		while (!facet_configs.empty()) {
-			const std::string &aspect = facet_configs.front().first;
-			const config &facet_config = facet_configs.front().second;
+			const std::string& aspect = facet_configs.front().first;
+			const config& facet_config = facet_configs.front().second;
 			aspect_configs[aspect]["id"] = aspect; // Will sometimes be redundant assignment
 			aspect_configs[aspect]["name"] = "composite_aspect";
 			aspect_configs[aspect].add_child("facet", facet_config);

--- a/src/ai/configuration.hpp
+++ b/src/ai/configuration.hpp
@@ -66,9 +66,9 @@ public:
 	 * Init the parameters of ai configuration parser
 	 * @param game_config game config
 	 */
-	static void init(const game_config_view &game_config);
-	static void add_era_ai_from_config(const config &game_config);
-	static void add_mod_ai_from_config(config::const_child_itors configs);
+	static void init(const game_config_view& game_config);
+	static void add_era_ai_from_config(const config& game_config);
+	static void add_mod_ai_from_config(const config::const_child_itors& configs);
 
 
 	/**
@@ -81,7 +81,7 @@ public:
 	/**
 	 * Return the config for a specified ai
 	 */
-	static const config& get_ai_config_for(const std::string &id);
+	static const config& get_ai_config_for(const std::string& id);
 
 
 	/**
@@ -99,7 +99,7 @@ public:
 	 * @retval true success
 	 * @retval false failure
 	 */
-	static bool get_side_config_from_file( const std::string& file, config& cfg );
+	static bool get_side_config_from_file(const std::string& file, config& cfg);
 
 
 	/**
@@ -110,14 +110,14 @@ public:
 	 * @retval true success
 	 * @retval false failure
 	 */
-	static bool parse_side_config(side_number side, const config& original_cfg, config &cfg);
+	static bool parse_side_config(side_number side, const config& original_cfg, config& cfg);
 
 
 	/**
 	 * Expand simplified aspects, similar to the change from 1.7.2 to 1.7.3
 	 * but with some additional syntax options.
 	 */
-	static void expand_simplified_aspects(side_number side, config &cfg);
+	static void expand_simplified_aspects(side_number side, config& cfg);
 private:
 
 	typedef std::map<std::string, description> description_map;

--- a/src/game_events/manager_impl.cpp
+++ b/src/game_events/manager_impl.cpp
@@ -198,7 +198,7 @@ void event_handlers::clean_up_expired_handlers(const std::string& event_name)
 	// Might be more than one so we split.
 	for(const std::string& name : utils::split(event_name)) {
 		by_name_[standardize_name(name)].remove_if(
-			[](weak_handler_ptr ptr) { return ptr.expired(); }
+			[](const weak_handler_ptr& ptr) { return ptr.expired(); }
 		);
 	}
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -96,7 +96,7 @@ static std::string format_mp_entry(const int cost, const int max_cost) {
 
 typedef t_translation::ter_list::const_iterator ter_iter;
 // Gets an english description of a terrain ter_list alias behavior: "Best of cave, hills", "Worst of Swamp, Forest" etc.
-static std::string print_behavior_description(ter_iter start, ter_iter end, const std::shared_ptr<terrain_type_data> & tdata, bool first_level = true, bool begin_best = true)
+static std::string print_behavior_description(const ter_iter& start, const ter_iter& end, const std::shared_ptr<terrain_type_data> & tdata, bool first_level = true, bool begin_best = true)
 {
 
 	if (start == end) return "";

--- a/src/network_asio.cpp
+++ b/src/network_asio.cpp
@@ -37,7 +37,7 @@ static lg::log_domain log_network("network");
 
 namespace
 {
-std::deque<boost::asio::const_buffer> split_buffer(boost::asio::streambuf::const_buffers_type source_buffer)
+std::deque<boost::asio::const_buffer> split_buffer(const boost::asio::streambuf::const_buffers_type& source_buffer)
 {
 	const unsigned int chunk_size = 4096;
 

--- a/src/recall_list_manager.cpp
+++ b/src/recall_list_manager.cpp
@@ -140,6 +140,6 @@ std::vector<unit_ptr>::iterator recall_list_manager::erase_index(std::size_t idx
 	return recall_list_.erase(recall_list_.begin()+idx);
 }
 
-std::vector<unit_ptr>::iterator recall_list_manager::erase(std::vector<unit_ptr>::iterator it) {
+std::vector<unit_ptr>::iterator recall_list_manager::erase(const std::vector<unit_ptr>::iterator& it) {
 	return recall_list_.erase(it);
 }

--- a/src/recall_list_manager.hpp
+++ b/src/recall_list_manager.hpp
@@ -65,7 +65,7 @@ public:
 	/** Erase by index. */
 	iterator erase_index(std::size_t index);
 	/** Erase an iterator to this object. */
-	iterator erase(iterator it);
+	iterator erase(const iterator& it);
 
 	/** Find the index of a unit by its id. */
 	std::size_t find_index(const std::string & unit_id) const;

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -438,7 +438,7 @@ bool dbconn::topic_id_exists(int topic_id) {
 	}
 }
 
-void dbconn::insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id, const std::string uploader)
+void dbconn::insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id, const std::string& uploader)
 {
 	try
 	{
@@ -558,7 +558,7 @@ void dbconn::delete_addon_authors(const std::string& instance_version, const std
 	}
 }
 
-void dbconn::insert_addon_author(const std::string& instance_version, const std::string& id, const std::string author, int is_primary) {
+void dbconn::insert_addon_author(const std::string& instance_version, const std::string& id, const std::string& author, int is_primary) {
 	try
 	{
 		modify(connection_, "INSERT INTO `"+db_addon_authors_table_+"`(INSTANCE_VERSION, ADDON_ID, AUTHOR, IS_PRIMARY) VALUES(?,?,?,?)",
@@ -586,17 +586,17 @@ bool dbconn::do_any_authors_exist(const std::string& instance_version, const std
 //
 // handle complex query results
 //
-void dbconn::get_complex_results(mariadb::connection_ref connection, rs_base& base, const std::string& sql, const sql_parameters& params)
+void dbconn::get_complex_results(const mariadb::connection_ref& connection, rs_base& base, const std::string& sql, const sql_parameters& params)
 {
-	mariadb::result_set_ref rslt = select(connection, sql, params);
+	mariadb::result_set_ref rslt = select(std::move(connection), sql, params);
 	base.read(rslt);
 }
 //
 // handle single values
 //
-std::string dbconn::get_single_string(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+std::string dbconn::get_single_string(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
-	mariadb::result_set_ref rslt = select(connection, sql, params);
+	mariadb::result_set_ref rslt = select(std::move(connection), sql, params);
 	if(rslt->next())
 	{
 		return rslt->get_string(0);
@@ -606,9 +606,9 @@ std::string dbconn::get_single_string(mariadb::connection_ref connection, const 
 		throw mariadb::exception::base("No string value found in the database!");
 	}
 }
-long dbconn::get_single_long(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+long dbconn::get_single_long(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
-	mariadb::result_set_ref rslt = select(connection, sql, params);
+	mariadb::result_set_ref rslt = select(std::move(connection), sql, params);
 	if(rslt->next())
 	{
 		// mariadbpp checks for strict integral equivalence, but we don't care
@@ -639,20 +639,20 @@ long dbconn::get_single_long(mariadb::connection_ref connection, const std::stri
 		throw mariadb::exception::base("No long value found in the database!");
 	}
 }
-bool dbconn::exists(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+bool dbconn::exists(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
-	mariadb::result_set_ref rslt = select(connection, sql, params);
+	mariadb::result_set_ref rslt = select(std::move(connection), sql, params);
 	return rslt->next();
 }
 
 //
 // select or modify values
 //
-mariadb::result_set_ref dbconn::select(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+mariadb::result_set_ref dbconn::select(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
 	try
 	{
-		mariadb::statement_ref stmt = query(connection, sql, params);
+		mariadb::statement_ref stmt = query(std::move(connection), sql, params);
 		mariadb::result_set_ref rslt = mariadb::result_set_ref(stmt->query());
 		return rslt;
 	}
@@ -662,11 +662,11 @@ mariadb::result_set_ref dbconn::select(mariadb::connection_ref connection, const
 		throw e;
 	}
 }
-unsigned long long dbconn::modify(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+unsigned long long dbconn::modify(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
 	try
 	{
-		mariadb::statement_ref stmt = query(connection, sql, params);
+		mariadb::statement_ref stmt = query(std::move(connection), sql, params);
 		unsigned long long count = stmt->execute();
 		return count;
 	}
@@ -676,11 +676,11 @@ unsigned long long dbconn::modify(mariadb::connection_ref connection, const std:
 		throw e;
 	}
 }
-unsigned long long dbconn::modify_get_id(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+unsigned long long dbconn::modify_get_id(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
 	try
 	{
-		mariadb::statement_ref stmt = query(connection, sql, params);
+		mariadb::statement_ref stmt = query(std::move(connection), sql, params);
 		unsigned long long count = stmt->insert();
 		return count;
 	}
@@ -691,7 +691,7 @@ unsigned long long dbconn::modify_get_id(mariadb::connection_ref connection, con
 	}
 }
 
-mariadb::statement_ref dbconn::query(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params)
+mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
 	mariadb::statement_ref stmt = connection->create_statement(sql);
 

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -132,7 +132,8 @@ public:
 	/**
 	 * @see forum_user_handler::db_insert_game_info().
 	 */
-	void insert_game_info(const std::string& uuid,
+	void insert_game_info(
+		const std::string& uuid,
 		int game_id,
 		const std::string& version,
 		const std::string& name,
@@ -149,7 +150,8 @@ public:
 	/**
 	 * @see forum_user_handler::db_insert_game_player_info().
 	 */
-	void insert_game_player_info(const std::string& uuid,
+	void insert_game_player_info(
+		const std::string& uuid,
 		int game_id,
 		const std::string& username,
 		int side_number,
@@ -163,7 +165,8 @@ public:
 	/**
 	 * @see forum_user_handler::db_insert_game_content_info().
 	 */
-	unsigned long long insert_game_content_info(const std::string& uuid,
+	unsigned long long insert_game_content_info(
+		const std::string& uuid,
 		int game_id,
 		const std::string& type,
 		const std::string& name,
@@ -184,14 +187,15 @@ public:
 	/**
 	 * @see forum_user_handler::db_insert_addon_info().
 	 */
-	void insert_addon_info(const std::string& instance_version,
+	void insert_addon_info(
+		const std::string& instance_version,
 		const std::string& id,
 		const std::string& name,
 		const std::string& type,
 		const std::string& version,
 		bool forum_auth,
 		int topic_id,
-		const std::string uploader);
+		const std::string& uploader);
 
 	/**
 	 * @see forum_user_handler::db_insert_login().
@@ -235,7 +239,7 @@ public:
 	 * @see forum_user_handler::db_insert_addon_authors().
 	 */
 	void insert_addon_author(
-		const std::string& instance_version, const std::string& id, const std::string author, int is_primary);
+		const std::string& instance_version, const std::string& id, const std::string& author, int is_primary);
 
 	/**
 	 * @see forum_user_handler::do_any_authors_exist().
@@ -301,7 +305,7 @@ private:
 	 * @param params The parameterized values to be inserted into the query.
 	 */
 	void get_complex_results(
-		mariadb::connection_ref connection, rs_base& base, const std::string& sql, const sql_parameters& params);
+		const mariadb::connection_ref& connection, rs_base& base, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * @param connection The database connection that will be used to execute the query.
@@ -311,7 +315,7 @@ private:
 	 * @throws mariadb::exception::base when the query finds no value to be retrieved.
 	 */
 	std::string get_single_string(
-		mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+		const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * @param connection The database connection that will be used to execute the query.
@@ -320,7 +324,7 @@ private:
 	 * @return The single long value queried.
 	 * @throws mariadb::exception::base when the query finds no value to be retrieved.
 	 */
-	long get_single_long(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+	long get_single_long(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * @param connection The database connection that will be used to execute the query.
@@ -328,7 +332,7 @@ private:
 	 * @param params The parameterized values to be inserted into the query.
 	 * @return True if any data was returned by the query, otherwise false.
 	 */
-	bool exists(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+	bool exists(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * Executes a select statement.
@@ -339,7 +343,7 @@ private:
 	 * @return A result set containing the results of the select statement executed.
 	 */
 	mariadb::result_set_ref select(
-		mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+		const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * Executes non-select statements (ie: insert, update, delete).
@@ -349,7 +353,7 @@ private:
 	 * @param params The parameterized values to be inserted into the query.
 	 * @return The number of rows modified.
 	 */
-	unsigned long long modify(mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+	unsigned long long modify(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * Executes non-select statements (ie: insert, update, delete), but primarily intended for inserts that return a
@@ -361,7 +365,7 @@ private:
 	 * @return The value of an AUTO_INCREMENT column on the table being modified.
 	 */
 	unsigned long long modify_get_id(
-		mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+		const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 
 	/**
 	 * For a given connection, set the provided SQL and parameters on a statement.
@@ -372,5 +376,5 @@ private:
 	 * @return A statement ready to be executed.
 	 */
 	mariadb::statement_ref query(
-		mariadb::connection_ref connection, const std::string& sql, const sql_parameters& params);
+		const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params);
 };

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -506,7 +506,7 @@ static void append_special_note(std::vector<t_string>& notes, const t_string& ne
 	notes.push_back(new_note);
 }
 
-std::vector<t_string> combine_special_notes(const std::vector<t_string>& direct, const config& abilities, const_attack_itors attacks, const movetype& mt)
+std::vector<t_string> combine_special_notes(const std::vector<t_string>& direct, const config& abilities, const const_attack_itors& attacks, const movetype& mt)
 {
 	std::vector<t_string> notes;
 	for(const auto& note : direct) {

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -455,4 +455,8 @@ private:
  *
  * @return the special notes for a unit or unit_type.
  */
-std::vector<t_string> combine_special_notes(const std::vector<t_string>& direct, const config& abilities, const_attack_itors attacks, const movetype& mt);
+std::vector<t_string> combine_special_notes(
+	const std::vector<t_string>& direct,
+	const config& abilities,
+	const const_attack_itors& attacks,
+	const movetype& mt);


### PR DESCRIPTION
Fixes leftover clang-tidy warnings that causes the CI to fail. (Most probably from #9618)