### PR TITLE
Restore old formatting for log timestamps

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -465,7 +465,7 @@ void log_in_progress::operator|(const formatter& message)
 		stream_ << "  ";
 	if(timestamp_) {
 		auto now = std::chrono::system_clock::now();
-		stream_ << chrono::format_local_timestamp(now); // Truncates precision to seconds
+		stream_ << chrono::format_local_timestamp(now, "%Y%m%d %H:%M:%S"); // Truncates precision to seconds
 		if(precise_timestamp) {
 			auto as_seconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
 			auto fractional = std::chrono::duration_cast<std::chrono::microseconds>(now - as_seconds);


### PR DESCRIPTION
Apparently, using `%Y-%m-%d %H:%M:%S` (the default of `format_local_timestamp` broke some external scripts. This does not re-add the trailing space which used to be part of the formatter (see 79120f1e313), since it's now appended separately.