### PR TITLE
Delete spacer in TDG's spellcasting dialog

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua
+++ b/data/campaigns/The_Deceivers_Gambit/lua/spellcasting.lua
@@ -353,13 +353,12 @@ function display_skills_dialog(selecting)
     -- HEADER
     -------------------------
     table.insert( grid[2], T.row{ T.column{ border="bottom", border_size=15, T.image{  label="icons/banner1.png"  }}} )
-    local spacer = "                                                                  "
     local                title_text = selecting and _"Select Delfador’s Spells"       or _"Cast Delfador’s Spells"
     if (apprentice) then title_text = selecting and _"Select the Apprentice’s Spells" or _"Cast the Apprentice’s Spells" end
     table.insert( grid[2], T.row{ T.column{ T.label{
         definition="title",
         horizontal_alignment="center",
-        label = spacer..title_text..spacer,
+        label = title_text,
     }}} )
     local                help_text = _"<span size='small'><i>Delfador knows many useful spells, and will learn more as he levels-up automatically throughout the campaign. Delfador does not use XP to level-up. Instead,\nDelfador uses XP to cast certain spells. If you select spells that cost XP, <b>double- or right-click on Delfador to cast them</b>. You can only cast 1 spell per turn.</i></span>"
     if (apprentice) then help_text = _"<span size='small'><i>The apprentice knows several useful spells, and will learn more as he levels-up automatically throughout the campaign. The apprentice does not use XP to level-up. Instead,\nhe uses XP to cast certain spells. If you select spells that cost XP,<b>double- or right-click on the apprentice to cast them</b>. You can only cast 1 spell per turn.</i></span>" end


### PR DESCRIPTION
This is my first in a series of PRs that will gradually replace the current TDG's magic system with a better and more developer-friendly version, which is currently used in CtL, as it was agreed with @Dalas121 

This PR removes a spacer that was significantly increasing the width of the spellcasting dialog in the new interface 1.19 due to the increased font size of title_text

**Before**
![1285](https://github.com/user-attachments/assets/b74985f8-46d0-400b-b765-30b97125eaa8)


**After**
![image4445465342](https://github.com/user-attachments/assets/afd21cab-fd79-4406-8f27-c8d2acc6d95a)
