### PR TITLE
GUI2/Listbox: unify registration of sorting options

### DIFF
--- a/src/gui/dialogs/game_stats.cpp
+++ b/src/gui/dialogs/game_stats.cpp
@@ -197,13 +197,12 @@ void game_stats::pre_show()
 	}
 
 	// Sorting options for the status list
-	stats_list.register_translatable_sorting_option(0, [this](const int i) {
+	stats_list.register_sorting_option(0, [this](const int i) {
 		unit_const_ptr leader = get_leader(i + 1);
-		return leader ? leader->name().str() : "";
+		return leader ? leader->name() : t_string();
 	});
 
-	stats_list.register_translatable_sorting_option(1, [this](const int i) {
-		return board_.teams()[i].user_team_name().str(); });
+	stats_list.register_sorting_option(1, [this](const int i) { return board_.teams()[i].user_team_name(); });
 	stats_list.register_sorting_option(2, [this](const int i) { return board_.teams()[i].gold(); });
 	stats_list.register_sorting_option(3, [this](const int i) { return board_.teams()[i].villages(); });
 	stats_list.register_sorting_option(4, [this](const int i) { return team_data_[i].units; });
@@ -211,9 +210,9 @@ void game_stats::pre_show()
 	stats_list.register_sorting_option(6, [this](const int i) { return team_data_[i].net_income; });
 
 	// Sorting options for the settings list
-	settings_list.register_translatable_sorting_option(0, [this](const int i) {
+	settings_list.register_sorting_option(0, [this](const int i) {
 		unit_const_ptr leader = get_leader(i + 1);
-		return leader ? leader->name().str() : "";
+		return leader ? leader->name() : t_string();
 	});
 
 	settings_list.register_sorting_option(1, [this](const int i) { return board_.teams()[i].side(); });

--- a/src/gui/dialogs/preferences_dialog.cpp
+++ b/src/gui/dialogs/preferences_dialog.cpp
@@ -842,7 +842,7 @@ void preferences_dialog::initialize_callbacks()
 	filter.set_text_changed_callback(std::bind(&preferences_dialog::hotkey_filter_callback, this));
 
 	// Action column
-	hotkey_list.register_translatable_sorting_option(0, [this](const int i) { return visible_hotkeys_[i]->description.str(); });
+	hotkey_list.register_sorting_option(0, [this](const int i) { return visible_hotkeys_[i]->description; });
 
 	// Hotkey column
 	hotkey_list.register_sorting_option(1, [this](const int i) { return hotkey::get_names(visible_hotkeys_[i]->id); });

--- a/src/gui/dialogs/unit_create.cpp
+++ b/src/gui/dialogs/unit_create.cpp
@@ -115,8 +115,8 @@ void unit_create::pre_show()
 				  << std::endl;
 	}
 
-	list.register_translatable_sorting_option(0, [this](const int i) { return (*units_[i]).race()->plural_name().str(); });
-	list.register_translatable_sorting_option(1, [this](const int i) { return (*units_[i]).type_name().str(); });
+	list.register_sorting_option(0, [this](const int i) { return (*units_[i]).race()->plural_name(); });
+	list.register_sorting_option(1, [this](const int i) { return (*units_[i]).type_name(); });
 
 	// Select the first entry on sort if no previous selection was provided.
 	list.set_active_sorting_option({0, sort_order::type::ascending}, choice_.empty());

--- a/src/gui/dialogs/unit_list.cpp
+++ b/src/gui/dialogs/unit_list.cpp
@@ -144,8 +144,8 @@ void unit_list::pre_show()
 		}
 	}
 
-	list.register_translatable_sorting_option(0, [this](const int i) { return unit_list_[i]->type_name().str(); });
-	list.register_translatable_sorting_option(1, [this](const int i) { return unit_list_[i]->name().str(); });
+	list.register_sorting_option(0, [this](const int i) { return unit_list_[i]->type_name(); });
+	list.register_sorting_option(1, [this](const int i) { return unit_list_[i]->name(); });
 	list.register_sorting_option(2, [this](const int i) { return unit_list_[i]->movement_left(); });
 	list.register_sorting_option(3, [this](const int i) { return unit_list_[i]->hitpoints(); });
 	list.register_sorting_option(4, [this](const int i) {
@@ -153,8 +153,8 @@ void unit_list::pre_show()
 		return std::tuple(u.level(), -static_cast<int>(u.experience_to_advance()));
 	});
 	list.register_sorting_option(5, [this](const int i) { return unit_list_[i]->experience(); });
-	list.register_translatable_sorting_option(6, [this](const int i) {
-		return !unit_list_[i]->trait_names().empty() ? unit_list_[i]->trait_names().front().str() : ""; });
+	list.register_sorting_option(6, [this](const int i) {
+		return !unit_list_[i]->trait_names().empty() ? unit_list_[i]->trait_names().front() : t_string(); });
 
 	list_item_clicked();
 }

--- a/src/gui/dialogs/unit_recall.cpp
+++ b/src/gui/dialogs/unit_recall.cpp
@@ -286,15 +286,15 @@ void unit_recall::pre_show()
 		}
 	}
 
-	list.register_translatable_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name().str(); });
-	list.register_translatable_sorting_option(1, [this](const int i) { return recall_list_[i]->name().str(); });
+	list.register_sorting_option(0, [this](const int i) { return recall_list_[i]->type_name(); });
+	list.register_sorting_option(1, [this](const int i) { return recall_list_[i]->name(); });
 	list.register_sorting_option(2, [this](const int i) {
 		const unit& u = *recall_list_[i];
 		return std::tuple(u.level(), -static_cast<int>(u.experience_to_advance()));
 	});
 	list.register_sorting_option(3, [this](const int i) { return recall_list_[i]->experience(); });
-	list.register_translatable_sorting_option(4, [this](const int i) {
-		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front().str() : "";
+	list.register_sorting_option(4, [this](const int i) {
+		return !recall_list_[i]->trait_names().empty() ? recall_list_[i]->trait_names().front() : t_string();
 	});
 
 	list.set_active_sorting_option(sort_last.first >= 0 ? sort_last	: sort_default, true);

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -375,11 +375,11 @@ void addon_list::finalize_setup()
 {
 	listbox& list = get_listbox();
 
-	list.register_translatable_sorting_option(0, [this](const int i) { return addon_vector_[i]->display_title_full(); });
+	list.register_sorting_option(0, [this](const int i) { return t_string(addon_vector_[i]->display_title_full()); });
 	list.register_sorting_option(1, [this](const int i) { return addon_vector_[i]->author; });
 	list.register_sorting_option(2, [this](const int i) { return addon_vector_[i]->size; });
 	list.register_sorting_option(3, [this](const int i) { return addon_vector_[i]->downloads; });
-	list.register_translatable_sorting_option(4, [this](const int i) { return addon_vector_[i]->display_type(); });
+	list.register_sorting_option(4, [this](const int i) { return t_string(addon_vector_[i]->display_type()); });
 
 	auto order = std::pair(0, sort_order::type::ascending);
 	list.set_active_sorting_option(order);

--- a/src/gui/widgets/listbox.cpp
+++ b/src/gui/widgets/listbox.cpp
@@ -600,21 +600,23 @@ void listbox::order_by(const generator_base::order_func& func)
 	update_layout();
 }
 
-void listbox::set_column_order(unsigned col, const generator_sort_array& func)
+void listbox::set_column_order(unsigned col, generator_sort_array&& func)
 {
 	if(col >= orders_.size()) {
 		orders_.resize(col + 1);
 	}
 
-	orders_[col].second = func;
+	orders_[col].second = std::move(func);
 }
 
-void listbox::register_translatable_sorting_option(const int col, const translatable_sorter_func_t& f)
+bool listbox::sort_helper::less(const t_string& lhs, const t_string& rhs)
 {
-	set_column_order(col, {{
-		[f](int lhs, int rhs) { return translation::icompare(f(lhs), f(rhs)) < 0; },
-		[f](int lhs, int rhs) { return translation::icompare(f(lhs), f(rhs)) > 0; }
-	}});
+	return translation::icompare(lhs, rhs) < 0;
+}
+
+bool listbox::sort_helper::more(const t_string& lhs, const t_string& rhs)
+{
+	return translation::icompare(lhs, rhs) > 0;
 }
 
 void listbox::set_active_sorting_option(const order_pair& sort_by, const bool select_first)

--- a/src/gui/widgets/listbox.hpp
+++ b/src/gui/widgets/listbox.hpp
@@ -254,21 +254,33 @@ public:
 
 	void order_by(const generator_base::order_func& func);
 
-	void set_column_order(unsigned col, const generator_sort_array& func);
+private:
+	void set_column_order(unsigned col, generator_sort_array&& func);
 
+	struct sort_helper
+	{
+		template<typename T>
+		static bool less(const T& lhs, const T& rhs) { return lhs < rhs; }
+
+		/** Performs case-insensitive comparison using the current locale. */
+		static bool less(const t_string& lhs, const t_string& rhs);
+
+		template<typename T>
+		static bool more(const T& lhs, const T& rhs) { return lhs > rhs; }
+
+		/** Performs case-insensitive comparison using the current locale. */
+		static bool more(const t_string& lhs, const t_string& rhs);
+	};
+
+public:
 	template<typename Func>
 	void register_sorting_option(const int col, const Func& f)
 	{
-		set_column_order(col, {{
-			[f](int lhs, int rhs) { return f(lhs) < f(rhs); },
-			[f](int lhs, int rhs) { return f(lhs) > f(rhs); }
-		}});
+		set_column_order(col, {
+			[f](int lhs, int rhs) { return sort_helper::less(f(lhs), f(rhs)); },
+			[f](int lhs, int rhs) { return sort_helper::more(f(lhs), f(rhs)); }
+		});
 	}
-
-	using translatable_sorter_func_t = std::function<std::string(const int)>;
-
-	/** Registers a special sorting function specifically for translatable values. */
-	void register_translatable_sorting_option(const int col, const translatable_sorter_func_t& f);
 
 	using order_pair = std::pair<int, sort_order::type>;
 


### PR DESCRIPTION
Instead of two functions for translatable and non-translatable options, comparison will be determined by the return value of the sorter. Existing translatable sorting options have been adjusted to return t_string rather than string.