### PR TITLE
EI: remove the rest of unused schedules

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/schedule.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/schedule.cfg
@@ -162,10 +162,6 @@
     {MORNING} {TOD_COLOR_SHIFT -5 -5 15}
 #enddef
 
-#define NORTHERN_MIDDAY
-    {MIDDAY} {TOD_COLOR_SHIFT -5 -5 15}
-#enddef
-
 #define NORTHERN_AFTERNOON
     {AFTERNOON} {TOD_COLOR_SHIFT -5 -5 15}
 #enddef

--- a/data/campaigns/Eastern_Invasion/utils/schedule.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/schedule.cfg
@@ -130,28 +130,6 @@
     [/time_area]
 #enddef
 
-#define BRAZIER_ILLUMINATION X Y
-    [item]
-        x,y={X},{Y}
-        halo=halo/fire-aura-small.png
-    [/item]
-    [time_area] # illuminate everything in a 1 tile radius
-        x,y={X},{Y}
-        radius=1
-        {ILLUMINATED_TZ_DAWN}
-        {ILLUMINATED_TZ_MORNING}
-        {ILLUMINATED_TZ_AFTERNOON}
-        {ILLUMINATED_TZ_DUSK}
-        {ILLUMINATED_TZ_FIRSTWATCH}
-        {ILLUMINATED_TZ_SECONDWATCH}
-    [/time_area]
-    [time_area] # undo illumination in a 0 tile radius (braizer already illuminates)
-        x,y={X},{Y}
-        radius=0
-        {DEFAULT_SCHEDULE}
-    [/time_area]
-#enddef
-
 # Includes the color shifted ToDs used in the northern scenarios.
 
 #define NORTHERN_DAWN


### PR DESCRIPTION
Fixes #9748

- Remove `NORTHERN_MIDDAY` time of day which was used by removed `NORTHERN_WINTER_SCHEDULE` (see commit a5a84c4)
- Remove unused `BRAZIER_ILLUMINATION` schedule