### PR TITLE
EI S09: fix minor bugs, code improvements

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1050,16 +1050,18 @@ As you command."
             time=300
         [/delay]
 
-        {FIND_NEARBY (
-            race=drake
-            canrecruit=yes
-            [or]
-                id=Mortic
-            [/or]
-        )
-        $x1 $y1 99} # probably mortic
+        [if]
+            {VARIABLE_CONDITIONAL unit.race equals drake}
+            [then]
+                {VARIABLE their_id $unit.id}
+            [/then]
+            [else]
+                {VARIABLE their_id Mortic}
+            [/else]
+        [/if] # probably mortic
+
         [message]
-            speaker=$found_unit.id
+            speaker=$their_id
             #po: speaker is a drake, probably Mortic
             message= _ "An unknown creature approaches.
 Paler than an Orc.
@@ -1071,7 +1073,7 @@ Tell me of your kin."
             message= _ "We are men, of Wesnoth! We come in peace, seeking magic to help in our war against an undead horde."
         [/message]
         [message]
-            speaker=$found_unit.id
+            speaker=$their_id
             message= _ "Dra-Nak warned us.
 You men of Wes-Noth speak of peace.
 Yet you brandish your spears at our flight.
@@ -1083,11 +1085,11 @@ No further tribute can be paid."
             message= _ "No, wait, we just want to-"
         [/message]
         [message]
-            speaker=$found_unit.id
+            speaker=$their_id
             message= _ "Our Hunt must continue."
         [/message]
 
-        {CLEAR_VARIABLE found_unit}
+        {CLEAR_VARIABLE their_id}
 
         [modify_side]
             side=2

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1096,7 +1096,6 @@ No further tribute can be paid."
             side=3
             gold={ON_DIFFICULTY 10 30 50}
         [/modify_side]
-        {CAPTURE_VILLAGES 3 32 13 0} # cap the village near Mortic, so he doesn't waste his first turn taking it
         {CLEAR_VARIABLE drakes_no_income}
 
         {SCROLL_TO 12 6}

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -600,8 +600,8 @@
         [remove_shroud]
             side=1
             radius=1
-            x=39,44,  6 # villages
-            y=29,28, 21
+            x=42,  6 # villages
+            y=29, 21
         [/remove_shroud]
         [remove_shroud]
             side=1

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -739,9 +739,8 @@
 
         [foreach]
             array=frostbite_units
-            variable=unit
             [do]
-                {MODIFY_UNIT (id=$unit.id) status.slowed yes}
+                {MODIFY_UNIT (id=$this_item.id) status.slowed yes}
                 [delay]
                     time=100
                 [/delay]
@@ -750,13 +749,13 @@
                     # elixir of elements and yetiburger grant immunity to frostbite
                     # (there's only 2 immunity items and you have 3 heroes, so this isn't abusable to farm infinite gold)
                     [have_unit]
-                        id=$unit.id
+                        id=$this_item.id
                         trait=TRAIT_{ID_YETIBURGER},TRAIT_elements
                     [/have_unit]
 
                     [then]
                         [floating_text]
-                            x,y=$unit.x,$unit.y
+                            x,y=$this_item.x,$this_item.y
                             #po: other units are taking damage from the cold, but this unit is immune (through the elixir or yetiburger)
                             text= _ "<span color='#00FF00' size='small'>resist</span>"
                         [/floating_text]
@@ -766,7 +765,7 @@
                         [if]
                             # if the unit is about to die, deal the damage after turn refresh, so we have a chance to heal first
                             [have_unit]
-                                id=$unit.id
+                                id=$this_item.id
                                 formula=(self.hitpoints<=$frostbite_amount)
                             [/have_unit]
                             [then]
@@ -775,7 +774,7 @@
                                     delayed_variable_substitution=no
                                     [harm_unit]
                                         [filter]
-                                            id=$unit.id
+                                            id=$this_item.id
                                         [/filter]
                                         amount=$frostbite_amount
                                         animate=yes
@@ -789,7 +788,7 @@
                             [else]
                                 [harm_unit]
                                     [filter]
-                                        id=$unit.id
+                                        id=$this_item.id
                                     [/filter]
                                     amount=$frostbite_amount
                                     animate=no
@@ -800,7 +799,7 @@
                         [/if]
                     [/else]
                 [/if]
-                {MODIFY_UNIT (id=$unit.id) status.slowed no}
+                {MODIFY_UNIT (id=$this_item.id) status.slowed no}
             [/do]
         [/foreach]
         [delay]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -62,7 +62,6 @@
         # wmllint: recognize Gweddry
         {CHARACTER_STATS_GWEDDRY}
     [/side]
-    {STARTING_VILLAGES 1 5}
 
     #---------------------
     # DRAKES

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1332,8 +1332,6 @@ I shall not fall here."
         name=moveto
         [filter_condition] # works for either side's moves, unlike filter
             [have_unit]
-                side=1
-                race=ogre
                 id=Grug
                 [filter_adjacent]
                     side=5
@@ -1341,8 +1339,12 @@ I shall not fall here."
             [/have_unit]
         [/filter_condition]
 
-        {FIND_NEARBY id=Grug 39 29 99}
-        {FIND_NEARBY side=5 $found_unit.x $found_unit.y 99}
+        {STORE_UNIT_VAR (
+            side=5
+            [filter_adjacent]
+                id=Grug
+            [/filter_adjacent]
+        ) id their_id}
 
         {VARIABLE ogres_sighted yes}
         [fire_event]
@@ -1351,7 +1353,7 @@ I shall not fall here."
 
         [message]
             image_pos=right
-            x,y=$found_unit.x,$found_unit.y
+            speaker=$their_id
             #po: hostile ogre to Grug
             message= _ "Guuuh... who you?"
         [/message]
@@ -1361,7 +1363,7 @@ I shall not fall here."
         [/message]
         [message]
             image_pos=right
-            x,y=$found_unit.x,$found_unit.y
+            speaker=$their_id
             message= _ "Uhhhh... friend... human?"
         [/message]
         [message]
@@ -1370,9 +1372,11 @@ I shall not fall here."
         [/message]
         [message]
             image_pos=right
-            x,y=$unit.x,$unit.y
+            speaker=$their_id
             message= _ "OK, me help human fight! Human good!"
         [/message]
+
+        {CLEAR_VARIABLE their_id}
 
         {CLEAR_VARIABLE grug_event_active}
         {VARIABLE ogres_peaceful yes}

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1053,15 +1053,15 @@ As you command."
         [if]
             {VARIABLE_CONDITIONAL unit.race equals drake}
             [then]
-                {VARIABLE their_id $unit.id}
+                {VARIABLE their_unit_id $unit.id}
             [/then]
             [else]
-                {VARIABLE their_id Mortic}
+                {VARIABLE their_unit_id Mortic}
             [/else]
         [/if] # probably mortic
 
         [message]
-            speaker=$their_id
+            speaker=$their_unit_id
             #po: speaker is a drake, probably Mortic
             message= _ "An unknown creature approaches.
 Paler than an Orc.
@@ -1073,7 +1073,7 @@ Tell me of your kin."
             message= _ "We are men, of Wesnoth! We come in peace, seeking magic to help in our war against an undead horde."
         [/message]
         [message]
-            speaker=$their_id
+            speaker=$their_unit_id
             message= _ "Dra-Nak warned us.
 You men of Wes-Noth speak of peace.
 Yet you brandish your spears at our flight.
@@ -1085,11 +1085,11 @@ No further tribute can be paid."
             message= _ "No, wait, we just want to-"
         [/message]
         [message]
-            speaker=$their_id
+            speaker=$their_unit_id
             message= _ "Our Hunt must continue."
         [/message]
 
-        {CLEAR_VARIABLE their_id}
+        {CLEAR_VARIABLE their_unit_id}
 
         [modify_side]
             side=2
@@ -1224,26 +1224,26 @@ I shall not fall here."
         [if]
             {VARIABLE_CONDITIONAL unit.side equals 1}
             [then]
-                {VARIABLE our_id $unit.id}
-                {VARIABLE their_id $second_unit.id}
+                {VARIABLE our_unit_id $unit.id}
+                {VARIABLE their_unit_id $second_unit.id}
             [/then]
             [else]
-                {VARIABLE their_id $unit.id}
-                {VARIABLE our_id $second_unit.id}
+                {VARIABLE their_unit_id $unit.id}
+                {VARIABLE our_unit_id $second_unit.id}
             [/else]
         [/if]
 
         [message]
-            speaker=$their_id
+            speaker=$their_unit_id
             #po: speaker is a hostile ogre
             message= _ "Guuuh... human?"
         [/message]
         [message]
-            speaker=$our_id
+            speaker=$our_unit_id
             message= _ "Err, hello?"
         [/message]
         [message]
-            speaker=$their_id
+            speaker=$their_unit_id
             message= _ "Human! Human human human!"
         [/message]
         [message]
@@ -1251,7 +1251,7 @@ I shall not fall here."
             message= _ "They don’t look very friendly..."
         [/message]
 
-        {CLEAR_VARIABLE our_id,their_id}
+        {CLEAR_VARIABLE our_unit_id,their_unit_id}
 
         {VARIABLE ogres_sighted yes}
     [/event]
@@ -1277,47 +1277,47 @@ I shall not fall here."
         [if]
             {VARIABLE_CONDITIONAL unit.side equals 1}
             [then]
-                {VARIABLE our_id $unit.id}
+                {VARIABLE our_unit_id $unit.id}
                 {STORE_UNIT_VAR (
                     side=5
                     [filter_adjacent]
-                        id=$our_id
+                        id=$our_unit_id
                     [/filter_adjacent]
-                ) id their_id}
+                ) id their_unit_id}
             [/then]
             [else]
-                {VARIABLE their_id $unit.id}
+                {VARIABLE their_unit_id $unit.id}
                 {STORE_UNIT_VAR (
                     side=1
                     [filter_adjacent]
-                        id=$their_id
+                        id=$their_unit_id
                     [/filter_adjacent]
-                ) id our_id}
+                ) id our_unit_id}
             [/else]
         [/if]
 
         [message]
-            speaker=$our_id
+            speaker=$our_unit_id
             #po: player's ogre (but not Grug, who gets different lines) to hostile ogre
             message= _ "Guuuh... who you?"
         [/message]
         [message]
             image_pos=right
-            speaker=$their_id
+            speaker=$their_unit_id
             #po: hostile ogre to player's ogre
             message= _ "Uhhhh... who <i><b>you</b></i>?"
         [/message]
         [message]
-            speaker=$our_id
+            speaker=$our_unit_id
             message= _ "Me... friend? New friend?"
         [/message]
         [message]
             image_pos=right
-            speaker=$their_id
+            speaker=$their_unit_id
             message= _ "New friend! Me no fight friend."
         [/message]
 
-        {CLEAR_VARIABLE our_id,their_id}
+        {CLEAR_VARIABLE our_unit_id,their_unit_id}
 
         {VARIABLE ogres_peaceful yes}
         [modify_side]
@@ -1347,7 +1347,7 @@ I shall not fall here."
             [filter_adjacent]
                 id=Grug
             [/filter_adjacent]
-        ) id their_id}
+        ) id their_unit_id}
 
         {VARIABLE ogres_sighted yes}
         [fire_event]
@@ -1356,7 +1356,7 @@ I shall not fall here."
 
         [message]
             image_pos=right
-            speaker=$their_id
+            speaker=$their_unit_id
             #po: hostile ogre to Grug
             message= _ "Guuuh... who you?"
         [/message]
@@ -1366,7 +1366,7 @@ I shall not fall here."
         [/message]
         [message]
             image_pos=right
-            speaker=$their_id
+            speaker=$their_unit_id
             message= _ "Uhhhh... friend... human?"
         [/message]
         [message]
@@ -1375,11 +1375,11 @@ I shall not fall here."
         [/message]
         [message]
             image_pos=right
-            speaker=$their_id
+            speaker=$their_unit_id
             message= _ "OK, me help human fight! Human good!"
         [/message]
 
-        {CLEAR_VARIABLE their_id}
+        {CLEAR_VARIABLE their_unit_id}
 
         {CLEAR_VARIABLE grug_event_active}
         {VARIABLE ogres_peaceful yes}

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1218,26 +1218,37 @@ I shall not fall here."
             {VARIABLE_CONDITIONAL ogres_peaceful not_equals yes}
         [/filter_condition]
 
-        {FIND_NEARBY side=5 $unit.x $unit.y 99}
+        [if]
+            {VARIABLE_CONDITIONAL unit.side equals 1}
+            [then]
+                {VARIABLE our_id $unit.id}
+                {VARIABLE their_id $second_unit.id}
+            [/then]
+            [else]
+                {VARIABLE their_id $unit.id}
+                {VARIABLE our_id $second_unit.id}
+            [/else]
+        [/if]
+
         [message]
-            speaker=$found_unit.id
+            speaker=$their_id
             #po: speaker is a hostile ogre
             message= _ "Guuuh... human?"
         [/message]
-        {FIND_NEARBY side=1 $unit.x $unit.y 99}
         [message]
-            speaker=$found_unit.id
+            speaker=$our_id
             message= _ "Err, hello?"
         [/message]
-        {FIND_NEARBY side=5 $unit.x $unit.y 99}
         [message]
-            speaker=$found_unit.id
+            speaker=$their_id
             message= _ "Human! Human human human!"
         [/message]
         [message]
             speaker=Gweddry
             message= _ "They don’t look very friendly..."
         [/message]
+
+        {CLEAR_VARIABLE our_id,their_id}
 
         {VARIABLE ogres_sighted yes}
     [/event]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1087,6 +1087,8 @@ No further tribute can be paid."
             message= _ "Our Hunt must continue."
         [/message]
 
+        {CLEAR_VARIABLE found_unit}
+
         [modify_side]
             side=2
             gold={ON_DIFFICULTY 10 30 50}
@@ -1435,6 +1437,7 @@ I shall not fall here."
             side=1
             amount=$gold
         [/gold]
+        {CLEAR_VARIABLE gold}
         {REMOVE_IMAGE $unit.x $unit.y}
     [/event]
 
@@ -1466,6 +1469,7 @@ I shall not fall here."
             side=1
             amount=$gold
         [/gold]
+        {CLEAR_VARIABLE gold}
         {REMOVE_IMAGE $unit.x $unit.y}
     [/event]
 
@@ -1497,6 +1501,7 @@ I shall not fall here."
             side=1
             amount=$gold
         [/gold]
+        {CLEAR_VARIABLE gold}
         {REMOVE_IMAGE $unit.x $unit.y}
     [/event]
 
@@ -1526,8 +1531,7 @@ I shall not fall here."
     [/event]
     [event]
         name=victory
-        {CLEAR_VARIABLE frostbite_animate,frostbite_amount,frostbite_units,frostbite_ogres,unit}
-        {CLEAR_VARIABLE elixir_drinker}
+        {CLEAR_VARIABLE frostbite_amount,frostbite_units,frostbite_ogres,ogres_sighted,ogres_peaceful,grug_event_active,drakes_no_income}
     [/event]
 
     #---------------------
@@ -1548,9 +1552,6 @@ I shall not fall here."
             message= _ "This is the place! Let us enter."
         [/message]
 
-        {CLEAR_VARIABLE ogres_sighted}
-        {CLEAR_VARIABLE ogres_peaceful}
-        {CLEAR_VARIABLE grug_event_active}
         [endlevel]
             result=victory
             bonus=no

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1057,7 +1057,7 @@ As you command."
                 id=Mortic
             [/or]
         )
-        $unit.x $unit.y 99} # probably mortic
+        $x1 $y1 99} # probably mortic
         [message]
             speaker=$found_unit.id
             #po: speaker is a drake, probably Mortic
@@ -1438,7 +1438,7 @@ I shall not fall here."
             amount=$gold
         [/gold]
         {CLEAR_VARIABLE gold}
-        {REMOVE_IMAGE $unit.x $unit.y}
+        {REMOVE_IMAGE $x1 $y1}
     [/event]
 
     #---------------------
@@ -1470,7 +1470,7 @@ I shall not fall here."
             amount=$gold
         [/gold]
         {CLEAR_VARIABLE gold}
-        {REMOVE_IMAGE $unit.x $unit.y}
+        {REMOVE_IMAGE $x1 $y1}
     [/event]
 
     #---------------------
@@ -1502,7 +1502,7 @@ I shall not fall here."
             amount=$gold
         [/gold]
         {CLEAR_VARIABLE gold}
-        {REMOVE_IMAGE $unit.x $unit.y}
+        {REMOVE_IMAGE $x1 $y1}
     [/event]
 
     #---------------------
@@ -1523,7 +1523,7 @@ I shall not fall here."
         [filter]
             type=Yeti
         [/filter]
-        {PLACE_ITEM_YETIBURGER $unit.x $unit.y}
+        {PLACE_ITEM_YETIBURGER $x1 $y1}
         [message]
             speaker=Gweddry
             message= _ "I’ve never tried Yeti meat. I wonder what it tastes like?"

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -1271,30 +1271,50 @@ I shall not fall here."
             [/have_unit]
         [/filter_condition]
 
-        {FIND_NEARBY side=1 $unit.x $unit.y 99}
+        [if]
+            {VARIABLE_CONDITIONAL unit.side equals 1}
+            [then]
+                {VARIABLE our_id $unit.id}
+                {STORE_UNIT_VAR (
+                    side=5
+                    [filter_adjacent]
+                        id=$our_id
+                    [/filter_adjacent]
+                ) id their_id}
+            [/then]
+            [else]
+                {VARIABLE their_id $unit.id}
+                {STORE_UNIT_VAR (
+                    side=1
+                    [filter_adjacent]
+                        id=$their_id
+                    [/filter_adjacent]
+                ) id our_id}
+            [/else]
+        [/if]
+
         [message]
-            speaker=$found_unit.id
+            speaker=$our_id
             #po: player's ogre (but not Grug, who gets different lines) to hostile ogre
             message= _ "Guuuh... who you?"
         [/message]
-        {FIND_NEARBY side=5 $unit.x $unit.y 99}
         [message]
             image_pos=right
-            speaker=$found_unit.id
+            speaker=$their_id
             #po: hostile ogre to player's ogre
             message= _ "Uhhhh... who <i><b>you</b></i>?"
         [/message]
-        {FIND_NEARBY side=1 $unit.x $unit.y 99}
         [message]
-            speaker=$found_unit.id
+            speaker=$our_id
             message= _ "Me... friend? New friend?"
         [/message]
-        {FIND_NEARBY side=5 $unit.x $unit.y 99}
         [message]
             image_pos=right
-            speaker=$found_unit.id
+            speaker=$their_id
             message= _ "New friend! Me no fight friend."
         [/message]
+
+        {CLEAR_VARIABLE our_id,their_id}
 
         {VARIABLE ogres_peaceful yes}
         [modify_side]

--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -1197,8 +1197,6 @@ plague_staff #enddef
         text= _ "<span color='#E8B923' size='x-small'>elemental resist</span>"
     [/floating_text]
 
-    {STORE_UNIT_VAR x,y={X},{Y} id elixir_drinker} # used for frostbite immunity
-
     [modify_unit]
         [filter]
             side=1


### PR DESCRIPTION
Explanation commit-by commit:

### Villages

It looks like this map had more villages before, and the scenario code wasn't changed to reflect that. 

#### Commit 1

There are no villages close enough to the player's starting position, so `STARTING_VILLAGES` macro does nothing, so I remove it. No changes in behavior.

#### Commit 2

 Two of the revealed coordinates are empty spots near the ogre camp. I've changed them to the coordinates of the village there. So, now on turn 1 we have 2 villages revealed instead of 1. There are 4 villages in total, and the other 2 are close to the main path.

#### Commit 3

There is no village at this coordinates, so `CAPTURE_VILLAGES` macro does nothing.

There is a village a bit further east, but Mortic needs 2 turns to reach it from the keep. I tested it, and he doesn't try to capture that eastern village, but fights my units instead.

No changes in behavior.

### Simplify meeting events

These events all used `FIND_NEARBY` macro, which is not necessary here; and I think using it repeatedly does not guarantee that the same units will be chosen every time (if there are more than 1 at the same distance).

I also replaced this macro in the event for sighting the drakes: see commit 10.

#### Commit 4

In human-meets-ogre event, we already have `unit` and `second unit`, we only need to find which is ours. No changes in behavior.

#### Commit 5

In ogre-meets-ogre event,  we only have `unit`, so we need to also store the unit adjacent to it. No changes in behavior.

#### Commit 6

Here using `FIND_NEARBY` actually caused a bug, because it's used with `found_unit` in its arguments, and inside the macro code that variable is being overwritten. The effect is, it just finds any unit fitting the filter, not necessary nearest; so Grug talks to an ogre not directly adjacent to him.

Another bug was caused by using `unit` instead of `found_unit` in the last message, which made Grug say this line instead of the newly allied ogre.

Anyway, I remove `FIND_NEARBY` and just store the side 5 unit adjacent to Grug. This commit fixes both bugs.

### Misc

#### Commit 7

I've noticed that `unit` variable is explicitly cleared in the end of the scenario. I think that's because it's used in the frostbite loop.

As `unit` variable is automatically set in many types of events, I think it may be bug-prone to name the custom variable the same. Instead I've just deleted the variable naming line, so the loop uses the default `this_item` variable.

#### Commit 8

There are several changes related to clearing the variables:

* Clear temporary variables like 'found_unit' and `gold` in the same event
* Clear all scenario-wide variables in one line in the `victory` event
* Don't clear standard `unit` variable
* Don't clear `frostbite_animate` variable because it was never created
* Clear `drakes_no_income` in `victory` event in case we never meet the drakes
* Remove creating `elixir_drinker` variable from the macro, and clearing it from the scenario, as the frostbite filter use the trait instead.

#### Commit 9

Use `x1` and `y1` variables instead of `unit.x` and `unit.y`.

### Commit 10

Simplify the event for meeting drakes. Instead of using `FIND_NEARBY`, just switch to Mortic if the orcs were sighted first. As Mortic is the drake closest to the orcs' location, there is no changes in behavior.