### PR TITLE
EI S06b: fix a couple of small bugs, code improvements

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
@@ -834,8 +834,8 @@
             side=1
             x,y=27,1
         [/filter]
-        {MESSAGE_IF_COUNT 4-3 unit _"I’ve broken through the undead lines. Follow me before we are overwhelmed!"}
-        {MESSAGE_IF_COUNT 2-0 unit _"The northern path is clear! Follow me, let us cross the Great River."}
+        {MESSAGE_IF_COUNT 3-4 unit _"I’ve broken through the undead lines. Follow me before we are overwhelmed!"}
+        {MESSAGE_IF_COUNT 0-2 unit _"The northern path is clear! Follow me, let us cross the Great River."}
         [endlevel]
             result=victory
             bonus=no

--- a/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
@@ -829,7 +829,6 @@
     # win when any unit reaches the north signpost
     [event]
         name=moveto
-        first_time_only=no
         [filter]
             side=1
             x,y=27,1

--- a/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
@@ -977,12 +977,6 @@
 
     [event] # once your turn is over, you can't win, so skip straight to time-over
         name=side 1 turn {SCENARIO_TURN_LIMIT} end
-        [fire_event]
-            name=time over
-        [/fire_event]
-    [/event]
-    [event]
-        name=time over
 
         {FIND_NEARBY (type=Skeleton,Skeleton Archer,Revenant,Bone Shooter,Draug,Banebow,Chocobone) 29 34 999}
         {SPAWN_IF_UNFOUND 4 (Skeleton) 28 35}
@@ -1034,10 +1028,6 @@
             animate=no
         [/kill]
         {KILL id=Dacyn ANIMATE=yes FIRE_EVENT=yes}
-
-        [fire_event]
-            name=defeat
-        [/fire_event]
     [/event]
 
     {ENEMYDEATHS_SORADOC}

--- a/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
@@ -758,18 +758,20 @@
             #po: there were originally 4 of them, and 3 are now defeated
             message= _ "That’s almost all the undead leaders defeated!"
         [/message]
-        [fire_event]
-            name=meet_yannic
-        [/fire_event]
+        [if]
+            [have_unit]
+                id=Yannic
+            [/have_unit]
+            [then]
+                [fire_event]
+                    name=meet_yannic
+                [/fire_event]
+            [/then]
+        [/if]
     [/event]
 
     [event]
         name=meet_yannic
-        [filter_condition]
-            [have_unit]
-                id=Yannic
-            [/have_unit]
-        [/filter_condition]
         [message]
             speaker=Owaec
             message= _ "Who commands this garrison? Time is short. We must evacuate what’s left of your men before—"

--- a/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06b_Soradoc.cfg
@@ -728,15 +728,11 @@
         name=moveto
         [filter]
             id=Owaec
-        [/filter]
-        [filter_condition] # if Owaec moves adjacent to Yannic
-            [have_unit]
+            # if Owaec moves adjacent to Yannic
+            [filter_adjacent]
                 id=Yannic
-                [filter_adjacent]
-                    id=Owaec
-                [/filter_adjacent]
-            [/have_unit]
-        [/filter_condition]
+            [/filter_adjacent]
+        [/filter]
         [fire_event]
             name=meet_yannic
         [/fire_event]

--- a/data/campaigns/Eastern_Invasion/utils/deaths.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/deaths.cfg
@@ -245,7 +245,7 @@
             speaker=Yannic
             message= _ "Alas, I fall..."
         [/message]
-        [if] {VARIABLE_CONDITIONAL saved_yannic equals yes}
+        [if] {VARIABLE_CONDITIONAL met_yannic equals yes}
             [or]
                 [have_unit]
                     id=Yannic


### PR DESCRIPTION
I'll explain them by commit.

## Commit 1

Write the event for moving one unit next to another in a simpler way. No behavior changes.

## Commit 2

The `meet_yannic` custom event can be fired from two other events, and one of them (Owaec moves next to Yannic) already guarantees that Yannic is alive. For another event (3 enemy leaders killed) we should check, so I moved the condition into that event. I think it makes the code more readable. No behavior changes.

## Commit 3

Fix a minor bug: Owaec's "eulogy" message for Yannic didn't appear even after they met. That's because the event used wrong variable: `saved_yannic` (which doesn't appear anywhere else) instead of `met_yannic`.

## Commit 4

Fix another bug: the message from the unit who reached the exit marker didn't appear because the engine doesn't understand reverse integer ranges.

To be precise, such "ranges" ("4-3" or "2-0") only match their first number. So, the messages appeared if there were 4 or 2 enemy leaders left, but didn't appear if there were 3, 1, or 0.

## Commit 5

This event wins the scenario, no need to declare it repeatable. No behavior changes.

## Commit 6

It's no need to make the `side 1 turn {SCENARIO_TURN_LIMIT} end` event to fire the `time over` event. All that code may reside inside the former event; that's how it's done in most scenarios in this campaign.

Also, killing Dacyn triggers the defeat anyway, so no need to trigger in manually.

No behavior changes.

The issue with firing `time over` manually is also present in S07b and S13, I'll fix that when I reach them.