### PR TITLE
THoT: remove duplicate macro

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/utils/characters.cfg
@@ -25,18 +25,6 @@
     [/modifications]
 #enddef
 
-#define CHARACTER_STATS_ANGARTHING
-    type=Dwarvish Witness
-    id=Angarthing
-    name= _ "Angarthing"
-    profile=portraits/angarthing.webp
-    unrenamable=yes
-    [modifications]
-        {TRAIT_LOYAL_HERO}
-        {TRAIT_QUICK}
-    [/modifications]
-#enddef
-
 #define CHARACTER_STATS_MOVRUR
     type=Dwarvish Masked Steelclad
     id=Movrur


### PR DESCRIPTION
The macro `CHARACTER_STATS_ANGARTHING` was defined. twice.