### PR TITLE
Improving Wose Shaman

### DIFF
--- a/data/core/units/wose/Wose_Shaman.cfg
+++ b/data/core/units/wose/Wose_Shaman.cfg
@@ -34,7 +34,7 @@
         description=_"crush"
         type=impact
         range=melee
-        damage=12
+        damage=13
         number=2
         icon=attacks/crush-wose.png
     [/attack]
@@ -45,8 +45,8 @@
         [specials]
             {WEAPON_SPECIAL_SLOW}
         [/specials]
-        damage=11
-        number=2
+        damage=8
+        number=3
         range=ranged
     [/attack]
     [attack_anim]


### PR DESCRIPTION
I, @MechanicalDragon963 and @Jonathan-Kelly are improving the Legend of Wesmere campaign and we're gonna introduce Wose Shaman as a playable unit at some point. But the current Wose Shaman in mainline looks pretty weird. Its melee damage decreases in comparison with Wose and its stats look weak-ish overall. Our proposal on how to improve it:

1. Melee 13-2, the same as lvl 1 Wose
2. 3 strikes on the slowing attack so the Shaman can use it more effectively (which is handy considering its slowness)