### PR TITLE
[Units] Dune Paragon redesign to avoid RIPLIB and ensure consistency with Blademaster

### DIFF
--- a/data/core/units/dunefolk/Paragon.cfg
+++ b/data/core/units/dunefolk/Paragon.cfg
@@ -30,9 +30,18 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
         description= _ "sword"
         type=blade
         range=melee
-        damage=13
+        damage=15
         number=4
         icon=attacks/longsword.png
+    [/attack]
+    [attack]
+        name=sword
+        description= _ "scimitar"
+        type=blade
+        range=melee
+        damage=25
+        number=2
+        icon=attacks/scimitar.png
         [specials]
             {WEAPON_SPECIAL_MARKSMAN}
         [/specials]
@@ -42,7 +51,7 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
         description= _ "pommel strike"
         type=impact
         range=melee
-        damage=11
+        damage=13
         number=3
         icon=attacks/quarterstaff.png
     [/attack]

--- a/data/core/units/dunefolk/Paragon.cfg
+++ b/data/core/units/dunefolk/Paragon.cfg
@@ -51,9 +51,12 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
         description= _ "pommel strike"
         type=impact
         range=melee
-        damage=13
+        damage=14
         number=3
         icon=attacks/quarterstaff.png
+        [specials]
+            {WEAPON_SPECIAL_STUN}
+        [/specials]
     [/attack]
 
     [attack_anim]

--- a/data/core/units/dunefolk/Paragon.cfg
+++ b/data/core/units/dunefolk/Paragon.cfg
@@ -27,12 +27,12 @@ Among the Dunefolk, while great leaders are required to have mastered the blade,
 
     [attack]
         name=sword
-        description= _ "sword"
+        description= _ "scimitar"
         type=blade
         range=melee
         damage=15
         number=4
-        icon=attacks/longsword.png
+        icon=attacks/scimitar.png
     [/attack]
     [attack]
         name=sword


### PR DESCRIPTION
I noticed that the 1.18/1.19 Dune Paragon currently has major inconsistencies with the Dune Blademaster - the latter has 15x3 melee without marksman, and 18x2 melee with marksman, while Paragon has 13x4 marksman. Considering the Paragon is an macro-locked advancement for Blademaster, it is a major RIPLIB violation. The 13x4 marksman attack seems to be identical to the 1.14 version, and even has an identical name/icon. Another telltale sign of imperfect copying of old stats is the 11x3 pommel attack, losing 1.14's slow special without any buffs to compensate such a massive nerf. Therefore, I am making this PR to make the Dune Paragon's design consistent with the new 1.16+ dunefolk redesign, and slightly more powerful overall to make him better compete with other level 4 units.

What this PR does:
the 13x4 marksman attack is turned into 15x4 without marksman
NEW ATTACK: sword 25x2 marksman
pommel strike buffed from 11x3 to 14x3 and gains the stun special (suggested by lhybrideur/Dalas)
longsword renamed to scimitar, icon adjusted accordingly