### PR TITLE
add a tag [affect_distant] to abilities(ver 4)

### DIFF
--- a/changelog_entries/add_affect_distant.md
+++ b/changelog_entries/add_affect_distant.md
@@ -1,0 +1,2 @@
+### WML Engine
+* add a [affect_distant] tag for affect units distant to owner of ability with 'radius' attribute for distance evaluation.

--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -128,109 +128,21 @@
 #enddef
 
 #define ABILITY_SHADOW_VEIL
-    [dummy]
+    [hides]
         id=did_shadow_veil
         name= _ "shadow veil"
         name_inactive= _ "shadow veil"
         description= _ "Allied undead units within a 5 hex radius are hidden."
         description_inactive= _ "Allied undead units within a 5 hex radius are hidden."
-        {DID_SHADOW_VEIL_HANDLER}
-    [/dummy]
-#enddef
-
-#define ABILITY_SHADOW_VEIL_HELPER SIDE
-    [hides]
-        id=did_shadow_veil_helper
-        [filter]
-            [filter_location]
-                radius=5
-                [filter]
-                    ability=did_shadow_veil
-                    [filter_side]
-                        [allied_with]
-                            side={SIDE}
-                        [/allied_with]
-                    [/filter_side]
-                [/filter]
-            [/filter_location]
-        [/filter]
-    [/hides]
-#enddef
-
-#define DID_SHADOW_VEIL_HANDLER
-    [event]
-        id=did_shadow_veil_unit_placed
-        name=unit placed
-        first_time_only=no
-        [filter]
-            side=1
-            race=undead
-            [not]
-                ability=did_shadow_veil_helper
-            [/not]
-        [/filter]
-        [filter_condition]
-            [have_unit]
-                ability=did_shadow_veil
-                side=1
-            [/have_unit]
-        [/filter_condition]
-        [modify_unit]
-            [filter]
-                x,y=$x1,$y1
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-            [/filter]
-            [object]
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
-    [event]
-        id=did_shadow_veil_malkeshar
-        name=post advance
-        first_time_only=yes
-        [filter]
-            type=Mal Keshar
-            ability=did_shadow_veil
-        [/filter]
-        [modify_unit]
+        affect_self=no
+        affect_allies=yes
+        [affect_distant]
+            radius=5
             [filter]
                 race=undead
-                [not]
-                    ability=did_shadow_veil_helper
-                    [or]
-                        ability=did_shadow_veil
-                    [/or]
-                [/not]
-                [filter_side]
-                    [allied_with]
-                        side=$unit.side
-                    [/allied_with]
-                [/filter_side]
             [/filter]
-            [object]
-                take_only_once=no
-                duration=scenario
-                [effect]
-                    apply_to=new_ability
-                    [abilities]
-                        {ABILITY_SHADOW_VEIL_HELPER $this_unit.side}
-                    [/abilities]
-                [/effect]
-            [/object]
-        [/modify_unit]
-    [/event]
+        [/affect_distant]
+    [/hides]
 #enddef
 
 #define WEAPON_SPECIAL_FROST_NOVA

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -16,6 +16,7 @@
 	{SIMPLE_KEY multiply s_real_range_list_default}
 	{SIMPLE_KEY divide s_real_range_list_default}
 	{SIMPLE_KEY affect_adjacent s_bool}
+	{SIMPLE_KEY affect_distant s_bool}
 	{SIMPLE_KEY affect_self s_bool}
 	{SIMPLE_KEY affect_allies bool_or_empty}
 	{SIMPLE_KEY affect_enemies s_bool}

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -40,6 +40,11 @@
 		[/key]
 		{FILTER_TAG "filter" unit ()}
 	[/tag]
+	[tag]
+		name="affect_distant"
+		{SIMPLE_KEY radius s_int}
+		{FILTER_TAG "filter" unit ()}
+	[/tag]
 	{FILTER_TAG "filter_self" unit ()}
 	{FILTER_TAG "filter_adjacent" adjacent ()}
 	{FILTER_TAG "filter_adjacent_location" adjacent_location ()}

--- a/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
+++ b/data/test/macros/start_position_separate_keep_a_b_c_d.cfg
@@ -1,0 +1,74 @@
+#textdomain wesnoth-test
+
+##
+# Starting state:
+#
+# Side 1 leader Alice (Orcish Grunt)
+# Side 2 leader Bob (Orcish Grunt)
+# Side 3 leader Charlie (Orcish Grunt)
+# Side 4 leader Dave (Orcish Grunt)
+#
+# None of the sides are allied.
+#
+# On the default map (used unless overridden with the MAP_FILE argument:
+# * All four leaders are on a single keep, with Alice and Bob already in position to attack any of the other units.
+# * There is no free castle hex to recruit onto.
+##
+#define SEPARATE_KEEP_A_B_C_D_UNIT_TEST NAME CONTENT
+
+#arg SIDE_LEADER
+Orcish Grunt#endarg
+
+#arg MAP_FILE
+test/maps/4p_separate_castles.map#endarg
+
+    [test]
+        name=_ "Unit Test " + {NAME}
+        map_file={MAP_FILE}
+        turns=unlimited
+        id={NAME}
+        random_start_time=no
+        is_unit_test=yes
+
+        {DAWN}
+
+        [side]
+            side=1
+            controller=human
+            [leader]
+                name = _ "Alice"
+                type = {SIDE_LEADER}
+                id=alice
+            [/leader]
+        [/side]
+        [side]
+            side=2
+            controller=human
+            [leader]
+                name = _ "Bob"
+                type = {SIDE_LEADER}
+                id=bob
+            [/leader]
+        [/side]
+        [side]
+            side=3
+            controller=human
+            [leader]
+                name = _ "Charlie"
+                type = {SIDE_LEADER}
+                id=charlie
+            [/leader]
+        [/side]
+        [side]
+            side=4
+            controller=human
+            [leader]
+                name = _ "Dave"
+                type = {SIDE_LEADER}
+                id=dave
+            [/leader]
+        [/side]
+
+        {CONTENT}
+    [/test]
+#enddef

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active.cfg
@@ -1,0 +1,54 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 10 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should affect alice.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 10 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=10
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alice
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_active_with_second_ability.cfg
@@ -1,0 +1,121 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 7"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=7
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                id=alex
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 7 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active and affect alex.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_active_with_second_ability" (
+    {TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_ACTIVE_WITH_SECOND_ABILITY

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive.cfg
@@ -1,0 +1,57 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give charlie an ability specialX, which is affect alice if she in 1 hexes of distance of alex.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alice.
+#####
+
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one unit within 1 hex radius is alice"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=1
+                            [filter]
+                                id=alice
+                            [/filter]
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=charlie
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alice
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/affect_distant_inactive_with_second_ability.cfg
@@ -1,0 +1,125 @@
+#textdomain wesnoth-test
+#define TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY FILTER
+    [event]
+        name=start
+        [unit]
+            id=alex
+            name=_"Alex"
+            x,y=1,1
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=bobby
+            name=_"Bobby"
+            x,y=1,5
+            type=Elvish Hero
+            side=1
+        [/unit]
+        [unit]
+            id=carlos
+            name=_"Carlos"
+            x,y=1,12
+            type=Elvish Hero
+            side=1
+        [/unit]
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [leadership]
+                        id=specialY
+                        name=_ "specialY"
+                        description=_ "specialY affect units within radius of 5"
+                        value=25
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/leadership]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=carlos
+            [/filter]
+        [/object]
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if within radius of specialY ability"
+                        value=100
+                        apply_to=self
+                        affect_self=no
+                        affect_allies=yes
+                        affect_enemies=yes
+                        [filter]
+                            {FILTER}
+                        [/filter]
+                        [affect_distant]
+                            radius=5
+                        [/affect_distant]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=bobby
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    id=alex
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+#enddef
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability_type" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_type_active=leadership)}
+)}
+
+#####
+# API(s) being tested: ability[affect_distant]radius=
+##
+# Actions:
+# Give carlos a leadership ability, specialY, that affects all units in a 5 hex radius
+# Give bobby a damage ability, specialX, that affects all units in a 5 hex radius when affected by carlos' ability
+# Place alex within range of bobby's ability but out of range of carlos' ability
+# Place bobby out of range of carlos' ability
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouln'd be affect alex because inactive.
+#####
+{SEPARATE_KEEP_A_B_C_D_UNIT_TEST "affect_distant_inactive_with_second_ability" (
+    {TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY (ability_id_active=specialY)}
+)}
+
+#undef TEST_AFFECT_DISTANT_INACTIVE_WITH_SECOND_ABILITY

--- a/src/actions/undo_move_action.cpp
+++ b/src/actions/undo_move_action.cpp
@@ -56,25 +56,6 @@ void move_action::write(config & cfg) const
 }
 
 /**
- * Reset halo of adjacent units when undo move.
- */
-static void reset_adjacent(bool& halo_adjacent, unit_map& units, const map_location& loc)
-{
-	if(halo_adjacent){
-		unit_map::iterator u = units.find(loc);
-		const auto adjacent = get_adjacent_tiles(loc);
-		for(unsigned i = 0; i < adjacent.size(); ++i) {
-			const unit_map::const_iterator it = units.find(adjacent[i]);
-			if (it == units.end() || it->incapacitated())
-				continue;
-			if ( &*it == &*u )
-				continue;
-			it->anim_comp().set_standing();
-		}
-	}
-}
-
-/**
  * Undoes this action.
  * @return true on success; false on an error.
  */
@@ -103,17 +84,10 @@ bool move_action::undo(int)
 
 	// Move the unit.
 	unit_display::move_unit(rev_route, u.get_shared_ptr(), true, starting_dir);
-	bool halo_adjacent = false;
-	for(const auto [_, cfg] : u->abilities().all_children_view()){
-		if(!cfg["halo_image"].empty() && cfg.has_child("affect_adjacent")){
-			halo_adjacent = true;
-			break;
-		}
-	}
-	reset_adjacent(halo_adjacent, units, rev_route.front());
+	u->anim_comp().reset_affect_adjacent(gui);
 	units.move(u->get_location(), rev_route.back());
 	unit::clear_status_caches();
-	reset_adjacent(halo_adjacent, units, rev_route.back());
+	u->anim_comp().reset_affect_adjacent(gui);
 
 	// Restore the unit's old state.
 	u = units.find(rev_route.back());

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -2154,6 +2154,15 @@ namespace
 			}
 		}
 
+		//when affect_distant=yes detect presence of [affect_distant] in abilities, if no
+		//then matches when tag not present.
+		if(!filter["affect_distant"].empty()){
+			bool distant = cfg.has_child("affect_distant");
+			if(filter["affect_distant"].to_bool() != distant){
+				return false;
+			}
+		}
+
 		//these attributs below filter attribute used in all engine abilities.
 		//matches if filter attribute have same boolean value what attribute
 		if(!bool_matches_if_present(filter, cfg, "affect_self", true))

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -183,6 +183,27 @@ bool affects_side(const config& cfg, std::size_t side, std::size_t other_side)
 
 }
 
+void unit::set_distant(const std::string& key, const config& ability)
+{
+	if(resources::gameboard){
+		unit_map& units = resources::gameboard->units();
+		if(loc_.valid() && ability.has_child("affect_distant")) {
+			for(unit& unit_itor : units){
+				if (unit_itor.abilities_.has_child(key + "_distant") || unit_itor.incapacitated() || &(unit_itor) == this) {
+					continue;
+				}
+				config o;
+				o["duration"] = "scenario";
+				config& effect = o.add_child("effect");
+				effect["apply_to"] = "new_ability";
+				config& effect_ab = effect.add_child("abilities");
+				effect_ab.add_child(key + "_distant");
+				unit_itor.add_modification("object", o);
+			}
+		}
+	}
+}
+
 bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc) const
 {
 	for (const config &i : this->abilities_.child_range(tag_name)) {
@@ -210,6 +231,18 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 			if (get_adj_ability_bool(j, tag_name, i, loc,*it))
 			{
 				return true;
+			}
+		}
+	}
+	if(this->abilities_.has_child(tag_name + "_distant")) {
+		for(const unit& unit_itor : units){
+			if (unit_itor.incapacitated() || &(unit_itor) == this) {
+				continue;
+			}
+			for(const config& i : unit_itor.abilities_.child_range(tag_name)){
+				if(get_dist_ability_bool(i, tag_name, loc, unit_itor, unit_itor.get_location())){
+					return true;
+				}
 			}
 		}
 	}
@@ -246,6 +279,18 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 		for(const config& j : it->abilities_.child_range(tag_name)) {
 			if(get_adj_ability_bool(j, tag_name, i, loc,*it)) {
 				res.emplace_back(&j, loc, adjacent[i]);
+			}
+		}
+	}
+	if(this->abilities_.has_child(tag_name + "_distant")) {
+		for(const unit& unit_itor : units){
+			if (unit_itor.incapacitated() || &(unit_itor) == this) {
+				continue;
+			}
+			for(const config& i : unit_itor.abilities_.child_range(tag_name)) {
+				if(get_dist_ability_bool(i, tag_name, loc, unit_itor, unit_itor.get_location())){
+					res.emplace_back(&i, loc, unit_itor.get_location());
+				}
 			}
 		}
 	}
@@ -521,6 +566,46 @@ bool unit::ability_affects_adjacent(const std::string& ability, const config& cf
 	return false;
 }
 
+bool unit::ability_affects_distant(const std::string& ability, const config& cfg, const map_location& loc, const unit& from, const map_location& from_loc) const
+{
+	unsigned int radius = 0;
+	bool illuminates = ability == "illuminates";
+	for (const config &i : cfg.child_range("affect_distant"))
+	{
+		if(i.has_attribute("radius")){
+			radius = i["radius"].to_int(0);
+			if(radius == 0){
+				continue;
+			}
+			unsigned int distance = distance_between(from_loc, loc);
+			if(distance > radius){
+				continue;
+			}
+		}
+		auto filter = i.optional_child("filter");
+		if (!filter || //filter tag given
+			unit_filter(vconfig(*filter)).set_use_flat_tod(illuminates).matches(*this, loc, from) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool unit::get_dist_ability_bool(const config& cfg, const std::string& ability, const map_location& loc, const unit& from, const map_location& from_loc) const
+{
+	auto filter_lock = from.update_variables_recursion(cfg);
+	if(!filter_lock) {
+		show_recursion_warning(from, cfg);
+		return false;
+	}
+	return (ability_affects_distant(ability, cfg, loc, from, from_loc) && affects_side(cfg, side(), from.side()) && from.ability_active_impl(ability, cfg, from_loc));
+}
+
+bool unit::get_dist_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
+{
+	return (get_dist_ability_bool(special, tag_name, loc, from, from_loc) && ability_affects_weapon(special, weapon, false) && ability_affects_weapon(special, opp_weapon, true));
+}
+
 bool unit::ability_affects_self(const std::string& ability,const config& cfg,const map_location& loc) const
 {
 	auto filter = cfg.optional_child("filter_self");
@@ -555,18 +640,25 @@ bool unit::has_ability_type(const std::string& ability) const
 
 //these two functions below are used in order to add to the unit
 //a second set of halo encoded in the abilities (like illuminates halo in [illuminates] ability for example)
-static void add_string_to_vector(std::vector<std::string>& image_list, const config& cfg, const std::string& attribute_name)
+namespace
 {
-	auto ret = std::find(image_list.begin(), image_list.end(), cfg[attribute_name].str());
-	if(ret == image_list.end()){
-		image_list.push_back(cfg[attribute_name].str());
+	void add_string_to_vector(std::vector<std::string>& image_list, const config& cfg, const std::string& attribute_name)
+	{
+		auto ret = std::find(image_list.begin(), image_list.end(), cfg[attribute_name].str());
+		if(ret == image_list.end()){
+			image_list.push_back(cfg[attribute_name].str());
+		}
 	}
 }
 
 std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_type) const
 {
 	std::vector<std::string> image_list;
+	bool ability_distant = false;
 	for(const auto [key, cfg] : abilities_.all_children_view()){
+		if(!ability_distant && key.find("_distant") != std::string::npos) {
+			ability_distant = true;
+		}
 		bool is_active = ability_active(key, cfg, loc_);
 		//Add halo/overlay to owner of ability if active and affect_self is true.
 		if( !cfg[image_type + "_image"].str().empty() && is_active && ability_affects_self(key, cfg, loc_)){
@@ -593,6 +685,19 @@ std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_t
 			if(!cfg[image_type + "_image"].str().empty() && affects_side(cfg, side(), it->side()) && it->ability_active(key, cfg, adjacent[i]) && ability_affects_adjacent(key, cfg, i, loc_, *it))
 			{
 				add_string_to_vector(image_list, cfg, image_type + "_image");
+			}
+		}
+	}
+	if(ability_distant) {
+		for(const unit& unit_itor : units){
+			if (unit_itor.incapacitated() || &(unit_itor) == this) {
+				continue;
+			}
+			for(const auto [key, cfg] : unit_itor.abilities_.all_children_view()) {
+				if(!cfg[image_type + "_image"].str().empty() && get_dist_ability_bool(cfg, key, loc_, unit_itor, unit_itor.get_location()))
+				{
+					add_string_to_vector(image_list, cfg, image_type + "_image");
+				}
 			}
 		}
 	}
@@ -1785,6 +1890,26 @@ bool attack_type::check_adj_abilities_impl(const const_attack_ptr& self_attack, 
 	}
 	return false;
 }
+
+bool attack_type::check_dist_abilities(const config& cfg, const std::string& special, const unit& from, const map_location& from_loc) const
+{
+	return check_dist_abilities_impl(shared_from_this(), other_attack_, cfg, self_, from, self_loc_, from_loc, AFFECT_SELF, special, "filter_student");
+}
+
+bool attack_type::check_dist_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const config& special, const unit_const_ptr& u, const unit& from, const map_location& loc, const map_location& from_loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
+{
+	if(tag_name == "leadership" && leader_bool){
+		if((*u).get_dist_ability_bool_weapon(special, tag_name, loc, from, from_loc, self_attack, other_attack)) {
+			return true;
+		}
+	}
+	if((*u).checking_tags().count(tag_name) != 0){
+		if((*u).get_dist_ability_bool(special, tag_name, loc, from, from_loc) && special_active_impl(self_attack, other_attack, special, whom, tag_name, "filter_student")) {
+			return true;
+		}
+	}
+	return false;
+}
 /**
  * Returns whether or not @a *this has a special ability with a tag or id equal to
  * @a special. the Check is for a special ability
@@ -1795,6 +1920,12 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 {
 	const unit_map& units = get_unit_map();
 	if(self_){
+		bool special_distant = false;
+		for(const auto [key, cfg] : self_->abilities().all_children_view()) {
+			if(!special_distant && key.find("_distant") != std::string::npos) {
+				special_distant = true;
+			}
+		}
 		std::vector<special_match> special_tag_matches_self;
 		std::vector<special_match> special_id_matches_self;
 		get_ability_children(special_tag_matches_self, special_id_matches_self, (*self_).abilities(), special, special_id , special_tags);
@@ -1839,9 +1970,40 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 				}
 			}
 		}
+		if(special_distant){
+			for(const unit& unit_itor : units){
+				if (unit_itor.incapacitated() || &(unit_itor) == self_.get()) {
+					continue;
+				}
+
+				std::vector<special_match> special_tag_matches_dist;
+				std::vector<special_match> special_id_matches_dist;
+				get_ability_children(special_tag_matches_dist, special_id_matches_dist, unit_itor.abilities(), special, special_id , special_tags);
+				if(special_tags){
+					for(const special_match& entry : special_tag_matches_dist) {
+						if(check_dist_abilities(*entry.cfg, entry.tag_name, unit_itor, unit_itor.get_location())){
+							return true;
+						}
+					}
+				}
+				if(special_id){
+					for(const special_match& entry : special_id_matches_dist) {
+						if(check_dist_abilities(*entry.cfg, entry.tag_name, unit_itor, unit_itor.get_location())){
+							return true;
+						}
+					}
+				}
+			}
+		}
 	}
 
 	if(other_){
+		bool special_distant = false;
+		for(const auto [key, cfg] : other_->abilities().all_children_view()) {
+			if(!special_distant && key.find("_distant") != std::string::npos) {
+				special_distant = true;
+			}
+		}
 		std::vector<special_match> special_tag_matches_other;
 		std::vector<special_match> special_id_matches_other;
 		get_ability_children(special_tag_matches_other, special_id_matches_other, (*other_).abilities(), special, special_id , special_tags);
@@ -1884,6 +2046,31 @@ bool attack_type::has_weapon_ability(const std::string& special, bool special_id
 				for(const special_match& entry : special_id_matches_oadj) {
 					if(check_adj_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, *it, i, other_loc_, AFFECT_OTHER, entry.tag_name)){
 						return true;
+					}
+				}
+			}
+		}
+		if(special_distant){
+			for(const unit& unit_itor : units){
+				if (unit_itor.incapacitated() || &(unit_itor) == other_.get()) {
+					continue;
+				}
+
+				std::vector<special_match> special_tag_matches_odist;
+				std::vector<special_match> special_id_matches_odist;
+				get_ability_children(special_tag_matches_odist, special_id_matches_odist, unit_itor.abilities(), special, special_id , special_tags);
+				if(special_tags){
+					for(const special_match& entry : special_tag_matches_odist) {
+						if(check_dist_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, unit_itor, other_loc_, unit_itor.get_location(), AFFECT_OTHER, entry.tag_name)){
+							return true;
+						}
+					}
+				}
+				if(special_id){
+					for(const special_match& entry : special_id_matches_odist) {
+						if(check_dist_abilities_impl(other_attack_, shared_from_this(), *entry.cfg, other_, unit_itor, other_loc_, unit_itor.get_location(), AFFECT_OTHER, entry.tag_name)){
+							return true;
+						}
 					}
 				}
 			}
@@ -2141,11 +2328,15 @@ bool attack_type::has_ability_with_filter(const config & filter) const
 	}
 	const unit_map& units = get_unit_map();
 	if(self_){
+		bool special_distant = false;
 		for(const auto [key, cfg] : (*self_).abilities().all_children_view()) {
 			if(self_->ability_matches_filter(cfg, key, filter)){
 				if(check_self_abilities(cfg, key)){
 					return true;
 				}
+			}
+			if(!special_distant && key.find("_distant") != std::string::npos) {
+				special_distant = true;
 			}
 		}
 
@@ -2163,12 +2354,29 @@ bool attack_type::has_ability_with_filter(const config & filter) const
 				}
 			}
 		}
+		if(special_distant){
+			for(const unit& unit_itor : units){
+				if (unit_itor.incapacitated() || &(unit_itor) == self_.get()) {
+					continue;
+				}
+
+				for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+					if(unit_itor.ability_matches_filter(cfg, key, filter) && check_dist_abilities(cfg, key, unit_itor, unit_itor.get_location())){
+						return true;
+					}
+				}
+			}
+		}
 	}
 
 	if(other_){
+		bool special_distant = false;
 		for(const auto [key, cfg] : (*other_).abilities().all_children_view()) {
 			if(other_->ability_matches_filter(cfg, key, filter) && check_self_abilities_impl(other_attack_, shared_from_this(), cfg, other_, other_loc_, AFFECT_OTHER, key)){
 				return true;
+			}
+			if(!special_distant && key.find("_distant") != std::string::npos) {
+				special_distant = true;
 			}
 		}
 
@@ -2183,6 +2391,19 @@ bool attack_type::has_ability_with_filter(const config & filter) const
 			for(const auto [key, cfg] : it->abilities().all_children_view()) {
 				if(it->ability_matches_filter(cfg, key, filter) && check_adj_abilities_impl(other_attack_, shared_from_this(), cfg, other_, *it, i, other_loc_, AFFECT_OTHER, key)){
 					return true;
+				}
+			}
+		}
+		if(special_distant){
+			for(const unit& unit_itor : units){
+				if (unit_itor.incapacitated() || &(unit_itor) == other_.get()) {
+					continue;
+				}
+
+				for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+					if(unit_itor.ability_matches_filter(cfg, key, filter) && check_dist_abilities_impl(other_attack_, shared_from_this(), cfg, other_, unit_itor, other_loc_, unit_itor.get_location(), AFFECT_OTHER, key)){
+						return true;
+					}
 				}
 			}
 		}

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -196,11 +196,17 @@ void unit_animation_component::reset_after_advance(const unit_type * newtype)
 
 void unit_animation_component::reset_affect_adjacent(const unit_map& units)
 {
+	bool affect_distant = false;
 	bool affect_adjacent = false;
 	for(const auto [key, cfg] : u_.abilities().all_children_view()) {
 		bool image_or_hides = (key == "hides" || cfg.has_attribute("halo_image") || cfg.has_attribute("overlay_image"));
-		if(image_or_hides && cfg.has_child("affect_adjacent")){
+		if(!affect_adjacent && image_or_hides && cfg.has_child("affect_adjacent")){
 			affect_adjacent = true;
+		}
+		if(!affect_distant && image_or_hides && cfg.has_child("affect_distant")){
+			affect_distant = true;
+		}
+		if(affect_adjacent && affect_distant){
 			break;
 		}
 	}
@@ -213,6 +219,14 @@ void unit_animation_component::reset_affect_adjacent(const unit_map& units)
 			if ( &*it == &u_ )
 				continue;
 			it->anim_comp().set_standing();
+		}
+	}
+	if(affect_distant){
+		for(const unit& unit_itor : units){
+			if (unit_itor.incapacitated() || &(unit_itor) == &u_) {
+				continue;
+			}
+			unit_itor.anim_comp().set_standing();
 		}
 	}
 }

--- a/src/units/animation_component.cpp
+++ b/src/units/animation_component.cpp
@@ -16,8 +16,6 @@
 #include "units/animation_component.hpp"
 
 #include "config.hpp"
-#include "display.hpp"
-#include "map/map.hpp"
 #include "preferences/preferences.hpp"
 #include "random.hpp"
 #include "units/unit.hpp"
@@ -194,6 +192,29 @@ void unit_animation_component::reset_after_advance(const unit_type * newtype)
 
 	refreshing_ = false;
 	anim_.reset();
+}
+
+void unit_animation_component::reset_affect_adjacent(const unit_map& units)
+{
+	bool affect_adjacent = false;
+	for(const auto [key, cfg] : u_.abilities().all_children_view()) {
+		bool image_or_hides = (key == "hides" || cfg.has_attribute("halo_image") || cfg.has_attribute("overlay_image"));
+		if(image_or_hides && cfg.has_child("affect_adjacent")){
+			affect_adjacent = true;
+			break;
+		}
+	}
+	if(affect_adjacent) {
+		const auto adjacent = get_adjacent_tiles(u_.get_location());
+		for(unsigned i = 0; i < adjacent.size(); ++i) {
+			const unit_map::const_iterator it = units.find(adjacent[i]);
+			if (it == units.end() || it->incapacitated())
+				continue;
+			if ( &*it == &u_ )
+				continue;
+			it->anim_comp().set_standing();
+		}
+	}
 }
 
 void unit_animation_component::apply_new_animation_effect(const config & effect) {

--- a/src/units/animation_component.hpp
+++ b/src/units/animation_component.hpp
@@ -17,7 +17,11 @@
 
 #pragma once
 
+#include "display.hpp"
+#include "game_board.hpp"
 #include "halo.hpp"
+#include "map/map.hpp"
+
 #include "units/animation.hpp" //Note: only needed for enum
 
 class config;
@@ -105,6 +109,11 @@ public:
 
 	/** Resets the animations list after the unit is advanced. */
 	void reset_after_advance(const unit_type * newtype = nullptr);
+
+	/** Refresh map around unit if has ability with [affect_adjacent/distant] tag */
+	void reset_affect_adjacent(const unit_map& units);
+
+	void reset_affect_adjacent(const display & disp) {reset_affect_adjacent(disp.context().units());}
 
 	/** Adds an animation described by a config. Uses an internal cache to avoid redoing work. */
 	void apply_new_animation_effect(const config & effect);

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -271,6 +271,14 @@ private:
 	 * @param from unit adjacent to self_ is checked.
 	 */
 	bool check_adj_abilities(const config& cfg, const std::string& special, int dir, const unit& from) const;
+	/** check_dist_abilities : return an boolean value for checking of activities of abilities used like weapon
+	 * @return True if the special @a special is active.
+	 * @param cfg the config to one special ability checked.
+	 * @param special The special ability type who is being checked.
+	 * @param from unit distant to self_ is checked.
+	 * @param from_loc location of @ from
+	 */
+	bool check_dist_abilities(const config& cfg, const std::string& special, const unit& from, const map_location& from_loc) const;
 	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool in_abilities_tag = false) const;
 
@@ -356,6 +364,32 @@ private:
 		AFFECTS whom,
 		const std::string& tag_name,
 		bool leader_bool=false
+	);
+
+	/** check_dist_abilities_impl : return an boolean value for checking of activities of abilities used like weapon in unit adjacent to fighter
+	 * @return True if the special @a tag_name is active.
+	 * @param self_attack the attack used by unit who fight.
+	 * @param other_attack the attack used by opponent.
+	 * @param special the config to one special ability checked.
+	 * @param u the unit who is or not affected by an abilities owned by @a from.
+	 * @param from unit distant to @a u is checked.
+	 * @param loc location of the unit checked.
+	 * @param from_loc location of the unit distant to @a u.
+	 * @param whom determine if unit affected or not by special ability.
+	 * @param tag_name The special ability type who is being checked.
+	 * @param leader_bool If true, [leadership] abilities are checked.
+	 */
+	static bool check_dist_abilities_impl(
+		const const_attack_ptr& self_attack,
+		const const_attack_ptr& other_attack,
+		const config& special,
+		const unit_const_ptr& u,
+		const unit& from,
+		const map_location& loc,
+		const map_location& from_loc,
+		AFFECTS whom,
+		const std::string& tag_name,
+		bool leader_bool = false
 	);
 
 	static bool special_active_impl(

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -441,15 +441,24 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					}
-					for(const unit& unit_itor : units){
-						if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
-							continue;
+					bool affect_distant = false;
+					for(const auto [key, cfg] : args.u.abilities().all_children_view()) {
+						if (key.find("_distant") != std::string::npos) {
+							affect_distant = true;
+							break;
 						}
-						std::vector<ability_match> ability_id_matches_dist;
-						get_ability_children_id(ability_id_matches_dist, unit_itor.abilities(), ability);
-						for(const ability_match& entry : ability_id_matches_dist) {
-							if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, unit_itor, unit_itor.get_location())){
-								return true;
+					}
+					if(affect_distant){
+						for(const unit& unit_itor : units){
+							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+								continue;
+							}
+							std::vector<ability_match> ability_id_matches_dist;
+							get_ability_children_id(ability_id_matches_dist, unit_itor.abilities(), ability);
+							for(const ability_match& entry : ability_id_matches_dist) {
+								if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, unit_itor, unit_itor.get_location())){
+									return true;
+								}
 							}
 						}
 					}
@@ -805,12 +814,16 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					} else {
+						bool affect_distant = false;
 						const unit_map& units = args.context().get_disp_context().units();
 						for(const auto [key, cfg] : args.u.abilities().all_children_view()) {
 							if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
 								if (args.u.get_self_ability_bool(cfg, key, args.loc)) {
 									return true;
 								}
+							}
+							if (!affect_distant && key.find("_distant") != std::string::npos) {
+								affect_distant = true;
 							}
 						}
 
@@ -830,13 +843,15 @@ void unit_filter_compound::fill(const vconfig& cfg)
 								}
 							}
 						}
-						for(const unit& unit_itor : units){
-							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
-								continue;
-							}
-							for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
-								if(args.u.get_dist_ability_bool(cfg, key, args.loc, unit_itor, unit_itor.get_location())){
-									return true;
+						if(affect_distant){
+							for(const unit& unit_itor : units){
+								if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+									continue;
+								}
+								for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+									if(args.u.get_dist_ability_bool(cfg, key, args.loc, unit_itor, unit_itor.get_location())){
+										return true;
+									}
 								}
 							}
 						}

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -441,6 +441,18 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							}
 						}
 					}
+					for(const unit& unit_itor : units){
+						if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+							continue;
+						}
+						std::vector<ability_match> ability_id_matches_dist;
+						get_ability_children_id(ability_id_matches_dist, unit_itor.abilities(), ability);
+						for(const ability_match& entry : ability_id_matches_dist) {
+							if(args.u.get_dist_ability_bool(*entry.cfg, entry.tag_name, args.loc, unit_itor, unit_itor.get_location())){
+								return true;
+							}
+						}
+					}
 				}
 				return false;
 			}
@@ -815,6 +827,16 @@ void unit_filter_compound::fill(const vconfig& cfg)
 									if (args.u.get_adj_ability_bool(cfg, key, i, args.loc, *it)) {
 										return true;
 									}
+								}
+							}
+						}
+						for(const unit& unit_itor : units){
+							if (unit_itor.incapacitated() || &(unit_itor) == args.u.shared_from_this().get()) {
+								continue;
+							}
+							for(const auto [key, cfg] : unit_itor.abilities().all_children_view()) {
+								if(args.u.get_dist_ability_bool(cfg, key, args.loc, unit_itor, unit_itor.get_location())){
+									return true;
 								}
 							}
 						}

--- a/src/units/udisplay.cpp
+++ b/src/units/udisplay.cpp
@@ -90,6 +90,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 		animator.add_animation(temp_unit.shared_from_this(),"pre_teleport",a);
 		animator.start_animations();
 		animator.wait_for_end();
+		temp_unit.anim_comp().reset_affect_adjacent(disp);
 	}
 
 	temp_unit.set_location(b);
@@ -104,6 +105,7 @@ void teleport_unit_between(const map_location& a, const map_location& b, unit& t
 		animator.add_animation(temp_unit.shared_from_this(),"post_teleport",b);
 		animator.start_animations();
 		animator.wait_for_end();
+		temp_unit.anim_comp().reset_affect_adjacent(disp);
 	}
 
 	temp_unit.anim_comp().set_standing();
@@ -260,6 +262,7 @@ void unit_mover::start(const unit_ptr& u)
 	if ( !can_draw_ )
 		return;
 	// If no animation then hide unit until end of movement
+	(*u).anim_comp().reset_affect_adjacent(*disp_);
 	if ( !animate_ ) {
 		was_hidden_ = u->get_hidden();
 		u->set_hidden(true);
@@ -464,6 +467,7 @@ void unit_mover::finish(const unit_ptr& u, map_location::direction dir)
 		// Switch the display back to the real unit.
 		u->set_hidden(was_hidden_);
 		temp_unit_ptr_->set_hidden(true);
+		(*u).anim_comp().reset_affect_adjacent(*disp_);
 
 		if(events::mouse_handler* mousehandler = events::mouse_handler::get_singleton()) {
 			mousehandler->invalidate_reachmap();
@@ -589,6 +593,7 @@ void unit_die(const map_location& loc, unit& loser,
 	if(events::mouse_handler* mousehandler = events::mouse_handler::get_singleton()) {
 		mousehandler->invalidate_reachmap();
 	}
+	loser.anim_comp().reset_affect_adjacent(*disp);
 }
 
 
@@ -837,6 +842,7 @@ void unit_recruited(const map_location& loc,const map_location& leader_loc)
 			}
 		}
 	}
+	(*u).anim_comp().reset_affect_adjacent(*disp);
 	animator.add_animation(u.get_shared_ptr(), "recruited", loc, leader_loc);
 	animator.start_animations();
 	animator.wait_for_end();

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1788,6 +1788,27 @@ public:
 	 */
 	bool get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, int dir, const map_location& loc, const unit& from, const const_attack_ptr& weapon=nullptr, const const_attack_ptr& opp_weapon = nullptr) const;
 
+	/** Checks whether this unit is affected by a given ability, and that that ability is active.
+	 * @return True if the ability @a tag_name is active.
+	 * @param cfg the const config to one of abilities @a ability checked.
+	 * @param ability name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit distant to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc the 'other unit' location.
+	 */
+	bool get_dist_ability_bool(const config& cfg, const std::string& ability, const map_location& loc, const unit& from, const map_location& from_loc) const;
+	/** Checks whether this unit is affected by a given ability of leadership type
+	 * @return True if the ability @a tag_name is active.
+	 * @param special the const config to one of abilities @a tag_name checked.
+	 * @param tag_name name of ability type checked.
+	 * @param loc location of the unit checked.
+	 * @param from unit adjacent to @a this is checked in case of [affect_distant] abilities.
+	 * @param from_loc location of the @a from unit.
+	 * @param weapon the attack used by unit checked in this function.
+	 * @param opp_weapon the attack used by opponent to unit checked.
+	 */
+	bool get_dist_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const;
+
 	/**
 	 * Gets the unit's active abilities of a particular type if it were on a specified location.
 	 * @param tag_name The type of ability to check for
@@ -1947,6 +1968,22 @@ private:
 	 */
 	bool ability_affects_adjacent(const std::string& ability, const config& cfg, int dir, const map_location& loc, const unit& from) const;
 
+	/**
+	 * if unit own a ability with affect_ditant, give tag_nem + "_distant" abilities to units on the map
+	 * @param key The type (tag name) of the ability
+	 * @param ability an ability WML structure
+	 */
+	void set_distant(const std::string& key, const config& ability);
+
+	/**
+	 * Check if an ability affects distant units.
+	 * @param ability The type (tag name) of the ability
+	 * @param cfg an ability WML structure
+	 * @param loc The location on which to resolve the ability
+	 * @param from The "other unit" for filter matching
+	 * @param from_loc the "other unit" location
+	 */
+	bool ability_affects_distant(const std::string& ability, const config& cfg, const map_location& loc, const unit& from, const map_location& from_loc) const;
 	/**
 	 * Check if an ability affects the owning unit.
 	 * @param ability The type (tag name) of the ability

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -424,6 +424,10 @@
 0 filter_ability_special_id_active
 0 affect_distant_active
 0 affect_distant_inactive
+0 affect_distant_active_with_second_ability
+0 affect_distant_active_with_second_ability_type
+0 affect_distant_inactive_with_second_ability
+0 affect_distant_inactive_with_second_ability_type
 0 filter_special_id_not_exists
 0 special_id_active_lua_function
 0 leadership_when_other_has_special

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -422,6 +422,8 @@
 0 filter_adjacent_direction_inactive
 0 filter_special_id_active
 0 filter_ability_special_id_active
+0 affect_distant_active
+0 affect_distant_inactive
 0 filter_special_id_not_exists
 0 special_id_active_lua_function
 0 leadership_when_other_has_special


### PR DESCRIPTION

like [affect_adjacent] this tag affects other units than the owner of the ability but this time, it concerns units located in a radius defined in the tag or all units on the map.

I had already tried to make one a few years ago but the code was too heavy and I had given up.