### PR TITLE
Improve keyboard navigation in MP Method Selection dialog

### DIFF
--- a/data/gui/themes/default/window/mp_method_selection.cfg
+++ b/data/gui/themes/default/window/mp_method_selection.cfg
@@ -5,7 +5,7 @@
 
 [window]
 	id = "mp_method_selection"
-	description = "Language selection dialog."
+	description = "Multiplayer playing mode selection dialog."
 
 	[resolution]
 		definition = "default"
@@ -40,17 +40,31 @@
 				grow_factor = 0
 
 				[column]
-					grow_factor = 1
+					horizontal_grow = true
+					[grid]
+						[row]
+							[column]
+								grow_factor = 1
 
-					border = "all"
-					border_size = 5
-					horizontal_alignment = "left"
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "left"
 
-					[label]
-						definition = "title"
-						label = _ "Multiplayer"
-					[/label]
+								[label]
+									definition = "title"
+									label = _ "Multiplayer"
+								[/label]
+							[/column]
+							[column]
+								horizontal_alignment = "right"
 
+								[button]
+									id = "cancel"
+									definition = "close"
+								[/button]
+							[/column]
+						[/row]
+					[/grid]
 				[/column]
 
 			[/row]

--- a/src/gui/dialogs/multiplayer/mp_method_selection.cpp
+++ b/src/gui/dialogs/multiplayer/mp_method_selection.cpp
@@ -22,7 +22,6 @@
 #include "gui/widgets/button.hpp"
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/text_box.hpp"
-#include "gui/widgets/window.hpp"
 #include "preferences/preferences.hpp"
 
 namespace gui2::dialogs
@@ -30,20 +29,20 @@ namespace gui2::dialogs
 
 REGISTER_DIALOG(mp_method_selection)
 
+/** Link to the wesnoth forum account registration page */
 static const std::string forum_registration_url = "https://forums.wesnoth.org/ucp.php?mode=register";
 
 void mp_method_selection::pre_show()
 {
-	user_name_ = prefs::get().login();
-
 	text_box* user_widget = find_widget<text_box>("user_name", false, true);
-	user_widget->set_value(user_name_);
+	user_widget->set_value(prefs::get().login());
 	user_widget->set_maximum_length(mp::max_login_size);
 
-	keyboard_capture(user_widget);
-
 	listbox* list = find_widget<listbox>("method_list", false, true);
-	add_to_keyboard_chain(list);
+	list->select_row(prefs::get().mp_connect_type());
+
+	add_to_tab_order(list);
+	add_to_tab_order(user_widget);
 
 	connect_signal_mouse_left_click(find_widget<button>("register"),
 		std::bind(&desktop::open_object, forum_registration_url));
@@ -51,16 +50,18 @@ void mp_method_selection::pre_show()
 
 void mp_method_selection::post_show()
 {
-	if(get_retval() == retval::OK) {
-		listbox& list = find_widget<listbox>("method_list");
-		choice_ = static_cast<choice>(list.get_selected_row());
+	prefs::get().set_mp_connect_type(find_widget<listbox>("method_list").get_selected_row());
 
+	if(get_retval() == retval::OK) {
 		text_box& user_widget = find_widget<text_box>("user_name");
 		user_widget.save_to_history();
-
-		user_name_ = user_widget.get_value();
-		prefs::get().set_login(user_name_);
+		prefs::get().set_login(user_widget.get_value());
 	}
+}
+
+mp_method_selection::choice mp_method_selection::get_choice() const
+{
+	return static_cast<choice>(prefs::get().mp_connect_type());
 }
 
 } // namespace dialogs

--- a/src/gui/dialogs/multiplayer/mp_method_selection.hpp
+++ b/src/gui/dialogs/multiplayer/mp_method_selection.hpp
@@ -27,27 +27,13 @@ public:
 	enum class choice { JOIN = 0, CONNECT, HOST, LOCAL };
 
 	mp_method_selection()
-		: modal_dialog(window_id()) , user_name_(), choice_()
+		: modal_dialog(window_id())
 	{
 	}
 
-	const std::string& user_name() const
-	{
-		return user_name_;
-	}
-
-	choice get_choice() const
-	{
-		return choice_;
-	}
+	choice get_choice() const;
 
 private:
-	/** The name to use on the MP server. */
-	std::string user_name_;
-
-	/** The selected method to `connect' to the MP server. */
-	choice choice_;
-
 	virtual const std::string& window_id() const override;
 
 	virtual void pre_show() override;

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -551,6 +551,7 @@ public:
 	PREF_GETTER_SETTER(mp_era, std::string, std::string(""))
 	PREF_GETTER_SETTER(mp_level, std::string, std::string(""))
 	PREF_GETTER_SETTER(mp_level_type, int, 0)
+	PREF_GETTER_SETTER(mp_connect_type, int, 0)
 	PREF_GETTER_SETTER(skip_ai_moves, bool, false)
 	PREF_GETTER_SETTER(save_replays, bool, true)
 	PREF_GETTER_SETTER(delete_saves, bool, false)
@@ -752,6 +753,7 @@ private:
 		prefs_list::mp_countdown_turn_bonus,
 		prefs_list::mp_fog,
 		prefs_list::mp_level_type,
+		prefs_list::mp_connect_type,
 		prefs_list::mp_random_start_time,
 		prefs_list::mp_server_warning_disabled,
 		prefs_list::mp_shroud,

--- a/src/preferences/preferences_list.hpp
+++ b/src/preferences/preferences_list.hpp
@@ -176,6 +176,8 @@ struct preferences_list_defines
 	ADDPREF(mp_level)
 	/** most recently selected type of game: scenario, campaign, random map, etc */
 	ADDPREF(mp_level_type)
+	/** most recently selected mp playing mode/connection type */
+	ADDPREF(mp_connect_type)
 	/** list of the last selected multiplayer modifications */
 	ADDPREF(mp_modifications)
 	/** whether to use a random start time for the scenario */
@@ -448,6 +450,7 @@ struct preferences_list_defines
 		minimap_movement_coding,
 		minimap_terrain_coding,
 		moved_orb_color,
+		mp_connect_type,
 		mp_countdown,
 		mp_countdown_action_bonus,
 		mp_countdown_init_time,


### PR DESCRIPTION
Allows method selection using arrow keys once again (Resolves #9501).

Adds Tab ordering to the MP method selection dialog. Initially the method list has focus so method can be selected using Left/Right keys. To change username, the player just needs to press Tab once to move focus to the Login textbox.
Additionally, the layout and message is adjusted a bit and @ProditorMagnus's suggestion of remembering the last connection method has been implemented. (https://github.com/wesnoth/wesnoth/issues/9501#issuecomment-2560330243)
Also, a close button has been added so that the window can be close using mouse once again.

![Screenshot from 2025-01-07 09-38-47](https://github.com/user-attachments/assets/a011cd08-1c92-47c4-88e7-2c044bf8d089)

(Changed from initial idea of removing the login textbox based on feedback received on Discord/IRC.)