### PR TITLE
Fix a possible recursion error involving [has_attack]

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1519,7 +1519,7 @@ namespace { // Helpers for attack_type::special_active()
 
 
 		attack_type::recursion_guard filter_lock;
-		if (weapon && (filter_child->optional_child("has_attack") || filter_child->optional_child("filter_weapon"))) {
+		if (weapon && filter_child->optional_child("filter_weapon")) {
 			filter_lock  = weapon->update_variables_recursion(filter);
 			if(!filter_lock) {
 				show_recursion_warning(weapon, filter);
@@ -1532,6 +1532,14 @@ namespace { // Helpers for attack_type::special_active()
 				return false;
 		}
 
+		unit::recursion_guard u_filter_lock;
+		if (filter_child->optional_child("has_attack")) {
+			u_filter_lock = u->update_variables_recursion(filter);
+			if(!u_filter_lock) {
+				show_recursion_warning(*u, filter);
+				return false;
+			}
+		}
 		// Passed.
 		// If the other unit doesn't exist, try matching without it
 		if (!u2) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1870,8 +1870,6 @@ public:
 	bool ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const;
 
 
-private:
-
 	/**
 	 * Helper similar to std::unique_lock for detecting when calculations such as abilities
 	 * have entered infinite recursion.
@@ -1909,6 +1907,8 @@ private:
 	};
 
 	recursion_guard update_variables_recursion(const config& ability) const;
+
+private:
 
 	const std::set<std::string> checking_tags_{"disable", "attacks", "damage", "chance_to_hit", "berserk", "swarm", "drains", "heal_on_hit", "plague", "slow", "petrifies", "firststrike", "poison", "damage_type"};
 	/**


### PR DESCRIPTION
I noticed that when using [has_attack], o does not necessarily track the attack used, and that if the unit checked does not use an attack, the recursion count does not work.