### PR TITLE
Fix build with boost >= 1.87.0

### DIFF
--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -738,7 +738,7 @@ void server::handle_sighup(const boost::system::error_code&, int)
 
 void server::flush_cfg()
 {
-	flush_timer_.expires_from_now(std::chrono::minutes(10));
+	flush_timer_.expires_after(std::chrono::minutes(10));
 	flush_timer_.async_wait(std::bind(&server::handle_flush, this, std::placeholders::_1));
 }
 

--- a/src/server/common/forum_user_handler.cpp
+++ b/src/server/common/forum_user_handler.cpp
@@ -210,7 +210,7 @@ std::string fuh::get_tournaments(){
 	return conn_.get_tournaments();
 }
 
-void fuh::async_get_and_send_game_history(boost::asio::io_service& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
+void fuh::async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) {
 	boost::asio::post([this, &s, socket, player_id, offset, &io_service, search_game_name, search_content_type, search_content] {
 		boost::asio::post(io_service, [socket, &s, doc = conn_.get_game_history(player_id, offset, search_game_name, search_content_type, search_content)]{
 			s.send_to_player(socket, *doc);
@@ -238,7 +238,7 @@ void fuh::db_set_oos_flag(const std::string& uuid, int game_id){
 	conn_.set_oos_flag(uuid, game_id);
 }
 
-void fuh::async_test_query(boost::asio::io_service& io_service, int limit) {
+void fuh::async_test_query(boost::asio::io_context& io_service, int limit) {
 	boost::asio::post([this, limit, &io_service] {
 		ERR_UH << "async test query starts!";
 		int i = conn_.async_test_query(limit);

--- a/src/server/common/forum_user_handler.hpp
+++ b/src/server/common/forum_user_handler.hpp
@@ -133,7 +133,7 @@ public:
 	 * @param search_content_type The content type to query for (ie: scenario)
 	 * @param search_content Query for games using this content ID. Supports leading and/or trailing wildcards.
 	 */
-	void async_get_and_send_game_history(boost::asio::io_service& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content);
+	void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content);
 
 	/**
 	 * Inserts game related information.
@@ -203,7 +203,7 @@ public:
 	 * @param io_service The boost io_service to use to post the query results back to the main boost::asio thread.
 	 * @param limit How many recursions to make in the query.
 	 */
-	void async_test_query(boost::asio::io_service& io_service, int limit);
+	void async_test_query(boost::asio::io_context& io_service, int limit);
 
 	/**
 	 * Checks whether a forum thread with @a topic_id exists.

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -39,6 +39,9 @@
 #ifndef _WIN32
 #include <boost/asio/read_until.hpp>
 #endif
+#ifndef BOOST_NO_EXCEPTIONS
+#include <boost/exception/diagnostic_information.hpp>
+#endif
 
 #include <iostream>
 #include <queue>

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -31,7 +31,7 @@
 #include "serialization/unicode_cast.hpp"
 #endif
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #ifndef _WIN32
 #include <boost/asio/posix/stream_descriptor.hpp>
@@ -136,7 +136,7 @@ public:
 protected:
 	unsigned short port_;
 	bool keep_alive_;
-	boost::asio::io_service io_service_;
+	boost::asio::io_context io_service_;
 	boost::asio::ssl::context tls_context_ { boost::asio::ssl::context::sslv23 };
 	bool tls_enabled_ { false };
 	boost::asio::ip::tcp::acceptor acceptor_v6_;

--- a/src/server/common/user_handler.hpp
+++ b/src/server/common/user_handler.hpp
@@ -21,7 +21,7 @@ class config;
 
 #include <string>
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 
 #include "server/wesnothd/player_connection.hpp"
 
@@ -126,13 +126,13 @@ public:
 
 	virtual std::string get_uuid() = 0;
 	virtual std::string get_tournaments() = 0;
-	virtual void async_get_and_send_game_history(boost::asio::io_service& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
+	virtual void async_get_and_send_game_history(boost::asio::io_context& io_service, wesnothd::server& s, any_socket_ptr socket, int player_id, int offset, std::string& search_game_name, int search_content_type, std::string& search_content) =0;
 	virtual void db_insert_game_info(const std::string& uuid, int game_id, const std::string& version, const std::string& name, int reload, int observers, int is_public, int has_password) = 0;
 	virtual void db_update_game_end(const std::string& uuid, int game_id, const std::string& replay_location) = 0;
 	virtual void db_insert_game_player_info(const std::string& uuid, int game_id, const std::string& username, int side_number, int is_host, const std::string& faction, const std::string& version, const std::string& source, const std::string& current_user, const std::string& leaders) = 0;
 	virtual unsigned long long db_insert_game_content_info(const std::string& uuid, int game_id, const std::string& type, const std::string& name, const std::string& id, const std::string& addon_id, const std::string& addon_version) = 0;
 	virtual void db_set_oos_flag(const std::string& uuid, int game_id) = 0;
-	virtual void async_test_query(boost::asio::io_service& io_service, int limit) = 0;
+	virtual void async_test_query(boost::asio::io_context& io_service, int limit) = 0;
 	virtual bool db_topic_id_exists(int topic_id) = 0;
 	virtual void db_insert_addon_info(const std::string& instance_version, const std::string& id, const std::string& name, const std::string& type, const std::string& version, bool forum_auth, int topic_id, const std::string uploader) = 0;
 	virtual unsigned long long db_insert_login(const std::string& username, const std::string& ip, const std::string& version) = 0;

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -25,6 +25,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include <boost/coroutine/exceptions.hpp>
+
 static lg::log_domain log_server("server");
 #define ERR_GAME LOG_STREAM(err, log_server)
 #define WRN_GAME LOG_STREAM(warn, log_server)

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -298,14 +298,14 @@ void server::handle_graceful_timeout(const boost::system::error_code& error)
 		process_command("msg All games ended. Shutting down now. Reconnect to the new server instance.", "system");
 		BOOST_THROW_EXCEPTION(server_shutdown("graceful shutdown timeout"));
 	} else {
-		timer_.expires_from_now(1s);
+		timer_.expires_after(1s);
 		timer_.async_wait(std::bind(&server::handle_graceful_timeout, this, std::placeholders::_1));
 	}
 }
 
 void server::start_lan_server_timer()
 {
-	lan_server_timer_.expires_from_now(lan_server_);
+	lan_server_timer_.expires_after(lan_server_);
 	lan_server_timer_.async_wait([this](const boost::system::error_code& ec) { handle_lan_server_shutdown(ec); });
 }
 
@@ -2133,7 +2133,7 @@ void server::shut_down_handler(
 		acceptor_v6_.close();
 		acceptor_v4_.close();
 
-		timer_.expires_from_now(10s);
+		timer_.expires_after(10s);
 		timer_.async_wait(std::bind(&server::handle_graceful_timeout, this, std::placeholders::_1));
 
 		process_command(
@@ -2164,7 +2164,7 @@ void server::restart_handler(const std::string& issuer_name,
 		graceful_restart = true;
 		acceptor_v6_.close();
 		acceptor_v4_.close();
-		timer_.expires_from_now(10s);
+		timer_.expires_after(10s);
 		timer_.async_wait(std::bind(&server::handle_graceful_timeout, this, std::placeholders::_1));
 
 		start_new_server();


### PR DESCRIPTION
Boost 1.87.0 removes some functions that have been deprecated for a few releases, but are still used in wesnoth.