### PR TITLE
Add various terrain type subtables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
    * `Convert To Scenario` menu item added to `File` menu that allows converting an already opened map to a scenario.
 ### Multiplayer
 ### Lua API
+   * Add `mvt_alias` and `def_alias` to `wesnoth.terrain_types`.
 ### Packaging
    * Boost 1.70 or later is now required
 ### Terrain

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -1126,6 +1126,30 @@ int game_lua_kernel::impl_get_terrain_info(lua_State *L)
 	lua_pushinteger(L, info.gives_healing());
 	lua_setfield(L, -2, "healing");
 
+	// movement alias
+	lua_newtable(L);
+	int idx = 1;
+	for (const auto& terrain : info.mvt_type()) {
+		const terrain_type& base = board().map().tdata()->get_terrain_info(terrain);
+		if (!base.id().empty()) {
+			lua_pushstring(L, t_translation::write_terrain_code(base.number()).c_str());
+			lua_rawseti(L, -2, idx++);
+		}
+	}
+	lua_setfield(L, -2, "mvt_alias");
+
+	// defense alias
+	lua_newtable(L);
+	idx = 1;
+	for (const auto& terrain : info.def_type()) {
+		const terrain_type& base = board().map().tdata()->get_terrain_info(terrain);
+		if (!base.id().empty()) {
+			lua_pushstring(L, t_translation::write_terrain_code(base.number()).c_str());
+			lua_rawseti(L, -2, idx++);
+		}
+	}
+	lua_setfield(L, -2, "def_alias");
+
 	return 1;
 }
 
@@ -5292,10 +5316,10 @@ game_lua_kernel::game_lua_kernel(game_state & gs, play_controller & pc, reports 
 	// Create the unit_types table
 	cmd_log_ << lua_unit_type::register_table(L);
 
-	// Create the unit_types table
+	// Create the terrainmap metatables
 	cmd_log_ << lua_terrainmap::register_metatables(L);
 
-	// Create the unit_types table
+	// Create the terrain_types table
 	cmd_log_ << "Adding terrain_types table...\n";
 	lua_getglobal(L, "wesnoth");
 	lua_newuserdatauv(L, 0, 0);

--- a/utils/emmylua/wesnoth.lua
+++ b/utils/emmylua/wesnoth.lua
@@ -291,6 +291,8 @@ wesnoth.scenario = {}
 ---@field castle boolean
 ---@field keep boolean
 ---@field healing boolean
+---@field mvt_alias string[]
+---@field def_alias string[]
 
 ---@type table<string, terrain_info>
 wesnoth.terrain_types = {}


### PR DESCRIPTION
Resolves #9969.
These expose `terrain_type::mvt_type()` and `terrain_type::def_type()` as `mvt_alias` and `def_alias` subtables (array) to `wesnoth.terrain_types` table, which have the same meaning as mentioned in [TerrainWML](https://wiki.wesnoth.org/TerrainWML).

(Note: no way to figure out whether it is a `best of` or `worst of` for the latter two yet, because it's a bit too involved, but may be done in future.)