### PR TITLE
canvas [attribute]: use character indices

### DIFF
--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -159,22 +159,35 @@ public:
 	int get_max_glyph_height() const;
 
 	/**
+	 * Given a character index and optionally the starting line,
+	 * returns the corresponding byte index.
+	 * @param offset              The character index of the cursor position.
+	 *                            Can be bigger than the line, in which case it
+	 *                            spills over to the next line and so on.
+	 * @param line                The line from which the offset counting should start.
+	 *
+	 * @returns                   The corresponding byte index.
+	 */
+	unsigned get_byte_index(const unsigned offset, const unsigned line = 0) const;
+
+	/**
 	 * Gets the location for the cursor, in drawing coordinates.
 	 *
-	 * @param column              The column character index of the cursor.
-	 * @param line                The line character index of the cursor.
+	 * @param offset              The character index of the cursor position.
+	 *                            Can be bigger than the line, in which case it
+	 *                            spills over to the next line and so on.
+	 * @param line                The line from which the offset counting should start.
 	 *
 	 * @returns                   The position of the top of the cursor. It the
 	 *                            requested location is out of range 0,0 is
 	 *                            returned.
 	 */
-	point get_cursor_position(
-		const unsigned column, const unsigned line = 0) const;
+	point get_cursor_position(const unsigned offset, const unsigned line = 0) const;
 
 	/**
 	 * Gets the location for the cursor, in drawing coordinates.
 	 *
-	 * @param offset              The column byte index of the cursor.
+	 * @param offset              The byte index corresponding to the cursor position.
 	 *
 	 * @returns                   The position of the top of the cursor. It the
 	 *                            requested location is out of range 0,0 is

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -303,7 +303,7 @@ private:
 	wfl::formula actions_formula_;
 
 	/** Any custom Pango text attributes. */
-	font::attribute_list text_attributes_;
+	config::const_child_itors text_attributes_;
 };
 
 }

--- a/src/gui/widgets/rich_label.cpp
+++ b/src/gui/widgets/rich_label.cpp
@@ -130,9 +130,9 @@ point rich_label::get_image_size(config& img_cfg) const
 std::pair<size_t, size_t> rich_label::add_text(config& curr_item, const std::string& text)
 {
 	auto& attr = curr_item["text"];
-	size_t start = attr.str().size();
+	size_t start = utf8::size(attr.str());
 	attr = attr.str() + text;
-	size_t end = attr.str().size();
+	size_t end = utf8::size(attr.str());
 	return { start, end };
 }
 


### PR DESCRIPTION
Resolves #10105

Uses character indices instead of byte indices in `[attribute]`.