### PR TITLE
EI S08: replace mention of Ulrek with Relgorn

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -370,8 +370,8 @@
         [/if]
         [message]
             speaker=Pelathsil
-            #po: "Never! Not since the days of Ulrek and Delfador have any of our clan helped one of you gangly humans!"
-            message= _ "Never! Not since tha days o’ Ulrek and Delfador ha’ any o’ our clan helped one o’ ye gangly humans!"
+            #po: "Never! Not since the days of Relgorn and Delfador have any of our clan helped one of you gangly humans!"
+            message= _ "Never! Not since tha days o’ Relgorn and Delfador ha’ any o’ our clan helped one o’ ye gangly humans!"
         [/message]
         [message]
             speaker=Aleii


### PR DESCRIPTION
Fixes #9730

I think we don't need to mention prince Konrad (HttT) because:

1. Players may confuse him with the current king Konrad II.
2. Delfador made a greater impression on dwarves with his magic, they remember him better than the prince.