### PR TITLE
Fix tutorial help text cutoff on macOS by removing location assignment in hint_message.lua

### DIFF
--- a/data/campaigns/tutorial/lua/hint_message.lua
+++ b/data/campaigns/tutorial/lua/hint_message.lua
@@ -11,8 +11,9 @@ function wesnoth.wml_actions.hint_message(cfg)
             hint_text = "<b><big>" .. cfg.caption .. "</big></b>\n" .. hint_text
         end
         hint_message = wesnoth.interface.add_overlay_text(hint_text, {
+            -- Be careful of setting location here, as it could cause issues
+            -- with the border of the text box
             size = 18,
-            location = {5,5},
             color = {255, 255, 255},
             bgcolor = {0, 0, 0},
             bgalpha = 85,


### PR DESCRIPTION
This PR addresses Issue #9591, where the tutorial help text in the Battle Training Campaign was partially cut off on macOS.

**Fix Details**

The issue was caused by the `location` assignment in `hint_message.lua`, which introduced padding between the text box and the screen edge. It appears that the rectangle’s width was being set before the text’s starting point was adjusted to account for `location`. This mismatch caused some text to overflow when it exceeded the pre-defined width. By removing this assignment, the help text now displays fully without being truncated, resolving the immediate issue.

![Screenshot 2024-12-05 at 11 59 51 PM](https://github.com/user-attachments/assets/b1618e59-eab2-4f5f-826a-fdc28cf5f7c5)

**Alternative Fix Considered:**

An alternative approach would involve retaining the `location = {5, 5}` assignment in `hint_message.lua` and adding the following line to the `intf_set_floating_label()` function in `game_lua_kernel.cpp`:

`flabel.set_width(rect.w - loc.wml_x());`

While this adjustment would fix the cutoff, the resulting visual design is suboptimal:

- The fix proposed in this PR only impacts the tutorial hint messages.
- I'm not sure what impact the alternative fix would have on other callers of the function.
- The background color and text both extend to the rectangle’s edge which, when padded away from the screen's borders, creates an unpolished appearance.
- A better long-term solution might involve introducing padding between the text and the rectangle’s borders while maintaining the box’s position relative to the screen.

![Screenshot 2024-12-06 at 12 03 36 AM](https://github.com/user-attachments/assets/7056bd72-5fe3-4c68-aa49-04dc0b6b7a6e)

**Next Steps**

For now, removing the location assignment is the most straightforward and effective fix. However, I recommend exploring a more comprehensive solution in the future to enhance visual consistency and maintainability. I’d appreciate feedback from maintainers and contributors familiar with the codebase on the best approach to achieve this.