### PR TITLE
WFL/Formula: use a unique_ptr for the managed instance

### DIFF
--- a/src/formula/formula.cpp
+++ b/src/formula/formula.cpp
@@ -249,6 +249,9 @@ formula::formula(const tk::token* i1, const tk::token* i2, function_symbol_table
 	}
 }
 
+// Explicitly defaulted out-of-line destructor (see header comment)
+formula::~formula() = default;
+
 formula_ptr formula::create_optional_formula(const std::string& str, function_symbol_table* symbols)
 {
 	if(str.empty()) {

--- a/src/formula/formula.hpp
+++ b/src/formula/formula.hpp
@@ -37,6 +37,14 @@ public:
 	formula(const std::string& str, function_symbol_table* symbols = nullptr, bool manage_symbols = false);
 	formula(const tk::token* i1, const tk::token* i2, function_symbol_table* symbols = nullptr);
 
+	formula(formula&&) = default;
+	formula& operator=(formula&&) = default;
+
+	// Since function_symbol_table is an incomplete type at this point,
+	// a destructor must be defined out-of-line once its definition is
+	// complete, otherwise compilation fails when used with unique_ptr.
+	~formula();
+
 	static variant evaluate(
 			const const_formula_ptr& f,
 			const formula_callable& variables,
@@ -80,9 +88,7 @@ private:
 
 	expression_ptr expr_;
 	std::string str_;
-	// Can't be a unique_ptr because function_symbol_table is an incomplete type,
-	// and the header it's declared in depends on this one.
-	const std::shared_ptr<function_symbol_table> managed_symbols_;
+	std::unique_ptr<function_symbol_table> managed_symbols_;
 	function_symbol_table* symbols_;
 
 	friend class formula_debugger;


### PR DESCRIPTION
Turns out we can use a unique_ptr after all, we just need to define the dtor out-of-line once function_symbol_table is a complete type.

Also adds a move ctor and assignment operator. This is necessary since the unique_ptr makes the class non-copyable, and also fixes a case in unit_filter_attribute_literal where a move was attempted but no move ctor provided.