### PR TITLE
Deployed std::span via compat wrapper

### DIFF
--- a/src/color_range.cpp
+++ b/src/color_range.cpp
@@ -21,22 +21,15 @@
 
 #include "color_range.hpp"
 
+#include "utils/span.hpp"
+
 #include <array>
 #include <cassert>
 #include <sstream>
 
-#ifdef __cpp_lib_span
-#include <span>
-#endif
-
 namespace
 {
-#ifdef __cpp_lib_span
-std::vector<color_t> recolor_range_impl(const color_range& new_range, std::span<const color_t> old_rgb)
-#else
-template<typename Container>
-std::vector<color_t> recolor_range_impl(const color_range& new_range, const Container& old_rgb)
-#endif
+std::vector<color_t> recolor_range_impl(const color_range& new_range, utils::span<const color_t> old_rgb)
 {
 	std::vector<color_t> clist;
 	clist.reserve(old_rgb.size());

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1123,13 +1123,12 @@ std::vector<uint8_t> read_file_binary(const std::string& fname)
 std::string read_file_as_data_uri(const std::string& fname)
 {
 	std::vector<uint8_t> file_contents = filesystem::read_file_binary(fname);
-	utils::byte_string_view view = {file_contents.data(), file_contents.size()};
 	std::string name = filesystem::base_name(fname);
 	std::string img = "";
 
 	if(name.find(".") != std::string::npos) {
 		// convert to web-safe base64, since the + symbols will get stripped out when reading this back in later
-		img = "data:image/"+name.substr(name.find(".")+1)+";base64,"+base64::encode(view);
+		img = "data:image/" + name.substr(name.find(".") + 1) + ";base64," + base64::encode(file_contents);
 	}
 
 	return img;

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -560,11 +560,7 @@ bool ci_search(const std::string& s1, const std::string& s2)
 	return std::search(ls1.begin(), ls1.end(), ls2.begin(), ls2.end()) != ls1.end();
 }
 
-#ifdef __cpp_lib_span
-bool ci_search(std::span<std::string> s1, const std::string& s2)
-#else
-bool ci_search(const std::vector<std::string>& s1, const std::string& s2)
-#endif
+bool ci_search(utils::span<const std::string> s1, const std::string& s2)
 {
 	return std::any_of(s1.begin(), s1.end(), [&s2](const auto& s1) { return ci_search(s1, s2); });
 }

--- a/src/gettext.hpp
+++ b/src/gettext.hpp
@@ -40,9 +40,7 @@
 #include <ctime>
 #include <boost/locale/info.hpp>
 
-#ifdef __cpp_lib_span
-#include <span>
-#endif
+#include "utils/span.hpp"
 
 #ifndef GETTEXT_DOMAIN
 # define GETTEXT_DOMAIN PACKAGE
@@ -84,11 +82,7 @@ namespace translation
 	bool ci_search(const std::string& s1, const std::string& s2);
 
 	/** Case-insensitive search. @a s2 will be checked against any element of @a s1. */
-#ifdef __cpp_lib_span
-	bool ci_search(std::span<std::string> s1, const std::string& s2);
-#else
-	bool ci_search(const std::vector<std::string>& s1, const std::string& s2);
-#endif
+	bool ci_search(utils::span<const std::string> s1, const std::string& s2);
 
 	/**
 	 * A facet that holds general information about the effective locale.

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -44,8 +44,7 @@ const std::string hash_prefix = "$H$";
 
 template<std::size_t len>
 std::string encode_hash(const std::array<uint8_t, len>& bytes) {
-	utils::byte_string_view view{bytes.data(), len};
-	return crypt64::encode(view);
+	return crypt64::encode(bytes);
 }
 
 template<std::size_t len>

--- a/src/serialization/base64.cpp
+++ b/src/serialization/base64.cpp
@@ -135,9 +135,9 @@ std::vector<uint8_t> generic_decode_le(std::string_view in, const std::vector<in
 	return out;
 }
 
-std::string generic_encode_be(utils::byte_string_view in, const std::string& itoa_map, bool pad)
+std::string generic_encode_be(utils::byte_view in, const std::string& itoa_map, bool pad)
 {
-	const int in_len = in.length();
+	const int in_len = in.size();
 	const int groups = (in_len + 2) / 3;
 	const int out_len = groups * 4;
 
@@ -168,9 +168,9 @@ std::string generic_encode_be(utils::byte_string_view in, const std::string& ito
 	return out;
 
 }
-std::string generic_encode_le(utils::byte_string_view in, const std::string& itoa_map, bool pad)
+std::string generic_encode_le(utils::byte_view in, const std::string& itoa_map, bool pad)
 {
-	const int in_len = in.length();
+	const int in_len = in.size();
 	const int groups = (in_len + 2) / 3;
 	const int out_len = groups * 4;
 
@@ -222,7 +222,7 @@ std::vector<uint8_t> decode(std::string_view in)
 {
 	return generic_decode_be(in, base64_atoi_map());
 }
-std::string encode(utils::byte_string_view bytes)
+std::string encode(utils::byte_view bytes)
 {
 	return generic_encode_be(bytes, base64_itoa_map, true);
 }
@@ -232,7 +232,7 @@ std::vector<uint8_t> decode(std::string_view in)
 {
 	return generic_decode_le(in, crypt64_atoi_map());
 }
-std::string encode(utils::byte_string_view bytes)
+std::string encode(utils::byte_view bytes)
 {
 	return generic_encode_le(bytes, crypt64_itoa_map, false);
 }

--- a/src/serialization/base64.hpp
+++ b/src/serialization/base64.hpp
@@ -16,24 +16,25 @@
 #pragma once
 
 #include <cstdint>
+#include "utils/span.hpp"
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace utils
 {
-using byte_string_view = std::basic_string_view<uint8_t>;
+using byte_view = utils::span<const uint8_t>;
 }
 
 // Official Base64 encoding (RFC4648)
 namespace base64 {
 	std::vector<uint8_t> decode(std::string_view encoded);
-	std::string encode(utils::byte_string_view bytes);
+	std::string encode(utils::byte_view bytes);
 }
 // crypt()-compatible radix-64 encoding
 namespace crypt64 {
 	std::vector<uint8_t> decode(std::string_view encoded);
-	std::string encode(utils::byte_string_view bytes);
+	std::string encode(utils::byte_view bytes);
 	// Single character functions. For special use only
 	int decode(char encoded_char);
 	char encode(int value);

--- a/src/tests/test_sdl.cpp
+++ b/src/tests/test_sdl.cpp
@@ -16,6 +16,7 @@
 
 #include "sdl/surface.hpp"
 #include "sdl/utils.hpp"
+#include "utils/span.hpp"
 
 #include <algorithm>
 #include <array>
@@ -61,16 +62,6 @@ surface array_to_surface(const std::array<uint32_t, w * h>& arr)
 	return surf;
 }
 
-static std::vector<uint32_t> surface_to_vec(const surface& surf)
-{
-	const_surface_lock lock{surf};
-	const uint32_t* const pixels = lock.pixels();
-	std::vector<uint32_t> pixel_vec;
-	const int surf_size = surf->w * surf->h;
-	std::copy(pixels, pixels + surf_size, std::back_inserter(pixel_vec));
-	return pixel_vec;
-}
-
 BOOST_AUTO_TEST_SUITE(sdl)
 
 BOOST_AUTO_TEST_CASE(test_scale_sharp_nullptr)
@@ -91,7 +82,8 @@ BOOST_AUTO_TEST_CASE(test_scale_sharp_round)
 {
 	surface src = array_to_surface<4, 4>(img_4x4);
 	surface result = scale_surface_sharp(src, 2, 2);
-	std::vector<uint32_t> result_pixels = surface_to_vec(result);
+	const_surface_lock lock{result};
+	auto result_pixels = utils::span(lock.pixels(), result.area());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		result_pixels.begin(), result_pixels.end(), img_4x4_to_2x2_result.begin(), img_4x4_to_2x2_result.end());
 }
@@ -100,7 +92,8 @@ BOOST_AUTO_TEST_CASE(test_scale_sharp_fractional)
 {
 	surface src = array_to_surface<4, 4>(img_4x4);
 	surface result = scale_surface_sharp(src, 3, 2);
-	std::vector<uint32_t> result_pixels = surface_to_vec(result);
+	const_surface_lock lock{result};
+	auto result_pixels = utils::span(lock.pixels(), result.area());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		result_pixels.begin(), result_pixels.end(), img_4x4_to_3x2_result.begin(), img_4x4_to_3x2_result.end());
 }

--- a/src/tests/test_serialization.cpp
+++ b/src/tests/test_serialization.cpp
@@ -604,18 +604,18 @@ BOOST_AUTO_TEST_CASE( test_base64_encodings )
 		many_bytes[i] = i % 256;
 	}
 
-	BOOST_CHECK(base64::encode({empty.data(), empty.size()}).empty());
-	BOOST_CHECK_EQUAL(base64::encode({foo.data(), foo.size()}), foo_b64);
-	BOOST_CHECK_EQUAL(base64::encode({foob.data(), foob.size()}), foob_b64);
+	BOOST_CHECK(base64::encode(empty).empty());
+	BOOST_CHECK_EQUAL(base64::encode(foo), foo_b64);
+	BOOST_CHECK_EQUAL(base64::encode(foob), foob_b64);
 
 	BOOST_CHECK(base64::decode(empty_b64).empty());
 	// Not using CHECK_EQUAL because vector<uint8_t> is not printable
 	BOOST_CHECK(base64::decode(foo_b64) == foo);
 	BOOST_CHECK(base64::decode(foob_b64) == foob);
 
-	BOOST_CHECK(crypt64::encode({empty.data(), empty.size()}).empty());
-	BOOST_CHECK_EQUAL(crypt64::encode({foo.data(), foo.size()}), foo_c64);
-	BOOST_CHECK_EQUAL(crypt64::encode({foob.data(), foob.size()}), foob_c64);
+	BOOST_CHECK(crypt64::encode(empty).empty());
+	BOOST_CHECK_EQUAL(crypt64::encode(foo), foo_c64);
+	BOOST_CHECK_EQUAL(crypt64::encode(foob), foob_c64);
 
 	BOOST_CHECK(crypt64::decode(empty_c64).empty());
 	// Not using CHECK_EQUAL because vector<uint8_t> is not printable
@@ -627,8 +627,8 @@ BOOST_AUTO_TEST_CASE( test_base64_encodings )
 	BOOST_CHECK_EQUAL(crypt64::encode(0), '.');
 	BOOST_CHECK_EQUAL(crypt64::encode(63), 'z');
 
-	BOOST_CHECK(base64::decode(base64::encode({many_bytes.data(), many_bytes.size()})) == many_bytes);
-	BOOST_CHECK(crypt64::decode(crypt64::encode({many_bytes.data(), many_bytes.size()})) == many_bytes);
+	BOOST_CHECK(base64::decode(base64::encode(many_bytes)) == many_bytes);
+	BOOST_CHECK(crypt64::decode(crypt64::encode(many_bytes)) == many_bytes);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/utils/span.hpp
+++ b/src/utils/span.hpp
@@ -1,0 +1,468 @@
+/*
+	Copyright (C) 2025 - 2025
+	Part of the Battle for Wesnoth Project https://www.wesnoth.org/
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY.
+
+	See the COPYING file for more details.
+*/
+
+#pragma once
+
+// We need to include *something* so __cpp_lib_span is defined properly here
+#if __has_include(<version>)
+#include <version>
+#endif
+
+#include <boost/version.hpp>
+
+// C++20 compatible
+#ifdef __cpp_lib_span
+
+#include <span>
+namespace utils { using std::span; }
+
+// Boost 1.78 or later
+#elif BOOST_VERSION >= 107800
+
+#include <boost/core/span.hpp>
+namespace utils { using boost::span; }
+
+// Full manual fallback, copied from Boost with some tweaks
+#else
+
+/*
+Copyright 2019-2023 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <type_traits>
+
+namespace boost {
+
+template<class C>
+inline constexpr auto
+data(C& c) noexcept(noexcept(c.data())) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template<class C>
+inline constexpr auto
+data(const C& c) noexcept(noexcept(c.data())) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template<class T, std::size_t N>
+inline constexpr T*
+data(T(&a)[N]) noexcept
+{
+    return a;
+}
+
+template<class T>
+inline constexpr const T*
+data(std::initializer_list<T> l) noexcept
+{
+    return l.begin();
+}
+
+constexpr std::size_t dynamic_extent = static_cast<std::size_t>(-1);
+
+template<class T, std::size_t E = dynamic_extent>
+class span;
+
+namespace detail {
+
+template<class U, class T>
+struct span_convertible {
+    static constexpr bool value = std::is_convertible<U(*)[], T(*)[]>::value;
+};
+
+template<std::size_t E, std::size_t N>
+struct span_capacity {
+    static constexpr bool value = E == boost::dynamic_extent || E == N;
+};
+
+template<class T, std::size_t E, class U, std::size_t N>
+struct span_compatible {
+    static constexpr bool value = span_capacity<E, N>::value &&
+        span_convertible<U, T>::value;
+};
+
+template<class T>
+using span_uncvref = typename std::remove_cv<typename
+    std::remove_reference<T>::type>::type;
+
+template<class>
+struct span_is_span {
+    static constexpr bool value = false;
+};
+
+template<class T, std::size_t E>
+struct span_is_span<boost::span<T, E> > {
+    static constexpr bool value = true;
+};
+
+template<class T>
+struct span_is_array {
+    static constexpr bool value = false;
+};
+
+template<class T, std::size_t N>
+struct span_is_array<std::array<T, N> > {
+    static constexpr bool value = true;
+};
+
+template<class T>
+using span_ptr = decltype(boost::data(std::declval<T&>()));
+
+template<class, class = void>
+struct span_data { };
+
+template<class T>
+struct span_data<T,
+    typename std::enable_if<std::is_pointer<span_ptr<T> >::value>::type> {
+    typedef typename std::remove_pointer<span_ptr<T> >::type type;
+};
+
+template<class, class, class = void>
+struct span_has_data {
+    static constexpr bool value = false;
+};
+
+template<class R, class T>
+struct span_has_data<R, T, typename std::enable_if<span_convertible<typename
+    span_data<R>::type, T>::value>::type> {
+    static constexpr bool value = true;
+};
+
+template<class, class = void>
+struct span_has_size {
+    static constexpr bool value = false;
+};
+
+template<class R>
+struct span_has_size<R, typename
+    std::enable_if<std::is_convertible<decltype(std::declval<R&>().size()),
+        std::size_t>::value>::type> {
+    static constexpr bool value = true;
+};
+
+template<class R, class T>
+struct span_is_range {
+    static constexpr bool value = (std::is_const<T>::value ||
+        std::is_lvalue_reference<R>::value) &&
+        !span_is_span<span_uncvref<R> >::value &&
+        !span_is_array<span_uncvref<R> >::value &&
+        !std::is_array<span_uncvref<R> >::value &&
+        span_has_data<R, T>::value &&
+        span_has_size<R>::value;
+};
+
+template<std::size_t E, std::size_t N>
+struct span_implicit {
+    static constexpr bool value = E == boost::dynamic_extent ||
+        N != boost::dynamic_extent;
+};
+
+template<class T, std::size_t E, class U, std::size_t N>
+struct span_copyable {
+    static constexpr bool value = (N == boost::dynamic_extent ||
+        span_capacity<E, N>::value) && span_convertible<U, T>::value;
+};
+
+template<std::size_t E, std::size_t O>
+struct span_sub {
+    static constexpr std::size_t value = E == boost::dynamic_extent ?
+        boost::dynamic_extent : E - O;
+};
+
+template<class T, std::size_t E>
+struct span_store {
+    constexpr span_store(T* p_, std::size_t) noexcept
+        : p(p_) { }
+    static constexpr std::size_t n = E;
+    T* p;
+};
+
+template<class T>
+struct span_store<T, boost::dynamic_extent> {
+    constexpr span_store(T* p_, std::size_t n_) noexcept
+        : p(p_)
+        , n(n_) { }
+    T* p;
+    std::size_t n;
+};
+
+template<class T, std::size_t E>
+struct span_bytes {
+    static constexpr std::size_t value = sizeof(T) * E;
+};
+
+template<class T>
+struct span_bytes<T, boost::dynamic_extent> {
+    static constexpr std::size_t value = boost::dynamic_extent;
+};
+
+} /* detail */
+
+template<class T, std::size_t E>
+class span {
+public:
+    typedef T element_type;
+    typedef typename std::remove_cv<T>::type value_type;
+    typedef std::size_t size_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef T* pointer;
+    typedef const T* const_pointer;
+    typedef T& reference;
+    typedef const T& const_reference;
+    typedef T* iterator;
+    typedef const T* const_iterator;
+    typedef std::reverse_iterator<T*> reverse_iterator;
+    typedef std::reverse_iterator<const T*> const_reverse_iterator;
+
+    static constexpr std::size_t extent = E;
+
+    template<std::size_t N = E,
+        typename std::enable_if<N == dynamic_extent || N == 0, int>::type = 0>
+    constexpr span() noexcept
+        : s_(0, 0) { }
+
+    template<class I,
+        typename std::enable_if<E == dynamic_extent &&
+            detail::span_convertible<I, T>::value, int>::type = 0>
+    constexpr span(I* f, size_type c)
+        : s_(f, c) { }
+
+    template<class I,
+        typename std::enable_if<E != dynamic_extent &&
+            detail::span_convertible<I, T>::value, int>::type = 0>
+    explicit constexpr span(I* f, size_type c)
+        : s_(f, c) { }
+
+    template<class I, class L,
+        typename std::enable_if<E == dynamic_extent &&
+            detail::span_convertible<I, T>::value, int>::type = 0>
+    constexpr span(I* f, L* l)
+        : s_(f, l - f) { }
+
+    template<class I, class L,
+        typename std::enable_if<E != dynamic_extent &&
+            detail::span_convertible<I, T>::value, int>::type = 0>
+    explicit constexpr span(I* f, L* l)
+        : s_(f, l - f) { }
+
+    template<std::size_t N,
+        typename std::enable_if<detail::span_capacity<E, N>::value,
+            int>::type = 0>
+    constexpr span(typename std::enable_if<true, T>::type (&a)[N]) noexcept
+        : s_(a, N) { }
+
+    template<class U, std::size_t N,
+        typename std::enable_if<detail::span_compatible<T, E, U, N>::value,
+            int>::type = 0>
+    constexpr span(std::array<U, N>& a) noexcept
+        : s_(a.data(), N) { }
+
+    template<class U, std::size_t N,
+        typename std::enable_if<detail::span_compatible<T, E, const U,
+            N>::value, int>::type = 0>
+    constexpr span(const std::array<U, N>& a) noexcept
+        : s_(a.data(), N) { }
+
+    template<class R,
+        typename std::enable_if<E == dynamic_extent &&
+            detail::span_is_range<R, T>::value, int>::type = 0>
+    constexpr span(R&& r) noexcept(noexcept(boost::data(r)) &&
+        noexcept(r.size()))
+        : s_(boost::data(r), r.size()) { }
+
+    template<class R,
+        typename std::enable_if<E != dynamic_extent &&
+            detail::span_is_range<R, T>::value, int>::type = 0>
+    explicit constexpr span(R&& r) noexcept(noexcept(boost::data(r)) &&
+        noexcept(r.size()))
+        : s_(boost::data(r), r.size()) { }
+
+    template<class U, std::size_t N,
+        typename std::enable_if<detail::span_implicit<E, N>::value &&
+            detail::span_copyable<T, E, U, N>::value, int>::type = 0>
+    constexpr span(const span<U, N>& s) noexcept
+        : s_(s.data(), s.size()) { }
+
+    template<class U, std::size_t N,
+        typename std::enable_if<!detail::span_implicit<E, N>::value &&
+            detail::span_copyable<T, E, U, N>::value, int>::type = 0>
+    explicit constexpr span(const span<U, N>& s) noexcept
+        : s_(s.data(), s.size()) { }
+
+    template<std::size_t C>
+    constexpr span<T, C> first() const {
+        static_assert(C <= E, "Count <= Extent");
+        return span<T, C>(s_.p, C);
+    }
+
+    template<std::size_t C>
+    constexpr span<T, C> last() const {
+        static_assert(C <= E, "Count <= Extent");
+        return span<T, C>(s_.p + (s_.n - C), C);
+    }
+
+    template<std::size_t O, std::size_t C = dynamic_extent>
+    constexpr typename std::enable_if<C == dynamic_extent,
+        span<T, detail::span_sub<E, O>::value> >::type subspan() const {
+        static_assert(O <= E, "Offset <= Extent");
+        return span<T, detail::span_sub<E, O>::value>(s_.p + O, s_.n - O);
+    }
+
+    template<std::size_t O, std::size_t C = dynamic_extent>
+    constexpr typename std::enable_if<C != dynamic_extent,
+        span<T, C> >::type subspan() const {
+        static_assert(O <= E && C <= E - O,
+            "Offset <= Extent && Count <= Extent - Offset");
+        return span<T, C>(s_.p + O, C);
+    }
+
+    constexpr span<T, dynamic_extent> first(size_type c) const {
+        return span<T, dynamic_extent>(s_.p, c);
+    }
+
+    constexpr span<T, dynamic_extent> last(size_type c) const {
+        return span<T, dynamic_extent>(s_.p + (s_.n - c), c);
+    }
+
+    constexpr span<T, dynamic_extent> subspan(size_type o,
+        size_type c = dynamic_extent) const {
+        return span<T, dynamic_extent>(s_.p + o,
+            c == dynamic_extent ? s_.n - o : c);
+    }
+
+    constexpr size_type size() const noexcept {
+        return s_.n;
+    }
+
+    constexpr size_type size_bytes() const noexcept {
+        return s_.n * sizeof(T);
+    }
+
+    constexpr bool empty() const noexcept {
+        return s_.n == 0;
+    }
+
+    constexpr reference operator[](size_type i) const {
+        return s_.p[i];
+    }
+
+    constexpr reference front() const {
+        return *s_.p;
+    }
+
+    constexpr reference back() const {
+        return s_.p[s_.n - 1];
+    }
+
+    constexpr pointer data() const noexcept {
+        return s_.p;
+    }
+
+    constexpr iterator begin() const noexcept {
+        return s_.p;
+    }
+
+    constexpr iterator end() const noexcept {
+        return s_.p + s_.n;
+    }
+
+    constexpr reverse_iterator rbegin() const noexcept {
+        return reverse_iterator(s_.p + s_.n);
+    }
+
+    constexpr reverse_iterator rend() const noexcept {
+        return reverse_iterator(s_.p);
+    }
+
+    constexpr const_iterator cbegin() const noexcept {
+        return s_.p;
+    }
+
+    constexpr const_iterator cend() const noexcept {
+        return s_.p + s_.n;
+    }
+
+    constexpr const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(s_.p + s_.n);
+    }
+
+    constexpr const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(s_.p);
+    }
+
+private:
+    detail::span_store<T, E> s_;
+};
+
+#if defined(BOOST_NO_CXX17_INLINE_VARIABLES)
+template<class T, std::size_t E>
+constexpr std::size_t span<T, E>::extent;
+#endif
+
+#ifdef __cpp_deduction_guides
+template<class I, class L>
+span(I*, L) -> span<I>;
+
+template<class T, std::size_t N>
+span(T(&)[N]) -> span<T, N>;
+
+template<class T, std::size_t N>
+span(std::array<T, N>&) -> span<T, N>;
+
+template<class T, std::size_t N>
+span(const std::array<T, N>&) -> span<const T, N>;
+
+template<class R>
+span(R&&) -> span<typename detail::span_data<R>::type>;
+
+template<class T, std::size_t E>
+span(span<T, E>) -> span<T, E>;
+#endif
+
+#ifdef __cpp_lib_byte
+template<class T, std::size_t E>
+inline span<const std::byte, detail::span_bytes<T, E>::value>
+as_bytes(span<T, E> s) noexcept
+{
+    return span<const std::byte, detail::span_bytes<T,
+        E>::value>(reinterpret_cast<const std::byte*>(s.data()),
+            s.size_bytes());
+}
+
+template<class T, std::size_t E>
+inline typename std::enable_if<!std::is_const<T>::value,
+    span<std::byte, detail::span_bytes<T, E>::value> >::type
+as_writable_bytes(span<T, E> s) noexcept
+{
+    return span<std::byte, detail::span_bytes<T,
+        E>::value>(reinterpret_cast<std::byte*>(s.data()), s.size_bytes());
+}
+#endif
+
+} /* boost */
+
+namespace utils { using boost::span; }
+
+#endif


### PR DESCRIPTION
Boosts the boost requirements to 1.78 so we can use boost::span as a fallback when targeting C++17 (currently the default).

Covers existing conditional uses of std::span as well as utils::byte_string_view (here renamed to byte_view). This use of std::string_view is not standard-compliant, causes build issues, and should properly be a span anyway.

Resolves #10101, resolves #9546.