### PR TITLE
canvas: add a `parse_text_as_formula` key to `[text]`

### DIFF
--- a/data/schema/gui/generic.cfg
+++ b/data/schema/gui/generic.cfg
@@ -149,6 +149,7 @@
                 {DEFAULT_KEY "text_link_color" f_color "255, 255, 0"}
                 {DEFAULT_KEY "text_wrap_mode" f_unsigned 0}
                 {DEFAULT_KEY "outline" f_bool false}
+                {DEFAULT_KEY "parse_text_as_formula" bool true}
                 {DEFAULT_KEY "h" f_unsigned 0}
                 {DEFAULT_KEY "w" f_unsigned 0}
                 {DEFAULT_KEY "x" f_unsigned 0}

--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -431,7 +431,7 @@ void text_shape::draw(wfl::map_formula_callable& variables)
 	// We first need to determine the size of the text which need the rendered
 	// text. So resolve and render the text first and then start to resolve
 	// the other formulas.
-	const t_string text = text_(variables);
+	const t_string& text = cfg_["parse_text_as_formula"].to_bool(true) ? text_(variables) : cfg_["text"].t_str();
 
 	if(text.empty()) {
 		DBG_GUI_D << "Text: no text to render, leave.";

--- a/src/gui/widgets/rich_label.cpp
+++ b/src/gui/widgets/rich_label.cpp
@@ -744,6 +744,7 @@ void rich_label::default_text_config(config* txt_ptr, const t_string& text) {
 		(*txt_ptr)["y"] = "(pos_y)";
 		(*txt_ptr)["w"] = "(text_width)";
 		(*txt_ptr)["h"] = "(text_height)";
+		(*txt_ptr)["parse_text_as_formula"] = false;
 		// tw -> table width, used for wrapping text inside table cols
 		// ww -> wrap width, used for wrapping around floating image
 		// max text width shouldn't go beyond the rich_label's specified width


### PR DESCRIPTION
Resolves #9822.

This key toggles parsing of `text` key as formula or not. Default: true.