### PR TITLE
TSG help.cfg: improve translatability of "ranged attack" help message

### DIFF
--- a/data/campaigns/The_South_Guard/utils/sg_help.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_help.cfg
@@ -181,7 +181,7 @@ in the next scenario, so don’t delay!"
                     [message]
                         speaker=unit
                         #po: second_unit may be a Walking Corpse, Ghoul, Skeleton, or one of their advancements
-                        message=_"I just made a <i><b>ranged attack</b></i>! I had to stand right next to this $second_unit.language_name <i>(yes, this is different from how most games handle ranged attacks)</i>, but because the $second_unit.language_name has no ranged weapon of his own he was unable to retaliate."
+                        message=_"I just made a <i><b>ranged attack</b></i>! I had to stand right next to this $second_unit.language_name <i>(yes, this is different from how most games handle ranged attacks)</i>, but because the $second_unit.language_name has no ranged weapon of its own it was unable to retaliate."
                     [/message]
                 [/then]
             [/elseif]

--- a/data/campaigns/The_South_Guard/utils/sg_help.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_help.cfg
@@ -163,16 +163,36 @@ in the next scenario, so don’t delay!"
         name=attack end
         {FILTER side=1}
         {FILTER_ATTACK range=ranged}
-        {FILTER_SECOND( type_adv_tree=Quintain,Thug,Thief,Walking Corpse,Ghoul,Skeleton )}
+        {FILTER_SECOND( type_adv_tree=Quintain,Thug,Walking Corpse,Ghoul,Skeleton )}
         {FILTER_CONDITION(
             {VARIABLE_CONDITIONAL enable_tutorial_elements equals yes}
             {VARIABLE_CONDITIONAL sg_ranged_info not_equals yes}
         )}
         {VARIABLE sg_ranged_info yes}
-        [message]
-            speaker=unit
-            message=_"I just made a <i><b>ranged attack</b></i>! I had to stand right next to this $second_unit.language_name <i>(yes, this is different from how most games handle ranged attacks)</i>, but because the $second_unit.language_name has no ranged weapon of his own he was unable to retaliate."
-        [/message]
+        [if] {VARIABLE_CONDITIONAL second_unit.type equals Quintain}
+            [then]
+                [message]
+                    speaker=unit
+                    message=_"I just made a <i><b>ranged attack</b></i>! I had to stand right next to this Quintain <i>(yes, this is different from how most games handle ranged attacks)</i>, but because the dummy has no ranged weapon of its own it was unable to retaliate."
+                [/message]
+            [/then]
+            [elseif] {VARIABLE_CONDITIONAL second_unit.race equals undead}
+                [then]
+                    [message]
+                        speaker=unit
+                        #po: second_unit may be a Walking Corpse, Ghoul, Skeleton, or one of their advancements
+                        message=_"I just made a <i><b>ranged attack</b></i>! I had to stand right next to this $second_unit.language_name <i>(yes, this is different from how most games handle ranged attacks)</i>, but because the $second_unit.language_name has no ranged weapon of his own he was unable to retaliate."
+                    [/message]
+                [/then]
+            [/elseif]
+            [else]
+                [message]
+                    speaker=unit
+                    #po: second_unit may be a Thug (always male) or one of its advancements
+                    message=_"I just made a <i><b>ranged attack</b></i>! I had to stand right next to this $second_unit.language_name <i>(yes, this is different from how most games handle ranged attacks)</i>, but because the $second_unit.language_name has no ranged weapon of his own he was unable to retaliate."
+                [/message]
+            [/else]
+        [/if]
     [/event]
 #enddef
 


### PR DESCRIPTION
As pointed out by @Wedge009 / @stevecotton in #9682, this string may need to be translated differently depending on the type of unit being attacked.

Also removes the message when attacking a Thief - Rogues (which IIRC are the only thief-line unit you fight in this campaign) have a ranged attack.