### PR TITLE
rich label: support setting table bgcolors from definition

### DIFF
--- a/data/gui/themes/default/widgets/rich_label_default.cfg
+++ b/data/gui/themes/default/widgets/rich_label_default.cfg
@@ -28,6 +28,12 @@
 
 		link_color = "255, 225, 0"
 
+		[colors]
+			table_header = "51, 55, 79, 255"
+			table_row1   = "26, 31, 51, 255"
+			table_row2   = "35, 40, 66, 255"
+		[/colors]
+
 		[state_enabled]
 
 			[draw][/draw]

--- a/data/schema/gui/widget_definitions.cfg
+++ b/data/schema/gui/widget_definitions.cfg
@@ -228,6 +228,12 @@
         max="infinite"
         super="$generic/widget_definition/resolution"
         [tag]
+            name="colors"
+            min=0
+            max=1
+            {SIMPLE_KEY * color}
+        [/tag]
+        [tag]
             name="state_disabled"
             min="0"
             max="1"

--- a/src/gui/widgets/rich_label.hpp
+++ b/src/gui/widgets/rich_label.hpp
@@ -93,11 +93,6 @@ public:
 		can_wrap_ = wrap;
 	}
 
-	void set_characters_per_line(const unsigned characters_per_line)
-	{
-		characters_per_line_ = characters_per_line;
-	}
-
 	void set_link_aware(bool l);
 
 	void set_link_color(const color_t& color);
@@ -123,15 +118,6 @@ public:
 	}
 
 	void set_text_alpha(unsigned short alpha);
-
-	void set_text_color(const color_t& color, bool enabled)
-	{
-		if (enabled) {
-			text_color_enabled_ = color;
-		} else {
-			text_color_disabled_ = color;
-		}
-	}
 
 	const t_string& get_label() const
 	{
@@ -208,6 +194,11 @@ private:
 	color_t link_color_;
 
 	/**
+	 * Color variables that can be used in place of colors strings, like `<row bgcolor=color1>`
+	 */
+	std::map<std::string, color_t> predef_colors_;
+
+	/**
 	 * Base font family
 	 */
 	std::string font_family_;
@@ -244,6 +235,9 @@ private:
 
 	/** Padding */
 	int padding_;
+
+	/** If color is a predefined color set in resolution, return it, otherwise decode using `font::string_to_color`. */
+	color_t get_color(const std::string& color);
 
 	/** Create template for text config that can be shown in canvas */
 	void default_text_config(config* txt_ptr, const point& pos, const int max_width, const t_string& text = "");
@@ -341,6 +335,7 @@ struct rich_label_definition : public styled_widget_definition
 		std::string font_family;
 		int font_size;
 		std::string font_style;
+		std::map<std::string, color_t> colors;
 	};
 };
 

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -676,6 +676,7 @@ std::string unit_topic_generator::operator()() const {
 
 		// Print headers for the table.
 		table_ss << markup::tag("row",
+			{ {"bgcolor", "table_header"} },
 			//FIXME space/tab does not work, but nbsp does
 			//empty tags will be skipped by rich_label
 			markup::tag("col", font::nbsp),
@@ -742,7 +743,7 @@ std::string unit_topic_generator::operator()() const {
 				}
 			}
 
-			table_ss << markup::tag("row", {{"valign", "center"}}, attack_ss.str());
+			table_ss << markup::tag("row", { {"valign", "center"} }, attack_ss.str());
 		}
 
 		ss << markup::tag("table", table_ss.str());
@@ -777,10 +778,12 @@ std::string unit_topic_generator::operator()() const {
 
 	std::stringstream().swap(table_ss);
 	table_ss << markup::tag("row",
+		{ {"bgcolor", "table_header"} },
 		markup::tag("col", markup::bold(_("Attack Type"))),
 		markup::tag("col", markup::bold(_("Resistance"))));
 
 	utils::string_map_res dam_tab = movement_type.damage_table();
+	bool odd_row = true;
 	for(std::pair<std::string, std::string> dam_it : dam_tab) {
 		int resistance = 100;
 		try {
@@ -795,8 +798,11 @@ std::string unit_topic_generator::operator()() const {
 		const std::string lang_type = string_table["type_" + dam_it.first];
 		const std::string type_icon = "icons/profiles/" + dam_it.first + ".png~SCALE_INTO(16,16)";
 		table_ss << markup::tag("row",
+			{ {"bgcolor", (odd_row ? "table_row1" : "table_row2")} },
 			markup::tag("col", markup::img(type_icon), lang_type),
 			markup::tag("col", markup::span_color(color, resist)));
+
+		odd_row = !odd_row;
 	}
 	ss << markup::tag("table", table_ss.str());
 
@@ -816,7 +822,7 @@ std::string unit_topic_generator::operator()() const {
 		if (has_terrain_defense_caps) { row_ss << markup::tag("col", markup::bold(_("Defense Cap"))); }
 		if (has_vision)				  { row_ss << markup::tag("col", markup::bold(_("Vision Cost"))); }
 		if (has_jamming)			  { row_ss << markup::tag("col", markup::bold(_("Jamming Cost"))); }
-		table_ss << markup::tag("row", row_ss.str());
+		table_ss << markup::tag("row", { {"bgcolor", "table_header"} }, row_ss.str());
 
 		// Organize terrain movetype data
 		std::set<terrain_movement_info> terrain_moves;
@@ -848,6 +854,7 @@ std::string unit_topic_generator::operator()() const {
 		}
 
 		// Add movement table rows
+		odd_row = true;
 		for(const terrain_movement_info& m : terrain_moves)
 		{
 			std::stringstream().swap(row_ss);
@@ -887,7 +894,9 @@ std::string unit_topic_generator::operator()() const {
 				row_ss << markup::tag("col", format_mp_entry(type_.jamming(), m.jamming_cost));
 			}
 
-			table_ss << markup::tag("row", row_ss.str());
+			table_ss << markup::tag("row", { {"bgcolor", (odd_row ? "table_row1" : "table_row2")} }, row_ss.str());
+
+			odd_row = !odd_row;
 		}
 
 		ss << markup::tag("table", table_ss.str());


### PR DESCRIPTION
Adds a `[colors]` tag under `[rich_label_definition]`. This allows associating color values with names which can later be accessed from Help Markup (for now just from `<table><row bgcolor=...>`).
Uses this functionality to improve Help Browser table's  appearance.
![Screenshot from 2025-03-17 17-29-01](https://github.com/user-attachments/assets/f208c46e-dddf-4d6b-b32f-768bcef342a9)
![Screenshot from 2025-03-17 17-29-08](https://github.com/user-attachments/assets/07b3a11f-7f88-4661-be3e-94968ac9f4ee)
