### PR TITLE
SotBE-S17: add message to event

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/17_The_Human_Attack.cfg
@@ -436,6 +436,12 @@
         [/message]
 
         [message]
+            speaker="Earl Lanbec'h"
+            image=portraits/lanbech.webp~FL()~RIGHT()
+            message={ASIDE (_"Curses! He is here already?! I had the messengers of the Alliance bribed to ensure no messages reached Dwarven Doors. I suppose it was only a matter of time...")}
+        [/message]
+
+        [message]
             speaker="Kapou'e"
             message= _ "Just who do you think you are, slug?"
             image=portraits/kapoue-angry.webp


### PR DESCRIPTION
Players have complained why the NA was so unaware of such a brutal war erupting in the Far North. Provided a possible reason in one message. This is a better alternative than scripting 1-2 cutscenes in between scenarios.