### PR TITLE
Necromancer: emphasize plague, reduce durability

### DIFF
--- a/changelog_entries/necromancer-more-plague.md
+++ b/changelog_entries/necromancer-more-plague.md
@@ -2,6 +2,6 @@
    * Necromancer:
         * Changes to emphasize the Necro's thematic plague ability, while lowering his/her durability closer to that of other mages:
         * hitpoints 76 -> 62, impact resist 10% -> 0%
-        * plague staff 6-3 -> 8-3
-        * chill wave 19-2 -> 20-2
-        * shadow wave 16-2 -> 12-2, added "plague" weapon special
+        * plague staff (melee impact) 6-3 -> 8-3
+        * chill wave (ranged cold) 19-2 -> 20-2
+        * shadow wave (ranged arcane) 16-2 -> 12-2, added "plague" weapon special

--- a/changelog_entries/necromancer-more-plague.md
+++ b/changelog_entries/necromancer-more-plague.md
@@ -1,7 +1,7 @@
 ### Units
    * Necromancer:
         * Changes to emphasize the Necro's thematic plague ability, while lowering his/her durability closer to that of other mages:
-        * hitpoints 76 -> 62, impact resist 10% -> 0%
-        * plague staff (melee impact) 6-3 -> 8-3
+        * hitpoints 76 -> 64, impact resist 10% -> 0%, cold resist 0% -> 10%
+        * plague staff (melee impact) 6-3 -> 7-3
         * chill wave (ranged cold) 19-2 -> 20-2
-        * shadow wave (ranged arcane) 16-2 -> 12-2, added "plague" weapon special
+        * shadow wave (ranged arcane) 16-2 -> 13-2, added "plague" weapon special

--- a/changelog_entries/necromancer-more-plague.md
+++ b/changelog_entries/necromancer-more-plague.md
@@ -1,0 +1,7 @@
+### Units
+   * Necromancer:
+        * Changes to emphasize the Necro's thematic plague ability, while lowering his/her durability closer to that of other mages:
+        * hitpoints 76 -> 62, impact resist 10% -> 0%
+        * plague staff 6-3 -> 8-3
+        * chill wave 19-2 -> 20-2
+        * shadow wave 16-2 -> 12-2, added "plague" weapon special

--- a/data/core/units/undead/Necromancer.cfg
+++ b/data/core/units/undead/Necromancer.cfg
@@ -6,11 +6,8 @@
     race=human
     image="units/undead-necromancers/necromancer.png"
     profile="portraits/humans/necromancer.webp"
-    hitpoints=76
+    hitpoints=62
     movement_type=smallfoot
-    [resistance]
-        impact=90
-    [/resistance]
     movement=5
     experience=150
     level=3
@@ -30,7 +27,7 @@ This ability, in all aspects, is the first step towards cheating death of its ul
         icon=attacks/staff-plague.png
         type=impact
         range=melee
-        damage=6
+        damage=8
         number=3
         [specials]
             {WEAPON_SPECIAL_PLAGUE}
@@ -44,7 +41,7 @@ This ability, in all aspects, is the first step towards cheating death of its ul
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
         range=ranged
-        damage=19
+        damage=20
         number=2
         icon=attacks/iceball.png
     [/attack]
@@ -54,9 +51,10 @@ This ability, in all aspects, is the first step towards cheating death of its ul
         type=arcane
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
+            {WEAPON_SPECIAL_PLAGUE}
         [/specials]
         range=ranged
-        damage=16
+        damage=12
         number=2
         icon=attacks/dark-missile.png
     [/attack]

--- a/data/core/units/undead/Necromancer.cfg
+++ b/data/core/units/undead/Necromancer.cfg
@@ -6,8 +6,11 @@
     race=human
     image="units/undead-necromancers/necromancer.png"
     profile="portraits/humans/necromancer.webp"
-    hitpoints=62
+    hitpoints=64
     movement_type=smallfoot
+    [resistance]
+        cold=90
+    [/resistance]
     movement=5
     experience=150
     level=3
@@ -27,7 +30,7 @@ This ability, in all aspects, is the first step towards cheating death of its ul
         icon=attacks/staff-plague.png
         type=impact
         range=melee
-        damage=8
+        damage=7
         number=3
         [specials]
             {WEAPON_SPECIAL_PLAGUE}
@@ -54,7 +57,7 @@ This ability, in all aspects, is the first step towards cheating death of its ul
             {WEAPON_SPECIAL_PLAGUE}
         [/specials]
         range=ranged
-        damage=12
+        damage=13
         number=2
         icon=attacks/dark-missile.png
     [/attack]


### PR DESCRIPTION
The 1.18 Necromancer is in an odd spot. His/her damage is very similar to the Lich, but inferior to both the Enchantress and Arch Mage (and MoL, if we factor in Illuminates). But unlike every other mage, the Necromancer boasts a whopping 76 hp and 10% impact resistance.

These stats (more hp than a Royal Guard!?) point the Necromancer towards a front-line tank/shock trooper role. I get that this is reasonable for balance - undead don't have good impact-resistant tanks - but I also feel that using Necromancers as meatshields runs contrary to the unit fantasy.

This PR lowers the Necro's durability closer to that of the other mages, while instead emphasizing his/her thematic plague ability:
- hitpoints 76 -> 62, impact resist 10% -> 0%
- plague staff (melee impact) 6-3 -> 8-3
- chill wave (ranged cold) 19-2 -> 20-2
- shadow wave (ranged arcane) 16-2 -> 12-2, add "plague" weapon special

(unit cost and exact stats may need adjustment)