### PR TITLE
WFL: add byte_index function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 ### Units
 ### User interface
 ### WML Engine
+   * Added WFL `byte_index` function to convert between character indices and byte indices, accounting for multi-codepoint characters
 ### Miscellaneous and Bug Fixes
 
 ## Version 1.19.10

--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -22,6 +22,7 @@
 #include "game_display.hpp"
 #include "log.hpp"
 #include "pathutils.hpp"
+#include "serialization/unicode.hpp"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/math/constants/constants.hpp>
@@ -410,7 +411,7 @@ DEFINE_WFL_FUNCTION(substring, 2, 3)
 			offset = std::max(0, offset - size + 1);
 		}
 
-		return variant(result.substr(offset, size));
+		return variant(result.substr(offset, utf8::index(result, offset + size)));
 	}
 
 	return variant(result.substr(offset));
@@ -442,7 +443,7 @@ DEFINE_WFL_FUNCTION(replace, 3, 4)
 			offset = std::max(0, offset - size + 1);
 		}
 
-		return variant(result.replace(offset, size, replacement));
+		return variant(result.replace(offset, utf8::index(result, offset + size), replacement));
 	}
 
 	return variant(result.replace(offset, std::string::npos, replacement));

--- a/src/formula/function.cpp
+++ b/src/formula/function.cpp
@@ -411,7 +411,7 @@ DEFINE_WFL_FUNCTION(substring, 2, 3)
 			offset = std::max(0, offset - size + 1);
 		}
 
-		return variant(result.substr(offset, utf8::index(result, offset + size)));
+		return variant(result.substr(offset, size));
 	}
 
 	return variant(result.substr(offset));
@@ -443,7 +443,7 @@ DEFINE_WFL_FUNCTION(replace, 3, 4)
 			offset = std::max(0, offset - size + 1);
 		}
 
-		return variant(result.replace(offset, utf8::index(result, offset + size), replacement));
+		return variant(result.replace(offset, size, replacement));
 	}
 
 	return variant(result.replace(offset, std::string::npos, replacement));
@@ -494,6 +494,13 @@ DEFINE_WFL_FUNCTION(insert, 3, 3)
 DEFINE_WFL_FUNCTION(length, 1, 1)
 {
 	return variant(args()[0]->evaluate(variables, fdb).as_string().length());
+}
+
+DEFINE_WFL_FUNCTION(byte_index, 2, 2)
+{
+	return variant(utf8::index(
+		args()[0]->evaluate(variables, fdb).as_string(),
+		args()[1]->evaluate(variables, fdb).as_int()));
 }
 
 DEFINE_WFL_FUNCTION(concatenate, 1, -1)
@@ -1641,6 +1648,7 @@ std::shared_ptr<function_symbol_table> function_symbol_table::get_builtins()
 		DECLARE_WFL_FUNCTION(starts_with);
 		DECLARE_WFL_FUNCTION(ends_with);
 		DECLARE_WFL_FUNCTION(length);
+		DECLARE_WFL_FUNCTION(byte_index);
 		DECLARE_WFL_FUNCTION(concatenate);
 		DECLARE_WFL_FUNCTION(sin);
 		DECLARE_WFL_FUNCTION(cos);

--- a/src/tests/test_formula_function.cpp
+++ b/src/tests/test_formula_function.cpp
@@ -122,6 +122,11 @@ BOOST_AUTO_TEST_CASE(test_formula_function_length)
 			, 11);
 }
 
+BOOST_AUTO_TEST_CASE(test_formula_function_byte_index)
+{
+	BOOST_CHECK_EQUAL(formula("byte_index('À partir du niveau un', 1").evaluate().as_int(), 2);
+}
+
 BOOST_AUTO_TEST_CASE(test_formula_function_concatenate)
 {
 	BOOST_CHECK_EQUAL(


### PR DESCRIPTION
According to [the docs](https://wiki.wesnoth.org/Wesnoth_formula_language#substring), the optional size arguments are supposed to be the number of characters to take, relative to `offset`. ~Small fix to handle multi-byte characters. Confirmed while testing a fix for #9917.~

EDIT: After discussion on discord, I decided to add a `byte_index` function instead that takes a character index and a string. It seems better to opt into multibyte handling, especially since the logic for indices is very annoying complicated...