### PR TITLE
DiD, EI, NR: replace "ken" with "can" in dwarf speech

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/10_Endless_Night.cfg
@@ -1263,7 +1263,7 @@
                             [message]
                                 role=speakinghero
                                 # po: regular english: Yes, but the lich still seems to be hurt. Let's take it and retreat. Maybe the forge can destroy it.
-                                message= _ "Aye, but the lich still seems ta be hurtin’. Let’s take it ’n retreat. Maybe tha forge ken destroy it."
+                                message= _ "Aye, but the lich still seems ta be hurtin’. Let’s take it ’n retreat. Maybe tha forge can destroy it."
                             [/message]
                         [/case]
 
@@ -1892,7 +1892,7 @@
                         [message]
                             role=second
                             # po: regular english - I don't know. You think the lich's castle can be useful
-                            message= _ "I dinna know. Ye think tha lich’s castle ken be useful?"
+                            message= _ "I dinna know. Ye think tha lich’s castle can be useful?"
                         [/message]
 
                         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -426,7 +426,7 @@
             speaker=Dolburras
             #po: to Gweddry
             #po: "Ack, that Pelathsil has a skull full of mud. If you get me next to him, I'm sure I can talk some sense into him."
-            message= _ "Ack, that Pelathsil ha’ a skull full o’ mud. If ye get me next ta him I’m sure I ken talk some sense into him."
+            message= _ "Ack, that Pelathsil ha’ a skull full o’ mud. If ye get me next ta him I’m sure I can talk some sense into him."
         [/message]
         {VARIABLE dolburras_event_active yes}
         [show_objectives]
@@ -458,7 +458,7 @@
             [message]
                 speaker=Pelathsil
                 #po: "A man-friend and a blood-traitor you are... but I suppose I can see your point. We won't fight you any longer."
-                message= _ "A man-friend and a blood-traitor ye be... but I suppose I ken see yer point. We won’t be fightin’ ye any longer."
+                message= _ "A man-friend and a blood-traitor ye be... but I suppose I can see yer point. We won’t be fightin’ ye any longer."
             [/message]
             [modify_side]
                 side=2
@@ -549,7 +549,7 @@
         [message]
             speaker=Dolburras
             #po: "It's a sad day when dwarf fights dwarf... can you not let us pass peacefully?"
-            message= _ "It be a sad day when dwarf fights dwarf... ken ye not let us pass peaceable-like?"
+            message= _ "It be a sad day when dwarf fights dwarf... can ye not let us pass peaceable-like?"
         [/message]
         [message]
             speaker=second_unit

--- a/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/05a_02_Dealings.cfg
@@ -161,7 +161,7 @@
         [message]
             speaker=Hamel
             # po: As you can see, Tallin there are a lot of them ready to be born into battle. Some of us dwarves are experts in the sword, mace, and bow and can aid your veterans in teaching others.
-            message= _ "As ye ken see, Tallin, there be muckle heaps o’ them, all ready to be borne inta battle. And, some o’ us dwarves be experts in the sword, mace, and bow and ken aid yer veterans in teaching others."
+            message= _ "As ye can see, Tallin, there be muckle heaps o’ them, all ready to be borne inta battle. And, some o’ us dwarves be experts in the sword, mace, and bow and can aid yer veterans in teaching others."
         [/message]
 
         [message]

--- a/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
@@ -71,7 +71,7 @@
 
         {STORY_PART_TALLIN (_ "But it would be unwise to trust that the orcs will stay stupid forever. If we do go ahead with this raid, we are going to have to be in and out like lightning.")}
         #  po: My shinsplitters are invaluable for this kind of job. They are brave warriors and don't stop fighting until either they or their opponent lies dead. No fortress can stand against them.
-        {STORY_PART_STALRAG (_ "My Shinsplitters be invaluable for this kind o’ job. They be braw warriors and dinna stop their assault till either they or their opponent lie dae. Nae a fortress ken stand against them.")}
+        {STORY_PART_STALRAG (_ "My Shinsplitters be invaluable for this kind o’ job. They be braw warriors and dinna stop their assault till either they or their opponent lie dae. Nae a fortress can stand against them.")}
 
         {STORY_PART_ARTHIAN (_ "Ha ha, I like this plan! Once we get our hands on this little sorceress the elves will be forced to do whatever we want them to!")}
 


### PR DESCRIPTION
Use "ken" only for "know" or "see" meanings, not for "can" meaning.

Fixes #9731