### PR TITLE
help browser: add search functionality

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
    * Updated translations: Bengali, British English, Finnish, Italian
 ### Units
 ### User interface
+   * It is now possible to search help topics by name/id in the Help Browser.
 ### WML Engine
 ### Miscellaneous and Bug Fixes
 

--- a/data/gui/themes/default/dialogs/help_browser.cfg
+++ b/data/gui/themes/default/dialogs/help_browser.cfg
@@ -157,6 +157,19 @@
 							[/column]
 
 							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
+								[text_box]
+									id = "filter_box"
+									definition = "default"
+									{FILTER_TEXT_BOX_HINT}
+									tooltip = _ "Search help topic names"
+								[/text_box]
+							[/column]
+
+							[column]
 								grow_factor = 0
 								border = "all"
 								border_size = 5

--- a/src/gui/dialogs/help_browser.hpp
+++ b/src/gui/dialogs/help_browser.hpp
@@ -58,7 +58,8 @@ private:
 	void on_topic_select();
 	void on_history_navigate(bool backwards);
 
-	void add_topics_for_section(const help::section& parent_section, tree_view_node& parent_node);
+	void update_list(const std::string&);
+	bool add_topics_for_section(const help::section& parent_section, tree_view_node& parent_node, const std::string& filter_text = "");
 	tree_view_node& add_topic(const std::string& topic_id, const std::string& topic_title,
 			bool expands, tree_view_node& parent);
 	void show_topic(std::string topic_id, bool add_to_history = true);


### PR DESCRIPTION
Resolves #4450.

- [x] Does not work with topics generated by a help topic generator for some reason.
- [ ] ~~Add "Search contents" functionality.~~ (Might be done in a future PR)

![Screenshot from 2025-03-03 22-48-43](https://github.com/user-attachments/assets/e5d6e7ce-655f-428f-80a8-057e27168687)
