### PR TITLE
EI S07a: init counter variables in prestart

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07a_Capturing_the_Ogres.cfg
@@ -129,6 +129,9 @@
         {GENERIC_UNIT 2 (Young Ogre) 24 12}
         {GENERIC_UNIT 2 (Ogre) 26 13}
 
+        {VARIABLE next_ogre_escape_msg 0}
+        {VARIABLE next_ogre_capture_msg 0}
+
         [objectives]
             side=1
             [objective]
@@ -203,24 +206,13 @@
                 message= _ "Ruuuunnnn!"
             [/value]
         [/set_variables]
-
-        [if]
-            [variable]
-                name=next_ogre_escape_msg
-                equals=$empty
-            [/variable]
-            [then]
-                {VARIABLE next_ogre_escape_msg 0}
-            [/then]
-            [else]
-                {VARIABLE_OP next_ogre_escape_msg add 1}
-                {VARIABLE_OP next_ogre_escape_msg modulo $ogre_escape_msgs.length}
-            [/else]
-        [/if]
         [message]
             speaker=unit
             message=$ogre_escape_msgs[$next_ogre_escape_msg].message
         [/message]
+        {VARIABLE_OP next_ogre_escape_msg add 1}
+        {VARIABLE_OP next_ogre_escape_msg modulo $ogre_escape_msgs.length}
+
         {KILL x,y=$x1,$y1}
         {CLEAR_VARIABLE ogre_escape_msgs}
         [fire_event]
@@ -290,23 +282,13 @@
                         message= _ "$ogre_name be good will! Promise!"
                     [/value]
                 [/set_variables]
-                [if]
-                    [variable]
-                        name=next_ogre_capture_msg
-                        equals=$empty
-                    [/variable]
-                    [then]
-                        {VARIABLE next_ogre_capture_msg 0}
-                    [/then]
-                    [else]
-                        {VARIABLE_OP next_ogre_capture_msg add 1}
-                        {VARIABLE_OP next_ogre_capture_msg modulo $ogre_capture_msgs.length}
-                    [/else]
-                [/if]
                 [message]
                     x,y=$this_item.x,$this_item.y
                     message=$ogre_capture_msgs[$next_ogre_capture_msg].message
                 [/message]
+                {VARIABLE_OP next_ogre_capture_msg add 1}
+                {VARIABLE_OP next_ogre_capture_msg modulo $ogre_capture_msgs.length}
+
                 {KILL x,y=$this_item.x,$this_item.y}
                 {VARIABLE this_item.side 1}
                 [unstore_unit]


### PR DESCRIPTION
This is a small code improvement, without changes in behavior.
If we initialize these cyclic counter variables in the `prestart` event, then we don't need to check for their existence every time.
Also, to preserve the message order, increment the counters after use rather than before.