### PR TITLE
help: link base and overlay terrains in terrain help pages (#9456)

### DIFF
--- a/src/gui/dialogs/help_browser.cpp
+++ b/src/gui/dialogs/help_browser.cpp
@@ -17,32 +17,19 @@
 
 #include "gui/dialogs/help_browser.hpp"
 
-#include "game_config_manager.hpp"
 #include "gui/widgets/button.hpp"
-#include "gui/widgets/image.hpp"
 #include "gui/widgets/label.hpp"
 #include "gui/widgets/rich_label.hpp"
 #include "gui/widgets/scroll_label.hpp"
 #include "gui/widgets/scrollbar_panel.hpp"
-#include "gui/widgets/settings.hpp"
-#include "gui/widgets/text_box.hpp"
 #include "gui/widgets/toggle_button.hpp"
 #include "gui/widgets/tree_view.hpp"
 #include "gui/widgets/tree_view_node.hpp"
 #include "gui/widgets/window.hpp"
-#include "log.hpp"
 #include "video.hpp"
-
-#ifdef GUI2_EXPERIMENTAL_LISTBOX
-#include "gui/widgets/list.hpp"
-#else
-#include "gui/widgets/listbox.hpp"
-#endif
 
 #include "help/help.hpp"
 #include "help/help_impl.hpp"
-#include "font/pango/escape.hpp"
-#include "font/pango/hyperlink.hpp"
 
 namespace gui2::dialogs
 {
@@ -137,6 +124,7 @@ tree_view_node& help_browser::add_topic(const std::string& topic_id, const std::
 
 	return new_node;
 }
+
 void help_browser::show_topic(std::string topic_id, bool add_to_history)
 {
 	if(topic_id.empty()) {

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -126,8 +126,11 @@ public:
 	 * \todo unclear what this should mean, so replace it with a clearly-named
 	 * successor.
 	 */
-	bool is_nonnull() const { return  (number_ != t_translation::NONE_TERRAIN) &&
-		(number_ != t_translation::VOID_TERRAIN ); }
+	bool is_nonnull() const {
+		return (number_ != t_translation::NONE_TERRAIN)
+			&& (number_ != t_translation::VOID_TERRAIN);
+	}
+
 	/** Returns the light (lawful) bonus for this terrain when the time of day gives a @a base bonus. */
 	int light_bonus(int base) const
 	{


### PR DESCRIPTION
Resolves #9456 by linking the help pages for Base and Overlay terrain for composite terrains.

![Screenshot from 2025-02-23 16-20-28](https://github.com/user-attachments/assets/a5957dc7-4ed5-490d-800f-7c1e8c42655c)
