### PR TITLE
Warn against old tutorial in description

### DIFF
--- a/data/campaigns/tutorial/_main.cfg
+++ b/data/campaigns/tutorial/_main.cfg
@@ -20,7 +20,7 @@
     end_credits=no
     description= _ "Learn the basics of Wesnoth gameplay with a tutorial.
     
-" + _ "Note: No longer reccomended for first-time players. Try <i>The South Guard</i> instead."
+" + _ "Note: No longer recommended for first-time players. Try <i>The South Guard</i> instead."
     [difficulty]
         # The difficulty-select dialog won’t be shown to the player, as there's
         # only one difficulty. However, if the [campaign] tag doesn't include

--- a/data/campaigns/tutorial/_main.cfg
+++ b/data/campaigns/tutorial/_main.cfg
@@ -18,7 +18,9 @@
     define=TUTORIAL
     first_scenario=tutorial
     end_credits=no
-    description= _ "Learn the basics of Wesnoth gameplay with a tutorial. Recommended for first-time players."
+    description= _ "Learn the basics of Wesnoth gameplay with a tutorial.
+    
+" + _ "Note: No longer reccomended for first-time players. Try <i>The South Guard</i> instead."
     [difficulty]
         # The difficulty-select dialog won’t be shown to the player, as there's
         # only one difficulty. However, if the [campaign] tag doesn't include


### PR DESCRIPTION
I am aware the title was changed to include Old Tutorial. This is intended to further clarify to players that this tutorial is no longer reccomended fow new players. This is intended to remove contradictions between the title and description to prevent confusion for new players.