### PR TITLE
Use boost to hash lightmap range

### DIFF
--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -488,19 +488,18 @@ light_adjust::light_adjust(int op, int rr, int gg, int bb)
 	b = std::clamp(bb / 2, min, max);
 }
 
-namespace
-{
-std::size_t hash_light_range(const utils::span<const light_adjust>& range)
+/** Hash function overload for boost::hash. Must be in the image namespace to satisfy ADL. */
+static std::size_t hash_value(const light_adjust& adj)
 {
 	std::size_t hash{0};
-	for(const auto& adjustment : range) {
-		hash += adjustment.l + adjustment.r + adjustment.g + adjustment.b;
-	}
+
+	boost::hash_combine(hash, adj.l);
+	boost::hash_combine(hash, adj.r);
+	boost::hash_combine(hash, adj.g);
+	boost::hash_combine(hash, adj.b);
 
 	return hash;
 }
-
-} // namespace
 
 static surface apply_light(surface surf, utils::span<const light_adjust> ls)
 {
@@ -515,7 +514,7 @@ static surface apply_light(surface surf, utils::span<const light_adjust> ls)
 
 	const auto get_lightmap = [&ls]
 	{
-		const auto hash = hash_light_range(ls);
+		const auto hash = boost::hash_range(ls.begin(), ls.end());
 		const auto iter = surface_lightmaps_.find(hash);
 
 		if(iter != surface_lightmaps_.end()) {
@@ -739,7 +738,7 @@ surface get_lighted_image(const image::locator& i_locator, utils::span<const lig
 	lit_surface_variants& lvar = lit_surfaces_.access_in_cache(i_locator);
 
 	// Check the matching list_string variants for this locator
-	const auto hash = hash_light_range(ls);
+	const auto hash = boost::hash_range(ls.begin(), ls.end());
 	const auto iter = lvar.find(hash);
 
 	if(iter != lvar.end()) {
@@ -765,7 +764,7 @@ texture get_lighted_texture(const image::locator& i_locator, utils::span<const l
 	lit_texture_variants& lvar = lit_textures_.access_in_cache(i_locator);
 
 	// Check the matching list_string variants for this locator
-	const auto hash = hash_light_range(ls);
+	const auto hash = boost::hash_range(ls.begin(), ls.end());
 	const auto iter = lvar.find(hash);
 
 	if(iter != lvar.end()) {


### PR DESCRIPTION
Supersedes and closes #10154. Confirmed this fixes at least one issue with ToD borders I noticed when testing with EI S2.

After giving the problem more thought, I decided to just let boost handle the actual has implementation instead of trying to come up with a suitable one myself. This is consistent with the `image::locator` hash which also uses `boost::hash_combine`.

I considered the feedback that suggests using the vector directly as a map key and relying on lexicographical comparison for cache lookup. That would require using a plain map instead of an unordered_map. As long as the cache uses an unordered map, a hash needs to come from *somewhere*, and using the span view (or even the vector itself) as a key would require specializing a range hash object. `boost::hash_range` provides a convenient method to implement such an object, for which the `hash_value` overload added here is required (`boost::hash` takes a different approach to customization than `std::hash`, which relies on specialization). In either case, a hash function for `light_adjust` is required. It seems wise to simply let boost handle the details of Good Hashing. Why call `hash_range` directly instead of using the span view as a map key? As I explained on Discord, it seems in contrast *unwise* to leave a bunch of pointers to freed memory sitting around in the cache.

One change I'm considering is whether it makes more sense to use `hash_unordered_range`. The order of `light_adjust`s is well-defined (always in ascending order by their `l` value, so perhaps it's not a practical consideration here. Semantically, though, swapping the order of the range elements shouldn't affect the hash...