### PR TITLE
GUI2/Canvas: fix issues with literal text

### DIFF
--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -17,6 +17,7 @@
 #include "gui/auxiliary/typed_formula.hpp"
 
 #include "font/attributes.hpp"
+#include "utils/variant.hpp"
 
 namespace gui2
 {
@@ -264,7 +265,7 @@ private:
 	typed_formula<color_t> color_;
 
 	/** The text to draw. */
-	typed_formula<t_string> text_;
+	utils::variant<typed_formula<t_string>, t_string> text_;
 
 	/** The text markup switch of the text. */
 	typed_formula<bool> text_markup_;


### PR DESCRIPTION
Resolves #9981
Resolves #9982

Bit of overkill... but it works. Really hope the use of variant doesn't cause CI issues with MacOS... I don't want to have to add compat wrappers for std::in_place_type.