### PR TITLE
CI: run boost unit tests on a release build only

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -156,7 +156,7 @@ jobs:
         if: success() || steps.build.outcome == 'success'
         run: ./utils/CI/mp_test_executor.sh
       - name: Run unit tests
-        if: success() || steps.build.outcome == 'success'
+        if: matrix.cc == 'clang' && (success() || steps.build.outcome == 'success')
         run: ./run_boost_tests
 
   steam-runtime:


### PR DESCRIPTION
The debug CI build is consistently the last CI job to finish, usually behind even the Windows and Mac jobs.