### PR TITLE
NR S2, 3, 6, 8: fix carryover gold %

### DIFF
--- a/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/02_01_Infested_Caves.cfg
@@ -1056,6 +1056,7 @@
         [endlevel]
             result=victory
             bonus=yes
+            {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
     [/event]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/03_To_the_Mines.cfg
@@ -187,6 +187,7 @@
         [endlevel]
             result=victory
             bonus=no
+            {NEW_GOLD_CARRYOVER 40}
         [/endlevel]
     [/event]
 

--- a/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/06a_Old_Friend.cfg
@@ -195,7 +195,7 @@
                 show_turn_counter=yes
             [/objective]
 
-            {ALTERNATIVE_OBJECTIVE ( _ "Defeat Rakshas, if you can...")}
+            {ALTERNATIVE_OBJECTIVE_BONUS ( _ "Defeat Rakshas, if you can...")}
 
             [objective]
                 description= _ "Death of Tallin"
@@ -496,6 +496,11 @@
             id=Tallin
             message= _ "Damn! We had the opportunity to end the war in one stroke there. Now we will have to go after him, assuming we can break this siege!"
         [/message]
+        [endlevel]
+            result=victory
+            bonus=yes
+            {NEW_GOLD_CARRYOVER 100}
+        [/endlevel]
     [/event]
 
     # Time over. Player didn't kill the bad guy but still survived, and that's also a victory.

--- a/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
+++ b/data/campaigns/Northern_Rebirth/scenarios/08a_Elvish_Princess.cfg
@@ -444,6 +444,8 @@
 
                 [endlevel]
                     result=victory
+                    bonus=no
+                    {NEW_GOLD_CARRYOVER 40}
                     # Skipping one scenario
                     next_scenario=10a_Stolen_Gold
                 [/endlevel]


### PR DESCRIPTION
Currently, carryover gold % for meeting the main objective and the alternative objective are respectively;
S2: 40%, 80%
S3: 80%, 40%
S8: 40%, 80%
because `{NEW_GOLD_CARRYOVER 40}` was added only once per scenario by b0a302b. Also, S6 lacks `[endlevel]` for meeting the alternative objective and the scenario doesn't end (although it is probably impossible anyway), but the scenario automatically ends with 80% carryover gold when all enemy leaders are killed. For the record, S10 has multiple objectives as well, but they are all 40%, so no fix seems necessary.

This PR turns all 80% into 40% and adds `[endlevel]` with 100% for the alternative objective in S6.