### PR TITLE
Use boost::unordered_flat_map for image caches

### DIFF
--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -103,7 +103,7 @@ private:
 	int center_y_ = 0;
 
 public:
-	friend struct std::hash<locator>;
+	friend std::size_t hash_value(const locator&);
 };
 
 // write a readable representation of a locator, mostly for debugging


### PR DESCRIPTION
In testing, this change not only results in a noticeable improvement to map scrolling, but reduced cache access times across the board, sometimes by an order of magnitude. Given this is one of the most frequently hit codepaths, the little (and not-so-little) gains add up.

The locator hash remains unchanged, only moved to a static `hash_value` function in the `image` namespace, as `boost::hash` expects,