### PR TITLE
[1.18] Fix failure to build on current versions of MSVC

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 ### User interface
 ### WML Engine
 ### Miscellaneous and Bug Fixes
+   * Fix failure to build with recent versions of Visual Studio due to missing `<chrono>` include.
 
 ## Version 1.18.4
 ### Campaigns

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -28,6 +28,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/iostreams/stream.hpp>
 
+#include <chrono> // MSVC needs this
 #include <map>
 #include <ctime>
 #include <mutex>


### PR DESCRIPTION
A recent change in an upstream library must've resulted in an indirect inclusion of `<chrono>` disappearing:

```
D:\wesnoth-1.18\src\log.cpp(429): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'
```

Whatever the case may be, adding one of our own fixes this and poses no issue on other platforms.

(Not needed in the dev branch since the same include was already added by commit 2d765118ed48a976b102c5b296a8062d0846922a.)