### PR TITLE
Remove instance of 4 repeated exclamation marks

### DIFF
--- a/data/ai/micro_ais/scenarios/guardians.cfg
+++ b/data/ai/micro_ais/scenarios/guardians.cfg
@@ -492,7 +492,7 @@ separate attack Zone"
         [message]
             speaker=Kraa
             image=$profile~FL()~RIGHT()
-            message= _ "Kraahhh!!!!"
+            message= _ "Kraahhh!!!"
         [/message]
         [message]
             speaker=Another Bad Orc


### PR DESCRIPTION
Follow-up to #9918

It was decided that three exclamation marks is fine and the style guide has been changed accordingly, but this instance of four should still be removed. I replaced this with three exclamation marks.