### PR TITLE
(1.18 backport) Switch default Pango/Cairo render backend to Fontconfig on macOS

### DIFF
--- a/changelog_entries/macos-font-render-backend.md
+++ b/changelog_entries/macos-font-render-backend.md
@@ -1,0 +1,2 @@
+### User interface
+   * Switched default Pango/Cairo backend from CoreText to Fontconfig on macOS to fix issues with certain fonts such as Oldania ADF Std being unrecognized on current OS versions (issue #8488).

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -1039,6 +1039,11 @@ int main(int argc, char** argv)
 	_putenv("PANGOCAIRO_BACKEND=fontconfig");
 	_putenv("FONTCONFIG_PATH=fonts");
 #endif
+#ifdef __APPLE__
+	// Using setenv with overwrite disabled so we can override this in the
+	// original process environment for research/testing purposes.
+	setenv("PANGOCAIRO_BACKEND", "fontconfig", 0);
+#endif
 
 	// write_to_log_file means that writing to the log file will be done, if true.
 	// if false, output will be written to the terminal


### PR DESCRIPTION
This is a backport to 1.18 of PR #9593, which fixes issue #8488.