### PR TITLE
image_icon rendering adjustments

### DIFF
--- a/data/core/units/monsters/Fire_Dragon.cfg
+++ b/data/core/units/monsters/Fire_Dragon.cfg
@@ -4,7 +4,7 @@
     name= _ "Fire Dragon"
     race=monster
     image="units/monsters/fire-dragon.png"
-    image_icon="units/monsters/fire-dragon.png~CROP(0,0,160,160)"
+    image_icon="units/monsters/fire-dragon.png~CROP(8,10,144,144)"
     profile="portraits/monsters/fire-dragon.webp"
     {DEFENSE_ANIM_RANGE "units/monsters/fire-dragon.png" "units/monsters/fire-dragon.png" {SOUND_LIST:DRAKE_HIT} melee}
     [abilities]

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -5,7 +5,7 @@
     #not 'race=monster', because we need the not_living attribute
     race=undead
     image="units/monsters/skeletal-dragon/skeletal-dragon.png"
-    image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(0,0,160,160)"
+    image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(14,10,144,144)"
     hitpoints=98
     movement_type=undeadfly
     movement=5

--- a/data/gui/themes/default/dialogs/units_dialog.cfg
+++ b/data/gui/themes/default/dialogs/units_dialog.cfg
@@ -153,10 +153,22 @@
 									horizontal_grow = true
 									vertical_alignment = "center"
 
-									[image]
+									[drawing]
 										id = "unit_image"
+										definition = "default"
 										linked_group = "image"
-									[/image]
+										width = 72
+										height = 72
+
+										[draw]
+											[image]
+												name = "(text)"
+												w = "(width)"
+												h = "(height)"
+												resize_mode = "scale_sharp"
+											[/image]
+										[/draw]
+									[/drawing]
 								[/column]
 
 								[column]

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -23,10 +23,8 @@
 #include "gui/dialogs/message.hpp"
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/button.hpp"
-#include "gui/widgets/image.hpp"
 #include "gui/widgets/label.hpp"
 #include "gui/widgets/menu_button.hpp"
-#include "gui/widgets/styled_widget.hpp"
 #include "gui/widgets/text_box.hpp"
 #include "gui/widgets/toggle_button.hpp"
 #include "gui/widgets/unit_preview_pane.hpp"
@@ -469,7 +467,6 @@ std::unique_ptr<units_dialog> units_dialog::build_recruit_dialog(
 			image_string = recruit->image();
 		}
 		image_string += "~RC(" + recruit->flag_rgb() + ">" + team.color() + ")";
-		image_string += "~SCALE_INTO(72,72)";
 		return image_string;
 	}, sort_type::none);
 


### PR DESCRIPTION
1. Fire and Skeletal Dragon's image_icon is now cropped to 144x144px instead of 160x160px value, since image_icon is supposed to be used in places that have either 72x72px or 144x144px drawing area. This avoids non-integral scaling.
2. Units Dialog scaling moved to cfg, since it's easier to change without compiling.

Additionally, the `image_icon` documentation in [the wiki page for Unit Type WML](https://wiki.wesnoth.org/UnitTypeWML) will be adjusted based on this PR. Namely, the `image_icon`s are recommended to have dimensions that are integral multiples of 72x72 (such as 72x72 or 144x144) since the Unit Preview Panel has a `[drawing]` which is 144x144px. The list in recruit/create dialog is now 72x72px, so the recommended values will avoid non-integral scaling.

![Screenshot from 2025-01-13 18-58-59](https://github.com/user-attachments/assets/72a3af28-8ef6-4d54-84e1-7c1993ba987b)

(Related: #9701 and #9702)