### PR TITLE
EI S5: reduce code duplication

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -517,6 +517,38 @@
     [/event]
 
     [event]
+        name=owaec_joins
+
+        [capture_village]
+            owner_side=2
+            side=1
+        [/capture_village]
+        [modify_unit]
+            [filter]
+                side=2
+            [/filter]
+
+            side=1
+            moves=$($this_unit.max_moves)
+            attacks_left=1
+            {TEAM_COLOR_OVERRIDE () blue}
+        [/modify_unit]
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message= _ "(You may now recruit Horsemen and Cavalrymen!)"
+        [/message]
+        [set_extra_recruit] # need to set recruits per-unit (instead of per-side) so we don't mess up the plague staff
+            id=Gweddry
+            extra_recruit={REGULAR_RECRUIT_LIST}
+        [/set_extra_recruit]
+        [set_extra_recruit]
+            id=Owaec
+            extra_recruit={REGULAR_RECRUIT_LIST}
+        [/set_extra_recruit]
+    [/event]
+
+    [event]
         name=capture
         first_time_only=no
 
@@ -718,34 +750,9 @@
                     speaker=Owaec
                     message= _ "Huzzah!! At last, these villagers are liberated! Gweddry, thank you for your aid. I place my Clansmen and myself at your service."
                 [/message]
-                [capture_village]
-                    owner_side=2
-                    side=1
-                [/capture_village]
-                [modify_unit]
-                    [filter]
-                        side=2
-                    [/filter]
-
-                    side=1
-                    moves=$($this_unit.max_moves)
-                    attacks_left=1
-                    {TEAM_COLOR_OVERRIDE () blue}
-                [/modify_unit]
-                [message]
-                    speaker=narrator
-                    image=wesnoth-icon.png
-                    message= _ "(You may now recruit Horsemen and Cavalrymen!)"
-                [/message]
-                [set_extra_recruit] # need to set recruits per-unit (instead of per-side) so we don't mess up the plague staff
-                    id=Gweddry
-                    extra_recruit={REGULAR_RECRUIT_LIST}
-                [/set_extra_recruit]
-                [set_extra_recruit]
-                    id=Owaec
-                    extra_recruit={REGULAR_RECRUIT_LIST}
-                [/set_extra_recruit]
-
+                [fire_event]
+                    name=owaec_joins
+                [/fire_event]
                 [if]
                     [not]
                         [have_unit]
@@ -879,33 +886,9 @@
                     speaker=Owaec
                     message= _ "Huzzah!! May these be the first of many undead to fall before our hooves! Gweddry, thank you for your aid. I place my Clansmen and myself at your service."
                 [/message]
-                [capture_village]
-                    owner_side=2
-                    side=1
-                [/capture_village]
-                [modify_unit]
-                    [filter]
-                        side=2
-                    [/filter]
-
-                    side=1
-                    moves=$($this_unit.max_moves)
-                    attacks_left=1
-                    {TEAM_COLOR_OVERRIDE () blue}
-                [/modify_unit]
-                [message]
-                    speaker=narrator
-                    image=wesnoth-icon.png
-                    message= _ "(You may now recruit Horsemen and Cavalrymen!)"
-                [/message]
-                [set_extra_recruit] # need to set recruits per-unit (instead of per-side) so we don't mess up the plague staff
-                    id=Gweddry
-                    extra_recruit={REGULAR_RECRUIT_LIST}
-                [/set_extra_recruit]
-                [set_extra_recruit]
-                    id=Owaec
-                    extra_recruit={REGULAR_RECRUIT_LIST}
-                [/set_extra_recruit]
+                [fire_event]
+                    name=owaec_joins
+                [/fire_event]
                 [message]
                     speaker=Owaec
                     message= _ "Now let us free these villagers from the outlaws terrorizing them!"


### PR DESCRIPTION
The code for Owaec's side joining the player was duplicated, so I moved it into a custom event. This involves only the code merging the sides, without any dialogues.

There is no changes in behavior.

An alternative would be to join the `die` events like
```
[event]
        name=die
        [filter]
            id=Shodrano,Rilaka
        [/filter]
```
but then it would require 2-3 `[if]` blocks inside for differing dialogues and actions, so it would be less readable.