### PR TITLE
THoT S3 Map: Aesthetic Revision

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/maps/03_Strange_Allies.map
+++ b/data/campaigns/The_Hammer_of_Thursagan/maps/03_Strange_Allies.map
@@ -1,27 +1,27 @@
-Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rp, Gg, Gg, Gg, Gg, Gs^Fp, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Gg, Re^Gvs, Gg, Gg, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gs^Fp, Gg, Gg, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Rp, Gg^Efm, Gg, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gg, Ww, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Rp, Gg^Efm, Gg^Efm, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Ww, Ww, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Rp, Gg, Gg, Hh, Hh, Gs, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gll^Fp, Ww, Ww, Gg, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Rp, Gg, Hh, Hh, Hh, Hh, Gs, Gs, Gs^Fp, Gs^Vl, Gs, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Sm, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rp, Gg, Gg, Gg, Gg, Gs^Fp, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Gg, Re^Gvs, Gg, Gg, Gg, Gg, Gg, Sm, Ww, Gg, Gg, Gs^Fp, Gg, Gg, Gg, Gs^Fp, Gs^Fms, Gs^Fp, Gg, Gg, Rp, Gg^Efm, Gg, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fms, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gg, Gg, Ww, Gg, Gs^Fp, Gs^Fms, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fms, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Rp, Gg^Efm, Gg^Efm, Gg, Gs^Fms, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fms, Gs^Fp, Gg, Gg, Gg, Gg
+Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Ww^Ewf, Ww^Ewl, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fms, Gs^Fp, Gs^Fms, Gs^Fp, Gs^Fp, Gg, Rp, Gg, Gg, Hh, Hh, Gs, Gs^Fp, Gs^Fp, Gs^Fms, Gs^Fp, Gg^Edb, Gg, Gg, Gg
+Gg, Gg, Gg^Es, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg^Wm, Gg, Gg, Gll^Fp, Ww, Ww, Gg, Gg, Gs^Fp, Gs^Fp, Gs^Fms, Gs^Fp, Gg, Gg, Rp, Gg, Hh, Hh, Hh, Hh, Gs, Gs^Em, Gs^Fp, Gs^Vl, Gs, Gg, Gg, Gg
 Gg, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gg, Ww, Gg, Gg, Gg, Gs^Fp, Hh^Fp, Hh^Fp, Hh, Rp, Gg, Hh, Hh, Hh, Hh^Fp, Hh^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs, Gg, Gs
 Gg, Gg, Gg, Gg, Gg, Gg, Gg, Re^Gvs, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gg, Ww, Ww, Gg, Gg, Hh, Hh^Fp, Hh^Fp, Hh, Rp, Rp, Hh, Hh, Gs, Hh^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Ce, Ce, Gs
-Gg, Gg, Gg, Gg^Efm, Gg^Efm, Gg, Gg, Gg^Vc, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Vc, Gg, Gg, Gg, Wwf, Gg, Hh, Hh, Hh, Hh^Fp, Gg, Gg, Hh, Rp, Hh^Fp, Hh^Fp, Gs^Fp, Gs^Fp, Gg^Efm, Gs^Vl, Gs, Ce, 3 Ke, Ce, Gs
-Gs^Fp, Gs^Fp, Gs, Gg^Efm, Gs^Fp, Hh, Hh, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Efm, Gg^Efm, Re^Gvs, Re^Gvs, Re^Gvs, Ww, Re^Gvs, Hh, Re^Gvs, Hh, Gg, Gg, Hh, Rp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Ce, Ce, Ce, Gs
-Hh, Hh, Gs^Fp, Gs, Gs, Gs^Fp, Hh, Hh, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Ww, Re^Gvs, Re^Gvs, Re^Gvs, Gg^Vl, Re^Gvs, Re^Gvs, Re^Gvs, Rp, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg, Ce, Gg
-Hh, Hh, Gs, Gs, Ce, Gs, Gg, Hh, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Ww, Ww, Ww, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Rp, Gg, Gg, Gg, Gs^Fp, Rr, Gg, Gg, Gg^Vl, Gg, Gg, Rp
-Rp, Gs^Vl, Gs, Ce, 1 Ke, Ce, Gg, Gs^Vl, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Ww, Ww, Mm, Mm, Hh, Ww, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Rr, Rr, Rr, Gg, Rr, Rr, Re^Gvs, Rr, Rr, Gg, Rr, Rr, Gg
-Gg, Rr, Rr, Ce, Ce, Ce, Gg, Gg, Gg, Gg, Gg, Gg, Ww, Ww, Hh, Mm, Mm, Hh, Gs^Fp, Ww, Ww, Re^Gvs, Rr, Rr, Hh, Hh, Hh, Rr, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Rr, Hh, Hh, Gg
-Gg, Gg, Gs^Fp, Rr, Rr, Gg, Gs^Vl, Gg, Hh^Fp, Hh^Fp, Hh, Ww, Gg, Gg, Gg, Gg, Gg, Hh, Gs^Fp, Gs^Fp, Rr, Ww^Bw/, Ww, Mm, Mm, Mm, Hh^Vhh, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Hh, Hh, Hh^Fp, Hh^Vhh, Hh
+Gg, Gg, Gg, Gg^Efm, Gg^Efm, Gg, Gg, Gg^Vc, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Vc, Gg, Re^Gvs, Re^Gvs, Wwf, Gg, Hh, Hh, Hh, Hh^Fp, Gg, Gg, Hh, Rp, Hh^Fp, Hh^Fp, Gs^Fp, Gs^Fp, Gg^Efm, Gs^Vl, Gs, Ce, 3 Ke, Ce, Gs
+Gs^Fp, Gs^Fp, Gs, Gg^Efm, Gs^Fp, Hh, Hh, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Efm, Gg^Efm, Re^Gvs, Re^Gvs, Ww^Ewf, Gg, Re^Gvs, Hh, Re^Gvs, Hh, Gg, Gg, Hh, Rp, Gs^Fp, Gs^Fms, Gs^Fp, Gs^Fms, Gs^Fp, Gg, Gg, Ce, Ce, Ce, Gs
+Hh, Hh, Gs^Fp, Gs, Gs, Gs^Fp, Hh, Hh, Gg, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Wwr, Ww, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg^Vl, Re^Gvs, Re^Gvs, Re^Gvs, Rp, Gg, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fms, Gg^Edt, Gg, Gg, Gg, Ce, Gg
+Hh, Hh, Gs, Gs, Ce, Gs, Gg, Hh, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Wwr, Ww, Ww, Ww^Wkf, Ww^Wkf, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Rp, Gg, Gg, Gg, Gs^Fp, Rr, Gg, Gg, Gg^Vl, Gg, Gg, Rp
+Rp, Gs^Vl, Gs, Ce, 1 Ke, Ce, Gg, Gs^Vl, Gg, Gg, Gg, Re^Gvs, Re^Gvs, Re^Gvs, Ww, Ww, Mm, Ww, Ww, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Rr, Rr, Rr, Gg, Rr, Rr, Re^Gvs, Rr, Rr, Gg, Rr, Rr, Gg
+Gg, Rr, Rr, Ce, Ce, Ce, Gg, Gg, Gg, Gg, Gg, Gg, Ww, Ww, Hh, Mm, Hh, Mm, Mm, Ww, Ww, Re^Gvs, Rr, Rr, Hh, Hh, Hh, Rr, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Rr, Hh, Hh, Gg
+Gg, Gg, Gs^Fp, Rr, Rr, Gg, Gs^Vl, Gg, Hh^Fp, Hh^Fp, Hh, Ww, Gg, Hh, Gg, Hh, Gg, Hh, Hh^Fp, Hh^Fp, Rr, Ww^Bw/, Ww^Ewl, Mm, Mm, Mm, Hh^Vhh, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Re^Gvs, Hh, Hh, Hh^Fp, Hh^Vhh, Hh
 Gg, Gg, Gg, Gs^Fp, Gg, Rr, Rr, Gg, Hh^Fp, Hh, Rr, Ww, Gg, Gg, Gg, Gg, Gs^Fp, Gg, Rr, Rr, Rb^Gvs, Rb^Gvs, Rb^Gvs, Ww, Ww, Mm, Hh, Re^Gvs, Re^Gvs, Re^Gvs, Gg, Gg, Hh^Fp, Hh^Fp, Gll^Fp, Hh^Fp, Gg^Fp
 Gg, Gg, Hh, Gg, Gg, Gg^Efm, Gg^Efm, Rr, Rr, Rr, Gg, Ww^Bw\, Rr, Gg, Gg, Gg, Rr, Rr, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gg, Ww, Hh, Hh, Hh, Gg, Gg, Gg, Hh^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Fp
-Gg^Fp, Gs^Fp, Gs^Fp, Hh, Hh, Gg, Gg^Efm, Gg, Gg, Gs^Vl, Gg, Ww, Gg, Rr, Rr, Rr, Gg^Vo, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gs^Fp, Gg, Ww, Hh, Gg, Gg, Gll^Fp, Gg, Gll^Fp, Gll^Fp, Gs^Ve, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Fp
-Gg^Fp, Gs^Fp, Gs^Fp, Hh, Hh, Hh, Gg, Gg, Gg, Gg, Ww, Ww, Rb^Gvs, Gg, Rp, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gg, Gs, Hh, Hh, Wwf, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gs, Gll^Fp, Gll^Fp, Gll^Fp, Gs
-Gg^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Hh, Gg, Gg, Gg, Ww, Ww, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Gg, Hh, Gg, Gs, Gs, Rb^Gvs, Rb^Gvs, Ww, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gs, Gs, Gll^Fp, Gs, Gs
-Gg, Gs^Fp, Gg, Gg, Gg, Gg, Ww, Wwf, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Hh, Gs^Fp, Hh, Gs, Gs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Ww, Ww, Gg, Gg, Gs, Hh, Gs, Gs, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Fp
-Gg, Gg, Gg, Gg, Gg, Ww, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gs^Vo, Gs, Rp, Gs, Hh, Hh, Gs^Fp, Gs, Co, Co, Co, Gs, Gs, Gg, Ww, Gg, Gg, Gg, Hh, Hh, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gs
-Gg, Gg, Gg, Gg, Gg, Ww, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gg, Gs, Gs, Gs, Rp, Gs, Gs, Hh, Gs^Fp, Gs, Co, 2 Ko, Co, Gs, Gs^Vo, Gg, Ww, Gg, Gg, Hh, Hh, Hh, Gg, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Gg, Ww, Ww, Gg, Rb^Gvs, Gg, Gg, Gg, Gg, Gg, Gg, Rp, Gs, Gs, Gs, Gs^Fp, Gs^Vo, Gs, Co, Gs, Gs, Gg, Gg, Wwf, Gg, Gs^Fp, Hh, Gg, Hh^Vhh, Gg^Efm, Gg, Gg^Efm, Gg, Gg
-Gg, Gg, Ww, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg^Efm, Gg^Efm, Gg, Gg, Gs^Vo, Rp, Rp, Gs, Gs, Gs^Fp, Gs^Fp, Gs, Gs, Gs^Vo, Gg, Gg, Ww, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg^Efm, Gg, Gg, Gg
-Ww, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gs, Gs^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg, Ww, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
-Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg^Fp, Gs^Fp, Gs^Fp, Hh, Hh, Gg, Gg^Efm, Gg, Gg, Gs^Vl, Ww, Ww, Gg, Rr, Rr, Rr, Gg^Vo, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gs^Fp, Gg, Ww, Hh, Gg, Gg, Gll^Fp, Gg, Gll^Fp, Gll^Fp, Gll^Ve, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Fp
+Gg^Fp, Gs^Fp, Gs^Fp, Hh, Hh, Hh, Gg, Gg, Gg, Gg, Ww, Ww, Rb^Gvs, Gg, Rp, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gg, Gs, Hh, Hh, Wwf, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gs, Gll^Fp, Gll^Fp, Gll^Fp, Gll
+Gg^Fp, Gs^Fp, Gs^Fp, Gs^Fp, Hh, Gg, Gg, Gg, Ww, Ww, Ww, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Gg, Hh, Gg, Gs, Gs, Rb^Gvs, Rb^Gvs, Ww, Gg, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gll^Fp, Gs, Gs, Gll^Fp, Gll, Gll
+Gg, Gs^Fp, Gg, Gg, Gg, Gg, Ww, Wwf, Wwf, Ww, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Hh, Hh^Fp, Hh, Gs, Gs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Ww, Ww, Gg, Gg, Gs, Hh, Gs, Gs, Gll^Fp, Gll^Fp, Gll^Fp, Gg^Fp
+Gg, Gg, Gg, Gg, Gg, Ww, Ww, Wwf, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gs^Vo, Gs, Rp, Gs, Hh, Hh, Hh^Fp, Gs, Co, Co, Co, Gs, Gs, Ww, Ww, Gg, Gg, Gg, Hh, Hh, Gg, Gll^Fp, Gll^Fp, Gll^Fp, Gs
+Gg, Gg, Gg, Gg, Ww^Ewl, Ww, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Gg^Eff, Gs^Eff, Gs, Gs, Rp, Gs, Gs, Hh, Gs^Fp, Gs, Co, 2 Ko, Co, Gs, Gs^Vo, Gg, Ww, Gg, Gg, Hh, Hh, Hh, Gg, Gg, Gg, Gg, Gg
+Gg, Gg, Ww, Ww, Ww, Ww, Gg^Eff, Rb^Gvs, Gg^Eff, Gg^Eff, Gg, Gg, Gg, Gg, Rp, Gs, Gs, Gs^Dr, Gs^Fp, Gs^Vo, Gs, Co, Gs, Gs, Gg, Gg, Wwf, Gg, Gs^Fp, Hh, Gg, Hh^Vhh, Gg^Efm, Gg, Gg^Efm, Gg, Gg
+Ww, Ww, Ww, Ww, Ds, Gg, Gg, Gg^Eff, Gg, Gg, Gg^Efm, Gg^Efm, Gg, Gg, Gs^Vo, Rp, Rp, Gs, Gs, Gs^Fp, Gs^Fp, Gs, Gs, Gs^Vo, Gg, Gg, Ww, Gs^Fp, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg^Efm, Gg, Gg, Gg
+Ww, Ww^Ewl, Ds, Ds, Gg^Efm, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gs, Gs^Fp, Gs^Fms, Gs^Fp, Gs^Fp, Gg, Gg, Gg, Gg, Ww, Gs^Fp, Gs^Fp, Gs^Fms, Gg^Efm, Gg, Gg, Gg, Gg, Gg, Gg
+Ds, Ds, Ds, Gg, Gg, Gg^Efm, Gg, Gg, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Gg, Gg, Gg, Gs, Gg, Gg, Gg, Gg, Ww^Ewl, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg
+Gg, Ds, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rb^Gvs, Rp, Gg, Gg, Gs, Gg, Gs, Gg, Gg, Gg, Gg, Gg, Ww, Gg, Gg, Gg, Gg, Gg, Gg, Gg, Gg^Efm, Gg


### PR DESCRIPTION
Some slight aesthetic revisions to THoT's S3 Map similar to last time. Changes are largely aesthetic involving small additions and embellishments and should not need scenario changes.

Current Map:

![Old-THoT-S3](https://github.com/user-attachments/assets/a3b4a8f6-b1f6-4863-8cc1-6f67ce49f731)

Proposed Map:

![THoT-S3-Rework-1](https://github.com/user-attachments/assets/99bac4a8-3dac-4634-865c-9efa65dcd062)

@Dalas121