### PR TITLE
[SotBE] S10: refine objectives flow

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
@@ -28,6 +28,10 @@
         [objectives]
             side=1
             [objective]
+                description= _ "Destroy the southern part of the bridge"
+                condition=win
+            [/objective]
+            [objective]
                 description= _ "Wait for Inarix’s arrival from the south on turn 4"
                 condition=win
                 [show_if]
@@ -38,13 +42,19 @@
                 [/show_if]
             [/objective]
             [objective]
-                description= _ "Destroy the southern part of the bridge"
+                # bonus caption as rescusing them
+                # is not actually a win condition
+                {BONUS_OBJECTIVE_CAPTION}
+                description= _ "Escort Inarix and at least four saurians to Prestim"
                 condition=win
+                [show_if]
+                    [variable]
+                        name=turn_number
+                        greater_than_equal_to=4
+                    [/variable]
+                [/show_if]
             [/objective]
-            [objective]
-                description= _ "In order to recruit saurians later on, bring Inarix and at least four saurians to safety"
-                condition=win
-            [/objective]
+
             [objective]
                 description= _ "Death of Kapou’e"
                 condition=lose
@@ -63,6 +73,9 @@
 
             [note]
                 description= _ "Whoever detonates the bridge will die."
+            [/note]
+            [note]
+                description= _ "In order to recruit saurians later on, bring Inarix and at least four saurians to safety"
             [/note]
         [/objectives]
     [/event]
@@ -257,6 +270,10 @@
             speaker="Inarix"
             message= _ "Hurry-hurry, friends. Lanbec’h and his kind are right on our tails, we must reach Prestim quickly."
         [/message]
+
+        # let player know the objectives have updated
+        [show_objectives]
+        [/show_objectives]
     [/event]
 
     [event]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
@@ -42,10 +42,10 @@
                 [/show_if]
             [/objective]
             [objective]
-                # bonus caption as rescusing them
+                # bonus caption as rescuing them
                 # is not actually a win condition
                 {BONUS_OBJECTIVE_CAPTION}
-                description= _ "Escort Inarix and at least four saurians to Prestim"
+                description= _ "Escort Inarix and at least four saurians to Prestim."
                 condition=win
                 [show_if]
                     [variable]
@@ -75,7 +75,7 @@
                 description= _ "Whoever detonates the bridge will die."
             [/note]
             [note]
-                description= _ "In order to recruit saurians later on, bring Inarix and at least four saurians to safety"
+                description= _ "In order to recruit saurians later on, bring Inarix and at least four saurians to safety."
             [/note]
         [/objectives]
     [/event]


### PR DESCRIPTION
- updated objectives to the player once Inarix and party arrive on turn 4
- move note part of objective win to notes section. Self-Explanatory
- add bonus objective caption to the saving inarix and her 4 saurians objective