### PR TITLE
Refactor static const array into string_view

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <cstring>
+#include <string_view>
 
 #include "ai/lua/core.hpp"
 #include "ai/composite/aspect.hpp"
@@ -44,7 +45,7 @@ static lg::log_domain log_ai_engine_lua("ai/engine/lua");
 #define WRN_LUA LOG_STREAM(warn, log_ai_engine_lua)
 #define ERR_LUA LOG_STREAM(err, log_ai_engine_lua)
 
-static char const aisKey[] = "ai contexts";
+static constexpr std::string_view aisKey = "ai contexts";
 
 namespace ai {
 
@@ -54,14 +55,14 @@ void lua_ai_context::init(lua_State *L)
 {
 	// Create the ai elements table.
 	lua_newtable(L);
-	lua_setfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_setfield(L, LUA_REGISTRYINDEX, aisKey.data());
 }
 
 void lua_ai_context::get_arguments(config &cfg) const
 {
 	int top = lua_gettop(L);
 
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());
 	lua_rawgeti(L, -1, num_);
 
 	lua_getfield(L, -1, "params");
@@ -74,7 +75,7 @@ void lua_ai_context::set_arguments(const config &cfg)
 {
 	int top = lua_gettop(L);
 
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());
 	lua_rawgeti(L, -1, num_);
 
 	luaW_pushconfig(L, cfg);
@@ -87,7 +88,7 @@ void lua_ai_context::get_persistent_data(config &cfg) const
 {
 	int top = lua_gettop(L);
 
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());
 	lua_rawgeti(L, -1, num_);
 
 	lua_getfield(L, -1, "data");
@@ -100,7 +101,7 @@ void lua_ai_context::set_persistent_data(const config &cfg)
 {
 	int top = lua_gettop(L);
 
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());
 	lua_rawgeti(L, -1, num_);
 
 	luaW_pushconfig(L, cfg);
@@ -957,7 +958,7 @@ static void generate_and_push_ai_table(lua_State* L, ai::engine_lua* engine) {
 static size_t generate_and_push_ai_state(lua_State* L, ai::engine_lua* engine)
 {
 	// Retrieve the ai elements table from the registry.
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey); // [-1: AIs registry table]
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data()); // [-1: AIs registry table]
 	size_t length_ai = lua_rawlen(L, -1); // length of table
 	lua_newtable(L); // [-1: AI state table  -2: AIs registry table]
 	generate_and_push_ai_table(L, engine); // [-1: AI routines  -2: AI state  -3: AIs registry]
@@ -1029,7 +1030,7 @@ lua_ai_action_handler* lua_ai_action_handler::create(lua_State *L, char const *c
 	}
 
 	// Retrieve the ai elements table from the registry.
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);   //stack size is now 2  [-1: ais_table -2: f]
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());   //stack size is now 2  [-1: ais_table -2: f]
 	// Push the function in the table so that it is not collected.
 	size_t length = lua_rawlen(L, -1);//length of ais_table
 	lua_pushvalue(L, -2); //stack size is now 3: [-1: f  -2: ais_table  -3: f]
@@ -1045,7 +1046,7 @@ int lua_ai_load::refcount = 0;
 lua_ai_load::lua_ai_load(lua_ai_context& ctx, bool read_only) : L(ctx.L), was_readonly(false)
 {
 	refcount++;
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey); // [-1: AI registry]
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data()); // [-1: AI registry]
 	lua_rawgeti(L, -1, ctx.num_); // [-1: AI state  -2: AI registry]
 	lua_remove(L,-2); // [-1: AI state]
 
@@ -1092,7 +1093,7 @@ lua_ai_load::~lua_ai_load()
 lua_ai_context::~lua_ai_context()
 {
 	// Remove the ai context from the registry, so that it can be collected.
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());
 	lua_pushnil(L);
 	lua_rawseti(L, -2, num_);
 	lua_pop(L, 1);
@@ -1106,7 +1107,7 @@ void lua_ai_action_handler::handle(const config &cfg, const config &filter_own, 
 	lua_ai_load ctx(context_, read_only); // [-1: AI state table]
 
 	// Load the user function from the registry.
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey); // [-1: AI registry  -2: AI state]
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data()); // [-1: AI registry  -2: AI state]
 	lua_rawgeti(L, -1, num_); // [-1: AI action  -2: AI registry  -3: AI state]
 	lua_remove(L, -2); // [-1: AI action  -2: AI state]
 
@@ -1134,7 +1135,7 @@ void lua_ai_action_handler::handle(const config &cfg, const config &filter_own, 
 lua_ai_action_handler::~lua_ai_action_handler()
 {
 	// Remove the function from the registry, so that it can be collected.
-	lua_getfield(L, LUA_REGISTRYINDEX, aisKey);
+	lua_getfield(L, LUA_REGISTRYINDEX, aisKey.data());
 	lua_pushnil(L);
 	lua_rawseti(L, -2, num_);
 	lua_pop(L, 1);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1283,7 +1283,7 @@ std::ostream& operator<<(std::ostream& outstream, const config& cfg)
 std::string config::hash() const
 {
 	static const unsigned int hash_length = 128;
-	static const char hash_string[] = "+-,.<>0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	static constexpr std::string_view hash_string = "+-,.<>0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	char hash_str[hash_length + 1];
 
 	unsigned int i;

--- a/src/network_asio.cpp
+++ b/src/network_asio.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
+#include <string_view>
 
 static lg::log_domain log_network("network");
 #define DBG_NW LOG_STREAM(debug, log_network)
@@ -97,7 +98,7 @@ connection::~connection()
 		boost::system::error_code ec;
 		// this sends close_notify for secure connection shutdown
 		(*socket)->async_shutdown([](const boost::system::error_code&) {} );
-		const char buffer[] = "";
+		static constexpr std::string_view buffer = "";
 		// this write is needed to trigger immediate close instead of waiting for other side's close_notify
 		boost::asio::write(**socket, boost::asio::buffer(buffer, 0), ec);
 	}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -124,6 +124,7 @@
 #include <new>                          // for operator new
 #include <set>                          // for set
 #include <sstream>                      // for operator<<, basic_ostream, etc
+#include <string_view>
 #include <thread>
 #include <utility>                      // for pair
 #include <algorithm>
@@ -262,17 +263,17 @@ static int intf_handle_user_interact(lua_State *)
 	return 0;
 }
 
-static const char animatorKey[] = "unit animator";
+static constexpr std::string_view animatorKey = "unit animator";
 
 static int impl_animator_collect(lua_State* L) {
-	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey));
+	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey.data()));
 	anim.~unit_animator();
 	return 0;
 }
 
 static int impl_add_animation(lua_State* L)
 {
-	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey));
+	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey.data()));
 	unit_ptr up = luaW_checkunit_ptr(L, 2, false);
 	unit& u = *up;
 	std::string which = luaL_checkstring(L, 3);
@@ -377,7 +378,7 @@ int game_lua_kernel::impl_run_animation(lua_State* L)
 		return 0;
 	}
 	events::command_disabler command_disabler;
-	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey));
+	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey.data()));
 	play_controller_.play_slice();
 	anim.start_animations();
 	anim.wait_for_end();
@@ -388,7 +389,7 @@ int game_lua_kernel::impl_run_animation(lua_State* L)
 
 static int impl_clear_animation(lua_State* L)
 {
-	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey));
+	unit_animator& anim = *static_cast<unit_animator*>(luaL_checkudata(L, 1, animatorKey.data()));
 	anim.clear();
 	return 0;
 }
@@ -402,7 +403,7 @@ static int impl_animator_get(lua_State* L)
 int game_lua_kernel::intf_create_animator(lua_State* L)
 {
 	new(L) unit_animator;
-	if(luaL_newmetatable(L, animatorKey)) {
+	if(luaL_newmetatable(L, animatorKey.data())) {
 		luaL_Reg metafuncs[] {
 			{"__gc", impl_animator_collect},
 			{"__index", impl_animator_get},
@@ -413,7 +414,7 @@ int game_lua_kernel::intf_create_animator(lua_State* L)
 		};
 		luaL_setfuncs(L, metafuncs, 0);
 		lua_pushstring(L, "__metatable");
-		lua_setfield(L, -2, animatorKey);
+		lua_setfield(L, -2, animatorKey.data());
 	}
 	lua_setmetatable(L, -2);
 	return 1;
@@ -2635,12 +2636,12 @@ int game_lua_kernel::intf_set_floating_label(lua_State* L, bool spawn)
 			loc = luaW_checklocation(L, -1);
 		}
 		if(luaW_tableget(L, 2, "halign")) {
-			static const char* options[] = {"left", "center", "right"};
-			alignment = font::ALIGN(luaL_checkoption(L, -1, nullptr, options));
+			static constexpr auto options = []() { return std::array{"left", "center", "right"}; }();
+			alignment = font::ALIGN(luaL_checkoption(L, -1, nullptr, options.data()));
 		}
 		if(luaW_tableget(L, 2, "valign")) {
-			static const char* options[] = {"top", "center", "bottom"};
-			vertical_alignment = font::ALIGN(luaL_checkoption(L, -1, nullptr, options));
+			static constexpr auto options = []() { return std::array{"top", "center", "bottom"}; }();
+			vertical_alignment = font::ALIGN(luaL_checkoption(L, -1, nullptr, options.data()));
 		}
 	}
 

--- a/src/scripting/lua_color.cpp
+++ b/src/scripting/lua_color.cpp
@@ -19,15 +19,17 @@
 #include "log.hpp"
 #include "game_config.hpp"
 
+#include <string_view>
+
 static lg::log_domain log_scripting_lua("scripting/lua");
 #define LOG_LUA LOG_STREAM(info, log_scripting_lua)
 #define ERR_LUA LOG_STREAM(err, log_scripting_lua)
 
-static const char colorKey[] = "color range";
+static constexpr std::string_view colorKey = "color range";
 
 static bool luaW_iscolor(lua_State* L, int index)
 {
-	return luaL_testudata(L, index, colorKey) != nullptr;
+	return luaL_testudata(L, index, colorKey.data()) != nullptr;
 }
 
 static color_range& LuaW_checkcolor(lua_State *L, int index)
@@ -43,7 +45,7 @@ static color_range& LuaW_checkcolor(lua_State *L, int index)
 static color_range* luaW_pushcolor(lua_State *L, const color_range& color)
 {
 	color_range* res = new(L) color_range(color);
-	luaL_setmetatable(L, colorKey);
+	luaL_setmetatable(L, colorKey.data());
 	return res;
 }
 
@@ -159,7 +161,7 @@ namespace lua_colors {
 		// Create the color metatable.
 		cmd_out << "Adding color metatable...\n";
 
-		luaL_newmetatable(L, colorKey);
+		luaL_newmetatable(L, colorKey.data());
 		lua_pushcfunction(L, impl_color_collect);
 		lua_setfield(L, -2, "__gc");
 		lua_pushcfunction(L, impl_color_equality);

--- a/src/scripting/lua_formula_bridge.cpp
+++ b/src/scripting/lua_formula_bridge.cpp
@@ -29,7 +29,9 @@
 #include "units/map.hpp"
 #include "units/unit.hpp"
 
-static const char formulaKey[] = "formula";
+#include <string_view>
+
+static constexpr std::string_view formulaKey = "formula";
 
 using namespace wfl;
 
@@ -226,7 +228,7 @@ variant luaW_tofaivariant(lua_State* L, int i) {
 lua_formula_bridge::fpointer luaW_check_formula(lua_State* L, int idx, bool allow_str) {
 	using namespace lua_formula_bridge;
 	fpointer form;
-	if(void* ud = luaL_testudata(L, idx, formulaKey)) {
+	if(void* ud = luaL_testudata(L, idx, formulaKey.data())) {
 		form.get_deleter() = [](fwrapper*) {};
 		form.reset(static_cast<fwrapper*>(ud));
 		// Setting a no-op deleter guarantees the Lua-held object is not deleted
@@ -274,7 +276,7 @@ int lua_formula_bridge::intf_compile_formula(lua_State* L)
 		luaW_type_error(L, 1, "string");
 	}
 	new(L) fwrapper(lua_tostring(L, 1));
-	luaL_setmetatable(L, formulaKey);
+	luaL_setmetatable(L, formulaKey.data());
 	return 1;
 }
 
@@ -316,7 +318,7 @@ static int impl_formula_tostring(lua_State* L)
 
 std::string lua_formula_bridge::register_metatables(lua_State* L)
 {
-	luaL_newmetatable(L, formulaKey);
+	luaL_newmetatable(L, formulaKey.data());
 	lua_pushcfunction(L, impl_formula_collect);
 	lua_setfield(L, -2, "__gc");
 	lua_pushcfunction(L, impl_formula_tostring);

--- a/src/scripting/lua_team.cpp
+++ b/src/scripting/lua_team.cpp
@@ -26,6 +26,7 @@
 #include "map/map.hpp"
 
 #include <string>
+#include <string_view>
 
 
 /**
@@ -41,12 +42,12 @@
  */
 
 // Registry key
-static const char * Team = "side";
-static const char teamVar[] = "side variables";
+static constexpr std::string_view Team = "side";
+static constexpr std::string_view teamVar = "side variables";
 
 #define SIDE_GETTER(name, type) LATTR_GETTER(name, type, team, t)
 #define SIDE_SETTER(name, type) LATTR_SETTER(name, type, team, t)
-luaW_Registry sideReg{"wesnoth", "sides", Team};
+luaW_Registry sideReg{"wesnoth", "sides", Team.data()};
 
 template<> struct lua_object_traits<team> {
 	inline static auto metatable = Team;
@@ -348,7 +349,7 @@ SIDE_GETTER("variables", lua_index_raw) {
 	lua_createtable(L, 1, 0);
 	lua_pushvalue(L, 1);
 	lua_rawseti(L, -2, 1);
-	luaL_setmetatable(L, teamVar);
+	luaL_setmetatable(L, teamVar.data());
 	return lua_index_raw(L);
 }
 
@@ -503,7 +504,7 @@ namespace lua_team {
 
 		cmd_out << "Adding getside metatable...\n";
 
-		luaL_newmetatable(L, Team);
+		luaL_newmetatable(L, Team.data());
 
 		static luaL_Reg const callbacks[] {
 			{ "__index", 	    &impl_side_get},
@@ -515,13 +516,13 @@ namespace lua_team {
 		};
 		luaL_setfuncs(L, callbacks, 0);
 
-		lua_pushstring(L, Team);
+		lua_pushstring(L, Team.data());
 		lua_setfield(L, -2, "__metatable");
 
 		// Create the side variables metatable.
 		cmd_out << "Adding side variables metatable...\n";
 
-		luaL_newmetatable(L, teamVar);
+		luaL_newmetatable(L, teamVar.data());
 		lua_pushcfunction(L, impl_side_variables_get);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, impl_side_variables_set);
@@ -537,12 +538,12 @@ void luaW_pushteam(lua_State *L, team & tm)
 {
 	team** t = static_cast<team**>(lua_newuserdatauv(L, sizeof(team*), 0));
 	*t = &tm;
-	luaL_setmetatable(L, Team);
+	luaL_setmetatable(L, Team.data());
 }
 
 team& luaW_checkteam(lua_State* L, int idx)
 {
-	return **static_cast<team **>(luaL_checkudata(L, idx, Team));
+	return **static_cast<team **>(luaL_checkudata(L, idx, Team.data()));
 }
 
 team& luaW_checkteam(lua_State* L, int idx, game_board& board)
@@ -556,12 +557,12 @@ team& luaW_checkteam(lua_State* L, int idx, game_board& board)
 		}
 		return board.get_team(side);
 	}
-	return **static_cast<team **>(luaL_checkudata(L, idx, Team));
+	return **static_cast<team **>(luaL_checkudata(L, idx, Team.data()));
 }
 
 team* luaW_toteam(lua_State* L, int idx)
 {
-	if(void* p = luaL_testudata(L, idx, Team)) {
+	if(void* p = luaL_testudata(L, idx, Team.data())) {
 		return *static_cast<team **>(p);
 	}
 	return nullptr;

--- a/src/scripting/lua_terrainfilter.cpp
+++ b/src/scripting/lua_terrainfilter.cpp
@@ -29,6 +29,7 @@
 #include "formula/formula.hpp"
 
 #include <boost/dynamic_bitset.hpp>
+#include <string_view>
 #include <unordered_map>
 
 static lg::log_domain log_scripting_lua_mapgen("scripting/lua/mapgen");
@@ -51,7 +52,7 @@ using std::string_view;
 using dynamic_bitset  = boost::dynamic_bitset<>;
 using location_set = std::set<map_location>;
 
-static const char terrinfilterKey[] = "terrainfilter";
+static constexpr std::string_view terrainfilterKey = "terrainfilter";
 #define LOG_MATCHES(NAME) \
 LOG_LMG << #NAME << ":matches(" << l << ") line:" << __LINE__;
 
@@ -762,7 +763,7 @@ int intf_mg_get_tiles_radius(lua_State* L)
 
 bool luaW_is_mgfilter(lua_State* L, int index)
 {
-	return luaL_testudata(L, index, terrinfilterKey) != nullptr;
+	return luaL_testudata(L, index, terrainfilterKey.data()) != nullptr;
 }
 
 
@@ -792,7 +793,7 @@ lua_mapgen::filter_ptr luaW_check_mgfilter(lua_State *L, int index, bool allow_c
 
 void lua_mgfilter_setmetatable(lua_State *L)
 {
-	luaL_setmetatable(L, terrinfilterKey);
+	luaL_setmetatable(L, terrainfilterKey.data());
 }
 
 template<typename... T>
@@ -881,7 +882,7 @@ namespace lua_terrainfilter {
 
 		cmd_out << "Adding terrainmamap metatable...\n";
 
-		luaL_newmetatable(L, terrinfilterKey);
+		luaL_newmetatable(L, terrainfilterKey.data());
 		lua_pushcfunction(L, impl_terrainfilter_collect);
 		lua_setfield(L, -2, "__gc");
 		lua_pushcfunction(L, impl_terrainfilter_get);

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -37,9 +37,9 @@ static lg::log_domain log_scripting_lua("scripting/lua");
 #define LOG_LUA LOG_STREAM(info, log_scripting_lua)
 #define ERR_LUA LOG_STREAM(err, log_scripting_lua)
 
-static const char getunitKey[] = "unit";
-static const char ustatusKey[] = "unit status";
-static const char unitvarKey[] = "unit variables";
+static constexpr std::string_view getunitKey = "unit";
+static constexpr std::string_view ustatusKey = "unit status";
+static constexpr std::string_view unitvarKey = "unit variables";
 
 lua_unit::~lua_unit()
 {
@@ -112,7 +112,7 @@ bool lua_unit::put_map(const map_location &loc)
 
 bool luaW_isunit(lua_State* L, int index)
 {
-	return luaL_testudata(L, index,getunitKey) != nullptr;
+	return luaL_testudata(L, index,getunitKey.data()) != nullptr;
 }
 
 enum {
@@ -206,7 +206,7 @@ lua_unit* luaW_checkunit_ref(lua_State *L, int index)
 
 void lua_unit::setmetatable(lua_State *L)
 {
-	luaL_setmetatable(L, getunitKey);
+	luaL_setmetatable(L, getunitKey.data());
 }
 
 lua_unit* luaW_pushlocalunit(lua_State *L, unit& u)
@@ -273,7 +273,7 @@ static int impl_unit_tostring(lua_State* L)
 
 #define UNIT_GETTER(name, type) LATTR_GETTER(name, type, unit, u)
 #define UNIT_SETTER(name, type) LATTR_SETTER(name, type, unit, u)
-luaW_Registry unitReg{"wesnoth", "units", getunitKey};
+luaW_Registry unitReg{"wesnoth", "units", getunitKey.data()};
 
 template<> struct lua_object_traits<lua_unit*> {
 	inline static auto metatable = getunitKey;
@@ -632,7 +632,7 @@ UNIT_GETTER("status", lua_index_raw) {
 	lua_createtable(L, 1, 0);
 	lua_pushvalue(L, 1);
 	lua_rawseti(L, -2, 1);
-	luaL_setmetatable(L, ustatusKey);
+	luaL_setmetatable(L, ustatusKey.data());
 	return lua_index_raw(L);
 }
 
@@ -641,7 +641,7 @@ UNIT_GETTER("variables", lua_index_raw) {
 	lua_createtable(L, 1, 0);
 	lua_pushvalue(L, 1);
 	lua_rawseti(L, -2, 1);
-	luaL_setmetatable(L, unitvarKey);
+	luaL_setmetatable(L, unitvarKey.data());
 	return lua_index_raw(L);
 }
 
@@ -946,7 +946,7 @@ namespace lua_units {
 		// Create the getunit metatable.
 		cmd_out << "Adding getunit metatable...\n";
 
-		luaL_newmetatable(L, getunitKey);
+		luaL_newmetatable(L, getunitKey.data());
 		lua_pushcfunction(L, impl_unit_collect);
 		lua_setfield(L, -2, "__gc");
 		lua_pushcfunction(L, impl_unit_equality);
@@ -965,7 +965,7 @@ namespace lua_units {
 		// Create the unit status metatable.
 		cmd_out << "Adding unit status metatable...\n";
 
-		luaL_newmetatable(L, ustatusKey);
+		luaL_newmetatable(L, ustatusKey.data());
 		lua_pushcfunction(L, impl_unit_status_get);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, impl_unit_status_set);
@@ -978,7 +978,7 @@ namespace lua_units {
 		// Create the unit variables metatable.
 		cmd_out << "Adding unit variables metatable...\n";
 
-		luaL_newmetatable(L, unitvarKey);
+		luaL_newmetatable(L, unitvarKey.data());
 		lua_pushcfunction(L, impl_unit_variables_get);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, impl_unit_variables_set);

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -24,12 +24,12 @@
 #include "units/attack_type.hpp"
 #include "utils/const_clone.hpp"
 
-
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
-static const char uattacksKey[] = "unit attacks table";
-static const char uattackKey[] = "unit attack";
+static constexpr std::string_view uattacksKey = "unit attacks table";
+static constexpr std::string_view uattackKey = "unit attack";
 
 struct attack_ref {
 	attack_ptr attack;
@@ -45,14 +45,14 @@ void push_unit_attacks_table(lua_State* L, int idx)
 	lua_pushvalue(L, idx);
 	// hack: store the unit_type at 0 because we want positive indices to refer to the attacks.
 	lua_rawseti(L, -2, 0);
-	luaL_setmetatable(L, uattacksKey);
+	luaL_setmetatable(L, uattacksKey.data());
 }
 
 void luaW_pushweapon(lua_State* L, const attack_ptr& weapon)
 {
 	if(weapon != nullptr) {
 		new(L) attack_ref(weapon);
-		luaL_setmetatable(L, uattackKey);
+		luaL_setmetatable(L, uattackKey.data());
 	} else {
 		lua_pushnil(L);
 	}
@@ -62,7 +62,7 @@ void luaW_pushweapon(lua_State* L, const const_attack_ptr& weapon)
 {
 	if(weapon != nullptr) {
 		new(L) attack_ref(weapon);
-		luaL_setmetatable(L, uattackKey);
+		luaL_setmetatable(L, uattackKey.data());
 	} else {
 		lua_pushnil(L);
 	}
@@ -70,12 +70,12 @@ void luaW_pushweapon(lua_State* L, const const_attack_ptr& weapon)
 
 static attack_ref& luaW_checkweapon_ref(lua_State* L, int idx)
 {
-	return *static_cast<attack_ref*>(luaL_checkudata(L, idx, uattackKey));
+	return *static_cast<attack_ref*>(luaL_checkudata(L, idx, uattackKey.data()));
 }
 
 const_attack_ptr luaW_toweapon(lua_State* L, int idx)
 {
-	if(void* p = luaL_testudata(L, idx, uattackKey)) {
+	if(void* p = luaL_testudata(L, idx, uattackKey.data())) {
 		return static_cast<attack_ref*>(p)->cattack;
 	}
 	return nullptr;
@@ -349,7 +349,7 @@ static int impl_unit_attack_match(lua_State* L)
 
 static int impl_unit_attack_collect(lua_State* L)
 {
-	attack_ref* atk = static_cast<attack_ref*>(luaL_checkudata(L, 1, uattackKey));
+	attack_ref* atk = static_cast<attack_ref*>(luaL_checkudata(L, 1, uattackKey.data()));
 	atk->~attack_ref();
 	return 0;
 }
@@ -369,7 +369,7 @@ namespace lua_units {
 		// Create the unit attacks metatable.
 		cmd_out << "Adding unit attacks metatable...\n";
 
-		luaL_newmetatable(L, uattacksKey);
+		luaL_newmetatable(L, uattacksKey.data());
 		lua_pushcfunction(L, impl_unit_attacks_get);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, impl_unit_attacks_set);
@@ -378,11 +378,11 @@ namespace lua_units {
 		lua_setfield(L, -2, "__len");
 		lua_pushcfunction(L, impl_unit_attacks_iter);
 		lua_setfield(L, -2, "__ipairs");
-		lua_pushstring(L, uattacksKey);
+		lua_pushstring(L, uattacksKey.data());
 		lua_setfield(L, -2, "__metatable");
 
 		// Create the unit attack metatable
-		luaL_newmetatable(L, uattackKey);
+		luaL_newmetatable(L, uattackKey.data());
 		lua_pushcfunction(L, impl_unit_attack_get);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, impl_unit_attack_set);
@@ -393,7 +393,7 @@ namespace lua_units {
 		lua_setfield(L, -2, "__tostring");
 		lua_pushcfunction(L, impl_unit_attack_collect);
 		lua_setfield(L, -2, "__gc");
-		lua_pushstring(L, uattackKey);
+		lua_pushstring(L, uattackKey.data());
 		lua_setfield(L, -2, "__metatable");
 		lua_pushcfunction(L, impl_unit_attack_match);
 		lua_setfield(L, -2, "matches");

--- a/src/scripting/lua_unit_type.cpp
+++ b/src/scripting/lua_unit_type.cpp
@@ -22,6 +22,7 @@
 #include "units/types.hpp"
 
 #include <string>
+#include <string_view>
 #include <cstring>
 
 
@@ -30,12 +31,12 @@
  */
 
 // Registry key
-static const char UnitType[] = "unit type";
-static const char UnitTypeTable[] = "unit types";
+static constexpr std::string_view UnitType = "unit type";
+static constexpr std::string_view UnitTypeTable = "unit types";
 
 #define UNIT_TYPE_GETTER(name, type) LATTR_GETTER(name, type, unit_type, ut)
 #define UNIT_TYPE_VALID(name) LATTR_VALID(name, unit_type, ut)
-luaW_Registry unitTypeReg{UnitType};
+luaW_Registry unitTypeReg{UnitType.data()};
 
 template<> struct lua_object_traits<unit_type> {
 	inline static auto metatable = UnitType;
@@ -138,7 +139,7 @@ UNIT_TYPE_VALID("variations") {
 UNIT_TYPE_GETTER("variations", lua_index_raw) {
 	// TODO: Should this only exist for base units?
 	*new(L) const unit_type* = &ut;
-	luaL_setmetatable(L, UnitTypeTable);
+	luaL_setmetatable(L, UnitTypeTable.data());
 	return lua_index_raw(L);
 }
 
@@ -175,7 +176,7 @@ static int impl_unit_type_equal(lua_State* L)
 
 static int impl_unit_type_list(lua_State* L) {
 	std::vector<std::string> keys;
-	if(const unit_type* base = *static_cast<const unit_type**>(luaL_testudata(L, 1, UnitTypeTable))) {
+	if(const unit_type* base = *static_cast<const unit_type**>(luaL_testudata(L, 1, UnitTypeTable.data()))) {
 		keys = base->variations();
 		if(base->has_gender_variation(unit_race::MALE)) {
 			keys.push_back("male");
@@ -197,7 +198,7 @@ static int impl_unit_type_lookup(lua_State* L)
 {
 	std::string id = luaL_checkstring(L, 2);
 	const unit_type* ut;
-	if(const unit_type* base = *static_cast<const unit_type**>(luaL_testudata(L, 1, UnitTypeTable))) {
+	if(const unit_type* base = *static_cast<const unit_type**>(luaL_testudata(L, 1, UnitTypeTable.data()))) {
 		if(id == "male" || id == "female") {
 			ut = &base->get_gender_unit_type(id);
 		} else {
@@ -229,7 +230,7 @@ static int impl_unit_type_count(lua_State* L)
 
 static int impl_unit_type_next(lua_State* L)
 {
-	const unit_type* base = *static_cast<const unit_type**>(luaL_checkudata(L, 1, UnitTypeTable));
+	const unit_type* base = *static_cast<const unit_type**>(luaL_checkudata(L, 1, UnitTypeTable.data()));
 	const auto& unit_map = base ? base->variation_types() : unit_types.types();
 	auto it = unit_map.end();
 	if(lua_isnoneornil(L, 2)) {
@@ -300,7 +301,7 @@ static int impl_unit_type_tostring(lua_State* L)
 namespace lua_unit_type {
 	std::string register_metatable(lua_State * L)
 	{
-		luaL_newmetatable(L, UnitType);
+		luaL_newmetatable(L, UnitType.data());
 
 		lua_pushcfunction(L, impl_unit_type_get);
 		lua_setfield(L, -2, "__index");
@@ -310,7 +311,7 @@ namespace lua_unit_type {
 		lua_setfield(L, -2, "__tostring");
 		lua_pushcfunction(L, impl_unit_type_equal);
 		lua_setfield(L, -2, "__eq");
-		lua_pushstring(L, UnitType);
+		lua_pushstring(L, UnitType.data());
 		lua_setfield(L, -2, "__metatable");
 
 		return "Adding unit type metatable...\n";
@@ -320,7 +321,7 @@ namespace lua_unit_type {
 	{
 		lua_getglobal(L, "wesnoth");
 		*new(L) unit_type* = nullptr;
-		luaL_newmetatable(L, UnitTypeTable);
+		luaL_newmetatable(L, UnitTypeTable.data());
 		lua_pushcfunction(L, impl_unit_type_lookup);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, impl_unit_type_list);
@@ -331,7 +332,7 @@ namespace lua_unit_type {
 		lua_setfield(L, -2, "__len");
 		lua_pushcfunction(L, impl_unit_type_pairs);
 		lua_setfield(L, -2, "__pairs");
-		lua_pushstring(L, UnitTypeTable);
+		lua_pushstring(L, UnitTypeTable.data());
 		lua_setfield(L, -2, "__metatable");
 		lua_setmetatable(L, -2);
 		lua_setfield(L, -2, "unit_types");
@@ -344,12 +345,12 @@ namespace lua_unit_type {
 void luaW_pushunittype(lua_State *L, const unit_type& ut)
 {
 	*static_cast<const unit_type**>(lua_newuserdatauv(L, sizeof(unit_type*), 0)) = &ut;
-	luaL_setmetatable(L, UnitType);
+	luaL_setmetatable(L, UnitType.data());
 }
 
 const unit_type* luaW_tounittype(lua_State* L, int idx)
 {
-	if(void* p = luaL_testudata(L, idx, UnitType)) {
+	if(void* p = luaL_testudata(L, idx, UnitType.data())) {
 		return *static_cast<const unit_type**>(p);
 	}
 	return nullptr;
@@ -357,5 +358,5 @@ const unit_type* luaW_tounittype(lua_State* L, int idx)
 
 const unit_type& luaW_checkunittype(lua_State* L, int idx)
 {
-	return **static_cast<const unit_type**>(luaL_checkudata(L, idx, UnitType));
+	return **static_cast<const unit_type**>(luaL_checkudata(L, idx, UnitType.data()));
 }

--- a/src/scripting/lua_widget.cpp
+++ b/src/scripting/lua_widget.cpp
@@ -26,21 +26,21 @@
 #include "scripting/lua_ptr.hpp"
 #include "scripting/push_check.hpp"
 
+#include <string>
+#include <string_view>
 
-
-
-static const char widgetKey[] = "widget";
-static char widgetdataKey[] = "widgetdata";
+static constexpr std::string_view widgetKey = "widget";
+static std::string widgetdataKey = "widgetdata";
 
 void luaW_pushwidget(lua_State* L, gui2::widget& w)
 {
 	new(L) lua_ptr<gui2::widget>(w);
-	luaL_setmetatable(L, widgetKey);
+	luaL_setmetatable(L, widgetKey.data());
 }
 
 gui2::widget& luaW_checkwidget(lua_State* L, int n)
 {
-	lua_ptr<gui2::widget>& lp =  *static_cast<lua_ptr<gui2::widget>*>(luaL_checkudata(L, n, widgetKey));
+	lua_ptr<gui2::widget>& lp =  *static_cast<lua_ptr<gui2::widget>*>(luaL_checkudata(L, n, widgetKey.data()));
 	auto ptr = lp.get_ptr();
 	if(!ptr) {
 		luaL_argerror(L, n, "widget was deleted");
@@ -50,7 +50,7 @@ gui2::widget& luaW_checkwidget(lua_State* L, int n)
 
 lua_ptr<gui2::widget>& luaW_checkwidget_ptr(lua_State* L, int n)
 {
-	lua_ptr<gui2::widget>& lp =  *static_cast<lua_ptr<gui2::widget>*>(luaL_checkudata(L, n, widgetKey));
+	lua_ptr<gui2::widget>& lp =  *static_cast<lua_ptr<gui2::widget>*>(luaL_checkudata(L, n, widgetKey.data()));
 	auto ptr = lp.get_ptr();
 	if(!ptr) {
 		luaL_argerror(L, n, "widget was deleted");
@@ -61,18 +61,18 @@ lua_ptr<gui2::widget>& luaW_checkwidget_ptr(lua_State* L, int n)
 
 bool luaW_iswidget(lua_State* L, int index)
 {
-	return luaL_testudata(L, index, widgetKey) != nullptr;
+	return luaL_testudata(L, index, widgetKey.data()) != nullptr;
 }
 
 
 static void luaW_pushwidgettablecontainer(lua_State* L)
 {
-	lua_pushlightuserdata(L, &widgetdataKey[0]);
+	lua_pushlightuserdata(L, widgetdataKey.data());
 	lua_rawget(L, LUA_REGISTRYINDEX);
 	if(lua_isnoneornil(L, -1)) {
 		lua_pop(L, 1);
 		lua_createtable(L, 0, 0);
-		lua_pushlightuserdata(L, &widgetdataKey[0]);
+		lua_pushlightuserdata(L, widgetdataKey.data());
 		lua_pushvalue(L , -2);
 		lua_rawset(L, LUA_REGISTRYINDEX);
 	}
@@ -182,7 +182,7 @@ void luaW_callwidgetcallback(lua_State* L, gui2::widget* wg, gui2::window* owner
 
 static int impl_widget_collect(lua_State* L)
 {
-	lua_ptr<gui2::widget>* w = static_cast<lua_ptr<gui2::widget>*>(luaL_checkudata(L, 1, widgetKey));
+	lua_ptr<gui2::widget>* w = static_cast<lua_ptr<gui2::widget>*>(luaL_checkudata(L, 1, widgetKey.data()));
 	w->~lua_ptr<gui2::widget>();
 	return 0;
 }
@@ -212,7 +212,7 @@ namespace lua_widget {
 	void register_metatable(lua_State* L)
 	{
 
-		luaL_newmetatable(L, widgetKey);
+		luaL_newmetatable(L, widgetKey.data());
 		lua_pushcfunction(L, lua_widget::impl_widget_get);
 		lua_setfield(L, -2, "__index");
 		lua_pushcfunction(L, lua_widget::impl_widget_set);
@@ -223,7 +223,7 @@ namespace lua_widget {
 		lua_setfield(L, -2, "__gc");
 		lua_pushcfunction(L, impl_widget_length);
 		lua_setfield(L, -2, "__len");
-		lua_pushstring(L, widgetKey);
+		lua_pushstring(L, widgetKey.data());
 		lua_setfield(L, -2, "__metatable");
 	}
 }

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -56,6 +56,7 @@
 #include <map>
 #include <set>
 #include <sstream>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -1961,7 +1962,7 @@ void server::disconnect_player(player_iterator player)
 	utils::visit([](auto&& socket) {
 		if constexpr (utils::decayed_is_same<tls_socket_ptr, decltype(socket)>) {
 			socket->async_shutdown([socket](...) {});
-			const char buffer[] = "";
+			static constexpr std::string_view buffer = "";
 			async_write(*socket, boost::asio::buffer(buffer), [socket](...) { socket->lowest_layer().close(); });
 		} else {
 			socket->lowest_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_receive);

--- a/src/wesnothd_connection.cpp
+++ b/src/wesnothd_connection.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
+#include <string_view>
 
 static lg::log_domain log_network("network");
 #define DBG_NW LOG_STREAM(debug, log_network)
@@ -125,7 +126,7 @@ wesnothd_connection::~wesnothd_connection()
 		error_code ec;
 		// this sends close_notify for secure connection shutdown
 		(*socket)->async_shutdown([](const error_code&) {} );
-		const char buffer[] = "";
+		static constexpr std::string_view buffer = "";
 		// this write is needed to trigger immediate close instead of waiting for other side's close_notify
 		boost::asio::write(**socket, boost::asio::buffer(buffer, 0), ec);
 	}


### PR DESCRIPTION
In scenarios where a static const array of char is used for a string constant, refactors to a static constexpr std::string_view. This has the same effect of making it a compile-time string, except that it no longer implicitly decays to a char pointer (necessitating the use of the .data() member function).

Partially addresses #9743 .