### PR TITLE
Generalise log domain matching rules

### DIFF
--- a/doc/man/wesnoth.6
+++ b/doc/man/wesnoth.6
@@ -133,11 +133,12 @@ Example:
 .B --language ang_GB@latin
 .TP
 .BI --log- level = domain1 , domain2 , ...
-sets the severity level of the log domains.
-.B all
-can be used to match any log domain. Available levels:
+sets the severity level of the log domains. The wildcard
+.B *
+may be used to match a subset of domains, e.g. gui/* or conf* or * (the latter matches all domains).
+Available levels:
 .BR error ,\  warning ,\  info ,\  debug ,\  none .
-By default the
+By default, the
 .B warning
 level is used for most domains, but
 .B deprecation
@@ -146,6 +147,7 @@ defaults to
 unless combined with the
 .B -d
 option.
+This option can be specified multiple times.
 .TP
 .B --log-precise
 shows the timestamps in log output with more precision.

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -346,23 +346,21 @@ log_domain::log_domain(char const *name, severity severity)
 
 bool set_log_domain_severity(const std::string& name, severity severity)
 {
-	std::string::size_type s = name.size();
 	if (name == "all") {
 		for(logd &l : *domains) {
 			l.second = severity;
 		}
-	} else if (s > 2 && name.compare(s - 2, 2, "/*") == 0) {
-		for(logd &l : *domains) {
-			if (l.first.compare(0, s - 1, name, 0, s - 1) == 0)
-				l.second = severity;
-		}
+		return true;
 	} else {
-		domain_map::iterator it = domains->find(name);
-		if (it == domains->end())
-			return false;
-		it->second = severity;
+		bool any_matched = false;
+		for (logd &l : *domains) {
+			if (utils::wildcard_string_match(l.first, name)) {
+				l.second = severity;
+				any_matched = true;
+			}
+		}
+		return any_matched;
 	}
-	return true;
 }
 bool set_log_domain_severity(const std::string& name, const logger &lg) {
 	return set_log_domain_severity(name, lg.get_severity());


### PR DESCRIPTION
Previously, `--log-debug='*'` would not match all domains. Similarly, `conf*` would not be a correct pattern, etc.

With this change, special handling of top-level domains is removed. For example, the `config` domain will be matched by `conf*`.

All domains can be matched by the magic string `all` as before, or by using `*`.

Basic manual testing was performed for this PR:

* broken domain patterns that do not match anything result in an error, as expected.

* patterns `all` and `*` were tested.

* specifying `conf*` correctly enables the config domain.

* specifying `gui/*` does not enable the config domain.

* patterns containing a comma (delimiter) are handled "correctly", that is, individual components are understood and processed separately. For example, `--log-debug='gui/*,conf*'` would enable debug logging for everything in the `gui` domain and `config` (as it's the only domain that matches `conf*`).

Fixes https://github.com/wesnoth/wesnoth/issues/10052