### PR TITLE
Bump min and default game window size

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
         * new secondary melee attack: 25-2 scimitar melee blade marksman
 ### User interface
    * A new "Customize Reach Map (Unit Movement UI)" option has been added under the advanced settings category. It provides highlight color, enemy highlight color, border opacity and tint opacity customization options for the reach map UI.
+   * The game will now default to 1920x1080 with a minimum of 1280x720
 ### WML Engine
    * [unit] no longer accepts hp_bar_scaling and xp_bar_scaling keys
 ### Miscellaneous and Bug Fixes

--- a/src/preferences/preferences.hpp
+++ b/src/preferences/preferences.hpp
@@ -33,11 +33,11 @@ class game_board;
 
 namespace pref_constants
 {
-const int min_window_width  = 800;
-const int min_window_height = 540;
+const int min_window_width  = 1280;
+const int min_window_height = 720;
 
-const int def_window_width  = 1280;
-const int def_window_height = 720;
+const int def_window_width  = 1920;
+const int def_window_height = 1080;
 
 const int max_window_width = 1920;
 const int max_window_height = 1080;


### PR DESCRIPTION
Hopefully, we'll be able to implement better support for layouts that don't relay on pixel canvas sizes, but for now, this solves two important issues:

Using 1280x720 as the default window size means 3x auto pixel scaling for 4k fullscreen, which looks utterly horrendous and unusable. 2x is the practical limit of usability without going so far in the opposite direction as to actually reduce the available space.

Bumping the min window size also resolves #9898 and saves us from having to deal with layouts on unusably small windows.

As a side note, we should not be thinking in terms of pixel size anymore. I'm hoping SDL3 can give us better control over our HDPI support (which is much improved from before), but the fact remains that our current pixel scaling implementation is, essentially, a method to scale up the canvas if your resolution is grater than 1080p. It does nothing for size calculations, and it does nothing if you actually set a window size smaller than 1080p even on a 4k monitor.

So, for now, imperfect solution while we wait for SDL3, but solves the immediate issues with scaling and small window sizes.

Resolves #9898