### PR TITLE
EI S04c: clear dangling variables

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/04c_Mal-Ravanals_Capital.cfg
@@ -577,6 +577,7 @@
         [/message]
         {KILL (type=Dark Shape)}
         {RAVANAL_POSSESS 37 15 (x,y=40,15) (sw)}
+        {CLEAR_VARIABLE possessee}
         [message]
             speaker=Mal-Ravanal
             message= _ "Well paladin, this has been amusing, but apparently we have a new group of guests to entertain. Back into the cage with you."
@@ -645,6 +646,7 @@
         {GENERIC_UNIT 5 ({ON_DIFFICULTY Wraith Spectre Spectre}) $possessee.x $possessee.y} {ANIMATE}
         {GENERIC_UNIT 5 ({ON_DIFFICULTY Wraith Wraith Spectre}) $possessee.x $possessee.y} {ANIMATE}
         {GENERIC_UNIT 5 ({ON_DIFFICULTY Wraith Spectre Spectre}) $possessee.x $possessee.y} {ANIMATE}
+        {CLEAR_VARIABLE dead_ravanal,possessee}
 
         [message]
             speaker=Mal-Ravanal


### PR DESCRIPTION
These variables are not used later, so they may be cleared. Otherwise they appear uselessly in later scenarios.
- `dead_ravanal` variable is used in this scenario only
- `possessee` may be kept to use in `RAVANAL_DEPOSSESS`, but this macro is not used in this scenario