### PR TITLE
Change Fabi/Fendrin to former maintainer of LoW

### DIFF
--- a/data/campaigns/Legend_of_Wesmere/_main.cfg
+++ b/data/campaigns/Legend_of_Wesmere/_main.cfg
@@ -71,7 +71,7 @@
         title= _ "Campaign Maintenance"
         [entry]
             name="Fabi/Fendrin"
-            comment="Current maintainer"
+            comment="Former maintainer"
         [/entry]
         [entry]
             name= _ "Spiros, George and Alexander Alexiou (Santi/fnaek)"


### PR DESCRIPTION
No commits to LoW since 2016 from @fendrin or Fabian Müller (not sure who this reffers to, but neither of these accounts have contributed in a very long time).