### PR TITLE
Improve Galleon Unit Description

### DIFF
--- a/data/core/units/boats/Galleon.cfg
+++ b/data/core/units/boats/Galleon.cfg
@@ -20,5 +20,5 @@
     {AMLA_DEFAULT}
     cost=10
     usage=null
-    description= _ "Galleons are blue-water ships built for trade and transport."
+    description= _ "Galleons are large and sturdy wooden ships used primarily to swiftly trade and transport goods across rivers and oceans in massive quantities. The earliest Galleons were built long ago by ancient sailors from the Green Isle, before even the times of Haldric. Centuries later, their skilled designs continue to be used by many Wesnothian sailors."
 [/unit_type]

--- a/data/core/units/boats/Galleon.cfg
+++ b/data/core/units/boats/Galleon.cfg
@@ -20,5 +20,5 @@
     {AMLA_DEFAULT}
     cost=10
     usage=null
-    description= _ "Galleons are large and sturdy wooden ships used primarily to swiftly trade and transport goods across rivers and oceans in massive quantities. The earliest Galleons were built long ago by ancient sailors from the Green Isle, before even the times of Haldric. Centuries later, their skilled designs continue to be used by many Wesnothian sailors."
+    description= _ "Galleons are large and sturdy wooden ships used primarily to swift transport of goods across rivers and oceans in large quantities. The earliest Galleons were built long ago by ancient sailors from the Green Isle, before even the times of Haldric. Centuries later, their skillful designs continue to be used by many Wesnothian sailors."
 [/unit_type]

--- a/data/core/units/boats/Galleon.cfg
+++ b/data/core/units/boats/Galleon.cfg
@@ -20,5 +20,5 @@
     {AMLA_DEFAULT}
     cost=10
     usage=null
-    description= _ "Galleons are large and sturdy wooden ships used primarily to swift transport of goods across rivers and oceans in large quantities. The earliest Galleons were built long ago by ancient sailors from the Green Isle, before even the times of Haldric. Centuries later, their skillful designs continue to be used by many Wesnothian sailors."
+    description= _ "Galleons are large and sturdy wooden ships used primarily for swift transport of goods across rivers and oceans in large quantities. The earliest Galleons were built long ago by ancient sailors from the Green Isle, before even the times of Haldric. Centuries later, their skillfully-crafted designs continue to be used by many Wesnothian sailors."
 [/unit_type]


### PR DESCRIPTION
I remade the Galleon unit description. The detail on their origin in the Green Isle in new, but their appearance in TRoW would suggest this.