### PR TITLE
Always default to NO_LAYER for the overlay

### DIFF
--- a/src/terrain/builder.cpp
+++ b/src/terrain/builder.cpp
@@ -774,7 +774,7 @@ void terrain_builder::add_constraints(terrain_builder::constraint_set& constrain
 
 {
 	terrain_constraint& constraint = add_constraints(
-			constraints, loc, t_translation::ter_match(cfg["type"].str(), t_translation::WILDCARD), global_images);
+			constraints, loc, t_translation::ter_match(cfg["type"].str()), global_images);
 
 	std::vector<std::string> item_string = utils::square_parenthetical_split(cfg["set_flag"], ',', "[", "]");
 	constraint.set_flag.insert(constraint.set_flag.end(), item_string.begin(), item_string.end());

--- a/src/terrain/translation.hpp
+++ b/src/terrain/translation.hpp
@@ -103,7 +103,7 @@ namespace t_translation {
 	 */
 	struct ter_match{
 		ter_match();
-		ter_match(std::string_view str, const ter_layer filler = NO_LAYER);
+		ter_match(std::string_view str);
 		ter_match(const terrain_code& tcode);
 
 		ter_list terrain;
@@ -176,11 +176,9 @@ namespace t_translation {
 	 *                  the first group is the base terrain,
 	 *                  the second the overlay terrain.
 	 *
-	 * @param filler    if there's no layer this value will be used as the second layer
-	 *
 	 * @return          A single terrain code
 	 */
-	terrain_code read_terrain_code(std::string_view str, const ter_layer filler = NO_LAYER);
+	terrain_code read_terrain_code(std::string_view str);
 
 	/**
 	 * Writes a single terrain code to a string.
@@ -198,11 +196,10 @@ namespace t_translation {
 	 * Reads a list of terrains from a string, when reading the
 	 *
 	 * @param str		A string with one or more terrain codes (see read_terrain_code)
-	 * @param filler	If there's no layer, this value will be used as the second layer
 	 *
 	 * @returns		A vector which contains the terrain codes found in the string
 	 */
-	 ter_list read_list(std::string_view str, const ter_layer filler = NO_LAYER);
+	ter_list read_list(std::string_view str);
 
 	/**
 	 * Writes a list of terrains to a string, only writes the new format.


### PR DESCRIPTION
The only place WILDCARD was the default was [terrain_graphics][tile]type= and this had still exceptions for * and !. Should be simpler to have this work constistently in every context.