### PR TITLE
EI S06a: improve Hahid's eleixir-related messages

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -237,7 +237,7 @@
         [/message]
         [message]
             speaker=Hahid al-Ali
-            message= _ "One drink from this shimmering blue vial and you’ll move at full speed* through swamps and shallow water! <span color='#BCB088' size='x-small'><i>*less effective on cavalry</i></span>"
+            message= _ "One drink from this shimmering blue vial and you’ll move at full speed through swamps and shallow water!"
         [/message]
         [event]
             name=buy_elixir

--- a/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/06a_Undead_Crossing.cfg
@@ -264,7 +264,7 @@
         [/event]
         [message]
             speaker=Hahid al-Ali
-            message= _ "Supplies are limited so <span strikethrough='true'>call</span> buy now! <i>(elixirs only last for 1 scenario)</i>"
+            message= _ "Supplies are limited so <span strikethrough='true'>call now</span> buy now! <i>(elixirs only last for 1 scenario)</i>"
             [option]
                 label= _ "Buy the elixir (10 gold)."
                 [command]


### PR DESCRIPTION
I noticed there's some differences between Hahid's dialogue in S06a and S07b:

- In S06a, there's small print saying the elixir is less effective on cavalry. But on testing it doesn't seem to be the case (in both scenarios).
- In S06a, the strike-through text is just "call". In S07b, it's "call now". The latter seems more readable to me.

So, I copied these two lines from S07b to S06a. 