### PR TITLE
add a tag [affect_distant] to abilities

### DIFF
--- a/changelog_entries/add_affect_distant.md
+++ b/changelog_entries/add_affect_distant.md
@@ -1,0 +1,2 @@
+### WML Engine
+* add a [affect_distant] tag for affect units distant to owner of ability with 'radius' attribute for distance evaluation.

--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -128,109 +128,21 @@
 #enddef
 
 #define ABILITY_SHADOW_VEIL
-    [dummy]
+    [hides]
         id=did_shadow_veil
         name= _ "shadow veil"
         name_inactive= _ "shadow veil"
         description= _ "Allied undead units within a 5 hex radius are hidden."
         description_inactive= _ "Allied undead units within a 5 hex radius are hidden."
-        {DID_SHADOW_VEIL_HANDLER}
-    [/dummy]
-#enddef
-
-#define ABILITY_SHADOW_VEIL_HELPER SIDE
-    [hides]
-        id=did_shadow_veil_helper
-        [filter]
-            [filter_location]
-                radius=5
-                [filter]
-                    ability=did_shadow_veil
-                    [filter_side]
-                        [allied_with]
-                            side={SIDE}
-                        [/allied_with]
-                    [/filter_side]
-                [/filter]
-            [/filter_location]
-        [/filter]
-    [/hides]
-#enddef
-
-#define DID_SHADOW_VEIL_HANDLER
-    [event]
-        id=did_shadow_veil_unit_placed
-        name=unit placed
-        first_time_only=no
-        [filter]
-            side=1
-            race=undead
-            [not]
-                ability=did_shadow_veil_helper
-            [/not]
-        [/filter]
-        [filter_condition]
-            [have_unit]
-                ability=did_shadow_veil
-                side=1
-            [/have_unit]
-        [/filter_condition]
-        [modify_unit]
-            [filter]
-                x,y=$x1,$y1
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-            [/filter]
-            [object]
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
-    [event]
-        id=did_shadow_veil_malkeshar
-        name=post advance
-        first_time_only=yes
-        [filter]
-            type=Mal Keshar
-            ability=did_shadow_veil
-        [/filter]
-        [modify_unit]
+        affect_self=no
+        affect_allies=yes
+        [affect_distant]
+            radius=5
             [filter]
                 race=undead
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-                [filter_side]
-                    [allied_with]
-                        side=$unit.side
-                    [/allied_with]
-                [/filter_side]
             [/filter]
-            [object]
-                take_only_once=no
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $this_unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
+        [/affect_distant]
+    [/hides]
 #enddef
 
 #define WEAPON_SPECIAL_FROST_NOVA

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -16,6 +16,7 @@
 	{SIMPLE_KEY multiply s_real_range_list_default}
 	{SIMPLE_KEY divide s_real_range_list_default}
 	{SIMPLE_KEY affect_adjacent s_bool}
+	{SIMPLE_KEY affect_distant s_bool}
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies bool_or_empty}
 	{SIMPLE_KEY affect_enemies s_bool}

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -40,6 +40,11 @@
 		[/key]
 		{FILTER_TAG "filter" unit ()}
 	[/tag]
+	[tag]
+		name="affect_distant"
+		{REQUIRED_KEY radius s_int}
+		{FILTER_TAG "filter" unit ()}
+	[/tag]
 	{FILTER_TAG "filter_self" unit ()}
 	{FILTER_TAG "filter_adjacent" adjacent ()}
 	{FILTER_TAG "filter_adjacent_location" adjacent_location ()}

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -42,7 +42,7 @@
 	[/tag]
 	[tag]
 		name="affect_distant"
-		{REQUIRED_KEY radius s_int}
+		{SIMPLE_KEY radius s_int}
 		{FILTER_TAG "filter" unit ()}
 	[/tag]
 	{FILTER_TAG "filter_self" unit ()}

--- a/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
+++ b/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
@@ -1,0 +1,74 @@
+#textdomain wesnoth-test
+
+##
+# Starting state:
+#
+# Side 1 leader Alice (Orcish Grunt)
+# Side 2 leader Bob (Orcish Grunt)
+# Side 3 leader Charlie (Orcish Grunt)
+# Side 4 leader Dave (Orcish Grunt)
+#
+# None of the sides are allied.
+#
+# On the default map (used unless overridden with the MAP_FILE argument:
+# * All four leaders are on a single keep, with Alice and Bob already in position to attack any of the other units.
+# * There is no free castle hex to recruit onto.
+##
+#define SEPARATE_KEEP_A_B_C_D_UNIT_TEST NAME CONTENT
+
+#arg SIDE_LEADER
+Orcish Grunt#endarg
+
+#arg MAP_FILE
+test/maps/4p_separate_castles.map#endarg
+
+    [test]
+        name=_ "Unit Test " + {NAME}
+        map_file={MAP_FILE}
+        turns=unlimited
+        id={NAME}
+        random_start_time=no
+        is_unit_test=yes
+
+        {DAWN}
+
+        [side]
+            side=1
+            controller=human
+            [leader]
+                name = _ "Alice"
+                type = {SIDE_LEADER}
+                id=alice
+            [/leader]
+        [/side]
+        [side]
+            side=2
+            controller=human
+            [leader]
+                name = _ "Bob"
+                type = {SIDE_LEADER}
+                id=bob
+            [/leader]
+        [/side]
+        [side]
+            side=3
+            controller=human
+            [leader]
+                name = _ "Charlie"
+                type = {SIDE_LEADER}
+                id=charlie
+            [/leader]
+        [/side]
+        [side]
+            side=4
+            controller=human
+            [leader]
+                name = _ "Dave"
+                type = {SIDE_LEADER}
+                id=dave
+            [/leader]
+        [/side]
+
+        {CONTENT}
+    [/test]
+#enddef

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
@@ -1,0 +1,54 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 10 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should affect alice.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 10 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=10
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alice
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
@@ -1,0 +1,121 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 7"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=7
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alex
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
@@ -1,0 +1,57 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 1 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alice.
+#####
+
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 1 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=1
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alice
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
@@ -1,0 +1,125 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 5"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alex
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1327,6 +1327,7 @@ void attack::unit_killed(unit_info& attacker,
 			units_.insert(newunit);
 
 			game_events::entity_location reanim_loc(defender.loc_, newunit->underlying_id());
+			newunit->set_affect_distant_max_radius(reanim_loc);
 			resources::game_events->pump().fire("unit_placed", reanim_loc);
 
 			prefs::get().encountered_units().insert(newunit->type_id());

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -657,6 +657,7 @@ place_recruit_result place_recruit(const unit_ptr& u, const map_location &recrui
 	recruit_checksums(*u, wml_triggered);
 	resources::whiteboard->on_gamestate_change();
 
+	new_unit_itor->set_affect_distant_max_radius(current_loc);
 	std::get<0>(res) |= std::get<0>(resources::game_events->pump().fire("unit_placed", current_loc));
 	if(!new_unit_itor.valid()) {
 		return place_recruit_result { true, 0, false };

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -230,6 +230,8 @@ void unit_creator::post_create(const map_location &loc, const unit &new_unit, bo
 		}
 	}
 
+	new_unit.set_affect_distant_max_radius(loc);
+
 	// Only fire the events if it's safe; it's not if we're in the middle of play_controller::reset_gamestate()
 	if (fire_event && resources::lua_kernel != nullptr) {
 		resources::game_events->pump().fire("unit_placed", loc);

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -182,6 +182,27 @@ void game_board::check_victory(bool& continue_level,
 	continue_level = false;
 }
 
+void game_board::set_affect_distant_max_radius(utils::optional<int> value, const std::string& tag_name)
+{
+	if(value){
+		if(!affect_distant_max_radius_[tag_name] || *affect_distant_max_radius_[tag_name] < *value){
+			affect_distant_max_radius_[tag_name] = value;
+		}
+		if(!affect_distant_max_radius_for_filtering_ || *affect_distant_max_radius_for_filtering_ < *value){
+			affect_distant_max_radius_for_filtering_ = value;
+		}
+	}
+}
+
+void game_board::set_affect_distant_max_radius_image(utils::optional<int> value)
+{
+	if(value){
+		if(!affect_distant_max_radius_for_image_ || *affect_distant_max_radius_for_image_ < *value){
+			affect_distant_max_radius_for_image_ = value;
+		}
+	}
+}
+
 unit_map::iterator game_board::find_visible_unit(const map_location& loc, const team& current_team, bool see_all)
 {
 	if(!map_->on_board(loc)) {

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -182,24 +182,29 @@ void game_board::check_victory(bool& continue_level,
 	continue_level = false;
 }
 
-void game_board::set_affect_distant_max_radius(utils::optional<int> value, const std::string& tag_name)
+void game_board::set_affect_distant_max_radius(int value, const std::string& tag_name)
 {
-	if(value){
-		if(!affect_distant_max_radius_[tag_name] || *affect_distant_max_radius_[tag_name] < *value){
+	if(value >= 0){
+		if(!affect_distant_max_radius_[tag_name] || (*affect_distant_max_radius_[tag_name] >=0 && *affect_distant_max_radius_[tag_name] < value)){
 			affect_distant_max_radius_[tag_name] = value;
 		}
-		if(!affect_distant_max_radius_for_filtering_ || *affect_distant_max_radius_for_filtering_ < *value){
+		if(!affect_distant_max_radius_for_filtering_ || (*affect_distant_max_radius_for_filtering_ >=0 && *affect_distant_max_radius_for_filtering_ < value)){
 			affect_distant_max_radius_for_filtering_ = value;
 		}
+	} else {
+		affect_distant_max_radius_[tag_name] = value;
+		affect_distant_max_radius_for_filtering_ = value;
 	}
 }
 
-void game_board::set_affect_distant_max_radius_image(utils::optional<int> value)
+void game_board::set_affect_distant_max_radius_image(int value)
 {
-	if(value){
-		if(!affect_distant_max_radius_for_image_ || *affect_distant_max_radius_for_image_ < *value){
+	if(value >= 0){
+		if(!affect_distant_max_radius_for_image_ || (*affect_distant_max_radius_for_image_ >=0 && *affect_distant_max_radius_for_image_ < value)){
 			affect_distant_max_radius_for_image_ = value;
 		}
+	} else {
+		affect_distant_max_radius_for_image_ = value;
 	}
 }
 

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -146,8 +146,8 @@ public:
 	utils::optional<int> affect_distant_max_radius(const std::string& value){return affect_distant_max_radius_[value];}
 	utils::optional<int> affect_distant_max_radius_for_filtering() const {return affect_distant_max_radius_for_filtering_;}
 	utils::optional<int> affect_distant_max_radius_for_image() const {return affect_distant_max_radius_for_image_;}
-	void set_affect_distant_max_radius(utils::optional<int> value, const std::string& tag_name = "");
-	void set_affect_distant_max_radius_image(utils::optional<int> value);
+	void set_affect_distant_max_radius(int value, const std::string& tag_name = "");
+	void set_affect_distant_max_radius_image(int value);
 
 	// Saving
 

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -53,6 +53,17 @@ class game_board : public display_context
 	unit_map units_;
 
 	/**
+	 * Variables used for define radius for abilities [affect_distant]radius= checking.
+	 *
+	 * @ affect_distant_max_radius_ is used for checking in abilities of defined type.
+	 * @ affect_distant_max_radius_for_filtering_ used when checking abilities in [filter] or animations.
+	 * @ affect_distant_max_radius_for_image_ define radius for images in abilities.
+	 **/
+	std::map<std::string, utils::optional<int>> affect_distant_max_radius_;
+	utils::optional<int> affect_distant_max_radius_for_filtering_;
+	utils::optional<int> affect_distant_max_radius_for_image_;
+
+	/**
 	 * Temporary unit move structs:
 	 *
 	 * Probably don't remove these friends, this is actually fairly useful. These structs are used by:
@@ -130,6 +141,13 @@ public:
 	game_board& operator=(const game_board& other) = delete;
 
 	friend void swap(game_board & one, game_board & other);
+
+	//when used define radius max for check unit who own a ability with [affect_distant] tag.
+	utils::optional<int> affect_distant_max_radius(const std::string& value){return affect_distant_max_radius_[value];}
+	utils::optional<int> affect_distant_max_radius_for_filtering() const {return affect_distant_max_radius_for_filtering_;}
+	utils::optional<int> affect_distant_max_radius_for_image() const {return affect_distant_max_radius_for_image_;}
+	void set_affect_distant_max_radius(utils::optional<int> value, const std::string& tag_name = "");
+	void set_affect_distant_max_radius_image(utils::optional<int> value);
 
 	// Saving
 

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -400,6 +400,7 @@ void play_controller::fire_prestart()
 	// Fire these right before prestart events, to catch only the units sides
 	// have started with.
 	for(const unit& u : get_units()) {
+		u.set_affect_distant_max_radius(u.get_location());
 		pump().fire("unit_placed", map_location(u.get_location()));
 	}
 

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2810,6 +2810,7 @@ int game_lua_kernel::intf_put_unit(lua_State *L)
 		put_unit_helper(loc);
 		u->set_location(loc);
 		units().insert(u);
+		u->set_affect_distant_max_radius(loc);
 		u->anim_comp().reset_affect_adjacent(units());
 	}
 

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -527,6 +527,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child, spectator)
 	std::tie(unit_it, std::ignore) = resources::gameboard->units().replace(loc, created);
 
 	game_display::get_singleton()->invalidate_unit();
+	unit_it->set_affect_distant_max_radius(loc);
 	resources::game_events->pump().fire("unit_placed", loc);
 	unit_display::unit_recruited(loc);
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -2147,6 +2147,15 @@ namespace
 			}
 		}
 
+		//when affect_distant=yes detect presence of [affect_distant] in abilities, if no
+		//then matches when tag not present.
+		if(!filter["affect_distant"].empty()){
+			bool distant = cfg.has_child("affect_distant");
+			if(filter["affect_distant"].to_bool() != distant){
+				return false;
+			}
+		}
+
 		//these attributs below filter attribute used in all engine abilities.
 		//matches if filter attribute have same boolean value what attribute
 		if(!bool_matches_if_present(filter, cfg, "affect_self", true))

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -230,7 +230,7 @@ void unit_animation_component::reset_affect_adjacent(const unit_map& units)
 		}
 	}
 	utils::optional<int> max_radius = u_.affect_distant_max_radius();
-	if(max_radius && affect_distant){
+	if(max_radius && *max_radius > 0 && affect_distant){
 		std::vector<map_location> surrounding;
 		get_tiles_in_radius(u_.get_location(), (*max_radius + 1), surrounding);
 		for(unsigned j = 0; j < surrounding.size(); ++j){
@@ -239,6 +239,13 @@ void unit_animation_component::reset_affect_adjacent(const unit_map& units)
 				continue;
 			}
 			unit_itor->anim_comp().set_standing();
+		}
+	} else if(max_radius && *max_radius < 0  && affect_distant){
+		for(const unit& unit_itor : units){
+			if (unit_itor.incapacitated() || &(unit_itor) == &u_) {
+				continue;
+			}
+			unit_itor.anim_comp().set_standing();
 		}
 	}
 }

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -271,6 +271,14 @@ private:
 	 * @param from unit adjacent to self_ is checked.
 	 */
 	bool check_adj_abilities(const config& cfg, const std::string& special, int dir, const unit& from) const;
+	/** check_dist_abilities : return an boolean value for checking of activities of abilities used like weapon
+	 * @return True if the special @a special is active.
+	 * @param cfg the config to one special ability checked.
+	 * @param special The special ability type who is being checked.
+	 * @param from unit distant to self_ is checked.
+	 * @param from_loc location of @ from
+	 */
+	bool check_dist_abilities(const config& cfg, const std::string& special, const unit& from, const map_location& from_loc) const;
 	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool in_abilities_tag = false) const;
 
@@ -356,6 +364,32 @@ private:
 		AFFECTS whom,
 		const std::string& tag_name,
 		bool leader_bool=false
+	);
+
+	/** check_dist_abilities_impl : return an boolean value for checking of activities of abilities used like weapon in unit adjacent to fighter
+	 * @return True if the special @a tag_name is active.
+	 * @param self_attack the attack used by unit who fight.
+	 * @param other_attack the attack used by opponent.
+	 * @param special the config to one special ability checked.
+	 * @param u the unit who is or not affected by an abilities owned by @a from.
+	 * @param from unit distant to @a u is checked.
+	 * @param loc location of the unit checked.
+	 * @param from_loc location of the unit distant to @a u.
+	 * @param whom determine if unit affected or not by special ability.
+	 * @param tag_name The special ability type who is being checked.
+	 * @param leader_bool If true, [leadership] abilities are checked.
+	 */
+	static bool check_dist_abilities_impl(
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
+		const config& special,
+		const unit_const_ptr& u,
+		const unit& from,
+		const map_location& loc,
+		const map_location& from_loc,
+		AFFECTS whom,
+		const std::string& tag_name,
+		bool leader_bool = false
 	);
 
 	static bool special_active_impl(

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -442,7 +442,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 						}
 					}
 					utils::optional<int> max_radius = args.u.affect_distant_max_radius();
-					if(max_radius){
+					if(max_radius && *max_radius > 0){
 						std::vector<map_location> surrounding;
 						get_tiles_in_radius(args.loc, *max_radius, surrounding);
 						for(unsigned j = 0; j < surrounding.size(); ++j){
@@ -454,6 +454,19 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							get_ability_children_id(ability_id_matches_dist, unit_itor->abilities(), ability);
 							for(const ability_match& entry : ability_id_matches_dist) {
 								if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, *unit_itor, surrounding[j])){
+									return true;
+								}
+							}
+						}
+					} else if(max_radius && *max_radius < 0){
+						for(const unit& unit_itor : units){
+							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+								continue;
+							}
+							std::vector<ability_match> ability_id_matches_dist;
+							get_ability_children_id(ability_id_matches_dist, unit_itor.abilities(), ability);
+							for(const ability_match& entry : ability_id_matches_dist) {
+								if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, unit_itor, unit_itor.get_location())){
 									return true;
 								}
 							}
@@ -837,7 +850,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 						utils::optional<int> max_radius = args.u.affect_distant_max_radius();
-						if(max_radius){
+						if(max_radius && *max_radius > 0){
 							std::vector<map_location> surrounding;
 							get_tiles_in_radius(args.loc, *max_radius, surrounding);
 							for(unsigned j = 0; j < surrounding.size(); ++j){
@@ -847,6 +860,17 @@ void unit_filter_compound::fill(const vconfig& cfg)
 								}
 								for(const auto [key, cfg] : unit_itor->abilities().all_children_view()) {
 									if(args.u.get_dist_ability_bool(cfg, key, args.loc, *unit_itor, surrounding[j])){
+										return true;
+									}
+								}
+							}
+						} else if(max_radius && *max_radius < 0){
+							for(const unit& unit_itor : units){
+								if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+									continue;
+								}
+								for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+									if(args.u.get_dist_ability_bool(cfg, key, args.loc, unit_itor, unit_itor.get_location())){
 										return true;
 									}
 								}

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -441,6 +441,24 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					}
+					utils::optional<int> max_radius = args.u.affect_distant_max_radius();
+					if(max_radius){
+						std::vector<map_location> surrounding;
+						get_tiles_in_radius(args.loc, *max_radius, surrounding);
+						for(unsigned j = 0; j < surrounding.size(); ++j){
+							unit_map::const_iterator unit_itor = units.find(surrounding[j]);
+							if (unit_itor == units.end() || unit_itor->incapacitated() || &(*unit_itor) == args.u.shared_from_this().get()) {
+								continue;
+							}
+							std::vector<ability_match> ability_id_matches_dist;
+							get_ability_children_id(ability_id_matches_dist, unit_itor->abilities(), ability);
+							for(const ability_match& entry : ability_id_matches_dist) {
+								if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, *unit_itor, surrounding[j])){
+									return true;
+								}
+							}
+						}
+					}
 				}
 				return false;
 			}
@@ -813,6 +831,22 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							for(const auto [key, cfg] : it->abilities().all_children_view()) {
 								if(it->ability_matches_filter(cfg, key, c.get_parsed_config())) {
 									if (args.u.get_adj_ability_bool(cfg, key, i, args.loc, *it)) {
+										return true;
+									}
+								}
+							}
+						}
+						utils::optional<int> max_radius = args.u.affect_distant_max_radius();
+						if(max_radius){
+							std::vector<map_location> surrounding;
+							get_tiles_in_radius(args.loc, *max_radius, surrounding);
+							for(unsigned j = 0; j < surrounding.size(); ++j){
+								unit_map::const_iterator unit_itor = units.find(surrounding[j]);
+								if (unit_itor == units.end() || unit_itor->incapacitated() || &(*unit_itor) == (args.u.shared_from_this()).get()) {
+									continue;
+								}
+								for(const auto [key, cfg] : unit_itor->abilities().all_children_view()) {
+									if(args.u.get_dist_ability_bool(cfg, key, args.loc, *unit_itor, surrounding[j])){
 										return true;
 									}
 								}

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -408,7 +408,7 @@ unit::unit(unit_ctor_t)
 
 namespace
 {
-	void set_affect_distant_max_radius(utils::optional<int> value, const std::string& tag_name)
+	void set_affect_distant_max_radius(int value, const std::string& tag_name)
 	{
 		if(resources::gameboard) {
 			resources::gameboard->set_affect_distant_max_radius(value, tag_name);
@@ -418,11 +418,9 @@ namespace
 	void set_affect_distant_max_radius(const config& cfg, const std::string& tag_name)
 	{
 		for(const config& affect_distant : cfg.child_range("affect_distant")) {
-			if(affect_distant.has_attribute("radius")){
-				set_affect_distant_max_radius(affect_distant["radius"].to_int(), tag_name);
-				if(resources::gameboard && (cfg.has_attribute("halo_image") || cfg.has_attribute("overlay_image"))){
-					resources::gameboard->set_affect_distant_max_radius_image(affect_distant["radius"].to_int());
-				}
+			set_affect_distant_max_radius(affect_distant["radius"].to_int(-1), tag_name);
+			if(resources::gameboard && (cfg.has_attribute("halo_image") || cfg.has_attribute("overlay_image"))){
+				resources::gameboard->set_affect_distant_max_radius_image(affect_distant["radius"].to_int(-1));
 			}
 		}
 	}
@@ -480,11 +478,9 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 				}
 				const vconfig::child_list& affect_distants = child.get_children("affect_distant");
 				for(const vconfig& affect_distant : affect_distants) {
-					if(affect_distant.has_attribute("radius")){
-						set_affect_distant_max_radius(affect_distant["radius"].to_int(), key);
-						if(resources::gameboard && (child.has_attribute("halo_image") || child.has_attribute("overlay_image"))){
-							resources::gameboard->set_affect_distant_max_radius_image(affect_distant["radius"].to_int());
-						}
+					set_affect_distant_max_radius(affect_distant["radius"].to_int(-1), key);
+					if(resources::gameboard && (child.has_attribute("halo_image") || child.has_attribute("overlay_image"))){
+						resources::gameboard->set_affect_distant_max_radius_image(affect_distant["radius"].to_int(-1));
 					}
 				}
 			}

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1904,6 +1904,11 @@ public:
 	 * @param tag_name the type of ability corresponding to the variable used, if empty return affect_distant_max_radius_for_filtering_.
 	 */
 	utils::optional<int> affect_distant_max_radius(const std::string& tag_name = "") const;
+	/**
+	 * set game_board affect_distant_max_radius_[tag_name] or affect_distant_max_radius_for_filtering_ when location is valid.
+	 * @param loc location of unit with ability with [affect_distant for verify what unit is on the map.
+	 */
+	void set_affect_distant_max_radius(const map_location& loc) const;
 
 private:
 

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1788,6 +1788,27 @@ public:
 	 */
 	bool get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const const_attack_ptr& weapon=nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 
+	/** Checks whether this unit is affected by a given ability, and that that ability is active.
+	 * @return True if the ability @a tag_name is active.
+	 * @param cfg the const config to one of abilities @a ability checked.
+	 * @param ability name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit distant to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc the 'other unit' location.
+	 */
+	bool get_dist_ability_bool(const config& cfg, const std::string& ability, const map_location& loc, const unit& from, const map_location& from_loc) const;
+	/** Checks whether this unit is affected by a given ability of leadership type
+	 * @return True if the ability @a tag_name is active.
+	 * @param special the const config to one of abilities @a tag_name checked.
+	 * @param tag_name name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit adjacent to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc location of the @a from unit.
+	 * @param weapon the attack used by unit checked in this function.
+	 * @param opp_weapon the attack used by opponent to unit checked.
+	 */
+	bool get_dist_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const;
+
 	/**
 	 * Gets the unit's active abilities of a particular type if it were on a specified location.
 	 * @param tag_name The type of ability to check for
@@ -1878,6 +1899,11 @@ public:
 	 */
 	bool ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const;
 
+	/**
+	 * @returns game_board affect_distant_max_radius_[tag_name] or affect_distant_max_radius_for_filtering_
+	 * @param tag_name the type of ability corresponding to the variable used, if empty return affect_distant_max_radius_for_filtering_.
+	 */
+	utils::optional<int> affect_distant_max_radius(const std::string& tag_name = "") const;
 
 private:
 
@@ -1947,6 +1973,15 @@ private:
 	 */
 	bool ability_affects_adjacent(const std::string& ability, const config& cfg, int dir, const map_location& loc, const unit& from) const;
 
+	/**
+	 * Check if an ability affects distant units.
+	 * @param ability The type (tag name) of the ability
+	 * @param cfg an ability WML structure
+	 * @param loc The location on which to resolve the ability
+	 * @param from The "other unit" for filter matching
+	 * @param from_loc the "other unit" location
+	 */
+	bool ability_affects_distant(const std::string& ability, const config& cfg, const map_location& loc, const unit& from, const map_location& from_loc) const;
 	/**
 	 * Check if an ability affects the owning unit.
 	 * @param ability The type (tag name) of the ability

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -424,6 +424,12 @@
 0 filter_adjacent_direction_inactive
 0 filter_special_id_active
 0 filter_ability_special_id_active
+0 affect_distant_active
+0 affect_distant_inactive
+0 affect_distant_active_with_second_ability
+0 affect_distant_active_with_second_ability_type
+0 affect_distant_inactive_with_second_ability
+0 affect_distant_inactive_with_second_ability_type
 0 filter_special_id_not_exists
 0 special_id_active_lua_function
 0 leadership_when_other_has_special


### PR DESCRIPTION
resolve https://github.com/wesnoth/wesnoth/issues/4981 issue
like [affect_adjacent] this tag affects other units than the owner of the ability but this time, it concerns units located in a radius defined in the tag.

I had already tried to make one a few years ago but the code was too heavy and I had given up.