### PR TITLE
Target Windows 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿# set minimum version
+# set minimum version
 cmake_minimum_required(VERSION 3.14)
 
 project(wesnoth)
@@ -480,7 +480,7 @@ if(NOT MSVC)
 else()
 	set(CMAKE_CXX_FLAGS "/W3 /WX /wd4503 /wd4351 /wd4250 /wd4244 /wd4267 /we4239 /wd4275 /EHsc /utf-8 /Zc:__cplusplus" CACHE STRING "Global flags used by the CXX compiler during all builds." FORCE)
 	set(CMAKE_C_FLAGS "/WX" CACHE STRING "Global flags used by the C compiler during all builds." FORCE)
-	add_definitions(-D_WIN32_WINNT=0x0601 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -DNOMINMAX)
+	add_definitions(-D_WIN32_WINNT=0x0A00 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -DNOMINMAX)
 
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_LUA")
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")

--- a/SConstruct
+++ b/SConstruct
@@ -193,7 +193,7 @@ if env['ccache']: env.Tool('ccache')
 if env['compile_db']:
     env.Tool('compilation_db')
     cdb = env.CompilationDatabase()
-    Alias('cdb', cdb) 
+    Alias('cdb', cdb)
 
 boost_version = "1.67"
 
@@ -672,7 +672,7 @@ for env in [test_env, client_env, env]:
         env[d] = os.path.join(env["prefix"], env[d])
 
     if env["PLATFORM"] == 'win32':
-        env.Append(LIBS = ["wsock32", "crypt32", "iconv", "z", "shlwapi", "winmm", "ole32", "uuid"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0601"])
+        env.Append(LIBS = ["wsock32", "crypt32", "iconv", "z", "shlwapi", "winmm", "ole32", "uuid"], CCFLAGS = ["-mthreads"], LINKFLAGS = ["-mthreads"], CPPDEFINES = ["_WIN32_WINNT=0x0A00"])
 
     if env["PLATFORM"] == 'darwin':            # Mac OS X
         env.Append(FRAMEWORKS = "Cocoa")            # Cocoa GUI

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 ### Multiplayer
 ### Lua API
 ### Packaging
+   * Windows 10 or later is now required
 ### Terrain
 ### Translations
    * Updated translations: Bengali, British English, Chinese (Simplified), Hungarian, Italian

--- a/projectfiles/CodeBlocks/campaignd.cbp
+++ b/projectfiles/CodeBlocks/campaignd.cbp
@@ -40,8 +40,8 @@
 			<Add option="-DBOOST_NO_CXX98_FUNCTION_BASE" />
 			<Add option="-DHAVE_PYTHON" />
 			<Add option="-DUSE_GZIP" />
-			<Add option="-D_WIN32_WINNT=0x0601" />
-			<Add option="-D_WIN32_IE=0x0601" />
+			<Add option="-D_WIN32_WINNT=0x0A00" />
+			<Add option="-D_WIN32_IE=0x0A00" />
 			<Add directory="../../src" />
 		</Compiler>
 		<Linker>

--- a/projectfiles/CodeBlocks/tests.cbp
+++ b/projectfiles/CodeBlocks/tests.cbp
@@ -43,8 +43,8 @@
 			<Add option="-D_GLIBCXX_USE_DEPRECATED=0" />
 			<Add option="-DBOOST_NO_CXX98_FUNCTION_BASE" />
 			<Add option="-D_WIN32_WINDOWS" />
-			<Add option="-D_WIN32_WINNT=0x0601" />
-			<Add option="-D_WIN32_IE=0x0601" />
+			<Add option="-D_WIN32_WINNT=0x0A00" />
+			<Add option="-D_WIN32_IE=0x0A00" />
 			<Add option="-DBOOST_TEST_DYN_LINK=1" />
 			<Add directory="../../src" />
 		</Compiler>

--- a/projectfiles/CodeBlocks/wesnoth.cbp
+++ b/projectfiles/CodeBlocks/wesnoth.cbp
@@ -43,8 +43,8 @@
 			<Add option="-D_GLIBCXX_USE_DEPRECATED=0" />
 			<Add option="-DBOOST_NO_CXX98_FUNCTION_BASE" />
 			<Add option="-D_WIN32_WINDOWS" />
-			<Add option="-D_WIN32_WINNT=0x0601" />
-			<Add option="-D_WIN32_IE=0x0601" />
+			<Add option="-D_WIN32_WINNT=0x0A00" />
+			<Add option="-D_WIN32_IE=0x0A00" />
 			<Add directory="../../src" />
 		</Compiler>
 		<Linker>

--- a/projectfiles/CodeBlocks/wesnothd.cbp
+++ b/projectfiles/CodeBlocks/wesnothd.cbp
@@ -40,8 +40,8 @@
 			<Add option="-DBOOST_NO_CXX98_FUNCTION_BASE" />
 			<Add option="-DHAVE_PYTHON" />
 			<Add option="-DUSE_GZIP" />
-			<Add option="-D_WIN32_WINNT=0x0601" />
-			<Add option="-D_WIN32_IE=0x0601" />
+			<Add option="-D_WIN32_WINNT=0x0A00" />
+			<Add option="-D_WIN32_IE=0x0A00" />
 			<Add directory="../../src" />
 		</Compiler>
 		<Linker>

--- a/src/desktop/windows_tray_notification.hpp
+++ b/src/desktop/windows_tray_notification.hpp
@@ -21,19 +21,6 @@
 #ifndef UNICODE
 #define UNICODE
 #endif
-//defines that mingw misses
-#ifndef _WIN32_IE
-    #define _WIN32_IE _WIN32_WINNT_WIN10 //specifying target platform to be Windows 10 and higher
-#endif
-#ifndef NIIF_USER
-    #define NIIF_USER 0x00000004
-#endif
-#ifndef NIN_BALLOONTIMEOUT
-    #define NIN_BALLOONTIMEOUT (WM_USER + 4)
-#endif
-#ifndef NIN_BALLOONUSERCLICK
-    #define NIN_BALLOONUSERCLICK (WM_USER + 5)
-#endif
 // ShellAPI.h should be included after Windows.h only!
 #include <windows.h>
 #include <shellapi.h>

--- a/src/desktop/windows_tray_notification.hpp
+++ b/src/desktop/windows_tray_notification.hpp
@@ -23,7 +23,7 @@
 #endif
 //defines that mingw misses
 #ifndef _WIN32_IE
-    #define _WIN32_IE _WIN32_WINNT_WIN7 //specifying target platform to be Windows 7 and higher
+    #define _WIN32_IE _WIN32_WINNT_WIN10 //specifying target platform to be Windows 10 and higher
 #endif
 #ifndef NIIF_USER
     #define NIIF_USER 0x00000004


### PR DESCRIPTION
As mentioned on Discord, it looks as if the ~current~ upcoming VS 17.13 release cycle will be the last, and support for targeting Windows 7 is going to be [dropped when VS 18.x comes out](https://github.com/microsoft/STL/issues/4560#issuecomment-2348622212). Additionally, boost::filesystem just dropped support for Windows versions prior to 10 with 1.87, so it seems a good a time as any to do this, especially since we're targeting 2026 for 1.20.