### PR TITLE
Capitalize both parts of Pirate Galleon in Unit Description

### DIFF
--- a/data/core/units/boats/Pirate_Galleon.cfg
+++ b/data/core/units/boats/Pirate_Galleon.cfg
@@ -19,7 +19,7 @@
     {AMLA_DEFAULT}
     cost=15
     usage=null
-    description= _ "Pirate galleons are to transport ships what wolves are to sheep. The pirates who crew them are more than happy to help relieve other ships of their weighty cargo."
+    description= _ "Pirate Galleons are to transport ships what wolves are to sheep. The pirates who crew them are more than happy to help relieve other ships of their weighty cargo."
     # we put the sprite on a non-primary frame group so we don't need to worry about effects
     # like submerge or making the ellipse bob
     [standing_anim]


### PR DESCRIPTION
According to the typography style guide, both parts of unit names should be capitalized.