### PR TITLE
EI: forbid dunefolk from taking the Plague Staff and add custom rejection messages

### DIFF
--- a/changelog_entries/ei-dialogue-fixes.md
+++ b/changelog_entries/ei-dialogue-fixes.md
@@ -1,5 +1,5 @@
 ### Campaigns
    * Eastern Invasion
-    * S04c: give Mal-Ravanal gold to recruit more units when their army becomes too small
-    * forbid all Dunefolk units to take the Plague Staff
-    * fix minor bugs with dialogues
+     * S04c: give Mal-Ravanal gold to recruit more units when their army becomes too small
+     * forbid all Dunefolk units to take the Plague Staff
+     * fix minor bugs with dialogues

--- a/changelog_entries/ei-dialogue-fixes.md
+++ b/changelog_entries/ei-dialogue-fixes.md
@@ -1,0 +1,5 @@
+### Campaigns
+   * Eastern Invasion
+    * S04c: give Mal-Ravanal gold to recruit more units when their army becomes too small
+    * forbid all Dunefolk units to take the Plague Staff
+    * fix minor bugs with dialogues

--- a/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
@@ -423,34 +423,15 @@
                     time=750
                 [/delay]
 
-                [if]
-                    {VARIABLE_CONDITIONAL plague_staff_wielder_id equals "Hahid al-Ali"}
-                    [then]
-                        [message]
-                            speaker=Konrad
-                            image=portraits/konrad_II.webp
-                            #po: the player chose to give Hahid the plague staff
-                            message= _ "Southerner, <i>necromancer</i>, know that Wesnoth will never tolerate your kind. You shall surrender that accursed stave to be destroyed, you shall foreswear the practice of all magic on penalty of death, and you are hereby exiled back to the desert wastes. Be grateful for Our mercy."
-                        [/message]
-                        [message]
-                            speaker=Hahid al-Ali
-                            message= _ "Bah, I save you barbarians from an invasion, and this is the thanks I get! What happened to being paid thrice what I’m owed? So much for northerner generosity!"
-                        [/message]
-                        {CLEAR_VARIABLE plague_staff_wielder_id}
-                    [/then]
-
-                    [else]
-                        [message]
-                            speaker=Konrad
-                            image=portraits/konrad_II.webp
-                            message= _ "Hahid al-Ali, We know of your far-off people, but great distance has caused little contact between us. May it be thus no longer. If you accept, We would appoint you as ambassador between our two realms."
-                        [/message]
-                        [message]
-                            speaker=Hahid al-Ali
-                            message= _ "Me, ambassador to the barbarian kingdoms, what a thought! I am honored, and would be even more honored to learn that the job comes with... excellent pay I hope?"
-                        [/message]
-                    [/else]
-                [/if]
+                [message]
+                    speaker=Konrad
+                    image=portraits/konrad_II.webp
+                    message= _ "Hahid al-Ali, We know of your far-off people, but great distance has caused little contact between us. May it be thus no longer. If you accept, We would appoint you as ambassador between our two realms."
+                [/message]
+                [message]
+                    speaker=Hahid al-Ali
+                    message= _ "Me, ambassador to the barbarian kingdoms, what a thought! I am honored, and would be even more honored to learn that the job comes with... excellent pay I hope?"
+                [/message]
             [/then]
         [/if]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/18_Epilogue.cfg
@@ -315,50 +315,30 @@
                     time=750
                 [/delay]
 
+                [message]
+                    speaker=Konrad
+                    image=portraits/konrad_II.webp
+                    message= _ "Dolburras, Owaec has told me of the help you provided his men; both your skill at arms and your tenacious spirit. We wish to offer you this finely crafted shield — an heirloom of my line — and an honor guard as you return to Knalga."
+                [/message]
                 [if]
-                    {VARIABLE_CONDITIONAL plague_staff_wielder_id equals Dolburras}
+                    [have_unit]
+                        id=Owaec
+                    [/have_unit]
+
                     [then]
                         [message]
-                            speaker=Konrad
-                            image=portraits/konrad_II.webp
-                            #po: the player chose to give Dolburras the plague staff
-                            message= _ "Dwarf, <i>necromancer</i>, know that Wesnoth will never tolerate your kind. You shall surrender that accursed stave to be destroyed, you shall foreswear the practice of all magic on penalty of death, and you are hereby exiled from Wesnoth. Be grateful for Our mercy."
-                        [/message]
-                        [message]
                             speaker=Dolburras
-                            #po: "Yeah, fair enough. I don't think my kinsmen will look kindly upon necromancies either."
-                            message= _ "Aye, fair enough. I dinnae think my kinsmen will look kindly upon necromancies either."
+                            #po: "Aye, I am honored. You have my sincerest thanks, your Majesty."
+                            message= _ "Aye, I be honored. Ye have my sincerest thanks, yer Majesty."
                         [/message]
-                        {CLEAR_VARIABLE plague_staff_wielder_id}
                     [/then]
 
                     [else]
                         [message]
-                            speaker=Konrad
-                            image=portraits/konrad_II.webp
-                            message= _ "Dolburras, Owaec has told me of the help you provided his men; both your skill at arms and your tenacious spirit. We wish to offer you this finely crafted shield — an heirloom of my line — and an honor guard as you return to Knalga."
+                            speaker=Dolburras
+                            #po: Owaec's dead
+                            message= _ "Aye, I be honored. I only wish he were here to see the Clans avenged."
                         [/message]
-                        [if]
-                            [have_unit]
-                                id=Owaec
-                            [/have_unit]
-
-                            [then]
-                                [message]
-                                    speaker=Dolburras
-                                    #po: "Aye, I am honored. You have my sincerest thanks, your Majesty."
-                                    message= _ "Aye, I be honored. Ye have my sincerest thanks, yer Majesty."
-                                [/message]
-                            [/then]
-
-                            [else]
-                                [message]
-                                    speaker=Dolburras
-                                    #po: Owaec's dead
-                                    message= _ "Aye, I be honored. I only wish he were here to see the Clans avenged."
-                                [/message]
-                            [/else]
-                        [/if]
                     [/else]
                 [/if]
             [/then]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -782,12 +782,89 @@ plague_staff #enddef
 <i><b>6x3 impact</b></i> damage, <i>plague</i>."
     {NOTE_REUSEABLE}
     (
-        [message]
-            speaker=unit
-            message=_"I will not wield such a dark magical artifact, though I shall not begrudge its use by my companions."
-        [/message]
+        [switch]
+            variable=unit.id
+            [case]
+                value=Owaec
+                [message]
+                    speaker=unit
+                    message=_"OWAEC REJECTION MESSAGE"
+                [/message]
+            [/case]
+            [case]
+                value=Gweddry
+                [message]
+                    speaker=unit
+                    message=_"GWEDDRY REJECTION MESSAGE"
+                [/message]
+            [/case]
+            [case]
+                value=Dacyn
+                [message]
+                    speaker=unit
+                    message=_"DACYN REJECTION MESSAGE"
+                [/message]
+            [/case]
+            [case]
+                value=Hahid al-Ali
+                [message]
+                    speaker=unit
+                    message=_"HAHID REJECTION MESSAGE"
+                [/message]
+            [/case]
+            [case]
+                value=Terraent
+                [message]
+                    speaker=unit
+                    message=_"TERRAENT REJECTION MESSAGE"
+                [/message]
+            [/case]
+            [case]
+                value=Konrad
+                [message]
+                    speaker=unit
+                    message=_"KONRAD REJECTION MESSAGE"
+                [/message]
+            [/case]
+            [else]
+                [switch]
+                    variable=unit.type_adv_tree
+                    [case]
+                        value=White Mage
+                        [message]
+                            speaker=unit
+                            message=_"WHITE_MAGE REJECTION MESSAGE"
+                        [/message]
+                    [/case]
+                    [case]
+                        value=Paladin
+                        [message]
+                            speaker=unit
+                            message=_"PALADIN REJECTION MESSAGE"
+                        [/message]
+                    [/case]
+                    [else]
+                        [switch]
+                            variable=unit.race
+                            [case]
+                                value=dunefolk
+                                [message]
+                                    speaker=unit
+                                    message=_"DUNEFOLK REJECTION MESSAGE"
+                                [/message]
+                            [/case]
+                            [else]
+                                [message]
+                                    speaker=unit
+                                    message=_"I will not wield such a dark magical artifact, though I shall not begrudge its use by my companions."
+                                [/message]
+                            [/else]
+                        [/switch]
+                    [/else]
+                [/switch]
+            [/else]
+        [/switch]
     )
-    # this message makes no sense for Dacyn (his entire quest is to get a dark magical artifact), but I couldn't think of something good and generic that works for everyone.
     (
         [effect]
             apply_to=new_attack

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -769,14 +769,10 @@ plague_staff #enddef
 
         [not]
             type_adv_tree=White Mage,Paladin
-
-            [not]
-                id=Dacyn
-            [/not]
         [/not]
 
         [not]
-            id=Owaec,Gweddry,Dacyn,Hahid al-Ali,Terraent,Konrad
+            id=Owaec,Gweddry,Dacyn,Terraent,Konrad
         [/not]
         # messes with existing recruiting, and messes with the S18 cutscene
         # if Dacyn gets this, it also breaks his scripted advancements (and his S17a recruitment)

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -70,10 +70,7 @@
             [/then]
 
             [else]
-                [message]
-                    speaker=unit
-                    message={INVALID_DESC}
-                [/message]
+                {INVALID_DESC}
             [/else]
         [/if]
     [/event]
@@ -139,7 +136,7 @@ crystal_quiver #enddef
     _"Crystal Quiver"
     _"Arrows from this crystalline quiver glimmer with a pale magical light, <i><b>illuminating</b></i> the surrounding area and making your bow or crossbow attacks <i><b>arcane</b></i>."
     {NOTE_REUSEABLE}
-    ""
+    ()
     (
         [effect]
             apply_to=new_ability
@@ -181,7 +178,7 @@ holy_amulet_3 #enddef
     _"Holy Amulet"
     _"Engraved with a consecrated symbol, this amulet will bless both your <i><b>melee</b></i> and <i><b>ranged</b></i> attacks with <i><b>arcane</b></i> damage."
     {NOTE_REUSEABLE}
-    ""
+    ()
     (
         [effect]
             apply_to=new_ability
@@ -216,7 +213,7 @@ sentinel #enddef
     _"Shield of the Sentinel"
     _"Deep within this shield’s towering bulk, enchanted machinery whirrs faintly. Whenever an adjacent ally is hit by an attack, <i><b>this shield’s bearer is hit instead</b></i>."
     {NOTE_REUSEABLE}
-    ""
+    ()
     (
         [effect]
             apply_to=overlay
@@ -568,7 +565,7 @@ yeti_steak #enddef
     _"Yetiburger"
     _"Eating this funny tasting meat <i><b>doubles your hitpoints</b></i> and grants <i><b>immunity to cold</b></i>."
     {NOTE_SINGLE_USE}
-    ""
+    ()
     (
         [effect]
             apply_to=hitpoints
@@ -598,7 +595,7 @@ yeti_steak #enddef
 
 <i><b><span color='#FF0000'>-1</span> damage, <span color='#FF0000'>-1</span> movement, <span color='#00FF00'>+10</span> hitpoints</b></i>."
     {NOTE_SINGLE_USE}
-    ""
+    ()
     (
         [effect]
             apply_to=movement
@@ -631,7 +628,7 @@ baneblade #enddef
     _"This incorporeal sword resembles those wielded by undead wraiths. Any mortal brave enough to wield it becomes <i><b>chaotic</b></i> and lashes out at their foes with reckless abandon.
 <i><b>6x4 arcane</b></i> damage, <i><b>drains</b></i>, <i><b>berserk</b></i>."
     {NOTE_REUSEABLE}
-    ""
+    ()
     (
         [effect]
             apply_to=attack
@@ -696,7 +693,7 @@ potion_of_barkskin #enddef
     _"Potion of Barkskin"
     _"This potion bubbles as though over an open flame, yet is cool to the touch. Its drinker gains the <i><b>steadfast</b></i> ability and can <i><b>heal 2 hitpoints each turn</b></i>, like dwarves with the ‘healthy’ trait."
     {NOTE_SINGLE_USE}
-    ""
+    ()
     (
         [effect]
             apply_to=new_ability
@@ -728,7 +725,7 @@ ring_of_invisibility #enddef
     _"Ring of Invisibility"
     _"This plain gold ring looks unremarkable, but its wearer gains <i><b>skirmisher</b></i> and <i><b>nightstalk</b></i>, becoming invisible in the dark."
     {NOTE_REUSEABLE}
-    ""
+    ()
     (
         [effect]
             apply_to=new_ability
@@ -784,7 +781,12 @@ plague_staff #enddef
     _"Looted from a dead necromancer, the wielder of this dark staff becomes <i><b>chaotic</b></i>, and can <i><b>recruit and recall</b></i> Walking Corpses and Soulless.
 <i><b>6x3 impact</b></i> damage, <i>plague</i>."
     {NOTE_REUSEABLE}
-    _"I will not wield such a dark magical artifact, though I shall not begrudge its use by my companions."
+    (
+        [message]
+            speaker=unit
+            message=_"I will not wield such a dark magical artifact, though I shall not begrudge its use by my companions."
+        [/message]
+    )
     # this message makes no sense for Dacyn (his entire quest is to get a dark magical artifact), but I couldn't think of something good and generic that works for everyone.
     (
         [effect]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -857,7 +857,7 @@ plague_staff #enddef
                                 value=dunefolk
                                 [message]
                                     speaker=unit
-                                    message=_"DUNEFOLK REJECTION MESSAGE"
+                                    message=_"Fighting your northerners’ foul magic is bad enough. Don’t expect me to wield that — civilized cultures don’t mess around with magic."
                                 [/message]
                             [/case]
                             [else]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -823,7 +823,7 @@ plague_staff #enddef
                 value=Konrad
                 [message]
                     speaker=unit
-                    message=_"...what foul thing is this? Remove it from my presence; such things shall not take root under my watch."
+                    message=_"...what foul thing is this? Remove it from my presence; necromancy shall not take root in Wesnoth, not under my watch."
                 [/message]
             [/case]
             [else]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -788,42 +788,42 @@ plague_staff #enddef
                 value=Owaec
                 [message]
                     speaker=unit
-                    message=_"OWAEC REJECTION MESSAGE"
+                    message=_"Do not insult me! No clansman will ever stoop to such black magic."
                 [/message]
             [/case]
             [case]
                 value=Gweddry
                 [message]
                     speaker=unit
-                    message=_"GWEDDRY REJECTION MESSAGE"
+                    message=_"I already have an army of human soldiers — living soldiers. Let someone else use this staff."
                 [/message]
             [/case]
             [case]
                 value=Dacyn
                 [message]
                     speaker=unit
-                    message=_"DACYN REJECTION MESSAGE"
+                    message=_"Tempting! Most tempting... but I fear it would be unwise for me to wield such a thing. That privilege passes onto another."
                 [/message]
             [/case]
             [case]
                 value=Hahid al-Ali
                 [message]
                     speaker=unit
-                    message=_"HAHID REJECTION MESSAGE"
+                    message=_"Ha! Good joke! I’m not about to mess around with any of your foul northerner magic; necromancy was the cause of all this trouble in the first place."
                 [/message]
             [/case]
             [case]
                 value=Terraent
                 [message]
                     speaker=unit
-                    message=_"TERRAENT REJECTION MESSAGE"
+                    message=_"I serve the light, not this staff of foul darkness! We should cast away this thing and be done with it."
                 [/message]
             [/case]
             [case]
                 value=Konrad
                 [message]
                     speaker=unit
-                    message=_"KONRAD REJECTION MESSAGE"
+                    message=_"...what foul thing is this? Remove it from my presence; such things shall not take root under my watch."
                 [/message]
             [/case]
             [else]
@@ -833,21 +833,21 @@ plague_staff #enddef
                         value=White Mage
                         [message]
                             speaker=unit
-                            message=_"WHITE_MAGE REJECTION MESSAGE"
+                            message=_"No. I serve that which is good and light, and will not wield such a dark magical artifact."
                         [/message]
                     [/case]
                     [case]
                         value=Mage of Light
                         [message]
                             speaker=unit
-                            message=_"MAGE_OF_LIGHT REJECTION MESSAGE"
+                            message=_"No. I serve that which is good and light, and will not wield such a dark magical artifact."
                         [/message]
                     [/case]
                     [case]
                         value=Paladin
                         [message]
                             speaker=unit
-                            message=_"PALADIN REJECTION MESSAGE"
+                            message=_"No. I serve that which is good and light, and will not wield such a dark magical artifact."
                         [/message]
                     [/case]
                     [else]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -830,21 +830,7 @@ plague_staff #enddef
                 [switch]
                     variable=unit.type
                     [case]
-                        value=White Mage
-                        [message]
-                            speaker=unit
-                            message=_"No. I serve that which is good and light, and will not wield such a dark magical artifact."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=Mage of Light
-                        [message]
-                            speaker=unit
-                            message=_"No. I serve that which is good and light, and will not wield such a dark magical artifact."
-                        [/message]
-                    [/case]
-                    [case]
-                        value=Paladin
+                        value=White Mage,Mage of Light,Paladin
                         [message]
                             speaker=unit
                             message=_"No. I serve that which is good and light, and will not wield such a dark magical artifact."

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -828,12 +828,19 @@ plague_staff #enddef
             [/case]
             [else]
                 [switch]
-                    variable=unit.type_adv_tree
+                    variable=unit.type
                     [case]
                         value=White Mage
                         [message]
                             speaker=unit
                             message=_"WHITE_MAGE REJECTION MESSAGE"
+                        [/message]
+                    [/case]
+                    [case]
+                        value=Mage of Light
+                        [message]
+                            speaker=unit
+                            message=_"MAGE_OF_LIGHT REJECTION MESSAGE"
                         [/message]
                     [/case]
                     [case]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -764,6 +764,10 @@ plague_staff #enddef
     {ID_PLAGUE_STAFF}  _"staff"  items/plague-staff.png  {X}  {Y}
     (
         [not]
+            race=dunefolk
+        [/not]
+
+        [not]
             type_adv_tree=White Mage,Paladin
 
             [not]


### PR DESCRIPTION
Fixes #9627 . I've also added a changelog entry for my previous PR #9637 where I forgot to add one.

The INVALID_DESC parameter in PLACE_ITEM macro is now supposed to contain WML code rather than a single string. It should be at least a single [message] tag. Correspondingly, I replaced empty strings for this parameter with empty parentheses. This way I don't need to change a lot of code in the macro (which may break other items). However, that means that if the code is changed in the future, you need to make sure there's no contradictions between the code in REQUIREMENTS and in INVALID_DESC.

The unreachable dialogue in S18 (for the cases when Dolburras or Hahid wear the staff) is removed.

I have verified that different units produce different rejection messages, but I didn't fill the messages themselves, so this is a draft PR. @Dalas121 , as you are the author of this campaign, can you write Plague Staff rejection messages for:

* Individual units
  * Owaec
  * Gweddry
  * Dacyn
  * Hahid
  * Terraent
  * Konrad
* Unit types
  * White Mage
  * Mage of light
  * Paladin
* Races
  * Dunefolk

Of course some of them may be identical. I left the original message as a fallback in case no other specific messages were selected.