### PR TITLE
label inline link mechanism code simplification

### DIFF
--- a/src/font/text.hpp
+++ b/src/font/text.hpp
@@ -211,10 +211,10 @@ public:
 	 * @param delimiters
 	 *
 	 * @returns                   The token containing position, and none of the
-	 * 			      delimiter characters. If position is out of bounds,
-	 *			      it returns the empty string.
+	 *                            delimiter characters. If position is out of bounds,
+	 *                            it returns the empty string.
 	 */
-	std::string get_token(const point & position, const char * delimiters = " \n\r\t") const;
+	std::string get_token(const point& position, std::string_view delimiters = " \n\r\t") const;
 
 	/**
 	 * Checks if position points to a character in a link in the text, returns it
@@ -223,7 +223,7 @@ public:
 	 *
 	 * @returns                   The link if one is found, the empty string otherwise.
 	 */
-	std::string get_link(const point & position) const;
+	std::string get_link(const point& position) const;
 
 	/**
 	 * Gets the column of line of the character at the position.
@@ -236,7 +236,7 @@ public:
 	 */
 	point get_column_line(const point& position) const;
 
-	int xy_to_index(const point& position) const;
+	std::pair<int, int> xy_to_index(const point& position) const;
 
 	/**
 	 * Retrieves a list of strings with contents for each rendered line.

--- a/src/gui/widgets/label.cpp
+++ b/src/gui/widgets/label.cpp
@@ -116,25 +116,20 @@ void label::signal_handler_left_button_click(bool& handled)
 {
 	DBG_GUI_E << "label click";
 
-	if (!get_link_aware()) {
+	if(!get_link_aware()) {
 		return; // without marking event as "handled".
 	}
 
-	if (!desktop::open_object_is_supported()) {
+	if(!desktop::open_object_is_supported()) {
 		show_message("", _("Opening links is not supported, contact your packager"), dialogs::message::auto_close);
 		handled = true;
 		return;
 	}
 
-	point mouse = get_mouse_position();
+	std::string link = get_label_link(get_mouse_position());
 
-	mouse.x -= get_x();
-	mouse.y -= get_y();
-
-	std::string link = get_label_link(mouse);
-
-	if (link.length() == 0) {
-		return ; // without marking event as "handled"
+	if(link.empty()) {
+		return; // without marking event as "handled"
 	}
 
 	DBG_GUI_E << "Clicked Link:\"" << link << "\"";
@@ -151,18 +146,12 @@ void label::signal_handler_right_button_click(bool& handled)
 {
 	DBG_GUI_E << "label right click";
 
-	if (!get_link_aware()) {
-		return ; // without marking event as "handled".
+	if(!get_link_aware()) {
+		return; // without marking event as "handled".
 	}
 
-	point mouse = get_mouse_position();
-
-	mouse.x -= get_x();
-	mouse.y -= get_y();
-
-	std::string link = get_label_link(mouse);
-
-	if (link.length() == 0) {
+	std::string link = get_label_link(get_mouse_position());
+	if(link.empty()) {
 		return ; // without marking event as "handled"
 	}
 
@@ -170,7 +159,7 @@ void label::signal_handler_right_button_click(bool& handled)
 
 	desktop::clipboard::copy_to_clipboard(link);
 
-	(void) show_message("", _("Copied link!"), dialogs::message::auto_close);
+	show_message("", _("Copied link!"), dialogs::message::auto_close);
 
 	handled = true;
 }
@@ -183,12 +172,7 @@ void label::signal_handler_mouse_motion(bool& handled, const point& coordinate)
 		return; // without marking event as "handled"
 	}
 
-	point mouse = coordinate;
-
-	mouse.x -= get_x();
-	mouse.y -= get_y();
-
-	update_mouse_cursor(!get_label_link(mouse).empty());
+	update_mouse_cursor(!get_label_link(coordinate).empty());
 
 	handled = true;
 }

--- a/src/gui/widgets/rich_label.hpp
+++ b/src/gui/widgets/rich_label.hpp
@@ -268,7 +268,7 @@ private:
 
 	int get_offset_from_xy(const point& position) const
 	{
-		return font::get_text_renderer().xy_to_index(position);
+		return font::get_text_renderer().xy_to_index(position).first;
 	}
 
 	point get_xy_from_offset(const unsigned offset) const

--- a/src/gui/widgets/styled_widget.hpp
+++ b/src/gui/widgets/styled_widget.hpp
@@ -440,7 +440,7 @@ protected:
 	virtual bool impl_draw_foreground() override;
 
 	/** Exposes font::pango_text::get_token, for the text label of this styled_widget */
-	std::string get_label_token(const point & position, const char * delimiters = " \n\r\t") const;
+	std::string get_label_token(const point & position, std::string_view delimiters = " \n\r\t") const;
 
 	std::string get_label_link(const point & position) const;
 


### PR DESCRIPTION
Also fixes non-left aligned inline links having wrong link click bounds. (resolves #8915)

Note: I came upon the solution accidentally while doing some cleanup. Fix is:
https://github.com/wesnoth/wesnoth/blob/4976f0a3f8cb6d5d10f608fbcb220fa36cabffce/src/gui/widgets/styled_widget.cpp#L560-L567