### PR TITLE
allow to register custom lua map generators

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/17_Scepter_of_Fire.cfg
@@ -3,11 +3,10 @@
     id=17_Sceptre_of_Fire
     name= _ "The Sceptre of Fire"
     next_scenario=18_A_Choice_Must_Be_Made
-    map_generation=lua
+    map_generation=cave
     [generator]
         id="cavegen"
         config_name=_"Sceptre of Fire Caves"
-        create_map = << return wesnoth.require("cave_map_generator").generate_map(...) >>
 
         map_width=50
         map_height=75

--- a/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/4_Gathering_Materials.cfg
@@ -2,7 +2,7 @@
 [scenario]
     name= _ "Gathering Materials"
     id=4_Gathering_Materials
-    map_generation=lua
+    map_generation=cave
     next_scenario=4t_The_Jeweler
 
     [story]
@@ -19,7 +19,6 @@
     [generator]
         id="cavegen"
         config_name=_"Sceptre of Fire Mines"
-        create_map = << return wesnoth.require("cave_map_generator").generate_map(...) >>
 
         map_width=45
         map_height=45

--- a/data/campaigns/World_Conquest/map_generators/world_conquest.lua
+++ b/data/campaigns/World_Conquest/map_generators/world_conquest.lua
@@ -1,0 +1,10 @@
+wesnoth.dofile('./../lua/map/main.lua')
+return {
+	create_scenario = function(cfg)
+		return wc_ii_generate_scenario(cfg.nplayers, cfg)
+	end,
+	user_config = function(cfg)
+		wesnoth.dofile('./../lua/map/settings/settings_dialog.lua')
+		return wc2_debug_settings()
+	end
+}

--- a/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
+++ b/data/campaigns/World_Conquest/scenarios/WC_II_scenario.cfg
@@ -189,7 +189,7 @@ _ "World Conquest 4p" #enddef
         id = {ID}
         name={NAME}
         allow_new_game=no
-        scenario_generation=lua
+        scenario_generation=world_conquest
         experience_modifier=100
         victory_when_enemies_defeated=yes
         carryover_percentage=0
@@ -200,38 +200,6 @@ _ "World Conquest 4p" #enddef
             id={ID}
             config_name={NAME}
             nplayers={PLAYERS}
-            create_scenario = <<
-                local a = ...
-                local function doit()
-                    wesnoth.dofile('campaigns/World_Conquest/lua/map/main.lua')
-                    return wc_ii_generate_scenario(a.nplayers, a)
-                end
-
-                local status, res = xpcall(doit, function(e) std_print(e, debug.traceback()) end)
-                if status then
-                    return res
-                else
-                    print(res)
-                    std_print(res)
-                end
-            >>
-#ifdef EDITOR
-            user_config = <<
-                local a = ...
-                local function doit()
-                    wesnoth.dofile('campaigns/World_Conquest/lua/map/main.lua');
-                    wesnoth.dofile('campaigns/World_Conquest/lua/map/settings/settings_dialog.lua');
-                    return wc2_debug_settings()
-                end
-
-                local status, res = xpcall(doit, function(e) std_print(e, debug.traceback()) end)
-                if status then
-                    return res
-                else
-                    std_print(res)
-                end
-            >>
-#endif
             nplayers={PLAYERS}
             [scenario]
                 {DEFAULT_SCHEDULE}

--- a/data/core/map_generators/cave.lua
+++ b/data/core/map_generators/cave.lua
@@ -1,0 +1,1 @@
+return wesnoth.require("cave_map_generator")

--- a/data/core/map_generators/lua.lua
+++ b/data/core/map_generators/lua.lua
@@ -1,0 +1,14 @@
+return {
+	create_scenario = function(cfg)
+		local f = load(cfg.create_scenario)
+		return f(cfg)
+	end,
+	create_map = function(cfg)
+		local f = load(cfg.create_map)
+		return f(cfg)
+	end,
+	user_config = function(cfg)
+		local f = load(cfg.user_config)
+		return f(cfg)
+	end,
+}

--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -159,7 +159,7 @@ bool addons_client::upload_addon(const std::string& id, std::string& response_me
 	response_message.clear();
 
 	utils::string_map i18n_symbols;
-	i18n_symbols["addon_title"] = font::escape_text(cfg["title"]);
+	i18n_symbols["addon_title"] = font::escape_text(cfg["title"].str());
 	if(i18n_symbols["addon_title"].empty()) {
 		i18n_symbols["addon_title"] = font::escape_text(make_addon_title(id));
 	}
@@ -275,7 +275,7 @@ bool addons_client::delete_remote_addon(const std::string& id, std::string& resp
 	config cfg = get_addon_pbl_info(id, false);
 
 	utils::string_map i18n_symbols;
-	i18n_symbols["addon_title"] = font::escape_text(cfg["title"]);
+	i18n_symbols["addon_title"] = font::escape_text(cfg["title"].str());
 	if(i18n_symbols["addon_title"].empty()) {
 		i18n_symbols["addon_title"] = font::escape_text(make_addon_title(id));
 	}

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1733,6 +1733,27 @@ utils::optional<std::string> get_independent_binary_file_path(const std::string&
 	return full_path.generic_string();
 }
 
+utils::optional<std::string> get_wml_binary_file_path(const std::string& type, const std::string& filename)
+{
+	auto bp = get_binary_file_location(type, filename);
+	if(!bp) {
+		return utils::nullopt;
+	}
+
+	bfs::path full_path{bp.value()};
+	bfs::path partial = subtract_path(full_path, get_user_data_path() / "data");
+	if(!partial.empty()) {
+		return std::string("~") + partial.generic_string();
+	}
+
+	partial = subtract_path(full_path, bfs::path(game_config::path) / "data");
+	if(!partial.empty()) {
+		return partial.generic_string();
+	}
+
+	return utils::nullopt;
+}
+
 std::string get_program_invocation(const std::string& program_name)
 {
 #ifdef _WIN32

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -489,6 +489,15 @@ std::string get_short_wml_path(const std::string &filename);
 utils::optional<std::string> get_independent_binary_file_path(const std::string& type, const std::string &filename);
 
 /**
+ * Returns an asset path to @a filename for binary path-independent use in wml. (that can be passed to get_wml_location)
+ *
+ * Example:
+ *   images, units/konrad-fighter.png ->
+ *   campaigns/Heir_To_The_Throne/images/units/konrad-fighter.png
+ */
+utils::optional<std::string> get_wml_binary_file_path(const std::string& type, const std::string &filename);
+
+/**
  * Returns the appropriate invocation for a Wesnoth-related binary, assuming
  * that it is located in the same directory as the running wesnoth binary.
  * This is just a string-transformation based on argv[0], so the returned

--- a/src/font/pango/escape.hpp
+++ b/src/font/pango/escape.hpp
@@ -30,7 +30,7 @@ namespace font
  *
  * @returns                       The escaped text.
  */
-inline std::string escape_text(const std::string& text)
+inline std::string escape_text(std::string_view text)
 {
 	std::ostringstream ss;
 	for(const char c : text) {

--- a/src/game_initialization/lobby_data.cpp
+++ b/src/game_initialization/lobby_data.cpp
@@ -112,7 +112,7 @@ std::string make_game_type_marker(const std::string& text, bool color_for_missin
 game_info::game_info(const config& game, const std::vector<std::string>& installed_addons)
 	: id(game["id"].to_int())
 	, map_data(game["map_data"])
-	, name(font::escape_text(game["name"]))
+	, name(font::escape_text(game["name"].str()))
 	, scenario()
 	, type_marker()
 	, remote_scenario(false)

--- a/src/generators/default_map_generator.cpp
+++ b/src/generators/default_map_generator.cpp
@@ -56,7 +56,7 @@ default_map_generator::default_map_generator(const config& cfg)
 {
 }
 
-bool default_map_generator::allow_user_config() const { return true; }
+bool default_map_generator::allow_user_config() { return true; }
 
 void default_map_generator::user_config()
 {

--- a/src/generators/default_map_generator.hpp
+++ b/src/generators/default_map_generator.hpp
@@ -43,7 +43,7 @@ class default_map_generator : public map_generator
 public:
 	default_map_generator(const config &game_config);
 
-	bool allow_user_config() const override;
+	bool allow_user_config() override;
 	void user_config() override;
 
 	std::string name() const override;

--- a/src/generators/lua_map_generator.hpp
+++ b/src/generators/lua_map_generator.hpp
@@ -24,13 +24,11 @@
 
 class lua_map_generator : public map_generator {
 public:
-	lua_map_generator(const config & cfg, const config* vars);
+	lua_map_generator(const std::string& file_name, const config & cfg, const config* vars);
 
-	bool allow_user_config() const override { return !user_config_.empty(); }
+	bool allow_user_config() override;
 
 	std::string name() const override { return "lua"; }
-
-	std::string id() const { return id_; }
 
 	std::string config_name() const override { return config_name_; }
 
@@ -39,11 +37,8 @@ public:
 	virtual config create_scenario(utils::optional<uint32_t> randomseed) override;
 
 private:
-	std::string id_, config_name_;
-
-	std::string user_config_;
-	std::string create_map_;
-	std::string create_scenario_;
+	std::string config_name_;
+	std::string file_name_;
 
 	mapgen_lua_kernel lk_;
 

--- a/src/generators/map_create.cpp
+++ b/src/generators/map_create.cpp
@@ -15,6 +15,7 @@
 
 #include "generators/map_create.hpp"
 
+#include "filesystem.hpp"
 #include "generators/cave_map_generator.hpp"
 #include "generators/default_map_generator.hpp"
 #include "generators/lua_map_generator.hpp"
@@ -29,13 +30,8 @@ map_generator* create_map_generator(const std::string& name, const config &cfg, 
 {
 	if(name == "default" || name.empty()) {
 		return new default_map_generator(cfg);
-	} else if(name == "cave") {
-		ERR_CF << "map/scenario_generation=cave is deprecatd and will be removed soon, use map/scenario_generation=lua with lua/cave_map_generator.lua instead.";
-		return new cave_map_generator(cfg);
-	} else if(name == "lua") {
-		return new lua_map_generator(cfg, vars);
 	} else {
-		return nullptr;
+		return new lua_map_generator(name, cfg, vars);
 	}
 }
 

--- a/src/generators/map_generator.cpp
+++ b/src/generators/map_generator.cpp
@@ -40,7 +40,7 @@ std::string map_generator::create_map(utils::optional<uint32_t> randomseed)
 /**
 	by default we don't allow user configs.
 */
-bool map_generator::allow_user_config() const
+bool map_generator::allow_user_config()
 {
 	return false;
 }

--- a/src/generators/map_generator.hpp
+++ b/src/generators/map_generator.hpp
@@ -39,7 +39,7 @@ public:
 	 * Returns true if the map generator has an interactive screen,
 	 * which allows the user to modify how the generator behaves.
 	 */
-	virtual bool allow_user_config() const;
+	virtual bool allow_user_config();
 
 	/**
 	 * Display the interactive screen, which allows the user

--- a/src/gui/dialogs/lua_interpreter.cpp
+++ b/src/gui/dialogs/lua_interpreter.cpp
@@ -122,7 +122,7 @@ public:
 		log_ << font::escape_text(lk.get_log().str()) << std::flush;
 		raw_log_ << lk.get_log().str() << std::flush;
 		// Lua kernel sends log strings to this function
-		L_.set_external_log([this](const std::string & str) {
+		L_.set_external_log([this](std::string_view str) {
 			log_ << font::escape_text(str);
 			raw_log_ << str;
 		});

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -168,7 +168,7 @@ static config unit_name(const unit *u)
 	 * The name needs to be escaped, it might be set by the user and using
 	 * markup. Also names often contain a forbidden single quote.
 	 */
-	const std::string& name = font::escape_text(u->name());
+	const std::string& name = font::escape_text(u->name().str());
 	std::ostringstream str, tooltip;
 	str << markup::bold(name);
 	tooltip << _("Name: ") << markup::bold(name);

--- a/src/scripting/lua_kernel_base.hpp
+++ b/src/scripting/lua_kernel_base.hpp
@@ -60,7 +60,7 @@ public:
 	void add_log(const char* str) { cmd_log_ << str; }
 	void clear_log() { cmd_log_.log_.str(""); cmd_log_.log_.clear(); }
 
-	using external_log_type = std::function<void(const std::string &)>;
+	using external_log_type = std::function<void(std::string_view)>;
 	void set_external_log( external_log_type lg ) { cmd_log_.external_log_ = lg; }
 
 	/** Error reporting mechanisms, used by virtual methods protected_call and load_string*/
@@ -92,7 +92,7 @@ protected:
 			, external_log_(nullptr)
 		{}
 
-		inline command_log & operator<< (const std::string & str) {
+		inline command_log & operator<< (std::string_view str) {
 			log_ << str;
 			if (external_log_) {
 				external_log_(str);

--- a/src/scripting/mapgen_lua_kernel.hpp
+++ b/src/scripting/mapgen_lua_kernel.hpp
@@ -31,14 +31,19 @@ public:
 
 	virtual std::string my_name() { return "Mapgen Lua Kernel"; }
 
-	void user_config(const char * prog, const config & generator); // throws game::lua_error
-	std::string create_map(const char * prog, const config & generator, utils::optional<uint32_t> seed); // throws game::lua_error
-	config create_scenario(const char * prog, const config & generator, utils::optional<uint32_t> seed); // throws game::lua_error
+	bool has_user_config(std::string_view file);
+	void user_config(std::string_view file, const config & generator); // throws game::lua_error
+
+	std::string create_map(std::string_view file, const config & generator, utils::optional<uint32_t> seed); // throws game::lua_error
+	config create_scenario(std::string_view file, const config & generator, utils::optional<uint32_t> seed); // throws game::lua_error
 
 	virtual uint32_t get_random_seed();
 	std::mt19937& get_default_rng();
 private:
-	void run_generator(const char * prog, const config & generator);
+	std::string return_map(); // throws game::lua_error
+	config return_scenario(); // throws game::lua_error
+	bool run_generator(std::string_view file, const char * field, const config & generator);
+
 	int intf_get_variable(lua_State *L);
 	int intf_get_all_vars(lua_State *L);
 	utils::optional<uint32_t> random_seed_;


### PR DESCRIPTION
it's now possible to register custom lua map generators that can be called like map_generation=cave or
scenario_generation=world_conquest, so that the map generation lua code no longer has to be put into the [generator] into [scenario]

This in particular makes it easier to finally remove the deprecated c++ cavegen code, but also allows us to provide an easier way to user the world_conquest map_generator.