### PR TITLE
Elvish Champion: revert hp to 1.16, explain accuracy bonus via a weapon special

### DIFF
--- a/changelog_entries/elvish-champion-honed.md
+++ b/changelog_entries/elvish-champion-honed.md
@@ -1,2 +1,2 @@
 ### Units
-   * Elvish Champion: HP 72 -> 70, accuracy bonus is now explained via a weapon special
+   * Elvish Champion: HP 72 -> 70, cost 61 -> 60, accuracy bonus is now explained via a weapon special

--- a/changelog_entries/elvish-champion-honed.md
+++ b/changelog_entries/elvish-champion-honed.md
@@ -1,0 +1,2 @@
+### Units
+   * Elvish Champion: HP 72 -> 70, accuracy bonus is now explained via a weapon special

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -121,8 +121,8 @@
     [chance_to_hit]
         id=honed
         name= _ "honed"
-        description= _ "This attack is 10% more likely to hit."
-        special_note= _ "This unit has a “honed” attack, which is more accurate than regular attacks."
+        description= _ "This attack is 10% more accurate than other attacks."
+        special_note= _ "This unit’s “honed” attack is slightly more accurate than other attacks."
         add=10
         cumulative=yes
     [/chance_to_hit]

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -122,7 +122,7 @@
         id=honed
         name= _ "honed"
         description= _ "This attack is 10% more likely to hit."
-        special_note= _ "This unit has a honed attack, which is more accurate than regular attacks."
+        special_note= _ "This unit has a “honed” attack, which is more accurate than regular attacks."
         add=10
         cumulative=yes
     [/chance_to_hit]

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -115,6 +115,19 @@
     [/chance_to_hit]
 #enddef
 
+#define WEAPON_SPECIAL_HONED
+    # Canned definition of the Honed ability to be included in a
+    # [specials] clause.
+    [chance_to_hit]
+        id=honed
+        name= _ "honed"
+        description= _ "This attack is 10% more likely to hit."
+        special_note= _ "This unit has a honed attack, which is more accurate than regular attacks."
+        add=10
+        cumulative=yes
+    [/chance_to_hit]
+#enddef
+
 #define WEAPON_SPECIAL_SWARM
     # Canned definition of the Swarm ability to be included in a
     # [specials] clause.

--- a/data/core/units/elves/Champion.cfg
+++ b/data/core/units/elves/Champion.cfg
@@ -14,7 +14,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=61
+    cost=60
     usage=fighter
     description= _ "Elves are typically peaceable by nature and most will attack only in retaliation for some wrongdoing wrought upon them. However, there are some elves who deliberately seek battle, purposeful or otherwise, for their own enjoyment. Through constant combat, these warriors either learn to hone their swordsmanship to a level far beyond most of their peers or perish in the volatile frenzy of melee. Those capable of persisting eventually grow skilled enough to wholly conquer the battlegrounds, becoming veritable champions of war as they mercilessly cut through their foes. Having spent their whole lives refining their prowess with the blade, these elves are exceptionally dangerous and should never be underestimated."
     die_sound={SOUND_LIST:ELF_HIT}

--- a/data/core/units/elves/Champion.cfg
+++ b/data/core/units/elves/Champion.cfg
@@ -5,7 +5,7 @@
     race=elf
     image="units/elves-wood/champion.png"
     profile="portraits/elves/hero.webp"
-    hitpoints=72
+    hitpoints=70
     movement_type=woodland
     movement=5
     {LESS_NIMBLE_ELF}
@@ -26,7 +26,9 @@
         range=melee
         damage=8
         number=5
-        accuracy=10
+        [specials]
+            {WEAPON_SPECIAL_HONED}
+        [/specials]
     [/attack]
     [attack]
         name=bow


### PR DESCRIPTION
Following the failed balance team vote for #9557, we held a follow-up vote for a partial reversion: lowering the Champion's hp to 1.16 and explaining his accuracy bonus via a weapon special. The follow-up vote passed 3-0, so I'm implementing it here.

I don't mean to block off any possible future reversion to 1.16's 9-5, if the balance team decides to vote differently in the future - but this is still hopefully an improvement over 1.18.

Resolves #8706

Since discussion about this topic has already taken place on #9557 and since a vote for this partial reversion has already been held, I'll merge this PR once the checks finish.