### PR TITLE
Touch persistence fix

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -661,10 +661,8 @@ void pump()
 				// Not used.
 				break;
 			}
-
 			raise_window_event(event);
-
-					// This event was just distributed, don't re-distribute.
+		    // This event was just distributed, don't re-distribute.
 			continue;
 
 		case SDL_MOUSEMOTION: {


### PR DESCRIPTION
Added logic for touch being negative, as well as extra code to make sure any touch event is cleaned up.

All changes occur inside the definition of "#ifdef MOUSE_TOUCH_EMULATION" and the most important line change is at 581