### PR TITLE
TDG S06: clarify scenario objectives

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg
@@ -437,9 +437,9 @@
         # OBJECTIVES
         #############################
 #define OBJECTIVE__DEFEAT_IRBIRCH
-    _"Defeat Irbirch, recapturing Queen Asheviere"#enddef
+        _"Defeat Irbirch, recapturing Queen Asheviere"#enddef
 #define OBJECTIVE__FAIL_TO_RESCUE
-    _"Fail to rescue Asheviere before turns run out"#enddef
+        _"Fail to rescue Asheviere before turns run out"#enddef
         [objectives]
             [objective]
                 description= _ "Survive until turns run out"

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg
@@ -441,14 +441,37 @@
                 description= _ "Survive until turns run out"
                 condition=win
             [/objective]
+            
             [objective]
                 description= _ "Defeat Irbirch, recapturing Queen Asheviere"
                 condition=win
+                [show_if]
+                    {NOT({HAVE_UNIT id,side=Asheviere,1})}
+                [/show_if]
             [/objective]
             [objective]
                 description= _ "Fail to rescue Asheviere before turns run out"
                 condition=lose
+                [show_if]
+                    {NOT({HAVE_UNIT id,side=Asheviere,1})}
+                [/show_if]
             [/objective]
+            
+            [objective]
+                description= _ "<span strikethrough='true'>Defeat Irbirch, recapturing Queen Asheviere</span>"
+                condition=win
+                [show_if]
+                    {HAVE_UNIT id,side=Asheviere,1}
+                [/show_if]
+            [/objective]
+            [objective]
+                description= _ "<span strikethrough='true'>Fail to rescue Asheviere before turns run out</span>"
+                condition=lose
+                [show_if]
+                    {HAVE_UNIT id,side=Asheviere,1}
+                [/show_if]
+            [/objective]
+            
             [objective]
                 description= _ "Death of Delfador or Deoran"
                 condition=lose
@@ -689,6 +712,8 @@ Fencers are fragile but evasive, and possess the “<i>skirmisher</i>” ability
                 #po: both Deoran and Garard talk over Asheviere. She doesn't get any agency of her own, even from Deoran (who generally stands up for her)
                 message=_"Not now, milady! We have to get you out of here!"
             [/message]
+            [show_objectives]
+            [/show_objectives]
 
             [event]
                 name=side 1 turn end,asheviere_speaks_to_garard

--- a/data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/scenarios/06_Ring_of_Swords.cfg
@@ -436,42 +436,46 @@
         #############################
         # OBJECTIVES
         #############################
+#define OBJECTIVE__DEFEAT_IRBIRCH
+    _"Defeat Irbirch, recapturing Queen Asheviere"#enddef
+#define OBJECTIVE__FAIL_TO_RESCUE
+    _"Fail to rescue Asheviere before turns run out"#enddef
         [objectives]
             [objective]
                 description= _ "Survive until turns run out"
                 condition=win
             [/objective]
-            
+
             [objective]
-                description= _ "Defeat Irbirch, recapturing Queen Asheviere"
+                description= {OBJECTIVE__DEFEAT_IRBIRCH}
                 condition=win
                 [show_if]
                     {NOT({HAVE_UNIT id,side=Asheviere,1})}
                 [/show_if]
             [/objective]
             [objective]
-                description= _ "Fail to rescue Asheviere before turns run out"
+                description= {OBJECTIVE__FAIL_TO_RESCUE}
                 condition=lose
                 [show_if]
                     {NOT({HAVE_UNIT id,side=Asheviere,1})}
                 [/show_if]
             [/objective]
-            
+
             [objective]
-                description= _ "<span strikethrough='true'>Defeat Irbirch, recapturing Queen Asheviere</span>"
+                description= "<span strikethrough='true'>" + {OBJECTIVE__DEFEAT_IRBIRCH} + "</span>"
                 condition=win
                 [show_if]
                     {HAVE_UNIT id,side=Asheviere,1}
                 [/show_if]
             [/objective]
             [objective]
-                description= _ "<span strikethrough='true'>Fail to rescue Asheviere before turns run out</span>"
+                description= "<span strikethrough='true'>" + {OBJECTIVE__FAIL_TO_RESCUE} + "</span>"
                 condition=lose
                 [show_if]
                     {HAVE_UNIT id,side=Asheviere,1}
                 [/show_if]
             [/objective]
-            
+
             [objective]
                 description= _ "Death of Delfador or Deoran"
                 condition=lose
@@ -971,3 +975,6 @@ Fencers are fragile but evasive, and possess the “<i>skirmisher</i>” ability
 
     {HERODEATHS}
 [/scenario]
+
+#undef OBJECTIVE__DEFEAT_IRBIRCH
+#undef OBJECTIVE__FAIL_TO_RESCUE


### PR DESCRIPTION
TDG S06 requires the player to both rescue Asheviere and also survive until turns run out.

With this commit, re-show objectives after rescuing Asheviere, and strikethrough the completed ones.