### PR TITLE
extend tag_name check to has_attack using a class similar to recursion_guard

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -292,7 +292,6 @@
 # Have Bob attack Alice during side 2's turn
 ##
 # Expected end state:
-# BROKE STRICT due to infinite recursion.
 # The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
 #####
 {COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1526,9 +1526,13 @@ namespace { // Helpers for attack_type::special_active()
 				return false;
 			}
 		}
+		attack_type::tag_name_guard tag_name_lock;
+		if (weapon && (filter_child->optional_child("has_attack") || filter_child->optional_child("filter_weapon"))) {
+			tag_name_lock  = weapon->update_variables_tag_name(check_if_recursion);
+		}
 		// Check for a weapon match.
 		if (auto filter_weapon = filter_child->optional_child("filter_weapon") ) {
-			if ( !weapon || !weapon->matches_filter(*filter_weapon, check_if_recursion) )
+			if ( !weapon || !weapon->matches_filter(*filter_weapon) )
 				return false;
 		}
 
@@ -1570,6 +1574,10 @@ unit_ability_list attack_type::get_weapon_ability(const std::string& ability) co
 
 unit_ability_list attack_type::get_specials_and_abilities(const std::string& special) const
 {
+	const std::string& check_if_recursion = !open_tag_name_.empty() ? open_tag_name_.front() : "";
+	if(check_if_recursion == special){
+		return {};
+	}
 	// get all weapon specials of the provided type
 	unit_ability_list abil_list = get_specials(special);
 	// append all such weapon specials as abilities as well

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -392,7 +392,7 @@
 0 damage_secondary_type_test
 0 damage_type_apply_to_both_filter_self_opponent
 0 damage_type_apply_to_attacker_filter_attacker_defender
-9 event_test_filter_damage_type_recursion
+0 event_test_filter_damage_type_recursion
 9 four_cycle_recursion_branching
 9 four_cycle_recursion_by_id
 9 four_cycle_recursion_by_tagname


### PR DESCRIPTION
It annoys me that the tag_name check for filter_weapon doesn't work for has_attack and that it's recursion_guard that prevents infinite recursion (with error message in log), so I decided to reuse a similar method to solve of infinite recursion.

In addition to solving the has_attack problem, its implementation opens the possibility to create new attributes in [filter_weapo/attack] like a real_number that would check the number of attacks actually used (and not just the base number without attacks or swarm)