### PR TITLE
TDG: add help-message explaining that campaigns are developed by different authors

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/03_The_Ambassador.cfg
@@ -148,6 +148,18 @@
     [/event]
 
     #############################
+    # EXPLAIN CAMPAIGNS AND SPELLCASTING
+    #############################
+    [event]
+        name=turn 2
+        [message]
+            speaker=narrator
+            image=wesnoth-icon.png
+            message=_"<i>The various campaigns in “Battle for Wesnoth” are developed by a number of authors, many of whom have different styles. Delfador’s spellcasting mechanic is unique to “The Deceiver’s Gambit” and does not reappear in other campaigns.</i>"
+        [/message]
+    [/event]
+
+    #############################
     # LIGHT BRAZIER (COSMETIC)
     #############################
     [event]


### PR DESCRIPTION
TDG's spellcasting isn't a core mechanic, and isn't reused in any other campaigns. Additionally, gameplay style varies significantly between mainline campaigns. Explain this here.

Suggested by @babaissarkar in #9767
