### PR TITLE
Revert change in recommended next campaign in old tutorial

### DIFF
--- a/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
+++ b/data/campaigns/tutorial/scenarios/02_Tutorial_part_2.cfg
@@ -1496,7 +1496,7 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
 
         [message]
             speaker=Galdrad
-            message= _ "You have beaten the orcs! You may want to try one of the novice-level campaigns next. <i>A Tale of Two Brothers</i> is the easiest and is the recommended first campaign."
+            message= _ "You have beaten the orcs! You may want to try one of the novice-level campaigns next. <i>The South Guard</i> is the easiest and is the recommended first campaign."
         [/message]
         [message]
             speaker=narrator


### PR DESCRIPTION
TSG is now the easier than AToTB and the recommend3d first campaign before even the old tutorial (now not recommended for new players), so it seems reasonable to revert my earlier change and recommend TSG instead.