### PR TITLE
TDG: allow the levitate spell to improve cave movement

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -520,11 +520,13 @@ Summoned elementals dissipate at the end of each scenario."
                 [/abilities])}
                 {EFFECT defense (replace=yes
                     [defense]
-                        {FLY_DEFENSE -50} # 50% hit-chance on all terrain
+                        {FLY_DEFENSE -50} # no more than 50% hit-chance on all terrain
+                        cave=-50
                     [/defense])}
                 {EFFECT movement_costs (replace=yes
                     [movement_costs]
                         {FLY_MOVE} # fast movement on most terrains
+                        cave=1 # fast on cave as well, but allow fungus to serve as a barrier
                     [/movement_costs])}
             [/object]
         [/modify_unit]


### PR DESCRIPTION
Cave movement was previously left out as an oversight.