### PR TITLE
Capitalize Kingdom in TRoW Campaign Description

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -21,7 +21,7 @@
     {CAMPAIGN_DIFFICULTY NORMAL "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-commander.png" ( _ "Commander") ( _ "Challenging")} {DEFAULT_DIFFICULTY}
     {CAMPAIGN_DIFFICULTY HARD   "data/campaigns/The_Rise_Of_Wesnoth/images/units/noble-lord.png" ( _ "Lord") ( _ "Difficult")}
 
-    description= _ "Lead Prince Haldric through the destruction of the Green Isle and across the Ocean to establish the very kingdom of Wesnoth itself. The confrontation with Lich-Lord Jevyan awaits...
+    description= _ "Lead Prince Haldric through the destruction of the Green Isle and across the Ocean to establish the very Kingdom of Wesnoth itself. The confrontation with Lich-Lord Jevyan awaits...
 
 " + _"(Hard level, 20 scenarios.)"
 


### PR DESCRIPTION
Other instances of “Kingdom of Wesntoh” have Kingdom capitalized (e.g. DW S2) and capitalizing this would be the general convention in this case so it makes sense to do it in the TRoW Campaign Description as well.