### PR TITLE
Only attempt to load .cfg scenarios in MP lobby

### DIFF
--- a/src/game_initialization/create_engine.cpp
+++ b/src/game_initialization/create_engine.cpp
@@ -688,6 +688,10 @@ void create_engine::init_all_levels()
 		{
 			config data;
 			try {
+				// Only attempt to load .cfg files (.cfg extension is enforced in Editor save)
+				if (!filesystem::is_cfg(user_scenario_names_[i]))
+					continue;
+
 				read(data, *preprocess_file(filesystem::get_legacy_editor_dir() + "/scenarios/" + user_scenario_names_[i]));
 			} catch(const config::error & e) {
 				ERR_CF << "Caught a config error while parsing user made (editor) scenarios:\n" << e.message;


### PR DESCRIPTION
The built-in editor only allows saving to `.cfg` files. Even the editor only tries to load `.cfg`, `.map`, or `.mask` files.

https://github.com/wesnoth/wesnoth/blob/c5c7674cf5e079113e918126ab9a038f1e434951/src/editor/map/map_context.cpp#L198-L204

So it makes sense to me to only attempt to load .cfg files when the MP lobby tries to find user scenarios.

Closes #4363