### PR TITLE
EI S04c: avoid contradictory dialogue if Ravanal is triggered early

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -665,6 +665,12 @@
             side=4
             amount={ON_DIFFICULTY 15 45 75} # otherwise his armies start to feel a little thin around now
         [/gold]
+        [fire_event]
+            name=dacyn_warning
+        [/fire_event]
+    [/event]
+    [event]
+        name=dacyn_warning
         [message]
             speaker=Dacyn
             message= _ "Gweddry, we should not be here. They are merely toying with us right now, but all will be lost if Mal-Ravanal finds me amongst you!"
@@ -688,6 +694,9 @@
     [event]
         name=ravanal_gets_serious
 
+        [fire_event]
+            name=dacyn_warning
+        [/fire_event]
         {REPLACE_SCENARIO_MUSIC silence.ogg}
         [message]  # if you change this, also change 06b_Soradoc
             speaker=Mal-Ravanal


### PR DESCRIPTION
The problem is, if `ravanal_gets_serious` event is triggered before turn 8, then Dacyn's words in `turn 8` event:
> all will be lost if Mal-Ravanal finds me amongst you

are nonsense - as Ravanal has already found him.

To fix this, I put Dacyn saying those words into a separate single-use event `dacyn_warning`, and trigger it either in `turn 8` or in the beginning of `ravanal_gets_serious`, whichever happens earlier. 