### PR TITLE
EI S08: fix bug, code improvements

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -809,6 +809,9 @@
                     [option]
                         label= _ "Restart the level."
                         [command]
+                            [remove_event]
+                                id=foreign_defeat
+                            [/remove_event]
                             [endlevel]
                                 result=defeat
                             [/endlevel]

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -129,7 +129,7 @@
         [/modifications]
         controller=ai
         team_name=orc
-        #po: Whitefang Orcs, the same clan that attacked Tath at the start of Descent into Darkness
+        #po: Whitefang Orcs, the same clan that attacked Parthyn at the start of Descent into Darkness
         user_team_name= _ "Clan Whitefang"
         recruit=Orcish Grunt,Orcish Archer,Orcish Assassin,Wolf Rider
         {GOLD 70 140 210} # reduced scaling, since enemies spend most of their gold fighting each other
@@ -379,7 +379,7 @@
         [/message]
         [message]
             speaker=Prok-Bak
-            #po: Whitefang Orcs, the same clan that attacked Tath at the start of Descent into Darkness
+            #po: Whitefang Orcs, the same clan that attacked Parthyn at the start of Descent into Darkness
             message= _ "That’s Whitefang territory you’re squatting in, snake! Show some respect for the Chief!"
         [/message]
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -811,7 +811,6 @@
                         [command]
                             [endlevel]
                                 result=defeat
-                                bonus=no
                             [/endlevel]
                             [return]
                             [/return]

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -418,6 +418,9 @@
             [have_unit]
                 id=Dolburras
             [/have_unit]
+            [have_unit]
+                id=Pelathsil
+            [/have_unit]
         [/filter_condition]
         [message]
             speaker=Dolburras

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -473,6 +473,15 @@
             [show_objectives]
             [/show_objectives]
         [/event]
+        [event]
+            name=die
+            [filter]
+                id=Dolburras,Pelathsil
+            [/filter]
+            {CLEAR_VARIABLE dolburras_event_active}
+            [show_objectives]
+            [/show_objectives]
+        [/event]
     [/event]
 
     # be careful about spending too much gold

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -340,7 +340,7 @@
         [/if]
         [message]
             speaker=Prok-Bak
-            #po: A 3-way battle between orcs, dwarves and saurians was just starting when our protagonists arrived on the scene
+            #po: A 3-way battle between orcs, dwarves and nagas was just starting when our protagonists arrived on the scene
             message= _ "Don’t bother asking those freeloading dwarves for anything! They can’t even manage to pay their tribute on time."
         [/message]
         [message]
@@ -571,7 +571,7 @@
         [/filter_second]
         [message]
             speaker=Dolburras
-            #po: attacking a saurian
+            #po: attacking a naga
             message= _ "Ooch, what manner o’ creature be you?"
         [/message]
         [message]

--- a/data/campaigns/Eastern_Invasion/utils/deaths.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/deaths.cfg
@@ -334,6 +334,7 @@
 #define FOREIGN_DEFEAT
     [event]
         name=defeat
+        id=foreign_defeat
         [message]
             speaker=narrator
             image=wesnoth-icon.png


### PR DESCRIPTION
Explanation by commit:

### Commit 1

`po` comments mentioned saurians. Side 5 is actually nagas.

### Commit 2

`po` comments mentioned that Whitefang orcs attacked Tath in the beginning of DiD. It was actually Parthyn.

### Commit 3

Prevent the Dolburras - Pelanthsil task from starting if Pelanthsil is dead. He can't actually be reached by enemies at that point (turn 2), but this makes the event more error-proof in case of future scenario changes.

### Commit 4

Fix a bug: the Dolburras - Pelanthsil task stays in the objective list even if one of them is killed.

### Commit 5

According to https://wiki.wesnoth.org/DirectActionsWML , keys like `bonus` in `[endlevel]` are not used if the result is `defeat`, so I remove it. No behavior changes.

### Commit 6

Minor improvement: if we choose to replay the level from the options, the defeat message seems odd, so I remove it in that case.