### PR TITLE
TDG: Capitalize Queen in Queen Unit Description

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/units/Human_Asheviere.cfg
@@ -11,9 +11,9 @@
     level,experience,advances_to=2,100,null
     {AMLA_DEFAULT}
     usage=fighter
-    description= _"While some queens are influential leaders, many others have their role restricted to mere social companionship.
+    description= _"While some Queens are influential leaders, many others have their role restricted to mere social companionship.
 
-Nevertheless, even when she does not share political and military power with the king, a queen can still take part in the kingdom’s internal politics, both by influencing the royal court and through her kinship with the royal family."
+Nevertheless, even when she does not share political and military power with the king, a Queen can still take part in the kingdom’s internal politics, both by influencing the royal court and through her kinship with the royal family."
     die_sound={SOUND_LIST:HUMAN_DIE}
     [resistance]
         blade=110


### PR DESCRIPTION
Though generally uncapitalized in Wesnoth, this refers to a unit type and should be capitalized according to the style guide.