### PR TITLE
Make liminal bonus implementable in resource campaings

### DIFF
--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -348,6 +348,7 @@
 	{SIMPLE_KEY victory_music string}
 	{SIMPLE_KEY theme string_list}
 	{DEFAULT_KEY victory_when_enemies_defeated bool yes}
+	{SIMPLE_KEY liminal_bonus int}
 	[if]
 		[not]
 			victory_when_enemies_defeated=no
@@ -528,7 +529,6 @@
 		{SIMPLE_KEY image string}
 		{SIMPLE_KEY mask string}
 		{SIMPLE_KEY lawful_bonus int}
-		{SIMPLE_KEY liminal_bonus int}
 		{SIMPLE_KEY red int}
 		{SIMPLE_KEY green int}
 		{SIMPLE_KEY blue int}

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -146,6 +146,7 @@
 	{REQUIRED_KEY id string}
 	# Not sure if this key is allowed in all addons, but it should be...
 	{SIMPLE_KEY addon_min_version version}
+	{SIMPLE_KEY liminal_bonus int}
 	[tag]
 		name="load_resource"
 		max=infinite

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -395,6 +395,11 @@ void saved_game::load_non_scenario(const std::string& type, const std::string& i
 		for(const config& load_resource : cfg->child_range("load_resource")) {
 			starting_point_.add_child_at_total("load_resource", load_resource, pos++);
 		}
+
+		//copy liminal_bonus value
+		if(cfg->has_attribute("liminal_bonus")) {
+			starting_point_["liminal_bonus"] = cfg["liminal_bonus"].to_int();
+		}
 	} else {
 		// TODO: A user message instead?
 		ERR_NG << "Couldn't find [" << type << "] with id=" << id;


### PR DESCRIPTION
Before that 'liminal_bonus' must be defined in each scenario when it want define a value diffrent to default