### PR TITLE
EI: some assorted fixes and tweaks

### DIFF
--- a/changelog_entries/ei-fixes-and-tweaks.md
+++ b/changelog_entries/ei-fixes-and-tweaks.md
@@ -1,0 +1,10 @@
+### Campaigns
+   * Eastern Invasion
+     * S01: initial objective text now includes the 10,15 trapdoor
+     * S05: added objective note explaining how to check for bandits
+     * S05: fix Gweddry or Owaec not getting XP if they personally kill the final enemy leader
+     * S09: cold damage now starts lower, but grows faster
+     * S09: drakes no longer avoid the objective area once the guarding icemonax are cleared
+     * S10: replaced wild Wyvern with a more climate-appropriate Yeti
+     * S15: Gweddry and co. now enter Weldyn through a tunnel, instead of effortlessly penetrating the undead siege
+     * achievements: use white teamcolor instead of magenta for S10's achievement

--- a/data/campaigns/Eastern_Invasion/achievements.cfg
+++ b/data/campaigns/Eastern_Invasion/achievements.cfg
@@ -55,7 +55,7 @@ data/core/images#enddef
     "ei_S08"    _"Scenario 8: And My Axe"                     _"Ally with the dwarves in ‘<i>Xenophobia</i>’."}
     {ACHIEVEMENT {CORE_PATH}/attacks/cleaver.png
     "ei_S09"    _"Scenario 9: Guuuh..."                       _"Recruit the wild ogres in ‘<i>Castle in the Ice</i>’."}
-    {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(72,72)~BLIT({CORE_PATH}/units/undead/zombie.png,-2,-2)"
+    {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(72,72)~BLIT({CORE_PATH}/units/undead/zombie.png~RC(magenta>white),-2,-2)"
     "ei_S10"    _"Scenario 10: Brains"                        _"Find the legendary Staff of Power in ‘<i>Dark Sanctuary</i>’."}
     {ACHIEVEMENT {CORE_PATH}/icons/ring_gold.png
     "ei_S11"    _"Scenario 11: And In The Darkness Bind Them" _"Find the Ring of Invisibility in ‘<i>Captured</i>’."}

--- a/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/01_Eastern_Invasion.cfg
@@ -219,6 +219,7 @@
     # some cowardly peasants/woodsmen, for flavor
     [side]
         side=5
+        color=red
         controller=ai
         hidden=yes
         team_name=wesnothians
@@ -293,7 +294,7 @@
         [objectives]
             side=1
             [objective]
-                description= _ "Survive until turns run out"
+                description= _ "Survive until turns run out, then move any unit to 10,15"
                 condition=win
                 [show_if]
                     [variable]

--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -1050,7 +1050,7 @@
         [/message]
         [message]
             speaker=Dacyn
-            message= _ "Ravan took this quietly enough, or so I had thought, but it must have been more of a blow than I had realized. We drifted apart for a long while, and several years passed without me seeing my once close friend."
+            message= _ "Ravan took this quietly enough, or so I had thought, but it must have been more of a blow than I had realized. We drifted apart for a long while, and several years passed without my seeing my once close friend."
         [/message]
 
         [delay]

--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -299,6 +299,12 @@
                     [/have_unit]
                 [/show_if]
             [/note]
+            [note]
+                description= _ "Move any unit to a village to check it for outlaws."
+                [show_if]
+                    {VARIABLE_CONDITIONAL boss_found not_equals yes}
+                [/show_if]
+            [/note]
         [/objectives]
 
         {VARIABLE shodrano_killed no}
@@ -770,6 +776,17 @@
                 [show_objectives][/show_objectives]
             [/then]
             [else]
+                # if Gweddry or Owaec got the kill AND we're about to fire the victory_cutscene, we need to manually award them XP.
+                # otherwise they get no XP, since they're `teleported away during the victory_cutscene
+                [modify_unit]
+                    [filter]
+                        id=$second_unit.id
+                        [and]
+                            id=Gweddry,Owaec
+                        [/and]
+                    [/filter]
+                    experience="$( $this_unit.experience + 24 )"
+                [/modify_unit]
                 [fire_event]
                     name=victory_cutscene
                 [/fire_event]
@@ -896,6 +913,17 @@
                 [show_objectives][/show_objectives]
             [/then]
             [else]
+                # if Gweddry or Owaec got the kill AND we're about to fire the victory_cutscene, we need to manually award them XP.
+                # otherwise they get no XP, since they're `teleported away during the victory_cutscene
+                [modify_unit]
+                    [filter]
+                        id=$second_unit.id
+                        [and]
+                            id=Gweddry,Owaec
+                        [/and]
+                    [/filter]
+                    experience="$( $this_unit.experience + 8 )"
+                [/modify_unit]
                 [fire_event]
                     name=victory_cutscene
                 [/fire_event]
@@ -1022,7 +1050,7 @@
         [/message]
         [message]
             speaker=Dacyn
-            message= _ "Ravan took this quietly enough, or so I had thought, but it must have been more of a blow than I had realized. We drifted apart for a long while, and several years passed without my seeing my once close friend."
+            message= _ "Ravan took this quietly enough, or so I had thought, but it must have been more of a blow than I had realized. We drifted apart for a long while, and several years passed without me seeing my once close friend."
         [/message]
 
         [delay]

--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -300,7 +300,7 @@
                 [/show_if]
             [/note]
             [note]
-                description= _ "Move any unit to a village to check it for outlaws."
+                description= _ "Capture any village to check it for outlaws."
                 [show_if]
                     {VARIABLE_CONDITIONAL boss_found not_equals yes}
                 [/show_if]

--- a/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/09_Castle_in_the_Ice.cfg
@@ -86,8 +86,11 @@
         [ai]
             grouping=defensive
             [avoid]
-                x= 0-19, 0-99,   34-99,39-99,42-99 # avoid fighting the icemonax
-                y=17-99,22-99,     0-8, 0-10, 0-14
+                # avoid fighting the icemonax
+                radius=4
+                [filter]
+                    side=4
+                [/filter]
             [/avoid]
             leader_value=0
         [/ai]
@@ -116,8 +119,11 @@
         [ai]
             grouping=defensive
             [avoid]
-                x= 0-19, 0-99,   34-99,39-99,42-99 # avoid fighting the icemonax
-                y=17-99,22-99,    0-8, 0-10, 0-14
+                # avoid fighting the icemonax
+                radius=4
+                [filter]
+                    side=4
+                [/filter]
             [/avoid]
             leader_value=0
         [/ai]
@@ -453,9 +459,9 @@
                 description= _ "It is winter, daytime is shorter"
             [/note]
             [note]
-                #po: The amount is likely between 2 and 10 per turn.
-                #po: With the current balancing it’s the same for every difficulty, starting at 2/turn and rising by 1 every 10 turns.
-                description= _ "Living units take $|frostbite_amount cold damage every turn. Damage increases every 10 turns."
+                #po: The amount is likely between 1 and 10 per turn.
+                #po: With the current balancing it’s the same for every difficulty, starting at 1/turn and rising by 1 every 6 turns.
+                description= _ "Living units take $|frostbite_amount cold damage every turn. Damage increases every 6 turns."
                 [show_if]
                     [variable]
                         name=frostbite_amount
@@ -679,22 +685,23 @@
         {VARIABLE frostbite_amount {AMOUNT}}
     [/event]
 #enddef
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY  1   1   1}    2}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 10  10  10}    3}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 20  20  20}    4}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 30  30  30}    5}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 40  40  40}    6}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 50  50  50}    7}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 60  60  60}    8}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 70  70  70}    9}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 80  80  80}   10}
-    {SET_FROSTBITE_AMOUNT  {ON_DIFFICULTY 90  90  90}   11}
-    {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 100 100 100}   12}
-    {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 110 110 110}   13} # good luck surviving long enough for these numbers to matter
-    {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 120 120 120}   14}
-    {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 130 130 130}   15}
-    {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 140 140 140}   16}
-    {SET_FROSTBITE_AMOUNT {ON_DIFFICULTY 150 150 150}   17}
+    {SET_FROSTBITE_AMOUNT   1  1}
+    {SET_FROSTBITE_AMOUNT   6  2}
+    {SET_FROSTBITE_AMOUNT  12  3}
+    {SET_FROSTBITE_AMOUNT  18  4}
+    {SET_FROSTBITE_AMOUNT  24  5}
+    {SET_FROSTBITE_AMOUNT  30  6}
+    {SET_FROSTBITE_AMOUNT  36  7}
+    {SET_FROSTBITE_AMOUNT  42  8}
+    {SET_FROSTBITE_AMOUNT  48  9}
+    {SET_FROSTBITE_AMOUNT  54 10}
+    {SET_FROSTBITE_AMOUNT  60 11}
+    {SET_FROSTBITE_AMOUNT  66 12} # good luck surviving long enough for these numbers to matter
+    {SET_FROSTBITE_AMOUNT  66 13}
+    {SET_FROSTBITE_AMOUNT  72 14}
+    {SET_FROSTBITE_AMOUNT  78 15}
+    {SET_FROSTBITE_AMOUNT  84 16}
+
     [event]
         name=turn end
         first_time_only=no

--- a/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/10_Dark_Sanctuary.cfg
@@ -254,29 +254,26 @@
         {RECALL_XY Grug 43 21}
 
         #---------------------------
-        # WYVERN
+        # YETI
         #---------------------------
         {GENERIC_UNIT 3 (Giant Rat) 31 16} {GUARDIAN}
-        {GENERIC_UNIT 3 (Wild Wyvern) 27 11} {GUARDIAN} # sitting on a pile of gold
+        {GENERIC_UNIT 3 (Yeti) 27 11} {GUARDIAN} # sitting on a pile of gold
+        {MODIFY_UNIT type=Yeti name _"Injured Yeti"}
         [object]
             [filter]
-                type=Wild Wyvern
+                type=Yeti
             [/filter]
-
             [effect]
                 apply_to=movement
                 set=3
             [/effect]
-
+            [effect]
+                apply_to=attack
+                increase_damage={ON_DIFFICULTY -16 -8 0}
+            [/effect]
             [effect]
                 apply_to=hitpoints
-                heal_full=yes
-                increase_total={ON_DIFFICULTY -40 -10 0}
-            [/effect]
-
-            [effect]
-                apply_to=alignment
-                set={ON_DIFFICULTY lawful neutral chaotic}
+                increase={ON_DIFFICULTY -85 -65 -35} # expect the yeti to rest-heal 4-6 hitpoints before Gweddry kills it
             [/effect]
         [/object]
 
@@ -1114,7 +1111,7 @@ The darkness between worlds opens its maw."
             [then]
                 [message]
                     speaker=Terraent
-                    #po: at the moment he's seeing the inside of a castle, the lit torches, and a wild wyvern
+                    #po: at the moment he's seeing the inside of a castle, the lit torches, and a wild yeti
                     #po: there's nothing particularly unholy to focus on
                     message= _ "May this unholy place be cleansed by the Light!"
                 [/message]
@@ -1196,11 +1193,11 @@ The darkness between worlds opens its maw."
     [event]
         name=attacker hits,attacker misses,defender hits,defender misses
         [filter_second]
-            type="Wild Wyvern"
+            type="Yeti"
         [/filter_second]
         [message]
             speaker=second_unit
-            message= _ "Hissssss..."
+            message= _ "GROWWR!!"
         [/message]
     [/event]
     [event]
@@ -1215,7 +1212,7 @@ The darkness between worlds opens its maw."
         [message]
             speaker=unit
             #po: 200, 160, or 130 gold
-            message= _ "This wyvern was rich! I count $gold gold in its hoard."
+            message= _ "This yeti was rich! I count $gold gold in its hoard."
             sound=gold.ogg
         [/message]
         [message]

--- a/data/campaigns/Eastern_Invasion/scenarios/15_Return_to_Wesnoth.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/15_Return_to_Wesnoth.cfg
@@ -625,7 +625,7 @@
         {SCROLL_TO 19 1}
         [message]
             speaker=Gweddry
-            message= _ "Then we must break through to the city at once! Come on men, follow me!"
+            message= _ "Then we must reinforce the city at once. There is a relief tunnel nearby, its entrance still hidden from the dead. Come on men, follow me!"
         [/message]
 
         {MOVE_UNIT id=Gweddry 20 6}


### PR DESCRIPTION
Things that've been on my list for a while, to do before 1.20:
- S01: initial objective text now includes the 10,15 trapdoor
- S05: added objective note explaining how to check for bandits
- S05: fix Gweddry or Owaec not getting XP if they personally kill the final enemy leader
- S09: cold damage now starts lower, but grows faster
- S09: drakes no longer avoid the objective area after the guarding icemonax are cleared
- S10: replaced wild Wyvern with a more climate-appropriate Yeti
- S15: Gweddry and co. now enter Weldyn through a tunnel, instead of effortlessly penetrating the undead siege
- achievements: use white teamcolor instead of magenta for S10's achievement