### PR TITLE
Fix defining formula function with existing name silently fails

### DIFF
--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -1547,10 +1547,14 @@ function_symbol_table::function_symbol_table(const std::shared_ptr<function_symb
 	: parent(parent ? parent : get_builtins())
 {
 }
-
 void function_symbol_table::add_function(const std::string& name, formula_function_ptr&& fcn)
 {
-	custom_formulas_.emplace(name, std::move(fcn));
+	auto iter = custom_formulas_.find(name);
+	if (iter != custom_formulas_.end()) {
+		(*iter).second = std::move(fcn);
+	} else {
+		custom_formulas_.emplace(name, std::move(fcn));
+	}
 }
 
 expression_ptr function_symbol_table::create_function(

--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -1547,13 +1547,12 @@ function_symbol_table::function_symbol_table(const std::shared_ptr<function_symb
 	: parent(parent ? parent : get_builtins())
 {
 }
+
 void function_symbol_table::add_function(const std::string& name, formula_function_ptr&& fcn)
 {
-	auto iter = custom_formulas_.find(name);
-	if (iter != custom_formulas_.end()) {
-		(*iter).second = std::move(fcn);
-	} else {
-		custom_formulas_.emplace(name, std::move(fcn));
+	auto iter_pair = custom_formulas_.emplace(name, std::move(fcn));
+	if(!iter_pair.second) {
+		(*(iter_pair.first)).second = std::move(fcn);
 	}
 }
 


### PR DESCRIPTION
### Goal of the PR
- Fix #9795
### How does the PR work?
- By adding a replace situation when the function name already exists in `custom_formulas_`.
### Does it resolve any reported issue?
- #9795
### If not a bug fix, why is this PR needed? What use cases does it solve?
- This is a bug fix.

## To do

Adjust possibly missed related method and changes I mistakenly made, remove redundant notes I used for quickly locating(all after this pr is nearly ready for review).

This PR is Ready for Review.

## How to test
Compile and run, see the test video I might upload later if needed, or see changes in the src.