### PR TITLE
EI: display the note for Owaec's weapon special in unit description

### DIFF
--- a/data/campaigns/Eastern_Invasion/units/Human_Owaec_Clan_Captain.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Owaec_Clan_Captain.cfg
@@ -25,7 +25,6 @@
     profile="portraits/owaec.webp"
     description= _ "The leaders-to-be of the Horse Clans, each of these proud nobles is skilled in combat and adheres to a strict code of honor. Even the most tenacious of opponents will quake at the sight of a horse charge spearheaded by one of these fearless riders."
 
-    {NOTE_VANGUARD}
     die_sound=horse-die.ogg
     [abilities]
         {ABILITY_VANGUARD}

--- a/data/campaigns/Eastern_Invasion/units/Human_Owaec_Horse_Lord.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Owaec_Horse_Lord.cfg
@@ -26,7 +26,6 @@
     profile="portraits/owaec.webp"
     description= _ "The greatest of the men of the plains, Horse Lords are heads of their houses and are respected by all, friend or foe. These lords lead by example, dominating the battlefield from the head of a cavalry charge."
 
-    {NOTE_VANGUARD}
     die_sound=horse-die.ogg
     [abilities]
         {ABILITY_VANGUARD}

--- a/data/campaigns/Eastern_Invasion/units/Human_Owaec_Princeling.cfg
+++ b/data/campaigns/Eastern_Invasion/units/Human_Owaec_Princeling.cfg
@@ -25,7 +25,6 @@
     profile="portraits/owaec.webp"
     description= _ "From early age, the nobles of the plains train vigorously in both combat and governance, preparing to someday become captains of the Clans. Though young and brash, these fighters have the potential to become great warriors one day."
 
-    {NOTE_VANGUARD}
     die_sound=horse-die.ogg
     [abilities]
         {ABILITY_VANGUARD}

--- a/data/campaigns/Eastern_Invasion/utils/abilities.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/abilities.cfg
@@ -151,6 +151,7 @@
         id=shock
         name= _ "shock"
         description= _ "The crushing power of this attack overwhelms enemies. When used on offense, the opponent can only retaliate with one strike."
+        special_note=_"This unit’s melee attack can overwhelm enemies’ defenses, preventing them from retaliating as effectively."
         value=1
         active_on=offense
         apply_to=opponent
@@ -170,6 +171,7 @@
         description=_ "This unit fights best in the heart of battle, surrounded by friends and foes alike.
 
 Deals an additional 25% damage for each adjacent ally and/or enemy after the first."
+        special_note=_"This unit gains increased damage for each adjacent ally and/or enemy."
     [/dummy]
     [leadership]
         id=vanguard1
@@ -226,12 +228,6 @@ Deals an additional 25% damage for each adjacent ally and/or enemy after the fir
             [/filter_adjacent]
         [/filter_self]
     [/leadership]
-#enddef
-
-#define NOTE_VANGUARD
-    [special_note]
-        note=_"This unit gains increased damage for each adjacent ally and/or enemy."
-    [/special_note]
 #enddef
 
 #define ABILITY_DARKENS


### PR DESCRIPTION
I've noticed that PR #9864 removes an unused `NOTE_SHOCK` macro.

The text in that note is actually useful. Currently it doesn't appear in Owaec's unit description page, and that's a mistake.

Instead of including it into `[unit_type]` files, I put it directly into the tag for that weapon special. It's the newer and simpler way of achieving the same effect, see wiki: [UnitTypeWML#Special_Notes](https://wiki.wesnoth.org/UnitTypeWML#Special_Notes)

I've also changed the way the "vanguard" ability note is included to the newer one. No behavior change for this note: it's displayed the same way as before.

Note: I don't delete the unused macro `NOTE_SHOCK` because it's deleted in PR #9864, to avoid a merge conflict. The code will stay in a working state regardless which PR is merged first.