### PR TITLE
Lua: optional parameter to ignore scrolling to fogged hex in wesnoth.interface.move_unit_fake

### DIFF
--- a/data/lua/core/interface.lua
+++ b/data/lua/core/interface.lua
@@ -10,11 +10,11 @@ if wesnoth.kernel_type() == "Game Lua Kernel" then
 	---@param filter WML
 	---@param to_x integer
 	---@param to_y integer
-	function wesnoth.interface.move_unit_fake(filter, to_x, to_y)
+	function wesnoth.interface.move_unit_fake(filter, to_x, to_y, respect_fog)
 		local moving_unit = wesnoth.units.find_on_map(filter)[1]
 		local from_x, from_y = moving_unit.x, moving_unit.y
 
-		wesnoth.interface.scroll_to_hex(from_x, from_y)
+		wesnoth.interface.scroll_to_hex(from_x, from_y, respect_fog)
 		to_x, to_y = wesnoth.paths.find_vacant_hex(to_x, to_y, moving_unit)
 
 		if to_x < from_x then


### PR DESCRIPTION
Currently it can reveal where a unit is on the map by scrolling there. with this change one could pass an fourth parameter whether to only scroll only if the starting hex is not under fog.