### PR TITLE
help: separate unit help page id generation logic

### DIFF
--- a/src/editor/controller/editor_controller.cpp
+++ b/src/editor/controller/editor_controller.cpp
@@ -22,14 +22,12 @@
 #include "editor/action/action.hpp"
 #include "editor/action/action_unit.hpp"
 #include "editor/action/action_select.hpp"
+#include "editor/action/mouse/mouse_action.hpp"
 #include "editor/controller/editor_controller.hpp"
-
 #include "editor/palette/terrain_palettes.hpp"
 #include "editor/palette/location_palette.hpp"
 
-#include "editor/action/mouse/mouse_action.hpp"
-
-#include "preferences/preferences.hpp"
+#include "help/help.hpp"
 
 #include "gui/dialogs/edit_text.hpp"
 #include "gui/dialogs/editor/edit_unit.hpp"
@@ -41,6 +39,7 @@
 #include "gui/dialogs/units_dialog.hpp"
 #include "gui/dialogs/transient_message.hpp"
 
+#include "preferences/preferences.hpp"
 #include "resources.hpp"
 #include "reports.hpp"
 #include "wml_exception.hpp"
@@ -102,8 +101,8 @@ editor_controller::editor_controller(bool clear_id)
 
 void editor_controller::init_gui()
 {
-	gui_->change_display_context(&get_current_map_context());
-	gui_->add_redraw_observer(std::bind(&editor_controller::display_redraw_callback, this, std::placeholders::_1));
+	gui().change_display_context(&get_current_map_context());
+	gui().add_redraw_observer(std::bind(&editor_controller::display_redraw_callback, this, std::placeholders::_1));
 	floating_label_manager_.reset(new font::floating_label_context());
 	gui().set_debug_flag(display::DEBUG_COORDINATES, prefs::get().editor_draw_hex_coordinates());
 	gui().set_debug_flag(display::DEBUG_TERRAIN_CODES, prefs::get().editor_draw_terrain_codes());
@@ -1297,10 +1296,10 @@ void editor_controller::toggle_grid()
 void editor_controller::unit_description()
 {
 	map_location loc = gui_->mouseover_hex();
-	const unit_map & units = get_current_map_context().units();
+	const unit_map& units = get_current_map_context().units();
 	const unit_map::const_unit_iterator un = units.find(loc);
 	if(un != units.end()) {
-		help::show_unit_help(un->type_id(), un->type().show_variations_in_help(), false);
+		help::show_unit_description(un->type());
 	} else {
 		help::show_help("..units");
 	}

--- a/src/help/help.cpp
+++ b/src/help/help.cpp
@@ -60,31 +60,24 @@ namespace help {
  * doesn't already exist, that would likely destroy the referenced object at
  * the point that this function exited.
  */
-void show_with_toplevel(const section &toplevel, const std::string& show_topic="");
+void show_with_toplevel(const section& toplevel, const std::string& show_topic = "");
 
-
-void show_unit_description(const unit &u)
+void show_terrain_description(const terrain_type& t)
 {
-	auto cache_lifecycle = ensure_cache_lifecycle();
-	help::show_unit_description(u.type());
+	show_help(hidden_symbol(t.hide_help()) + terrain_prefix + t.id());
 }
 
-void show_terrain_description(const terrain_type &t)
+std::string get_unit_type_help_id(const unit_type& t)
 {
-	auto cache_lifecycle = ensure_cache_lifecycle();
-	help::show_terrain_help(t.id(), t.hide_help());
-}
-
-void show_unit_description(const unit_type &t)
-{
-	auto cache_lifecycle = ensure_cache_lifecycle();
 	std::string var_id = t.variation_id();
-	if (var_id.empty())
+	if(var_id.empty()) {
 		var_id = t.variation_name();
+	}
 	bool hide_help = t.hide_help();
 	bool use_variation = false;
-	if (!var_id.empty()) {
-		const unit_type *parent = unit_types.find(t.id());
+
+	if(!var_id.empty()) {
+		const unit_type* parent = unit_types.find(t.id());
 		assert(parent);
 		if (hide_help) {
 			hide_help = parent->hide_help();
@@ -93,10 +86,21 @@ void show_unit_description(const unit_type &t)
 		}
 	}
 
-	if (use_variation)
-		help::show_variation_help(t.id(), var_id, hide_help);
-	else
-		help::show_unit_help(t.id(), t.show_variations_in_help(), hide_help);
+	if(use_variation) {
+		return hidden_symbol(hide_help) + variation_prefix + t.id() + "_" + var_id;
+	} else {
+		return hidden_symbol(hide_help) + (t.show_variations_in_help() ? ".." : "") + unit_prefix + t.id();
+	}
+}
+
+void show_unit_description(const unit& u)
+{
+	show_unit_description(u.type());
+}
+
+void show_unit_description(const unit_type& t)
+{
+	show_help(get_unit_type_help_id(t));
 }
 
 help_manager::help_manager(const game_config_view *cfg)
@@ -136,38 +140,6 @@ void show_help(const std::string& show_topic)
 {
 	auto cache_lifecycle = ensure_cache_lifecycle();
 	show_with_toplevel(default_toplevel, show_topic);
-}
-
-/**
- * Open the help browser, show unit with id unit_id.
- *
- * If show_topic is the empty string, the default topic will be shown.
- */
-void show_unit_help(const std::string& show_topic, bool has_variations, bool hidden)
-{
-	auto cache_lifecycle = ensure_cache_lifecycle();
-	show_with_toplevel(default_toplevel,
-			  hidden_symbol(hidden) + (has_variations ? ".." : "") + unit_prefix + show_topic);
-}
-
-/**
- * Open the help browser, show terrain with id terrain_id.
- *
- * If show_topic is the empty string, the default topic will be shown.
- */
-void show_terrain_help(const std::string& show_topic, bool hidden)
-{
-	auto cache_lifecycle = ensure_cache_lifecycle();
-	show_with_toplevel(default_toplevel, hidden_symbol(hidden) + terrain_prefix + show_topic);
-}
-
-/**
- * Open the help browser, show the variation of the unit matching.
- */
-void show_variation_help(const std::string& unit, const std::string &variation, bool hidden)
-{
-	auto cache_lifecycle = ensure_cache_lifecycle();
-	show_with_toplevel(default_toplevel, hidden_symbol(hidden) + variation_prefix + unit + "_" + variation);
 }
 
 void init_help() {

--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -66,18 +66,12 @@ void init_help();
  *@pre game_config_manager has been initialised, or the instance of help_manager
  * has been created with an alternative config.
  */
-void show_help(const std::string& show_topic="");
+void show_help(const std::string& show_topic = "");
 
-/** wrapper to add unit prefix and hiding symbol */
-void show_unit_help(const std::string& unit_id, bool has_variations=false,
-				bool hidden = false);
-
-/** wrapper to add variation prefix and hiding symbol */
-void show_variation_help(const std::string &unit_id, const std::string &variation,
-				bool hidden = false);
-
-/** wrapper to add terrain prefix and hiding symbol */
-void show_terrain_help(const std::string& unit_id, bool hidden = false);
+/**
+ * Given a unit type, find the corresponding help topic's id.
+ */
+std::string get_unit_type_help_id(const unit_type& t);
 
 void show_unit_description(const unit_type &t);
 void show_unit_description(const unit &u);

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -24,6 +24,7 @@
 #include "formatter.hpp"
 #include "formula/string_utils.hpp"
 #include "gettext.hpp"
+#include "help/help.hpp"
 #include "language.hpp"
 #include "map/map.hpp"
 #include "mouse_events.hpp"
@@ -201,14 +202,7 @@ static config unit_type(const unit* u)
 		}
 	}
 
-	std::string topic_id;
-	if(u->variation().empty()) {
-		topic_id = "unit_" + u->type_id();
-	} else {
-		topic_id = "variation_" + u->type_id() + "_" + u->variation();
-	}
-	topic_id = (u->type().show_variations_in_help() ? ".." : "") + topic_id;
-	return text_report(u->type_name(), tooltip.str(), topic_id);
+	return text_report(u->type_name(), tooltip.str(), help::get_unit_type_help_id(u->type()));
 }
 REPORT_GENERATOR(unit_type, rc)
 {


### PR DESCRIPTION
Follow-up to https://github.com/wesnoth/wesnoth/commit/53b08325e7729397859b476dcd8c306aa514cb27 and https://github.com/wesnoth/wesnoth/commit/81a7ba55dfb0771e1e03110eb69c040849ef7de5, separates out the help topic id generation logic from `help::show_unit_description()` so it can also be used in `reports.cpp`.
Also includes some cleanup and collapses one-use small methods