### PR TITLE
dismiss recall: add edge case handling code

### DIFF
--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -247,7 +247,7 @@ void units_dialog::dismiss_unit(std::vector<unit_const_ptr>& unit_list, const te
 	// If the unit is of level > 1, or is close to advancing, we warn the player about it
 	std::stringstream message;
 	// first case: has no upkeep but is not a loyal unit, and not a level zero
-	if(u.upkeep() == 0 && u.level() > 1 && !u.loyal()) {
+	if(u.upkeep() == 0 && u.level() >= 1 && !u.loyal()) {
 		message << _("This unit requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -247,11 +247,11 @@ void units_dialog::dismiss_unit(std::vector<unit_const_ptr>& unit_list, const te
 	// If the unit is of level > 1, or is close to advancing, we warn the player about it
 	std::stringstream message;
 	// first case: has no upkeep but is not a loyal unit
-	if(u.upkeep() == 0 &&! u.loyal()) {
+	if(u.upkeep() == 0 && !u.loyal()) {
 		message << _("This unit requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));
-
+	// second case: has no upkeep and is a loyal unit
 	} else if(u.upkeep() == 0 && u.loyal()) {
 		message << _("This unit is loyal and requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -246,7 +246,13 @@ void units_dialog::dismiss_unit(std::vector<unit_const_ptr>& unit_list, const te
 
 	// If the unit is of level > 1, or is close to advancing, we warn the player about it
 	std::stringstream message;
-	if(u.loyal()) {
+	// first case: has no upkeep but is not a loyal unit
+	if(u.upkeep() == 0 &&! u.loyal()) {
+		message << _("This unit requires no upkeep.") << " " << (u.gender() == unit_race::MALE
+		         ? _("Do you really want to dismiss him?")
+		         : _("Do you really want to dismiss her?"));
+
+	} else if(u.upkeep() == 0 && u.loyal()) {
 		message << _("This unit is loyal and requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -246,16 +246,7 @@ void units_dialog::dismiss_unit(std::vector<unit_const_ptr>& unit_list, const te
 
 	// If the unit is of level > 1, or is close to advancing, we warn the player about it
 	std::stringstream message;
-	const auto& traits_list = u.get_traits_list();
-	bool has_loyal_trait = std::find(traits_list.begin(), traits_list.end(), "loyal") != traits_list.end();
-
-	// first case: has no upkeep but is not a loyal unit, and not a level zero
-	if(u.upkeep() == 0 && u.level() >= 1 && !has_loyal_trait) {
-		message << _("This unit requires no upkeep.") << " " << (u.gender() == unit_race::MALE
-		         ? _("Do you really want to dismiss him?")
-		         : _("Do you really want to dismiss her?"));
-	// second case: has no upkeep and is a loyal unit
-	} else if(u.upkeep() == 0 && has_loyal_trait) {
+	if(u.upkeep_raw() == unit::upkeep_loyal()) {
 		message << _("This unit is loyal and requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -246,13 +246,16 @@ void units_dialog::dismiss_unit(std::vector<unit_const_ptr>& unit_list, const te
 
 	// If the unit is of level > 1, or is close to advancing, we warn the player about it
 	std::stringstream message;
+	const auto& traits_list = u.get_traits_list();
+	bool has_loyal_trait = std::find(traits_list.begin(), traits_list.end(), "loyal") != traits_list.end();
+
 	// first case: has no upkeep but is not a loyal unit, and not a level zero
-	if(u.upkeep() == 0 && u.level() >= 1 && !u.loyal()) {
+	if(u.upkeep() == 0 && u.level() >= 1 && !has_loyal_trait) {
 		message << _("This unit requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));
 	// second case: has no upkeep and is a loyal unit
-	} else if(u.upkeep() == 0 && u.loyal()) {
+	} else if(u.upkeep() == 0 && has_loyal_trait) {
 		message << _("This unit is loyal and requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));

--- a/src/gui/dialogs/units_dialog.cpp
+++ b/src/gui/dialogs/units_dialog.cpp
@@ -246,8 +246,8 @@ void units_dialog::dismiss_unit(std::vector<unit_const_ptr>& unit_list, const te
 
 	// If the unit is of level > 1, or is close to advancing, we warn the player about it
 	std::stringstream message;
-	// first case: has no upkeep but is not a loyal unit
-	if(u.upkeep() == 0 && !u.loyal()) {
+	// first case: has no upkeep but is not a loyal unit, and not a level zero
+	if(u.upkeep() == 0 && u.level() > 1 && !u.loyal()) {
 		message << _("This unit requires no upkeep.") << " " << (u.gender() == unit_race::MALE
 		         ? _("Do you really want to dismiss him?")
 		         : _("Do you really want to dismiss her?"));


### PR DESCRIPTION
SotBE: after S11, you get level 1 units with no upkeep. They trigger loyal unit dismissal dialogue warning. This should not happen. closes #8265

Disclaimer: I do not know any cpp. I just wrote this based on what I thought was okay. 