### PR TITLE
Android: hardcode landscape (right) orientation

### DIFF
--- a/packaging/android/AndroidManifest.xml
+++ b/packaging/android/AndroidManifest.xml
@@ -74,6 +74,7 @@
             android:label="@string/app_name"
             android:alwaysRetainTaskState="true"
             android:launchMode="singleInstance"
+            android:screenOrientation="landscape"
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:preferMinimalPostProcessing="true"
             android:exported="true"

--- a/packaging/android/AndroidManifest.xml
+++ b/packaging/android/AndroidManifest.xml
@@ -74,7 +74,6 @@
             android:label="@string/app_name"
             android:alwaysRetainTaskState="true"
             android:launchMode="singleInstance"
-            android:screenOrientation="landscape"
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:preferMinimalPostProcessing="true"
             android:exported="true"

--- a/packaging/android/app/src/main/AndroidManifest.xml
+++ b/packaging/android/app/src/main/AndroidManifest.xml
@@ -80,7 +80,6 @@
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:exported="true"
             android:screenOrientation="landscape"
-            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/packaging/android/app/src/main/AndroidManifest.xml
+++ b/packaging/android/app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
             android:launchMode="singleInstance"
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:exported="true"
-            android:screenOrientation="landscape"
+            android:screenOrientation="landscape">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -98,8 +98,8 @@
             -->
         </activity>
         
-        <activity android:name=".WesnothActivity">
-            android:screenOrientation="landscape"
+        <activity android:name=".WesnothActivity"
+            android:screenOrientation="landscape">
         </activity>
     </application>
 

--- a/packaging/android/app/src/main/AndroidManifest.xml
+++ b/packaging/android/app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
             android:launchMode="singleInstance"
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:exported="true"
-            android:screenOrientation="sensorLandscape"
+            android:screenOrientation="landscape"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -100,6 +100,7 @@
         </activity>
         
         <activity android:name=".WesnothActivity">
+            android:screenOrientation="landscape"
         </activity>
     </application>
 


### PR DESCRIPTION
Added 1 line for landscape orientation, at line 77, the following: _android:screenOrientation="landscape"_
This instructs Android to always have landscape orientation (to right side of screen)