### PR TITLE
SDL: surface-related cleanups

### DIFF
--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -89,7 +89,7 @@ bool use_color_cursors()
 	return game_config::editor == false && prefs::get().use_color_cursors();
 }
 
-SDL_Cursor* create_cursor(surface surf)
+SDL_Cursor* create_cursor(const surface& surf)
 {
 	if(surf == nullptr) {
 		return nullptr;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -26,6 +26,9 @@
 
 #include <boost/logic/tribool.hpp>
 
+#include <SDL2/SDL_events.h>
+#include <SDL2/SDL_mouse.h>
+
 #include <array>
 #include <memory>
 
@@ -88,7 +91,6 @@ bool use_color_cursors()
 
 SDL_Cursor* create_cursor(surface surf)
 {
-	surf.make_neutral();
 	if(surf == nullptr) {
 		return nullptr;
 	}

--- a/src/gui/core/event/distributor.cpp
+++ b/src/gui/core/event/distributor.cpp
@@ -24,6 +24,8 @@
 #include "gui/widgets/widget.hpp"
 #include "sdl/input.hpp" // get_mouse_button_mask
 
+#include <SDL2/SDL.h>
+
 #include <array>
 #include <functional>
 

--- a/src/gui/core/event/handler.cpp
+++ b/src/gui/core/event/handler.cpp
@@ -28,6 +28,8 @@
 #include "video.hpp"
 #include "utils/ranges.hpp"
 
+#include <SDL2/SDL.h>
+
 #include <cassert>
 
 /**

--- a/src/gui/dialogs/end_credits.cpp
+++ b/src/gui/dialogs/end_credits.cpp
@@ -25,8 +25,9 @@
 #include "gettext.hpp"
 #include "serialization/markup.hpp"
 
-#include <functional>
+#include <SDL2/SDL_timer.h>
 
+#include <functional>
 #include <sstream>
 
 namespace gui2::dialogs

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -60,9 +60,10 @@
 #include "sdl/userevent.hpp"
 #include "sdl/input.hpp" // get_mouse_button_mask
 
-#include <functional>
+#include <SDL2/SDL_timer.h>
 
 #include <algorithm>
+#include <functional>
 
 
 static lg::log_domain log_gui("gui/layout");

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -17,6 +17,8 @@
 
 #include "color_range.hpp"
 #include "lua_jailbreak_exception.hpp"
+#include "sdl/point.hpp"
+#include "sdl/rect.hpp"
 #include "sdl/surface.hpp"
 #include "sdl/utils.hpp"
 

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -52,6 +52,8 @@
 #include "utils/context_free_grammar_generator.hpp"
 #include "utils/scope_exit.hpp"
 
+#include <SDL2/SDL_timer.h>
+
 #include <cstring>
 #include <string>
 #include <sstream>

--- a/src/sdl/surface.cpp
+++ b/src/sdl/surface.cpp
@@ -17,14 +17,37 @@
 #include "color.hpp"
 #include "sdl/rect.hpp"
 
-const SDL_PixelFormat surface::neutral_pixel_format = []() {
-	return *SDL_CreateRGBSurfaceWithFormat(0, 1, 1, 32, SDL_PIXELFORMAT_ARGB8888)->format;
-}();
+#include <utility>
+
+namespace
+{
+void add_refcount(surface& surf)
+{
+	if(surf) {
+		++surf->refcount;
+	}
+}
+
+void free_surface(surface& surf)
+{
+	if(surf) {
+		SDL_FreeSurface(surf);
+	}
+}
+
+void make_neutral(surface& surf)
+{
+	if(surf && surf->format->format != SDL_PIXELFORMAT_ARGB8888) {
+		surf = surf.clone();
+	}
+}
+
+} // namespace
 
 surface::surface(SDL_Surface* surf)
 	: surface_(surf)
 {
-	make_neutral(); // EXTREMELY IMPORTANT!
+	make_neutral(*this); // EXTREMELY IMPORTANT!
 }
 
 surface::surface(int w, int h)
@@ -34,51 +57,52 @@ surface::surface(int w, int h)
 		throw std::invalid_argument("Creating surface with negative dimensions");
 	}
 
-	surface_ = SDL_CreateRGBSurfaceWithFormat(0, w, h, neutral_pixel_format.BitsPerPixel, neutral_pixel_format.format);
+	surface_ = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32, SDL_PIXELFORMAT_ARGB8888);
 }
 
-bool surface::is_neutral() const
+surface::surface(const surface& s)
+	: surface_(s)
 {
-	return surface_
-		&& SDL_ISPIXELFORMAT_INDEXED(surface_->format->format) == SDL_FALSE
-		&&  surface_->format->BytesPerPixel == 4
-		&&  surface_->format->Rmask == SDL_RED_MASK
-		&& (surface_->format->Amask | SDL_ALPHA_MASK) == SDL_ALPHA_MASK;
+	add_refcount(*this);
 }
 
-surface& surface::make_neutral()
+surface::surface(surface&& s) noexcept
+	: surface_(std::exchange(s.surface_, nullptr))
 {
-	if(surface_ && !is_neutral()) {
-		SDL_Surface* res = SDL_ConvertSurface(surface_, &neutral_pixel_format, 0);
+}
 
-		// Ensure we don't leak memory with the old surface.
-		free_surface();
+surface::~surface()
+{
+	free_surface(*this);
+}
 
-		surface_ = res;
+surface& surface::operator=(const surface& s)
+{
+	if(this != &s) {
+		free_surface(*this);
+		surface_ = s;
+		add_refcount(*this);
 	}
 
 	return *this;
 }
 
+surface& surface::operator=(surface&& s) noexcept
+{
+	free_surface(*this);
+	surface_ = std::exchange(s.surface_, nullptr);
+	return *this;
+}
+
 surface surface::clone() const
 {
-	// Use SDL_ConvertSurface to make a copy
-	return surface(SDL_ConvertSurface(surface_, &neutral_pixel_format, 0));
+	// Use SDL_ConvertSurfaceFormat to make a copy
+	return surface(SDL_ConvertSurfaceFormat(surface_, SDL_PIXELFORMAT_ARGB8888, 0));
 }
 
-void surface::assign_surface_internal(SDL_Surface* surf)
+std::size_t surface::area() const
 {
-	add_surface_ref(surf); // Needs to be done before assignment to avoid corruption on "a = a;"
-	free_surface();
-	surface_ = surf;
-	make_neutral(); // EXTREMELY IMPORTANT!
-}
-
-void surface::free_surface()
-{
-	if(surface_) {
-		SDL_FreeSurface(surface_);
-	}
+	return surface_ ? surface_->w * surface_->h : 0;
 }
 
 std::ostream& operator<<(std::ostream& stream, const surface& surf)

--- a/src/sdl/surface.hpp
+++ b/src/sdl/surface.hpp
@@ -16,6 +16,7 @@
 
 #include "sdl/rect.hpp"
 #include "utils/const_clone.hpp"
+#include "utils/span.hpp"
 
 #include <SDL2/SDL.h>
 
@@ -87,7 +88,7 @@ public:
 	surface clone() const;
 
 	/** Total area of the surface in square pixels. */
-	int area() const
+	std::size_t area() const
 	{
 		return surface_ ? surface_->w * surface_->h : 0;
 	}
@@ -143,7 +144,15 @@ public:
 		}
 	}
 
-	pixel_t* pixels() const { return reinterpret_cast<pixel_t*>(surface_->pixels); }
+	pixel_t* pixels() const
+	{
+		return reinterpret_cast<pixel_t*>(surface_->pixels);
+	}
+
+	utils::span<pixel_t> pixel_span() const
+	{
+		return { pixels(), surface_.area() };
+	}
 
 private:
 	T& surface_;

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -18,6 +18,7 @@
  *  Support-routines for the SDL-graphics-library.
  */
 
+#include "sdl/rect.hpp"
 #include "sdl/utils.hpp"
 #include "color.hpp"
 #include "log.hpp"
@@ -27,6 +28,8 @@
 #include <cassert>
 #include <cstring>
 #include "utils/span.hpp"
+
+#include <SDL2/SDL_version.h>
 
 #include <boost/circular_buffer.hpp>
 #include <boost/math/constants/constants.hpp>

--- a/src/sdl/utils.hpp
+++ b/src/sdl/utils.hpp
@@ -24,6 +24,8 @@
 #include <cstdlib>
 #include <string>
 
+struct rect;
+
 namespace sdl
 {
 

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -18,6 +18,7 @@
 #include "sdl/exception.hpp"
 #include "sdl/surface.hpp"
 
+#include <SDL2/SDL_hints.h>
 #include <SDL2/SDL_render.h>
 
 namespace sdl

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -30,6 +30,7 @@
 #include "game_version.hpp"
 #endif
 
+#include <SDL2/SDL.h>
 #include <SDL2/SDL_render.h> // SDL_Texture
 
 #include <cassert>

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -26,6 +26,8 @@
 #include "serialization/string_utils.hpp"
 #include "sdl/input.hpp" // get_mouse_state
 
+#include <SDL2/SDL_timer.h>
+
 static lg::log_domain log_display("display");
 #define WRN_DP LOG_STREAM(warn, log_display)
 #define DBG_G LOG_STREAM(debug, lg::general())


### PR DESCRIPTION
- Use a mutable span for iterating over surface pixels (convers simple cases for now)
- Use the appropriate SDL_PixelFormatEnum directly rather than getting the value from a dummy surface. Likewise, simplified the is-neutral check by checking the format type (this wasn't available in SDL 1.2 when the check was originally written)
- Remove is_neutral and make_neutral as class members. All surfaces are already converted to the neutral format internally, so we don't need these as part of the public API. Likewise, removed the only remaining external use of make_neutral in the cursor code.
- Move most function implementations out of the header and cleaned up implementation helpers. These didn't need to be class members and just made the code harder to read.
- Simplify ctor/assignment ops and disallow self copy assignment
- Cleaned up unnecessary includes in the header. surface.hpp was pulling in the whole SDL.h header, the removal of which necessitated adding SDL includes to several other places. Just goes to show how much it was indirectly touching...