### PR TITLE
Add [clear_chat], [get_zoom], and optional scrolling support

### DIFF
--- a/data/lua/wml-tags.lua
+++ b/data/lua/wml-tags.lua
@@ -84,6 +84,10 @@ function wml_actions.chat(cfg)
 	end
 end
 
+function wesnoth.wml_actions.clear_chat(cfg)
+	wesnoth.interface.clear_chat_messages()
+end
+
 function wml_actions.gold(cfg)
 	local amount = tonumber(cfg.amount) or
 		wml.error "[gold] missing required amount= attribute."
@@ -308,7 +312,7 @@ function wml_actions.scroll_to(cfg)
 	local loc = wesnoth.map.find( cfg )[1]
 	if not loc then return end
 	if not utils.optional_side_filter(cfg) then return end
-	wesnoth.interface.scroll_to_hex(loc[1], loc[2], cfg.check_fogged, cfg.immediate)
+	wesnoth.interface.scroll_to_hex(loc[1], loc[2], cfg.check_fogged, cfg.immediate, cfg.only_if_needed)
 	if cfg.highlight then
 		wesnoth.interface.highlight_hex(loc[1], loc[2])
 		wml_actions.redraw{}
@@ -319,7 +323,7 @@ function wml_actions.scroll_to_unit(cfg)
 	local u = wesnoth.units.find_on_map(cfg)[1]
 	if not u then return end
 	if not utils.optional_side_filter(cfg, "for_side", "for_side") then return end
-	wesnoth.interface.scroll_to_hex(u.x, u.y, cfg.check_fogged, cfg.immediate)
+	wesnoth.interface.scroll_to_hex(u.x, u.y, cfg.check_fogged, cfg.immediate, cfg.only_if_needed)
 	if cfg.highlight then
 		wesnoth.interface.highlight_hex(u.x, u.y)
 		wml_actions.redraw{}
@@ -928,6 +932,10 @@ end
 
 function wesnoth.wml_actions.zoom(cfg)
 	wesnoth.interface.zoom(cfg.factor, cfg.relative)
+end
+
+function wesnoth.wml_actions.get_zoom(cfg)
+	wml.variables[cfg.variable or "zoom"] = wesnoth.interface.zoom(1, true)
 end
 
 function wesnoth.wml_actions.story(cfg)

--- a/data/lua/wml/kill.lua
+++ b/data/lua/wml/kill.lua
@@ -46,7 +46,9 @@ function wesnoth.wml_actions.kill(cfg)
 			wesnoth.game_events.fire("last breath", death_loc, killer_loc)
 		end
 		if cfg.animate and unit.valid == "map" then
-			wesnoth.interface.scroll_to_hex(death_loc, true)
+			if cfg.scroll_to == nil or cfg.scroll_to == true then
+				wesnoth.interface.scroll_to_hex(death_loc, true)
+			end
 			local anim = wesnoth.units.create_animator()
 			local primary = wml.get_child(cfg, "primary_attack")
 			local secondary = wml.get_child(cfg, "secondary_attack")


### PR DESCRIPTION
Add a couple simple (but potentially useful) wml actions, and add support for scrolling only if a tile is not currently visible.

`[clear_chat]`: as the name implies, clears recent chat messages. Could be used with cutscenes or transitions between different phases of a multiplayer scenario, or also if a scenario is using chat messages to provide information to the player.

`[get_zoom]`: implements request in #7423. Useful if a cutscene or other animation requires a fixed (non-relative) zoom level, so it can be set back, and I could also envision need for animations to scale based on current zoom level.

In addition, extends `[scroll_to]` and `[scroll_to_unit]` to support `only_if_needed`; if this is true then the map will only scroll if the hex or unit is not already visible. Primarily intended for extended dialog scenes with animations where units are (probably) all visible anyway so they can be less choppy.

Finally, extends `[kill]` with a `scroll_to` attribute. Defaults to true. If set to false, then map will not scroll to the unit being killed. Similar use cases as `only_if_needed`.