### PR TITLE
Use orcs instead of goblins in Sea Orc unit description

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/units/Sea_Orc.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Sea_Orc.cfg
@@ -29,7 +29,7 @@
     cost=12
     usage=fighter
     # this description needs revision
-    description= _ "While often viewed as inferior to their land-loving counterparts, Sea Orcs represent a great leap for all goblins as they have adapted to aquatic environments. With their curved swords they are competent fighters, although their lack of a ranged attack and poor defense on land do represent strategic weaknesses."
+    description= _ "While often viewed as inferior to their land-loving counterparts, Sea Orcs represent a great leap for all orcs as they have adapted to aquatic environments. With their curved swords they are competent fighters, although their lack of a ranged attack and poor defense on land do represent strategic weaknesses."
     die_sound={SOUND_LIST:ORC_SMALL_DIE}
     {DEFENSE_ANIM "units/sea-orc-defend2.png" "units/sea-orc-defend1.png" {SOUND_LIST:ORC_SMALL_HIT} }
     [attack]

--- a/data/campaigns/Heir_To_The_Throne/units/Sea_Orc.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Sea_Orc.cfg
@@ -29,7 +29,7 @@
     cost=12
     usage=fighter
     # this description needs revision
-    description= _ "While often viewed as inferior to their land-loving counterparts, Sea Orcs represent a great leap for all orcs as they have adapted to aquatic environments. With their curved swords they are competent fighters, although their lack of a ranged attack and poor defense on land do represent strategic weaknesses."
+    description= _ "While often viewed as inferior to their land-loving counterparts, Sea Orcs represent a great leap for all orcs and goblins as they have adapted to aquatic environments. With their curved swords they are competent fighters, although their lack of a ranged attack and poor defense on land do represent strategic weaknesses."
     die_sound={SOUND_LIST:ORC_SMALL_DIE}
     {DEFENSE_ANIM "units/sea-orc-defend2.png" "units/sea-orc-defend1.png" {SOUND_LIST:ORC_SMALL_HIT} }
     [attack]


### PR DESCRIPTION
"a great leap for all orcs" makes more sense since they are supposed to be orcs.