### PR TITLE
TSG: Correctly show which arm Mari is missing in po note

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
@@ -1241,7 +1241,7 @@ panel."
         #------------------------
         [message]
             speaker=Mari
-            #po: Mari lost her left arm fighting undead in the Estmarks
+            #po: Mari lost her right arm fighting undead in the Estmarks
             message= _ "Undead again. As if losing one arm to these things wasn’t bad enough, now they’re back for my second."
         [/message]
         [message]

--- a/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/01_Born_to_the_Banner.cfg
@@ -1241,7 +1241,7 @@ panel."
         #------------------------
         [message]
             speaker=Mari
-            #po: Mari lost her right arm fighting undead in the Estmarks
+            #po: Mari lost her arm fighting undead in the Estmarks, but don't specify which one because the sprite gets mirrored
             message= _ "Undead again. As if losing one arm to these things wasn’t bad enough, now they’re back for my second."
         [/message]
         [message]


### PR DESCRIPTION
@Dalas121 Was this the arm intended to have been lost? The sprite would suggest the right arm was lost:

https://github.com/wesnoth/wesnoth/blob/529f4caca9ebfb1e94e2edad722d9f64e0821152/data/campaigns/The_South_Guard/images/units/mari2/mari.png

So I changed this po note to say right instead of left.