### PR TITLE
advanced prefs: clear list everytime advanced prefs are reloaded.

### DIFF
--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -160,6 +160,8 @@ prefs::~prefs()
 
 void prefs::load_advanced_prefs(const game_config_view& gc)
 {
+	advanced_prefs_.clear();
+
 	for(const config& pref : gc.child_range("advanced_preference")) {
 		try {
 			advanced_prefs_.emplace_back(pref);


### PR DESCRIPTION
Resolves #9581.

The advanced preference list variable was not being cleared before loading from advanced preferences file.