### PR TITLE
Capitalize Elvish Captain in unit description

### DIFF
--- a/data/core/units/elves/Captain.cfg
+++ b/data/core/units/elves/Captain.cfg
@@ -22,7 +22,7 @@
     advances_to=Elvish Marshal
     cost=28
     usage=fighter
-    description= _ "Elvish captains usually command patrols and garrisons that stand guard over the vast forests in elvish territory. Unlike leaders from other races, they are most proficient at navigating small skirmishes rather than large-scale battles, and are especially skilled at defensive maneuvering. Captains typically lead small units that remain together for extended periods of time, allowing them to personally mentor and befriend their troops. They are often observed to lead through camaraderie and amicability, but still command great respect from their kin."
+    description= _ "Elvish Captains usually command patrols and garrisons that stand guard over the vast forests in elvish territory. Unlike leaders from other races, they are most proficient at navigating small skirmishes rather than large-scale battles, and are especially skilled at defensive maneuvering. Captains typically lead small units that remain together for extended periods of time, allowing them to personally mentor and befriend their troops. They are often observed to lead through camaraderie and amicability, but still command great respect from their kin."
     die_sound={SOUND_LIST:ELF_HIT}
     {DEFENSE_ANIM_RANGE "units/elves-wood/captain-defend.png" "units/elves-wood/captain.png" {SOUND_LIST:ELF_HIT} melee}
     {DEFENSE_ANIM_RANGE "units/elves-wood/captain-bow-defend.png" "units/elves-wood/captain-bow.png" {SOUND_LIST:ELF_HIT} ranged }


### PR DESCRIPTION
Elvish Captain is a unit name, so according to the typogrpahy style guide both parts need to be capitalized.