### PR TITLE
Balance Arcane for 1.20 + Miscellaneous

### DIFF
--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -133,6 +133,6 @@
         impact=80
         fire=50
         cold=150
-        arcane=110
+        arcane=130
     [/resistance]
 #enddef

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -540,7 +540,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=110
+            arcane=90
         [/resistance]
     [/movetype]
 

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -496,7 +496,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 
@@ -540,7 +540,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=100
+            arcane=110
         [/resistance]
     [/movetype]
 
@@ -584,7 +584,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=110
+            arcane=120
         [/resistance]
     [/movetype]
 
@@ -626,7 +626,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=90
             fire=110
             cold=100
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 
@@ -670,7 +670,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=120
             fire=100
             cold=100
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 
@@ -834,7 +834,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=60
             fire=150
             cold=100
-            arcane=120
+            arcane=130
         [/resistance]
     [/movetype]
 
@@ -1211,7 +1211,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=120
             cold=40
-            arcane=120
+            arcane=140
         [/resistance]
     [/movetype]
 
@@ -1355,7 +1355,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=120
             cold=120
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 
@@ -1410,7 +1410,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=30
             fire=200
             cold=120
-            arcane=150
+            arcane=130
         [/resistance]
     [/movetype]
 
@@ -1558,7 +1558,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=70
             fire=50
             cold=150
-            arcane=110
+            arcane=130
         [/resistance]
     [/movetype]
 
@@ -1589,7 +1589,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=30
             cold=150
-            arcane=110
+            arcane=130
         [/resistance]
     [/movetype]
 
@@ -1631,7 +1631,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=100
             fire=100
             cold=100
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 
@@ -1673,7 +1673,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=100
             cold=100
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 
@@ -1715,7 +1715,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=110
             fire=100
             cold=100
-            arcane=90
+            arcane=80
         [/resistance]
     [/movetype]
 

--- a/data/core/units/bats/Bat_Dread.cfg
+++ b/data/core/units/bats/Bat_Dread.cfg
@@ -22,6 +22,7 @@
 
     [resistance]
         cold=70
+        arcane=80
     [/resistance]
     [defense]
         village=50

--- a/data/core/units/elves/Enchantress.cfg
+++ b/data/core/units/elves/Enchantress.cfg
@@ -10,7 +10,7 @@
     hitpoints=50
     movement_type=woodland
     movement=5
-    experience=180
+    experience=190
     level=3
     alignment=neutral
     advances_to=Elvish Sylph
@@ -48,7 +48,7 @@
         name=faerie fire
         description=_"faerie fire"
         type=arcane
-        damage=11
+        damage=10
         number=4
         range=ranged
         [specials]

--- a/data/core/units/elves/Sylph.cfg
+++ b/data/core/units/elves/Sylph.cfg
@@ -55,7 +55,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=13
+        damage=10
         number=5
         range=ranged
         icon=attacks/faerie-fire.png

--- a/data/core/units/humans/Horse_Paladin.cfg
+++ b/data/core/units/humans/Horse_Paladin.cfg
@@ -22,7 +22,7 @@
 Full paladins are generally not quite as fearsome as the ‘Grand Knights’ that champion most armies, but they are first-class fighters nonetheless. Additionally, their wisdom and piety grants these warrior monks certain curious abilities; a paladin is very powerful in fighting magical or unnatural things, and most have some skill at medicine and healing."
     die_sound=horse-die.ogg
     [resistance]
-        arcane=70
+        arcane=60
     [/resistance]
     [abilities]
         {ABILITY_HEALS}
@@ -40,7 +40,7 @@ Full paladins are generally not quite as fearsome as the ‘Grand Knights’ tha
         icon=attacks/sword-holy.png
         type=arcane
         range=melee
-        damage=9
+        damage=8
         number=5
     [/attack]
     [attack]

--- a/data/core/units/humans/Mage_of_Light.cfg
+++ b/data/core/units/humans/Mage_of_Light.cfg
@@ -61,7 +61,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=12
+        damage=11
         number=3
     [/attack]
     [attack_anim]

--- a/data/core/units/merfolk/Diviner.cfg
+++ b/data/core/units/merfolk/Diviner.cfg
@@ -56,7 +56,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=8
+        damage=7
         number=4
     [/attack]
     [attack_anim]

--- a/data/core/units/monsters/Ant.cfg
+++ b/data/core/units/monsters/Ant.cfg
@@ -27,6 +27,9 @@
         fungus=50
         village=50
     [/defense]
+    [resistance]
+        arcane=100
+    [/resistance]
     [attack]
         name=fangs
         description= _"fangs"

--- a/data/core/units/monsters/Ant_Fire.cfg
+++ b/data/core/units/monsters/Ant_Fire.cfg
@@ -65,6 +65,7 @@ units/monsters/ant/#enddef
     [resistance]
         cold=120
         fire=80
+        arcane=100
     [/resistance]
     [attack]
         name=fangs

--- a/data/core/units/monsters/Ant_Fire_Queen.cfg
+++ b/data/core/units/monsters/Ant_Fire_Queen.cfg
@@ -69,6 +69,7 @@ units/monsters/ant/#enddef
     [resistance]
         cold=120
         fire=80
+        arcane=100
     [/resistance]
     [attack]
         name=fangs

--- a/data/core/units/monsters/Ant_Firebane.cfg
+++ b/data/core/units/monsters/Ant_Firebane.cfg
@@ -64,6 +64,7 @@ units/monsters/ant/#enddef
         impact=80
         cold=120
         fire=80
+        arcane=100
     [/resistance]
     [attack]
         name=fangs

--- a/data/core/units/monsters/Ant_Firebomb.cfg
+++ b/data/core/units/monsters/Ant_Firebomb.cfg
@@ -68,6 +68,7 @@ units/monsters/ant/#enddef
         pierce=110
         cold=80
         fire=70
+        arcane=100
     [/resistance]
     [attack]
         name=fangs

--- a/data/core/units/monsters/Ant_Queen.cfg
+++ b/data/core/units/monsters/Ant_Queen.cfg
@@ -31,6 +31,9 @@
         fungus=40
         village=50
     [/defense]
+    [resistance]
+        arcane=100
+    [/resistance]
     [attack]
         name=fangs
         description= _"fangs"

--- a/data/core/units/monsters/Ant_Soldier.cfg
+++ b/data/core/units/monsters/Ant_Soldier.cfg
@@ -26,6 +26,7 @@
         blade=80
         pierce=90
         impact=90
+        arcane=100
     [/resistance]
     [defense]
         castle=50

--- a/data/core/units/monsters/Frost_Stoat.cfg
+++ b/data/core/units/monsters/Frost_Stoat.cfg
@@ -43,7 +43,7 @@
     [/defense]
     [resistance]
         cold=60
-        arcane=120
+        arcane=110
     [/resistance]
     [standing_anim]
         start_time=-50

--- a/data/core/units/monsters/Giant_Scorpion.cfg
+++ b/data/core/units/monsters/Giant_Scorpion.cfg
@@ -28,7 +28,7 @@
         impact=110
         fire=90
         cold=110
-        arcane=80
+        arcane=90
     [/resistance]
     movement=8
     experience=50

--- a/data/core/units/monsters/Giant_Scorpling.cfg
+++ b/data/core/units/monsters/Giant_Scorpling.cfg
@@ -14,7 +14,7 @@
         impact=110
         fire=90
         cold=110
-        arcane=80
+        arcane=90
     [/resistance]
     movement=6
     experience=20

--- a/data/core/units/monsters/Horse_Dark.cfg
+++ b/data/core/units/monsters/Horse_Dark.cfg
@@ -41,7 +41,7 @@
         pierce=120
         impact=90
         cold=90
-        arcane=100
+        arcane=90
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]

--- a/data/core/units/monsters/Horse_Dark.cfg
+++ b/data/core/units/monsters/Horse_Dark.cfg
@@ -41,7 +41,7 @@
         pierce=120
         impact=90
         cold=90
-        arcane=90
+        arcane=110
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_BLACK_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_BLACK_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]

--- a/data/core/units/monsters/Horse_White.cfg
+++ b/data/core/units/monsters/Horse_White.cfg
@@ -35,7 +35,7 @@
     [resistance]
         pierce=120
         impact=100
-        arcane=90
+        arcane=110
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_WHITE_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_WHITE_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]

--- a/data/core/units/monsters/Horse_White.cfg
+++ b/data/core/units/monsters/Horse_White.cfg
@@ -35,7 +35,7 @@
     [resistance]
         pierce=120
         impact=100
-        arcane=100
+        arcane=90
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-defend-2.png{HORSE_WHITE_IPF}" "units/monsters/horse/horse-defend-1.png{HORSE_WHITE_IPF}" {SOUND_LIST:HORSE_HIT} }
     [attack]

--- a/data/core/units/monsters/Icemonax_Greater.cfg
+++ b/data/core/units/monsters/Icemonax_Greater.cfg
@@ -47,7 +47,7 @@
         impact=80
         fire=70
         cold=50
-        arcane=90
+        arcane=110
     [/resistance]
     [attack]
         name=claws

--- a/data/core/units/monsters/Icemonax_Greater.cfg
+++ b/data/core/units/monsters/Icemonax_Greater.cfg
@@ -47,7 +47,7 @@
         impact=80
         fire=70
         cold=50
-        arcane=100
+        arcane=90
     [/resistance]
     [attack]
         name=claws

--- a/data/core/units/monsters/Raven_Harbinger.cfg
+++ b/data/core/units/monsters/Raven_Harbinger.cfg
@@ -78,6 +78,9 @@
             primary=yes
         [/bird_frame]
     [/defend]
+    [resistance]
+        arcane=100
+    [/resistance]
     [attack]
         name=claws
         description= _ "claws"

--- a/data/core/units/monsters/Raven_Omen.cfg
+++ b/data/core/units/monsters/Raven_Omen.cfg
@@ -77,6 +77,9 @@
             primary=yes
         [/bird_frame]
     [/defend]
+    [resistance]
+        arcane=100
+    [/resistance]
     [attack]
         name=beak
         description= _ "beak"

--- a/data/core/units/monsters/Rock_Scorpion.cfg
+++ b/data/core/units/monsters/Rock_Scorpion.cfg
@@ -33,7 +33,7 @@
         impact=90
         fire=90
         cold=110
-        arcane=100
+        arcane=90
     [/resistance]
     movement=5
     experience=50

--- a/data/core/units/monsters/Sand_Scamperer.cfg
+++ b/data/core/units/monsters/Sand_Scamperer.cfg
@@ -15,10 +15,10 @@
     [resistance]
         blade=90
         pierce=90
-        impact=30
-        fire=200
+        impact=60
+        fire=140
         cold=120
-        arcane=150
+        arcane=120
     [/resistance]
     movement=6
     experience=20

--- a/data/core/units/monsters/Sand_Scuttler.cfg
+++ b/data/core/units/monsters/Sand_Scuttler.cfg
@@ -26,10 +26,10 @@
     [resistance]
         blade=90
         pierce=90
-        impact=30
-        fire=200
+        impact=60
+        fire=140
         cold=120
-        arcane=150
+        arcane=120
     [/resistance]
     movement=8
     experience=50

--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -21,7 +21,7 @@
         pierce=40
         impact=120
         fire=80 #since it is the bones of a dragon, retain some fire resistance
-        arcane=120
+        arcane=130
     [/resistance]
     description= _ "Long ago one of the mightiest living creatures, the feared Dragon has become only bones and dark sinew. Long after its death, it was raised through the dark powers of necromancy, which it now serves. The Skeletal Dragon may look like nothing more than a pile of bones, but few people who thought that way lived long enough to change their minds."
     die_sound=skeleton-big-die.ogg

--- a/data/core/units/orcs/Assassin.cfg
+++ b/data/core/units/orcs/Assassin.cfg
@@ -8,7 +8,7 @@
     hitpoints=26
     movement_type=elusivefoot
     [resistance]
-        arcane=100
+        arcane=90
     [/resistance]
     movement=6
     experience=34

--- a/data/core/units/orcs/Nightblade.cfg
+++ b/data/core/units/orcs/Nightblade.cfg
@@ -8,7 +8,7 @@
     hitpoints=48
     movement_type=elusivefoot
     [resistance]
-        arcane=100
+        arcane=90
     [/resistance]
     movement=6
     experience=150

--- a/data/core/units/orcs/Slayer.cfg
+++ b/data/core/units/orcs/Slayer.cfg
@@ -8,7 +8,7 @@
     hitpoints=36
     movement_type=elusivefoot
     [resistance]
-        arcane=100
+        arcane=90
     [/resistance]
     movement=6
     experience=62

--- a/data/core/units/undead/Necro_Dark_Sorcerer.cfg
+++ b/data/core/units/undead/Necro_Dark_Sorcerer.cfg
@@ -72,7 +72,7 @@ Despite any design they may have of using this to wrest their own immortality fr
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
         range=ranged
-        damage=9
+        damage=10
         number=2
         icon=attacks/dark-missile.png
     [/attack]


### PR DESCRIPTION
My revision of [What is Arcane](https://forums.wesnoth.org/viewtopic.php?t=58949) proposal.

Changed Arcane Resistances of **movement types**: gruefoot, flamefly, drakefly/foot, smallfoot, orcishfoot, largefoot, armoredfoot, elusivefoot, dune(elusive/armored)foot, mounted, treefolk, lizard, scuttlefoot.

**- Arcane Changes**

Undeads: -40% Arcane
Skeletal Dragon: -30% Arcane
Drakes: -30% Arcane
Fire Wisps: -30% Arcane
Wose: -30% Arcane
Mudclawers: -30% Arcane
Trolls: -20% Arcane
Great Icemonax: -10% Arcane
Frost Stoat: -10% Arcane
White Horse: -10% Arcane
Dark Horse: -10% Arcane
Raven Harbringer/Omen: 0% Arcane
Rock/Giant Scorpion/Scorpling: +10% Arcane
Orcs/Goblins: +10% Arcane (conseguential changes to Northeners Faction if approved)
Humans/Dunefolks on horse: +10% Arcane
Dread Bat: +20% Arcane
Saurians: +20% Arcane
Humans/Dunefolks: +20% Arcane
Paladin: +40% Arcane, from 9x5 melee Arcane to 8x5 melee Arcane
Mage of Light: from 12x3 ranged Arcane to 11x3 ranged Arcane
Mermaid Diviner: from 8x4 ranged Arcane to 7x4 ranged Arcane
Dark Sorcerer: from 9x2 ranged Arcane to 10x2 ranged Arcane
Elvish Enchantress: from 11x4 ranged Arcane to 10x4 ranged Arcane
Elvish Sylph: from 13x5 ranged Arcane to 10x5 ranged Arcane

**- Misc Changes**

Elvish Enchantress: from 180xp to 190xp
Sand Scuttler/Scamperer: impact from +70% to +40%, fire from -100% to -40%, arcane from -50% to -20%