### PR TITLE
lua api: add double click event handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Editor
 ### Multiplayer
 ### Lua API
+   * All widgets now have the event handler `on_double_click`. If set, it will be fired when the user left double clicks on that widget.
 ### Packaging
 ### Terrain
 ### Translations

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Editor
 ### Multiplayer
 ### Lua API
-   * All widgets now have the event handler `on_double_click`. If set, it will be fired when the user left double clicks on that widget.
+   * Toggle panel now have the event handler `on_double_click`. If set, it will be fired when the user left double clicks on that widget. For other widgets, they can be wrapped inside a toggle panel for this to work.
 ### Packaging
 ### Terrain
 ### Translations

--- a/src/scripting/lua_widget_attributes.cpp
+++ b/src/scripting/lua_widget_attributes.cpp
@@ -877,6 +877,18 @@ WIDGET_SETTER("on_left_click", lua_index_raw, gui2::widget)
 	}
 }
 
+WIDGET_SETTER("on_double_click", lua_index_raw, gui2::widget)
+{
+	gui2::window* wd = w.get_window();
+	if(!wd) {
+		throw std::invalid_argument("the widget has no window assigned");
+	}
+	lua_pushvalue(L, value.index);
+	if (!luaW_setwidgetcallback(L, &w, wd, "on_double_click")) {
+		connect_signal_mouse_left_double_click(w, std::bind(&dialog_callback, L, lua_ptr<gui2::widget>(w), "on_double_click"));
+	}
+}
+
 WIDGET_SETTER("on_button_click", lua_index_raw, gui2::widget)
 {
 	gui2::window* wd = w.get_window();

--- a/utils/emmylua/gui.lua
+++ b/utils/emmylua/gui.lua
@@ -126,7 +126,8 @@ function gui.add_widget_definition(type, id, content) end
 ---@field text_alignment "'left'"|"'right'"|"'center'"
 ---@field ellipsize_mode "'none'"|"'start'"|"'middle'"|"'end'"
 ---@field overflow_to_tooltip boolean
----@field on_left_click fun()
+---@field on_left_click fun() a function that is called when the widget is left clicked once
+---@field on_double_click fun() a function that is called when the widget is left clicked twice
 
 ---The window widget is a container that contains all other widgets in the dialog
 ---@class window : widget


### PR DESCRIPTION
Adds a new `on_double_click` function to toggle panels that get called when the user left double clicks on it. For other widgets, they can be wrapped inside a `[toggle_panel]` to add double click handlers, because the C++ dbl click handler supports only `[toggle_panel]`-s.