### PR TITLE
Improve light_adjust range hash

### DIFF
--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -494,7 +494,7 @@ uint32_t hash_light_range(const utils::span<const light_adjust>& range)
 {
 	uint32_t hash{0};
 	for(const auto& adjustment : range) {
-		hash += adjustment.l << 24 | adjustment.r << 16 | adjustment.g << 8 | adjustment.b;
+		hash |= adjustment.l << 24 | adjustment.r << 16 | adjustment.g << 8 | adjustment.b;
 	}
 
 	return hash;

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -494,7 +494,7 @@ uint32_t hash_light_range(const utils::span<const light_adjust>& range)
 {
 	uint32_t hash{0};
 	for(const auto& adjustment : range) {
-		hash += adjustment.l + adjustment.r + adjustment.g + adjustment.b;
+		hash += adjustment.l << 24 | adjustment.r << 16 | adjustment.g << 8 | adjustment.b;
 	}
 
 	return hash;

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -494,10 +494,10 @@ uint32_t hash_light_range(const utils::span<const light_adjust>& range)
 {
 	uint32_t hash{0};
 	for(const auto& adjustment : range) {
-		hash |= static_cast<uint8_t>(~adjustment.l + 1) << 24;
-		hash |= static_cast<uint8_t>(~adjustment.r + 1) << 16;
-		hash |= static_cast<uint8_t>(~adjustment.g + 1) << 8;
-		hash |= static_cast<uint8_t>(~adjustment.b + 1);
+		hash ^= static_cast<uint8_t>(adjustment.l) << 24;
+		hash ^= static_cast<uint8_t>(adjustment.r) << 16;
+		hash ^= static_cast<uint8_t>(adjustment.g) << 8;
+		hash ^= static_cast<uint8_t>(adjustment.b);
 	}
 
 	return hash;

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -494,7 +494,10 @@ uint32_t hash_light_range(const utils::span<const light_adjust>& range)
 {
 	uint32_t hash{0};
 	for(const auto& adjustment : range) {
-		hash |= adjustment.l << 24 | adjustment.r << 16 | adjustment.g << 8 | adjustment.b;
+		hash |= static_cast<uint8_t>(~adjustment.l + 1) << 24;
+		hash |= static_cast<uint8_t>(~adjustment.r + 1) << 16;
+		hash |= static_cast<uint8_t>(~adjustment.g + 1) << 8;
+		hash |= static_cast<uint8_t>(~adjustment.b + 1);
 	}
 
 	return hash;

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -122,8 +122,8 @@ using texture_cache = cache_type<texture>;
 using bool_cache = cache_type<bool>;
 
 /** Type used to pair light possibilities with the corresponding lit surface. */
-using lit_surface_variants = std::unordered_map<std::size_t, surface>;
-using lit_texture_variants = std::unordered_map<std::size_t, texture>;
+using lit_surface_variants = std::unordered_map<uint32_t, surface>;
+using lit_texture_variants = std::unordered_map<uint32_t, texture>;
 
 /** Lit variants for each locator. */
 using lit_surface_cache = cache_type<lit_surface_variants>;
@@ -490,9 +490,9 @@ light_adjust::light_adjust(int op, int rr, int gg, int bb)
 
 namespace
 {
-std::size_t hash_light_range(const utils::span<const light_adjust>& range)
+uint32_t hash_light_range(const utils::span<const light_adjust>& range)
 {
-	std::size_t hash{0};
+	uint32_t hash{0};
 	for(const auto& adjustment : range) {
 		hash += adjustment.l + adjustment.r + adjustment.g + adjustment.b;
 	}


### PR DESCRIPTION
Given these values are 8 bit ints, there's no way they will ever come close to filling up size_t (unsigned long long). Also adjusted the has function to avoid duplicate hashes if two colors have the same value.