### PR TITLE
EI: add macro for multiracial messages

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -628,7 +628,7 @@
     [/event]
 
     # some gold guarded by each of the factions
-#define GOLD_PICKUP X Y PICTURE AMOUNT LABEL_TEXT MESSAGE
+#define GOLD_PICKUP X Y PICTURE AMOUNT LABEL_TEXT DEFAULT_MESSAGE DWARF_MESSAGE OGRE_MESSAGE UNDEAD_MESSAGE
     {PLACE_IMAGE {PICTURE} {X} {Y}}
     {SET_LABEL {X} {Y} {LABEL_TEXT}}
     [event]
@@ -637,11 +637,13 @@
             side=1
             x,y={X},{Y}
         [/filter]
-        [message]
-            speaker=unit
-            message={MESSAGE}
-            sound=gold.ogg
-        [/message]
+        {MESSAGE_BY_RACE
+            {DEFAULT_MESSAGE}
+            {DWARF_MESSAGE}
+            {OGRE_MESSAGE}
+            {UNDEAD_MESSAGE}
+            SOUND=gold.ogg
+        }
         [gold]
             side=1
             amount={AMOUNT}
@@ -650,9 +652,24 @@
         {REMOVE_LABEL $unit.x $unit.y}
     [/event]
 #enddef
-    {GOLD_PICKUP 11 4  items/gold-coins-small.png 10 (_"10 gold") (_"These dwarves have a pile of 10 gold pieces!")}
-    {GOLD_PICKUP 37 26 items/gold-coins-small.png 20 (_"20 gold") (_"These nagas have a pile of 20 gold pieces!")}
-    {GOLD_PICKUP 38 10 items/gold-coins-small.png 20 (_"20 gold") (_"These orcs have a pile of 20 gold pieces!")}
+    {GOLD_PICKUP 11 4  items/gold-coins-small.png 10 (_"10 gold")
+        (_"These dwarves have a pile of 10 gold pieces!")
+        (_"DWARF FOUND DWARVEN COINS")
+        (_"OGRE FOUND DWARVEN COINS")
+        (_"UNDEAD FOUND DWARVEN COINS")
+    }
+    {GOLD_PICKUP 37 26 items/gold-coins-small.png 20 (_"20 gold")
+        (_"These nagas have a pile of 20 gold pieces!")
+        (_"DWARF FOUND NAGA COINS")
+        (_"OGRE FOUND NAGA COINS")
+        (_"UNDEAD FOUND NAGA COINS")
+    }
+    {GOLD_PICKUP 38 10 items/gold-coins-small.png 20 (_"20 gold")
+        (_"These orcs have a pile of 20 gold pieces!")
+        (_"DWARF FOUND ORCISH COINS")
+        (_"OGRE FOUND ORCISH COINS")
+        (_"UNDEAD FOUND ORCISH COINS")
+    }
     {PLACE_ITEM_SHIELD_OF_THE_SENTINEL 9 4}
     [item]
         x,y=9,4

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -638,11 +638,11 @@
             x,y={X},{Y}
         [/filter]
         {MESSAGE_BY_RACE
-            {DEFAULT_MESSAGE}
-            {DWARF_MESSAGE}
-            {OGRE_MESSAGE}
-            {UNDEAD_MESSAGE}
-            SOUND=gold.ogg
+        {DEFAULT_MESSAGE}
+        {DWARF_MESSAGE}
+        {OGRE_MESSAGE}
+        {UNDEAD_MESSAGE}
+        SOUND=gold.ogg
         }
         [gold]
             side=1
@@ -653,22 +653,22 @@
     [/event]
 #enddef
     {GOLD_PICKUP 11 4  items/gold-coins-small.png 10 (_"10 gold")
-        (_"These dwarves have a pile of 10 gold pieces!")
-        (_"DWARF FOUND DWARVEN COINS")
-        (_"OGRE FOUND DWARVEN COINS")
-        (_"UNDEAD FOUND DWARVEN COINS")
+    (_"These dwarves have a pile of 10 gold pieces!")
+    (_"DWARF FOUND DWARVEN COINS")
+    (_"OGRE FOUND DWARVEN COINS")
+    (_"UNDEAD FOUND DWARVEN COINS")
     }
     {GOLD_PICKUP 37 26 items/gold-coins-small.png 20 (_"20 gold")
-        (_"These nagas have a pile of 20 gold pieces!")
-        (_"DWARF FOUND NAGA COINS")
-        (_"OGRE FOUND NAGA COINS")
-        (_"UNDEAD FOUND NAGA COINS")
+    (_"These nagas have a pile of 20 gold pieces!")
+    (_"DWARF FOUND NAGA COINS")
+    (_"OGRE FOUND NAGA COINS")
+    (_"UNDEAD FOUND NAGA COINS")
     }
     {GOLD_PICKUP 38 10 items/gold-coins-small.png 20 (_"20 gold")
-        (_"These orcs have a pile of 20 gold pieces!")
-        (_"DWARF FOUND ORCISH COINS")
-        (_"OGRE FOUND ORCISH COINS")
-        (_"UNDEAD FOUND ORCISH COINS")
+    (_"These orcs have a pile of 20 gold pieces!")
+    (_"DWARF FOUND ORCISH COINS")
+    (_"OGRE FOUND ORCISH COINS")
+    (_"UNDEAD FOUND ORCISH COINS")
     }
     {PLACE_ITEM_SHIELD_OF_THE_SENTINEL 9 4}
     [item]

--- a/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/08_Xenophobia.cfg
@@ -654,21 +654,24 @@
 #enddef
     {GOLD_PICKUP 11 4  items/gold-coins-small.png 10 (_"10 gold")
     (_"These dwarves have a pile of 10 gold pieces!")
-    (_"DWARF FOUND DWARVEN COINS")
-    (_"OGRE FOUND DWARVEN COINS")
-    (_"UNDEAD FOUND DWARVEN COINS")
+    #po: These dwarves are lazy, having just 10 gold!
+    (_"These dwarves be lazy, ’aving just 10 gold!")
+    (_"Dwarf have 10 gold!")
+    (_"The zombie finds a pile of 10 gold pieces!")
     }
     {GOLD_PICKUP 37 26 items/gold-coins-small.png 20 (_"20 gold")
     (_"These nagas have a pile of 20 gold pieces!")
-    (_"DWARF FOUND NAGA COINS")
-    (_"OGRE FOUND NAGA COINS")
-    (_"UNDEAD FOUND NAGA COINS")
+    #po: Oi, this is 20 gold! Where do these reptiles even get it?
+    (_"Oi, this be 20 gold! Wher’ do these reptiles even get it?")
+    (_"Snake have 20 gold!")
+    (_"The zombie finds a pile of 20 gold pieces!")
     }
     {GOLD_PICKUP 38 10 items/gold-coins-small.png 20 (_"20 gold")
     (_"These orcs have a pile of 20 gold pieces!")
-    (_"DWARF FOUND ORCISH COINS")
-    (_"OGRE FOUND ORCISH COINS")
-    (_"UNDEAD FOUND ORCISH COINS")
+    #po: Look at that, 20 gold pieces these orcs have stolen from dwarves!
+    (_"Look a’ that, 20 gold pieces these orcs done steal from dwarves!")
+    (_"Orc have 20 gold!")
+    (_"The zombie finds a pile of 20 gold pieces!")
     }
     {PLACE_ITEM_SHIELD_OF_THE_SENTINEL 9 4}
     [item]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -882,8 +882,10 @@
             [else]
                 {MESSAGE_BY_RACE
                 (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
-                (_ "DWARF FOUND CASTLE")
-                (_ "OGRE FOUND CASTLE")
+                #po: Oi, do you see old castle ruin over there? It’s the one we’re looking for, isn’t it?
+                (_ "Oi, do ya ken ol’ castle ruin o’er yonder? It be one we lookin’ fer, eh?")
+                #po: I see a castle. It is very broken. Does the magic man want the broken castle?
+                (_ "Me see castle. Very broken. Magic man want broken castle?")
                 (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
                 UNDEAD_SPEAKER=Gweddry
                 UNDEAD_IMAGE=""
@@ -1387,12 +1389,14 @@ I shall not fall here."
         {MESSAGE_BY_RACE
         #po: circa 25 gold pieces
         (_ "This shipwreck was carrying chests of gold! Most of them are buried under the ice, but I can still reach $gold pieces.")
+        #po: My beard, a shipwreck full of gold chests! Though only $gold pieces are not under the blasted ice! I have to return here after this war’s over.
         #po: circa 25 gold pieces
-        (_ "DWARF FOUND SHIPWRECK: $gold GOLD")
+        (_ "Me beard, a shipwreck full o’ gold chests! Tho’ only $gold pieces not under blasted ice! Hafta return ’ere after this war’s o’er.")
+        #po: I see a shipwreck. I see a lot of gold in the ice. I cannot take it. $gold gold pieces are not deep. I can take them.
         #po: circa 25 gold pieces
-        (_ "OGRE FOUND SHIPWRECK: $gold GOLD")
+        (_ "Me see ship break. Me see in ice lot gold. No can take. $gold gold no deep. Can take.")
         #po: circa 25 gold pieces
-        (_ "UNDEAD FOUND SHIPWRECK: $gold GOLD")
+        (_ "The zombie finds an old shipwreck and manages to scratch out $gold gold pieces frozen in the ice. The rest of the chests are too deep.")
         SOUND=gold.ogg
         }
         [gold]
@@ -1416,12 +1420,14 @@ I shall not fall here."
         {MESSAGE_BY_RACE
         #po: circa 30 gold pieces
         (_ "This ruined town still has some valuables! I count enough to be worth $gold gold pieces.")
+        #po: This town is a ruin, though I’ve found some baubles worth $gold gold.
         #po: circa 30 gold pieces
-        (_ "DWARF FOUND TOWN: $gold GOLD")
+        (_ "This town’s a ruin, tho’ I done find some baubles worth $gold gold.")
+        #po: This town is very empty. I have found some shiny things. They are worth $gold gold pieces.
         #po: circa 30 gold pieces
-        (_ "OGRE FOUND TOWN: $gold GOLD")
+        (_ "Town very empty. Me find shinies. Shinies for $gold gold.")
         #po: circa 30 gold pieces
-        (_ "UNDEAD FOUND TOWN: $gold GOLD")
+        (_ "The zombie searches the ruined town and finds some valuables worth $gold gold pieces.")
         SOUND=gold.ogg
         }
         [gold]
@@ -1445,12 +1451,14 @@ I shall not fall here."
         {MESSAGE_BY_RACE
         #po: circa 15 gold pieces
         (_ "This drake only had $gold gold pieces in his camp. Not much of a dragon hoard...")
+        #po: Meh, this drake got just $gold gold. I would expect more from a bunch of walking furnaces.
         #po: circa 15 gold pieces
-        (_ "DWARF FOUND DRAKEGOLD: $gold GOLD")
+        (_ "Meh, this drake got just $gold gold. Woulda expect more from a bunch o’ walkin’ furnaces.")
+        #po: The drake has $gold gold pieces. The drake is mean. I am going to take the gold.
         #po: circa 15 gold pieces
-        (_ "OGRE FOUND DRAKEGOLD: $gold GOLD")
+        (_ "Hot lizard have $gold gold. Lizard mean. Me take gold.")
         #po: circa 15 gold pieces
-        (_ "UNDEAD FOUND GOLD: $gold GOLD")
+        (_ "The zombie finds $gold gold pieces in the drake camp.")
         SOUND=gold.ogg
         }
         [gold]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -881,12 +881,12 @@
 
             [else]
                 {MESSAGE_BY_RACE
-                    (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
-                    (_ "DWARF FOUND CASTLE")
-                    (_ "OGRE FOUND CASTLE")
-                    (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
-                    UNDEAD_SPEAKER=Gweddry
-                    UNDEAD_IMAGE=""
+                (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
+                (_ "DWARF FOUND CASTLE")
+                (_ "OGRE FOUND CASTLE")
+                (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
+                UNDEAD_SPEAKER=Gweddry
+                UNDEAD_IMAGE=""
                 }
             [/else]
         [/if]
@@ -1385,15 +1385,15 @@ I shall not fall here."
         [/filter]
         {VARIABLE gold 25}
         {MESSAGE_BY_RACE
-            #po: circa 25 gold pieces
-            (_ "This shipwreck was carrying chests of gold! Most of them are buried under the ice, but I can still reach $gold pieces.")
-            #po: circa 25 gold pieces
-            (_ "DWARF FOUND SHIPWRECK: $gold GOLD")
-            #po: circa 25 gold pieces
-            (_ "OGRE FOUND SHIPWRECK: $gold GOLD")
-            #po: circa 25 gold pieces
-            (_ "UNDEAD FOUND SHIPWRECK: $gold GOLD")
-            SOUND=gold.ogg
+        #po: circa 25 gold pieces
+        (_ "This shipwreck was carrying chests of gold! Most of them are buried under the ice, but I can still reach $gold pieces.")
+        #po: circa 25 gold pieces
+        (_ "DWARF FOUND SHIPWRECK: $gold GOLD")
+        #po: circa 25 gold pieces
+        (_ "OGRE FOUND SHIPWRECK: $gold GOLD")
+        #po: circa 25 gold pieces
+        (_ "UNDEAD FOUND SHIPWRECK: $gold GOLD")
+        SOUND=gold.ogg
         }
         [gold]
             side=1
@@ -1414,15 +1414,15 @@ I shall not fall here."
         [/filter]
         {VARIABLE gold 30}
         {MESSAGE_BY_RACE
-            #po: circa 30 gold pieces
-            (_ "This ruined town still has some valuables! I count enough to be worth $gold gold pieces.")
-            #po: circa 30 gold pieces
-            (_ "DWARF FOUND TOWN: $gold GOLD")
-            #po: circa 30 gold pieces
-            (_ "OGRE FOUND TOWN: $gold GOLD")
-            #po: circa 30 gold pieces
-            (_ "UNDEAD FOUND TOWN: $gold GOLD")
-            SOUND=gold.ogg
+        #po: circa 30 gold pieces
+        (_ "This ruined town still has some valuables! I count enough to be worth $gold gold pieces.")
+        #po: circa 30 gold pieces
+        (_ "DWARF FOUND TOWN: $gold GOLD")
+        #po: circa 30 gold pieces
+        (_ "OGRE FOUND TOWN: $gold GOLD")
+        #po: circa 30 gold pieces
+        (_ "UNDEAD FOUND TOWN: $gold GOLD")
+        SOUND=gold.ogg
         }
         [gold]
             side=1
@@ -1443,15 +1443,15 @@ I shall not fall here."
         [/filter]
         {VARIABLE gold 15}
         {MESSAGE_BY_RACE
-            #po: circa 15 gold pieces
-            (_ "This drake only had $gold gold pieces in his camp. Not much of a dragon hoard...")
-            #po: circa 15 gold pieces
-            (_ "DWARF FOUND DRAKEGOLD: $gold GOLD")
-            #po: circa 15 gold pieces
-            (_ "OGRE FOUND DRAKEGOLD: $gold GOLD")
-            #po: circa 15 gold pieces
-            (_ "UNDEAD FOUND GOLD: $gold GOLD")
-            SOUND=gold.ogg
+        #po: circa 15 gold pieces
+        (_ "This drake only had $gold gold pieces in his camp. Not much of a dragon hoard...")
+        #po: circa 15 gold pieces
+        (_ "DWARF FOUND DRAKEGOLD: $gold GOLD")
+        #po: circa 15 gold pieces
+        (_ "OGRE FOUND DRAKEGOLD: $gold GOLD")
+        #po: circa 15 gold pieces
+        (_ "UNDEAD FOUND GOLD: $gold GOLD")
+        SOUND=gold.ogg
         }
         [gold]
             side=1

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -880,10 +880,14 @@
             [/then]
 
             [else]
-                [message]
-                    speaker=unit
-                    message= _ "Look, a ruined castle off in the distance! Is that the one we’re looking for?"
-                [/message]
+                {MESSAGE_BY_RACE
+                    (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
+                    (_ "DWARF FOUND CASTLE")
+                    (_ "OGRE FOUND CASTLE")
+                    (_ "Look, a ruined castle off in the distance! Is that the one we’re looking for?")
+                    UNDEAD_SPEAKER=Gweddry
+                    UNDEAD_IMAGE=""
+                }
             [/else]
         [/if]
         [message]
@@ -1380,12 +1384,17 @@ I shall not fall here."
             x,y=9,16
         [/filter]
         {VARIABLE gold 25}
-        [message]
-            speaker=unit
+        {MESSAGE_BY_RACE
             #po: circa 25 gold pieces
-            message= _ "This shipwreck was carrying chests of gold! Most of them are buried under the ice, but I can still reach $gold pieces."
-            sound=gold.ogg
-        [/message]
+            (_ "This shipwreck was carrying chests of gold! Most of them are buried under the ice, but I can still reach $gold pieces.")
+            #po: circa 25 gold pieces
+            (_ "DWARF FOUND SHIPWRECK: $gold GOLD")
+            #po: circa 25 gold pieces
+            (_ "OGRE FOUND SHIPWRECK: $gold GOLD")
+            #po: circa 25 gold pieces
+            (_ "UNDEAD FOUND SHIPWRECK: $gold GOLD")
+            SOUND=gold.ogg
+        }
         [gold]
             side=1
             amount=$gold
@@ -1404,12 +1413,17 @@ I shall not fall here."
             x,y=27,32
         [/filter]
         {VARIABLE gold 30}
-        [message]
-            speaker=unit
+        {MESSAGE_BY_RACE
             #po: circa 30 gold pieces
-            message= _ "This ruined town still has some valuables! I count enough to be worth $gold gold pieces."
-            sound=gold.ogg
-        [/message]
+            (_ "This ruined town still has some valuables! I count enough to be worth $gold gold pieces.")
+            #po: circa 30 gold pieces
+            (_ "DWARF FOUND TOWN: $gold GOLD")
+            #po: circa 30 gold pieces
+            (_ "OGRE FOUND TOWN: $gold GOLD")
+            #po: circa 30 gold pieces
+            (_ "UNDEAD FOUND TOWN: $gold GOLD")
+            SOUND=gold.ogg
+        }
         [gold]
             side=1
             amount=$gold
@@ -1428,12 +1442,17 @@ I shall not fall here."
             x,y=30,12
         [/filter]
         {VARIABLE gold 15}
-        [message]
-            speaker=unit
+        {MESSAGE_BY_RACE
             #po: circa 15 gold pieces
-            message= _ "This drake only had $gold gold pieces in his camp. Not much of a dragon hoard..."
-            sound=gold.ogg
-        [/message]
+            (_ "This drake only had $gold gold pieces in his camp. Not much of a dragon hoard...")
+            #po: circa 15 gold pieces
+            (_ "DWARF FOUND DRAKEGOLD: $gold GOLD")
+            #po: circa 15 gold pieces
+            (_ "OGRE FOUND DRAKEGOLD: $gold GOLD")
+            #po: circa 15 gold pieces
+            (_ "UNDEAD FOUND GOLD: $gold GOLD")
+            SOUND=gold.ogg
+        }
         [gold]
             side=1
             amount=$gold

--- a/data/campaigns/Eastern_Invasion/utils/macros.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/macros.cfg
@@ -412,33 +412,28 @@ no#endarg
 #define MESSAGE_BY_RACE DEFAULT_MESSAGE DWARF_MESSAGE OGRE_MESSAGE UNDEAD_MESSAGE
 
 #arg DEFAULT_SPEAKER
-unit
-#endarg
+unit#endarg
 
 #arg DEFAULT_IMAGE
 #endarg
 
 #arg DWARF_SPEAKER
-unit
-#endarg
+unit#endarg
 
 #arg DWARF_IMAGE
 #endarg
 
 #arg OGRE_SPEAKER
-unit
-#endarg
+unit#endarg
 
 #arg OGRE_IMAGE
 #endarg
 
 #arg UNDEAD_SPEAKER
-narrator
-#endarg
+narrator#endarg
 
 #arg UNDEAD_IMAGE
-wesnoth-icon.png
-#endarg
+wesnoth-icon.png#endarg
 
 #arg SOUND
 #endarg

--- a/data/campaigns/Eastern_Invasion/utils/macros.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/macros.cfg
@@ -408,3 +408,77 @@ no#endarg
 
     {CLEAR_VARIABLE possessee}
 #enddef
+
+#define MESSAGE_BY_RACE DEFAULT_MESSAGE DWARF_MESSAGE OGRE_MESSAGE UNDEAD_MESSAGE
+
+#arg DEFAULT_SPEAKER
+unit
+#endarg
+
+#arg DEFAULT_IMAGE
+#endarg
+
+#arg DWARF_SPEAKER
+unit
+#endarg
+
+#arg DWARF_IMAGE
+#endarg
+
+#arg OGRE_SPEAKER
+unit
+#endarg
+
+#arg OGRE_IMAGE
+#endarg
+
+#arg UNDEAD_SPEAKER
+narrator
+#endarg
+
+#arg UNDEAD_IMAGE
+wesnoth-icon.png
+#endarg
+
+#arg SOUND
+#endarg
+
+    [switch]
+        variable=unit.race
+        [case]
+            value=dwarf
+            [message]
+                speaker={DWARF_SPEAKER}
+                message={DWARF_MESSAGE}
+                image={DWARF_IMAGE}
+                sound={SOUND}
+            [/message]
+        [/case]
+        [case]
+            value=ogre
+            [message]
+                speaker={OGRE_SPEAKER}
+                message={OGRE_MESSAGE}
+                image={OGRE_IMAGE}
+                sound={SOUND}
+            [/message]
+        [/case]
+        [case]
+            value=undead
+            [message]
+                speaker={UNDEAD_SPEAKER}
+                message={UNDEAD_MESSAGE}
+                image={UNDEAD_IMAGE}
+                sound={SOUND}
+            [/message]
+        [/case]
+        [else]
+            [message]
+                speaker={DEFAULT_SPEAKER}
+                message={DEFAULT_MESSAGE}
+                image={DEFAULT_IMAGE}
+                sound={SOUND}
+            [/message]
+        [/else]
+    [/switch]
+#enddef


### PR DESCRIPTION
Fixes #9816

It displays message depending on the race of the unit. Dwarves, ogres, and undead use their own custom messages, the rest use the default one.

Optional arguments allow changing the speaker and the image. By default, narrator speaks for the undead, other units speak themselves.

Another optional argument is for the sound (same for all races).

This new macro is used for messages in scenarios 8 and 9, with placeholder messages to be filled in later commit.