### PR TITLE
Network: Correct curl protocol configuration (resolves #10139)

### DIFF
--- a/src/network_download_file.cpp
+++ b/src/network_download_file.cpp
@@ -54,7 +54,7 @@ namespace network
 			curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
 			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 5000L);
 			#if LIBCURL_VERSION_NUM >= 0x075500
-				curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, CURLPROTO_HTTPS);
+				curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
 			#else
 				curl_easy_setopt(curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
 			#endif


### PR DESCRIPTION
Needs to be back-ported to 1.18 as well.