### PR TITLE
Continue work on chrono cleanup

### DIFF
--- a/src/config_attribute_value.cpp
+++ b/src/config_attribute_value.cpp
@@ -298,11 +298,6 @@ std::size_t config_attribute_value::to_size_t(std::size_t def) const
 	return apply_visitor(attribute_numeric_visitor<std::size_t>(def));
 }
 
-std::time_t config_attribute_value::to_time_t(std::time_t def) const
-{
-	return apply_visitor(attribute_numeric_visitor<std::time_t>(def));
-}
-
 double config_attribute_value::to_double(double def) const
 {
 	return apply_visitor(attribute_numeric_visitor<double>(def));

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -33,7 +33,6 @@
 
 #include <chrono>
 #include <climits>
-#include <ctime>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -153,7 +152,6 @@ public:
 	long long to_long_long(long long def = 0) const;
 	unsigned to_unsigned(unsigned def = 0) const;
 	std::size_t to_size_t(std::size_t def = 0) const;
-	std::time_t to_time_t(std::time_t def = 0) const;
 	double to_double(double def = 0.) const;
 	std::string str(const std::string& fallback = "") const;
 	t_string t_str() const;

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <chrono>
-#include <ctime>
 #include <cstdint>
 #include <fstream>
 #include <iosfwd>

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <ctime>
 #include <cstdint>
 #include <fstream>
@@ -274,7 +275,7 @@ bool is_directory(const std::string& fname);
 bool file_exists(const std::string& name);
 
 /** Get the modification time of a file. */
-std::time_t file_modified_time(const std::string& fname);
+std::chrono::system_clock::time_point file_modified_time(const std::string& fname);
 
 /** Returns true if the file ends with the mapfile extension. */
 bool is_map(const std::string& filename);
@@ -309,13 +310,12 @@ bool is_legal_user_file_name(const std::string& name, bool allow_whitespace = tr
 
 struct file_tree_checksum
 {
-	file_tree_checksum();
+	file_tree_checksum() = default;
 	explicit file_tree_checksum(const config& cfg);
 	void write(config& cfg) const;
-	void reset() {nfiles = 0;modified = 0;sum_size=0;}
 	// @todo make variables private!
-	std::size_t nfiles, sum_size;
-	std::time_t modified;
+	std::size_t nfiles{}, sum_size{};
+	std::chrono::system_clock::time_point modified{};
 	bool operator==(const file_tree_checksum &rhs) const;
 	bool operator!=(const file_tree_checksum &rhs) const
 	{ return !operator==(rhs); }

--- a/src/format_time_summary.cpp
+++ b/src/format_time_summary.cpp
@@ -15,22 +15,69 @@
 
 #include "format_time_summary.hpp"
 
-#include "assert.h"
 #include "gettext.hpp"
 #include "preferences/preferences.hpp"
+#include "serialization/chrono.hpp"
+#undef CPP20_CHRONO_SUPPORT
+#include <cassert>
+#ifndef CPP20_CHRONO_SUPPORT
+#include <ctime>
+#endif
 
-namespace utils {
+namespace utils
+{
+std::string format_time_summary(const std::chrono::system_clock::time_point& t)
+{
+#ifdef CPP20_CHRONO_SUPPORT
+	const auto now = std::chrono::system_clock::now();
+	std::string format_string;
 
-std::string format_time_summary(std::time_t t) {
-	std::time_t curtime = std::time(nullptr);
-	const std::tm* timeptr = std::localtime(&curtime);
+	auto curr_time = std::chrono::year_month_weekday{std::chrono::floor<std::chrono::days>(now)};
+	auto save_time = std::chrono::year_month_weekday{std::chrono::floor<std::chrono::days>(t)};
+
+	if(curr_time == save_time) {
+		// save is from today
+		format_string = prefs::get().use_twelve_hour_clock_format()
+			// TRANSLATORS: 12-hour time, eg '1:59 PM'
+			? _("%I:%M %p")
+			// TRANSLATORS: 24-hour time, eg '13:59'
+			: _("%H:%M");
+
+	} else if(curr_time.month() == save_time.month() && curr_time.index() == save_time.index()) {
+		// save is from this week
+		format_string = prefs::get().use_twelve_hour_clock_format()
+			// TRANSLATORS: Day of week + 12-hour time, eg 'Sunday, 1:59 PM'
+			? _("%A, %I:%M %p")
+			// TRANSLATORS: Day of week + 24-hour time, eg 'Sunday, 13:59'
+			: _("%A, %H:%M");
+
+	} else if(curr_time.year() == save_time.year()) {
+		// save is from current year
+		// TRANSLATORS: Month + day of month, eg 'Nov 02'. Format for your locale.
+		format_string = _("%b %d");
+
+	} else {
+		// save is from a different year
+		// TRANSLATORS: Month + day of month + year, eg 'Nov 02 2021'. Format for your locale.
+		format_string = _("%b %d %Y");
+	}
+
+	// TODO: make sure this doesn't result in #1709 coming back
+	assert(!format_string.empty());
+	return chrono::format_local_timestamp(t, format_string);
+#else
+	const auto now = std::chrono::system_clock::now();
+
+	auto as_time_t = std::chrono::system_clock::to_time_t(now);
+	const std::tm* timeptr = std::localtime(&as_time_t);
 	if(timeptr == nullptr) {
 		return "";
 	}
 
 	const std::tm current_time = *timeptr;
 
-	timeptr = std::localtime(&t);
+	as_time_t = std::chrono::system_clock::to_time_t(t);
+	timeptr = std::localtime(&as_time_t);
 	if(timeptr == nullptr) {
 		return "";
 	}
@@ -74,6 +121,7 @@ std::string format_time_summary(std::time_t t) {
 	assert(!format_string.empty());
 
 	return translation::strftime(format_string, &save_time);
+#endif
 }
 
-}
+} // namespace utils

--- a/src/format_time_summary.cpp
+++ b/src/format_time_summary.cpp
@@ -18,7 +18,7 @@
 #include "gettext.hpp"
 #include "preferences/preferences.hpp"
 #include "serialization/chrono.hpp"
-#undef CPP20_CHRONO_SUPPORT
+
 #include <cassert>
 #ifndef CPP20_CHRONO_SUPPORT
 #include <ctime>
@@ -61,10 +61,6 @@ std::string format_time_summary(const std::chrono::system_clock::time_point& t)
 		// TRANSLATORS: Month + day of month + year, eg 'Nov 02 2021'. Format for your locale.
 		format_string = _("%b %d %Y");
 	}
-
-	// TODO: make sure this doesn't result in #1709 coming back
-	assert(!format_string.empty());
-	return chrono::format_local_timestamp(t, format_string);
 #else
 	const auto now = std::chrono::system_clock::now();
 
@@ -118,10 +114,10 @@ std::string format_time_summary(const std::chrono::system_clock::time_point& t)
 		// TRANSLATORS: Month + day of month + year, eg 'Nov 02 2021'. Format for your locale.
 		format_string = _("%b %d %Y");
 	}
-	assert(!format_string.empty());
-
-	return translation::strftime(format_string, &save_time);
 #endif
+	// TODO: make sure this doesn't result in #1709 coming back
+	assert(!format_string.empty());
+	return chrono::format_local_timestamp(t, format_string);
 }
 
 } // namespace utils

--- a/src/format_time_summary.hpp
+++ b/src/format_time_summary.hpp
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include <ctime>
+#include <chrono>
 #include <string>
 
 namespace utils {
-	std::string format_time_summary(std::time_t t);
+	std::string format_time_summary(const std::chrono::system_clock::time_point& t);
 }

--- a/src/formula/string_utils.hpp
+++ b/src/formula/string_utils.hpp
@@ -21,7 +21,6 @@
 
 #include "serialization/string_utils.hpp"
 
-#include <ctime>
 #include <string_view>
 
 class variable_set;

--- a/src/game_initialization/lobby_data.hpp
+++ b/src/game_initialization/lobby_data.hpp
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <ctime>
 #include <vector>
 #include <string>
 

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -552,16 +552,6 @@ int icompare(const std::string& s1, const std::string& s2)
 #endif
 }
 
-std::string strftime(const std::string& format, const std::tm* time)
-{
-	std::basic_ostringstream<char> dummy;
-	dummy.imbue(get_manager().get_locale());	// TODO: Calling imbue() with hard-coded locale appears to work with put_time in glibc, but not with get_locale()...
-	// Revert to use of boost (from 1.14) instead of std::put_time() because the latter does not appear to handle locale properly in Linux
-	dummy << bl::as::ftime(format) << mktime(const_cast<std::tm*>(time));
-
-	return dummy.str();
-}
-
 bool ci_search(const std::string& s1, const std::string& s2)
 {
 	const std::locale& locale = get_manager().get_locale();

--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -80,8 +80,6 @@ namespace translation
 	/** Case-insensitive lexicographical comparison. */
 	int icompare(const std::string& s1,const std::string& s2);
 
-	std::string strftime(const std::string& format, const std::tm* time);
-
 	/** Case-insensitive search. @a s2 will be checked against @a s1. */
 	bool ci_search(const std::string& s1, const std::string& s2);
 

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -21,7 +21,6 @@
 #include "addon/manager.hpp"
 #include "addon/state.hpp"
 
-
 #include "help/help.hpp"
 #include "gettext.hpp"
 #include "gui/dialogs/addon/license_prompt.hpp"
@@ -38,6 +37,7 @@
 #include "gui/widgets/text_box.hpp"
 #include "gui/widgets/window.hpp"
 #include "preferences/preferences.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/string_utils.hpp"
 #include "formula/string_utils.hpp"
 #include "picture.hpp"
@@ -1097,8 +1097,7 @@ static std::string format_addon_time(const std::chrono::system_clock::time_point
 		// Format reference: https://www.boost.org/doc/libs/1_85_0/doc/html/date_time/date_time_io.html#date_time.format_flags
 		: _("%B %d %Y, %H:%M");
 
-	auto as_time_t = std::chrono::system_clock::to_time_t(time);
-	return translation::strftime(format, std::localtime(&as_time_t));
+	return chrono::format_local_timestamp(time, format);
 }
 
 void addon_manager::on_addon_select()

--- a/src/gui/widgets/debug.cpp
+++ b/src/gui/widgets/debug.cpp
@@ -15,7 +15,6 @@
 
 #define GETTEXT_DOMAIN "wesnoth-lib"
 
-
 #ifdef DEBUG_WINDOW_LAYOUT_GRAPHS
 
 #include "gui/widgets/debug.hpp"
@@ -26,6 +25,7 @@
 #include "gui/widgets/listbox.hpp"
 #include "gui/widgets/scrollbar_container.hpp"
 #include "gui/widgets/window.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/string_utils.hpp"
 
 #include <fstream>
@@ -82,8 +82,8 @@ std::string get_base_filename()
 {
 	std::ostringstream ss;
 
-	std::time_t t = std::time(nullptr);
-	ss << std::put_time(std::localtime(&t), "%Y%m%d_%H%M%S");
+	const auto now = std::chrono::system_clock::now();
+	ss << chrono::format_local_timestamp(now, "%Y%m%d_%H%M%S");
 
 	static unsigned counter = 0;
 	++counter;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -30,7 +30,6 @@
 #include <boost/algorithm/string.hpp>
 
 #include <map>
-#include <ctime>
 #include <mutex>
 #include <iostream>
 #include <iomanip>

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -133,11 +133,11 @@ void rotate_logs(const std::string& log_dir)
 std::string unique_log_filename()
 {
 	std::ostringstream o;
-	const std::time_t cur = std::time(nullptr);
+	const auto now = std::chrono::system_clock::now();
 	randomness::mt_rng rng;
 
 	o << lg::log_file_prefix
-	  << std::put_time(std::localtime(&cur), "%Y%m%d-%H%M%S-")
+	  << chrono::format_local_timestamp(now, "%Y%m%d-%H%M%S-")
 	  << rng.get_next_random();
 
 	return o.str();

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -56,7 +56,6 @@
 #include <string>
 #include <utility>
 #include <chrono>
-#include <ctime>
 #include <cstdint>
 
 #include "formatter.hpp"

--- a/src/log_windows.cpp
+++ b/src/log_windows.cpp
@@ -23,7 +23,6 @@
 #include "log.hpp"
 #include "serialization/unicode.hpp"
 
-#include <ctime>
 #include <iomanip>
 #include <iostream>
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -41,7 +41,6 @@
 #include "whiteboard/manager.hpp"
 
 #include <boost/format.hpp>
-#include <ctime>
 #include <iomanip>
 #include <utility>
 

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -29,6 +29,7 @@
 #include "pathfind/pathfind.hpp"
 #include "picture.hpp"
 #include "preferences/preferences.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/markup.hpp"
 #include "team.hpp"
 #include "terrain/movement.hpp"
@@ -1752,15 +1753,12 @@ REPORT_GENERATOR(report_clock, /*rc*/)
 	config report;
 	add_image(report, game_config::images::time_icon, "");
 
-	std::ostringstream ss;
-
 	const char* format = prefs::get().use_twelve_hour_clock_format()
 		? "%I:%M %p"
 		: "%H:%M";
 
-	std::time_t t = std::time(nullptr);
-	ss << std::put_time(std::localtime(&t), format);
-	add_text(report, ss.str(), _("Clock"));
+	const auto now = std::chrono::system_clock::now();
+	add_text(report, chrono::format_local_timestamp(now, format), _("Clock"));
 
 	return report;
 }

--- a/src/save_index.hpp
+++ b/src/save_index.hpp
@@ -17,6 +17,8 @@
 
 #include "config.hpp"
 
+#include <chrono>
+
 namespace savegame
 {
 class save_index_class;
@@ -27,7 +29,9 @@ class save_info
 private:
 	friend class create_save_info;
 
-	save_info(const std::string& name, const std::shared_ptr<save_index_class>& index, const std::time_t& modified)
+	save_info(const std::string& name,
+		const std::shared_ptr<save_index_class>& index,
+		const std::chrono::system_clock::time_point& modified)
 		: name_(name)
 		, save_index_(index)
 		, modified_(modified)
@@ -40,7 +44,7 @@ public:
 		return name_;
 	}
 
-	const std::time_t& modified() const
+	const auto& modified() const
 	{
 		return modified_;
 	}
@@ -52,7 +56,7 @@ public:
 private:
 	std::string name_;
 	std::shared_ptr<save_index_class> save_index_;
-	std::time_t modified_;
+	std::chrono::system_clock::time_point modified_;
 };
 
 /**
@@ -95,11 +99,11 @@ public:
 	void delete_game(const std::string& name);
 
 	void rebuild(const std::string& name);
-	void rebuild(const std::string& name, const std::time_t& modified);
+	void rebuild(const std::string& name, const std::chrono::system_clock::time_point& modified);
 
 	/** Delete a savegame from the index, without deleting the underlying file. */
 	void remove(const std::string& name);
-	void set_modified(const std::string& name, const std::time_t& modified);
+	void set_modified(const std::string& name, const std::chrono::system_clock::time_point& modified);
 
 	config& get(const std::string& name);
 	const std::string& dir() const;
@@ -128,7 +132,7 @@ private:
 
 	bool loaded_;
 	config data_;
-	std::map<std::string, std::time_t> modified_;
+	std::map<std::string, std::chrono::system_clock::time_point> modified_;
 	const std::string dir_;
 	/**
 	 * The instance for default_saves_dir() writes a cache file. For other instances,

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -38,6 +38,7 @@
 #include "save_index.hpp"
 #include "saved_game.hpp"
 #include "serialization/binary_or_text.hpp"
+#include "serialization/chrono.hpp"
 #include "serialization/utf8_exception.hpp"
 #include "utils/optimer.hpp"
 #include "video.hpp" // only for faked
@@ -572,10 +573,7 @@ replay_savegame::replay_savegame(saved_game& gamestate, const compression::forma
 
 std::string replay_savegame::create_initial_filename(unsigned int) const
 {
-	time_t t = std::time(nullptr);
-	tm tm = *std::localtime(&t);
-	auto time = std::put_time(&tm, "%Y%m%d-%H%M%S");
-
+	auto time = chrono::format_local_timestamp(std::chrono::system_clock::now(), "%Y%m%d-%H%M%S");
 	// TRANSLATORS: This string is used as part of a filename, as in, "HttT-The Elves Besieged replay.gz"
 	return formatter() << gamestate().classification().label << " " << _("replay") << " " << time;
 }

--- a/src/server/campaignd/server.cpp
+++ b/src/server/campaignd/server.cpp
@@ -48,7 +48,6 @@
 #endif
 
 #include <csignal>
-#include <ctime>
 #include <iomanip>
 #include <iostream>
 #include <utility>

--- a/src/server/wesnothd/ban.cpp
+++ b/src/server/wesnothd/ban.cpp
@@ -333,9 +333,6 @@ std::pair<bool, utils::optional<std::chrono::system_clock::time_point>> ban_mana
 	const std::string& duration, std::chrono::system_clock::time_point start_time) const
 {
 	if(duration.substr(0, 4) == "TIME") {
-		auto as_time_t = std::chrono::system_clock::to_time_t(start_time);
-		std::tm* loc = std::localtime(&as_time_t);
-
 		std::size_t number = 0;
 		for(auto i = duration.begin() + 4; i != duration.end(); ++i) {
 			if(is_digit(*i)) {
@@ -343,22 +340,22 @@ std::pair<bool, utils::optional<std::chrono::system_clock::time_point>> ban_mana
 			} else {
 				switch(*i) {
 				case 'Y':
-					loc->tm_year = number;
+					start_time += chrono::years{number};
 					break;
 				case 'M':
-					loc->tm_mon = number;
+					start_time += chrono::months{number};
 					break;
 				case 'D':
-					loc->tm_mday = number;
+					start_time += chrono::days{number};
 					break;
 				case 'h':
-					loc->tm_hour = number;
+					start_time += std::chrono::hours{number};
 					break;
 				case 'm':
-					loc->tm_min = number;
+					start_time += std::chrono::minutes{number};
 					break;
 				case 's':
-					loc->tm_sec = number;
+					start_time += std::chrono::seconds{number};
 					break;
 				default:
 					LOG_SERVER << "Invalid time modifier given: '" << *i << "'.";
@@ -367,7 +364,7 @@ std::pair<bool, utils::optional<std::chrono::system_clock::time_point>> ban_mana
 				number = 0;
 			}
 		}
-		return { true, std::chrono::system_clock::from_time_t(std::mktime(loc)) };
+		return { true, start_time };
 	}
 
 	std::string dur_lower;

--- a/src/tests/test_formula_core.cpp
+++ b/src/tests/test_formula_core.cpp
@@ -17,7 +17,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <array>
-#include <ctime>
 
 #include "formula/formula.hpp"
 #include "formula/callable.hpp"

--- a/src/units/id.hpp
+++ b/src/units/id.hpp
@@ -15,8 +15,6 @@
 
 #pragma once
 
-#include <ctime>
-
 namespace n_unit {
 
 	struct unit_id

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -43,6 +43,7 @@
 #include "scripting/plugins/manager.hpp"
 #include "sdl/exception.hpp" // for exception
 #include "serialization/binary_or_text.hpp" // for config_writer
+#include "serialization/chrono.hpp"
 #include "serialization/parser.hpp"         // for read
 #include "serialization/preprocessor.hpp"   // for preproc_define, etc
 #include "serialization/schema_validator.hpp" // for strict_validation_enabled and schema_validator
@@ -77,7 +78,6 @@
 #include <clocale>   // for setlocale, LC_ALL, etc
 #include <cstdio>    // for remove, fprintf, stderr
 #include <cstdlib>   // for srand, exit
-#include <ctime>     // for time, ctime, std::time_t
 #include <exception> // for exception
 #include <vector>
 #include <iostream>
@@ -422,8 +422,8 @@ static int process_command_args(commandline_options& cmdline_opts)
 
 	if(!cmdline_opts.nobanner) {
 		PLAIN_LOG << "Battle for Wesnoth v" << game_config::revision  << " " << game_config::build_arch();
-		const std::time_t t = std::time(nullptr);
-		PLAIN_LOG << "Started on " << ctime(&t);
+		static constexpr std::string_view format = "%a %b %d %T %Y"; // equivalent to std::ctime
+		PLAIN_LOG << "Started on " << chrono::format_local_timestamp(std::chrono::system_clock::now(), format) << '\n';
 	}
 
 	if(cmdline_opts.usercache_path) {

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -421,9 +421,9 @@ static int process_command_args(commandline_options& cmdline_opts)
 	}
 
 	if(!cmdline_opts.nobanner) {
+		const auto now = std::chrono::system_clock::now();
 		PLAIN_LOG << "Battle for Wesnoth v" << game_config::revision  << " " << game_config::build_arch();
-		static constexpr std::string_view format = "%a %b %d %T %Y"; // equivalent to std::ctime
-		PLAIN_LOG << "Started on " << chrono::format_local_timestamp(std::chrono::system_clock::now(), format) << '\n';
+		PLAIN_LOG << "Started on " << chrono::format_local_timestamp(now, "%a %b %d %T %Y") << '\n';
 	}
 
 	if(cmdline_opts.usercache_path) {


### PR DESCRIPTION
- Remove config_attribute_value::to_time_t (finally!)
- Add C++20 codepath for format_time_summary
- Deploy chrono::format_local_timestamp more widely, including replacing uses of translation::strftime (need to confirm this still plays nicely with translations - don't want #1709 to crop back up...)
- Clean up unnecessary includes
- Clean up uses of time_t in filesystem and save_index
- Clean up last use of ctime
- Simplify wesnothd ban duration calculations