### PR TITLE
help: correct inline image size for scaling > 1

### DIFF
--- a/src/font/attributes.cpp
+++ b/src/font/attributes.cpp
@@ -180,13 +180,14 @@ void add_attribute_line_height(attribute_list& list, unsigned offset_start, unsi
 void add_attribute_image_shape(attribute_list& list, unsigned offset_start, unsigned offset_end, const std::string& image_path)
 {
 	surface surf = ::image::get_surface(image_path);
+	int scale = video::get_pixel_scale();
 	auto cairo_surface = cairo::create_surface(
 		reinterpret_cast<uint8_t*>(surf->pixels), point(surf->w, surf->h));
 	PangoRectangle bounds {
 		0,
-		-PANGO_SCALE * surf->h,
-		PANGO_SCALE * surf->w,
-		PANGO_SCALE * surf->h
+		-PANGO_SCALE * surf->h * scale,
+		PANGO_SCALE * surf->w * scale,
+		PANGO_SCALE * surf->h * scale
 	};
 
 	attribute attr {

--- a/src/font/text.cpp
+++ b/src/font/text.cpp
@@ -46,10 +46,10 @@ namespace font
 
 namespace
 {
-void render_image_shape(cairo_t *cr, PangoAttrShape *pShape, int /* do_path */, void* /* data */)
+void render_image_shape(cairo_t* cr, PangoAttrShape* pShape, int /* do_path */, void* /* data */)
 {
 	// NOTE: this data is owned by the underlying SDL_Surface. See add_attribute_image_shape
-	cairo_surface_t *img = static_cast<cairo_surface_t*>(pShape->data);
+	cairo_surface_t* img = static_cast<cairo_surface_t*>(pShape->data);
 
 	cairo_rel_move_to (cr,
 		pShape->ink_rect.x/PANGO_SCALE,
@@ -57,6 +57,7 @@ void render_image_shape(cairo_t *cr, PangoAttrShape *pShape, int /* do_path */, 
 	double x, y;
 	cairo_get_current_point (cr, &x, &y);
 	cairo_translate (cr, x, y);
+	cairo_scale(cr, video::get_pixel_scale(), video::get_pixel_scale());
 
 	cairo_set_source_surface(cr, img, 0, 0);
 	cairo_rectangle(cr,


### PR DESCRIPTION
Without this, the inline images in help browser appear unscaled for pixel scale > 1. (smaller images with respect to text)

Tested with virtual scaling 2x. (My monitor is low res)