### PR TITLE
TDG: Improve Custom Saurian Unit Descriptions

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/units/Saurian_Devotee.cfg
@@ -34,7 +34,7 @@
     advances_to=Saurian Augur
     cost=10
     usage=archer
-    description= _ "Saurians have some knowledge of what men call sorcery, but their practice of it reeks of augury and black magic. It is little understood, but rightly regarded with fear by those against whom it is used."
+    description= _ "Young saurians particularly keen on the magical arts are trained as Devotees. Although they still lack the strength of Augurs and Prophets, they can still use their abilities to defend their clan in times of need."
     die_sound=hiss-die.wav
     {DEFENSE_ANIM "units/saurian-devotee/devotee-defend2.png" "units/saurian-devotee/devotee-defend1.png" hiss-hit.wav }
     {STANDING_ANIM_DIRECTIONAL_6_FRAME "units/saurian-devotee/devotee"}

--- a/data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/units/Saurian_Juvenile.cfg
@@ -11,7 +11,7 @@
     level,experience,advances_to=0,50,null
     {AMLA_DEFAULT}
     usage=fighter
-    description= _"Too young, weak, or infirm to hunt or fight, these saurians tend to basic duties within their clutch."
+    description= _"These young saurians are less than a year old, and are too weak and infirm to hunt or fight. Older Juveniles may tend to a few basic duties within their clutch, but are still defenceless in combat. As these saurians grow older, they will quickly learn to fend for themselves and become fully grown adults by the age of three."
     die_sound=hiss-die.wav
     [abilities]
         {ABILITY_SKIRMISHER}

--- a/data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/units/Saurian_Young.cfg
@@ -34,7 +34,7 @@
     advances_to=Saurian Skirmisher
     cost=10
     usage=fighter
-    description= _ "Saurians are very small of frame, and though they are somewhat frail because of this, they are very, very agile. In combat, their size allows them to dart past defenses that would hold any grown man at bay, making them a tricky foe to deal with."
+    description= _ "These young saurians are still learning to wield a proper spear, and have not yet attained the skills of their elders. They are skilled enough to hunt small animals, but are still unprepared for a true battle, fighting only on the most dire occasions."
     die_sound=hiss-die.wav
     {DEFENSE_ANIM "units/saurian-young-spear/young-defend2.png" "units/saurian-young-spear/young-defend1.png" hiss-hit.wav }
     {STANDING_ANIM_DIRECTIONAL_6_FRAME "units/saurian-young-spear/young"}


### PR DESCRIPTION
@Dalas121 I tried to improve these descriptions. The Devotee and Spike are currently using description from their level 1 counterparts, so I gave them something more unique. The saurian race description already said saurians become adults at the age of three, so I used that in the Saurian Juvenile description, which I hopefully improved from the original.

(Check failure in the first commit is unrelated to my changes)