### PR TITLE
Fix some indentation and make CI abort if wmlindent errors

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -30,7 +30,7 @@ jobs:
           ./utils/CI/utf8_bom_dog.sh
       - name: Whitespace and WML indentation check
         if: success() || failure()
-        run: ./utils/CI/fix_whitespace.sh; git status; git diff --exit-code
+        run: ./utils/CI/fix_whitespace.sh && git status && git diff --exit-code
       - name: WML missing images check
         if: success() || failure()
         run: utils/CI/check_wml_images.sh

--- a/data/campaigns/The_South_Guard/scenarios/03_Vale_of_Tears.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/03_Vale_of_Tears.cfg
@@ -209,17 +209,18 @@
                 alpha={ALPHA}
             [/frame]
         [/standing_anim])}
-        {EFFECT new_animation ([death]
-        base_score=99
-        [frame]
-            duration,image_mod=500,"~CS(127,0,127)~BL([15,10,20,30,40,50,60,70])"
-            blend_ratio,blend_color=0~1,255,255,255
-            alpha=1,1~0
-        [/frame]
-    [/death] )}
-[/object]
-[/modify_unit]
-{DELAY 150}
+        {EFFECT new_animation (
+            [death]
+                base_score=99
+                [frame]
+                    duration,image_mod=500,"~CS(127,0,127)~BL([15,10,20,30,40,50,60,70])"
+                    blend_ratio,blend_color=0~1,255,255,255
+                    alpha=1,1~0
+                [/frame]
+            [/death] )}
+        [/object]
+    [/modify_unit]
+    {DELAY 150}
 #enddef
         {REMOVE_IMAGE 28 12} {PLACE_IMAGE "scenery/rune4.png~CS(-50,100,-50)~O(0.5)" 28 12}
         {ELF (Elvish Captain  ) "captain.png"   "elves/captain.webp"   26 12 Ithelden  _"Ithelden" se   male   6000        "1~0.6:2250,0.6:500,0.6~1:2250,1:1000"}

--- a/data/campaigns/The_South_Guard/scenarios/04_Choice_in_the_Fog.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/04_Choice_in_the_Fog.cfg
@@ -1056,117 +1056,118 @@ Believe the truths you have seen, not the lies you have heard. No fake niceties 
     #############################
     [event]
         name=victory
-        [if] {NOT({HAVE_UNIT({FILTER_SIDE(
-            [enemy_of]
-                side=1
-            [/enemy_of]
-        )})})}
-        [then]
-            {ACHIEVE s04}
-        [/then]
-    [/if]
-[/event]
+        [if]
+            {NOT({HAVE_UNIT({FILTER_SIDE(
+                [enemy_of]
+                    side=1
+                [/enemy_of]
+            )})})}
+            [then]
+                {ACHIEVE s04}
+            [/then]
+        [/if]
+    [/event]
 
-#############################
-# TIME LOW
-#############################
-[event]
-    name=turn {TURN_WARNING}
-    [if] {VARIABLE_CONDITIONAL s04_phase equals elf_alliance}
-        [then]
-            [message]
-                speaker=Ethiliel
-                message= _ "Do not delay, Deoran! If we do not finish off this vermin Afalas soon, he shall surely make his escape!"
-            [/message]
-        [/then]
-    [/if]
-    [if] {VARIABLE_CONDITIONAL s04_phase equals bandit_alliance}
-        [then]
-            [message]
-                speaker=Afalas
-                message= _ "Better hurry, Deoran. Whatever Mebrin’s plans are, he gets closer to finishin’ them every day. We’ve got to finish him off soon!"
-            [/message]
-        [/then]
-    [/if]
-    [message]
-        speaker,image=narrator,wesnoth-icon.png
-        {TUTOR: _"You are running out of turns to complete this scenario! See your objectives by pressing Ctrl+J, and remember that the turn limit can be seen in the top-left-hand corner."}
-    [/message]
-[/event]
-[event]
-    name=time over
-    [message]
-        speaker=Deoran
-        message= _ "We have moved so slowly! If the last Urza brother was ever here, he has surely fled by now, and we still have no answers..."
-    [/message]
-    [message]
-        speaker,image=narrator,wesnoth-icon.png
-        {TUTOR: _"You have run out of turns to complete the scenario, and have been defeated!"}
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
-[/event]
+    #############################
+    # TIME LOW
+    #############################
+    [event]
+        name=turn {TURN_WARNING}
+        [if] {VARIABLE_CONDITIONAL s04_phase equals elf_alliance}
+            [then]
+                [message]
+                    speaker=Ethiliel
+                    message= _ "Do not delay, Deoran! If we do not finish off this vermin Afalas soon, he shall surely make his escape!"
+                [/message]
+            [/then]
+        [/if]
+        [if] {VARIABLE_CONDITIONAL s04_phase equals bandit_alliance}
+            [then]
+                [message]
+                    speaker=Afalas
+                    message= _ "Better hurry, Deoran. Whatever Mebrin’s plans are, he gets closer to finishin’ them every day. We’ve got to finish him off soon!"
+                [/message]
+            [/then]
+        [/if]
+        [message]
+            speaker,image=narrator,wesnoth-icon.png
+            {TUTOR: _"You are running out of turns to complete this scenario! See your objectives by pressing Ctrl+J, and remember that the turn limit can be seen in the top-left-hand corner."}
+        [/message]
+    [/event]
+    [event]
+        name=time over
+        [message]
+            speaker=Deoran
+            message= _ "We have moved so slowly! If the last Urza brother was ever here, he has surely fled by now, and we still have no answers..."
+        [/message]
+        [message]
+            speaker,image=narrator,wesnoth-icon.png
+            {TUTOR: _"You have run out of turns to complete the scenario, and have been defeated!"}
+        [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
+    [/event]
 
-#############################
-# TIME OVER
-#############################
-[event]
-    name=side 1 turn {TURN_LIMIT} end
-    [if] {VARIABLE_CONDITIONAL s04_phase equals elf_alliance}
-        [then]
-            {REVEAL x,y,radius=21,7,2}
-            {REVEAL x,y,radius=22,5,2}
-            {GENERIC_UNIT 2 Boat 24 4}
-            {SOUND ambient/ship.ogg}
-            {MOVE_UNIT type=Boat 20 7}
-            [message]
-                type,caption,image=boat,_"Sailor",portaits/humans/ruffian.webp
-                message= _ "Hey, boss, it’s me. Anyone still alive out here?"
-            [/message]
-            [message]
-                speaker=Afalas
-                message= _ "Finally, what took ye so long! C’mon, let’s get us all out o’ here afore that crazy elf lady kills any more o’ us!"
-            [/message]
-            {MOVE_UNIT id=Afalas 21 8}
-            {KILL id=Afalas}
-            {MOVE_UNIT type=Boat 35 1}
-            {KILL side=2}
-            [message]
-                speaker=Deoran
-                message= _ "Urza Afalas has fled up the river! If he ever held Mebrin prisoner, the gentle sage is now far beyond our reach..."
-            [/message]
-        [/then]
-    [/if]
+    #############################
+    # TIME OVER
+    #############################
+    [event]
+        name=side 1 turn {TURN_LIMIT} end
+        [if] {VARIABLE_CONDITIONAL s04_phase equals elf_alliance}
+            [then]
+                {REVEAL x,y,radius=21,7,2}
+                {REVEAL x,y,radius=22,5,2}
+                {GENERIC_UNIT 2 Boat 24 4}
+                {SOUND ambient/ship.ogg}
+                {MOVE_UNIT type=Boat 20 7}
+                [message]
+                    type,caption,image=boat,_"Sailor",portaits/humans/ruffian.webp
+                    message= _ "Hey, boss, it’s me. Anyone still alive out here?"
+                [/message]
+                [message]
+                    speaker=Afalas
+                    message= _ "Finally, what took ye so long! C’mon, let’s get us all out o’ here afore that crazy elf lady kills any more o’ us!"
+                [/message]
+                {MOVE_UNIT id=Afalas 21 8}
+                {KILL id=Afalas}
+                {MOVE_UNIT type=Boat 35 1}
+                {KILL side=2}
+                [message]
+                    speaker=Deoran
+                    message= _ "Urza Afalas has fled up the river! If he ever held Mebrin prisoner, the gentle sage is now far beyond our reach..."
+                [/message]
+            [/then]
+        [/if]
 
-    [if] {VARIABLE_CONDITIONAL s04_phase equals bandit_alliance}
-        [then]
-            {GENERIC_UNIT 6 "Vampire Bat" 30 13} {ROLE messenger}
-            {REVEAL x,y,radius=32,19,4}
-            {MOVE_UNIT role=messenger 33 19}
-            [message]
-                role=messenger
-                message= _ "Neep, neep!"
-            [/message]
-            [message]
-                speaker=Mebrin
-                message= _ "Ah ha, ha ha ha ha. You have tarried too long, mayflies! My messenger brings news — your beloved town of Westin has been destroyed!"
-            [/message]
-            [message]
-                speaker=Deoran
-                message= _ "What? How is this possible! With the undead armies fighting us here, how could Westin have already fallen?"
-            [/message]
-        [/then]
-    [/if]
+        [if] {VARIABLE_CONDITIONAL s04_phase equals bandit_alliance}
+            [then]
+                {GENERIC_UNIT 6 "Vampire Bat" 30 13} {ROLE messenger}
+                {REVEAL x,y,radius=32,19,4}
+                {MOVE_UNIT role=messenger 33 19}
+                [message]
+                    role=messenger
+                    message= _ "Neep, neep!"
+                [/message]
+                [message]
+                    speaker=Mebrin
+                    message= _ "Ah ha, ha ha ha ha. You have tarried too long, mayflies! My messenger brings news — your beloved town of Westin has been destroyed!"
+                [/message]
+                [message]
+                    speaker=Deoran
+                    message= _ "What? How is this possible! With the undead armies fighting us here, how could Westin have already fallen?"
+                [/message]
+            [/then]
+        [/if]
 
-    [message]
-        speaker,image=narrator,wesnoth-icon.png
-        {TUTOR: _"You have run out of turns to complete the scenario, and have been defeated!"}
-    [/message]
-    [endlevel]
-        result=defeat
-    [/endlevel]
-[/event]
+        [message]
+            speaker,image=narrator,wesnoth-icon.png
+            {TUTOR: _"You have run out of turns to complete the scenario, and have been defeated!"}
+        [/message]
+        [endlevel]
+            result=defeat
+        [/endlevel]
+    [/event]
 [/scenario]
 
 #undef TURN_LIMIT

--- a/data/campaigns/The_South_Guard/scenarios/06a_Vengeance.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06a_Vengeance.cfg
@@ -909,228 +909,229 @@ then survive until turns run out"
         # AFALAS ARRIVES
         #############################
         {SCROLL_TO 1 12} {DELAY 250}
-        {NAMED_UNIT 6 (Elvish Champion) 1 12 Galdrad  _"Galdrad" (canrecruit,facing,animate=yes,ne,yes
-        [modifications]
-            {TRAIT_RESILIENT}
-            {TRAIT_STRONG}
-        [/modifications]
-    )}
-    {MOVE_UNIT id=Galdrad 2 11}
-    {MODIFY_UNIT id=Ethiliel facing sw}
-    {DELAY 250}
-    [message]
-        speaker=Galdrad
-        message = _"Ethiliel! What in Irdya is going on here?"
-    [/message]
-    [message]
-        speaker,image=Ethiliel,portraits/ethiliel-mad.webp
-        message = _"These snakes have captured Mebrin, and committed who knows what horrible atrocities against him! Galdrad, we must take him back!"
-    [/message]
-    [message]
-        speaker=Galdrad
-        message = _"Kidnapped Mebrin? I have heard otherwise. Ethiliel, this is Urza Afalas of the humans."
-    [/message]
-    [unstore_unit]
-        variable=stored_afalas
-        x,y,animate=1,12,yes
-    [/unstore_unit]
-    {MODIFY_UNIT id=Afalas facing ne}
-    {MOVE_UNIT id=Afalas   1 11}
-    {DELAY 500}
-    {MOVE_UNIT id=Ethiliel 2 10}
-    [message]
-        speaker=Ethiliel
-        message = _"We’ve met. This absolute scum, pig of a mudling—"
-    [/message]
-    [harm_unit]
-        {FILTER id=Ethiliel}
-        {FILTER_SECOND id=Afalas}
-        [primary_attack]
-            name=ensnare
-        [/primary_attack]
-        amount,damage_type=6,impact
-        animate,delay=yes,0
-    [/harm_unit]
-    {MODIFY_UNIT id=Afalas status.slowed yes}
-    [message]
-        speaker=Afalas
-        message = _"Hey! Hands off, lady! I try to make things right, come back t’ try an’ explain, an’ this be what I get? Trussed up in vines an’ called names by some—"
-    [/message]
+        {NAMED_UNIT 6 (Elvish Champion) 1 12 Galdrad  _"Galdrad" (
+            canrecruit,facing,animate=yes,ne,yes
+            [modifications]
+                {TRAIT_RESILIENT}
+                {TRAIT_STRONG}
+            [/modifications]
+        )}
+        {MOVE_UNIT id=Galdrad 2 11}
+        {MODIFY_UNIT id=Ethiliel facing sw}
+        {DELAY 250}
+        [message]
+            speaker=Galdrad
+            message = _"Ethiliel! What in Irdya is going on here?"
+        [/message]
+        [message]
+            speaker,image=Ethiliel,portraits/ethiliel-mad.webp
+            message = _"These snakes have captured Mebrin, and committed who knows what horrible atrocities against him! Galdrad, we must take him back!"
+        [/message]
+        [message]
+            speaker=Galdrad
+            message = _"Kidnapped Mebrin? I have heard otherwise. Ethiliel, this is Urza Afalas of the humans."
+        [/message]
+        [unstore_unit]
+            variable=stored_afalas
+            x,y,animate=1,12,yes
+        [/unstore_unit]
+        {MODIFY_UNIT id=Afalas facing ne}
+        {MOVE_UNIT id=Afalas   1 11}
+        {DELAY 500}
+        {MOVE_UNIT id=Ethiliel 2 10}
+        [message]
+            speaker=Ethiliel
+            message = _"We’ve met. This absolute scum, pig of a mudling—"
+        [/message]
+        [harm_unit]
+            {FILTER id=Ethiliel}
+            {FILTER_SECOND id=Afalas}
+            [primary_attack]
+                name=ensnare
+            [/primary_attack]
+            amount,damage_type=6,impact
+            animate,delay=yes,0
+        [/harm_unit]
+        {MODIFY_UNIT id=Afalas status.slowed yes}
+        [message]
+            speaker=Afalas
+            message = _"Hey! Hands off, lady! I try to make things right, come back t’ try an’ explain, an’ this be what I get? Trussed up in vines an’ called names by some—"
+        [/message]
+
+        #############################
+        # EXPLAINING MEBRIN
+        #############################
+        [message]
+            speaker=Galdrad
+            message = _"What Urza Afalas <i><b>means</b></i> to say, is that I can corroborate the humans’ story. Some days ago, this outlaw came to me with unlikely words."
+        [/message]
+        [message]
+            speaker=Afalas
+            message = _"...yeah, I did. I heard them rangers in the forest southways, knew they’d be wantin’ my head. I could’a ran an’ hid, but I wanted to make things right. I went back t’ where we fought Mebrin, then t’ the Aethenwood."
+        [/message]
+        [message]
+            speaker=Afalas
+            message = _"You may think us men t’ all be criminals an’ outlaws, but we’re still human bei— err, livin’ beings, and we still know justice an’ truth. My brothers an’ I did wrong. It’s my responsibility to make things right."
+        [/message]
+        [message]
+            speaker=Galdrad
+            message = _"Afalas’ words could have seen him imprisoned, or worse, but at the height of my anger he produced the skull of a lich. The druids confirmed it — the skull was Mebrin’s."
+        [/message]
+        [message]
+            speaker,image=Ethiliel,portraits/ethiliel-mad.webp
+            message = _"The Mebrin I know is so gentle. So wise! It cannot be... can it?"
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"I did not want to believe the humans’ words. I could not bear to believe... But if Mebrin really did turn to undeath, then I have been the cause of so much meaningless bloodshed."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"It’s true, isn’t it..."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"..."
+        [/message]
+        {DELAY 250}
+        {MOVE_UNIT id=Ethiliel 3 10}
+        {DELAY 250}
+        {MODIFY_UNIT id=Ethiliel facing sw}
+        #############################
+        # ETHILIEL APOLOGIZES
+        #############################
+        [message]
+            speaker=Ethiliel
+            message = _"Urza Afalas, thank you. I see now that not all humans are alike, and that you, too, are capable of courage and loyalty. Vengeance only begets more vengeance. You — and your brothers, posthumously — are forgiven."
+        [/message]
+        [message]
+            speaker=Afalas
+            message = _"<i>You</i> forgive <i>me</i>! After all the blood—"
+        [/message]
+        [message]
+            speaker=Galdrad
+            message = _"And Urza Afalas graciously accepts your forgiveness. Now come, Ethiliel. You have been away from your people for far too long. Our attack against the humans is over."
+        [/message]
+
+        {VARIABLE epilogue elves}
+        [endlevel]
+            result=victory
+            linger_mode=no
+            carryover_report=no
+            save=no
+        [/endlevel]
+    [/event]
 
     #############################
-    # EXPLAINING MEBRIN
+    # TIME OVER (DEORAN)
     #############################
-    [message]
-        speaker=Galdrad
-        message = _"What Urza Afalas <i><b>means</b></i> to say, is that I can corroborate the humans’ story. Some days ago, this outlaw came to me with unlikely words."
-    [/message]
-    [message]
-        speaker=Afalas
-        message = _"...yeah, I did. I heard them rangers in the forest southways, knew they’d be wantin’ my head. I could’a ran an’ hid, but I wanted to make things right. I went back t’ where we fought Mebrin, then t’ the Aethenwood."
-    [/message]
-    [message]
-        speaker=Afalas
-        message = _"You may think us men t’ all be criminals an’ outlaws, but we’re still human bei— err, livin’ beings, and we still know justice an’ truth. My brothers an’ I did wrong. It’s my responsibility to make things right."
-    [/message]
-    [message]
-        speaker=Galdrad
-        message = _"Afalas’ words could have seen him imprisoned, or worse, but at the height of my anger he produced the skull of a lich. The druids confirmed it — the skull was Mebrin’s."
-    [/message]
-    [message]
-        speaker,image=Ethiliel,portraits/ethiliel-mad.webp
-        message = _"The Mebrin I know is so gentle. So wise! It cannot be... can it?"
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"I did not want to believe the humans’ words. I could not bear to believe... But if Mebrin really did turn to undeath, then I have been the cause of so much meaningless bloodshed."
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"It’s true, isn’t it..."
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"..."
-    [/message]
-    {DELAY 250}
-    {MOVE_UNIT id=Ethiliel 3 10}
-    {DELAY 250}
-    {MODIFY_UNIT id=Ethiliel facing sw}
-    #############################
-    # ETHILIEL APOLOGIZES
-    #############################
-    [message]
-        speaker=Ethiliel
-        message = _"Urza Afalas, thank you. I see now that not all humans are alike, and that you, too, are capable of courage and loyalty. Vengeance only begets more vengeance. You — and your brothers, posthumously — are forgiven."
-    [/message]
-    [message]
-        speaker=Afalas
-        message = _"<i>You</i> forgive <i>me</i>! After all the blood—"
-    [/message]
-    [message]
-        speaker=Galdrad
-        message = _"And Urza Afalas graciously accepts your forgiveness. Now come, Ethiliel. You have been away from your people for far too long. Our attack against the humans is over."
-    [/message]
+    [event]
+        name=side 6 turn {TURN_LIMIT} end
+        {FILTER_CONDITION({VARIABLE_CONDITIONAL s05c equals yes})}
+        {FADE_MUSIC_OUT 800}
+        {ACHIEVE s05c}
+        {REPLACE_SCENARIO_MUSIC heroes_rite.ogg}
+        {FADE_MUSIC_IN 100}
+        #############################
+        # DEORAN ARRIVES
+        #############################
+        {SCROLL_TO               9 22} {DELAY 500}
+        [unstore_unit]
+            variable=stored_deoran
+            x,y,animate=9,22,yes
+        [/unstore_unit]
+        {MODIFY_UNIT id=Deoran side 2}
+        {MODIFY_UNIT id=Deoran facing ne}
+        {DELAY 500}
+        [unstore_unit]
+            variable=stored_companion
+            x,y,animate=8,22,yes
+        [/unstore_unit]
+        {MODIFY_UNIT id=$companion_id facing ne}
+        {MODIFY_UNIT id=$companion_id side 2}
+        {DELAY 500}
+        {GENERIC_UNIT 1 "Troll" 10 22} {ANIMATE}
+        {DELAY 500}
+        #############################
+        # DEORAN CONFRONTS ETHILIEL
+        #############################
+        [message]
+            speaker,image=Deoran,portraits/deoran-mad.webp
+            message= _ "Ethiliel! What’s going on here? What have you done?!"
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message= _ "Deoran — good, you’re finally here. I knew that under enough pressure, Westin would eventually cave and summon you back. Does this mean you humans have reconsidered your decisions, and have finally freed Mebrin from his bonds?"
+        [/message]
+        [message]
+            speaker=Deoran
+            message= _ "No-one summoned me here, Ethiliel. Afalas was right. I saw the lich Mal M’Brin with my own two eyes, heard his ravings with my own two ears! I watched him raise the dead up out of the ground!"
+        [/message]
+        [message]
+            speaker,image=Ethiliel,portraits/ethiliel-mad.webp
+            message= _ "More lies, infuriating lies! Where is his corpse, mayfly? Where is the evidence for the horrible things of which you accuse? No elf would fall to undeath, much less our wisest teacher."
+        [/message]
+        {MOVE_UNIT id=Deoran 6 10}
+        [message]
+            speaker=Deoran
+            message= _ "No elf could fall to undeath? What is this, then? I show you the skull of a lich, unmistakably elven, and unmistakably undead!"
+        [/message]
+        [message]
+            speaker=Deoran
+            message= _ "My men and I chased Mal M’Brin down into the depths of the earth, pushing ourselves nearly to exhaustion. When at last the lich was on the brink of defeat, with his last gasp of foul magic he collapsed his cave on us."
+        [/message]
+        [message]
+            speaker=Deoran
+            message= _ "Many perished, including Mebrin himself. But after days of hard labor by both man and troll, we dug ourselves free and set out for Westin, bringing the skull of our vanquished foe. You recognize its elven features, Ethiliel, do you not?"
+        [/message]
 
-    {VARIABLE epilogue elves}
-    [endlevel]
-        result=victory
-        linger_mode=no
-        carryover_report=no
-        save=no
-    [/endlevel]
-[/event]
+        #############################
+        # ETHILIEL BELIEVES DEORAN
+        #############################
+        [message]
+            speaker=Ethiliel
+            message = _"The Mebrin I know is so gentle. So wise! It cannot be... can it?"
+        [/message]
+        [message]
+            speaker=Deoran
+            message= _ "You believe, but you do not want to believe. Please, Ethiliel — enough blood has been shed today."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"Mebrin... oh Mebrin... a lich!? But if Mebrin really did turn to undeath, then I have been the cause of so much meaningless bloodshed."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"It’s true, isn’t it..."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"..."
+        [/message]
+        {DELAY 250}
+        {MOVE_UNIT id=Ethiliel 3 10}
+        {DELAY 250}
+        {MODIFY_UNIT id=Ethiliel facing sw}
+        #############################
+        # ETHILIEL APOLOGIZES
+        #############################
+        [message]
+            speaker=Ethiliel
+            message = _"Deoran, thank you. I see now that not all humans are alike, and that you, too, are capable of courage and loyalty."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _"Vengeance only begets more vengeance. Our attack against Westin is over."
+        [/message]
 
-#############################
-# TIME OVER (DEORAN)
-#############################
-[event]
-    name=side 6 turn {TURN_LIMIT} end
-    {FILTER_CONDITION({VARIABLE_CONDITIONAL s05c equals yes})}
-    {FADE_MUSIC_OUT 800}
-    {ACHIEVE s05c}
-    {REPLACE_SCENARIO_MUSIC heroes_rite.ogg}
-    {FADE_MUSIC_IN 100}
-    #############################
-    # DEORAN ARRIVES
-    #############################
-    {SCROLL_TO               9 22} {DELAY 500}
-    [unstore_unit]
-        variable=stored_deoran
-        x,y,animate=9,22,yes
-    [/unstore_unit]
-    {MODIFY_UNIT id=Deoran side 2}
-    {MODIFY_UNIT id=Deoran facing ne}
-    {DELAY 500}
-    [unstore_unit]
-        variable=stored_companion
-        x,y,animate=8,22,yes
-    [/unstore_unit]
-    {MODIFY_UNIT id=$companion_id facing ne}
-    {MODIFY_UNIT id=$companion_id side 2}
-    {DELAY 500}
-    {GENERIC_UNIT 1 "Troll" 10 22} {ANIMATE}
-    {DELAY 500}
-    #############################
-    # DEORAN CONFRONTS ETHILIEL
-    #############################
-    [message]
-        speaker,image=Deoran,portraits/deoran-mad.webp
-        message= _ "Ethiliel! What’s going on here? What have you done?!"
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message= _ "Deoran — good, you’re finally here. I knew that under enough pressure, Westin would eventually cave and summon you back. Does this mean you humans have reconsidered your decisions, and have finally freed Mebrin from his bonds?"
-    [/message]
-    [message]
-        speaker=Deoran
-        message= _ "No-one summoned me here, Ethiliel. Afalas was right. I saw the lich Mal M’Brin with my own two eyes, heard his ravings with my own two ears! I watched him raise the dead up out of the ground!"
-    [/message]
-    [message]
-        speaker,image=Ethiliel,portraits/ethiliel-mad.webp
-        message= _ "More lies, infuriating lies! Where is his corpse, mayfly? Where is the evidence for the horrible things of which you accuse? No elf would fall to undeath, much less our wisest teacher."
-    [/message]
-    {MOVE_UNIT id=Deoran 6 10}
-    [message]
-        speaker=Deoran
-        message= _ "No elf could fall to undeath? What is this, then? I show you the skull of a lich, unmistakably elven, and unmistakably undead!"
-    [/message]
-    [message]
-        speaker=Deoran
-        message= _ "My men and I chased Mal M’Brin down into the depths of the earth, pushing ourselves nearly to exhaustion. When at last the lich was on the brink of defeat, with his last gasp of foul magic he collapsed his cave on us."
-    [/message]
-    [message]
-        speaker=Deoran
-        message= _ "Many perished, including Mebrin himself. But after days of hard labor by both man and troll, we dug ourselves free and set out for Westin, bringing the skull of our vanquished foe. You recognize its elven features, Ethiliel, do you not?"
-    [/message]
-
-    #############################
-    # ETHILIEL BELIEVES DEORAN
-    #############################
-    [message]
-        speaker=Ethiliel
-        message = _"The Mebrin I know is so gentle. So wise! It cannot be... can it?"
-    [/message]
-    [message]
-        speaker=Deoran
-        message= _ "You believe, but you do not want to believe. Please, Ethiliel — enough blood has been shed today."
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"Mebrin... oh Mebrin... a lich!? But if Mebrin really did turn to undeath, then I have been the cause of so much meaningless bloodshed."
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"It’s true, isn’t it..."
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"..."
-    [/message]
-    {DELAY 250}
-    {MOVE_UNIT id=Ethiliel 3 10}
-    {DELAY 250}
-    {MODIFY_UNIT id=Ethiliel facing sw}
-    #############################
-    # ETHILIEL APOLOGIZES
-    #############################
-    [message]
-        speaker=Ethiliel
-        message = _"Deoran, thank you. I see now that not all humans are alike, and that you, too, are capable of courage and loyalty."
-    [/message]
-    [message]
-        speaker=Ethiliel
-        message = _"Vengeance only begets more vengeance. Our attack against Westin is over."
-    [/message]
-
-    {VARIABLE epilogue elves}
-    [endlevel]
-        result=victory
-        linger_mode=no
-        carryover_report=no
-        save=no
-    [/endlevel]
-[/event]
+        {VARIABLE epilogue elves}
+        [endlevel]
+            result=victory
+            linger_mode=no
+            carryover_report=no
+            save=no
+        [/endlevel]
+    [/event]
 [/scenario]
 
 #undef TURN_LIMIT

--- a/data/campaigns/The_South_Guard/scenarios/06b_The_Tides_of_War.cfg
+++ b/data/campaigns/The_South_Guard/scenarios/06b_The_Tides_of_War.cfg
@@ -1,68 +1,69 @@
 #textdomain wesnoth-tsg
 
+# Ethiliel arrives at dawn
 #define TURN_LIMIT
-    15#enddef # Ethiliel arrives at dawn
+15#enddef
 
-    [scenario]
-        id=06b_The_Tides_of_War
-        map_file=06b_The_Tides_of_War.map
-        name= _ "The Tides of War"
-        next_scenario=06x_Epilogue
-        victory_when_enemies_defeated=no
-        {EXPERIENCE_MODIFIER_SCENARIO}
-        {DEFAULT_SCHEDULE} # remember that the braziers' ToD is tied to this. There are also ToD dialogue events
-        turns={TURN_LIMIT}
-        {ADD_WEATHER_SNOW}
-        {SCENARIO_MUSIC loyalists.ogg}
-        {EXTRA_SCENARIO_MUSIC the_dangerous_symphony.ogg}
-        {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
-        {TSG_BIGMAP {JOURNEY_06b_NEW} }
-        #######################################################################################################################################################
-        #                                                                   DEFINE SIDES
-        #######################################################################################################################################################
-        #############################
-        # DEORAN
-        #############################
-        [side]
-            side=1
-            controller=human
-            no_leader=yes
-            team_name=good
-            user_team_name=_"South Guard"
-            gold=20
-            recruit=Spearman,Bowman
-            {CUSTOM_SG_FLAG}
-            defeat_condition=never
-            save_id=player_side
-        [/side]
+[scenario]
+    id=06b_The_Tides_of_War
+    map_file=06b_The_Tides_of_War.map
+    name= _ "The Tides of War"
+    next_scenario=06x_Epilogue
+    victory_when_enemies_defeated=no
+    {EXPERIENCE_MODIFIER_SCENARIO}
+    {DEFAULT_SCHEDULE} # remember that the braziers' ToD is tied to this. There are also ToD dialogue events
+    turns={TURN_LIMIT}
+    {ADD_WEATHER_SNOW}
+    {SCENARIO_MUSIC loyalists.ogg}
+    {EXTRA_SCENARIO_MUSIC the_dangerous_symphony.ogg}
+    {EXTRA_SCENARIO_MUSIC the_city_falls.ogg}
+    {TSG_BIGMAP {JOURNEY_06b_NEW} }
+    #######################################################################################################################################################
+    #                                                                   DEFINE SIDES
+    #######################################################################################################################################################
+    #############################
+    # DEORAN
+    #############################
+    [side]
+        side=1
+        controller=human
+        no_leader=yes
+        team_name=good
+        user_team_name=_"South Guard"
+        gold=20
+        recruit=Spearman,Bowman
+        {CUSTOM_SG_FLAG}
+        defeat_condition=never
+        save_id=player_side
+    [/side]
 
-        #############################
-        # ELVES
-        #############################
-        [side]
-            side=2
-            color=green
-            controller=ai
-            team_name,user_team_name=good,_"Aethenwood"
-            no_leader,hidden=yes,yes
-            recruit=Elvish Fighter # no archers. Archers are signature elf units, but pretty useless vs skeletons
-            {FLAG_VARIANT wood-elvish}
-        [/side]
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Elvish Shaman"    2} # 1 guardian
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Elvish Druid"     1}
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Elvish Sorceress" 2}
-        [event]
-            name=side 2 turn
-            first_time_only=no
-            {RESET_SIDE_AI 2 offensive 0.6 0.2}
-            {MODIFY_SIDE_AI 2 ({GOAL_LOCATION 99 x,y=24,29})}
-            {MODIFY_SIDE_AI 2 retreat_factor=0.75}
-            {MODIFY_AI_DELETE_CANDIDATE_ACTION 2 main_loop grab_villages} # go straight for the undead; don't spread out and cap villages (unless we retreat to them for healing)
-        [/event]
+    #############################
+    # ELVES
+    #############################
+    [side]
+        side=2
+        color=green
+        controller=ai
+        team_name,user_team_name=good,_"Aethenwood"
+        no_leader,hidden=yes,yes
+        recruit=Elvish Fighter # no archers. Archers are signature elf units, but pretty useless vs skeletons
+        {FLAG_VARIANT wood-elvish}
+    [/side]
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Elvish Shaman"    2} # 1 guardian
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Elvish Druid"     1}
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 2 "Elvish Sorceress" 2}
+    [event]
+        name=side 2 turn
+        first_time_only=no
+        {RESET_SIDE_AI 2 offensive 0.6 0.2}
+        {MODIFY_SIDE_AI 2 ({GOAL_LOCATION 99 x,y=24,29})}
+        {MODIFY_SIDE_AI 2 retreat_factor=0.75}
+        {MODIFY_AI_DELETE_CANDIDATE_ACTION 2 main_loop grab_villages} # go straight for the undead; don't spread out and cap villages (unless we retreat to them for healing)
+    [/event]
 
-        #############################
-        # UNDEAD
-        #############################
+    #############################
+    # UNDEAD
+    #############################
 #define UNDEAD_SIDE SIDE INITIAL_GOLD INITLAL_INCOME RECRUITS
     [side]
         side={SIDE}
@@ -77,38 +78,38 @@
     [/side]
     {SILENTLY_LIMIT_LEADER_MOVES {SIDE} 1}
 #enddef
-        {UNDEAD_SIDE 3 {ON_DIFFICULTY 0 0 80} {ON_DIFFICULTY  6 14 30} "Skeleton Archer"} # mebrin pays an enormous amount of upkeep for all his guards
-        {UNDEAD_SIDE 4 {ON_DIFFICULTY 0 0 60} {ON_DIFFICULTY  0  2  6} "Walking Corpse" } # 0 villages
-        {UNDEAD_SIDE 5 {ON_DIFFICULTY 0 0 60} {ON_DIFFICULTY  0  2  6} "Walking Corpse" } # 0 villages
-        {UNDEAD_SIDE 6 {ON_DIFFICULTY 0 0  0} {ON_DIFFICULTY  0  2  6} "Walking Corpse" } # 0 villages
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 3 Skeleton {ON_DIFFICULTY 1 2 3}} # 1 guard. Prefer archers over skeletons, to make HI less strong (and Fencers marginally better)
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 4 Ghoul    {ON_DIFFICULTY 3 4 5}} # 3 guards.
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 5 Ghoul    {ON_DIFFICULTY 2 3 4}} # 2 guards.
-        {LIMIT_CONTEMPORANEOUS_RECRUITS 5 Ghoul    {ON_DIFFICULTY 1 2 3}} # 1 guard.
-        [event]
-            name=side 3 turn
-            first_time_only=no
-            {RESET_SIDE_AI 3     offensive 0.6 0.2}
-            {RESET_SIDE_AI 4,5,6 offensive 0.9 0.1}
-            [if] {VARIABLE_CONDITIONAL turn_number greater_than 5}
-                [then]
-                    {VARY_AI_BY_SCHEDULE 3,4,5,6}
-                [/then]
-            [/if]
-            {MODIFY_SIDE_AI 3,4,5,6 retreat_factor=0}
-            [if] {HAVE_UNIT id=Ethiliel}
-                [then]
-                    {MODIFY_SIDE_AI 3,4 (
-                        [goal] # not 5 because they're on the opposite side of the map
-                            name=target_unit
-                            [criteria]
-                                race=elf
-                            [/criteria]
-                            value=10
-                        [/goal]
-                    )}
-                [/then]
-            [/if]
+    {UNDEAD_SIDE 3 {ON_DIFFICULTY 0 0 80} {ON_DIFFICULTY  6 14 30} "Skeleton Archer"} # mebrin pays an enormous amount of upkeep for all his guards
+    {UNDEAD_SIDE 4 {ON_DIFFICULTY 0 0 60} {ON_DIFFICULTY  0  2  6} "Walking Corpse" } # 0 villages
+    {UNDEAD_SIDE 5 {ON_DIFFICULTY 0 0 60} {ON_DIFFICULTY  0  2  6} "Walking Corpse" } # 0 villages
+    {UNDEAD_SIDE 6 {ON_DIFFICULTY 0 0  0} {ON_DIFFICULTY  0  2  6} "Walking Corpse" } # 0 villages
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 3 Skeleton {ON_DIFFICULTY 1 2 3}} # 1 guard. Prefer archers over skeletons, to make HI less strong (and Fencers marginally better)
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 4 Ghoul    {ON_DIFFICULTY 3 4 5}} # 3 guards.
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 5 Ghoul    {ON_DIFFICULTY 2 3 4}} # 2 guards.
+    {LIMIT_CONTEMPORANEOUS_RECRUITS 5 Ghoul    {ON_DIFFICULTY 1 2 3}} # 1 guard.
+    [event]
+        name=side 3 turn
+        first_time_only=no
+        {RESET_SIDE_AI 3     offensive 0.6 0.2}
+        {RESET_SIDE_AI 4,5,6 offensive 0.9 0.1}
+        [if] {VARIABLE_CONDITIONAL turn_number greater_than 5}
+            [then]
+                {VARY_AI_BY_SCHEDULE 3,4,5,6}
+            [/then]
+        [/if]
+        {MODIFY_SIDE_AI 3,4,5,6 retreat_factor=0}
+        [if] {HAVE_UNIT id=Ethiliel}
+            [then]
+                {MODIFY_SIDE_AI 3,4 (
+                    [goal] # not 5 because they're on the opposite side of the map
+                        name=target_unit
+                        [criteria]
+                            race=elf
+                        [/criteria]
+                        value=10
+                    [/goal]
+                )}
+            [/then]
+        [/if]
 
             #wmlindent: start ignoring
             {RETREAT_WHEN_WEAK 3 {ON_DIFFICULTY 0-5 0-8 0-10} ( # 3/5/5 guards
@@ -126,151 +127,151 @@
                 {GOAL_LOCATION 11 x,y=26,27}
             )}
             #wmlindent: stop ignoring
-        [/event]
+    [/event]
 
-        # Statue
-        [side]
-            side,controller,color=7,null,wesred
-            team_name=good,undead
-            no_leader,hidden=yes,yes
-        [/side]
+    # Statue
+    [side]
+        side,controller,color=7,null,wesred
+        team_name=good,undead
+        no_leader,hidden=yes,yes
+    [/side]
 
-        # Trapdoor
-        [side]
-            side,controller,color=8,null,wesred
-            team_name=good,undead
-            no_leader,hidden=yes,yes
-        [/side]
-        [event] # only allow undead to attack the trapdoor if there's no side=1,2 units adjacent
-            name=side 2 turn end
-            first_time_only=no
-            [if] {HAVE_UNIT( side=1,2 {FILTER_ADJACENT side=8} )}
-                [then]
-                    [modify_side]
-                        side=8
-                        team_name=good,undead
-                    [/modify_side]
-                [/then]
-                [else]
-                    [modify_side]
-                        side=8
-                        team_name=good
-                    [/modify_side]
-                [/else]
-            [/if]
-        [/event]
+    # Trapdoor
+    [side]
+        side,controller,color=8,null,wesred
+        team_name=good,undead
+        no_leader,hidden=yes,yes
+    [/side]
+    [event] # only allow undead to attack the trapdoor if there's no side=1,2 units adjacent
+        name=side 2 turn end
+        first_time_only=no
+        [if] {HAVE_UNIT( side=1,2 {FILTER_ADJACENT side=8} )}
+            [then]
+                [modify_side]
+                    side=8
+                    team_name=good,undead
+                [/modify_side]
+            [/then]
+            [else]
+                [modify_side]
+                    side=8
+                    team_name=good
+                [/modify_side]
+            [/else]
+        [/if]
+    [/event]
 
-        #######################################################################################################################################################
-        #                                                                     PREPARE MAP
-        #######################################################################################################################################################
-        [event]
-            name=prestart
+    #######################################################################################################################################################
+    #                                                                     PREPARE MAP
+    #######################################################################################################################################################
+    [event]
+        name=prestart
 
-            #############################
-            # SCENERY
-            #############################
-            {BRAZIER_ILLUMINATION 18 8}
-            {BRAZIER_ILLUMINATION 22 9}
-            {BRAZIER_ILLUMINATION 17 13}
-            {PLACE_IMAGE scenery/stairway.png 22 7}
-            [item]
-                x,y,halo=22,7,"scenery/trapdoor-centered.png~FL()"
-                name=trapdoor
-            [/item]
-            {GENERIC_UNIT 8 Trapdoor 22 7}
-            {PLACE_IMAGE scenery/temple1.png 20 5}
-            {PLACE_IMAGE scenery/tent-fancy-red.png 16 13}
-            {PLACE_IMAGE scenery/tent-shop-weapons.png 17 14}
-            {GENERIC_UNIT 7 Statue 23 9}
-            #############################
-            # UNDEAD GUARDS
-            #############################
-            [unit]
-                side,x,y,facing=3,23,27,nw
-                {SINGLEUNITWML_MEBRIN}
-            [/unit]
-            [unit]
-                side,x,y,facing=4,4,23,nw
-                type,canrecruit=Necrophage,yes
-            [/unit]
-            [capture_village]
-                side,x,y,radius=3,4,23,3 # give these to mebrin, as he has lots of upkeep
-            [/capture_village]
-            [unit]
-                side,x,y,facing=5,34,20,nw
-                type,canrecruit=Necrophage,yes
-            [/unit]
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Bone Shooter"    "Banebow"     } 20 25 ({ZONE_GUARDIAN 20 25 x,y,radius=23,27,4} {ROLE vip_escort})}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Bone Shooter"    "Banebow"     } 24 27 ({ZONE_GUARDIAN 24 27 x,y,radius=23,27,4} {ROLE vip_escort})}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton Archer" "Bone Shooter"} 26 25 ({ZONE_GUARDIAN 26 25 x,y,radius=23,27,4} {ROLE vip_escort})}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton"        "Skeleton"        "Revenant"    } 21 26 ({ZONE_GUARDIAN 21 26 x,y,radius=23,27,4} {ROLE vip_escort})}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton"        "Skeleton"    } 20 26 ({ZONE_GUARDIAN 20 26 x,y,radius=23,27,4} {ROLE vip_escort})}
-            {GENERIC_UNITC 4 (Ghoul)         5 22 ({ZONE_GUARDIAN  5 22 x,y,radius=4,24,4})}
-            {GENERIC_UNITC 4 (Ghoul)         3 25 ({ZONE_GUARDIAN  3 25 x,y,radius=4,24,4})}
-            {GENERIC_UNITC 4 (Ghoul)         6 25 ({ZONE_GUARDIAN  6 25 x,y,radius=4,24,4})}
-            {GENERIC_UNITC 5 (Ghoul)        35 19 ({ZONE_GUARDIAN 35 19 x,y,radius=34,21,4})}
-            {GENERIC_UNITC 5 (Ghoul)        31 20 ({ZONE_GUARDIAN 31 20 x,y,radius=34,21,4})}
-            #############################
-            # UNDEAD ATTACKERS
-            #############################
-            # spawn instead of recruiting, so they arrive sooner with less downtime
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Skeleton Archer" "Skeleton Archer"} 22 27 ()}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton"        "Skeleton"        "Skeleton"       } 23 23 ()}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Skeleton Archer" "Skeleton Archer"} 24 23 ()}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton Archer" "Skeleton Archer"} 20 22 ()}
-            {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton"        "Skeleton"       } 21 25 ()}
-            {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          }  3 23 ()}
-            {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          }  7 23 ()}
-            {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          }  8 22 ()}
-            {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Walking Corpse"  "Walking Corpse" }  4 20 ()}
-            {GENERIC_UNITC 4 {ON_DIFFICULTY "none"            "Walking Corpse"  "Walking Corpse" }  3 21 ()}
-            {GENERIC_UNITC 5 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          } 33 20 ()}
-            {GENERIC_UNITC 5 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          } 33 21 ()}
-            {GENERIC_UNITC 5 {ON_DIFFICULTY "Walking Corpse"  "Walking Corpse"  "Walking Corpse" } 35 21 ()}
-            #############################
-            # DEORAN
-            #############################
-            [unstore_unit]
-                variable=stored_deoran
-                x,y=24,8
-            [/unstore_unit]
-            {MODIFY_UNIT id=Deoran facing sw}
-            [capture_village]
-                side,x,y,radius=1,20,10,7
-                {NOT( {FILTER side=2} )}
-            [/capture_village]
-            {VARIABLE ignore_companion_defeat yes}
-            [foreach]
-                array=stored_recall_list
-                [do]
-                    [unstore_unit]
-                        variable=this_item
-                        x,y,find_vacant=recall,recall,yes
-                    [/unstore_unit]
-                    {FULL_HEAL id=$this_item.id}
-                [/do]
-            [/foreach]
-            {CLEAR_VARIABLE stored_recall_list}
-            {FIRE_EVENT refresh_experience}
-            #############################
-            # HEROES
-            #############################
-            [unit]
-                side,x,y,facing=1,19,6,sw
-                {SINGLEUNITWML_HYLAS}
-            [/unit]
-            [unit]
-                side,x,y,facing=1,15,7,sw
-                {SINGLEUNITWML_GERRICK}
-            [/unit]
-            [unit]
-                side,x,y,facing=1,20,10,sw
-                {SINGLEUNITWML_MARI}
-            [/unit]
-            {KILL id=$companion_id} # our companion died last scenario
-            #############################
-            # GUARDS
-            #############################
+        #############################
+        # SCENERY
+        #############################
+        {BRAZIER_ILLUMINATION 18 8}
+        {BRAZIER_ILLUMINATION 22 9}
+        {BRAZIER_ILLUMINATION 17 13}
+        {PLACE_IMAGE scenery/stairway.png 22 7}
+        [item]
+            x,y,halo=22,7,"scenery/trapdoor-centered.png~FL()"
+            name=trapdoor
+        [/item]
+        {GENERIC_UNIT 8 Trapdoor 22 7}
+        {PLACE_IMAGE scenery/temple1.png 20 5}
+        {PLACE_IMAGE scenery/tent-fancy-red.png 16 13}
+        {PLACE_IMAGE scenery/tent-shop-weapons.png 17 14}
+        {GENERIC_UNIT 7 Statue 23 9}
+        #############################
+        # UNDEAD GUARDS
+        #############################
+        [unit]
+            side,x,y,facing=3,23,27,nw
+            {SINGLEUNITWML_MEBRIN}
+        [/unit]
+        [unit]
+            side,x,y,facing=4,4,23,nw
+            type,canrecruit=Necrophage,yes
+        [/unit]
+        [capture_village]
+            side,x,y,radius=3,4,23,3 # give these to mebrin, as he has lots of upkeep
+        [/capture_village]
+        [unit]
+            side,x,y,facing=5,34,20,nw
+            type,canrecruit=Necrophage,yes
+        [/unit]
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Bone Shooter"    "Banebow"     } 20 25 ({ZONE_GUARDIAN 20 25 x,y,radius=23,27,4} {ROLE vip_escort})}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Bone Shooter"    "Banebow"     } 24 27 ({ZONE_GUARDIAN 24 27 x,y,radius=23,27,4} {ROLE vip_escort})}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton Archer" "Bone Shooter"} 26 25 ({ZONE_GUARDIAN 26 25 x,y,radius=23,27,4} {ROLE vip_escort})}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton"        "Skeleton"        "Revenant"    } 21 26 ({ZONE_GUARDIAN 21 26 x,y,radius=23,27,4} {ROLE vip_escort})}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton"        "Skeleton"    } 20 26 ({ZONE_GUARDIAN 20 26 x,y,radius=23,27,4} {ROLE vip_escort})}
+        {GENERIC_UNITC 4 (Ghoul)         5 22 ({ZONE_GUARDIAN  5 22 x,y,radius=4,24,4})}
+        {GENERIC_UNITC 4 (Ghoul)         3 25 ({ZONE_GUARDIAN  3 25 x,y,radius=4,24,4})}
+        {GENERIC_UNITC 4 (Ghoul)         6 25 ({ZONE_GUARDIAN  6 25 x,y,radius=4,24,4})}
+        {GENERIC_UNITC 5 (Ghoul)        35 19 ({ZONE_GUARDIAN 35 19 x,y,radius=34,21,4})}
+        {GENERIC_UNITC 5 (Ghoul)        31 20 ({ZONE_GUARDIAN 31 20 x,y,radius=34,21,4})}
+        #############################
+        # UNDEAD ATTACKERS
+        #############################
+        # spawn instead of recruiting, so they arrive sooner with less downtime
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Skeleton Archer" "Skeleton Archer"} 22 27 ()}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton"        "Skeleton"        "Skeleton"       } 23 23 ()}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "Skeleton Archer" "Skeleton Archer" "Skeleton Archer"} 24 23 ()}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton Archer" "Skeleton Archer"} 20 22 ()}
+        {GENERIC_UNITC 3 {ON_DIFFICULTY "none"            "Skeleton"        "Skeleton"       } 21 25 ()}
+        {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          }  3 23 ()}
+        {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          }  7 23 ()}
+        {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          }  8 22 ()}
+        {GENERIC_UNITC 4 {ON_DIFFICULTY "Walking Corpse"  "Walking Corpse"  "Walking Corpse" }  4 20 ()}
+        {GENERIC_UNITC 4 {ON_DIFFICULTY "none"            "Walking Corpse"  "Walking Corpse" }  3 21 ()}
+        {GENERIC_UNITC 5 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          } 33 20 ()}
+        {GENERIC_UNITC 5 {ON_DIFFICULTY "Walking Corpse"  "Ghoul"           "Ghoul"          } 33 21 ()}
+        {GENERIC_UNITC 5 {ON_DIFFICULTY "Walking Corpse"  "Walking Corpse"  "Walking Corpse" } 35 21 ()}
+        #############################
+        # DEORAN
+        #############################
+        [unstore_unit]
+            variable=stored_deoran
+            x,y=24,8
+        [/unstore_unit]
+        {MODIFY_UNIT id=Deoran facing sw}
+        [capture_village]
+            side,x,y,radius=1,20,10,7
+            {NOT( {FILTER side=2} )}
+        [/capture_village]
+        {VARIABLE ignore_companion_defeat yes}
+        [foreach]
+            array=stored_recall_list
+            [do]
+                [unstore_unit]
+                    variable=this_item
+                    x,y,find_vacant=recall,recall,yes
+                [/unstore_unit]
+                {FULL_HEAL id=$this_item.id}
+            [/do]
+        [/foreach]
+        {CLEAR_VARIABLE stored_recall_list}
+        {FIRE_EVENT refresh_experience}
+        #############################
+        # HEROES
+        #############################
+        [unit]
+            side,x,y,facing=1,19,6,sw
+            {SINGLEUNITWML_HYLAS}
+        [/unit]
+        [unit]
+            side,x,y,facing=1,15,7,sw
+            {SINGLEUNITWML_GERRICK}
+        [/unit]
+        [unit]
+            side,x,y,facing=1,20,10,sw
+            {SINGLEUNITWML_MARI}
+        [/unit]
+        {KILL id=$companion_id} # our companion died last scenario
+        #############################
+        # GUARDS
+        #############################
 #define DO_IF_PEBBLES LIMIT WML
     [if] {VARIABLE_CONDITIONAL pebbles_defense_length greater_than_equal_to {LIMIT}}
         [then]
@@ -285,59 +286,59 @@
         [/then]
     [/if]
 #enddef
-            # these timings line up with the messages given in PEBBLES_DIALOGUE_SWITCH
-            {WML_COMPANION
-            (WML_MARI={VARIABLE tahn_type Fencer})
-            (WML_GERRICK={VARIABLE tahn_type "Heavy Infantryman"})
-            (WML_HYLAS={VARIABLE tahn_type Mage})
-            }
+        # these timings line up with the messages given in PEBBLES_DIALOGUE_SWITCH
+        {WML_COMPANION
+        (WML_MARI={VARIABLE tahn_type Fencer})
+        (WML_GERRICK={VARIABLE tahn_type "Heavy Infantryman"})
+        (WML_HYLAS={VARIABLE tahn_type Mage})
+        }
 
-            {DO_IF_PEBBLES  1 ( {GENERIC_UNIT 1 Peasant    14  7}{FACING sw} {ADD_MODIFICATIONS({TRAIT_INTELLIGENT}{TRAIT_STRONG})} )} # with quick, this guy can reach a village. Hardcode traits to remove randomness
-            {DO_IF_PEBBLES  2 ( {GENERIC_UNIT 1 Woodsman   18  4}{FACING sw} )}
-            {DO_IF_PEBBLES  3 ( {GENERIC_UNIT 1 Woodsman   19 11}{FACING se} )}
-            {DO_IF_PEBBLES  4 ( {GENERIC_UNIT 1 Peasant    25  9}{FACING se} {ADD_MODIFICATIONS({TRAIT_STRONG}{TRAIT_INTELLIGENT})} )} # with quick, these guys can get to the east shore much quicker
-            {DO_IF_PEBBLES  5 ( {GENERIC_UNIT 1 Woodsman   24  9}{FACING sw} {ADD_MODIFICATIONS({TRAIT_RESILIENT}{TRAIT_STRONG})}   )} # hardcode traits to remove randomness.
-            {DO_IF_PEBBLES  6 ( {GENERIC_UNIT 1 Peasant    15  8}{FACING sw} )}
-            {DO_IF_PEBBLES  7 ( {GENERIC_UNIT 1 Woodsman   20 11}{FACING se} )}
-            {DO_IF_PEBBLES  8 ( {GENERIC_UNIT 1 Woodsman   18  9}{FACING se} )}
-            {DO_IF_PEBBLES  9 ( {GENERIC_UNIT 1 Woodsman   19  9}{FACING se} )}
-            {DO_IF_PEBBLES 10 ( {GENERIC_UNIT 1 Peasant    19  8}{FACING se} )}
-            {DO_IF_PEBBLES 11 (
-                {GENERIC_UNIT 1 $tahn_type 15 14}{FACING sw}
-                {GENERIC_UNIT 1 $tahn_type 18 14}{FACING sw}
-                {GENERIC_UNIT 1 $tahn_type 17 14}{FACING sw}
-                {WML_COMPANION (WML_MARI={GENERIC_UNIT 1 Duelist 16 12}{FACING se})} # fencers are cheaper than HI/mages and also weak vs undead, so spawn an extra one
-            )}
-            {CLEAR_VARIABLE tahn_type}
-            {DO_IF_EXACTLY 11 ( {KILL x,y=19,8} {KILL x,y=19,9} {KILL x,y=18,9} {KILL x,y=20,11} {KILL x,y=15,8} )}
-            {DO_IF_EXACTLY 12 ( {KILL x,y=19,8} {KILL x,y=19,9} {KILL x,y=18,9} {KILL x,y=20,11} )}
-            {DO_IF_EXACTLY 13 ( {KILL x,y=19,8} {KILL x,y=19,9} {KILL x,y=18,9} )}
-            {DO_IF_EXACTLY 14 ( {KILL x,y=19,8} {KILL x,y=19,9} )}
-            {DO_IF_EXACTLY 15 ( {KILL x,y=19,8} )}
-            {DO_IF_EXACTLY 16 ( {KILL x,y=19,8} )}
-            {DO_IF_PEBBLES 18 ( {TRANSFORM_UNIT x,y=18,9  Bowman  } )}
-            {DO_IF_PEBBLES 20 ( {TRANSFORM_UNIT x,y=19,9  Bowman  } )}
-            {DO_IF_PEBBLES 22 ( {TRANSFORM_UNIT x,y=19,8  Spearman} )}
-            {DO_IF_PEBBLES 24 ( {TRANSFORM_UNIT x,y=14,7  Spearman} )}
-            {DO_IF_PEBBLES 26 ( {TRANSFORM_UNIT x,y=18,4  Bowman  } )}
-            {DO_IF_PEBBLES 28 ( {TRANSFORM_UNIT x,y=19,11 Bowman  } )}
-            {DO_IF_PEBBLES 30 ( {TRANSFORM_UNIT x,y=25,9  Spearman} )}
-            {DO_IF_PEBBLES 32 ( {TRANSFORM_UNIT x,y=24,9  Bowman  } )}
-            {DO_IF_PEBBLES 34 ( {TRANSFORM_UNIT x,y=15,8  Spearman} )}
-            {DO_IF_PEBBLES 36 ( {TRANSFORM_UNIT x,y=20,11 Bowman  } )}
-            {FULL_HEAL side=1} # {TRANSORM_UNIT} doesn't heal. {ADVANCE_UNIT} heals to full, but plays an animation even during prestart (and for some reason only the first one gets executed?)
-            {DO_IF_PEBBLES 37 (
-                [gold]
-                    side,amount=1,"$( ($pebbles_defense_length-36)*1 )" # 1 extra gold for each overflow turn survived
-                [/gold]
-            )}
+        {DO_IF_PEBBLES  1 ( {GENERIC_UNIT 1 Peasant    14  7}{FACING sw} {ADD_MODIFICATIONS({TRAIT_INTELLIGENT}{TRAIT_STRONG})} )} # with quick, this guy can reach a village. Hardcode traits to remove randomness
+        {DO_IF_PEBBLES  2 ( {GENERIC_UNIT 1 Woodsman   18  4}{FACING sw} )}
+        {DO_IF_PEBBLES  3 ( {GENERIC_UNIT 1 Woodsman   19 11}{FACING se} )}
+        {DO_IF_PEBBLES  4 ( {GENERIC_UNIT 1 Peasant    25  9}{FACING se} {ADD_MODIFICATIONS({TRAIT_STRONG}{TRAIT_INTELLIGENT})} )} # with quick, these guys can get to the east shore much quicker
+        {DO_IF_PEBBLES  5 ( {GENERIC_UNIT 1 Woodsman   24  9}{FACING sw} {ADD_MODIFICATIONS({TRAIT_RESILIENT}{TRAIT_STRONG})}   )} # hardcode traits to remove randomness.
+        {DO_IF_PEBBLES  6 ( {GENERIC_UNIT 1 Peasant    15  8}{FACING sw} )}
+        {DO_IF_PEBBLES  7 ( {GENERIC_UNIT 1 Woodsman   20 11}{FACING se} )}
+        {DO_IF_PEBBLES  8 ( {GENERIC_UNIT 1 Woodsman   18  9}{FACING se} )}
+        {DO_IF_PEBBLES  9 ( {GENERIC_UNIT 1 Woodsman   19  9}{FACING se} )}
+        {DO_IF_PEBBLES 10 ( {GENERIC_UNIT 1 Peasant    19  8}{FACING se} )}
+        {DO_IF_PEBBLES 11 (
+            {GENERIC_UNIT 1 $tahn_type 15 14}{FACING sw}
+            {GENERIC_UNIT 1 $tahn_type 18 14}{FACING sw}
+            {GENERIC_UNIT 1 $tahn_type 17 14}{FACING sw}
+            {WML_COMPANION (WML_MARI={GENERIC_UNIT 1 Duelist 16 12}{FACING se})} # fencers are cheaper than HI/mages and also weak vs undead, so spawn an extra one
+        )}
+        {CLEAR_VARIABLE tahn_type}
+        {DO_IF_EXACTLY 11 ( {KILL x,y=19,8} {KILL x,y=19,9} {KILL x,y=18,9} {KILL x,y=20,11} {KILL x,y=15,8} )}
+        {DO_IF_EXACTLY 12 ( {KILL x,y=19,8} {KILL x,y=19,9} {KILL x,y=18,9} {KILL x,y=20,11} )}
+        {DO_IF_EXACTLY 13 ( {KILL x,y=19,8} {KILL x,y=19,9} {KILL x,y=18,9} )}
+        {DO_IF_EXACTLY 14 ( {KILL x,y=19,8} {KILL x,y=19,9} )}
+        {DO_IF_EXACTLY 15 ( {KILL x,y=19,8} )}
+        {DO_IF_EXACTLY 16 ( {KILL x,y=19,8} )}
+        {DO_IF_PEBBLES 18 ( {TRANSFORM_UNIT x,y=18,9  Bowman  } )}
+        {DO_IF_PEBBLES 20 ( {TRANSFORM_UNIT x,y=19,9  Bowman  } )}
+        {DO_IF_PEBBLES 22 ( {TRANSFORM_UNIT x,y=19,8  Spearman} )}
+        {DO_IF_PEBBLES 24 ( {TRANSFORM_UNIT x,y=14,7  Spearman} )}
+        {DO_IF_PEBBLES 26 ( {TRANSFORM_UNIT x,y=18,4  Bowman  } )}
+        {DO_IF_PEBBLES 28 ( {TRANSFORM_UNIT x,y=19,11 Bowman  } )}
+        {DO_IF_PEBBLES 30 ( {TRANSFORM_UNIT x,y=25,9  Spearman} )}
+        {DO_IF_PEBBLES 32 ( {TRANSFORM_UNIT x,y=24,9  Bowman  } )}
+        {DO_IF_PEBBLES 34 ( {TRANSFORM_UNIT x,y=15,8  Spearman} )}
+        {DO_IF_PEBBLES 36 ( {TRANSFORM_UNIT x,y=20,11 Bowman  } )}
+        {FULL_HEAL side=1} # {TRANSORM_UNIT} doesn't heal. {ADVANCE_UNIT} heals to full, but plays an animation even during prestart (and for some reason only the first one gets executed?)
+        {DO_IF_PEBBLES 37 (
+            [gold]
+                side,amount=1,"$( ($pebbles_defense_length-36)*1 )" # 1 extra gold for each overflow turn survived
+            [/gold]
+        )}
 
-            {SCROLL_TO 23 27}
-        [/event]
+        {SCROLL_TO 23 27}
+    [/event]
 
-        #######################################################################################################################################################
-        #                                                                    PLAY SCENARIO
-        #######################################################################################################################################################
+    #######################################################################################################################################################
+    #                                                                    PLAY SCENARIO
+    #######################################################################################################################################################
 #define PEBBLES_DIALOGUE_SWITCH SPEAKER  MSG_NOT_ENOUGH_TIME  MSG_UNTRAINED_FARMERS  MSG_GARRISON_RECALLED  MSG_EQUIPPED_FARMERS
     [if] {VARIABLE_CONDITIONAL pebbles_defense_length greater_than_equal_to 23}
         [then]
@@ -370,9 +371,9 @@
         [/else]
     [/if]
 #enddef
-        [event]
-            name=start
-            {DELAY 500}
+    [event]
+        name=start
+        {DELAY 500}
             #wmlindent: start ignoring
             {WML_COMPANION
                 #############################
@@ -470,14 +471,448 @@
             }
             #wmlindent: stop ignoring
 
-            {S06_SACRIFICIAL_LAMB_TIP}
+        {S06_SACRIFICIAL_LAMB_TIP}
+        #############################
+        # OBJECTIVES
+        #############################
+        [objectives]
+            side=1
+            [objective]
+                description= _ "Survive until turns run out"
+                condition=win
+            [/objective]
+            [objective]
+                description= _ "The town cellars are breached"
+                condition=lose
+            [/objective]
+            [objective]
+                description= _ "Death of Deoran"
+                condition=lose
+            [/objective]
+            {IS_LAST_SCENARIO}
+        [/objectives]
+
+        #############################
+        # MEBRIN TAUNTS DEORAN
+        #############################
+        [event]
+            name=side 1 turn end
+            [message]
+                speaker=Mebrin
+                message= _ "So, the fleshbags have managed to mount a defense. I would seem that the pesky fly turned out to be more than a minor annoyance after all."
+            [/message]
+            [message]
+                speaker=Mebrin
+                message= _ "No matter. Slay them all, my servants! Even if we sustain losses here, the town’s inhabitants will be more than enough to replenish our ranks."
+            [/message]
+        [/event]
+    [/event]
+
+    #############################
+    # "FOR $COMPANION_NAME"
+    #############################
+    [event]
+        name=attack
+        {FILTER side=1}
+        {WML_COMPANION
+        (WML_MARI={VARIABLE message _"For mistress Mari! For all the fallen!"})
+        (WML_GERRICK={VARIABLE message _"For master Gerrick! For all the fallen!"})
+        (WML_HYLAS={VARIABLE message _"For master Hylas! For all the fallen!"})
+        }
+        [message]
+            speaker=unit
+            message=$message
+        [/message]
+        {CLEAR_VARIABLE message}
+    [/event]
+
+    #############################
+    # LAMENTING
+    #############################
+    [event]
+        name=turn 3
+        [message]
+            speaker=Deoran
+            message= _ "If only Ethiliel had not fled! I curse our isolation, so far removed from the great cities of the north. The capital garrison alone would make short work of this lich, if only we could have contacted them in time!"
+        [/message]
+        # it's possible but extremely unlikely that both Hylas and Gerrick are dead here
+        {SAY_IF_HAVE
+        Mari             _"That’s assuming Weldyn would even bother to help out a podunk like this. Capital of the southern province, sure, but that’s not saying much. Without Prince Arand’s ambitions for this place, I doubt anybody — you and me included — would much care what happened here."
+        "Minister Hylas" _"Even then, Westin is small and remote, and thus easy for others to overlook. Prince Arand’s ambitions for this place are the better part of the reason we have any significance at all — as well as the reason you were deployed here, Deoran."
+        }
+        {SAY_IF_HAVE
+        "Sir Gerrick" _"O’ course, if th’ prince had actually come here himself instead o’ spendin’ all ’is time up in Weldyn with the king, we might’ve not gotten in such trouble in th’ first place..."
+        Mari _"Of course, if the prince had actually come here himself instead of spending all his time up at Weldyn with the king, we might’ve not gotten in such trouble in the first place..."
+        }
+    [/event]
+
+    #############################
+    # NIGHT FALLS (AND DAY RISES)
+    #############################
+    [event]
+        name=turn 4
+        [message]
+            speaker=Mebrin
+            message= _ "The shroud of darkness descends once more. Night seeps through the cracks and crannies in the humans’ defenses, plaguing their minds and bodies with dreadful fear. As surely as the sanctity of the psyche is shattered, so is the physical form, and all that’s left is unthinking, unfeeling servitude."
+        [/message]
+        [message]
+            speaker=Deoran
+            message= _ "We don’t fear your unholy power, lich. We won’t succumb to your dark magics and we won’t be turned into your undead slaves."
+        [/message]
+        [message]
+            speaker=Mebrin
+            message= _ "Believe what you will, human. We shall see if you survive the night."
+        [/message]
+    [/event]
+    [event]
+        name=turn 7
+        [message]
+            speaker=Deoran
+            message= _ "Dawn breaks over the horizon! We’ve weathered the nighttime attack!"
+        [/message]
+    [/event]
+
+    #############################
+    # MEBRIN GETS REINFORCEMENTS
+    #############################
+    [event]
+        name=turn 8
+        [gold]
+            side=3
+            amount={ON_DIFFICULTY 15 30 60}
+        [/gold]
+        [gold]
+            side=4,5
+            amount={ON_DIFFICULTY 10 20 40}
+        [/gold]
+    [/event]
+    [event]
+        name=side 6 turn 10 refresh
+
+        [if]
+            {NOT({HAVE_UNIT( side,count=1,1-99 {FILTER_LOCATION x,y,radius=33,1,3} )})}
+            {NOT({HAVE_UNIT( side,count=1,3-99 {FILTER_LOCATION x,y,radius=31,1,5} )})}
+            [then]
+                {GENERIC_UNITC 6 (Ghoul)          35 3 ({ANIMATE}{ZONE_GUARDIAN 35 3 x,y,radius=37,1,4})}
+                {GENERIC_UNITC 6 (Walking Corpse) 34 2 ({ANIMATE})}
+                {GENERIC_UNITC 6 (Walking Corpse) 33 2 ({ANIMATE})}
+                [unit]
+                    side,x,y,facing=6,35,2,nw
+                    type,canrecruit=Necrophage,yes
+                    animate=yes
+                [/unit]
+                {MOVE_UNIT side,canrecruit=6,yes 33 1}
+                {MODIFY_TERRAIN Ke 33 1} [redraw][/redraw] {DELAY 150}
+                {MODIFY_TERRAIN Ce 33 2} [redraw][/redraw] {DELAY 150}
+                {MODIFY_TERRAIN Ce 32 1} [redraw][/redraw] {DELAY 150}
+                {MODIFY_TERRAIN Ce 31 1} [redraw][/redraw] {DELAY 150}
+            [/then]
+            [else]
+                {GENERIC_UNITC 6 (Ghoul)          3 1 ({ANIMATE}{ZONE_GUARDIAN 3 1 x,y,radius=37,1,4})}
+                {GENERIC_UNITC 6 (Walking Corpse) 1 2 ({ANIMATE})}
+                {GENERIC_UNITC 6 (Walking Corpse) 2 2 ({ANIMATE})}
+                [unit]
+                    side,x,y,facing=6,5,1,nw
+                    type,canrecruit=Necrophage,yes
+                    animate=yes
+                [/unit]
+                {MODIFY_TERRAIN Ke 5 1} [redraw][/redraw] {DELAY 150}
+                {MODIFY_TERRAIN Ce 5 2} [redraw][/redraw] {DELAY 150}
+                {MODIFY_TERRAIN Ce 6 1} [redraw][/redraw] {DELAY 150}
+                {MODIFY_TERRAIN Ce 7 1} [redraw][/redraw] {DELAY 150}
+            [/else]
+        [/if]
+
+        {MODIFY_UNIT side=6 moves        2} # let them move immediately to counter spawncamping, but not far enough that they're likely to hit any normally-positioned player units
+        {MODIFY_UNIT side=6 attacks_left 1}
+        [modify_side]
+            side=6
+            gold={ON_DIFFICULTY 0 15 45} # 2 free corpses, so real gold is 15/30/60
+            hidden=no
+        [/modify_side]
+
+        [message]
+            speaker=Deoran
+            message= _ "They’ve come around behind us! Stand fast, soldiers of the South Guard!"
+        [/message]
+    [/event]
+
+    #############################
+    # TRAPDOOR OBJECTIVE REMINDER
+    #############################
+    [event]
+        name=attack end
+        {FILTER_SECOND type=Trapdoor}
+        [message]
+            speaker=Deoran
+            message= _ "The undead are trying to break into the cellars! If they get among the refugees, all will be lost."
+        [/message]
+    [/event]
+
+    #############################
+    # PLAYER SUFFERS CASUALTIES
+    #############################
+    [event]
+        name=die {FILTER side=1}
+        [event]
+            name=die {FILTER side=1}
+            [event]
+                name=die {FILTER side=1}
+                {FILTER_CONDITION( {NOT({HAVE_UNIT id=Ethiliel})} )}
+                [message]
+                    speaker=Deoran
+                    message= _ "Hold fast, men of the South Guard! No matter how daunting the evil that opposes us, we must weather this darkness and defend our homes!"
+                [/message]
+                [message]
+                    speaker=Mebrin
+                    message= _ "Fool boy, you overestimate the strength of these decrepit peasants that you call soldiers. The rivers will run red with your blood! The smoke and ashes from your ruined homes will blot out the sky, and from the swamps and the black earth, your bones will rise again to serve me!"
+                [/message]
+            [/event]
+        [/event]
+    [/event]
+
+    #############################
+    # NECROPHAGE DIES
+    #############################
+    [event]
+        name=die
+        {FILTER type_adv_tree,canrecruit=Ghoul,yes}
+        #         {FILTER_SECOND side=1}
+        [event]
+            name=side 3 turn
+            [message]
+                speaker=Mebrin
+                message = _ "So, you’ve defeated my lackey. A great accomplishment, for ones so pitiful."
+            [/message]
+            [message]
+                speaker=Deoran
+                message = _ "What’s truly pitiful is the plight you’ve put yourself in, once wise sage of the elves. You’ve fallen to the black arts, twisted and corrupted by its use. Though you and your undead have ravaged our lands with your profane sorceries, I feel nothing but pity for the shambling shell you’ve become. Perhaps we can take solace in putting you out of your misery."
+            [/message]
+            [message]
+                speaker=Mebrin
+                message = _ "How little you understand. Such pompous words don’t benefit such an ignorant boy. Your foolish babble means nothing in the face of my insurmountable power! Rise, my warriors!"
+            [/message]
+            [gold]
+                side,amount=3,{ON_DIFFICULTY 20 40 60}
+            [/gold]
+        [/event]
+    [/event]
+
+    #############################
+    # PLAYER ATTACKS MEBRIN
+    #############################
+    [event]
+        name=attack end
+        {FILTER side=1}
+        {FILTER_SECOND id=Mebrin}
+        [message]
+            speaker=Mebrin
+            message = _ "You dare strike me?! Puny humans, I’m darkness incarnate! I’m power beyond your comprehension!"
+        [/message]
+    [/event]
+
+    #############################
+    # ELVES ATTACK MEBRIN
+    #############################
+    [event]
+        name=attack end
+        {FILTER side=2}
+        {FILTER_SECOND id=Mebrin}
+        [message]
+            speaker=Mebrin
+            message = _ "Ungrateful elves! I offer you secrets beyond your comprehension! I offer you immortality itself!"
+        [/message]
+    [/event]
+
+    #######################################################################################################################################################
+    #                                                                 ETHILIEL ARRIVES
+    #######################################################################################################################################################
+    # ensure Mebrin won't have troops near Ethiliel's spawn, to ensure she doesn't die
+    # it helps that she spawns in the middle of snow, which slows down skeletons
+    [event]
+        name=side 3 turn $( {TURN_LIMIT}-7 ) refresh
+        {MODIFY_SIDE_AI (3) (
+            [avoid]
+                x,y,radius=5,16,1
+            [/avoid]
+        )}
+    [/event]
+    [event]
+        name=side 3 turn $( {TURN_LIMIT}-6 ) refresh
+        {MODIFY_SIDE_AI (3) (
+            [avoid]
+                x,y,radius=5,16,2
+            [/avoid]
+        )}
+    [/event]
+    [event]
+        name=side 3 turn $( {TURN_LIMIT}-5 ) refresh
+        {MODIFY_SIDE_AI (3) (
+            [avoid]
+                x,y,radius=5,16,3
+            [/avoid]
+        )}
+    [/event]
+    [event]
+        name=side 3 turn $( {TURN_LIMIT}-4 ) refresh
+        {MODIFY_SIDE_AI (3) (
+            [avoid]
+                x,y,radius=5,16,4
+            [/avoid]
+        )}
+    [/event]
+    #############################
+    # ETHILIEL ARRIVES
+    #############################
+    # if we make this happen exactly when turns run out, you might still die before the elves reach the battle
+    # instead, trigger it 2 turns early. If you could have survived for 2 more turns, you'll probably be fine with the elves' help
+    # hopefully this timing feels exciting, not unfair...
+    [event]
+        name=side 3 turn $( {TURN_LIMIT}-2 ) # arrive at dawn
+        #############################
+        # HORNS IN THE FOREST
+        #############################
+        {REPLACE_SCENARIO_MUSIC silence.ogg}
+        {SOUND horn-signals/horn-2.ogg}
+        {DELAY 1000}
+        [message]
+            speaker=Deoran
+            message = _ "Did you hear that!? There are horns blowing in the west!"
+        [/message]
+        [unstore_unit]
+            variable=stored_ethiliel
+            x,y,animate=1,14,yes
+        [/unstore_unit]
+        {CLEAR_VARIABLE stored_ethiliel}
+        {FIRE_EVENT refresh_experience}
+        [modify_unit]
+            {FILTER id=Ethiliel}
+            side,canrecruit=2,yes
+            facing=se
+            [object]
+                {EFFECT overlay remove=misc/hero-icon.png}
+            [/object]
+        [/modify_unit]
+        {MOVE_UNIT id=Ethiliel 5 16} # 6 hexes away from her keep, so she can reach it in 1 turn
+        {REPLACE_SCENARIO_MUSIC vengeful.ogg}
+        {APPEND_MUSIC battle-epic.ogg}
+        {APPEND_MUSIC siege_of_laurelmor.ogg}
+        #############################
+        # ETHILIEL COMFRONTS MEBRIN
+        #############################
+        [message]
+            speaker=Ethiliel
+            message = _ "Mebrin! This has gone far enough."
+        [/message]
+        [message]
+            speaker=Mebrin
+            message = _ "Ethiliel, my student... How pleased am I to see you again! What wonderful secrets have I to share..."
+        [/message]
+        [message]
+            speaker=Mebrin
+            message = _ "I have touched the void at the heart of all things, and I have begun to probe the mystic arts far beyond what any living elf knows. There is infinity at the brink of death, Ethiliel... If you thought me wise before, I have now become omniscient!"
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _ "You’ve become <b><i>evil</i></b>, Mebrin. Surely you see it! Take a good look at yourself! Your servants are abominations worse than any human. They stink of death, tainted magic and... and corruption! Even you! Mebrin... you were the kindest and gentlest of the sages..."
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _ "No, the sage Mebrin is dead. You’re not the master I once revered. I have come to cleanse your soul and put you to rest, my beloved teacher."
+        [/message]
+        [message]
+            speaker=Mebrin
+            message = _ "Is that why you returned? Bah, I see you still have much foolishness to be rid of. I shall deal with you personally. You were always more of a hands-on learner, after all..."
+        [/message]
+
+        #############################
+        # MEBRIN FOCUSES ON ETHILIEL
+        #############################
+        # only change attack/defend stats on the first turn
+        {RESET_SIDE_AI 3,4 offensive -1 1} # still allow attacking the player this round, if we have a particularly juicy target
+        {MODIFY_SIDE_AI 3,4 (
+            [goal]        # but not side 5, since they're on the opposite side of the map from the elves
+                name=target_unit
+                [criteria]
+                    side=2
+                [/criteria]
+                value=10
+            [/goal]
+        )}
+
+        #############################
+        # MEBRIN ENRAGES
+        #############################
+        {REPEAT 99 (
+            [micro_ai]
+                side,ai_type,action=3,zone_guardian,delete
+            [/micro_ai]
+        )}
+        [micro_ai]
+            side,ai_type,action=3,zone_guardian,add
+            {FILTER role=vip_escort}
+            [filter_location]
+                radius=1 {FILTER id=Mebrin}
+            [/filter_location]
+            [filter_location_enemy]
+                radius=5 {FILTER id=Mebrin}
+            [/filter_location_enemy]
+        [/micro_ai]
+
+        [gold]
+            side=3
+            amount={ON_DIFFICULTY 15 30 60}
+        [/gold]
+        {MODIFY_SIDE_AI 3 retreat_factor=0}
+        {MODIFY_SIDE_AI 3 village_value=0}
+        [event]
+            name=side 3 turn end
+            {MODIFY_UNIT id=Mebrin canrecruit no} # for some reason leaders behave differently even with leader_ignores_keep=yes
+            {GIVE_OBJECT_TO id=Mebrin ({EFFECT overlay add=misc/leader-crown.png})}
+        [/event]
+        [event]
+            name=side 3 turn end
+            {FILTER_CONDITION( {NOT({HAVE_UNIT( side=1 {FILTER_LOCATION x,y,radius=22,25,3} )})} )}
+            {MOVE_UNIT id=Mebrin 22 24} # it's possible but unlikely that enough hexes are around here to make mebrin move weirdly
+        [/event]
+
+        #############################
+        # MORE ELVES ARRIVE
+        #############################
+        [event]
+            name=side 3 turn end
+            {GENERIC_UNIT 2 "Elvish Fighter"     3 13}{ANIMATE}{FACING ne} # none of these elves have NE sprites
+            {GENERIC_UNIT 2 "Elvish Hero"        2 14}{ANIMATE}{FACING ne} # but spawn them NE so that if any sprites get added we have some facing variety
+            {GENERIC_UNIT 2 "Elvish Shaman"      4 14}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Enchantress" 2 15}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Sorceress"   1 16}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Fighter"     3 17}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Shaman"      2 17}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Fighter"     3 18}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Fighter"     1 19}{ANIMATE}{FACING ne}
+            {GENERIC_UNIT 2 "Elvish Shaman"      4 11}{ANIMATE}{FACING se}{GUARDIAN}
+            [message]
+                speaker=Ethiliel
+                message = _ "Deoran, Mebrin is as much my people’s fault as he is yours. Forgive me for my cowardice at the river. With me come warriors of the Aethenwood — together, men and elves shall finally put my teacher’s tortured soul to rest."
+            [/message]
+
+            [modify_side]
+                side=2
+                gold={ON_DIFFICULTY 50 60 70}
+                income={ON_DIFFICULTY 12 14 16}
+                hidden=no
+            [/modify_side]
+            [modify_turns]
+                value=-1
+            [/modify_turns]
+
             #############################
             # OBJECTIVES
             #############################
             [objectives]
                 side=1
                 [objective]
-                    description= _ "Survive until turns run out"
+                    description= _ "Defeat Mebrin"
                     condition=win
                 [/objective]
                 [objective]
@@ -488,553 +923,119 @@
                     description= _ "Death of Deoran"
                     condition=lose
                 [/objective]
+                [objective]
+                    description= _ "Death of Ethiliel"
+                    condition=lose
+                [/objective]
                 {IS_LAST_SCENARIO}
             [/objectives]
-
-            #############################
-            # MEBRIN TAUNTS DEORAN
-            #############################
-            [event]
-                name=side 1 turn end
-                [message]
-                    speaker=Mebrin
-                    message= _ "So, the fleshbags have managed to mount a defense. I would seem that the pesky fly turned out to be more than a minor annoyance after all."
-                [/message]
-                [message]
-                    speaker=Mebrin
-                    message= _ "No matter. Slay them all, my servants! Even if we sustain losses here, the town’s inhabitants will be more than enough to replenish our ranks."
-                [/message]
-            [/event]
         [/event]
+    [/event]
 
-        #############################
-        # "FOR $COMPANION_NAME"
-        #############################
-        [event]
-            name=attack
-            {FILTER side=1}
-            {WML_COMPANION
-            (WML_MARI={VARIABLE message _"For mistress Mari! For all the fallen!"})
-            (WML_GERRICK={VARIABLE message _"For master Gerrick! For all the fallen!"})
-            (WML_HYLAS={VARIABLE message _"For master Hylas! For all the fallen!"})
-            }
-            [message]
-                speaker=unit
-                message=$message
-            [/message]
-            {CLEAR_VARIABLE message}
-        [/event]
+    #############################
+    # MEBRIN ASKS ETHILIEL TO JOIN HIM
+    #############################
+    [event]
+        name=side 3 turn "$( {TURN_LIMIT} + 2 )"
+        [message]
+            speaker=Mebrin
+            message = _ "Why do you aid these fools, Ethiliel? Join me! Stand by my side! The race of man shall be stricken off the face of the green world. Their corpses will serve us! Their bones will dance for our pleasure! We’ll make humanity into the mindless slaves that they all deserve to be!"
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _ "And when that’s done, what will us elves have become? Naught but hungering shadows, devouring all we once cherished."
+        [/message]
+        [message]
+            speaker=Deoran
+            message = _ "Even a mere human can see that you have become a mockery of all that you once believed in, Mebrin of the elves. We will destroy you and bury your perverse corruption!"
+        [/message]
+        [message]
+            speaker=Mebrin
+            message = _ "Ethiliel I respect, but you? Destroy me? Your man-flesh will provide a fine feast for my ghouls, and once they’re through, your bones will serve me forever in undeath!"
+        [/message]
+    [/event]
 
-        #############################
-        # LAMENTING
-        #############################
-        [event]
-            name=turn 3
-            [message]
-                speaker=Deoran
-                message= _ "If only Ethiliel had not fled! I curse our isolation, so far removed from the great cities of the north. The capital garrison alone would make short work of this lich, if only we could have contacted them in time!"
-            [/message]
-            # it's possible but extremely unlikely that both Hylas and Gerrick are dead here
-            {SAY_IF_HAVE
-            Mari             _"That’s assuming Weldyn would even bother to help out a podunk like this. Capital of the southern province, sure, but that’s not saying much. Without Prince Arand’s ambitions for this place, I doubt anybody — you and me included — would much care what happened here."
-            "Minister Hylas" _"Even then, Westin is small and remote, and thus easy for others to overlook. Prince Arand’s ambitions for this place are the better part of the reason we have any significance at all — as well as the reason you were deployed here, Deoran."
-            }
-            {SAY_IF_HAVE
-            "Sir Gerrick" _"O’ course, if th’ prince had actually come here himself instead o’ spendin’ all ’is time up in Weldyn with the king, we might’ve not gotten in such trouble in th’ first place..."
-            Mari _"Of course, if the prince had actually come here himself instead of spending all his time up at Weldyn with the king, we might’ve not gotten in such trouble in the first place..."
-            }
-        [/event]
-
-        #############################
-        # NIGHT FALLS (AND DAY RISES)
-        #############################
-        [event]
-            name=turn 4
-            [message]
-                speaker=Mebrin
-                message= _ "The shroud of darkness descends once more. Night seeps through the cracks and crannies in the humans’ defenses, plaguing their minds and bodies with dreadful fear. As surely as the sanctity of the psyche is shattered, so is the physical form, and all that’s left is unthinking, unfeeling servitude."
-            [/message]
-            [message]
-                speaker=Deoran
-                message= _ "We don’t fear your unholy power, lich. We won’t succumb to your dark magics and we won’t be turned into your undead slaves."
-            [/message]
-            [message]
-                speaker=Mebrin
-                message= _ "Believe what you will, human. We shall see if you survive the night."
-            [/message]
-        [/event]
-        [event]
-            name=turn 7
-            [message]
-                speaker=Deoran
-                message= _ "Dawn breaks over the horizon! We’ve weathered the nighttime attack!"
-            [/message]
-        [/event]
-
-        #############################
-        # MEBRIN GETS REINFORCEMENTS
-        #############################
-        [event]
-            name=turn 8
-            [gold]
-                side=3
-                amount={ON_DIFFICULTY 15 30 60}
-            [/gold]
-            [gold]
-                side=4,5
-                amount={ON_DIFFICULTY 10 20 40}
-            [/gold]
-        [/event]
-        [event]
-            name=side 6 turn 10 refresh
-
-            [if]
-                {NOT({HAVE_UNIT( side,count=1,1-99 {FILTER_LOCATION x,y,radius=33,1,3} )})}
-                {NOT({HAVE_UNIT( side,count=1,3-99 {FILTER_LOCATION x,y,radius=31,1,5} )})}
-                [then]
-                    {GENERIC_UNITC 6 (Ghoul)          35 3 ({ANIMATE}{ZONE_GUARDIAN 35 3 x,y,radius=37,1,4})}
-                    {GENERIC_UNITC 6 (Walking Corpse) 34 2 ({ANIMATE})}
-                    {GENERIC_UNITC 6 (Walking Corpse) 33 2 ({ANIMATE})}
-                    [unit]
-                        side,x,y,facing=6,35,2,nw
-                        type,canrecruit=Necrophage,yes
-                        animate=yes
-                    [/unit]
-                    {MOVE_UNIT side,canrecruit=6,yes 33 1}
-                    {MODIFY_TERRAIN Ke 33 1} [redraw][/redraw] {DELAY 150}
-                    {MODIFY_TERRAIN Ce 33 2} [redraw][/redraw] {DELAY 150}
-                    {MODIFY_TERRAIN Ce 32 1} [redraw][/redraw] {DELAY 150}
-                    {MODIFY_TERRAIN Ce 31 1} [redraw][/redraw] {DELAY 150}
-                [/then]
-                [else]
-                    {GENERIC_UNITC 6 (Ghoul)          3 1 ({ANIMATE}{ZONE_GUARDIAN 3 1 x,y,radius=37,1,4})}
-                    {GENERIC_UNITC 6 (Walking Corpse) 1 2 ({ANIMATE})}
-                    {GENERIC_UNITC 6 (Walking Corpse) 2 2 ({ANIMATE})}
-                    [unit]
-                        side,x,y,facing=6,5,1,nw
-                        type,canrecruit=Necrophage,yes
-                        animate=yes
-                    [/unit]
-                    {MODIFY_TERRAIN Ke 5 1} [redraw][/redraw] {DELAY 150}
-                    {MODIFY_TERRAIN Ce 5 2} [redraw][/redraw] {DELAY 150}
-                    {MODIFY_TERRAIN Ce 6 1} [redraw][/redraw] {DELAY 150}
-                    {MODIFY_TERRAIN Ce 7 1} [redraw][/redraw] {DELAY 150}
-                [/else]
-            [/if]
-
-            {MODIFY_UNIT side=6 moves        2} # let them move immediately to counter spawncamping, but not far enough that they're likely to hit any normally-positioned player units
-            {MODIFY_UNIT side=6 attacks_left 1}
-            [modify_side]
-                side=6
-                gold={ON_DIFFICULTY 0 15 45} # 2 free corpses, so real gold is 15/30/60
-                hidden=no
-            [/modify_side]
-
-            [message]
-                speaker=Deoran
-                message= _ "They’ve come around behind us! Stand fast, soldiers of the South Guard!"
-            [/message]
-        [/event]
-
-        #############################
-        # TRAPDOOR OBJECTIVE REMINDER
-        #############################
-        [event]
-            name=attack end
-            {FILTER_SECOND type=Trapdoor}
-            [message]
-                speaker=Deoran
-                message= _ "The undead are trying to break into the cellars! If they get among the refugees, all will be lost."
-            [/message]
-        [/event]
-
-        #############################
-        # PLAYER SUFFERS CASUALTIES
-        #############################
-        [event]
-            name=die {FILTER side=1}
-            [event]
-                name=die {FILTER side=1}
-                [event]
-                    name=die {FILTER side=1}
-                    {FILTER_CONDITION( {NOT({HAVE_UNIT id=Ethiliel})} )}
-                    [message]
-                        speaker=Deoran
-                        message= _ "Hold fast, men of the South Guard! No matter how daunting the evil that opposes us, we must weather this darkness and defend our homes!"
-                    [/message]
-                    [message]
-                        speaker=Mebrin
-                        message= _ "Fool boy, you overestimate the strength of these decrepit peasants that you call soldiers. The rivers will run red with your blood! The smoke and ashes from your ruined homes will blot out the sky, and from the swamps and the black earth, your bones will rise again to serve me!"
-                    [/message]
-                [/event]
-            [/event]
-        [/event]
-
-        #############################
-        # NECROPHAGE DIES
-        #############################
+    #######################################################################################################################################################
+    #                                                                 VICTORY / DEFEAT
+    #######################################################################################################################################################
+    #############################
+    # MEBRIN DIES (TO HUMANS)
+    #############################
+    [event]
+        name=last breath
+        {FILTER id=Mebrin}
+        {FILTER_SECOND side=1}
+        [message]
+            speaker=Mebrin
+            message = _ "Fools! Imbeciles! You humans are a worthless blight upon this wretched world! I must purge you all — I must take revenge on all your race... I must..."
+        [/message]
+        [message]
+            speaker=Deoran
+            message = _ "These worthless humans just bested you and your armies. Your time has come, once-wise sage of the elves."
+        [/message]
+        [message]
+            speaker=Mebrin
+            message = _ "I curse you, Deoran of Wesnoth! I curse you... may you one day know the same pain that your kind have inflicted on me..."
+        [/message]
         [event]
             name=die
-            {FILTER type_adv_tree,canrecruit=Ghoul,yes}
-            #         {FILTER_SECOND side=1}
-            [event]
-                name=side 3 turn
-                [message]
-                    speaker=Mebrin
-                    message = _ "So, you’ve defeated my lackey. A great accomplishment, for ones so pitiful."
-                [/message]
-                [message]
-                    speaker=Deoran
-                    message = _ "What’s truly pitiful is the plight you’ve put yourself in, once wise sage of the elves. You’ve fallen to the black arts, twisted and corrupted by its use. Though you and your undead have ravaged our lands with your profane sorceries, I feel nothing but pity for the shambling shell you’ve become. Perhaps we can take solace in putting you out of your misery."
-                [/message]
-                [message]
-                    speaker=Mebrin
-                    message = _ "How little you understand. Such pompous words don’t benefit such an ignorant boy. Your foolish babble means nothing in the face of my insurmountable power! Rise, my warriors!"
-                [/message]
-                [gold]
-                    side,amount=3,{ON_DIFFICULTY 20 40 60}
-                [/gold]
-            [/event]
-        [/event]
-
-        #############################
-        # PLAYER ATTACKS MEBRIN
-        #############################
-        [event]
-            name=attack end
-            {FILTER side=1}
-            {FILTER_SECOND id=Mebrin}
-            [message]
-                speaker=Mebrin
-                message = _ "You dare strike me?! Puny humans, I’m darkness incarnate! I’m power beyond your comprehension!"
-            [/message]
-        [/event]
-
-        #############################
-        # ELVES ATTACK MEBRIN
-        #############################
-        [event]
-            name=attack end
-            {FILTER side=2}
-            {FILTER_SECOND id=Mebrin}
-            [message]
-                speaker=Mebrin
-                message = _ "Ungrateful elves! I offer you secrets beyond your comprehension! I offer you immortality itself!"
-            [/message]
-        [/event]
-
-        #######################################################################################################################################################
-        #                                                                 ETHILIEL ARRIVES
-        #######################################################################################################################################################
-        # ensure Mebrin won't have troops near Ethiliel's spawn, to ensure she doesn't die
-        # it helps that she spawns in the middle of snow, which slows down skeletons
-        [event]
-            name=side 3 turn $( {TURN_LIMIT}-7 ) refresh
-            {MODIFY_SIDE_AI (3) (
-                [avoid]
-                    x,y,radius=5,16,1
-                [/avoid]
-            )}
-        [/event]
-        [event]
-            name=side 3 turn $( {TURN_LIMIT}-6 ) refresh
-            {MODIFY_SIDE_AI (3) (
-                [avoid]
-                    x,y,radius=5,16,2
-                [/avoid]
-            )}
-        [/event]
-        [event]
-            name=side 3 turn $( {TURN_LIMIT}-5 ) refresh
-            {MODIFY_SIDE_AI (3) (
-                [avoid]
-                    x,y,radius=5,16,3
-                [/avoid]
-            )}
-        [/event]
-        [event]
-            name=side 3 turn $( {TURN_LIMIT}-4 ) refresh
-            {MODIFY_SIDE_AI (3) (
-                [avoid]
-                    x,y,radius=5,16,4
-                [/avoid]
-            )}
-        [/event]
-        #############################
-        # ETHILIEL ARRIVES
-        #############################
-        # if we make this happen exactly when turns run out, you might still die before the elves reach the battle
-        # instead, trigger it 2 turns early. If you could have survived for 2 more turns, you'll probably be fine with the elves' help
-        # hopefully this timing feels exciting, not unfair...
-        [event]
-            name=side 3 turn $( {TURN_LIMIT}-2 ) # arrive at dawn
-            #############################
-            # HORNS IN THE FOREST
-            #############################
-            {REPLACE_SCENARIO_MUSIC silence.ogg}
-            {SOUND horn-signals/horn-2.ogg}
-            {DELAY 1000}
             [message]
                 speaker=Deoran
-                message = _ "Did you hear that!? There are horns blowing in the west!"
+                message = _ "At long last, it is done."
             [/message]
-            [unstore_unit]
-                variable=stored_ethiliel
-                x,y,animate=1,14,yes
-            [/unstore_unit]
-            {CLEAR_VARIABLE stored_ethiliel}
-            {FIRE_EVENT refresh_experience}
-            [modify_unit]
-                {FILTER id=Ethiliel}
-                side,canrecruit=2,yes
-                facing=se
-                [object]
-                    {EFFECT overlay remove=misc/hero-icon.png}
-                [/object]
-            [/modify_unit]
-            {MOVE_UNIT id=Ethiliel 5 16} # 6 hexes away from her keep, so she can reach it in 1 turn
-            {REPLACE_SCENARIO_MUSIC vengeful.ogg}
-            {APPEND_MUSIC battle-epic.ogg}
-            {APPEND_MUSIC siege_of_laurelmor.ogg}
-            #############################
-            # ETHILIEL COMFRONTS MEBRIN
-            #############################
-            [message]
-                speaker=Ethiliel
-                message = _ "Mebrin! This has gone far enough."
-            [/message]
-            [message]
-                speaker=Mebrin
-                message = _ "Ethiliel, my student... How pleased am I to see you again! What wonderful secrets have I to share..."
-            [/message]
-            [message]
-                speaker=Mebrin
-                message = _ "I have touched the void at the heart of all things, and I have begun to probe the mystic arts far beyond what any living elf knows. There is infinity at the brink of death, Ethiliel... If you thought me wise before, I have now become omniscient!"
-            [/message]
-            [message]
-                speaker=Ethiliel
-                message = _ "You’ve become <b><i>evil</i></b>, Mebrin. Surely you see it! Take a good look at yourself! Your servants are abominations worse than any human. They stink of death, tainted magic and... and corruption! Even you! Mebrin... you were the kindest and gentlest of the sages..."
-            [/message]
-            [message]
-                speaker=Ethiliel
-                message = _ "No, the sage Mebrin is dead. You’re not the master I once revered. I have come to cleanse your soul and put you to rest, my beloved teacher."
-            [/message]
-            [message]
-                speaker=Mebrin
-                message = _ "Is that why you returned? Bah, I see you still have much foolishness to be rid of. I shall deal with you personally. You were always more of a hands-on learner, after all..."
-            [/message]
-
-            #############################
-            # MEBRIN FOCUSES ON ETHILIEL
-            #############################
-            # only change attack/defend stats on the first turn
-            {RESET_SIDE_AI 3,4 offensive -1 1} # still allow attacking the player this round, if we have a particularly juicy target
-            {MODIFY_SIDE_AI 3,4 (
-                [goal]        # but not side 5, since they're on the opposite side of the map from the elves
-                    name=target_unit
-                    [criteria]
-                        side=2
-                    [/criteria]
-                    value=10
-                [/goal]
-            )}
-
-            #############################
-            # MEBRIN ENRAGES
-            #############################
-            {REPEAT 99 (
-                [micro_ai]
-                    side,ai_type,action=3,zone_guardian,delete
-                [/micro_ai]
-            )}
-            [micro_ai]
-                side,ai_type,action=3,zone_guardian,add
-                {FILTER role=vip_escort}
-                [filter_location]
-                    radius=1 {FILTER id=Mebrin}
-                [/filter_location]
-                [filter_location_enemy]
-                    radius=5 {FILTER id=Mebrin}
-                [/filter_location_enemy]
-            [/micro_ai]
-
-            [gold]
-                side=3
-                amount={ON_DIFFICULTY 15 30 60}
-            [/gold]
-            {MODIFY_SIDE_AI 3 retreat_factor=0}
-            {MODIFY_SIDE_AI 3 village_value=0}
-            [event]
-                name=side 3 turn end
-                {MODIFY_UNIT id=Mebrin canrecruit no} # for some reason leaders behave differently even with leader_ignores_keep=yes
-                {GIVE_OBJECT_TO id=Mebrin ({EFFECT overlay add=misc/leader-crown.png})}
-            [/event]
-            [event]
-                name=side 3 turn end
-                {FILTER_CONDITION( {NOT({HAVE_UNIT( side=1 {FILTER_LOCATION x,y,radius=22,25,3} )})} )}
-                {MOVE_UNIT id=Mebrin 22 24} # it's possible but unlikely that enough hexes are around here to make mebrin move weirdly
-            [/event]
-
-            #############################
-            # MORE ELVES ARRIVE
-            #############################
-            [event]
-                name=side 3 turn end
-                {GENERIC_UNIT 2 "Elvish Fighter"     3 13}{ANIMATE}{FACING ne} # none of these elves have NE sprites
-                {GENERIC_UNIT 2 "Elvish Hero"        2 14}{ANIMATE}{FACING ne} # but spawn them NE so that if any sprites get added we have some facing variety
-                {GENERIC_UNIT 2 "Elvish Shaman"      4 14}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Enchantress" 2 15}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Sorceress"   1 16}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Fighter"     3 17}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Shaman"      2 17}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Fighter"     3 18}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Fighter"     1 19}{ANIMATE}{FACING ne}
-                {GENERIC_UNIT 2 "Elvish Shaman"      4 11}{ANIMATE}{FACING se}{GUARDIAN}
-                [message]
-                    speaker=Ethiliel
-                    message = _ "Deoran, Mebrin is as much my people’s fault as he is yours. Forgive me for my cowardice at the river. With me come warriors of the Aethenwood — together, men and elves shall finally put my teacher’s tortured soul to rest."
-                [/message]
-
-                [modify_side]
-                    side=2
-                    gold={ON_DIFFICULTY 50 60 70}
-                    income={ON_DIFFICULTY 12 14 16}
-                    hidden=no
-                [/modify_side]
-                [modify_turns]
-                    value=-1
-                [/modify_turns]
-
-                #############################
-                # OBJECTIVES
-                #############################
-                [objectives]
-                    side=1
-                    [objective]
-                        description= _ "Defeat Mebrin"
-                        condition=win
-                    [/objective]
-                    [objective]
-                        description= _ "The town cellars are breached"
-                        condition=lose
-                    [/objective]
-                    [objective]
-                        description= _ "Death of Deoran"
-                        condition=lose
-                    [/objective]
-                    [objective]
-                        description= _ "Death of Ethiliel"
-                        condition=lose
-                    [/objective]
-                    {IS_LAST_SCENARIO}
-                [/objectives]
-            [/event]
+            {DELAY 500}
+            [endlevel]
+                result=victory
+                linger_mode=no
+                carryover_report=no
+                save=no
+            [/endlevel]
         [/event]
+    [/event]
 
-        #############################
-        # MEBRIN ASKS ETHILIEL TO JOIN HIM
-        #############################
+    #############################
+    # MEBRIN DIES (TO ELVES)
+    #############################
+    [event]
+        name=last breath
+        {FILTER id=Mebrin}
+        {FILTER_SECOND side=2}
+        [message]
+            speaker=Mebrin
+            message = _ "Wait! Ethiliel... think about it! Think of everything you’re throwing away! We could build an empire together, where the humans are our slaves and you and I are the immortal rulers of the world!"
+        [/message]
+        [message]
+            speaker=Ethiliel
+            message = _ "It would only be an empire of misery, Mebrin. I wish it hadn’t come to this, but you’ve been corrupted beyond saving. Still, I’ll fondly cherish the memories I had with the old you."
+        [/message]
+        [message]
+            speaker=Mebrin
+            message = _ "You wouldn’t dare strike me! I’m the darkness incarnate! I’m your master! You’ll obey me!"
+        [/message]
         [event]
-            name=side 3 turn "$( {TURN_LIMIT} + 2 )"
-            [message]
-                speaker=Mebrin
-                message = _ "Why do you aid these fools, Ethiliel? Join me! Stand by my side! The race of man shall be stricken off the face of the green world. Their corpses will serve us! Their bones will dance for our pleasure! We’ll make humanity into the mindless slaves that they all deserve to be!"
-            [/message]
+            name=die
             [message]
                 speaker=Ethiliel
-                message = _ "And when that’s done, what will us elves have become? Naught but hungering shadows, devouring all we once cherished."
+                message = _ "Goodbye, Mebrin."
             [/message]
-            [message]
-                speaker=Deoran
-                message = _ "Even a mere human can see that you have become a mockery of all that you once believed in, Mebrin of the elves. We will destroy you and bury your perverse corruption!"
-            [/message]
-            [message]
-                speaker=Mebrin
-                message = _ "Ethiliel I respect, but you? Destroy me? Your man-flesh will provide a fine feast for my ghouls, and once they’re through, your bones will serve me forever in undeath!"
-            [/message]
+            [endlevel]
+                result=victory
+                carryover_report,linger_mode=no,no
+            [/endlevel]
         [/event]
+    [/event]
 
-        #######################################################################################################################################################
-        #                                                                 VICTORY / DEFEAT
-        #######################################################################################################################################################
-        #############################
-        # MEBRIN DIES (TO HUMANS)
-        #############################
-        [event]
-            name=last breath
-            {FILTER id=Mebrin}
-            {FILTER_SECOND side=1}
-            [message]
-                speaker=Mebrin
-                message = _ "Fools! Imbeciles! You humans are a worthless blight upon this wretched world! I must purge you all — I must take revenge on all your race... I must..."
-            [/message]
-            [message]
-                speaker=Deoran
-                message = _ "These worthless humans just bested you and your armies. Your time has come, once-wise sage of the elves."
-            [/message]
-            [message]
-                speaker=Mebrin
-                message = _ "I curse you, Deoran of Wesnoth! I curse you... may you one day know the same pain that your kind have inflicted on me..."
-            [/message]
-            [event]
-                name=die
-                [message]
-                    speaker=Deoran
-                    message = _ "At long last, it is done."
-                [/message]
-                {DELAY 500}
-                [endlevel]
-                    result=victory
-                    linger_mode=no
-                    carryover_report=no
-                    save=no
-                [/endlevel]
-            [/event]
-        [/event]
-
-        #############################
-        # MEBRIN DIES (TO ELVES)
-        #############################
-        [event]
-            name=last breath
-            {FILTER id=Mebrin}
-            {FILTER_SECOND side=2}
-            [message]
-                speaker=Mebrin
-                message = _ "Wait! Ethiliel... think about it! Think of everything you’re throwing away! We could build an empire together, where the humans are our slaves and you and I are the immortal rulers of the world!"
-            [/message]
-            [message]
-                speaker=Ethiliel
-                message = _ "It would only be an empire of misery, Mebrin. I wish it hadn’t come to this, but you’ve been corrupted beyond saving. Still, I’ll fondly cherish the memories I had with the old you."
-            [/message]
-            [message]
-                speaker=Mebrin
-                message = _ "You wouldn’t dare strike me! I’m the darkness incarnate! I’m your master! You’ll obey me!"
-            [/message]
-            [event]
-                name=die
-                [message]
-                    speaker=Ethiliel
-                    message = _ "Goodbye, Mebrin."
-                [/message]
-                [endlevel]
-                    result=victory
-                    carryover_report,linger_mode=no,no
-                [/endlevel]
-            [/event]
-        [/event]
-
-        [event]
-            name=victory
-            {VARIABLE epilogue undead}
-            [if] {NOT({HAVE_UNIT id=Ethiliel})}
-                [then]
-                    {VARIABLE won_without_elves yes}
-                    {ACHIEVE s06b}
-                [/then]
-            [/if]
-        [/event]
-    [/scenario]
+    [event]
+        name=victory
+        {VARIABLE epilogue undead}
+        [if] {NOT({HAVE_UNIT id=Ethiliel})}
+            [then]
+                {VARIABLE won_without_elves yes}
+                {ACHIEVE s06b}
+            [/then]
+        [/if]
+    [/event]
+[/scenario]
 
 #undef TURN_LIMIT
 #undef TURN_WARNING

--- a/utils/CI/fix_whitespace.sh
+++ b/utils/CI/fix_whitespace.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-make -C data/tools reindent
-
 # use -i for GNU sed and -i '' otherwise
 sed --version 2>/dev/null | grep -q 'GNU sed' || i=1
 
@@ -12,3 +10,6 @@ find src -path src/modules -prune -o \
 find data -name '*.lua' -type f \
 	-exec sed -i ${i:+''} -e 's/[[:blank:]]*$//' -e '$a\' {} + \
 	-exec data/tools/check_mixed_indent {} +
+
+# run this last so it determines the exit status
+make -C data/tools reindent


### PR DESCRIPTION
Indentation was fixed by adding a newline to constructs with excessive density and running wmlindent again. While the constructs were not particularly readable it wouldn't hurt if wmlindent would cope a bit better.