### PR TITLE
add a tag [affect_distant] to abilities(second experimental version)

### DIFF
--- a/changelog_entries/add_affect_distant.md
+++ b/changelog_entries/add_affect_distant.md
@@ -1,0 +1,2 @@
+### WML Engine
+* add a [affect_distant]radius= tag for affect units distant to owner of ability.

--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -128,109 +128,21 @@
 #enddef
 
 #define ABILITY_SHADOW_VEIL
-    [dummy]
+    [hides]
         id=did_shadow_veil
         name= _ "shadow veil"
         name_inactive= _ "shadow veil"
         description= _ "Allied undead units within a 5 hex radius are hidden."
         description_inactive= _ "Allied undead units within a 5 hex radius are hidden."
-        {DID_SHADOW_VEIL_HANDLER}
-    [/dummy]
-#enddef
-
-#define ABILITY_SHADOW_VEIL_HELPER SIDE
-    [hides]
-        id=did_shadow_veil_helper
-        [filter]
-            [filter_location]
-                radius=5
-                [filter]
-                    ability=did_shadow_veil
-                    [filter_side]
-                        [allied_with]
-                            side={SIDE}
-                        [/allied_with]
-                    [/filter_side]
-                [/filter]
-            [/filter_location]
-        [/filter]
-    [/hides]
-#enddef
-
-#define DID_SHADOW_VEIL_HANDLER
-    [event]
-        id=did_shadow_veil_unit_placed
-        name=unit placed
-        first_time_only=no
-        [filter]
-            side=1
-            race=undead
-            [not]
-                ability=did_shadow_veil_helper
-            [/not]
-        [/filter]
-        [filter_condition]
-            [have_unit]
-                ability=did_shadow_veil
-                side=1
-            [/have_unit]
-        [/filter_condition]
-        [modify_unit]
-            [filter]
-                x,y=$x1,$y1
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-            [/filter]
-            [object]
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
-    [event]
-        id=did_shadow_veil_malkeshar
-        name=post advance
-        first_time_only=yes
-        [filter]
-            type=Mal Keshar
-            ability=did_shadow_veil
-        [/filter]
-        [modify_unit]
+        affect_self=no
+        affect_allies=yes
+        [affect_distant]
+            radius=5
             [filter]
                 race=undead
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-                [filter_side]
-                    [allied_with]
-                        side=$unit.side
-                    [/allied_with]
-                [/filter_side]
             [/filter]
-            [object]
-                take_only_once=no
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $this_unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
+        [/affect_distant]
+    [/hides]
 #enddef
 
 #define WEAPON_SPECIAL_FROST_NOVA

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -40,6 +40,11 @@
 		[/key]
 		{FILTER_TAG "filter" unit ()}
 	[/tag]
+	[tag]
+		name="affect_distant"
+		{REQUIRED_KEY radius s_int}
+		{FILTER_TAG "filter" unit ()}
+	[/tag]
 	{FILTER_TAG "filter_self" unit ()}
 	{FILTER_TAG "filter_adjacent" adjacent ()}
 	{FILTER_TAG "filter_adjacent_location" adjacent_location ()}

--- a/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
+++ b/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
@@ -1,0 +1,74 @@
+#textdomain wesnoth-test
+
+##
+# Starting state:
+#
+# Side 1 leader Alice (Orcish Grunt)
+# Side 2 leader Bob (Orcish Grunt)
+# Side 3 leader Charlie (Orcish Grunt)
+# Side 4 leader Dave (Orcish Grunt)
+#
+# None of the sides are allied.
+#
+# On the default map (used unless overridden with the MAP_FILE argument:
+# * All four leaders are on a single keep, with Alice and Bob already in position to attack any of the other units.
+# * There is no free castle hex to recruit onto.
+##
+#define SEPARATE_KEEP_A_B_C_D_UNIT_TEST NAME CONTENT
+
+#arg SIDE_LEADER
+Orcish Grunt#endarg
+
+#arg MAP_FILE
+test/maps/4p_separate_castles.map#endarg
+
+    [test]
+        name=_ "Unit Test " + {NAME}
+        map_file={MAP_FILE}
+        turns=unlimited
+        id={NAME}
+        random_start_time=no
+        is_unit_test=yes
+
+        {DAWN}
+
+        [side]
+            side=1
+            controller=human
+            [leader]
+                name = _ "Alice"
+                type = {SIDE_LEADER}
+                id=alice
+            [/leader]
+        [/side]
+        [side]
+            side=2
+            controller=human
+            [leader]
+                name = _ "Bob"
+                type = {SIDE_LEADER}
+                id=bob
+            [/leader]
+        [/side]
+        [side]
+            side=3
+            controller=human
+            [leader]
+                name = _ "Charlie"
+                type = {SIDE_LEADER}
+                id=charlie
+            [/leader]
+        [/side]
+        [side]
+            side=4
+            controller=human
+            [leader]
+                name = _ "Dave"
+                type = {SIDE_LEADER}
+                id=dave
+            [/leader]
+        [/side]
+
+        {CONTENT}
+    [/test]
+#enddef

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
@@ -1,0 +1,54 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 10 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should affect alice.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 10 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=10
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alice
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
@@ -1,0 +1,121 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 7"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=7
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alex
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
@@ -1,0 +1,57 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 1 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alice.
+#####
+
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 1 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=1
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alice
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
@@ -1,0 +1,125 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 5"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alex
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY

--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -390,9 +390,11 @@ void advance_unit(map_location loc, const advancement_option &advance_to, bool f
 		LOG_CF << "Added '" << new_unit->type_id() << "' to the encountered units.";
 	}
 	u->anim_comp().clear_haloes();
+	resources::gameboard->units_distant().erase(loc);
 	resources::gameboard->units().erase(loc);
 	resources::whiteboard->on_kill_unit();
 	u = resources::gameboard->units().insert(new_unit).first;
+	resources::gameboard->unit_distant(new_unit);
 
 	// Update fog/shroud.
 	actions::shroud_clearer clearer;

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1298,6 +1298,7 @@ void attack::unit_killed(unit_info& attacker,
 		return;
 	}
 
+    resources::gameboard->units_distant().erase(defender.loc_);
 	units_.erase(defender.loc_);
 	resources::whiteboard->on_kill_unit();
 
@@ -1324,6 +1325,7 @@ void attack::unit_killed(unit_info& attacker,
 			}
 
 			newunit->set_location(death_loc);
+			resources::gameboard->unit_distant(newunit);
 			units_.insert(newunit);
 
 			game_events::entity_location reanim_loc(defender.loc_, newunit->underlying_id());

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -642,6 +642,7 @@ place_recruit_result place_recruit(const unit_ptr& u, const map_location &recrui
 
 	// Add the unit to the board.
 	auto [new_unit_itor, success] = resources::gameboard->units().insert(u);
+	resources::gameboard->unit_distant(u);
 	assert(success);
 
 	map_location current_loc = recruit_location;

--- a/src/actions/move.cpp
+++ b/src/actions/move.cpp
@@ -609,6 +609,7 @@ namespace { // Private helpers for move_unit()
 		auto [unit_it, success] = resources::gameboard->units().move(*move_loc_, *step_to);
 
 		if(success) {
+            resources::gameboard->units_distant().move(*move_loc_, *step_to);
 			resources::undo_stack->add_move(
 				unit_it.get_shared_ptr(), move_loc_, step_to + 1, orig_moves_, unit_it->facing());
 			orig_moves_ = unit_it->movement_left();
@@ -648,6 +649,7 @@ namespace { // Private helpers for move_unit()
 
 		// Attempt actually moving. Fails if *step_to is occupied.
 		auto [unit_it, success] = resources::gameboard->units().move(*begin_, *step_to);
+		resources::gameboard->units_distant().move(*begin_, *step_to);
 
 		if(success) {
 			// Update the moving unit.

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -56,25 +56,6 @@ void move_action::write(config & cfg) const
 }
 
 /**
- * Reset halo of adjacent units when undo move.
- */
-static void reset_adjacent(bool& halo_adjacent, unit_map& units, const map_location& loc)
-{
-	if(halo_adjacent){
-		unit_map::iterator u = units.find(loc);
-		const auto adjacent = get_adjacent_tiles(loc);
-		for(unsigned i = 0; i < adjacent.size(); ++i) {
-			const unit_map::const_iterator it = units.find(adjacent[i]);
-			if (it == units.end() || it->incapacitated())
-				continue;
-			if ( &*it == &*u )
-				continue;
-			it->anim_comp().set_standing();
-		}
-	}
-}
-
-/**
  * Undoes this action.
  * @return true on success; false on an error.
  */
@@ -103,17 +84,10 @@ bool move_action::undo(int)
 
 	// Move the unit.
 	unit_display::move_unit(rev_route, u.get_shared_ptr(), true, starting_dir);
-	bool halo_adjacent = false;
-	for(const auto [_, cfg] : u->abilities().all_children_view()){
-		if(!cfg["halo_image"].empty() && cfg.has_child("affect_adjacent")){
-			halo_adjacent = true;
-			break;
-		}
-	}
-	reset_adjacent(halo_adjacent, units, rev_route.front());
+	u->anim_comp().reset_affect_distant(gui);
 	units.move(u->get_location(), rev_route.back());
 	unit::clear_status_caches();
-	reset_adjacent(halo_adjacent, units, rev_route.back());
+	u->anim_comp().reset_affect_distant(gui);
 
 	// Restore the unit's old state.
 	u = units.find(rev_route.back());

--- a/src/actions/unit_creator.cpp
+++ b/src/actions/unit_creator.cpp
@@ -185,6 +185,7 @@ void unit_creator::add_unit(const config &cfg, const vconfig* vcfg)
 		map_location loc = find_location(temp_cfg, new_unit.get());
 		if ( loc.valid() ) {
 			//add the new unit to map
+			board_->unit_distant_replace(loc, new_unit);
 			board_->units().replace(loc, new_unit);
 			LOG_NG << "inserting unit for side " << new_unit->side();
 			post_create(loc,*(board_->units().find(loc)),animate,fire_event);
@@ -199,6 +200,7 @@ void unit_creator::add_unit(const config &cfg, const vconfig* vcfg)
 		//get unit from recall list
 		map_location loc = find_location(temp_cfg, recall_list_element.get());
 		if ( loc.valid() ) {
+			board_->unit_distant_replace(loc, recall_list_element);
 			board_->units().replace(loc, recall_list_element);
 			LOG_NG << "inserting unit from recall list for side " << recall_list_element->side()<< " with id="<< id;
 			//if id is not empty, delete units with this ID from recall list

--- a/src/display_context.hpp
+++ b/src/display_context.hpp
@@ -37,6 +37,7 @@ public:
 	virtual const std::vector<team> & teams() const = 0;
 	virtual const gamemap & map() const = 0;
 	virtual const unit_map & units() const = 0;
+	virtual const unit_map & units_distant() const = 0;
 	virtual const std::vector<std::string> & hidden_label_categories() const = 0;
 	virtual std::vector<std::string> & hidden_label_categories() = 0;
 

--- a/src/editor/map/map_context.hpp
+++ b/src/editor/map/map_context.hpp
@@ -122,6 +122,7 @@ public:
 
 	// Import symbols from base class.
 	using display_context::units;
+	using display_context::units_distant;
 	using display_context::teams;
 	using display_context::map;
 
@@ -135,6 +136,16 @@ public:
 	unit_map& units()
 	{
 		return units_;
+	}
+
+	virtual const unit_map& units_distant() const override
+	{
+		return units_distant_;
+	}
+
+	unit_map& units_distant()
+	{
+		return units_distant_;
 	}
 
 	/** Const teams accessor. */
@@ -508,6 +519,7 @@ private:
 
 	map_labels labels_;
 	unit_map units_;
+	unit_map units_distant_;
 	std::vector<team> teams_;
 	std::vector<std::string> lbl_categories_;
 	std::unique_ptr<tod_manager> tod_manager_;

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -40,6 +40,7 @@ game_board::game_board(const config& level)
 	, map_(std::make_unique<gamemap>(level["map_data"]))
 	, unit_id_manager_(level["next_underlying_unit_id"].to_size_t())
 	, units_()
+	, units_distant_()
 {
 }
 
@@ -49,6 +50,7 @@ game_board::game_board(const game_board& other)
 	, map_(new gamemap(*(other.map_)))
 	, unit_id_manager_(other.unit_id_manager_)
 	, units_(other.units_)
+	, units_distant_(other.units_distant_)
 {
 }
 
@@ -63,6 +65,7 @@ void swap(game_board& one, game_board& other)
 {
 	std::swap(one.teams_, other.teams_);
 	std::swap(one.units_, other.units_);
+	std::swap(one.units_distant_, other.units_distant_);
 	std::swap(one.unit_id_manager_, other.unit_id_manager_);
 	one.map_.swap(other.map_);
 }

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -51,6 +51,8 @@ class game_board : public display_context
 	std::unique_ptr<gamemap> map_;
 	n_unit::id_manager unit_id_manager_;
 	unit_map units_;
+	unit_map units_distant_;
+
 
 	/**
 	 * Temporary unit move structs:
@@ -114,6 +116,15 @@ public:
 		return units_;
 	}
 
+	unit_map& units_distant()
+	{
+		return units_distant_;
+	}
+
+	void unit_distant(const unit_ptr& u);
+
+	void unit_distant_replace(const map_location& loc, const unit_ptr& u);
+
 	virtual const std::vector<std::string>& hidden_label_categories() const override
 	{
 		return labels_;
@@ -130,6 +141,7 @@ public:
 	game_board& operator=(const game_board& other) = delete;
 
 	friend void swap(game_board & one, game_board & other);
+
 
 	// Saving
 

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -116,6 +116,11 @@ public:
 		return units_;
 	}
 
+	virtual const unit_map& units_distant() const override
+	{
+		return units_distant_;
+	}
+
 	unit_map& units_distant()
 	{
 		return units_distant_;

--- a/src/pathfind/teleport.cpp
+++ b/src/pathfind/teleport.cpp
@@ -77,6 +77,7 @@ public:
 		um_ = &empty_unit_map;
 	}
 	const unit_map & units() const override { return *um_; }
+	const unit_map & units_distant() const override { return *udm_; }
 	const gamemap & map() const override { return *gm_; }
 	const std::vector<team> & teams() const override { return *tm_; }
 	const std::vector<std::string> & hidden_label_categories() const override { return *lbls_; }
@@ -84,6 +85,7 @@ public:
 
 private:
 	const unit_map * um_;
+	const unit_map * udm_;
 	const gamemap * gm_;
 	const std::vector<team> * tm_;
 	const std::vector<std::string> * lbls_;

--- a/src/scripting/game_lua_kernel.hpp
+++ b/src/scripting/game_lua_kernel.hpp
@@ -52,6 +52,7 @@ class game_lua_kernel : public lua_kernel_base
 
 	// Private functions to ease access to parts of game_state
 	unit_map & units();
+	unit_map & units_distant();
 	game_data & gamedata();
 	tod_manager & tod_man();
 

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -483,8 +483,10 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_unit, child, /*spectator*/)
 			// Don't remove the unit until after we've verified there are no errors in creating the new one,
 			// or else the unit would simply be removed from the map with no replacement.
 			resources::gameboard->units().erase(loc);
+			resources::gameboard->units_distant().erase(loc);
 			resources::whiteboard->on_kill_unit();
 			resources::gameboard->units().insert(new_u);
+			resources::gameboard->unit_distant(new_u);
 		} catch(const unit_type::error& e) {
 			ERR_REPLAY << e.what(); // TODO: more appropriate error message log
 			return false;
@@ -524,7 +526,9 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child, spectator)
 	unit_map::unit_iterator unit_it;
 
 	// Add the unit to the board.
+	resources::gameboard->unit_distant_replace(loc, created);
 	std::tie(unit_it, std::ignore) = resources::gameboard->units().replace(loc, created);
+
 
 	game_display::get_singleton()->invalidate_unit();
 	resources::game_events->pump().fire("unit_placed", loc);
@@ -593,7 +597,9 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_kill, child, /*spectator*/)
 		}
 		resources::controller->pump().fire("die", loc, loc);
 		if (i.valid()) {
+            resources::gameboard->units_distant().erase(i);
 			resources::gameboard->units().erase(i);
+
 		}
 		resources::whiteboard->on_kill_unit();
 		actions::recalculate_fog(dying_side);

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -177,7 +177,7 @@ const unit_map& get_unit_distant_map()
 
 	// If we get here, we're in the scenario editor
 	assert(display::get_singleton());
-	return display::get_singleton()->context().units();
+	return display::get_singleton()->context().units_distant();
 }
 
 const team& get_team(std::size_t side)

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -134,6 +134,25 @@ A poisoned unit cannot be cured of its poison by a healer, and must seek the car
  *
  */
 
+ void game_board::unit_distant(const unit_ptr& u)
+{
+	for(const auto [key, cfg] : u->abilities().all_children_view()) {
+		if(cfg.has_child("affect_distant")){
+			units_distant().insert(u);
+			break;
+		}
+	}
+}
+
+void game_board::unit_distant_replace(const map_location& loc, const unit_ptr& u)
+{
+	for(const auto [key, cfg] : u->abilities().all_children_view()) {
+		if(cfg.has_child("affect_distant")){
+			units_distant().replace(loc, u);
+			break;
+		}
+	}
+}
 
 namespace {
 
@@ -142,6 +161,18 @@ const unit_map& get_unit_map()
 	// Used if we're in the game, including during the construction of the display_context
 	if(resources::gameboard) {
 		return resources::gameboard->units();
+	}
+
+	// If we get here, we're in the scenario editor
+	assert(display::get_singleton());
+	return display::get_singleton()->context().units();
+}
+
+const unit_map& get_unit_distant_map()
+{
+	// Used if we're in the game, including during the construction of the display_context
+	if(resources::gameboard) {
+		return resources::gameboard->units_distant();
 	}
 
 	// If we get here, we're in the scenario editor
@@ -213,6 +244,17 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 			}
 		}
 	}
+	const unit_map& units_distant = get_unit_distant_map();
+	for(const unit& unit_itor : units_distant){
+		if (unit_itor.incapacitated() || &(unit_itor) == this) {
+			continue;
+		}
+		for(const config& i : unit_itor.abilities_.child_range(tag_name)) {
+			if(get_dist_ability_bool(i, tag_name, loc, unit_itor, unit_itor.get_location())){
+				return true;
+			}
+		}
+	}
 
 
 	return false;
@@ -246,6 +288,18 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 		for(const config& j : it->abilities_.child_range(tag_name)) {
 			if(get_adj_ability_bool(j, tag_name, i, loc,*it)) {
 				res.emplace_back(&j, loc, adjacent[i]);
+			}
+		}
+	}
+
+	const unit_map& units_distant = get_unit_distant_map();
+	for(const unit& unit_itor : units_distant){
+		if (unit_itor.incapacitated() || &(unit_itor) == this) {
+			continue;
+		}
+		for(const config& i : unit_itor.abilities_.child_range(tag_name)) {
+			if(get_dist_ability_bool(i, tag_name, loc, unit_itor, unit_itor.get_location())){
+				res.emplace_back(&i, loc, unit_itor.get_location());
 			}
 		}
 	}
@@ -521,6 +575,44 @@ bool unit::ability_affects_adjacent(const std::string& ability, const config& cf
 	return false;
 }
 
+bool unit::ability_affects_distant(const std::string& ability, const config& cfg, const map_location& loc, const unit& from, const map_location& from_loc) const
+{
+	unsigned int radius = 0;
+	bool illuminates = ability == "illuminates";
+	for (const config &i : cfg.child_range("affect_distant"))
+	{
+		radius = i["radius"].to_int(0);
+		if(radius == 0){
+			continue;
+		}
+		unsigned int distance = distance_between(from_loc, loc);
+		if(distance > radius){
+			continue;
+		}
+		auto filter = i.optional_child("filter");
+		if (!filter || //filter tag given
+			unit_filter(vconfig(*filter)).set_use_flat_tod(illuminates).matches(*this, loc, from) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool unit::get_dist_ability_bool(const config& cfg, const std::string& ability, const map_location& loc, const unit& from, const map_location& from_loc) const
+{
+	auto filter_lock = from.update_variables_recursion(cfg);
+	if(!filter_lock) {
+		show_recursion_warning(from, cfg);
+		return false;
+	}
+	return (ability_affects_distant(ability, cfg, loc, from, from_loc) && affects_side(cfg, side(), from.side()) && from.ability_active_impl(ability, cfg, from_loc));
+}
+
+bool unit::get_dist_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
+{
+	return (get_dist_ability_bool(special, tag_name, loc, from, from_loc) && ability_affects_weapon(special, weapon, false) && ability_affects_weapon(special, opp_weapon, true));
+}
+
 bool unit::ability_affects_self(const std::string& ability,const config& cfg,const map_location& loc) const
 {
 	auto filter = cfg.optional_child("filter_self");
@@ -591,6 +683,19 @@ std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_t
 			continue;
 		for(const auto [key, cfg] : it->abilities_.all_children_view()) {
 			if(!cfg[image_type + "_image"].str().empty() && affects_side(cfg, side(), it->side()) && it->ability_active(key, cfg, adjacent[i]) && ability_affects_adjacent(key, cfg, i, loc_, *it))
+			{
+				add_string_to_vector(image_list, cfg, image_type + "_image");
+			}
+		}
+	}
+
+	const unit_map& units_distant = get_unit_distant_map();
+	for(const unit& unit_itor : units_distant){
+		if (unit_itor.incapacitated() || &(unit_itor) == this) {
+			continue;
+		}
+		for(const auto [key, cfg] : unit_itor.abilities_.all_children_view()) {
+			if(!cfg[image_type + "_image"].str().empty() && get_dist_ability_bool(cfg, key, loc_, unit_itor, unit_itor.get_location()))
 			{
 				add_string_to_vector(image_list, cfg, image_type + "_image");
 			}
@@ -1785,6 +1890,26 @@ bool attack_type::check_adj_abilities_impl(const const_attack_ptr& self_attack, 
 	}
 	return false;
 }
+
+bool attack_type::check_dist_abilities(const config& cfg, const std::string& special, const unit& from, const map_location& from_loc) const
+{
+	return check_dist_abilities_impl(shared_from_this(), other_attack_, cfg, self_, from, self_loc_, from_loc, AFFECT_SELF, special, "filter_student");
+}
+
+bool attack_type::check_dist_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const config& special, const unit_const_ptr& u, const unit& from, const map_location& loc, const map_location& from_loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
+{
+	if(tag_name == "leadership" && leader_bool){
+		if((*u).get_dist_ability_bool_weapon(special, tag_name, loc, from, from_loc, self_attack, other_attack)) {
+			return true;
+		}
+	}
+	if((*u).checking_tags().count(tag_name) != 0){
+		if((*u).get_dist_ability_bool(special, tag_name, loc, from, from_loc) && special_active_impl(self_attack, other_attack, special, whom, tag_name, "filter_student")) {
+			return true;
+		}
+	}
+	return false;
+}
 /**
  * Returns whether or not @a *this has a special ability with a tag or id equal to
  * @a special. the Check is for a special ability
@@ -1794,6 +1919,7 @@ bool attack_type::check_adj_abilities_impl(const const_attack_ptr& self_attack, 
 bool attack_type::has_weapon_ability(const std::string& special, bool special_id, bool special_tags) const
 {
 	const unit_map& units = get_unit_map();
+	const unit_map& units_distant = get_unit_distant_map();
 	if(self_){
 		std::vector<special_match> special_tag_matches_self;
 		std::vector<special_match> special_id_matches_self;
@@ -1834,6 +1960,29 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 			if(special_id){
 				for(const special_match& entry : special_id_matches_adj) {
 					if(check_adj_abilities(*entry.cfg, entry.tag_name, i , *it)){
+						return true;
+					}
+				}
+			}
+		}
+		for(const unit& unit_itor : units_distant){
+			if (unit_itor.incapacitated() || &(unit_itor) == self_.get()) {
+				continue;
+			}
+
+			std::vector<special_match> special_tag_matches_dist;
+			std::vector<special_match> special_id_matches_dist;
+			get_ability_children(special_tag_matches_dist, special_id_matches_dist, unit_itor.abilities(), special, special_id , special_tags);
+			if(special_tags){
+				for(const special_match& entry : special_tag_matches_dist) {
+					if(check_dist_abilities(*entry.cfg, entry.tag_name, unit_itor, unit_itor.get_location())){
+						return true;
+					}
+				}
+			}
+			if(special_id){
+				for(const special_match& entry : special_id_matches_dist) {
+					if(check_dist_abilities(*entry.cfg, entry.tag_name, unit_itor, unit_itor.get_location())){
 						return true;
 					}
 				}
@@ -1883,6 +2032,29 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 			if(special_id){
 				for(const special_match& entry : special_id_matches_oadj) {
 					if(check_adj_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, *it, i, other_loc_, AFFECT_OTHER, entry.tag_name)){
+						return true;
+					}
+				}
+			}
+		}
+		for(const unit& unit_itor : units_distant){
+			if (unit_itor.incapacitated() || &(unit_itor) == other_.get()) {
+				continue;
+			}
+
+			std::vector<special_match> special_tag_matches_odist;
+			std::vector<special_match> special_id_matches_odist;
+			get_ability_children(special_tag_matches_odist, special_id_matches_odist, unit_itor.abilities(), special, special_id , special_tags);
+			if(special_tags){
+				for(const special_match& entry : special_tag_matches_odist) {
+					if(check_dist_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, unit_itor, other_loc_, unit_itor.get_location(), AFFECT_OTHER, entry.tag_name)){
+						return true;
+					}
+				}
+			}
+			if(special_id){
+				for(const special_match& entry : special_id_matches_odist) {
+					if(check_dist_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, unit_itor, other_loc_, unit_itor.get_location(), AFFECT_OTHER, entry.tag_name)){
 						return true;
 					}
 				}
@@ -2140,6 +2312,7 @@ bool attack_type::has_ability_with_filter(const config & filter) const
 		return false;
 	}
 	const unit_map& units = get_unit_map();
+	const unit_map& units_distant = get_unit_distant_map();
 	if(self_){
 		for(const auto [key, cfg] : (*self_).abilities().all_children_view()) {
 			if(self_->ability_matches_filter(cfg, key, filter)){
@@ -2163,6 +2336,17 @@ bool attack_type::has_ability_with_filter(const config & filter) const
 				}
 			}
 		}
+		for(const unit& unit_itor : units_distant){
+			if (unit_itor.incapacitated() || &(unit_itor) == self_.get()) {
+				continue;
+			}
+
+			for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+				if(unit_itor.ability_matches_filter(cfg, key, filter) && check_dist_abilities(cfg, key, unit_itor, unit_itor.get_location())){
+					return true;
+				}
+			}
+		}
 	}
 
 	if(other_){
@@ -2182,6 +2366,17 @@ bool attack_type::has_ability_with_filter(const config & filter) const
 
 			for(const auto [key, cfg] : it->abilities().all_children_view()) {
 				if(it->ability_matches_filter(cfg, key, filter) && check_adj_abilities_impl(other_attack_, shared_from_this(), cfg, other_, *it, i, other_loc_, AFFECT_OTHER, key)){
+					return true;
+				}
+			}
+		}
+		for(const unit& unit_itor : units_distant){
+			if (unit_itor.incapacitated() || &(unit_itor) == other_.get()) {
+				continue;
+			}
+
+			for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+				if(unit_itor.ability_matches_filter(cfg, key, filter) && check_dist_abilities_impl(other_attack_, shared_from_this(), cfg, other_, unit_itor, other_loc_, unit_itor.get_location(), AFFECT_OTHER, key)){
 					return true;
 				}
 			}

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -106,6 +106,9 @@ public:
 	/** Resets the animations list after the unit is advanced. */
 	void reset_after_advance(const unit_type * newtype = nullptr);
 
+	/** Refresh map around unit if has ability with [affect_adjacent/distant] tag */
+	void reset_affect_distant(const display & disp);
+
 	/** Adds an animation described by a config. Uses an internal cache to avoid redoing work. */
 	void apply_new_animation_effect(const config & effect);
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -271,6 +271,14 @@ private:
 	 * @param from unit adjacent to self_ is checked.
 	 */
 	bool check_adj_abilities(const config& cfg, const std::string& special, int dir, const unit& from) const;
+	/** check_dist_abilities : return an boolean value for checking of activities of abilities used like weapon
+	 * @return True if the special @a special is active.
+	 * @param cfg the config to one special ability checked.
+	 * @param special The special ability type who is being checked.
+	 * @param from unit distant to self_ is checked.
+	 * @param from_loc location of @ from
+	 */
+	bool check_dist_abilities(const config& cfg, const std::string& special, const unit& from, const map_location& from_loc) const;
 	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool in_abilities_tag = false) const;
 
@@ -356,6 +364,32 @@ private:
 		AFFECTS whom,
 		const std::string& tag_name,
 		bool leader_bool=false
+	);
+
+	/** check_dist_abilities_impl : return an boolean value for checking of activities of abilities used like weapon in unit adjacent to fighter
+	 * @return True if the special @a tag_name is active.
+	 * @param self_attack the attack used by unit who fight.
+	 * @param other_attack the attack used by opponent.
+	 * @param special the config to one special ability checked.
+	 * @param u the unit who is or not affected by an abilities owned by @a from.
+	 * @param from unit distant to @a u is checked.
+	 * @param loc location of the unit checked.
+	 * @param from_loc location of the unit distant to @a u.
+	 * @param whom determine if unit affected or not by special ability.
+	 * @param tag_name The special ability type who is being checked.
+	 * @param leader_bool If true, [leadership] abilities are checked.
+	 */
+	static bool check_dist_abilities_impl(
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
+		const config& special,
+		const unit_const_ptr& u,
+		const unit& from,
+		const map_location& loc,
+		const map_location& from_loc,
+		AFFECTS whom,
+		const std::string& tag_name,
+		bool leader_bool = false
 	);
 
 	static bool special_active_impl(

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -441,6 +441,18 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					}
+					for(const unit& unit_itor : units){
+						if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+							continue;
+						}
+						std::vector<ability_match> ability_id_matches_dist;
+						get_ability_children_id(ability_id_matches_dist, unit_itor.abilities(), ability);
+						for(const ability_match& entry : ability_id_matches_dist) {
+							if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, unit_itor, unit_itor.get_location())){
+								return true;
+							}
+						}
+					}
 				}
 				return false;
 			}
@@ -815,6 +827,16 @@ void unit_filter_compound::fill(const vconfig& cfg)
 									if (args.u.get_adj_ability_bool(cfg, key, i, args.loc, *it)) {
 										return true;
 									}
+								}
+							}
+						}
+						for(const unit& unit_itor : units){
+							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+								continue;
+							}
+							for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+								if(args.u.get_dist_ability_bool(cfg, key, args.loc, unit_itor, unit_itor.get_location())){
+									return true;
 								}
 							}
 						}

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -441,7 +441,8 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					}
-					for(const unit& unit_itor : units){
+					const unit_map& units_distant = args.context().get_disp_context().units_distant();
+					for(const unit& unit_itor : units_distant){
 						if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
 							continue;
 						}
@@ -830,7 +831,8 @@ void unit_filter_compound::fill(const vconfig& cfg)
 								}
 							}
 						}
-						for(const unit& unit_itor : units){
+						const unit_map& units_distant = args.context().get_disp_context().units_distant();
+						for(const unit& unit_itor : units_distant){
 							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
 								continue;
 							}

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -90,6 +90,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 		animator.add_animation(temp_unit.shared_from_this(),"pre_teleport",a);
 		animator.start_animations();
 		animator.wait_for_end();
+		temp_unit.anim_comp().reset_affect_distant(disp);
 	}
 
 	temp_unit.set_location(b);
@@ -104,6 +105,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 		animator.add_animation(temp_unit.shared_from_this(),"post_teleport",b);
 		animator.start_animations();
 		animator.wait_for_end();
+		temp_unit.anim_comp().reset_affect_distant(disp);
 	}
 
 	temp_unit.anim_comp().set_standing();
@@ -260,6 +262,7 @@ void unit_mover::start(const unit_ptr& u)
 	if ( !can_draw_ )
 		return;
 	// If no animation then hide unit until end of movement
+	(*u).anim_comp().reset_affect_distant(*disp_);
 	if ( !animate_ ) {
 		was_hidden_ = u->get_hidden();
 		u->set_hidden(true);
@@ -380,6 +383,7 @@ void unit_mover::proceed_to(const unit_ptr& u, std::size_t path_index, bool upda
 	u->anim_comp().set_standing(false);	// Need to reset u's animation so the new facing takes effect.
 	// Remember the unit to unhide when the animation finishes.
 	shown_unit_ = u;
+	(*u).anim_comp().reset_affect_distant(*disp_);
 	if ( wait )
 		wait_for_anims();
 }
@@ -464,6 +468,7 @@ void unit_mover::finish(const unit_ptr& u, map_location::direction dir)
 		// Switch the display back to the real unit.
 		u->set_hidden(was_hidden_);
 		temp_unit_ptr_->set_hidden(true);
+		(*u).anim_comp().reset_affect_distant(*disp_);
 
 		if(events::mouse_handler* mousehandler = events::mouse_handler::get_singleton()) {
 			mousehandler->invalidate_reachmap();
@@ -589,6 +594,7 @@ void unit_die(const map_location& loc, unit& loser,
 	if(events::mouse_handler* mousehandler = events::mouse_handler::get_singleton()) {
 		mousehandler->invalidate_reachmap();
 	}
+	loser.anim_comp().reset_affect_distant(*disp);
 }
 
 
@@ -837,6 +843,7 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 			}
 		}
 	}
+	(*u).anim_comp().reset_affect_distant(*disp);
 	animator.add_animation(u.get_shared_ptr(), "recruited", loc, leader_loc);
 	animator.start_animations();
 	animator.wait_for_end();

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1788,6 +1788,27 @@ public:
 	 */
 	bool get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const const_attack_ptr& weapon=nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 
+	/** Checks whether this unit is affected by a given ability, and that that ability is active.
+	 * @return True if the ability @a tag_name is active.
+	 * @param cfg the const config to one of abilities @a ability checked.
+	 * @param ability name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit distant to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc the 'other unit' location.
+	 */
+	bool get_dist_ability_bool(const config& cfg, const std::string& ability, const map_location& loc, const unit& from, const map_location& from_loc) const;
+	/** Checks whether this unit is affected by a given ability of leadership type
+	 * @return True if the ability @a tag_name is active.
+	 * @param special the const config to one of abilities @a tag_name checked.
+	 * @param tag_name name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit adjacent to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc location of the @a from unit.
+	 * @param weapon the attack used by unit checked in this function.
+	 * @param opp_weapon the attack used by opponent to unit checked.
+	 */
+	bool get_dist_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const;
+
 	/**
 	 * Gets the unit's active abilities of a particular type if it were on a specified location.
 	 * @param tag_name The type of ability to check for
@@ -1947,6 +1968,15 @@ private:
 	 */
 	bool ability_affects_adjacent(const std::string& ability, const config& cfg, int dir, const map_location& loc, const unit& from) const;
 
+	/**
+	 * Check if an ability affects distant units.
+	 * @param ability The type (tag name) of the ability
+	 * @param cfg an ability WML structure
+	 * @param loc The location on which to resolve the ability
+	 * @param from The "other unit" for filter matching
+	 * @param from_loc the "other unit" location
+	 */
+	bool ability_affects_distant(const std::string& ability, const config& cfg, const map_location& loc, const unit& from, const map_location& from_loc) const;
 	/**
 	 * Check if an ability affects the owning unit.
 	 * @param ability The type (tag name) of the ability

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -424,6 +424,10 @@
 0 filter_ability_special_id_active
 0 affect_distant_active
 0 affect_distant_inactive
+0 affect_distant_active_with_second_ability
+0 affect_distant_active_with_second_ability_type
+0 affect_distant_inactive_with_second_ability
+0 affect_distant_inactive_with_second_ability_type
 0 filter_special_id_not_exists
 0 special_id_active_lua_function
 0 leadership_when_other_has_special

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -422,6 +422,8 @@
 0 filter_adjacent_direction_inactive
 0 filter_special_id_active
 0 filter_ability_special_id_active
+0 affect_distant_active
+0 affect_distant_inactive
 0 filter_special_id_not_exists
 0 special_id_active_lua_function
 0 leadership_when_other_has_special


### PR DESCRIPTION

like [affect_adjacent] this tag affects other units than the owner of the ability but this time, it concerns units in a units_distant map for don't lower performances

I had already tried to make one a few years ago but the code was too heavy and I had given up.