### PR TITLE
EI S09: make frostbite affect wild ogres after they are sighted

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -712,6 +712,24 @@
             variable=frostbite_units
         [/store_unit]
 
+        [if]
+            {VARIABLE_CONDITIONAL ogres_sighted equals yes}
+            [then]
+                [store_unit]
+                    [filter]
+                        side=5
+                    [/filter]
+                    kill=no
+                    variable=frostbite_ogres
+                [/store_unit]
+                [set_variables]
+                    name=frostbite_units
+                    mode=append
+                    to_variable=frostbite_ogres
+                [/set_variables]
+            [/then]
+        [/if]
+
         [sound]
             name=wind.ogg
         [/sound]
@@ -1449,7 +1467,7 @@ I shall not fall here."
     [/event]
     [event]
         name=victory
-        {CLEAR_VARIABLE frostbite_animate,frostbite_amount,frostbite_units,unit}
+        {CLEAR_VARIABLE frostbite_animate,frostbite_amount,frostbite_units,frostbite_ogres,unit}
         {CLEAR_VARIABLE elixir_drinker}
     [/event]
 

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1135,34 +1135,29 @@ I shall not fall here."
     #---------------------
     # OGRE EVENTS
     #---------------------
-#define GRUG_OGRE_MESSAGE
-    [fire_event]
-        name=grug_ogre_message
-    [/fire_event]
-#enddef
     [event]
-        name=grug_ogre_message
-        [event]
-            name=side 1 turn,side 1 turn end,grug_ogre_now
-            [if]
-                [have_unit]
-                    id=Grug
-                [/have_unit]
+        name=side 1 turn,side 1 turn end,grug_ogre_now
+        [filter_condition]
+            {VARIABLE_CONDITIONAL ogres_sighted equals yes}
+        [/filter_condition]
+        [if]
+            [have_unit]
+                id=Grug
+            [/have_unit]
 
-                [then]
-                    [message]
-                        speaker=Grug
-                        #po: Grug to Gweddry
-                        message= _ "Grug make ogre friendly! Talk ogre Grug make friend."
-                    [/message]
-                    [message]
-                        speaker=Gweddry
-                        message= _ "I think he’s saying he wants to talk with the wild ogres?"
-                    [/message]
-                    {VARIABLE grug_event_active yes}
-                [/then]
-            [/if]
-        [/event]
+            [then]
+                [message]
+                    speaker=Grug
+                    #po: Grug to Gweddry
+                    message= _ "Grug make ogre friendly! Talk ogre Grug make friend."
+                [/message]
+                [message]
+                    speaker=Gweddry
+                    message= _ "I think he’s saying he wants to talk with the wild ogres?"
+                [/message]
+                {VARIABLE grug_event_active yes}
+            [/then]
+        [/if]
     [/event]
 #define OGRE_RECALL_COST
     [modify_unit]
@@ -1222,7 +1217,7 @@ I shall not fall here."
             message= _ "They don’t look very friendly..."
         [/message]
 
-        {GRUG_OGRE_MESSAGE}
+        {VARIABLE ogres_sighted yes}
     [/event]
 
     #
@@ -1274,7 +1269,7 @@ I shall not fall here."
             team_name=good
         [/modify_side]
 
-        {GRUG_OGRE_MESSAGE}
+        {VARIABLE ogres_sighted yes}
     [/event]
 
     #
@@ -1296,7 +1291,7 @@ I shall not fall here."
         {FIND_NEARBY id=Grug 39 29 99}
         {FIND_NEARBY side=5 $found_unit.x $found_unit.y 99}
 
-        {GRUG_OGRE_MESSAGE}
+        {VARIABLE ogres_sighted yes}
         [fire_event]
             name=grug_ogre_now
         [/fire_event]
@@ -1476,6 +1471,7 @@ I shall not fall here."
             message= _ "This is the place! Let us enter."
         [/message]
 
+        {CLEAR_VARIABLE ogres_sighted}
         {CLEAR_VARIABLE ogres_peaceful}
         {CLEAR_VARIABLE grug_event_active}
         [endlevel]


### PR DESCRIPTION
Fixes #9784

- The first commit simplifies the events for sighting the ogres and introduces `ogres_sighted` variable. No changes in behavior.
- The second commit adds `side 5` ogres to the list of frostbitten units, if `ogres_sighted` is set.