### PR TITLE
EI S04c: fix gold management for Ravanal

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -230,31 +230,32 @@
             [/effect]
         [/modify_unit]
     [/event]
-    [event] # manually set gold to 0
+    [event]
+        # if ravanal's low on units and ravanal_no_income is cleared, give him gold
+        # otherwise, clear Mal-Ravanal's gold so we don't go positive nor negative
         name=side 7 turn refresh
         first_time_only=no
-
-        [filter_condition]
-            {VARIABLE_CONDITIONAL ravanal_no_income equals yes}
-        [/filter_condition]
-
-        [modify_side]
-            side=7
-            gold=0
-        [/modify_side]
-    [/event]
-    [event] # manually set gold to 1000
-        name=side 1
-        first_time_only=no
-
-        [filter_condition]
+        [if]
             {VARIABLE_CONDITIONAL ravanal_no_income not_equals yes}
-        [/filter_condition]
-
-        [modify_side]
-            side=7
-            gold=9999
-        [/modify_side]
+            [and]
+                [have_unit]
+                    side=7
+                    count=0-10
+                [/have_unit]
+            [/and]
+            [then]
+                [modify_side]
+                    side=7
+                    gold=500
+                [/modify_side]
+            [/then]
+            [else]
+                [modify_side]
+                    side=7
+                    gold=0
+                [/modify_side]
+            [/else]
+        [/if]
     [/event]
 
     #--------------------


### PR DESCRIPTION
Fixes #9623
@Dalas121 I've changed the WML you proposed in the issue a bit.
I think it's more straightforward to have it in one "turn refresh" event, right before the side's AI launches.
I've tested it, it works as intended.