### PR TITLE
Fixed CMake build failure due to dependency on Boost CharConv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,14 @@ option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 
 set(BOOST_VERSION "1.70")
+set(BOOST_REQ_COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph)
+
+if(ENABLE_TESTS)
+  list(APPEND BOOST_REQ_COMPONENTS unit_test_framework)
+endif()
+
+find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS ${BOOST_REQ_COMPONENTS}
+                                           OPTIONAL_COMPONENTS charconv)
 
 if(NOT WIN32)
 	set(Lua_FIND_VERSION_MAJOR 5)
@@ -93,8 +101,6 @@ if(APPLE)
 	find_library(SECURITY_LIBRARY Security REQUIRED)
 endif()
 
-find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph
-                                    OPTIONAL_COMPONENTS charconv)
 find_package(ICU REQUIRED COMPONENTS data i18n uc)
 
 # no, gettext executables are not required when NLS is deactivated
@@ -550,10 +556,6 @@ if(ENABLE_GAME OR ENABLE_TESTS)
 	pkg_check_modules(PANGOCAIRO REQUIRED pangocairo>=1.50.0)
 	pkg_check_modules(PANGO REQUIRED pango>=1.50.0)
 	pkg_check_modules(LIBREADLINE readline)
-endif()
-
-if(ENABLE_TESTS)
-	find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS unit_test_framework)
 endif()
 
 if(ENABLE_GAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,8 @@ if(APPLE)
 	find_library(SECURITY_LIBRARY Security REQUIRED)
 endif()
 
-find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph charconv)
+find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph
+                                    OPTIONAL_COMPONENTS charconv)
 find_package(ICU REQUIRED COMPONENTS data i18n uc)
 
 # no, gettext executables are not required when NLS is deactivated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ option(ENABLE_MYSQL "Enable building MP/add-ons servers with mysql support" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 
-set(BOOST_VERSION "1.85")
+set(BOOST_VERSION "1.70")
 
 if(NOT WIN32)
 	set(Lua_FIND_VERSION_MAJOR 5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ option(ENABLE_MYSQL "Enable building MP/add-ons servers with mysql support" OFF)
 option(ENABLE_TESTS "Build unit tests")
 option(ENABLE_NLS "Enable building of translations" ${ENABLE_GAME})
 
-set(BOOST_VERSION "1.70")
+set(BOOST_VERSION "1.85")
 
 if(NOT WIN32)
 	set(Lua_FIND_VERSION_MAJOR 5)
@@ -93,7 +93,7 @@ if(APPLE)
 	find_library(SECURITY_LIBRARY Security REQUIRED)
 endif()
 
-find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph)
+find_package(Boost ${BOOST_VERSION} REQUIRED CONFIG COMPONENTS iostreams program_options regex system thread random coroutine locale filesystem graph charconv)
 find_package(ICU REQUIRED COMPONENTS data i18n uc)
 
 # no, gettext executables are not required when NLS is deactivated

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,14 +218,7 @@ if(ENABLE_GAME)
 		${game-external-libs}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-		Boost::iostreams
-		Boost::program_options
-		Boost::regex
-		Boost::system
-		Boost::random
-		Boost::coroutine
-		Boost::locale
-		Boost::filesystem
+    ${Boost_LIBRARIES}
 		Fontconfig::Fontconfig
 		SDL2::SDL2
 		SDL2::SDL2main

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,7 +218,7 @@ if(ENABLE_GAME)
 		${game-external-libs}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-    ${Boost_LIBRARIES}
+		${Boost_LIBRARIES}
 		Fontconfig::Fontconfig
 		SDL2::SDL2
 		SDL2::SDL2main
@@ -257,15 +257,7 @@ if(ENABLE_TESTS)
 		${game-external-libs}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-		Boost::iostreams
-		Boost::program_options
-		Boost::regex
-		Boost::system
-		Boost::random
-		Boost::coroutine
-		Boost::locale
-		Boost::filesystem
-		Boost::unit_test_framework
+		${Boost_LIBRARIES}
 		Fontconfig::Fontconfig
 		SDL2::SDL2
 		SDL2::SDL2main
@@ -306,14 +298,7 @@ if(ENABLE_SERVER)
 		${MYSQL_LIBS}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-		Boost::iostreams
-		Boost::program_options
-		Boost::regex
-		Boost::system
-		Boost::random
-		Boost::coroutine
-		Boost::locale
-		Boost::filesystem
+		${Boost_LIBRARIES}
 	)
 	if(MSVC)
 		target_link_options(wesnothd PRIVATE /WX)
@@ -347,14 +332,7 @@ if(ENABLE_CAMPAIGN_SERVER)
 		${MYSQL_LIBS}
 		OpenSSL::Crypto
 		OpenSSL::SSL
-		Boost::iostreams
-		Boost::program_options
-		Boost::regex
-		Boost::system
-		Boost::random
-		Boost::coroutine
-		Boost::locale
-		Boost::filesystem
+		${Boost_LIBRARIES}
 	)
 	if(MSVC)
 		target_link_options(campaignd PRIVATE /WX)


### PR DESCRIPTION
A fresh build on Manjaro Linux fails due to not including Boost::CharConv in the CMake build scripts. Adding the following patch fixes the issue.