### PR TITLE
Add myself to credits

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1350,6 +1350,9 @@
         comment = "2012 Google Code-in Students’ Micro AI development"
     [/entry]
     [entry]
+        name = "Gothyoba"
+    [/entry]
+    [entry]
         name = "Gregory Gauthier (rjaguar3)"
     [/entry]
     [entry]


### PR DESCRIPTION
 I think I may be eligible to be added miscellaneous contributor to the credits. I am an active contributor with  37 total commits (many of which are very minor) including a fairly significant revision of the in-game encyclopedia.

This PR should not be backported, since I only have two extremely minor contributions before 1.19.