### PR TITLE
Ei s06a death events

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -539,9 +539,11 @@
                 [/show_objectives]
             [/then]
             [else]
-                [fire_event]
-                    name=victory
-                [/fire_event]
+                [endlevel]
+                    result=victory
+                    bonus=yes
+                    {NEW_GOLD_CARRYOVER 40}
+                [/endlevel]
             [/else]
         [/if]
     [/event]
@@ -576,9 +578,11 @@
                 [/show_objectives]
             [/then]
             [else]
-                [fire_event]
-                    name=victory
-                [/fire_event]
+                [endlevel]
+                    result=victory
+                    bonus=yes
+                    {NEW_GOLD_CARRYOVER 40}
+                [/endlevel]
             [/else]
         [/if]
     [/event]
@@ -599,9 +603,11 @@
                 [/show_objectives]
             [/then]
             [else]
-                [fire_event]
-                    name=victory
-                [/fire_event]
+                [endlevel]
+                    result=victory
+                    bonus=yes
+                    {NEW_GOLD_CARRYOVER 40}
+                [/endlevel]
             [/else]
         [/if]
     [/event]
@@ -612,11 +618,6 @@
             speaker=Dacyn
             message= _ "If we intend to save Wesnoth, we must press onward into the mountains. Let us be off."
         [/message]
-        [endlevel]
-            result=victory
-            bonus=yes
-            {NEW_GOLD_CARRYOVER 40}
-        [/endlevel]
     [/event]
 
     [event]

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -82,6 +82,9 @@
                 side=2
                 count={ON_DIFFICULTY 0-6 0-8 0-10}
             [/have_unit]
+            [have_unit]
+                id=Mal-un-Karad
+            [/have_unit]
         [/filter_condition]
         [message]
             speaker=Mal-un-Karad

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -573,6 +573,7 @@
 
         [filter]
             id=Dolburras
+            side=4
         [/filter]
 
         [if]

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -74,7 +74,6 @@
     # when undead army has been whittled down, pull back to the central island
     [event]
         name=die
-        first_time_only=no
         [filter]
             side=2
         [/filter]
@@ -84,12 +83,6 @@
                 count={ON_DIFFICULTY 0-6 0-8 0-10}
             [/have_unit]
         [/filter_condition]
-        [fire_event]
-            name=undead_retreat
-        [/fire_event]
-    [/event]
-    [event]
-        name=undead_retreat
         [message]
             speaker=Mal-un-Karad
             message= _ "Fine, you can have the south shore! I’m going to stay nice and safe in my castle."

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -315,27 +315,6 @@
     [/event]
 
     [event]
-        name=last breath
-
-        [filter]
-            id=Dolburras
-            side=4
-        [/filter]
-
-        [message]
-            speaker=Dolburras
-            message= _ "Glug... glug..."
-        [/message]
-        [remove_item]
-            x,y=18,6
-        [/remove_item]
-
-        # modify id so its death no longer fire events
-        {MODIFY_UNIT (id=dolburras_jailer) id former_jailer}
-        {MODIFY_UNIT (id=former_jailer) max_moves 5}
-    [/event]
-
-    [event]
         name=spawn creatures
 
         [message]
@@ -452,6 +431,8 @@
         [/fire_event]
     [/event]
 
+    # victory is only when Dolburras is saved/dead and Mal-un-Karad is dead
+
     [event]
         name=last breath
 
@@ -464,8 +445,6 @@
             message= _ "No! I thought I’d be safe here..."
         [/message]
     [/event]
-
-    # victory is only when Dolburras is saved/dead and Mal-un-Karad is dead
     [event]
         name=die
 
@@ -498,6 +477,20 @@
             [/else]
         [/if]
     [/event]
+
+    [event]
+        name=last breath
+
+        [filter]
+            id=Dolburras
+            side=4
+        [/filter]
+
+        [message]
+            speaker=Dolburras
+            message= _ "Glug... glug..."
+        [/message]
+    [/event]
     [event]
         name=die
 
@@ -505,6 +498,14 @@
             id=Dolburras
             side=4
         [/filter]
+
+        [remove_item]
+            x,y=18,6
+        [/remove_item]
+
+        # modify id so its death no longer fire events
+        {MODIFY_UNIT (id=dolburras_jailer) id former_jailer}
+        {MODIFY_UNIT (id=former_jailer) max_moves 5}
 
         # kill immediately so we can spawn corpse
         {KILL id=Dolburras}

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -329,59 +329,10 @@
         [remove_item]
             x,y=18,6
         [/remove_item]
-        {MODIFY_UNIT (type=Banebow) max_moves 5}
-    [/event]
 
-    # dwarf is rescued
-    [event]
-        name=die
-
-        [filter]
-            id=dolburras_jailer
-        [/filter]
-
-        [if]
-            [have_unit]
-                id=Dolburras
-            [/have_unit]
-
-            [then]
-                [remove_item]
-                    x,y=18,6
-                [/remove_item]
-                [remove_event]
-                    id=harm_dolburras
-                [/remove_event]
-                [message]
-                    speaker=Dolburras
-                    #po: "Many thanks to you! Feels go to be finally breathing properly again."
-                    message= _ "Many thanks ta ye! Feels good ta be finally breathin’ proper again."
-                [/message]
-                [message]
-                    speaker=Gweddry
-                    message= _ "How did you come to be captured by these undead?"
-                [/message]
-                [message]
-                    speaker=Dolburras
-                    #po: "Ran into a whole blasted army of them marching from the Swamp of Dread. I think they're headed for Knalga! Someone ought to invade them for a change."
-                    message= _ "Ran into a whole blasted army of ’em marchin’ from the Swamp o’ Dread. I think they be headed for Knalga! Someone oughta invade them for a change."
-                [/message]
-                [message]
-                    speaker=Owaec
-                    message= _ "By the Clans! Do these undead mean to conquer all the world?"
-                [/message]
-                [message]
-                    speaker=Gweddry
-                    message= _ "Dolburras, we are men of the King of Wesnoth, seeking the power to destroy these foul undead. Will you join us in our quest?"
-                [/message]
-                [message]
-                    speaker=Dolburras
-                    #po: "Can't hardly go back to Knalga with all of the undead about! Yes, I'll join you."
-                    message= _ "Kinna hardly go back ta Knalga with all them undead about! Aye, I’ll join ye."
-                [/message]
-                {MODIFY_UNIT (side=4) side 1}
-            [/then]
-        [/if]
+        # modify id so its death no longer fire events
+        {MODIFY_UNIT (id=dolburras_jailer) id former_jailer}
+        {MODIFY_UNIT (id=former_jailer) max_moves 5}
     [/event]
 
     [event]
@@ -586,6 +537,8 @@
             [/else]
         [/if]
     [/event]
+
+    # dwarf is rescued
     [event]
         name=die
 
@@ -593,6 +546,40 @@
             id=dolburras_jailer
         [/filter]
 
+        [remove_item]
+            x,y=18,6
+        [/remove_item]
+        [remove_event]
+            id=harm_dolburras
+        [/remove_event]
+        [message]
+            speaker=Dolburras
+            #po: "Many thanks to you! Feels go to be finally breathing properly again."
+            message= _ "Many thanks ta ye! Feels good ta be finally breathin’ proper again."
+        [/message]
+        [message]
+            speaker=Gweddry
+            message= _ "How did you come to be captured by these undead?"
+        [/message]
+        [message]
+            speaker=Dolburras
+            #po: "Ran into a whole blasted army of them marching from the Swamp of Dread. I think they're headed for Knalga! Someone ought to invade them for a change."
+            message= _ "Ran into a whole blasted army of ’em marchin’ from the Swamp o’ Dread. I think they be headed for Knalga! Someone oughta invade them for a change."
+        [/message]
+        [message]
+            speaker=Owaec
+            message= _ "By the Clans! Do these undead mean to conquer all the world?"
+        [/message]
+        [message]
+            speaker=Gweddry
+            message= _ "Dolburras, we are men of the King of Wesnoth, seeking the power to destroy these foul undead. Will you join us in our quest?"
+        [/message]
+        [message]
+            speaker=Dolburras
+            #po: "Can't hardly go back to Knalga with all of the undead about! Yes, I'll join you."
+            message= _ "Kinna hardly go back ta Knalga with all them undead about! Aye, I’ll join ye."
+        [/message]
+        {MODIFY_UNIT (side=4) side 1}
         [if]
             [have_unit]
                 id=Mal-un-Karad

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -220,7 +220,7 @@
             message= _ "Let me out ’o this cage ye bag-o-bones! When the Alliance hears abo— <b>glug</b>"
         [/message]
         [fire_event]
-            name=side 1 turn end
+            id=harm_dolburras
         [/fire_event]
         [message]
             speaker=Mal-un-Karad
@@ -300,22 +300,18 @@
     [event]
         name=side 1 turn end
         first_time_only=no
-        [if]
-            {VARIABLE_CONDITIONAL dolburras_rescued not_equals yes}
-            [then]
-                [harm_unit]
-                    [filter]
-                        id=Dolburras
-                    [/filter]
+        id=harm_dolburras
+        [harm_unit]
+            [filter]
+                id=Dolburras
+            [/filter]
 
-                    amount={ON_DIFFICULTY 4 4 4} # rest healing is disabled
-                    animate=yes
-                    fire_event=yes
-                [/harm_unit]
-                {MODIFY_UNIT id=Dolburras status.slowed yes}
-                {MODIFY_UNIT id=Dolburras resting no}
-            [/then]
-        [/if]
+            amount={ON_DIFFICULTY 4 4 4} # rest healing is disabled
+            animate=yes
+            fire_event=yes
+        [/harm_unit]
+        {MODIFY_UNIT id=Dolburras status.slowed yes}
+        {MODIFY_UNIT id=Dolburras resting no}
     [/event]
 
     [event]
@@ -323,21 +319,17 @@
 
         [filter]
             id=Dolburras
+            side=4
         [/filter]
 
-        [if]
-            {VARIABLE_CONDITIONAL dolburras_rescued not_equals yes}
-            [then]
-                [message]
-                    speaker=Dolburras
-                    message= _ "Glug... glug..."
-                [/message]
-                [remove_item]
-                    x,y=18,6
-                [/remove_item]
-                {MODIFY_UNIT (type=Banebow) max_moves 5}
-            [/then]
-        [/if]
+        [message]
+            speaker=Dolburras
+            message= _ "Glug... glug..."
+        [/message]
+        [remove_item]
+            x,y=18,6
+        [/remove_item]
+        {MODIFY_UNIT (type=Banebow) max_moves 5}
     [/event]
 
     # dwarf is rescued
@@ -357,7 +349,9 @@
                 [remove_item]
                     x,y=18,6
                 [/remove_item]
-                {VARIABLE dolburras_rescued yes}
+                [remove_event]
+                    id=harm_dolburras
+                [/remove_event]
                 [message]
                     speaker=Dolburras
                     #po: "Many thanks to you! Feels go to be finally breathing properly again."

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -336,19 +336,6 @@
                     x,y=18,6
                 [/remove_item]
                 {MODIFY_UNIT (type=Banebow) max_moves 5}
-
-                # kill immediately so we can spawn corpse
-                {KILL id=Dolburras ANIMATE=yes FIRE_EVENT=yes}
-                [sound]
-                    name=zombie-attack.wav
-                [/sound]
-
-                {GENERIC_UNIT 2 (Walking Corpse) 18 6} {VARIATION dwarf}
-
-                [message]
-                    speaker=Owaec
-                    message= _ "I have failed in my duty to protect the helpless. I weep at his passing."
-                [/message]
             [/then]
         [/if]
     [/event]
@@ -571,6 +558,19 @@
             id=Dolburras
             side=4
         [/filter]
+
+        # kill immediately so we can spawn corpse
+        {KILL id=Dolburras}
+        [sound]
+            name=zombie-attack.wav
+        [/sound]
+
+        {GENERIC_UNIT 2 (Walking Corpse) 18 6} {VARIATION dwarf}
+
+        [message]
+            speaker=Owaec
+            message= _ "I have failed in my duty to protect the helpless. I weep at his passing."
+        [/message]
 
         [if]
             [have_unit]


### PR DESCRIPTION
This PR fixes several issues with death-related events in this scenario. It's easier to explain commit-by-commit.

# Commit 1

It fixes a simple bug: if we rescue Dolburras and then he dies, the objectives are shown. But objectives don't change at this moment, so it's unneeded.

# Commit 2

This is a small code simplification, without changes in behavior. The repeatable `die` event has only one action - to fire the non-repeatable `undead_retreat` event (which isn't fired anywhere else). So we can merge them into one non-repeatable event.

# Commit 3

This one fixes the bug which happens when Mal-un-Karad himself is the unit whose death triggers the retreat event (by dropping the side 2 unit count below the difficulty-dependent threshold). In a real game this is unlikely to happen unless you specifically try to do so. The problem is, he says his message even though his death animation has already played and his corpse disappeared from the hex. In https://wiki.wesnoth.org/EventWML#die it says

> Note: The primary unit is not removed from the game until the end of this event. The primary unit can still be manipulated, will block other units from taking its hex, and will still be found by standard unit filters (except [have_unit]). To prevent this behavior, you can use [kill] to remove the unit immediately. However, this will stop any (still unfired) other events that also match the unit from firing afterwards, so use with caution.

The actions of this event are the message (should not happen in this case), changes in recruit list (don't matter after the leader is dead), and changes in AI retreating back to castle. I thought whether the AI changes should happen in this case or not, and I think they're not:

1. Without the leader there's no one to order the retreat.
2. It doesn't make sense for undead to rush back to guard a leaderless castle.
3. It's not nice to the player if the enemy behaviour happens without any message or logical explanation.

The `have_unit` filter I added only matches units with greater than zero HP, so it won't match in the Mal-un-Karad's own `die` event.

# Commit 4

This one requires a longer explanation. I noticed that if you either

- kill Dolburras with `Shift-K` on the first turn
- or use `:unit hitpoints=1` on him on the first turn so he drowns after you end the turn

both this scenarios trigger the undead retreat event, which is weird (it's triggered by side 2 deaths, and Dolburras is side 4).

I ended up adding the following debug code (not included in PR commits) to see which events are triggered:

```
[event]
    name=last_breath
    first_time_only=no
    [message]
        speaker=narrator
        message=_"last breath | id = $unit.id | side = $unit.side"
    [/message]
[/event]
[event]
    name=die
    first_time_only=no
    [message]
        speaker=narrator
        message=_"die | id = $unit.id | side = $unit.side"
    [/message]
[/event]
```

In both cases, this showed the following messages:

```
last breath | id = Dolburras | side = 4
last breath | id = Dolburras | side = 4
die | id = Dolburras | side = 4
die | id = Walking Corpse-441 | side = 2
```

So what I think happens is:

1. Dolburras's `last_breath` is triggered normally.
2. Within it, the action `{KILL id=Dolburras ANIMATE=yes FIRE_EVENT=yes}` fires Dolburras's `last_breath` and `die` event once again. But because out custom `last_breath` is non-repeatable, it's already removed from the scenario's event list at that point, so it doesn't fire recursively.
2. Within the same `last_breath`, the action `{GENERIC_UNIT 2 (Walking Corpse) 18 6} {VARIATION dwarf}` creates a new unit at the same coordinates where Dolburras was.
3. After our customized `last_breath` is finished, it triggers the `die` event for a unit currently at the same coordinates - the walking corpse (but doesn't actually kill him). If we change the coordiantes where the walking corpse is created, this event still happens, but without a unit bound to it: `die | id =  | side = `

In actual game, this won't cause problems (because creating the walking corpse actually increases the unit count). But it could if the event conditions were different. In any case, this is an error-prone way. So I moved the code into Dolburras's `die` event; I also had to remove arguments from `KILL` macro for the animation to be correct.

I've checked other scenarios, and I don't think there's such a bug anywhere else. It requires killing the original unit and replacing it with another at the same coordinates, all inside the `last_breath` event, and that new unit must match at least one of the `die` events present in the scenatio. 

# Commit 5

We don't actually need `dolburras_rescued` variable, instead we can check if such a unit exists for side 4. This simplifies the code.

# Commit 6

I've noticed that this scenatio uses a non-standard way to end the level: it calls `[fire_event] name=victory [/fire_event]`, and has the `[endlevel]` tag inside the `victory` event. I switched it back to the standard way as in the rest of the scenarios. There is no change in behavior.

# Commit 7

Fix another simple bug: if we Dolburras drowns and then we kill the jailer, the objectives are shown unnecessarily. I fixed it by changing jailers's `id` when Dolburras drowns. Also, there are two `die` event for the jailer, and it's easier if we to merge them into one.

# Commit 8

Move `last breath` and `die` events next to each other for readability.