### PR TITLE
lua: expose rich_label link handling mechanism

### DIFF
--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -244,6 +244,7 @@ function gui.add_widget_definition(type, id, content) end
 ---@class rich_label : simple_widget
 ---@field link_color string
 ---@field wrap boolean
+---@field on_link_click fun(dest:string)
 
 ---A simple image
 ---@class image : simple_widget


### PR DESCRIPTION
Exposes Rich Label's `register_link_callback` function as the lua `on_link_click` setter. The function set to this will be called with the target of the clicked link.

Resolves #9124.

**Example:**
If you have a rich_label with id `test` in your dialog, say inside a grid like this:
```ini
[row]
    [column]
        horizontal_alignment = "left"
        [rich_label]
            id = "test"
            label = _ "<b>Link: </b><ref dst='..units'>Units</ref>"
        [/rich_label]
    [/column]
    [column]
        [spacer]
        [/spacer]
    [/column]
[/row]
```
then you can use it like this inside your `preshow` function:
```lua
local test = dialog:find("test")
test.on_link_click = function(dest)
    gui.alert(dest)
    gui.show_help(dest)
end
```