### PR TITLE
Improve unit filters in scenario end dialogue

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -915,7 +915,7 @@
                     [/then]
 
                     [else]
-                        {FIND_NEARBY (type,side=Knight,1) 36 15 99}
+                        {FIND_NEARBY (trait,side=survivor,1) 36 15 99}
                     [/else]
                 [/if]
                 [message]
@@ -924,7 +924,6 @@
                 [/message]
 
                 {FIND_NEARBY (
-                    type=Knight,Terraent
                     side=8
                 ) 36 15 99}
                 [message]


### PR DESCRIPTION
In case victory is achieved with, for example, only one knight freed, who also advanced to Paladin or Great Knight. Then the message "We cannot leave my companions behind" doesn't appear. This PR fixes it.

The filter will now use the survivor trait instead of the type, like it's done in the achievement-related code a few lines below. No other units with this trait appear until S13

Also remove unit type filter for side 8 because it's redundant - all side 8 units are of those types.