### PR TITLE
TSG S3: Correct ending scene

### DIFF
--- a/data/campaigns/The_South_Guard/scenarios/03_Vale_of_Tears.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/03_Vale_of_Tears.cfg
@@ -1002,10 +1002,11 @@ a healer (such as Ethiliel) will
     [event]
         name=ending_cutscene
         #############################
-        # GURANTEE UNIT POSITIONS
+        # GUARANTEE UNIT POSITIONS
         #############################
-        {PUT_TO_RECALL_LIST x,y=10,4}
+        {PUT_TO_RECALL_LIST x,y=11,4}
         {PUT_TO_RECALL_LIST x,y=11,5}
+        {PUT_TO_RECALL_LIST x,y=12,3}
         {PUT_TO_RECALL_LIST x,y=12,5}
         {PUT_TO_RECALL_LIST x,y=13,4}
         {PUT_TO_RECALL_LIST x,y=13,5}


### PR DESCRIPTION
A Skeleton is supposed to be summoned to (12,3), but it isn't properly cleared like the other hexes around (12,4).

Resolves #9920