### PR TITLE
TDG: remove silent raven speed reduction, and use TRAIT_SLOW instead

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -619,12 +619,7 @@ Summoned elementals dissipate at the end of each scenario."
                 {CLEAR_VARIABLE stored_familiar}
             )} {ELSE(
                 {NAMED_NOTRAIT_UNIT 1 Raven $delfX $delfY familiar _"Familiar"}
-                {ADD_MODIFICATION( {TRAIT_LOYAL} {TRAIT_STRONG} )}
-                {GIVE_OBJECT_TO id=familiar (
-                    {EFFECT movement ({FILTER level=0} set=6)} # nerf speed. Find Familiar is already a very strong skill
-                    {EFFECT movement ({FILTER level=1} set=6)}
-                    {EFFECT movement ({FILTER level=2} set=6)} # this speed is ALSO used in HttT
-                )}
+                {ADD_MODIFICATION( {TRAIT_LOYAL} {TRAIT_SLOW} )} # nerf with TRAIT_SLOW; Find Familiar is already a very powerful spell. These traits are also used in the HttT revision.
             )} {/IF}
             {CLEAR_VARIABLE delfX,delfY}
         )} {/IF}


### PR DESCRIPTION
TDG gives Delfador access to a loyal raven/dire raven/war harbinger. Currently, the speed for this unit is capped at 6, to prevent it from being overly-powerful when compared with other options.

revolting_peasant pointed out that this speed cap makes the raven's stats inconsistent with the numbers in "view unit type". To resolve that, this PR replaces the speed cap with {TRAIT_SLOW}.