### PR TITLE
Update Firebomb Ant and Grand Dragonfly XP

### DIFF
--- a/data/core/units/monsters/Ant_Firebomb.cfg
+++ b/data/core/units/monsters/Ant_Firebomb.cfg
@@ -43,7 +43,7 @@ units/monsters/ant/#enddef
     hitpoints=45
     movement_type=orcishfoot
     movement=5
-    experience=80
+    experience=100
     level=2
     alignment=neutral
     advances_to=null

--- a/data/core/units/monsters/Dragonfly_Grand.cfg
+++ b/data/core/units/monsters/Dragonfly_Grand.cfg
@@ -20,7 +20,7 @@
     vision=9
     level=2
     alignment=neutral
-    experience=80
+    experience=100
     {AMLA_DEFAULT}
     advances_to=null
     cost=30


### PR DESCRIPTION
These are L2 units with no L3 advancement, but have 80xp for some reason. This PR changes them to the more standard 100xp.