### PR TITLE
HttT S11, 13: Remove names from monsters

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/11_The_Ford_of_Abez.cfg
@@ -421,10 +421,10 @@
     [event]
         name=turn 5
 
-        {NAMED_LOYAL_UNIT 4 (Water Serpent) 1 15 (Water Serpent) ( _ "Water Serpent")}
+        {LOYAL_UNIT 4 (Water Serpent) 1 15}
 
 #define SEA_CREATURE
-    {NAMED_LOYAL_UNIT 4 (Cuttle Fish) 1 15 () ( _ "Cuttle Fish")}
+    {LOYAL_UNIT 4 (Cuttle Fish) 1 15}
 #enddef
 
         {SEA_CREATURE}

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -705,7 +705,7 @@ end
             y=10-15
         [/filter]
 
-        {NAMED_LOYAL_UNIT 5 (Cuttle Fish) 13 13 (Cuttle Fish) ( _ "Cuttle Fish")}
+        {LOYAL_UNIT 5 (Cuttle Fish) 13 13}
 
         [message]
             speaker=Cuttle Fish

--- a/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/13_The_Dwarven_Doors.cfg
@@ -708,7 +708,7 @@ end
         {LOYAL_UNIT 5 (Cuttle Fish) 13 13}
 
         [message]
-            speaker=Cuttle Fish
+            type=Cuttle Fish
             message= _ "Ruarrrrr!!!"    # wmllint: no spellcheck
         [/message]
         [message]


### PR DESCRIPTION
List of units from monster sides in HttT (scenario number: unit ID, unit name, manually defined "name.")
S11: Water Serpent, Water Serpent, "Water Serpent"
S11: Cuttle Fish, Cuttlefish, "Cuttle Fish"
S13: Cuttle Fish, Cuttlefish, "Cuttle Fish"
S14: Blood Bat, Blood Bat, no name
S14: Giant Spider, Giant Spider, "Hywyn"
S19c: Water Serpent, Water Serpent, no name

Giant Spider has an original name just like Konrad/Li'sar, but names like "Water Serpent" and "Cuttle Fish" in S11 and S13 seem unnecessary.

Because unit IDs are untouched, there should be no risk of messing up other parts of the game unlike #9907.