### PR TITLE
Don't skip fully transparent pixels when recoloring surfaces

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 ### User interface
 ### WML Engine
    * Added WFL `byte_index` function to convert between character indices and byte indices, accounting for multi-byte characters
+   * IPFs that affect color values no longer skip fully transparent pixels.
 ### Miscellaneous and Bug Fixes
 
 ## Version 1.19.10

--- a/src/sdl/utils.cpp
+++ b/src/sdl/utils.cpp
@@ -410,13 +410,11 @@ void adjust_surface_color(surface& nsurf, int red, int green, int blue)
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				r = std::clamp(static_cast<int>(r) + red, 0, 255);
-				g = std::clamp(static_cast<int>(g) + green, 0, 255);
-				b = std::clamp(static_cast<int>(b) + blue, 0, 255);
+			r = std::clamp(static_cast<int>(r) + red, 0, 255);
+			g = std::clamp(static_cast<int>(g) + green, 0, 255);
+			b = std::clamp(static_cast<int>(b) + blue, 0, 255);
 
-				pixel = (alpha << 24) + (r << 16) + (g << 8) + b;
-			}
+			pixel = (alpha << 24) + (r << 16) + (g << 8) + b;
 		}
 	}
 }
@@ -429,20 +427,18 @@ void greyscale_image(surface& nsurf)
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				//const uint8_t avg = (red+green+blue)/3;
+			//const uint8_t avg = (red+green+blue)/3;
 
-				// Use the correct formula for RGB to grayscale conversion.
-				// Ok, this is no big deal :)
-				// The correct formula being:
-				// gray=0.299red+0.587green+0.114blue
-				const uint8_t avg = static_cast<uint8_t>((
-					77  * static_cast<uint16_t>(r) +
-					150 * static_cast<uint16_t>(g) +
-					29  * static_cast<uint16_t>(b)  ) / 256);
+			// Use the correct formula for RGB to grayscale conversion.
+			// Ok, this is no big deal :)
+			// The correct formula being:
+			// gray=0.299red+0.587green+0.114blue
+			const uint8_t avg = static_cast<uint8_t>((
+				77  * static_cast<uint16_t>(r) +
+				150 * static_cast<uint16_t>(g) +
+				29  * static_cast<uint16_t>(b)  ) / 256);
 
-				pixel = (alpha << 24) | (avg << 16) | (avg << 8) | avg;
-			}
+			pixel = (alpha << 24) | (avg << 16) | (avg << 8) | avg;
 		}
 	}
 }
@@ -455,14 +451,12 @@ void monochrome_image(surface& nsurf, const int threshold)
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				// first convert the pixel to grayscale
-				// if the resulting value is above the threshold make it black
-				// else make it white
-				uint8_t result = static_cast<uint8_t>(0.299 * r + 0.587 * g + 0.114 * b) > threshold ? 255 : 0;
+			// first convert the pixel to grayscale
+			// if the resulting value is above the threshold make it black
+			// else make it white
+			uint8_t result = static_cast<uint8_t>(0.299 * r + 0.587 * g + 0.114 * b) > threshold ? 255 : 0;
 
-				pixel = (alpha << 24) | (result << 16) | (result << 8) | result;
-			}
+			pixel = (alpha << 24) | (result << 16) | (result << 8) | result;
 		}
 	}
 }
@@ -475,16 +469,14 @@ void sepia_image(surface& nsurf)
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				// this is the formula for applying a sepia effect
-				// that can be found on various web sites
-				// for example here: https://software.intel.com/sites/default/files/article/346220/sepiafilter-intelcilkplus.pdf
-				uint8_t outRed = std::min(255, static_cast<int>((r * 0.393) + (g * 0.769) + (b * 0.189)));
-				uint8_t outGreen = std::min(255, static_cast<int>((r * 0.349) + (g * 0.686) + (b * 0.168)));
-				uint8_t outBlue = std::min(255, static_cast<int>((r * 0.272) + (g * 0.534) + (b * 0.131)));
+			// this is the formula for applying a sepia effect
+			// that can be found on various web sites
+			// for example here: https://software.intel.com/sites/default/files/article/346220/sepiafilter-intelcilkplus.pdf
+			uint8_t outRed = std::min(255, static_cast<int>((r * 0.393) + (g * 0.769) + (b * 0.189)));
+			uint8_t outGreen = std::min(255, static_cast<int>((r * 0.349) + (g * 0.686) + (b * 0.168)));
+			uint8_t outBlue = std::min(255, static_cast<int>((r * 0.272) + (g * 0.534) + (b * 0.131)));
 
-				pixel = (alpha << 24) | (outRed << 16) | (outGreen << 8) | (outBlue);
-			}
+			pixel = (alpha << 24) | (outRed << 16) | (outGreen << 8) | (outBlue);
 		}
 	}
 }
@@ -497,17 +489,15 @@ void negative_image(surface& nsurf, const int thresholdR, const int thresholdG, 
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				// invert he channel only if its value is greater than the supplied threshold
-				// this can be used for solarization effects
-				// for a full negative effect, use a value of -1
-				// 255 is a no-op value (doesn't do anything, since a uint8_t cannot contain a greater value than that)
-				uint8_t newR = r > thresholdR ? 255 - r : r;
-				uint8_t newG = g > thresholdG ? 255 - g : g;
-				uint8_t newB = b > thresholdB ? 255 - b : b;
+			// invert he channel only if its value is greater than the supplied threshold
+			// this can be used for solarization effects
+			// for a full negative effect, use a value of -1
+			// 255 is a no-op value (doesn't do anything, since a uint8_t cannot contain a greater value than that)
+			uint8_t newR = r > thresholdR ? 255 - r : r;
+			uint8_t newG = g > thresholdG ? 255 - g : g;
+			uint8_t newB = b > thresholdB ? 255 - b : b;
 
-				pixel = (alpha << 24) | (newR << 16) | (newG << 8) | (newB);
-			}
+			pixel = (alpha << 24) | (newR << 16) | (newG << 8) | (newB);
 		}
 	}
 }
@@ -551,14 +541,12 @@ void shadow_image(surface& surf, int scale)
 		for(auto& pixel : lock.pixel_span()) {
 			uint8_t alpha = pixel >> 24;
 
-			if(alpha) {
-				// increase alpha and color in black (RGB=0)
-				// with some stupid optimization for handling maximum values
-				if(alpha < 255 / 4) {
-					pixel = (alpha * 4) << 24;
-				} else {
-					pixel = 0xFF000000; // we hit the maximum
-				}
+			// increase alpha and color in black (RGB=0)
+			// with some stupid optimization for handling maximum values
+			if(alpha < 255 / 4) {
+				pixel = (alpha * 4) << 24;
+			} else {
+				pixel = 0xFF000000; // we hit the maximum
 			}
 		}
 	}
@@ -571,80 +559,77 @@ void swap_channels_image(surface& nsurf, channel r, channel g, channel b, channe
 
 		for(auto& pixel : lock.pixel_span()) {
 			auto [red, green, blue, alpha] = color_t::from_argb_bytes(pixel);
+			uint8_t newRed, newGreen, newBlue, newAlpha;
 
-			if(alpha) {
-				uint8_t newRed, newGreen, newBlue, newAlpha;
-
-				switch (r) {
-					case RED:
-						newRed = red;
-						break;
-					case GREEN:
-						newRed = green;
-						break;
-					case BLUE:
-						newRed = blue;
-						break;
-					case ALPHA:
-						newRed = alpha;
-						break;
-					default:
-						return;
-				}
-
-				switch (g) {
-					case RED:
-						newGreen = red;
-						break;
-					case GREEN:
-						newGreen = green;
-						break;
-					case BLUE:
-						newGreen = blue;
-						break;
-					case ALPHA:
-						newGreen = alpha;
-						break;
-					default:
-						return;
-				}
-
-				switch (b) {
-					case RED:
-						newBlue = red;
-						break;
-					case GREEN:
-						newBlue = green;
-						break;
-					case BLUE:
-						newBlue = blue;
-						break;
-					case ALPHA:
-						newBlue = alpha;
-						break;
-					default:
-						return;
-				}
-
-				switch (a) {
-					case RED:
-						newAlpha = red;
-						break;
-					case GREEN:
-						newAlpha = green;
-						break;
-					case BLUE:
-						newAlpha = blue;
-						break;
-					case ALPHA:
-						newAlpha = alpha;
-						break;
-					default:
-						return;
-				}
-
-				pixel = (newAlpha << 24) | (newRed << 16) | (newGreen << 8) | newBlue;
+			switch (r) {
+				case RED:
+					newRed = red;
+					break;
+				case GREEN:
+					newRed = green;
+					break;
+				case BLUE:
+					newRed = blue;
+					break;
+				case ALPHA:
+					newRed = alpha;
+					break;
+				default:
+					return;
 			}
+
+			switch (g) {
+				case RED:
+					newGreen = red;
+					break;
+				case GREEN:
+					newGreen = green;
+					break;
+				case BLUE:
+					newGreen = blue;
+					break;
+				case ALPHA:
+					newGreen = alpha;
+					break;
+				default:
+					return;
+			}
+
+			switch (b) {
+				case RED:
+					newBlue = red;
+					break;
+				case GREEN:
+					newBlue = green;
+					break;
+				case BLUE:
+					newBlue = blue;
+					break;
+				case ALPHA:
+					newBlue = alpha;
+					break;
+				default:
+					return;
+			}
+
+			switch (a) {
+				case RED:
+					newAlpha = red;
+					break;
+				case GREEN:
+					newAlpha = green;
+					break;
+				case BLUE:
+					newAlpha = blue;
+					break;
+				case ALPHA:
+					newAlpha = alpha;
+					break;
+				default:
+					return;
+			}
+
+			pixel = (newAlpha << 24) | (newRed << 16) | (newGreen << 8) | newBlue;
 		}
 	}
 }
@@ -663,15 +648,12 @@ void recolor_image(surface& nsurf, const color_range_map& map_rgb)
 	for(auto& pixel : lock.pixel_span()) {
 		uint8_t alpha = pixel >> 24;
 
-		// Don't recolor invisible pixels.
-		if(alpha) {
-			// Palette use only RGB channels, so remove alpha
-			uint32_t oldrgb = pixel | 0xFF000000;
+		// Palette use only RGB channels, so remove alpha
+		uint32_t oldrgb = pixel | 0xFF000000;
 
-			auto i = map_rgb.find(color_t::from_argb_bytes(oldrgb));
-			if(i != map_rgb.end()) {
-				pixel = (alpha << 24) | (i->second.to_argb_bytes() & 0x00FFFFFF);
-			}
+		auto i = map_rgb.find(color_t::from_argb_bytes(oldrgb));
+		if(i != map_rgb.end()) {
+			pixel = (alpha << 24) | (i->second.to_argb_bytes() & 0x00FFFFFF);
 		}
 	}
 }
@@ -685,13 +667,11 @@ void brighten_image(surface& nsurf, int32_t amount)
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				r = std::min<unsigned>(fixed_point_multiply(r, amount),255);
-				g = std::min<unsigned>(fixed_point_multiply(g, amount),255);
-				b = std::min<unsigned>(fixed_point_multiply(b, amount),255);
+			r = std::min<unsigned>(fixed_point_multiply(r, amount),255);
+			g = std::min<unsigned>(fixed_point_multiply(g, amount),255);
+			b = std::min<unsigned>(fixed_point_multiply(b, amount),255);
 
-				pixel = (alpha << 24) + (r << 16) + (g << 8) + b;
-			}
+			pixel = (alpha << 24) + (r << 16) + (g << 8) + b;
 		}
 	}
 }
@@ -713,10 +693,8 @@ void adjust_surface_alpha_add(surface& nsurf, int amount)
 		for(auto& pixel : lock.pixel_span()) {
 			auto [r, g, b, alpha] = color_t::from_argb_bytes(pixel);
 
-			if(alpha) {
-				alpha = uint8_t(std::clamp(static_cast<int>(alpha) + amount, 0, 255));
-				pixel = (alpha << 24) + (r << 16) + (g << 8) + b;
-			}
+			alpha = uint8_t(std::clamp(static_cast<int>(alpha) + amount, 0, 255));
+			pixel = (alpha << 24) + (r << 16) + (g << 8) + b;
 		}
 	}
 }
@@ -757,22 +735,19 @@ void mask_surface(surface& nsurf, const surface& nmask, bool* empty_result, cons
 
 		while(beg != end && mbeg != mend) {
 			uint8_t alpha = (*beg) >> 24;
+			uint8_t r, g, b;
+			r = (*beg) >> 16;
+			g = (*beg) >> 8;
+			b = (*beg);
 
-			if(alpha) {
-				uint8_t r, g, b;
-				r = (*beg) >> 16;
-				g = (*beg) >> 8;
-				b = (*beg);
-
-				uint8_t malpha = (*mbeg) >> 24;
-				if (alpha > malpha) {
-					alpha = malpha;
-				}
-				if(alpha)
-					empty = false;
-
-				*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
+			uint8_t malpha = (*mbeg) >> 24;
+			if (alpha > malpha) {
+				alpha = malpha;
 			}
+			if(alpha)
+				empty = false;
+
+			*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
 
 			++beg;
 			++mbeg;
@@ -849,28 +824,27 @@ void light_surface(surface& nsurf, const surface &lightmap)
 
 		while(beg != end && lbeg != lend) {
 			uint8_t alpha = (*beg) >> 24;
-			if(alpha) {
-				uint8_t lr, lg, lb;
+			uint8_t lr, lg, lb;
 
-				lr = (*lbeg) >> 16;
-				lg = (*lbeg) >> 8;
-				lb = (*lbeg);
+			lr = (*lbeg) >> 16;
+			lg = (*lbeg) >> 8;
+			lb = (*lbeg);
 
-				uint8_t r, g, b;
-				r = (*beg) >> 16;
-				g = (*beg) >> 8;
-				b = (*beg);
+			uint8_t r, g, b;
+			r = (*beg) >> 16;
+			g = (*beg) >> 8;
+			b = (*beg);
 
-				int dr = (static_cast<int>(lr) - 128) * 2;
-				int dg = (static_cast<int>(lg) - 128) * 2;
-				int db = (static_cast<int>(lb) - 128) * 2;
-				//note that r + dr will promote r to int (needed to avoid uint8_t math)
-				r = std::clamp(r + dr, 0, 255);
-				g = std::clamp(g + dg, 0, 255);
-				b = std::clamp(b + db, 0, 255);
+			int dr = (static_cast<int>(lr) - 128) * 2;
+			int dg = (static_cast<int>(lg) - 128) * 2;
+			int db = (static_cast<int>(lb) - 128) * 2;
+			//note that r + dr will promote r to int (needed to avoid uint8_t math)
+			r = std::clamp(r + dr, 0, 255);
+			g = std::clamp(g + dg, 0, 255);
+			b = std::clamp(b + db, 0, 255);
 
-				*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
-			}
+			*beg = (alpha << 24) + (r << 16) + (g << 8) + b;
+
 			++beg;
 			++lbeg;
 		}


### PR DESCRIPTION
Resolves #8785. Diff best viewed with whitespace changes hidden. Functions affected:
- `adjust_surface_color`
- `greyscale_image`
- `monochrome_image`
- `sepia_image`
- `negative_image`
- `shadow_image`
- `swap_channels_image`
- `recolor_image`
- `brighten_image`
- `adjust_surface_alpha_add`
- `light_surface`