### PR TITLE
add a tag [affect_distant] to abilities(version 3)

### DIFF
--- a/changelog_entries/add_affect_distant.md
+++ b/changelog_entries/add_affect_distant.md
@@ -1,0 +1,2 @@
+### WML Engine
+* add a [affect_distant]radius= tag for affect units distant to owner of ability.

--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -128,109 +128,21 @@
 #enddef
 
 #define ABILITY_SHADOW_VEIL
-    [dummy]
+    [hides]
         id=did_shadow_veil
         name= _ "shadow veil"
         name_inactive= _ "shadow veil"
         description= _ "Allied undead units within a 5 hex radius are hidden."
         description_inactive= _ "Allied undead units within a 5 hex radius are hidden."
-        {DID_SHADOW_VEIL_HANDLER}
-    [/dummy]
-#enddef
-
-#define ABILITY_SHADOW_VEIL_HELPER SIDE
-    [hides]
-        id=did_shadow_veil_helper
-        [filter]
-            [filter_location]
-                radius=5
-                [filter]
-                    ability=did_shadow_veil
-                    [filter_side]
-                        [allied_with]
-                            side={SIDE}
-                        [/allied_with]
-                    [/filter_side]
-                [/filter]
-            [/filter_location]
-        [/filter]
-    [/hides]
-#enddef
-
-#define DID_SHADOW_VEIL_HANDLER
-    [event]
-        id=did_shadow_veil_unit_placed
-        name=unit placed
-        first_time_only=no
-        [filter]
-            side=1
-            race=undead
-            [not]
-                ability=did_shadow_veil_helper
-            [/not]
-        [/filter]
-        [filter_condition]
-            [have_unit]
-                ability=did_shadow_veil
-                side=1
-            [/have_unit]
-        [/filter_condition]
-        [modify_unit]
-            [filter]
-                x,y=$x1,$y1
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-            [/filter]
-            [object]
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
-    [event]
-        id=did_shadow_veil_malkeshar
-        name=post advance
-        first_time_only=yes
-        [filter]
-            type=Mal Keshar
-            ability=did_shadow_veil
-        [/filter]
-        [modify_unit]
+        affect_self=no
+        affect_allies=yes
+        [affect_distant]
+            radius=5
             [filter]
                 race=undead
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-                [filter_side]
-                    [allied_with]
-                        side=$unit.side
-                    [/allied_with]
-                [/filter_side]
             [/filter]
-            [object]
-                take_only_once=no
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $this_unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
+        [/affect_distant]
+    [/hides]
 #enddef
 
 #define WEAPON_SPECIAL_FROST_NOVA

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -40,6 +40,11 @@
 		[/key]
 		{FILTER_TAG "filter" unit ()}
 	[/tag]
+	[tag]
+		name="affect_distant"
+		{SIMPLE_KEY radius s_int}
+		{FILTER_TAG "filter" unit ()}
+	[/tag]
 	{FILTER_TAG "filter_self" unit ()}
 	{FILTER_TAG "filter_adjacent" adjacent ()}
 	{FILTER_TAG "filter_adjacent_location" adjacent_location ()}

--- a/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
+++ b/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
@@ -1,0 +1,74 @@
+#textdomain wesnoth-test
+
+##
+# Starting state:
+#
+# Side 1 leader Alice (Orcish Grunt)
+# Side 2 leader Bob (Orcish Grunt)
+# Side 3 leader Charlie (Orcish Grunt)
+# Side 4 leader Dave (Orcish Grunt)
+#
+# None of the sides are allied.
+#
+# On the default map (used unless overridden with the MAP_FILE argument:
+# * All four leaders are on a single keep, with Alice and Bob already in position to attack any of the other units.
+# * There is no free castle hex to recruit onto.
+##
+#define SEPARATE_KEEP_A_B_C_D_UNIT_TEST NAME CONTENT
+
+#arg SIDE_LEADER
+Orcish Grunt#endarg
+
+#arg MAP_FILE
+test/maps/4p_separate_castles.map#endarg
+
+    [test]
+        name=_ "Unit Test " + {NAME}
+        map_file={MAP_FILE}
+        turns=unlimited
+        id={NAME}
+        random_start_time=no
+        is_unit_test=yes
+
+        {DAWN}
+
+        [side]
+            side=1
+            controller=human
+            [leader]
+                name = _ "Alice"
+                type = {SIDE_LEADER}
+                id=alice
+            [/leader]
+        [/side]
+        [side]
+            side=2
+            controller=human
+            [leader]
+                name = _ "Bob"
+                type = {SIDE_LEADER}
+                id=bob
+            [/leader]
+        [/side]
+        [side]
+            side=3
+            controller=human
+            [leader]
+                name = _ "Charlie"
+                type = {SIDE_LEADER}
+                id=charlie
+            [/leader]
+        [/side]
+        [side]
+            side=4
+            controller=human
+            [leader]
+                name = _ "Dave"
+                type = {SIDE_LEADER}
+                id=dave
+            [/leader]
+        [/side]
+
+        {CONTENT}
+    [/test]
+#enddef

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
@@ -1,0 +1,54 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 10 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should affect alice.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 10 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=10
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alice
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
@@ -1,0 +1,121 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 7"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=7
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alex
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
@@ -1,0 +1,57 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 1 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alice.
+#####
+
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 1 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=1
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alice
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
@@ -1,0 +1,125 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 5"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alex
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY

--- a/src/actions/advancement.cpp
+++ b/src/actions/advancement.cpp
@@ -389,10 +389,12 @@ void advance_unit(map_location loc, const advancement_option &advance_to, bool f
 		prefs::get().encountered_units().insert(new_unit->type_id());
 		LOG_CF << "Added '" << new_unit->type_id() << "' to the encountered units.";
 	}
+	u->set_affect_distant(false);
 	u->anim_comp().clear_haloes();
 	resources::gameboard->units().erase(loc);
 	resources::whiteboard->on_kill_unit();
 	u = resources::gameboard->units().insert(new_unit).first;
+	u->set_affect_distant(true);
 
 	// Update fog/shroud.
 	actions::shroud_clearer clearer;

--- a/src/actions/attack.cpp
+++ b/src/actions/attack.cpp
@@ -1298,6 +1298,7 @@ void attack::unit_killed(unit_info& attacker,
 		return;
 	}
 
+	defender.get_unit().set_affect_distant(false);
 	units_.erase(defender.loc_);
 	resources::whiteboard->on_kill_unit();
 
@@ -1325,6 +1326,7 @@ void attack::unit_killed(unit_info& attacker,
 
 			newunit->set_location(death_loc);
 			units_.insert(newunit);
+			newunit->set_affect_distant(true);
 
 			game_events::entity_location reanim_loc(defender.loc_, newunit->underlying_id());
 			resources::game_events->pump().fire("unit_placed", reanim_loc);

--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -643,6 +643,7 @@ place_recruit_result place_recruit(const unit_ptr& u, const map_location &recrui
 	// Add the unit to the board.
 	auto [new_unit_itor, success] = resources::gameboard->units().insert(u);
 	assert(success);
+	u->set_affect_distant(true);
 
 	map_location current_loc = recruit_location;
 

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -56,25 +56,6 @@ void move_action::write(config & cfg) const
 }
 
 /**
- * Reset halo of adjacent units when undo move.
- */
-static void reset_adjacent(bool& halo_adjacent, unit_map& units, const map_location& loc)
-{
-	if(halo_adjacent){
-		unit_map::iterator u = units.find(loc);
-		const auto adjacent = get_adjacent_tiles(loc);
-		for(unsigned i = 0; i < adjacent.size(); ++i) {
-			const unit_map::const_iterator it = units.find(adjacent[i]);
-			if (it == units.end() || it->incapacitated())
-				continue;
-			if ( &*it == &*u )
-				continue;
-			it->anim_comp().set_standing();
-		}
-	}
-}
-
-/**
  * Undoes this action.
  * @return true on success; false on an error.
  */
@@ -103,17 +84,10 @@ bool move_action::undo(int)
 
 	// Move the unit.
 	unit_display::move_unit(rev_route, u.get_shared_ptr(), true, starting_dir);
-	bool halo_adjacent = false;
-	for(const auto [_, cfg] : u->abilities().all_children_view()){
-		if(!cfg["halo_image"].empty() && cfg.has_child("affect_adjacent")){
-			halo_adjacent = true;
-			break;
-		}
-	}
-	reset_adjacent(halo_adjacent, units, rev_route.front());
+	u->anim_comp().reset_affect_adjacent(gui);
 	units.move(u->get_location(), rev_route.back());
 	unit::clear_status_caches();
-	reset_adjacent(halo_adjacent, units, rev_route.back());
+	u->anim_comp().reset_affect_adjacent(gui);
 
 	// Restore the unit's old state.
 	u = units.find(rev_route.back());

--- a/src/game_board.cpp
+++ b/src/game_board.cpp
@@ -182,6 +182,34 @@ void game_board::check_victory(bool& continue_level,
 	continue_level = false;
 }
 
+void game_board::set_affect_distant(const std::string& tag_name, bool increase)
+{
+	if(increase){
+		affect_distant_[tag_name] += 1;
+		affect_distant_for_filtering_ += 1;
+	}
+	else {
+		if(affect_distant_[tag_name] > 0){
+			affect_distant_[tag_name] -= 1;
+		}
+		if(affect_distant_for_filtering_ > 0){
+			affect_distant_for_filtering_ -= 1;
+		}
+	}
+}
+
+void game_board::set_affect_distant_image(bool increase)
+{
+	if(increase){
+		affect_distant_for_image_ += 1;
+	}
+	else {
+		if(affect_distant_for_image_ > 0){
+			affect_distant_for_image_ -= 1;
+		}
+	}
+}
+
 unit_map::iterator game_board::find_visible_unit(const map_location& loc, const team& current_team, bool see_all)
 {
 	if(!map_->on_board(loc)) {

--- a/src/game_board.hpp
+++ b/src/game_board.hpp
@@ -53,6 +53,17 @@ class game_board : public display_context
 	unit_map units_;
 
 	/**
+	 * Variables used for define radius for abilities [affect_distant]radius= checking.
+	 *
+	 * @ affect_distant_ is used for checking in abilities of defined type.
+	 * @ affect_distant_for_filtering_ used when checking abilities in [filter] or animations.
+	 * @ affect_distant_for_image_ define radius for images in abilities.
+	 **/
+	std::map<std::string, int> affect_distant_;
+	int affect_distant_for_filtering_;
+	int affect_distant_for_image_;
+
+	/**
 	 * Temporary unit move structs:
 	 *
 	 * Probably don't remove these friends, this is actually fairly useful. These structs are used by:
@@ -130,6 +141,13 @@ public:
 	game_board& operator=(const game_board& other) = delete;
 
 	friend void swap(game_board & one, game_board & other);
+
+	//when used define radius max for check unit who own a ability with [affect_distant] tag.
+	int affect_distant(const std::string& value){return affect_distant_[value];}
+	int affect_distant_for_filtering() const {return affect_distant_for_filtering_;}
+	int affect_distant_for_image() const {return affect_distant_for_image_;}
+	void set_affect_distant(const std::string& tag_name, bool increase);
+	void set_affect_distant_image(bool increase);
 
 	// Saving
 

--- a/src/scripting/lua_unit.cpp
+++ b/src/scripting/lua_unit.cpp
@@ -98,8 +98,10 @@ bool lua_unit::put_map(const map_location &loc)
 		if (ui != resources::gameboard->units().end()) {
 			map_location from = ui->get_location();
 			if (from != loc) { // This check is redundant in current usage
+				ui->set_affect_distant(false);
 				resources::gameboard->units().erase(loc);
 				resources::gameboard->units().move(from, loc);
+				ui->set_affect_distant(true);
 			}
 			// No need to change our contents
 		} else {

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -482,9 +482,13 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_unit, child, /*spectator*/)
 			new_u->set_location(loc);
 			// Don't remove the unit until after we've verified there are no errors in creating the new one,
 			// or else the unit would simply be removed from the map with no replacement.
+			if(i){
+				i->set_affect_distant(false);
+			}
 			resources::gameboard->units().erase(loc);
 			resources::whiteboard->on_kill_unit();
 			resources::gameboard->units().insert(new_u);
+			new_u->set_affect_distant(true);
 		} catch(const unit_type::error& e) {
 			ERR_REPLAY << e.what(); // TODO: more appropriate error message log
 			return false;
@@ -525,6 +529,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_create_unit, child, spectator)
 
 	// Add the unit to the board.
 	std::tie(unit_it, std::ignore) = resources::gameboard->units().replace(loc, created);
+	created->set_affect_distant(true);
 
 	game_display::get_singleton()->invalidate_unit();
 	resources::game_events->pump().fire("unit_placed", loc);
@@ -593,6 +598,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(debug_kill, child, /*spectator*/)
 		}
 		resources::controller->pump().fire("die", loc, loc);
 		if (i.valid()) {
+			i->set_affect_distant(false);
 			resources::gameboard->units().erase(i);
 		}
 		resources::whiteboard->on_kill_unit();

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -200,11 +200,17 @@ void unit_animation_component::reset_after_advance(const unit_type * newtype)
 
 void unit_animation_component::reset_affect_adjacent(const display & disp)
 {
+	bool affect_distant = false;
 	bool affect_adjacent = false;
 	for(const auto [key, cfg] : u_.abilities().all_children_view()) {
 		bool image_or_hides = (key == "hides" || cfg.has_attribute("halo_image") || cfg.has_attribute("overlay_image"));
-		if(image_or_hides && cfg.has_child("affect_adjacent")){
+		if(!affect_adjacent && image_or_hides && cfg.has_child("affect_adjacent")){
 			affect_adjacent = true;
+		}
+		if(!affect_distant && image_or_hides && cfg.has_child("affect_distant")){
+			affect_distant = true;
+		}
+		if(affect_adjacent && affect_distant){
 			break;
 		}
 	}
@@ -218,6 +224,14 @@ void unit_animation_component::reset_affect_adjacent(const display & disp)
 			if ( &*it == &u_ )
 				continue;
 			it->anim_comp().set_standing();
+		}
+	}
+	if(affect_distant){
+		for(const unit& unit_itor : units){
+			if (unit_itor.incapacitated() || &(unit_itor) == &u_) {
+				continue;
+			}
+			unit_itor.anim_comp().set_standing();
 		}
 	}
 }

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -106,6 +106,9 @@ public:
 	/** Resets the animations list after the unit is advanced. */
 	void reset_after_advance(const unit_type * newtype = nullptr);
 
+	/** Refresh map around unit if has ability with [affect_adjacent/distant] tag */
+	void reset_affect_adjacent(const display & disp);
+
 	/** Adds an animation described by a config. Uses an internal cache to avoid redoing work. */
 	void apply_new_animation_effect(const config & effect);
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -271,6 +271,14 @@ private:
 	 * @param from unit adjacent to self_ is checked.
 	 */
 	bool check_adj_abilities(const config& cfg, const std::string& special, int dir, const unit& from) const;
+	/** check_dist_abilities : return an boolean value for checking of activities of abilities used like weapon
+	 * @return True if the special @a special is active.
+	 * @param cfg the config to one special ability checked.
+	 * @param special The special ability type who is being checked.
+	 * @param from unit distant to self_ is checked.
+	 * @param from_loc location of @ from
+	 */
+	bool check_dist_abilities(const config& cfg, const std::string& special, const unit& from, const map_location& from_loc) const;
 	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool in_abilities_tag = false) const;
 
@@ -356,6 +364,32 @@ private:
 		AFFECTS whom,
 		const std::string& tag_name,
 		bool leader_bool=false
+	);
+
+	/** check_dist_abilities_impl : return an boolean value for checking of activities of abilities used like weapon in unit adjacent to fighter
+	 * @return True if the special @a tag_name is active.
+	 * @param self_attack the attack used by unit who fight.
+	 * @param other_attack the attack used by opponent.
+	 * @param special the config to one special ability checked.
+	 * @param u the unit who is or not affected by an abilities owned by @a from.
+	 * @param from unit distant to @a u is checked.
+	 * @param loc location of the unit checked.
+	 * @param from_loc location of the unit distant to @a u.
+	 * @param whom determine if unit affected or not by special ability.
+	 * @param tag_name The special ability type who is being checked.
+	 * @param leader_bool If true, [leadership] abilities are checked.
+	 */
+	static bool check_dist_abilities_impl(
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
+		const config& special,
+		const unit_const_ptr& u,
+		const unit& from,
+		const map_location& loc,
+		const map_location& from_loc,
+		AFFECTS whom,
+		const std::string& tag_name,
+		bool leader_bool = false
 	);
 
 	static bool special_active_impl(

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -441,6 +441,20 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					}
+					if(args.u.affect_distant()){
+						for(const unit& unit_itor : units){
+							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+								continue;
+							}
+							std::vector<ability_match> ability_id_matches_dist;
+							get_ability_children_id(ability_id_matches_dist, unit_itor.abilities(), ability);
+							for(const ability_match& entry : ability_id_matches_dist) {
+								if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, unit_itor, unit_itor.get_location())){
+									return true;
+								}
+							}
+						}
+					}
 				}
 				return false;
 			}
@@ -813,6 +827,18 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							for(const auto [key, cfg] : it->abilities().all_children_view()) {
 								if(it->ability_matches_filter(cfg, key, c.get_parsed_config())) {
 									if (args.u.get_adj_ability_bool(cfg, key, i, args.loc, *it)) {
+										return true;
+									}
+								}
+							}
+						}
+						if(args.u.affect_distant()){
+							for(const unit& unit_itor : units){
+								if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+									continue;
+								}
+								for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+									if(args.u.get_dist_ability_bool(cfg, key, args.loc, unit_itor, unit_itor.get_location())){
 										return true;
 									}
 								}

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -90,6 +90,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 		animator.add_animation(temp_unit.shared_from_this(),"pre_teleport",a);
 		animator.start_animations();
 		animator.wait_for_end();
+		temp_unit.anim_comp().reset_affect_adjacent(disp);
 	}
 
 	temp_unit.set_location(b);
@@ -104,6 +105,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 		animator.add_animation(temp_unit.shared_from_this(),"post_teleport",b);
 		animator.start_animations();
 		animator.wait_for_end();
+		temp_unit.anim_comp().reset_affect_adjacent(disp);
 	}
 
 	temp_unit.anim_comp().set_standing();
@@ -260,6 +262,7 @@ void unit_mover::start(const unit_ptr& u)
 	if ( !can_draw_ )
 		return;
 	// If no animation then hide unit until end of movement
+	(*u).anim_comp().reset_affect_adjacent(*disp_);
 	if ( !animate_ ) {
 		was_hidden_ = u->get_hidden();
 		u->set_hidden(true);
@@ -464,6 +467,7 @@ void unit_mover::finish(const unit_ptr& u, map_location::direction dir)
 		// Switch the display back to the real unit.
 		u->set_hidden(was_hidden_);
 		temp_unit_ptr_->set_hidden(true);
+		(*u).anim_comp().reset_affect_adjacent(*disp_);
 
 		if(events::mouse_handler* mousehandler = events::mouse_handler::get_singleton()) {
 			mousehandler->invalidate_reachmap();
@@ -589,6 +593,7 @@ void unit_die(const map_location& loc, unit& loser,
 	if(events::mouse_handler* mousehandler = events::mouse_handler::get_singleton()) {
 		mousehandler->invalidate_reachmap();
 	}
+	loser.anim_comp().reset_affect_adjacent(*disp);
 }
 
 
@@ -837,6 +842,7 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 			}
 		}
 	}
+	(*u).anim_comp().reset_affect_adjacent(*disp);
 	animator.add_animation(u.get_shared_ptr(), "recruited", loc, leader_loc);
 	animator.start_animations();
 	animator.wait_for_end();

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -2242,6 +2242,7 @@ void unit::apply_builtin_effect(const std::string& apply_to, const config& effec
 			emit_zoc_ = v->to_bool();
 		}
 	} else if(apply_to == "new_ability") {
+		set_affect_distant(false);
 		if(auto ab_effect = effect.optional_child("abilities")) {
 			set_attr_changed(UA_ABILITIES);
 			config to_append;
@@ -2255,7 +2256,9 @@ void unit::apply_builtin_effect(const std::string& apply_to, const config& effec
 			}
 			abilities_.append(to_append);
 		}
+		set_affect_distant(true);
 	} else if(apply_to == "remove_ability") {
+		set_affect_distant(false);
 		if(auto ab_effect = effect.optional_child("abilities")) {
 			for(const auto [key, cfg] : ab_effect->all_children_view()) {
 				remove_ability_by_id(cfg["id"]);
@@ -2268,6 +2271,7 @@ void unit::apply_builtin_effect(const std::string& apply_to, const config& effec
 			deprecated_message("experimental_filter_ability", DEP_LEVEL::INDEFINITE, "", "Use filter_ability instead.");
 			remove_ability_by_attribute(*fab_effect);
 		}
+		set_affect_distant(true);
 	} else if(apply_to == "image_mod") {
 		LOG_UT << "applying image_mod";
 		std::string mod = effect["replace"];

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1788,6 +1788,27 @@ public:
 	 */
 	bool get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const const_attack_ptr& weapon=nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 
+	/** Checks whether this unit is affected by a given ability, and that that ability is active.
+	 * @return True if the ability @a tag_name is active.
+	 * @param cfg the const config to one of abilities @a ability checked.
+	 * @param ability name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit distant to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc the 'other unit' location.
+	 */
+	bool get_dist_ability_bool(const config& cfg, const std::string& ability, const map_location& loc, const unit& from, const map_location& from_loc) const;
+	/** Checks whether this unit is affected by a given ability of leadership type
+	 * @return True if the ability @a tag_name is active.
+	 * @param special the const config to one of abilities @a tag_name checked.
+	 * @param tag_name name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit adjacent to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc location of the @a from unit.
+	 * @param weapon the attack used by unit checked in this function.
+	 * @param opp_weapon the attack used by opponent to unit checked.
+	 */
+	bool get_dist_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const;
+
 	/**
 	 * Gets the unit's active abilities of a particular type if it were on a specified location.
 	 * @param tag_name The type of ability to check for
@@ -1878,6 +1899,13 @@ public:
 	 */
 	bool ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const;
 
+	/**
+	 * @returns game_board affect_distant_[tag_name] or affect_distant_for_filtering_
+	 * @param tag_name the type of ability corresponding to the variable used, if empty return affect_distant_for_filtering_.
+	 */
+	bool affect_distant(const std::string& tag_name = "") const;
+
+	void set_affect_distant(bool increase);
 
 private:
 
@@ -1947,6 +1975,15 @@ private:
 	 */
 	bool ability_affects_adjacent(const std::string& ability, const config& cfg, int dir, const map_location& loc, const unit& from) const;
 
+	/**
+	 * Check if an ability affects distant units.
+	 * @param ability The type (tag name) of the ability
+	 * @param cfg an ability WML structure
+	 * @param loc The location on which to resolve the ability
+	 * @param from The "other unit" for filter matching
+	 * @param from_loc the "other unit" location
+	 */
+	bool ability_affects_distant(const std::string& ability, const config& cfg, const map_location& loc, const unit& from, const map_location& from_loc) const;
 	/**
 	 * Check if an ability affects the owning unit.
 	 * @param ability The type (tag name) of the ability

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -422,6 +422,12 @@
 0 filter_adjacent_direction_inactive
 0 filter_special_id_active
 0 filter_ability_special_id_active
+0 affect_distant_active
+0 affect_distant_inactive
+0 affect_distant_active_with_second_ability
+0 affect_distant_active_with_second_ability_type
+0 affect_distant_inactive_with_second_ability
+0 affect_distant_inactive_with_second_ability_type
 0 filter_special_id_not_exists
 0 special_id_active_lua_function
 0 leadership_when_other_has_special


### PR DESCRIPTION

like [affect_adjacent] this tag affects other units than the owner of the ability but this time, i added variables for checking done only if unit with abilit[affect_distant] are on the map

I had already tried to make one a few years ago but the code was too heavy and I had given up.