### PR TITLE
Dwarvish Explorer: reduce resistances from 20% to 10%

### DIFF
--- a/changelog_entries/explorer_resistance_nerf.md
+++ b/changelog_entries/explorer_resistance_nerf.md
@@ -1,0 +1,2 @@
+ ### Units
+   * Dwarvish Explorer: physical resists reduced from 20% to 10%, melee damage increased from 10 to 11.

--- a/data/core/units/dwarves/Explorer.cfg
+++ b/data/core/units/dwarves/Explorer.cfg
@@ -34,11 +34,12 @@
     [/attack]
     [attack]
         name=axe
-        description= _"axe"
+        description= _"battle axe"
         type=blade
         range=ranged
-        damage=9
-        number=4
+        damage=11
+        number=3
+        icon=attacks/battleaxe.png
     [/attack]
     [attack_anim]
         [filter_attack]

--- a/data/core/units/dwarves/Explorer.cfg
+++ b/data/core/units/dwarves/Explorer.cfg
@@ -7,6 +7,11 @@
     profile="portraits/dwarves/explorer.webp"
     hitpoints=60
     movement_type=dwarvishfoot
+    [resistance]
+        blade=90
+        pierce=90
+        impact=90
+    [/resistance]
     movement=5
     experience=150
     level=3
@@ -14,17 +19,16 @@
     advances_to=null
     {AMLA_DEFAULT}
     cost=51
-    usage=scout
+    usage=mixed fighter
     description= _ "Dwarvish Explorers are peerless survivalists. Using only the equipment they carry, they can range for months around the forests and mountains looking for new seams of ore and deposits of minerals. Whilst their skill in a melee is less than some other dwarves, they are unmatched with throwing axes, having practiced this skill hunting in the mountains. Their maneuverability makes them dangerous and tricky foes."
     die_sound={SOUND_LIST:DWARF_DIE}
-    #weakened from 12 damage to 10 damage
     {DEFENSE_ANIM "units/dwarves/explorer-defend-2.png" units/dwarves/explorer-defend-1.png {SOUND_LIST:DWARF_HIT} }
     [attack]
-        name=battle axe
+        name=axe
         description= _"battle axe"
         type=blade
         range=melee
-        damage=10
+        damage=11
         number=3
         icon=attacks/battleaxe.png
     [/attack]
@@ -33,8 +37,8 @@
         description= _"axe"
         type=blade
         range=ranged
-        damage=11
-        number=3
+        damage=9
+        number=4
     [/attack]
     [attack_anim]
         [filter_attack]

--- a/data/core/units/dwarves/Explorer.cfg
+++ b/data/core/units/dwarves/Explorer.cfg
@@ -24,7 +24,7 @@
     die_sound={SOUND_LIST:DWARF_DIE}
     {DEFENSE_ANIM "units/dwarves/explorer-defend-2.png" units/dwarves/explorer-defend-1.png {SOUND_LIST:DWARF_HIT} }
     [attack]
-        name=axe
+        name=battle axe
         description= _"battle axe"
         type=blade
         range=melee

--- a/data/core/units/dwarves/Explorer.cfg
+++ b/data/core/units/dwarves/Explorer.cfg
@@ -34,12 +34,11 @@
     [/attack]
     [attack]
         name=axe
-        description= _"battle axe"
+        description= _"axe"
         type=blade
         range=ranged
         damage=11
         number=3
-        icon=attacks/battleaxe.png
     [/attack]
     [attack_anim]
         [filter_attack]

--- a/data/core/units/dwarves/Pathfinder.cfg
+++ b/data/core/units/dwarves/Pathfinder.cfg
@@ -18,7 +18,7 @@
     alignment=neutral
     advances_to=Dwarvish Explorer
     cost=24
-    usage=scout
+    usage=mixed fighter
     description= _ "These hardy dwarves are sometimes away from their caves for long periods, scouting and patrolling the borders. They spend this time watching for invaders, and fighting bandits and thieves who encroach on dwarvish territory. They are powerful fighters in a melee, and from a distance their deftly thrown axes can rival the power and accuracy of a human archer."
     die_sound={SOUND_LIST:DWARF_DIE}
     #weakened from 9 damage to 8 damage


### PR DESCRIPTION
The Dwarvish Scout and Pathfinder have 10% resistance to Blade/Pierce/Impact, but the Explorer has 20%. The Explorer's 20% resistance removes one of the unit line's unique attributes, and also makes him even more similar to the Dragonguard than he already was.

This PR lowers the Explorer's resistances to match the rest of the unit line, and moderately improves their damage in compensation.

I don't mean to make the unit as a whole significantly stronger or weaker, nor do I mean to change their role or affect the balance of existing content. I do mean to reduce one area of similarity between the Explorer and Dragonguard, and to emphasize the Scout/Pathfinder's unique identity as a 10%-resistance dwarf.

The Dwarvish Scout's usage is currently set to 'mixed fighter'. This PR also changes the Pathfinder/Explorer's usage to 'mixed fighter', which is a better reflection of their stats than 'scout'.