### PR TITLE
EI S07b: fix bugs, code improvements

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -828,7 +828,15 @@
             speaker=Izziasch
             message= _ "Curssessss!"
         [/message]
-        {KILL id=Izziasch}
+    [/event]
+
+    [event]
+        name=die
+
+        [filter]
+            id=Izziasch
+        [/filter]
+
         [if]
             [have_unit]
                 side=1

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -811,7 +811,7 @@
         first_time_only=no
 
         [filter]
-            id=Mal-Mana,Mal-Talar,ghast_leader,Naken-alvak,Izziasch
+            id=Mal-Mana,Mal-Talar,ghast_leader,Naken-alvak
         [/filter]
 
         {VARIABLE_OP leader_kills add 1}
@@ -856,6 +856,7 @@
             [/else]
         [/if]
 
+        {VARIABLE_OP leader_kills add 1}
         [if]
             {VARIABLE_CONDITIONAL leader_kills equals 5}
             [then]

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -885,12 +885,6 @@
 
     [event]
         name=side 1 turn {SCENARIO_TURN_LIMIT} end
-        [fire_event]
-            name=time over
-        [/fire_event]
-    [/event]
-    [event]
-        name=time over
         {GENERIC_UNIT 6 (Revenant)        1 2} {ANIMATE}
         {GENERIC_UNIT 6 (Banebow)         1 1} {ANIMATE}
         {GENERIC_UNIT 6 (Skeleton)        3 1} {ANIMATE}
@@ -909,6 +903,9 @@
             speaker=Dacyn
             message= _ "We are caught as well..."
         [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
     [/event]
 
     {ENEMYDEATHS_SORADOC}

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -263,7 +263,9 @@
         #
         # introduce the ogres
         #
-        {SCROLL_TO 99 0}
+        [scroll_to_unit]
+            id=Grug
+        [/scroll_to_unit]
         [message]
             speaker=Owaec
             #po: This is the first time the protagonists have seen ogres; the routes through the campaign go through exactly one of S07a or S07b.

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -806,8 +806,9 @@
         name=prestart
         {VARIABLE leader_kills 0}
     [/event]
+
     [event]
-        name=last breath
+        name=die
         first_time_only=no
 
         [filter]

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -875,7 +875,7 @@
                 [/set_achievement]
             [/then]
         [/if]
-        {CLEAR_VARIABLE leader_kills,saved_Garnad}
+        {CLEAR_VARIABLE leader_kills}
         [endlevel]
             result=victory
             bonus=yes

--- a/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/07b_Ogre_Crossing.cfg
@@ -546,17 +546,10 @@
         {CLEAR_VARIABLE Mal_Talar}
 
         # let them attack to prevent spawncamping, but limit movement
-        {VARIABLE limit_moves_4 yes}
-    [/event]
-    [event]
-        name=side 4 turn refresh
-
-        [filter_condition]
-            {VARIABLE_CONDITIONAL limit_moves_4 equals yes}
-        [/filter_condition]
-
-        {MODIFY_UNIT side=4 moves 2}
-        {CLEAR_VARIABLE limit_moves_4}
+        [event]
+            name=side 4 turn refresh
+            {MODIFY_UNIT side=4 moves 2}
+        [/event]
     [/event]
 
     #--------------------
@@ -714,26 +707,14 @@
         {CLEAR_VARIABLE Mal_Mana}
 
         # let them attack to prevent spawncamping, but limit movement
-        {VARIABLE limit_moves_56 yes}
-    [/event]
-    [event]
-        name=side 5 turn refresh
-
-        [filter_condition]
-            {VARIABLE_CONDITIONAL limit_moves_56 equals yes}
-        [/filter_condition]
-
-        {MODIFY_UNIT side=5 moves 1}
-    [/event]
-    [event]
-        name=side 6 turn refresh
-
-        [filter_condition]
-            {VARIABLE_CONDITIONAL limit_moves_56 equals yes}
-        [/filter_condition]
-
-        {MODIFY_UNIT side=6 moves 1}
-        {CLEAR_VARIABLE limit_moves_56}
+        [event]
+            name=side 5 turn refresh
+            {MODIFY_UNIT side=5 moves 1}
+        [/event]
+        [event]
+            name=side 6 turn refresh
+            {MODIFY_UNIT side=6 moves 1}
+        [/event]
     [/event]
 
     #--------------------


### PR DESCRIPTION
Explanation by commit.

# Commit 1

Fix a minor bug: the `SCROLL_TO` macro didn't work.

That's because it resolves to a `[scroll_to]` tag, which uses the [StandardLocationFilter](https://wiki.wesnoth.org/StandardLocationFilter) - so it can't match a location with coordinates outside of the map borders.

So I replace it with `[scroll_to_unit]` to Grug.

# Commit 2

By using the nested events, we can achieve the same effect (limiting undead moves on their first turn after appearing) without using variables. No changes in behavior.

# Commits 3 - 6

These commits improve the code for enemy leaders' deaths. No changes in behavior.

## Commit 3

Izziasch had two `last breath`, and the results (whether we get achievements or not) depended on the order they execute. While the events are [guaranteed](https://wiki.wesnoth.org/EventWML#priority) to fire in the order they are added to the scenario, that also means the code will be broken if someone changes the event order in the future. To avoid this, I moved incrementing the counter for Izziasch into her own event, and left the other event for undead leaders only.

## Commit 4

I split `last breath` and `die` events for Izziasch to avoid using manual kill (as I mentioned in #9700 commit 4, this is a less error-prone way).

## Commit 5

I replace `last breath` event with `die` for incrementing the counter for undead leaders. First, they already have `last breath` events imported through the `ENEMYDEATH_SORADOC` macro. Second, it seems that it's best to use the `last breath` events only for the unit's last messages, and put more complicated code into the `die` events.

## Commit 6

This `saved_Garnad` variable is not mentioned anywhere else, so no need to clear it.

# Commit 7

Fix a bug with ending the scenario on turn limit. After the undead appear from the northwestern swamp behind Izziasch's castle, the AI's sides still have their turns to play, and these new undead units can actually kill Izziasch, ending the scenario with victory for us, which I believe was not the intention.

That's because firing `time over` event manually doesn't actually end the level automatically, and this event had no `[endlevel]` tag inside it.

I previously mentioned this place as problematic in #9707 commit 6. I fix it the same way as there, by joining the events and inserting the `[endlevel]` tag. 