### PR TITLE
GUI2: hotkey registration and related callback cleanup

### DIFF
--- a/src/gui/core/event/dispatcher.cpp
+++ b/src/gui/core/event/dispatcher.cpp
@@ -144,29 +144,20 @@ bool dispatcher::fire(const ui_event event, widget& target, const message& msg)
 	return fire_event<event_category::message>(event, this, &target, msg);
 }
 
-void dispatcher::register_hotkey(const hotkey::HOTKEY_COMMAND id, const hotkey_function& function)
+void dispatcher::register_hotkey(const hotkey::HOTKEY_COMMAND id, hotkey_function&& function)
 {
-	hotkeys_[id] = function;
+	hotkeys_[id] = std::move(function);
 }
 
 bool dispatcher::execute_hotkey(const hotkey::HOTKEY_COMMAND id)
 {
-	std::map<hotkey::HOTKEY_COMMAND, hotkey_function>::iterator itor = hotkeys_.find(id);
+	auto itor = hotkeys_.find(id);
 
 	if(itor == hotkeys_.end()) {
 		return false;
 	}
 
-	itor->second(dynamic_cast<widget&>(*this), id);
-
-	/* NOTE: hotkey events used to return bool to indicate was-handled status. However,
-	 * every single usecase was returning true and cluttering up the code. I changed
-	 * the signature to return void, but if there's ever a need to restore the bool
-	 * retval on the hotkey functions, this is where it should be handled.
-	 *
-	 * -- vultraz, 2017-11-27
-	 */
-	return true;
+	return itor->second(dynamic_cast<widget&>(*this), id);
 }
 
 void connect_signal_pre_key_press(dispatcher& dispatcher, const signal_keyboard& signal)

--- a/src/gui/core/event/dispatcher.cpp
+++ b/src/gui/core/event/dispatcher.cpp
@@ -144,11 +144,6 @@ bool dispatcher::fire(const ui_event event, widget& target, const message& msg)
 	return fire_event<event_category::message>(event, this, &target, msg);
 }
 
-void dispatcher::register_hotkey(const hotkey::HOTKEY_COMMAND id, hotkey_function&& function)
-{
-	hotkeys_[id] = std::move(function);
-}
-
 bool dispatcher::execute_hotkey(const hotkey::HOTKEY_COMMAND id)
 {
 	auto itor = hotkeys_.find(id);

--- a/src/gui/core/event/dispatcher.hpp
+++ b/src/gui/core/event/dispatcher.hpp
@@ -129,7 +129,7 @@ using signal_raw_event = dispatcher_callback<const SDL_Event&>;
 using signal_text_input = dispatcher_callback<const std::string&, int32_t, int32_t>;
 
 /** Hotkey function handler signature. */
-using hotkey_function = std::function<void(widget& dispatcher, hotkey::HOTKEY_COMMAND id)>;
+using hotkey_function = std::function<bool(widget& dispatcher, hotkey::HOTKEY_COMMAND id)>;
 
 /**
  * Base class for event handling.
@@ -440,7 +440,7 @@ public:
 	 * @param id                  The hotkey to register.
 	 * @param function            The callback function to call.
 	 */
-	void register_hotkey(const hotkey::HOTKEY_COMMAND id, const hotkey_function& function);
+	void register_hotkey(const hotkey::HOTKEY_COMMAND id, hotkey_function&& function);
 
 	/**
 	 * Executes a hotkey.

--- a/src/gui/core/event/dispatcher.hpp
+++ b/src/gui/core/event/dispatcher.hpp
@@ -440,7 +440,11 @@ public:
 	 * @param id                  The hotkey to register.
 	 * @param function            The callback function to call.
 	 */
-	void register_hotkey(const hotkey::HOTKEY_COMMAND id, hotkey_function&& function);
+	template<typename Func>
+	void register_hotkey(const hotkey::HOTKEY_COMMAND id, Func&& function)
+	{
+		hotkeys_[id] = std::move(function);
+	}
 
 	/**
 	 * Executes a hotkey.

--- a/src/gui/dialogs/achievements_dialog.hpp
+++ b/src/gui/dialogs/achievements_dialog.hpp
@@ -25,7 +25,7 @@ namespace gui2::dialogs
 class achievements_dialog : public modal_dialog
 {
 public:
-	DEFINE_SIMPLE_EXECUTE_WRAPPER(achievements_dialog)
+	DEFINE_SIMPLE_DISPLAY_WRAPPER(achievements_dialog)
 
 	achievements_dialog();
 

--- a/src/gui/dialogs/gui_test_dialog.hpp
+++ b/src/gui/dialogs/gui_test_dialog.hpp
@@ -28,8 +28,8 @@ class gui_test_dialog : public modal_dialog
 public:
 	gui_test_dialog();
 
-	/** The execute function. See @ref modal_dialog for more information. */
-	DEFINE_SIMPLE_EXECUTE_WRAPPER(gui_test_dialog)
+	/** The display function. See @ref modal_dialog for more information. */
+	DEFINE_SIMPLE_DISPLAY_WRAPPER(gui_test_dialog)
 
 private:
 	virtual void pre_show() override;

--- a/src/gui/dialogs/multiplayer/lobby.cpp
+++ b/src/gui/dialogs/multiplayer/lobby.cpp
@@ -112,10 +112,10 @@ mp_lobby::mp_lobby(mp::lobby_info& info, wesnothd_connection& connection, int& j
 
 	/*** Local hotkeys. ***/
 	window::register_hotkey(hotkey::HOTKEY_HELP,
-		std::bind(&mp_lobby::show_help_callback, this));
+		[](auto&&...) { help::show_help(); return true; });
 
 	window::register_hotkey(hotkey::HOTKEY_PREFERENCES,
-		std::bind(&mp_lobby::show_preferences_button_callback, this));
+		[this](auto&&...) { show_preferences_button_callback(); return true; });
 }
 
 struct lobby_delay_gamelist_update_guard
@@ -919,11 +919,6 @@ void mp_lobby::enter_selected_game(JOIN_MODE mode)
 void mp_lobby::refresh_lobby()
 {
 	mp::send_to_server(config("refresh_lobby"));
-}
-
-void mp_lobby::show_help_callback()
-{
-	help::show_help();
 }
 
 void mp_lobby::show_preferences_button_callback()

--- a/src/gui/dialogs/multiplayer/lobby.hpp
+++ b/src/gui/dialogs/multiplayer/lobby.hpp
@@ -108,8 +108,6 @@ private:
 	/** Enter game by index, where index is the selected game listbox row. */
 	void enter_selected_game(JOIN_MODE mode);
 
-	void show_help_callback();
-
 	void show_preferences_button_callback();
 
 	void show_server_info();

--- a/src/gui/dialogs/multiplayer/mp_staging.cpp
+++ b/src/gui/dialogs/multiplayer/mp_staging.cpp
@@ -75,7 +75,7 @@ void mp_staging::pre_show()
 	set_escape_disabled(true);
 
 	// Ctrl+G triggers 'I'm Ready' (ok) button's functionality
-	register_hotkey(hotkey::HOTKEY_MP_START_GAME, std::bind(&mp_staging::start_game, this));
+	register_hotkey(hotkey::HOTKEY_MP_START_GAME, [this](auto&&...) { start_game(); return true; });
 	std::stringstream tooltip;
 	tooltip
 		<< vgettext_impl("wesnoth", "Hotkey(s): ",  {{}})

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -68,6 +68,24 @@ static lg::log_domain log_config("config");
 
 namespace gui2::dialogs
 {
+namespace
+{
+void show_lua_console()
+{
+	gui2::dialogs::lua_interpreter::display(gui2::dialogs::lua_interpreter::APP);
+}
+
+void make_screenshot()
+{
+	surface screenshot = video::read_pixels();
+	if(screenshot) {
+		std::string filename = filesystem::get_screenshot_dir() + "/" + _("Screenshot") + "_";
+		filename = filesystem::get_next_filename(filename, ".jpg");
+		gui2::dialogs::screenshot_notification::display(filename, screenshot);
+	}
+}
+
+} // anon namespace
 
 REGISTER_DIALOG(title_screen)
 
@@ -89,7 +107,7 @@ title_screen::~title_screen()
 void title_screen::register_button(const std::string& id, hotkey::HOTKEY_COMMAND hk, const std::function<void()>& callback)
 {
 	if(hk != hotkey::HOTKEY_NULL) {
-		register_hotkey(hk, std::bind(callback));
+		register_hotkey(hk, [callback](auto&&...) { callback(); return true; });
 	}
 
 	try {
@@ -99,21 +117,6 @@ void title_screen::register_button(const std::string& id, hotkey::HOTKEY_COMMAND
 		ERR_GUI_P << e.user_message;
 		prefs::get().set_gui2_theme("default");
 		set_retval(RELOAD_UI);
-	}
-}
-
-static void launch_lua_console()
-{
-	gui2::dialogs::lua_interpreter::display(gui2::dialogs::lua_interpreter::APP);
-}
-
-static void make_screenshot()
-{
-	surface screenshot = video::read_pixels();
-	if(screenshot) {
-		std::string filename = filesystem::get_screenshot_dir() + "/" + _("Screenshot") + "_";
-		filename = filesystem::get_next_filename(filename, ".jpg");
-		gui2::dialogs::screenshot_notification::display(filename, screenshot);
 	}
 }
 
@@ -163,19 +166,20 @@ void title_screen::init_callbacks()
 	// General hotkeys
 	//
 	register_hotkey(hotkey::TITLE_SCREEN__RELOAD_WML,
-		std::bind(&gui2::window::set_retval, std::ref(*this), RELOAD_GAME_DATA, true));
-
-	register_hotkey(hotkey::HOTKEY_ACHIEVEMENTS,
-		std::bind(&title_screen::show_achievements, this));
+		[this](auto&&...) { set_retval(RELOAD_GAME_DATA); return true; });
 
 	register_hotkey(hotkey::TITLE_SCREEN__TEST,
-		std::bind(&title_screen::hotkey_callback_select_tests, this));
+		[this](auto&&...) { hotkey_callback_select_tests(); return true; });
 
-	// A wrapper is needed here since the relevant display function is overloaded, and
-	// since the wrapper's signature doesn't exactly match what register_hotkey expects.
-	register_hotkey(hotkey::LUA_CONSOLE, std::bind(&launch_lua_console));
+	register_hotkey(hotkey::TITLE_SCREEN__CORES,
+		[this](auto&&...) { button_callback_cores(); return true; });
 
-	register_hotkey(hotkey::HOTKEY_SCREENSHOT, std::bind(&make_screenshot));
+	register_hotkey(hotkey::LUA_CONSOLE,
+		[](auto&&...) { show_lua_console(); return true; });
+
+	/** @todo: should eventually become part of global hotkey handling. */
+	register_hotkey(hotkey::HOTKEY_SCREENSHOT,
+		[](auto&&...) { make_screenshot(); return true; });
 
 	//
 	// Background and logo images
@@ -299,12 +303,6 @@ void title_screen::init_callbacks()
 	register_button("editor", hotkey::TITLE_SCREEN__EDITOR, [this]() { set_retval(MAP_EDITOR); });
 
 	//
-	// Cores
-	//
-	register_hotkey(hotkey::TITLE_SCREEN__CORES,
-		std::bind(&title_screen::button_callback_cores, this));
-
-	//
 	// Language
 	//
 	register_button("language", hotkey::HOTKEY_LANGUAGE, [this]() {
@@ -328,13 +326,13 @@ void title_screen::init_callbacks()
 	// Achievements
 	//
 	register_button("achievements", hotkey::HOTKEY_ACHIEVEMENTS,
-		std::bind(&title_screen::show_achievements, this));
+		[] { dialogs::achievements_dialog::display(); });
 
 	//
 	// Community
 	//
 	register_button("community", hotkey::HOTKEY_NULL,
-		std::bind(&title_screen::show_community, this));
+		[] { dialogs::game_version::display(4); }); // shows the 5th tab, community
 
 	//
 	// Quit
@@ -358,7 +356,7 @@ void title_screen::init_callbacks()
 	// GUI Test and Debug Window
 	//
 	register_button("test_dialog", hotkey::HOTKEY_NULL,
-		std::bind(&title_screen::show_gui_test_dialog, this));
+		[] { dialogs::gui_test_dialog::display(); });
 
 	auto test_dialog = find_widget<button>("test_dialog", false, false);
 	if(test_dialog) {
@@ -477,24 +475,6 @@ void title_screen::hotkey_callback_select_tests()
 		game_.set_test(options[choice]);
 		set_retval(LAUNCH_GAME);
 	}
-}
-
-void title_screen::show_achievements()
-{
-	achievements_dialog ach;
-	ach.show();
-}
-
-void title_screen::show_community()
-{
-	game_version dlg;
-	// shows the 5th tab, community, when the dialog is shown
-	dlg.display(4);
-}
-
-void title_screen::show_gui_test_dialog()
-{
-	gui2::dialogs::gui_test_dialog::execute();
 }
 
 void title_screen::show_preferences()

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -68,24 +68,6 @@ static lg::log_domain log_config("config");
 
 namespace gui2::dialogs
 {
-namespace
-{
-void show_lua_console()
-{
-	gui2::dialogs::lua_interpreter::display(gui2::dialogs::lua_interpreter::APP);
-}
-
-void make_screenshot()
-{
-	surface screenshot = video::read_pixels();
-	if(screenshot) {
-		std::string filename = filesystem::get_screenshot_dir() + "/" + _("Screenshot") + "_";
-		filename = filesystem::get_next_filename(filename, ".jpg");
-		gui2::dialogs::screenshot_notification::display(filename, screenshot);
-	}
-}
-
-} // anon namespace
 
 REGISTER_DIALOG(title_screen)
 
@@ -119,6 +101,25 @@ void title_screen::register_button(const std::string& id, hotkey::HOTKEY_COMMAND
 		set_retval(RELOAD_UI);
 	}
 }
+
+namespace
+{
+void show_lua_console()
+{
+	gui2::dialogs::lua_interpreter::display(gui2::dialogs::lua_interpreter::APP);
+}
+
+void make_screenshot()
+{
+	surface screenshot = video::read_pixels();
+	if(screenshot) {
+		std::string filename = filesystem::get_screenshot_dir() + "/" + _("Screenshot") + "_";
+		filename = filesystem::get_next_filename(filename, ".jpg");
+		gui2::dialogs::screenshot_notification::display(filename, screenshot);
+	}
+}
+
+} // anon namespace
 
 #ifdef DEBUG_TOOLTIP
 /*

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -90,17 +90,10 @@ private:
 	/** Shows the debug clock. */
 	void show_debug_clock_window();
 
-	/** Shows the gui test window. */
-	void show_gui_test_dialog();
-
 	/** Shows the preferences dialog. */
 	void show_preferences();
 
 	void hotkey_callback_select_tests();
-
-	void show_achievements();
-
-	void show_community();
 
 	void button_callback_multiplayer();
 

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -151,7 +151,7 @@ static void delay_event(const SDL_Event& event, const uint32_t delay)
  *
  * The event is used to show the helptip for the currently focused widget.
  */
-static void helptip()
+static bool helptip()
 {
 	DBG_GUI_E << "Pushing SHOW_HELPTIP_EVENT event in queue.";
 
@@ -162,6 +162,7 @@ static void helptip()
 	event.user = data;
 
 	SDL_PushEvent(&event);
+	return true;
 }
 
 /**
@@ -361,11 +362,12 @@ window::window(const builder_window::window_resolution& definition)
 
 	connect_signal<event::CLOSE_WINDOW>(std::bind(&window::signal_handler_close_window, this));
 
-	register_hotkey(hotkey::GLOBAL__HELPTIP, std::bind(gui2::helptip));
+	register_hotkey(hotkey::GLOBAL__HELPTIP,
+		[](auto&&...) { return helptip(); });
 
-	/** @todo: should eventally become part of global hotkey handling. */
+	/** @todo: should eventually become part of global hotkey handling. */
 	register_hotkey(hotkey::HOTKEY_FULLSCREEN,
-		std::bind(&video::toggle_fullscreen));
+		[](auto&&...) { video::toggle_fullscreen(); return true; });
 }
 
 window::~window()


### PR DESCRIPTION
- Restore the is-handled callback return value (functionally reverts 8bf95ce69a9bd59d98d14653cc727368d23f75c0)
- Take hotkey callbacks by rvalue reference
- Avoid registering achievement hotkey twice
- Clean up excessive callback wrappers in the lobby and main menu
- Properly define the display function for the test and achievement dialogs