### PR TITLE
THoT: Update Masked Dwarf Stats

### DIFF
--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Berserker.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Berserker.cfg
@@ -12,7 +12,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=33
+    cost=30
     usage=fighter
     #textdomain wesnoth-units
     description= _ "Berserkers are a rare caste of Dwarves, who work themselves into a towering rage before combat. These warriors disdain all notion of defense, thinking only of the unrelenting assaults for which they are legendary."

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Dragonguard.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Dragonguard.cfg
@@ -3,7 +3,7 @@
     id=Dwarvish Masked Dragonguard
     name= _ "Dwarvish Masked Dragonguard"
     race=dwarf
-    hitpoints=59
+    hitpoints=63
     movement_type=dwarvishfoot
     movement=4
     experience=150
@@ -11,7 +11,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=46
+    cost=61
     usage=archer
     #textdomain wesnoth-units
     description= _ "It is not clear why the Dragonguards are called what they are, a name given by their dwarven brethren. Some speculate that the name comes from their weapon of choice, these strange staves that belch fire and death. Others have surmised that it is because such weapons would be a threat against even a true Dragon, should such a thing be seen again in the known world. Whatever the case, it is for these weapons that the guardians of the great dwarven citadels are both renowned and feared; weapons that have broken the mightiest of warriors with a single blow."

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Fighter.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Fighter.cfg
@@ -7,7 +7,7 @@
     hitpoints=38
     movement_type=dwarvishfoot
     movement=4
-    experience=41
+    experience=45
     level=1
     alignment=neutral
     advances_to=Dwarvish Masked Steelclad

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Guardsman.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Guardsman.cfg
@@ -7,7 +7,7 @@
     hitpoints=42
     movement_type=dwarvishfoot
     movement=4
-    experience=47
+    experience=40
     level=1
     alignment=neutral
     advances_to=Dwarvish Masked Stalwart
@@ -39,7 +39,7 @@
         icon=attacks/javelin-human.png
         type=pierce
         range=ranged
-        damage=5
+        damage=6
         number=1
     [/attack]
     {DEFENSE_ANIM "units/masked_guard_defend2.png" "units/masked_guard_defend1.png" {SOUND_LIST:DWARF_HIT} }

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Lord.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Lord.cfg
@@ -4,7 +4,7 @@
     name= _ "Dwarvish Masked Lord"
     race=dwarf
     image="units/masked_lord.png"
-    hitpoints=79
+    hitpoints=74
     movement_type=dwarvishfoot
     movement=4
     experience=150
@@ -12,7 +12,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=54
+    cost=69
     usage=fighter
     description= _ "Feared in dwarven legend is the Dwarf Lord who masks his face, using the formidable fighting powers of his kind without accounting to his peers and to the loremasters of dwarven-kind for the dark and bloody uses to which he puts his weapons. Like his barefaced kin, the Dwarf Lord wields axe and hammer with masterful skill, and can hit a target with a thrown hand axe at several paces. Though slow on their feet, these dwarves are a testament to the prowess of their kind."
     die_sound={SOUND_LIST:DWARF_DIE}

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Sentinel.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Sentinel.cfg
@@ -12,7 +12,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=41
+    cost=63
     usage=fighter
     #textdomain wesnoth-units
     description= _ "Champions among their fellow troops, the dwarven sentinels form the bulwark of their battle lines. Leading a direct assault against a line that they fortify, is often out of the question; it tends toward being suicidal, rather than merely ineffectual. These dwarves are masters of the melee, and can hold a patch of earth with the single-minded tenacity of an oak."
@@ -38,7 +38,7 @@
         icon=attacks/spear.png
         type=pierce
         range=melee
-        damage=9
+        damage=10
         number=3
     [/attack]
     [attack]

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Stalwart.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Stalwart.cfg
@@ -4,14 +4,14 @@
     name= _ "Dwarvish Masked Stalwart"
     race=dwarf
     image="units/masked_stalwart.png"
-    hitpoints=54
+    hitpoints=59
     movement_type=dwarvishfoot
     movement=4
-    experience=85
+    experience=78
     level=2
     alignment=neutral
     advances_to=Dwarvish Masked Sentinel
-    cost=32
+    cost=30
     usage=fighter
     #textdomain wesnoth-units
     description= _ "The wiles of experience and training turn guardsmen into worthy soldiers. These stalwart troops are equipped to match their skills, and can hold their ground against all but the most visceral assault. It is a dangerous thing to lose a foothold to one such as these, for it will not be easily reprised."
@@ -33,7 +33,7 @@
         icon=attacks/spear.png
         type=pierce
         range=melee
-        damage=7
+        damage=8
         number=3
     [/attack]
     [attack]
@@ -43,7 +43,7 @@
         icon=attacks/javelin-human.png
         type=pierce
         range=ranged
-        damage=8
+        damage=9
         number=1
     [/attack]
     [attack_anim]

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Steelclad.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Steelclad.cfg
@@ -4,17 +4,17 @@
     name= _ "Dwarvish Masked Steelclad"
     race=dwarf
     image="units/masked_steelclad.png"
-    hitpoints=59
+    hitpoints=57
     movement_type=dwarvishfoot
     movement=4
-    experience=74
+    experience=88
     level=2
     alignment=neutral
     advances_to=Dwarvish Masked Lord
-    cost=32
+    cost=36
     usage=fighter
     # wmllint: local spelling dwarvenkind
-    description= _ "More experienced dwarvish fighters wear heavy chain mail and plate armor, for which they are rightly famous. In the dark dreams of dwarvenkind, some conceal their faces behind riveted masks."
+    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed."
     {DEFENSE_ANIM "units/masked_steelclad-defend.png" "units/masked_steelclad.png" {SOUND_LIST:DWARF_HIT} }
     die_sound={SOUND_LIST:DWARF_DIE}
     [resistance]

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Steelclad.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Steelclad.cfg
@@ -14,7 +14,7 @@
     cost=36
     usage=fighter
     # wmllint: local spelling dwarvenkind
-    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed."
+    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed. In the dark dreams of dwarvenkind, some conceal their faces behind riveted masks."
     {DEFENSE_ANIM "units/masked_steelclad-defend.png" "units/masked_steelclad.png" {SOUND_LIST:DWARF_HIT} }
     die_sound={SOUND_LIST:DWARF_DIE}
     [resistance]

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Thunderer.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Thunderer.cfg
@@ -7,7 +7,7 @@
     hitpoints=34
     movement_type=dwarvishfoot
     movement=4
-    experience=40
+    experience=35
     level=1
     alignment=neutral
     advances_to=Dwarvish Masked Thunderguard

--- a/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Thunderguard.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/units/Dwarvish_Masked_Thunderguard.cfg
@@ -5,14 +5,14 @@
     # wmllint: general spelling thunderguard thunderguards
     race=dwarf
     image="units/masked_thunderguard.png"
-    hitpoints=44
+    hitpoints=47
     movement_type=dwarvishfoot
     movement=4
-    experience=95
+    experience=65
     level=2
     alignment=neutral
     advances_to=Dwarvish Masked Dragonguard
-    cost=30
+    cost=24
     usage=mixed fighter
     #textdomain wesnoth-units
     description= _ "The Dwarven Thunderguards are famed for their curious weaponry, these strange staves of wood and iron that make a thunderous noise in their anger. The machinations behind this weaponry are a mystery, a secret taken to the grave by the dwarves of Knalga who wield them, and are assumed to have even forged them. The most that is known are reports of dwarves pouring a strange black dust into the mouth of their weapons, which some say is a food to fuel the beast imprisoned within.

--- a/data/core/units/dwarves/Steelclad.cfg
+++ b/data/core/units/dwarves/Steelclad.cfg
@@ -15,7 +15,7 @@
     advances_to=Dwarvish Lord
     cost=36
     usage=fighter
-    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed."
+    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed. In the dark dreams of dwarvenkind, some conceal their faces behind riveted masks."
     die_sound={SOUND_LIST:DWARF_DIE}
     {STANDING_ANIM_DIRECTIONAL_6_FRAME_FILTERED "units/dwarves/steelclad" {WOUNDED_UNIT ()} }
     {STANDING_ANIM_DIRECTIONAL "units/dwarves/steelclad.png" "units/dwarves/steelclad-ne.png"}

--- a/data/core/units/dwarves/Steelclad.cfg
+++ b/data/core/units/dwarves/Steelclad.cfg
@@ -15,7 +15,7 @@
     advances_to=Dwarvish Lord
     cost=36
     usage=fighter
-    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed. In the dark dreams of dwarvenkind, some conceal their faces behind riveted masks."
+    description= _ "Outfitted in the strongest plate and mail of Knalgan forges, the Steelclads are the vanguard of dwarvish armies. They are renowned for their resilience in the heat of battle, and their mastery of both battleaxe and warhammer make them imposing foes indeed."
     die_sound={SOUND_LIST:DWARF_DIE}
     {STANDING_ANIM_DIRECTIONAL_6_FRAME_FILTERED "units/dwarves/steelclad" {WOUNDED_UNIT ()} }
     {STANDING_ANIM_DIRECTIONAL "units/dwarves/steelclad.png" "units/dwarves/steelclad-ne.png"}


### PR DESCRIPTION
Updated the stats of Masked Dwarves in THoT to be up to date with default dwarves, as they are supposed to be he same in terms of stats. These hasn’t been updated in years despite several balancing changes for the default dwarves. I also updated the unit description the Dwarvish Masked Steelcad since the default one was reworked a few years ago.