### PR TITLE
TDG: Capitalize Silverback in Unit Description

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/units/Monster_Silverback.cfg
@@ -7,7 +7,7 @@ units/silverback/#enddef
     id=Silverback
     name= _ "Silverback"
     race=monster
-    description= _"The greatest of the apes are the silverbacks, so called for their distinctive rear coloration. Smaller than an ogre but much more muscular, the eldest of these creatures are said to possess the strength of a dozen men."
+    description= _"The greatest of the apes are the Silverbacks, so called for their distinctive rear coloration. Smaller than an ogre but much more muscular, the eldest of these creatures are said to possess the strength of a dozen men."
     hitpoints={ON_DIFFICULTY4 55 75 115 142}
     movement_type,movement=woodland,4
     level,experience={ON_DIFFICULTY4 1 2 2 3},{ON_DIFFICULTY4 50 100 100 150}


### PR DESCRIPTION
https://wiki.wesnoth.org/Typography_Style_Guide

According to the Typography Style Guide, races shouldn’t be capitalized but unit types should be. Silverbacks aren’t a species, and in this case I think this refer to the Unit Type.