### PR TITLE
Allow [modify_unit_type] to affect movetype entries

### DIFF
--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -166,6 +166,11 @@
 		# link the advancement tag
 		# to enable AMLA support
 		{LINK_TAG "units/$modifications/advancement"}
+		{LINK_TAG "units/movetype/movement_costs"}
+		{LINK_TAG "units/movetype/vision_costs"}
+		{LINK_TAG "units/movetype/jamming_costs"}
+		{LINK_TAG "units/movetype/defense"}
+		{LINK_TAG "units/movetype/resistance"}
 		[tag]
 			name="male"
 			{SIMPLE_KEY add_advancement string_list}
@@ -176,6 +181,11 @@
 			# link the advancement tag
 			# to enable AMLA support
 			{LINK_TAG "units/$modifications/advancement"}
+			{LINK_TAG "units/movetype/movement_costs"}
+			{LINK_TAG "units/movetype/vision_costs"}
+			{LINK_TAG "units/movetype/jamming_costs"}
+			{LINK_TAG "units/movetype/defense"}
+			{LINK_TAG "units/movetype/resistance"}
 		[/tag]
 		[tag]
 			name="female"
@@ -187,6 +197,11 @@
 			# link the advancement tag
 			# to enable AMLA support
 			{LINK_TAG "units/$modifications/advancement"}
+			{LINK_TAG "units/movetype/movement_costs"}
+			{LINK_TAG "units/movetype/vision_costs"}
+			{LINK_TAG "units/movetype/jamming_costs"}
+			{LINK_TAG "units/movetype/defense"}
+			{LINK_TAG "units/movetype/resistance"}
 		[/tag]
 		[tag]
 			name="variation"
@@ -198,6 +213,11 @@
 			# link the advancement tag
 			# to enable AMLA support
 			{LINK_TAG "units/$modifications/advancement"}
+			{LINK_TAG "units/movetype/movement_costs"}
+			{LINK_TAG "units/movetype/vision_costs"}
+			{LINK_TAG "units/movetype/jamming_costs"}
+			{LINK_TAG "units/movetype/defense"}
+			{LINK_TAG "units/movetype/resistance"}
 		[/tag]
 	[/tag]
 	{DATA_TAG "world_conquest_data" 0 1 any}

--- a/data/test/scenarios/wml_tests/ScenarioWML/merge_movetype.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/merge_movetype.cfg
@@ -50,9 +50,9 @@
 {GENERIC_UNIT_TEST "defense_changed" (
     [modify_unit_type]
         type="Horseman"
-        [movement_costs]
-            defense = 10
-        [/movement_costs]
+        [defense]
+            flat = 10
+        [/defense]
     [/modify_unit_type]
     [event]
         name=start

--- a/data/test/scenarios/wml_tests/ScenarioWML/merge_movetype.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/merge_movetype.cfg
@@ -1,0 +1,116 @@
+#####
+# API(s) being tested: [modify_unit_type][movement_costs]
+##
+# Actions:
+# Modify the horseman unit type to change movement cost on flat to 5
+# Spawn a horseman unit.
+##
+# Expected end state:
+# The spawned horseman should have movement cost on flat terrain type equal to 5.
+#####
+{GENERIC_UNIT_TEST "movement_cost_changed" (
+    [modify_unit_type]
+        type="Horseman"
+        [movement_costs]
+            flat = 5
+        [/movement_costs]
+    [/modify_unit_type]
+    [event]
+        name=start
+        [unit]
+            x = 1
+            y = 1
+            type = Horseman
+            side = 1
+            id = charlie
+            canrecruit = no
+        [/unit]
+        [store_unit]
+            variable=horseman
+            [filter]
+                id = charlie
+            [/filter]
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL horseman.movement_costs.flat equals 5})}
+
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [modify_unit_type][defense]
+##
+# Actions:
+# Modify the horseman unit type to change defense on flat to 10 (90%)
+# Spawn a horseman unit.
+##
+# Expected end state:
+# The spawned horseman should have defense on flat terrain type equal to 10.
+#####
+{GENERIC_UNIT_TEST "defense_changed" (
+    [modify_unit_type]
+        type="Horseman"
+        [movement_costs]
+            defense = 10
+        [/movement_costs]
+    [/modify_unit_type]
+    [event]
+        name=start
+        [unit]
+            x = 1
+            y = 1
+            type = Horseman
+            side = 1
+            id = charlie
+            canrecruit = no
+        [/unit]
+        [store_unit]
+            variable=horseman
+            [filter]
+                id = charlie
+            [/filter]
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL horseman.defense.flat equals 10})}
+
+        {SUCCEED}
+    [/event]
+)}
+
+#####
+# API(s) being tested: [modify_unit_type][resistance]
+##
+# Actions:
+# Modify the horseman unit type to change resistance to pierce to 10 (90%)
+# Spawn a horseman unit.
+##
+# Expected end state:
+# The spawned horseman should have resistance to pierce damage type equal to 10.
+#####
+{GENERIC_UNIT_TEST "resistance_changed" (
+    [modify_unit_type]
+        type="Horseman"
+        [resistance]
+            pierce = 10
+        [/resistance]
+    [/modify_unit_type]
+    [event]
+        name=start
+        [unit]
+            x = 1
+            y = 1
+            type = Horseman
+            side = 1
+            id = charlie
+            canrecruit = no
+        [/unit]
+        [store_unit]
+            variable=horseman
+            [filter]
+                id = charlie
+            [/filter]
+        [/store_unit]
+        {ASSERT ({VARIABLE_CONDITIONAL horseman.resistance.pierce equals 10})}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -1401,6 +1401,8 @@ void unit_type::apply_scenario_fix(const config& cfg)
 		advancements_ = cfg.child_range("advancement");
 	}
 
+	movement_type_.merge(cfg);
+
 	// apply recursively to subtypes.
 	for(int gender = 0; gender <= 1; ++gender) {
 		if(!gender_types_[gender]) {

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -242,6 +242,9 @@
 0 add_or_replace_amla
 0 add_specific_female_amla_on_female
 0 add_specific_female_amla_on_male
+0 movement_cost_changed
+0 defense_changed
+0 resistance_changed
 0 harm_unit_survivable_experience_no
 0 harm_unit_survivable_experience_unset
 0 harm_unit_survivable_experience_yes


### PR DESCRIPTION
Add support for [movement_costs], [resistance], [defense], [vision_costs], [jamming_costs] in [modify_unit_type]