### PR TITLE
remove [side] leader=

### DIFF
--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -42,7 +42,6 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 	, savegame_gender_()
 	, original_faction_(get_default_faction(side)["faction"].str())
 	, original_recruit_(utils::split(get_default_faction(side)["recruit"].str()))
-	, choose_faction_by_leader_(side["leader"].str())
 	, saved_game_(saved_game)
 	, has_no_recruits_(original_recruit_.empty() && side["previous_recruits"].empty())
 	, faction_lock_(side["faction_lock"].to_bool(lock_settings))
@@ -452,10 +451,6 @@ int flg_manager::find_suitable_faction() const
 		// Choose based on recruit.
 		find = original_recruit_;
 		search_field = "recruit";
-	} else if(!choose_faction_by_leader_.empty()) {
-		// Choose based on leader.
-		find.push_back(choose_faction_by_leader_);
-		search_field = "leader";
 	} else {
 		find.push_back("Custom");
 		search_field = "id";

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -114,7 +114,6 @@ private:
 	std::string savegame_gender_;
 	const std::string original_faction_;
 	const std::vector<std::string> original_recruit_;
-	const std::string choose_faction_by_leader_;
 	const bool saved_game_;
 	const bool has_no_recruits_;
 

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -105,7 +105,6 @@ const std::set<std::string> team::attributes {
 	"faction_lock",
 	"gold_lock",
 	"income_lock",
-	"leader",
 	"leader_lock",
 	"random_leader",
 	"team_lock",


### PR DESCRIPTION
previously the leader= attribute in [side] could be used to make the engine choose a faction by its leader, similar to how [side]faction_from_recruit worked.

However this was not documented in the wiki, and the name clash with the [side][leader] subtag could also cause problems and is also a litte confusing.

So it was decided to remove it. an alternative approach to fix the name clash would be to rename it, but i can't think of real usecases of this feature currently.