### PR TITLE
Change display name of Old Tutorial Achievement Group

### DIFF
--- a/data/campaigns/tutorial/achievements.cfg
+++ b/data/campaigns/tutorial/achievements.cfg
@@ -1,6 +1,6 @@
 #textdomain wesnoth-tutorial
 [achievement_group]
-    display_name=_"Tutorial"
+    display_name=_"Old Tutorial"
     content_for=tutorial
     [achievement]
         id="completed"


### PR DESCRIPTION
Changed from Tutorial to Old Tutorial given the TSG Rework.