### PR TITLE
HttT S5a: clearer objective

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/maps/05a_Muff_Malal_Peninsula.map
+++ b/data/campaigns/Heir_To_The_Throne/maps/05a_Muff_Malal_Peninsula.map
@@ -1,6 +1,6 @@
 Mm, Mm, Mm, Hh, Hh, Re, Re, Gg, Gs^Fp, Gg, Gg, Gg, Gs^Fp, Hh^Fms, Hh^Fms, Hh, Mm, Mm, Mm, Mm, Mm, Hh, Hh^Fms, Gg, Gs^Fp, Gg, Gg, Gg, Gg
-Mm, Mm, Mm, Hh, Hh, Re, Re, Gg, Gs^Fp, Gg, Gg, Gg, Gs^Fp, Gs^Fms, Hh^Fp, Hh, Mm, Mm, Mm, Mm, Mm, Hh^Fp, Hh^Fp, Gg, Gs^Fp, Gg, Gg, Gg, Gg
-Mm, Mm, Mm, Hh, Gg^Vh, Gg, Re, Gg, Gg, Gg, Gg, Gs^Fms, Gs^Fp, Gs^Fp, Gs^Fms, Hh, Hh, Hh, Mm, Mm, Hh, Hh^Fms, Hh^Fp, Gs^Fms, Gs^Fp, Gg, Gg, Gg, Gg
+Mm, Mm, Mm, Hh, Hh, Re, Gg, Gg, Gs^Fp, Gg, Gg, Gg, Gs^Fp, Gs^Fms, Hh^Fp, Hh, Mm, Mm, Mm, Mm, Mm, Hh^Fp, Hh^Fp, Gg, Gs^Fp, Gg, Gg, Gg, Gg
+Mm, Mm, Mm, Hh, Gg^Vh, Re, Re, Gg, Gg, Gg, Gg, Gs^Fms, Gs^Fp, Gs^Fp, Gs^Fms, Hh, Hh, Hh, Mm, Mm, Hh, Hh^Fms, Hh^Fp, Gs^Fms, Gs^Fp, Gg, Gg, Gg, Gg
 Hh, Hh, Hh, Mm, Gg, Gg, Re, Gg, Gg, Gs, Gs, Gs, Gs^Vh, Gs, Gs^Fp, Hh, Mm, Mm, Hh, Hh, Gg, Hh, Gg, Gg, Gg, Gg, Gg, Gg, Gg
 Gg, Gg, Gg, Gs, Gs, Gs, Gs, Re, Re, Gs, Ss, Ss, Gs, Gs, Hh, Hh, Mm, Mm, Hh, Hh, Gg, Gg, Gg, Gg^Vh, Re, Re, Re, Re, Re
 Ds, Ds, Ds, Gg, Gs, Ss, Gs, Gg, Re, Gs, Ss, Ss, Gs^Fp, Gs, Mm, Hh, Mm, Mm, Hh, Hh, Gg, Gg, Re, Re, Gg, Ss, Gg, Gg, Gg

--- a/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/05a_Muff_Malal_Peninsula.cfg
@@ -88,7 +88,6 @@
         {VARIABLE via_isle_of_the_damned no}
         {CLEAR_VARIABLE moremirmu}
 
-        {PLACE_IMAGE scenery/signpost.png 8 2}
         {PLACE_IMAGE scenery/rock2.png 17 20}
 
         {STORE_DELFADOR}
@@ -145,27 +144,7 @@
             role=Advisor
             message= _ "The decision is yours, sir. If we are to leave, I advise we hurry past before they are upon us. If we are to fight, then... to arms!"
         [/message]
-    [/event]
-
-    [event]
-        name=moveto
-        [filter]
-            side=1
-            x=8
-            y=2
-        [/filter]
-
-        [redraw]
-        [/redraw]
-
-        [message]
-            speaker=narrator
-            image="scenery/signpost.png"
-            message= _ "To Elensefar"
-        [/message]
-
-        [allow_undo]
-        [/allow_undo]
+        {HIGHLIGHT_IMAGE 5 1 scenery/signpost.png ()}
     [/event]
 
     [event]
@@ -184,6 +163,11 @@
             [/have_unit]
             [then]
                 [message]
+                    speaker=narrator
+                    image="scenery/signpost.png"
+                    message= _ "To Elensefar"
+                [/message]
+                [message]
                     speaker=Konrad
                     message= _ "We do not have time to tarry here! On to Elensefar!"
                 [/message]
@@ -195,6 +179,11 @@
                 [/endlevel]
             [/then]
             [else]
+                [message]
+                    speaker=narrator
+                    image="scenery/signpost.png"
+                    message= _ "To Elensefar"
+                [/message]
                 [message]
                     speaker=Konrad
                     message= _ "Shirk not your duty! I will decide when it is time to leave for Elensefar."


### PR DESCRIPTION
The main objective says "Escape down the road to Elensefar". It actually means that the scenario ends when Konrad moves to (5,1), but the signpost that says "To Elensefar" is at (8,2). In S1, the signpost was the place that Konrad was supposed to go to, so it’s natural for new players to assume the same for S5a (relevant feedback posts: [2019](https://forums.wesnoth.org/viewtopic.php?p=638143#p638143), [2024](https://forums.wesnoth.org/viewtopic.php?p=689695#p689695)).

Therefore, the signpost is moved to (5,1), and it is highlighted at the start of the scenario just like S1. Also, some minor terrain changes are made so that (5,1) is the only road-like terrain at the edge of the map at y=1.
![HttT-5a-all](https://github.com/user-attachments/assets/e81ff226-9149-48b4-910c-73fc78ab657e)

