### PR TITLE
Don't keep a static light adjust list

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1033,9 +1033,7 @@ void display::get_terrain_images(const map_location& loc, const std::string& tim
 {
 	terrain_image_vector_.clear();
 
-	static std::vector<image::light_adjust> lighting;
-	lighting.clear();
-
+	std::vector<image::light_adjust> lighting;
 	const time_of_day& tod = get_time_of_day(loc);
 
 	// get all the light transitions


### PR DESCRIPTION
This was an attempt at an optimization in line with the image vector class member, but it wasn't backed up by profiling. Better to optimize later if it's found to be needed.