### PR TITLE
EI S09: improve frostbite event

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -697,7 +697,7 @@
     {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 140 140 140}   16}
     {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 150 150 150}   17}
     [event]
-        name=side 5 turn end
+        name=turn end
         first_time_only=no
         [store_unit]
             [filter]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -754,7 +754,7 @@
                             [/have_unit]
                             [then]
                                 [event]
-                                    name=turn refresh
+                                    name=side 1 turn refresh
                                     delayed_variable_substitution=no
                                     [harm_unit]
                                         [filter]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -784,12 +784,6 @@
                     [/else]
                 [/if]
                 {MODIFY_UNIT (id=$unit.id) status.slowed no}
-                [fire_event]
-                    name=explain_frostbite
-                    [primary_unit]
-                        id=$unit.id
-                    [/primary_unit]
-                [/fire_event]
             [/do]
         [/foreach]
         [delay]
@@ -797,9 +791,12 @@
         [/delay]
     [/event]
     [event]
-        name=explain_frostbite
+        name=turn 1 end
         [message]
-            speaker=unit
+            id=Gweddry,Owaec
+            [not]
+                trait=TRAIT_elements
+            [/not]
             message= _ "<i>Brrrr</i>, I can’t feel my fingers or toes! We’ll die of cold if we’re trapped out here for too long."
         [/message]
         [message]


### PR DESCRIPTION
The main purpose of this PR is to fix a minor bug: it was always Gweddry who said "Brrrr, I can’t feel my fingers..." between turns 1 and 2, even if he drank Hahid's elixir on turn 1 and became resistant to cold.

In the current code the speaker depends on the order the units are stored into the array (which, AFAIK, is not guaranteed to stay the same in future versions of the game). So I think it's better to fix the speaker to either Gweddry, or Owaec if Gweddry takes the elixir. The other speakers seem less suitable:

- Dolburras and Grug speak other dialects, they shouldn't suddenly start speaking proper Wesnothish.
- Dacyn is unlikely to complain about cold because he visited this area before, and it was him who dragged everyone here in the first place.
- Terraent seems pretty stoic in general.
- Addogin has his own separate complaining message in this event.
- Hahid would complain, but his message should have his own Dunefolk specific flavor (it can simply be added into this event next to Addogin's).

Note that the former `explain frostbite` is now `turn 1 end`, and according to [wiki](https://wiki.wesnoth.org/Eventwml#side_turn_end) it fires after all other end-turn events. That means the message appears after the harming animations for all units began, but while they still play. Before, the message appeared after the harming animation of one unit, and the harming animations of other units played after the message is closed. This is a small change in behavior, but I actually like the new version better - it makes it clearer that the frostbite affects all you units.

Also I've changed event names so they reflect the logic better (no changes in behavior):

- For the main frostbite event: from `side 5 turn end` to `turn end`, so it's clearer that it happens after all sides' turns, and has nothing to do with side 5 specifically.
- For the nested event: from `turn refresh` to `side 1 turn refresh`, so it's clearer that it affects side 1 only.