### PR TITLE
Change zookeeper to former maintainer of HttT

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/_main.cfg
+++ b/data/campaigns/Heir_To_The_Throne/_main.cfg
@@ -41,7 +41,7 @@
         [/entry]
         [entry]
             name = "Lari Nieminen (zookeeper)"
-            comment = "current maintainer"
+            comment = "former maintainer"
         [/entry]
         [entry]
             name = "Scott Klempner"


### PR DESCRIPTION
@ln-zookeeper Hasn’t commited to HttT since 2018. I haven’t removed them from HttT’s credits, but I have replaced “current maintainer” with “former maintainer”, which is more accurate.