### PR TITLE
insert recursion_check for [damage_type] in the RAII system of recursion guard

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/special_damage_type.cfg
@@ -292,7 +292,6 @@
 # Have Bob attack Alice during side 2's turn
 ##
 # Expected end state:
-# BROKE STRICT due to infinite recursion.
 # The test reaches turn 2 without crashing; this tests for a C++ crash due to infinite recursion in the filters.
 #####
 {COMMON_KEEP_A_B_UNIT_TEST event_test_filter_damage_type_recursion (

--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -87,9 +87,9 @@ variant attack_type_callable::get_value(const std::string& key) const
 		return variant(att_->id());
 	} else if(key == "description") {
 		return variant(att_->name());
-	} else if(key == "base_type") {
+	} else if(key == "base_type" || (key == "type" && att_->open_tag_name() == "damage_type")) {
 		return variant(att_->type());
-	} else if(key == "type") {
+	} else if(key == "type" && att_->open_tag_name() != "damage_type") {
 		return variant(att_->effective_damage_type().first);
 	} else if(key == "icon") {
 		return variant(att_->icon());

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1519,7 +1519,7 @@ namespace { // Helpers for attack_type::special_active()
 
 		attack_type::recursion_guard filter_lock;
 		if (weapon && (filter_child->optional_child("has_attack") || filter_child->optional_child("filter_weapon"))) {
-			filter_lock  = weapon->update_variables_recursion(filter);
+			filter_lock  = weapon->update_variables_recursion(filter, check_if_recursion);
 			if(!filter_lock) {
 				show_recursion_warning(weapon, filter);
 				return false;
@@ -1527,7 +1527,7 @@ namespace { // Helpers for attack_type::special_active()
 		}
 		// Check for a weapon match.
 		if (auto filter_weapon = filter_child->optional_child("filter_weapon") ) {
-			if ( !weapon || !weapon->matches_filter(*filter_weapon, check_if_recursion) )
+			if ( !weapon || !weapon->matches_filter(*filter_weapon) )
 				return false;
 		}
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -151,7 +151,7 @@ public:
 
 	// In unit_types.cpp:
 
-	bool matches_filter(const config& filter, const std::string& check_if_recursion = "") const;
+	bool matches_filter(const config& filter) const;
 	bool apply_modification(const config& cfg);
 	bool describe_modification(const config& cfg,std::string* description);
 
@@ -177,7 +177,7 @@ public:
 		/**
 		 * Only expected to be called in update_variables_recursion(), which handles some of the checks.
 		 */
-		explicit recursion_guard(const attack_type& weapon, const config& special);
+		explicit recursion_guard(const attack_type& weapon, const config& special, const std::string& tag_name);
 	public:
 		/**
 		 * Construct an empty instance, only useful for extending the lifetime of a
@@ -211,7 +211,11 @@ public:
 	 * that assumption, for example its' mutable members are assumed to be set up by the current
 	 * caller (or caller's caller, probably several layers up).
 	 */
-	recursion_guard update_variables_recursion(const config& special) const;
+	recursion_guard update_variables_recursion(const config& special, const std::string& tag_name = "") const;
+	/**
+	 * Tests if equals to tag name of special, if yes, then don't call function checked.
+	 */
+	std::string open_tag_name() const {return !open_tag_name_.empty() ? open_tag_name_.back() : "";};
 
 private:
 	// In unit_abilities.cpp:
@@ -448,6 +452,8 @@ private:
 	 * which will pop the config off this stack when the recursion_guard is finalized.
 	 */
 	mutable std::vector<const config*> open_queries_;
+
+	mutable std::vector<std::string> open_tag_name_;
 };
 
 using attack_list = std::vector<attack_ptr>;

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -397,7 +397,7 @@
 0 damage_secondary_type_test
 0 damage_type_apply_to_both_filter_self_opponent
 0 damage_type_apply_to_attacker_filter_attacker_defender
-9 event_test_filter_damage_type_recursion
+0 event_test_filter_damage_type_recursion
 9 four_cycle_recursion_branching
 9 four_cycle_recursion_by_id
 9 four_cycle_recursion_by_tagname


### PR DESCRIPTION

the goal is to extend the check to has_attack but also to formulas.

I know I already proposed a variation but this time I use recursion_guard instead of creating a duplicate of the class for check_recursion.