### PR TITLE
Change boost download link in flatpak to archive.boost.io

### DIFF
--- a/packaging/flatpak/org.wesnoth.Wesnoth.json
+++ b/packaging/flatpak/org.wesnoth.Wesnoth.json
@@ -34,7 +34,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2",
+                    "url": "https://archives.boost.io/release/1.67.0/source/boost_1_67_0.tar.bz2",
                     "sha256": "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba"
                 }
             ],


### PR DESCRIPTION
because artifactory is down too much and they plan to move away from it
anyway.
