### PR TITLE
Uncapitalize goblin in pillager unit description

### DIFF
--- a/data/core/units/goblins/Pillager.cfg
+++ b/data/core/units/goblins/Pillager.cfg
@@ -15,7 +15,7 @@
     {AMLA_DEFAULT}
     cost=31
     usage=scout
-    description= _ "Some Goblins train their wolves to overcome their fear of fire. In raids, these goblins take a supporting role; they will torch the homes and crops of their foes, and also carry nets to wreak havoc against those attempting to rally for defense or reprisal."
+    description= _ "Some goblins train their wolves to overcome their fear of fire. In raids, these goblins take a supporting role; they will torch the homes and crops of their foes, and also carry nets to wreak havoc against those attempting to rally for defense or reprisal."
     die_sound={SOUND_LIST:WOLF_DIE}
     [standing_anim]
         start_time=0


### PR DESCRIPTION
Race names should not be capitalized according to the typography style guide.