### PR TITLE
Update .gitignore to ignore the LOCAL_APPDATA_FONTCONFIG_CACHE directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,6 @@ widgets_tested.log
 
 # clangd cache
 .cache/clangd
+
+# fontfig cache directory
+LOCAL_APPDATA_FONTCONFIG_CACHE


### PR DESCRIPTION
- Creates itself on latest master for some reason.