### PR TITLE
drop preferences.cpp from source lists (no longer needed)

### DIFF
--- a/source_lists/wesnoth
+++ b/source_lists/wesnoth
@@ -306,7 +306,6 @@ play_controller.cpp
 playmp_controller.cpp
 playsingle_controller.cpp
 playturn_network_adapter.cpp
-preferences/preferences.cpp
 random_deterministic.cpp
 random_synced.cpp
 recall_list_manager.cpp


### PR DESCRIPTION
Duplicate inclusion, exists in both `source_lists/wesnoth` and `source_lists/libwesnoth`. Opened PR for test CI run to see if one can be dropped.