### PR TITLE
EI S12: Use Eyrie instead of Aerie

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/12_Evacuation.cfg
@@ -778,7 +778,7 @@ His prey fled."
                                 #po: to his fellow drakes, and any surviving orcs
                                 message= _ "Long has our Honor been stained.
 No longer shall it be.
-Now we reclaim our Aerie,
+Now we reclaim our Eyrie,
 And the strength of our Flight."
                             [/message]
                             {FIND_NEARBY (side=2,4) 14 7 99}


### PR DESCRIPTION
Eyrie is much more commonly used in Wesnoth nowadays, and is the form used in WoF.