### PR TITLE
filesystem: simplify to_asset_path

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1432,27 +1432,29 @@ std::string normalize_path(const std::string& fpath, bool normalize_separators, 
 bool to_asset_path(std::string& path, const std::string& addon_id, const std::string& asset_type)
 {
 	// datadir is absoulute path to where wesnoth's data is installed
-	// Case 1 example: datadir/data/core/images/misc/image.png -> misc/images
 	bfs::path datadir = game_config::path;
 	bfs::path core_asset_dir = datadir / "data" / "core" / asset_type;
-	// Case 2 example: datadir/images/misc/image.png -> misc/images
-	bfs::path core_asset_dir_2 = datadir / asset_type;
+	bfs::path data_asset_dir = datadir / asset_type;
 
 	bool found = false;
 
 	if(is_prefix(path, core_asset_dir)) {
+		// Case 1: remove leading datadir/asset_type from given absolute path
+		// For example: given datadir/images/misc/image.png, returns misc/image.png
 		path = bfs::relative(path, core_asset_dir).string();
 		found = file_exists(core_asset_dir / path);
-	} else if(is_prefix(path, core_asset_dir_2)) {
-		path = bfs::relative(path, core_asset_dir_2).string();
-		found = file_exists(core_asset_dir_2 / path);
-	}
-
-	if(!addon_id.empty() && !found) {
+	} else if(is_prefix(path, data_asset_dir)) {
+		// Case 2: remove leading datadir/data/core/asset_type from given absolute path
+		// For example: given datadir/data/core/images/misc/image.png, returns misc/image.png
+		path = bfs::relative(path, data_asset_dir).string();
+		found = file_exists(data_asset_dir / path);
+	} else if(!addon_id.empty()) {
 		bfs::path addon_asset_dir = get_current_editor_dir(addon_id);
 		addon_asset_dir /= asset_type;
-		// Case 3 example: addondir/images/misc/image.png -> misc/images
-		// addondir is absolute path to the addon's directory
+
+		// Case 3: remove leading addondir/asset_type from given absolute path,
+		// where addondir is absolute path to the addon's directory
+		// For example: given addondir/images/misc/image.png, returns misc/image.png
 		if(is_prefix(path, addon_asset_dir)) {
 			path = bfs::relative(path, addon_asset_dir).string();
 			found = file_exists(addon_asset_dir / path);

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1429,25 +1429,26 @@ std::string normalize_path(const std::string& fpath, bool normalize_separators, 
 	}
 }
 
-bool to_asset_path(std::string& path, const std::string& addon_id, const std::string& asset_type)
+utils::optional<std::string> to_asset_path(const std::string& path, const std::string& addon_id, const std::string& asset_type)
 {
 	// datadir is absoulute path to where wesnoth's data is installed
 	bfs::path datadir = game_config::path;
 	bfs::path core_asset_dir = datadir / "data" / "core" / asset_type;
 	bfs::path data_asset_dir = datadir / asset_type;
+	bfs::path outpath = path;
 
 	bool found = false;
 
 	if(is_prefix(path, core_asset_dir)) {
 		// Case 1: remove leading datadir/asset_type from given absolute path
-		// For example: given datadir/images/misc/image.png, returns misc/image.png
-		path = bfs::relative(path, core_asset_dir).string();
-		found = file_exists(core_asset_dir / path);
+		// For example: given  datadir/data/core/images/misc/image.png, returns misc/image.png
+		outpath = bfs::relative(path, core_asset_dir);
+		found = file_exists(core_asset_dir / outpath);
 	} else if(is_prefix(path, data_asset_dir)) {
 		// Case 2: remove leading datadir/data/core/asset_type from given absolute path
-		// For example: given datadir/data/core/images/misc/image.png, returns misc/image.png
-		path = bfs::relative(path, data_asset_dir).string();
-		found = file_exists(data_asset_dir / path);
+		// For example: given datadir/images/misc/image.png, returns misc/image.png
+		outpath = bfs::relative(path, data_asset_dir);
+		found = file_exists(data_asset_dir / outpath);
 	} else if(!addon_id.empty()) {
 		bfs::path addon_asset_dir = get_current_editor_dir(addon_id);
 		addon_asset_dir /= asset_type;
@@ -1456,18 +1457,12 @@ bool to_asset_path(std::string& path, const std::string& addon_id, const std::st
 		// where addondir is absolute path to the addon's directory
 		// For example: given addondir/images/misc/image.png, returns misc/image.png
 		if(is_prefix(path, addon_asset_dir)) {
-			path = bfs::relative(path, addon_asset_dir).string();
-			found = file_exists(addon_asset_dir / path);
-		}
-
-		if(!found) {
-			// Not found in either core or addons dirs,
-			// return a possible path where the asset could be copied.
-			path = (addon_asset_dir / bfs::path(path).filename()).string();
+			outpath = bfs::relative(path, addon_asset_dir);
+			found = file_exists(addon_asset_dir / outpath);
 		}
 	}
 
-	return found;
+	return found ? utils::optional<std::string>{ outpath.string() } : utils::nullopt;
 }
 
 /**

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1442,22 +1442,26 @@ bool to_asset_path(std::string& path, const std::string& addon_id, const std::st
 
 	if(is_prefix(path, core_asset_dir)) {
 		path = bfs::relative(path, core_asset_dir).string();
-		found = true;
+		found = file_exists(core_asset_dir / path);
 	} else if(is_prefix(path, core_asset_dir_2)) {
 		path = bfs::relative(path, core_asset_dir_2).string();
-		found = true;
-	} else if(!addon_id.empty()) {
+		found = file_exists(core_asset_dir_2 / path);
+	}
+
+	if(!addon_id.empty() && !found) {
 		bfs::path addon_asset_dir = get_current_editor_dir(addon_id);
 		addon_asset_dir /= asset_type;
 		// Case 3 example: addondir/images/misc/image.png -> misc/images
 		// addondir is absolute path to the addon's directory
 		if(is_prefix(path, addon_asset_dir)) {
 			path = bfs::relative(path, addon_asset_dir).string();
-			found = true;
-		} else {
+			found = file_exists(addon_asset_dir / path);
+		}
+
+		if(!found) {
 			// Not found in either core or addons dirs,
 			// return a possible path where the asset could be copied.
-			path = bfs::path(path).filename().string();
+			path = (addon_asset_dir / bfs::path(path).filename()).string();
 		}
 	}
 

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -378,9 +378,9 @@ std::string normalize_path(const std::string& path,
 						   bool resolve_dot_entries = false);
 
 /** Helper function to convert absolute path to wesnoth relative path */
-bool to_asset_path(std::string& abs_path,
-                   const std::string& addon_id,
-                   const std::string& asset_type);
+utils::optional<std::string> to_asset_path(const std::string& abs_path,
+                                           const std::string& addon_id,
+                                           const std::string& asset_type);
 
 /**
  * Sanitizes a path to remove references to the user's name.

--- a/src/gui/dialogs/editor/custom_tod.cpp
+++ b/src/gui/dialogs/editor/custom_tod.cpp
@@ -173,32 +173,35 @@ void custom_tod::select_file(const std::string& default_dir)
 	   .set_path(dn)
 	   .set_read_only(true);
 
-	if(dlg.show()) {
-		dn = dlg.path();
-		const std::string& message
-						= _("This file is outside Wesnoth’s data dirs. Do you wish to copy it into your add-on?");
+	// If the file is found inside Wesnoth's data, give its relative path
+	// if not, ask user if they want to copy it into their addon.
+	// If yes, copy and return correct relative path inside addon.
+	// return empty otherwise.
+	auto find_or_copy = [](const std::string& path, const std::string& addon_id, const std::string& type) {
+		const std::string message
+			= _("This file is outside Wesnoth’s data dirs. Do you wish to copy it into your add-on?");
+		const auto optional_path = filesystem::to_asset_path(path, addon_id, type);
 
+		if(optional_path.has_value()) {
+			return optional_path.value();
+		} else if (gui2::show_message(_("Confirm"), message, message::yes_no_buttons) == gui2::retval::OK) {
+			boost::filesystem::path output_path = filesystem::get_current_editor_dir(addon_id);
+			output_path /= type;
+			output_path /= boost::filesystem::path(path).filename();
+			filesystem::copy_file(path, output_path.string());
+			return output_path.filename().string();
+		} else {
+			return std::string();
+		}
+	};
+
+	if(dlg.show()) {
 		if(data.first == "image") {
-			if (!filesystem::to_asset_path(dn, addon_id_, "images")) {
-				if(gui2::show_message(_("Confirm"), message, message::yes_no_buttons) == gui2::retval::OK) {
-					filesystem::copy_file(dlg.path(), dn);
-				}
-			}
-			times_[current_tod_].image = dn;
+			times_[current_tod_].image = find_or_copy(dlg.path(), addon_id_, "images");
 		} else if(data.first == "mask") {
-			if (!filesystem::to_asset_path(dn, addon_id_, "images")) {
-				if(gui2::show_message(_("Confirm"), message, message::yes_no_buttons) == gui2::retval::OK) {
-					filesystem::copy_file(dlg.path(), dn);
-				}
-			}
-			times_[current_tod_].image_mask = dn;
+			times_[current_tod_].image_mask = find_or_copy(dlg.path(), addon_id_, "images");
 		} else if(data.first == "sound") {
-			if (!filesystem::to_asset_path(dn, addon_id_, "sounds")) {
-				if(gui2::show_message(_("Confirm"), message, message::yes_no_buttons) == gui2::retval::OK) {
-					filesystem::copy_file(dlg.path(), dn);
-				}
-			}
-			times_[current_tod_].sounds = dn;
+			times_[current_tod_].sounds = find_or_copy(dlg.path(), addon_id_, "sounds");
 		}
 	}
 

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -180,6 +180,19 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 	BOOST_CHECK( !get_binary_file_location("music", "this_track_does_not_exist.aiff").has_value() );
 	BOOST_CHECK( !get_binary_file_location("sounds", "rude_noises.aiff").has_value() );
 	BOOST_CHECK( !get_independent_binary_file_path("images", "dopefish.txt").has_value() );
+
+	// to_asset_path checks
+	std::string path = gamedata + "/data/core/images/wesnoth-icon.png";
+	BOOST_CHECK( to_asset_path(path, "", "images") );
+	BOOST_CHECK_EQUAL( path, "wesnoth-icon.png" );
+	path = gamedata + "/images/icons/action/modern/language_25-active.png";
+	BOOST_CHECK( to_asset_path(path, "", "images") );
+	BOOST_CHECK_EQUAL( path, "icons/action/modern/language_25-active.png" );
+	path = gamedata + "/data/core/sounds/ambient/campfire.ogg";
+	BOOST_CHECK( to_asset_path(path, "", "sounds") );
+	BOOST_CHECK_EQUAL( path, "ambient/campfire.ogg" );
+	path = gamedata + "/images/this/path/doesn't/exist/campfire.ogg";
+	BOOST_CHECK( !to_asset_path(path, "", "images") );
 }
 
 BOOST_AUTO_TEST_CASE( test_fs_wml_path )

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -19,6 +19,7 @@
 #include "filesystem.hpp"
 #include "game_config.hpp"
 #include "log.hpp"
+#include "utils/optional_reference.hpp"
 
 #if 0
 namespace {
@@ -183,16 +184,22 @@ BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 
 	// to_asset_path checks
 	std::string path = gamedata + "/data/core/images/wesnoth-icon.png";
-	BOOST_CHECK( to_asset_path(path, "", "images") );
-	BOOST_CHECK_EQUAL( path, "wesnoth-icon.png" );
+	utils::optional<std::string> outpath = to_asset_path(path, "", "images");
+	BOOST_CHECK( outpath.has_value() );
+	BOOST_CHECK_EQUAL( outpath.value(), "wesnoth-icon.png" );
+
 	path = gamedata + "/images/icons/action/modern/language_25-active.png";
-	BOOST_CHECK( to_asset_path(path, "", "images") );
-	BOOST_CHECK_EQUAL( path, "icons/action/modern/language_25-active.png" );
+	outpath = to_asset_path(path, "", "images");
+	BOOST_CHECK( outpath.has_value() );
+	BOOST_CHECK_EQUAL( outpath.value(), "icons/action/modern/language_25-active.png" );
+
 	path = gamedata + "/data/core/sounds/ambient/campfire.ogg";
-	BOOST_CHECK( to_asset_path(path, "", "sounds") );
-	BOOST_CHECK_EQUAL( path, "ambient/campfire.ogg" );
+	outpath = to_asset_path(path, "", "sounds");
+	BOOST_CHECK( outpath.has_value() );
+	BOOST_CHECK_EQUAL( outpath.value(), "ambient/campfire.ogg" );
+
 	path = gamedata + "/images/this/path/doesn't/exist/campfire.ogg";
-	BOOST_CHECK( !to_asset_path(path, "", "images") );
+	BOOST_CHECK( !to_asset_path(path, "", "images").has_value() );
 }
 
 BOOST_AUTO_TEST_CASE( test_fs_wml_path )


### PR DESCRIPTION
Uses `boost::filesystem::path` and the `filesystem::is_prefix` method to improve the `filesystem::to_asset_path` method, hopefully improving cross-platform compatibility.

Resolves #9579
