### PR TITLE
EI: allow undo if we choose to not pick the item (or elixir)

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -66,6 +66,10 @@
                         [/modify_unit]
                         {EQUIP_WML}
                     [/then]
+                    [else]
+                        [allow_undo]
+                        [/allow_undo]
+                    [/else]
                 [/if]
             [/then]
 
@@ -1091,6 +1095,10 @@ plague_staff #enddef
                 [/remove_item]
                 {MODIFY}
             [/then]
+            [else]
+                [allow_undo]
+                [/allow_undo]
+            [/else]
         [/if]
     [/event]
 #enddef


### PR DESCRIPTION
If we select the option to leave the item on the ground, we should be able to undo and move another unit to take it.

I've tested it in S06a with the crystal quiver and the elixir of water breathing, seems to work without any bugs.