### PR TITLE
SotBE: S12: make loyalists AI smarter

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
@@ -263,14 +263,14 @@
     # event: Loyalists AI
     # side 4
     [event]
-        name="side 4 turn" 
+        name="side 4 turn"
         id=arthain_caution
-        first_time_only=no 
+        first_time_only=no
 
         [if]
             [have_unit]
                 side=1,2,3
-                count=3-100 
+                count=3-100
                 [filter_location]
                     x,y,radius=16,25,10
                 [/filter_location]
@@ -304,14 +304,14 @@
     # event: Loyalists AI
     # side 5
     [event]
-        name="side 5 turn" 
+        name="side 5 turn"
         id=hanak_caution
-        first_time_only=no 
+        first_time_only=no
 
         [if]
             [have_unit]
                 side=1,2,3
-                count=3-100 
+                count=3-100
                 [filter_location]
                     x,y,radius=16,17,10
                 [/filter_location]

--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/12_Giving_Some_Back.cfg
@@ -260,6 +260,88 @@
         [/endlevel]
     [/event]
 
+    # event: Loyalists AI
+    # side 4
+    [event]
+        name="side 4 turn" 
+        id=arthain_caution
+        first_time_only=no 
+
+        [if]
+            [have_unit]
+                side=1,2,3
+                count=3-100 
+                [filter_location]
+                    x,y,radius=16,25,10
+                [/filter_location]
+            [/have_unit]
+            [then]
+                {MODIFY_SIDE_AI (4) (grouping="defensive")}
+
+                {MODIFY_AI_ADD_GOAL 4 (
+                    [goal]
+                        id=defend_arthain
+                        name=protect_unit
+                        [criteria]
+                            id=Arthain
+                        [/criteria]
+                        value=100
+                    [/goal]
+                )}
+            [/then]
+            [else]
+                {MODIFY_SIDE_AI (4) (grouping="offensive")}
+
+                [modify_ai]
+                    side=4
+                    action=delete
+                    path=goal[defend_arthain]
+                [/modify_ai]
+            [/else]
+        [/if]
+    [/event]
+
+    # event: Loyalists AI
+    # side 5
+    [event]
+        name="side 5 turn" 
+        id=hanak_caution
+        first_time_only=no 
+
+        [if]
+            [have_unit]
+                side=1,2,3
+                count=3-100 
+                [filter_location]
+                    x,y,radius=16,17,10
+                [/filter_location]
+            [/have_unit]
+            [then]
+                {MODIFY_SIDE_AI (5) (grouping="defensive")}
+
+                {MODIFY_AI_ADD_GOAL 5 (
+                    [goal]
+                        id=defend_hanak
+                        name=protect_unit
+                        [criteria]
+                            id=Hanak
+                        [/criteria]
+                        value=100
+                    [/goal]
+                )}
+            [/then]
+            [else]
+                {MODIFY_SIDE_AI (5) (grouping="offensive")}
+
+                [modify_ai]
+                    side=5
+                    action=delete
+                    path=goal[defend_hanak]
+                [/modify_ai]
+            [/else]
+        [/if]
+    [/event]
+
     {HERO_DEATHS}
     {GENERALS_MUST_SURVIVE}
 [/scenario]

--- a/data/campaigns/Son_Of_The_Black_Eye/utils/utils.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/utils/utils.cfg
@@ -70,6 +70,15 @@
     [/if]
 #enddef
 
+#define MODIFY_SIDE_AI SIDE MODIFICATION
+    [modify_side]
+        side={SIDE}
+        [ai]
+            {MODIFICATION}
+        [/ai]
+    [/modify_side]
+#enddef
+
 #define ALBROCK_SIDE
     type=Orcish Warlord
     id="Al'Brock"


### PR DESCRIPTION
- Partially makes them focus on attacking only when no enemy is near their leader, but switch to full defensive if enemy leaders are nearing the vicinity