### PR TITLE
EI prose, encyclopedia: fix Soradoc and outposts locations

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
@@ -54,7 +54,7 @@
             #po: The River Guard posts had been built in 470 YW; they were abandoned in 544 YW.
             #po: The wave of colonization had begun around 530 YW.
             #po: This intro starts in 625 YW; the king's forces arrive at the outposts in 626 YW.
-            story= _ "In the days of King Garard I, two strong points had been built along the far bank of the River Weldyn, south of Soradoc, to stop bandits and orcish raiders out of the Estmarks from entering Wesnoth. In later years, the river guard posts had been abandoned as colonists spread into the Estmarks and the orcs were driven in retreat north of the Great River."
+            story= _ "In the days of King Garard I, two strong points had been built along the far bank of the River Weldyn, east of Soradoc, to stop bandits and orcish raiders out of the Estmarks from entering Wesnoth. In later years, the river guard posts had been abandoned as colonists spread into the Estmarks and the orcs were driven in retreat north of the Great River."
             {EI_BIGMAP}
         [/part]
         [part]

--- a/data/core/encyclopedia/geography.cfg
+++ b/data/core/encyclopedia/geography.cfg
@@ -115,7 +115,7 @@ Over the River Aethen, south of Fort Tahn, is a Wesnothian frontier region. It i
     • Blackwater Port: City lying south of the Bay of Pearls.
     • Carcyn: Located between the Grey Woods and the Great River.
     • Dan’Tonk: Wesnoth’s largest city, located in the center of the country, just west and north of Weldyn.
-    • Soradoc: The northernmost border outpost of Wesnoth, controls the confluence of the Weldyn River and the Great River.
+    • Soradoc: The easternmost town of Wesnoth, controls the confluence of the Weldyn River and the Great River.
     • Fort Tahn: The southernmost border outpost, controls the north/south road crossing the River Aethen.
     • Tath: Important fort city north of Dan’Tonk, exerts control over the wilderness country around the east of the Brown Hills and north to the Ford of Abez.
     • Westin: A small yet important town in Kerlath, the southernmost province of Wesnoth. The old Citadel of Westin can be found there.


### PR DESCRIPTION
On the title screen map, Soradoc seems to be the same latitude as Tath and Aldril, while Carcyn and Elensefar are even further north. Soradoc being the "northernmost outpost" seems to be a holdover from the early geography outline.

Also, as of EI years (which is the only current mainline campaign featuring Soradoc), there are settlements east of Weldyn river, so calling Soradoc an "outpost" seems wrong. Also, its description in EI S06b is:

> Established by the Crown and administered by the Horse Clans, Soradoc controlled the strategic confluence of the Great River and the River Weldyn. Since its founding in the early days of Wesnoth, it had grown into a prosperous and well-fortified border **town**.

As for location of the EI outposts, according to EI campaign map, the Northern Outpost is close to Soradoc and almost due east of it; the Southern outpost is much farther and almost due south of it. Describing them as being "east of Soradoc" seems more natural. The outposts being south of Soradoc seems to be a holdover from the earlier map when they and Soradoc were on the same (western) bank of Weldyn river (see my earlier PR ##9578).