### PR TITLE
units dialog (recruit): use image_icon instead of image

### DIFF
--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -474,7 +474,10 @@ std::unique_ptr<units_dialog> units_dialog::build_recruit_dialog(
 		.set_row_num(recruit_list.size())
 		.show_all_headers(false)
 		.set_column("unit_image", recruit_list, [&team](const auto& recruit) {
-			std::string image_string = recruit->image();
+			std::string image_string = recruit->icon();
+			if (image_string.empty()) {
+				image_string = recruit->image();
+			}
 			image_string += "~RC(" + recruit->flag_rgb() + ">" + team.color() + ")";
 			image_string += "~SCALE_INTO(72,72)";
 			return image_string;


### PR DESCRIPTION
Resolves #9701.

As already mentioned on #9701, the `image_icon` property is documented but not used. This updated the units dialog (recruit configuration) to use it if available and fallback to `image` if necessary. The image will be scaled to 72x72px if bigger.

Quoting from [UnitTypeWML](https://wiki.wesnoth.org/UnitTypeWML#Unit_Type) wiki page:
> **image_icon**: sets the image used to represent the unit in areas such as the attack dialog and the unit image box in the sidebar. [~CROP](https://wiki.wesnoth.org/ImagePathFunctions#Crop_Function) function can be useful here. You can see Loyalists Paladin as an example.
