### PR TITLE
show max_attacks/attack usage in Help and Units dialog

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -206,7 +206,11 @@ static inline std::string get_mp_tooltip(int total_movement, const std::function
  * attack data, meaning we can keep this as a helper function.
  */
 template<typename T>
-void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_node)
+void unit_preview_pane::print_attack_details(
+	T attacks,
+	const int attacks_left,
+	const int max_attacks,
+	tree_view_node& parent_node)
 {
 	if(attacks.empty()) {
 		return;
@@ -214,6 +218,14 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 
 
 	auto& header_node = add_name_tree_node(parent_node, "header", markup::bold(_("Attacks")));
+
+	if (max_attacks > 1) {
+		add_name_tree_node(header_node, "item",
+			VGETTEXT("Remaining: $left/$max",
+				{{"left", std::to_string(attacks_left)},
+				{"max",  std::to_string(max_attacks)}}),
+			_("This unit can attack multiple times per turn."));
+	}
 
 	for(const auto& a : attacks) {
 		const std::string range_png = std::string("icons/profiles/") + a.range() + "_attack.png~SCALE_INTO(16,16)";
@@ -244,6 +256,20 @@ void unit_preview_pane::print_attack_details(T attacks, tree_view_node& parent_n
 				subsection,
 				"item",
 				markup::span_color(font::weapon_details_color, range, font::weapon_details_sep, type)
+			);
+		}
+
+		if (max_attacks > 1) {
+			add_name_tree_node(
+				subsection,
+				"item",
+				markup::span_color(
+					font::weapon_details_color,
+					VNGETTEXT(
+					"uses $num attack",
+					"uses $num attacks",
+					a.attacks_used(),
+					{ {"num", std::to_string(a.attacks_used())} }))
 			);
 		}
 
@@ -385,7 +411,7 @@ void unit_preview_pane::set_display_data(const unit_type& type)
 			}
 		}
 
-		print_attack_details(type.attacks(), tree_details_->get_root_node());
+		print_attack_details(type.attacks(), type.max_attacks(), type.max_attacks(), tree_details_->get_root_node());
 	}
 }
 
@@ -521,7 +547,7 @@ void unit_preview_pane::set_display_data(const unit& u)
 				);
 			}
 		}
-		print_attack_details(u.attacks(), tree_details_->get_root_node());
+		print_attack_details(u.attacks(), u.attacks_left(), u.type().max_attacks(), tree_details_->get_root_node());
 	}
 }
 

--- a/src/gui/widgets/unit_preview_pane.hpp
+++ b/src/gui/widgets/unit_preview_pane.hpp
@@ -94,7 +94,11 @@ private:
 	std::string image_mods_;
 
 	template<typename T> // This is only a template to avoid including units/attack.hpp
-	void print_attack_details(T attacks, tree_view_node& parent_node);
+	void print_attack_details(
+		T attacks,
+		const int attacks_left,
+		const int max_attacks,
+		tree_view_node& parent_node);
 
 	enum state_t {
 		ENABLED

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -666,6 +666,10 @@ std::string unit_topic_generator::operator()() const {
 	//
 	ss << "\n" << markup::tag("header", _("Attacks"));
 
+	if (type_.max_attacks() > 1) {
+		ss << "\n" << markup::italic(_("Attacks per turn: ")) << type_.max_attacks();
+	}
+
 	if(!type_.attacks().empty()) {
 		// Check if at least one attack has special.
 		// Otherwise the Special column will be hidden.
@@ -702,9 +706,21 @@ std::string unit_topic_generator::operator()() const {
 			attack_ss << markup::tag("col", lang_weapon);
 
 			// damage x strikes
-			attack_ss << markup::tag("col",
-				attack.damage(), font::weapon_numbers_sep, attack.num_attacks(),
-				" ", attack.accuracy_parry_description());
+			if (type_.max_attacks() > 1) {
+				attack_ss << markup::tag("col",
+					attack.damage(), font::weapon_numbers_sep, attack.num_attacks(),
+					" ", attack.accuracy_parry_description(),
+					"\n",
+					VNGETTEXT(
+						"uses $num attack",
+						"uses $num attacks",
+						attack.attacks_used(),
+						{ {"num", std::to_string(attack.attacks_used())} }));
+			} else {
+				attack_ss << markup::tag("col",
+					attack.damage(), font::weapon_numbers_sep, attack.num_attacks(),
+					" ", attack.accuracy_parry_description());
+			}
 
 			// range
 			const std::string range_icon = "icons/profiles/" + attack.range() + "_attack.png~SCALE_INTO(16,16)";

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -1171,9 +1171,9 @@ static config unit_weapons(const reports::context& rc, const unit_const_ptr& att
  * Display the attacks of the displayed unit against the unit passed as argument.
  * 'hex' is the location the attacker will be at during combat.
  */
-static config unit_weapons(const reports::context& rc, const unit *u, const map_location &hex)
+static config unit_weapons(const reports::context& rc, const unit* u, const map_location& hex)
 {
-	config res = config();
+	config res;
 	if ((u != nullptr) && (!u->attacks().empty())) {
 		const std::string attack_headline = _n("Attack", "Attacks", u->attacks().size());
 
@@ -1189,7 +1189,7 @@ static config unit_weapons(const reports::context& rc, const unit *u, const map_
 				_("This unit can attack multiple times per turn."));
 		}
 
-		for (const attack_type &at : u->attacks())
+		for (const attack_type& at : u->attacks())
 		{
 			attack_info(rc, at, res, *u, hex);
 		}


### PR DESCRIPTION
Resolves #10108.

Unit List (should be similar in Recall)
![Screenshot from 2025-04-14 10-48-19](https://github.com/user-attachments/assets/8c02b6e6-2523-461e-a8f3-122feb6f8c9c)

Unit Create Dialog (should be same in recruit)
![Screenshot from 2025-04-14 10-46-54](https://github.com/user-attachments/assets/93d2cedc-3800-4797-9633-00bb47fd08e3)

Help page for Unit Type (cannot show remaining attack because it's the Unit Type's help, and not the Unit's)
![Screenshot from 2025-04-14 09-42-47](https://github.com/user-attachments/assets/9057edb8-8bfb-45e5-bb5f-1aec992424ac)
