### PR TITLE
TDG: some S00 onboarding improvements

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg
@@ -178,7 +178,11 @@
         [/message]
 
         {RECALL_XY Delfador 1 6}
-        {MODIFY_UNIT id=Delfador experience ({ON_DIFFICULTY4 30 30 20 10})} # do this here instead of in [side], so that we don't run into XP scaling issues
+        # set XP here instead of in [side], so that we don't run into XP scaling issues
+        # 20 XP lets Delfador levitate 3 times if he kills one mudcrawler (who spawns even on Easy),
+        # while also beying low enough that Delfador is unlikely to reach max XP (which triggers the "Delfador does not use XP to advance message")
+        # We don't want that message to appear before the player is familiar with the basics of spellcasting, so they understand what XP can be used for besides advancing.
+        {MODIFY_UNIT id=Delfador experience ({ON_DIFFICULTY4 20 20 20 10})}
         {FIRE_EVENT refresh_delfador_skills}
 
         [message]

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/00_Graduation.cfg
@@ -179,9 +179,10 @@
 
         {RECALL_XY Delfador 1 6}
         # set XP here instead of in [side], so that we don't run into XP scaling issues
-        # 20 XP lets Delfador levitate 3 times if he kills one mudcrawler (who spawns even on Easy),
-        # while also beying low enough that Delfador is unlikely to reach max XP (which triggers the "Delfador does not use XP to advance message")
+        # 20 XP lets Delfador levitate 3 times if he kills one mudcrawler (who spawns even on Easy).
+        # 20 XP is also low enough that Delfador is unlikely to reach max XP (which triggers the "Delfador does not use XP to advance message")
         # We don't want that message to appear before the player is familiar with the basics of spellcasting, so they understand what XP can be used for besides advancing.
+        # On Nightmare, 10XP means that you must kill one eystalk to cast levitate enough times to complete the scenario (and anti-RNG events in this scenario ensure this is possible)
         {MODIFY_UNIT id=Delfador experience ({ON_DIFFICULTY4 20 20 20 10})}
         {FIRE_EVENT refresh_delfador_skills}
 

--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -2762,7 +2762,7 @@ Summoned elementals dissipate at the end of each scenario."
         {FILTER_CONDITION({VARIABLE_CONDITIONAL explained_max_xp not_equals yes})}
         [message]
             speaker,image=narrator,wesnoth-icon.png
-            message=_"Unlike regular units, Delfador does not use XP to advance, and will instead advance automatically over time as he progresses through the story. Raising him to max XP has no effect."
+            message=_"Unlike regular units, Delfador does not use XP to advance, and will instead advance automatically over time as he progresses through the story. Delfador’s XP is useful for casting spells, but raising him to max XP has no special effect."
         [/message]
         {VARIABLE explained_max_xp yes}
     [/event]

--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -2762,7 +2762,7 @@ Summoned elementals dissipate at the end of each scenario."
         {FILTER_CONDITION({VARIABLE_CONDITIONAL explained_max_xp not_equals yes})}
         [message]
             speaker,image=narrator,wesnoth-icon.png
-            message=_"Unlike regular units, Delfador does not use XP to advance. Raising him to max XP has no effect."
+            message=_"Unlike regular units, Delfador does not use XP to advance, and will instead advance automatically over time as he progresses through the story. Raising him to max XP has no effect."
         [/message]
         {VARIABLE explained_max_xp yes}
     [/event]

--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -2762,7 +2762,7 @@ Summoned elementals dissipate at the end of each scenario."
         {FILTER_CONDITION({VARIABLE_CONDITIONAL explained_max_xp not_equals yes})}
         [message]
             speaker,image=narrator,wesnoth-icon.png
-            message=_"Unlike regular units, Delfador does not use XP to advance, and will instead advance automatically over time as he progresses through the story. Delfador’s XP is useful for casting spells, but raising him to max XP has no special effect."
+            message=_"Unlike regular units, Delfador does not use XP to advance, and will instead advance automatically over time as he progresses through the story. Delfador’s XP is useful for casting spells, but raising him to maximum XP has no special effect."
         [/message]
         {VARIABLE explained_max_xp yes}
     [/event]


### PR DESCRIPTION
Based on: https://forums.wesnoth.org/viewtopic.php?p=696551#p696551

Makes the "_Delfador does not use XP to level-up_" message less likely to appear in the first scenario, and elaborates on how delfador _does_ level-up.