### PR TITLE
For translation stats, TSG is now the tutorial

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,11 @@
      * S04c: give Mal-Ravanal gold to recruit more units when their army becomes too small
      * forbid all Dunefolk units to take the Plague Staff
      * fix minor bugs with dialogues
+   * The South Guard
+     * Major rewrite of the campaign
+     * Adds an embedded tutorial, which is now the official starting campaign for new players
+   * Tutorial
+     * Description changed to explain that the standalone tutorial is no longer the recommended one
 ### Editor
    * The PBL editor now validates whether DataURI images are too large
 ### Lua API

--- a/changelog_entries/south_guard_is_tutorial.md
+++ b/changelog_entries/south_guard_is_tutorial.md
@@ -1,0 +1,2 @@
+### Translations
+   * For translation statistics, wesnoth-tsg is now part of core, and wesnoth-tutorial isn't

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -185,7 +185,7 @@ if(ENABLE_POT_UPDATE_TARGET)
 			OUTPUT ${PROJECT_SOURCE_DIR}/po/po_stat.dummy
 			COMMAND python3 utils/po_stat.py
 			--update-cfg
-			--textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units,wesnoth-anl
+			--textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tsg,wesnoth-units,wesnoth-anl
 			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 			COMMENT "pot-update Updated data/languages/*.cfg files."
 			# Needs to depend on the subset of .po files matching po_stat.py's --textdomains argument,

--- a/po/SConscript
+++ b/po/SConscript
@@ -118,7 +118,7 @@ if "pot-update" in COMMAND_LINE_TARGETS:
             )
         env.Command(pot, new_pot, Action(update_pot))
 
-    env.Alias("pot-update", "../translations", "python3 utils/po_stat.py --update-cfg --textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units,wesnoth-anl")
+    env.Alias("pot-update", "../translations", "python3 utils/po_stat.py --update-cfg --textdomains=wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tsg,wesnoth-units,wesnoth-anl")
 
 if "update-po" in COMMAND_LINE_TARGETS or "pot-update" in COMMAND_LINE_TARGETS or "update-po4a" in COMMAND_LINE_TARGETS:
     for domain in textdomains:

--- a/utils/po_stat.py
+++ b/utils/po_stat.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
         elif arg.startswith('--textdomains='):
             arg = arg[14:]
             # Is supposed to be:
-            # wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tutorial,wesnoth-units
+            # wesnoth,wesnoth-editor,wesnoth-help,wesnoth-lib,wesnoth-multiplayer,wesnoth-tsg,wesnoth-units
             textdomains = re.split(r'[;, ]', arg)
 
     wesnoth_dir = os.path.realpath(os.path.join(os.path.dirname(sys.argv[0]), '..'))


### PR DESCRIPTION
For working out which languages have 80% of core translated, TSG is now relevant and the old tutorial isn't. This means that the 80% threshold has increased by around 500 strings.

Add missing changelog entries for 1.19.8 directly to the changelog. (Although I'm using the changelog_entries mechanism for the 1.19.9 change, there shouldn't be any danger of merge conflicts for the 1.19.8 part.)