### PR TITLE
Use numbers instead of words to write thirteen in WoF S11

### DIFF
--- a/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
+++ b/data/campaigns/Winds_of_Fate/scenarios/11_Crosswind.cfg
@@ -517,7 +517,7 @@ You are strangely far flown from that shoal you so coveted."
             speaker=Xatra
             image_pos=right
             mirror=yes
-            message= _ "Yet I feel all thirteen years in my bones!"
+            message= _ "Yet I feel all 13 years in my bones!"
         [/message]
     [/event]
 


### PR DESCRIPTION
According to the typography style guide, numbers above 12 (except from round numbers) should be represnted with numbers, not words, at least in regular character dialogue. So this “thirteen” should be written as “13”.