### PR TITLE
revert Unit/Type: drop bar_scaling keys as well

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
 ### Units
 ### User interface
 ### WML Engine
-   * [unit] and [unit_type] no longer accept hp_bar_scaling and xp_bar_scaling keys
+   * [unit] no longer accepts hp_bar_scaling and xp_bar_scaling keys
 ### Miscellaneous and Bug Fixes
 
 ## Version 1.19.8

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -19,6 +19,7 @@
 	{SIMPLE_KEY healed_sound string}
 	{SIMPLE_KEY hide_help bool}
 	{SIMPLE_KEY hitpoints int}
+	{SIMPLE_KEY hp_bar_scaling real}
 	{SIMPLE_KEY ignore_race_traits bool}
 	{SIMPLE_KEY image string}
 	{SIMPLE_KEY image_icon string}
@@ -35,6 +36,7 @@
 	{SIMPLE_KEY undead_variation string}
 	{SIMPLE_KEY usage ai_usage}
 	{SIMPLE_KEY vision int}
+	{SIMPLE_KEY xp_bar_scaling real}
 	{SIMPLE_KEY bar_offset_x int}
 	{SIMPLE_KEY bar_offset_y int}
 	{SIMPLE_KEY zoc bool}

--- a/src/units/drawer.cpp
+++ b/src/units/drawer.cpp
@@ -373,7 +373,7 @@ void unit_drawer::redraw_unit(const unit& u) const
 
 		if(u.max_hitpoints() > 0) {
 			bars.AGGREGATE_EMPLACE(
-				energy_bar::get_height(u.max_hitpoints(), game_config::hp_bar_scaling),
+				energy_bar::get_height(u.max_hitpoints(), u.hp_bar_scaling()),
 				energy_bar::get_filled(u.hitpoints(), u.max_hitpoints()),
 				energy_bar::get_color(u.hp_color(), bar_focus)
 			);
@@ -381,7 +381,7 @@ void unit_drawer::redraw_unit(const unit& u) const
 
 		if(u.experience() > 0 && u.can_advance()) {
 			bars.AGGREGATE_EMPLACE(
-				energy_bar::get_height(u.max_experience(), game_config::xp_bar_scaling / std::max(u.level(), 1)),
+				energy_bar::get_height(u.max_experience(), u.xp_bar_scaling() / std::max(u.level(), 1)),
 				energy_bar::get_filled(u.experience(), u.max_experience()),
 				energy_bar::get_color(u.xp_color(), bar_focus)
 			);

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -59,6 +59,8 @@ unit_type::unit_type(const unit_type& o)
 	, type_name_(o.type_name_)
 	, description_(o.description_)
 	, hitpoints_(o.hitpoints_)
+	, hp_bar_scaling_(o.hp_bar_scaling_)
+	, xp_bar_scaling_(o.xp_bar_scaling_)
 	, level_(o.level_)
 	, recall_cost_(o.recall_cost_)
 	, movement_(o.movement_)
@@ -108,6 +110,8 @@ unit_type::unit_type(defaut_ctor_t, const config& cfg, const std::string & paren
 	, type_name_()
 	, description_()
 	, hitpoints_(0)
+	, hp_bar_scaling_(0.0)
+	, xp_bar_scaling_(0.0)
 	, level_(0)
 	, recall_cost_()
 	, movement_(0)
@@ -212,6 +216,9 @@ void unit_type::build_full(
 	zoc_ = get_cfg()["zoc"].to_bool(level_ > 0);
 
 	game_config::add_color_info(game_config_view::wrap(get_cfg()));
+
+	hp_bar_scaling_ = get_cfg()["hp_bar_scaling"].to_double(game_config::hp_bar_scaling);
+	xp_bar_scaling_ = get_cfg()["xp_bar_scaling"].to_double(game_config::xp_bar_scaling);
 
 	// Propagate the build to the variations.
 	for(variations_map::value_type& variation : variations_) {

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -159,6 +159,8 @@ public:
 	 */
 	std::vector<t_string> special_notes() const;
 	int hitpoints() const { return hitpoints_; }
+	double hp_bar_scaling() const { return hp_bar_scaling_; }
+	double xp_bar_scaling() const { return xp_bar_scaling_; }
 	int level() const { return level_; }
 	int recall_cost() const { return recall_cost_;}
 	int movement() const { return movement_; }
@@ -328,6 +330,7 @@ private:
 	t_string description_;
 	std::vector<t_string> special_notes_;
 	int hitpoints_;
+	double hp_bar_scaling_, xp_bar_scaling_;
 	int level_;
 	int recall_cost_;
 	int movement_;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2779,6 +2779,15 @@ void unit::set_hidden(bool state) const
 	anim_comp_->clear_haloes();
 }
 
+double unit::hp_bar_scaling() const
+{
+	return type().hp_bar_scaling();
+}
+double unit::xp_bar_scaling() const
+{
+	return type().xp_bar_scaling();
+}
+
 void unit::set_image_halo(const std::string& halo)
 {
 	appearance_changed_ = true;

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -726,6 +726,17 @@ public:
 	void set_hidden(bool state) const;
 
 	/**
+	 * The factor by which the HP bar should be scaled.
+	 * Convenience wrapper around the unit_type value.
+	 */
+	double hp_bar_scaling() const;
+	/**
+	 * The factor by which the XP bar should be scaled.
+	 * Convenience wrapper around the unit_type value.
+	 */
+	double xp_bar_scaling() const;
+
+	/**
 	 * Whether the unit has been instructed to hold its position.
 	 * This excludes it from the unit cycling function.
 	 * @return true if it is holding position


### PR DESCRIPTION
revert https://github.com/wesnoth/wesnoth/commit/fc8e8eb09e92ef0c2fb1bad216d9ee64f2a3c372#diff-dc56bda7f509dc7a0a91fbd69d289b59257ae33e16556cff72e86598172f788f because scaling keys used in TSG and TDG