### PR TITLE
Store lightmap data keys explicitly

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2667,7 +2667,7 @@ void display::draw_overlays_at(const map_location& loc)
 	const time_of_day& tod = get_time_of_day(loc);
 	tod_color tod_col = tod.color + color_adjust_;
 
-	auto lt = image::light_adjust{-1, tod_col.r, tod_col.g, tod_col.b};
+	std::vector lt{image::light_adjust{-1, tod_col.r, tod_col.g, tod_col.b}};
 
 	for(const overlay& ov : overlays) {
 		if(fogged(loc) && !ov.visible_in_fog) {
@@ -2687,7 +2687,7 @@ void display::draw_overlays_at(const map_location& loc)
 		}
 
 		texture tex = ov.image.find("~NO_TOD_SHIFT()") == std::string::npos
-			? image::get_lighted_texture(ov.image, utils::span{&lt, 1})
+			? image::get_lighted_texture(ov.image, lt)
 			: image::get_texture(ov.image, image::HEXED);
 
 		// Base submerge value for the terrain at this location

--- a/src/picture.hpp
+++ b/src/picture.hpp
@@ -19,7 +19,6 @@
 #include "terrain/translation.hpp"
 
 #include "utils/optional_fwd.hpp"
-#include "utils/span.hpp"
 
 class surface;
 class texture;
@@ -129,6 +128,10 @@ struct light_adjust
 	int8_t r;
 	int8_t g;
 	int8_t b;
+
+	// TODO C++20: default these (╯°□°)╯︵ ┻━┻
+	bool operator==(const light_adjust& o) const;
+	bool operator!=(const light_adjust& o) const { return !operator==(o); }
 };
 
 /**
@@ -216,8 +219,8 @@ texture get_texture(const image::locator& i_locator, scale_quality quality,
  * @param i_locator            Image path.
  * @param ls                   Light map to apply to the image.
  */
-surface get_lighted_image(const image::locator& i_locator, utils::span<const light_adjust> ls);
-texture get_lighted_texture(const image::locator& i_locator, utils::span<const light_adjust> ls);
+surface get_lighted_image(const image::locator& i_locator, const std::vector<light_adjust>& ls);
+texture get_lighted_texture(const image::locator& i_locator, const std::vector<light_adjust>& ls);
 
 /**
  * Retrieves the standard hexagonal tile mask.


### PR DESCRIPTION
Apparently, using a hash could lead to potential collisions and the wrong surface being pulled.