### PR TITLE
Fix some linter issues relating to move/const refs

### DIFF
--- a/src/ai/lua/core.cpp
+++ b/src/ai/lua/core.cpp
@@ -739,7 +739,7 @@ static int cfun_ai_recalculate_move_maps_enemy(lua_State *L)
 }
 
 template<typename T>
-typesafe_aspect<T>* try_aspect_as(aspect_ptr p)
+typesafe_aspect<T>* try_aspect_as(const aspect_ptr& p)
 {
 	return std::dynamic_pointer_cast<typesafe_aspect<T> >(p).get();
 }

--- a/src/server/common/server_base.cpp
+++ b/src/server/common/server_base.cpp
@@ -276,7 +276,7 @@ template<class SocketPtr> std::string client_address(SocketPtr socket)
 		return result;
 }
 
-template<class SocketPtr> bool check_error(const boost::system::error_code& error, SocketPtr socket)
+template<class SocketPtr> bool check_error(const boost::system::error_code& error, const SocketPtr& socket)
 {
 	if(error) {
 		if(error == boost::asio::error::eof)
@@ -287,7 +287,7 @@ template<class SocketPtr> bool check_error(const boost::system::error_code& erro
 	}
 	return false;
 }
-template bool check_error<tls_socket_ptr>(const boost::system::error_code& error, tls_socket_ptr socket);
+template bool check_error<tls_socket_ptr>(const boost::system::error_code& error, const tls_socket_ptr& socket);
 
 namespace {
 
@@ -311,7 +311,7 @@ void info_table_into_simple_wml(simple_wml::document& doc, const std::string& pa
  * @param doc
  * @param yield The function will suspend on write operation using this yield context
  */
-template<class SocketPtr> void server_base::coro_send_doc(SocketPtr socket, simple_wml::document& doc, const boost::asio::yield_context& yield)
+template<class SocketPtr> void server_base::coro_send_doc(const SocketPtr& socket, simple_wml::document& doc, const boost::asio::yield_context& yield)
 {
 	if(dump_wml) {
 		std::cout << "Sending WML to " << log_address(socket) << ": \n" << doc.output() << std::endl;
@@ -343,10 +343,10 @@ template<class SocketPtr> void server_base::coro_send_doc(SocketPtr socket, simp
 		throw;
 	}
 }
-template void server_base::coro_send_doc<socket_ptr>(socket_ptr socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
-template void server_base::coro_send_doc<tls_socket_ptr>(tls_socket_ptr socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
+template void server_base::coro_send_doc<socket_ptr>(const socket_ptr& socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
+template void server_base::coro_send_doc<tls_socket_ptr>(const tls_socket_ptr& socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
 
-template<class SocketPtr> void coro_send_file_userspace(SocketPtr socket, const std::string& filename, const boost::asio::yield_context& yield)
+template<class SocketPtr> void coro_send_file_userspace(const SocketPtr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	std::size_t filesize { std::size_t(filesystem::file_size(filename)) };
 	union DataSize
@@ -378,11 +378,11 @@ template<class SocketPtr> void coro_send_file_userspace(SocketPtr socket, const 
 
 #ifdef HAVE_SENDFILE
 
-void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield)
+void server_base::coro_send_file(const tls_socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	// We fallback to userspace if using TLS socket because sendfile is not aware of TLS state
 	// TODO: keep in mind possibility of using KTLS instead. This seem to be available only in openssl3 branch for now
-	coro_send_file_userspace(std::move(socket), filename, yield);
+	coro_send_file_userspace(socket, filename, yield);
 }
 
 void server_base::coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
@@ -446,7 +446,7 @@ void server_base::coro_send_file(const socket_ptr& socket, const std::string& fi
 
 #elif defined(_WIN32)
 
-void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield)
+void server_base::coro_send_file(const tls_socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	coro_send_file_userspace(socket, filename, yield);
 }
@@ -511,7 +511,7 @@ void server_base::coro_send_file(const socket_ptr& socket, const std::string& fi
 
 #else
 
-void server_base::coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield)
+void server_base::coro_send_file(const tls_socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield)
 {
 	coro_send_file_userspace(socket, filename, yield);
 }
@@ -523,7 +523,7 @@ void server_base::coro_send_file(const socket_ptr& socket, const std::string& fi
 
 #endif
 
-template<class SocketPtr> std::unique_ptr<simple_wml::document> server_base::coro_receive_doc(SocketPtr socket, const boost::asio::yield_context& yield)
+template<class SocketPtr> std::unique_ptr<simple_wml::document> server_base::coro_receive_doc(const SocketPtr& socket, const boost::asio::yield_context& yield)
 {
 	union DataSize
 	{
@@ -563,10 +563,10 @@ template<class SocketPtr> std::unique_ptr<simple_wml::document> server_base::cor
 		return {};
 	}
 }
-template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<socket_ptr>(socket_ptr socket, const boost::asio::yield_context& yield);
-template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<tls_socket_ptr>(tls_socket_ptr socket, const boost::asio::yield_context& yield);
+template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<socket_ptr>(const socket_ptr& socket, const boost::asio::yield_context& yield);
+template std::unique_ptr<simple_wml::document> server_base::coro_receive_doc<tls_socket_ptr>(const tls_socket_ptr& socket, const boost::asio::yield_context& yield);
 
-template<class SocketPtr> void server_base::send_doc_queued(SocketPtr socket, std::unique_ptr<simple_wml::document>& doc_ptr, boost::asio::yield_context yield)
+template<class SocketPtr> void server_base::send_doc_queued(const SocketPtr& socket, std::unique_ptr<simple_wml::document>& doc_ptr, const boost::asio::yield_context& yield)
 {
 	static std::map<SocketPtr, std::queue<std::unique_ptr<simple_wml::document>>> queues;
 
@@ -583,10 +583,10 @@ template<class SocketPtr> void server_base::send_doc_queued(SocketPtr socket, st
 	}
 }
 
-template<class SocketPtr> void server_base::async_send_doc_queued(SocketPtr socket, simple_wml::document& doc)
+template<class SocketPtr> void server_base::async_send_doc_queued(const SocketPtr& socket, simple_wml::document& doc)
 {
 	boost::asio::spawn(
-		io_service_, [this, doc_ptr = doc.clone(), socket](boost::asio::yield_context yield) mutable {
+		io_service_, [this, doc_ptr = doc.clone(), socket](const boost::asio::yield_context& yield) mutable {
 			send_doc_queued(socket, doc_ptr, yield);
 		}
 #if BOOST_VERSION >= 108000
@@ -609,7 +609,7 @@ template<class SocketPtr> void server_base::async_send_error(SocketPtr socket, c
 template void server_base::async_send_error<socket_ptr>(socket_ptr socket, const std::string& msg, const char* error_code, const info_table& info);
 template void server_base::async_send_error<tls_socket_ptr>(tls_socket_ptr socket, const std::string& msg, const char* error_code, const info_table& info);
 
-template<class SocketPtr> void server_base::async_send_warning(SocketPtr socket, const std::string& msg, const char* warning_code, const info_table& info)
+template<class SocketPtr> void server_base::async_send_warning(const SocketPtr& socket, const std::string& msg, const char* warning_code, const info_table& info)
 {
 	simple_wml::document doc;
 	doc.root().add_child("warning").set_attr_dup("message", msg.c_str());
@@ -620,8 +620,8 @@ template<class SocketPtr> void server_base::async_send_warning(SocketPtr socket,
 
 	async_send_doc_queued(socket, doc);
 }
-template void server_base::async_send_warning<socket_ptr>(socket_ptr socket, const std::string& msg, const char* warning_code, const info_table& info);
-template void server_base::async_send_warning<tls_socket_ptr>(tls_socket_ptr socket, const std::string& msg, const char* warning_code, const info_table& info);
+template void server_base::async_send_warning<socket_ptr>(const socket_ptr& socket, const std::string& msg, const char* warning_code, const info_table& info);
+template void server_base::async_send_warning<tls_socket_ptr>(const tls_socket_ptr& socket, const std::string& msg, const char* warning_code, const info_table& info);
 
 void server_base::load_tls_config(const config& cfg)
 {

--- a/src/server/common/server_base.hpp
+++ b/src/server/common/server_base.hpp
@@ -79,7 +79,7 @@ struct server_shutdown : public game::error
  */
 class server_base
 {
-	template<class SocketPtr> void send_doc_queued(SocketPtr socket, std::unique_ptr<simple_wml::document>& doc_ptr, boost::asio::yield_context yield);
+	template<class SocketPtr> void send_doc_queued(const SocketPtr& socket, std::unique_ptr<simple_wml::document>& doc_ptr, const boost::asio::yield_context& yield);
 
 public:
 	server_base(unsigned short port, bool keep_alive);
@@ -92,7 +92,7 @@ public:
 	 * @param doc
 	 * @param yield The function will suspend on write operation using this yield context
 	 */
-	template<class SocketPtr> void coro_send_doc(SocketPtr socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
+	template<class SocketPtr> void coro_send_doc(const SocketPtr& socket, simple_wml::document& doc, const boost::asio::yield_context& yield);
 	/**
 	 * Send contents of entire file directly to socket from within a coroutine
 	 * @param socket
@@ -100,14 +100,14 @@ public:
 	 * @param yield The function will suspend on write operations using this yield context
 	 */
 	void coro_send_file(const socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield);
-	void coro_send_file(tls_socket_ptr socket, const std::string& filename, const boost::asio::yield_context& yield);
+	void coro_send_file(const tls_socket_ptr& socket, const std::string& filename, const boost::asio::yield_context& yield);
 	/**
 	 * Receive WML document from a coroutine
 	 * @param socket
 	 * @param yield The function will suspend on read operation using this yield context
 	 * @return unique_ptr with doc deceived. In case of error empty unique_ptr
 	 */
-	template<class SocketPtr> std::unique_ptr<simple_wml::document> coro_receive_doc(SocketPtr socket, const boost::asio::yield_context& yield);
+	template<class SocketPtr> std::unique_ptr<simple_wml::document> coro_receive_doc(const SocketPtr& socket, const boost::asio::yield_context& yield);
 
 	/**
 	 * High level wrapper for sending a WML document
@@ -117,11 +117,11 @@ public:
 	 * @param socket
 	 * @param doc Document to send. A copy of it will be made so there is no need to keep the reference live after the function returns.
 	 */
-	template<class SocketPtr> void async_send_doc_queued(SocketPtr socket, simple_wml::document& doc);
+	template<class SocketPtr> void async_send_doc_queued(const SocketPtr& socket, simple_wml::document& doc);
 
 	typedef std::map<std::string, std::string> info_table;
 	template<class SocketPtr> void async_send_error(SocketPtr socket, const std::string& msg, const char* error_code = "", const info_table& info = {});
-	template<class SocketPtr> void async_send_warning(SocketPtr socket, const std::string& msg, const char* warning_code = "", const info_table& info = {});
+	template<class SocketPtr> void async_send_warning(const SocketPtr& socket, const std::string& msg, const char* warning_code = "", const info_table& info = {});
 
 	/**
 	 * Handles hashing the password provided by the player before comparing it to the hashed password in the forum database.
@@ -178,4 +178,4 @@ protected:
 
 template<class SocketPtr> std::string client_address(SocketPtr socket);
 template<class SocketPtr> std::string log_address(SocketPtr socket) { return (utils::decayed_is_same<tls_socket_ptr, decltype(socket)> ? "+" : "") + client_address(socket); }
-template<class SocketPtr> bool check_error(const boost::system::error_code& error, SocketPtr socket);
+template<class SocketPtr> bool check_error(const boost::system::error_code& error, const SocketPtr& socket);

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -873,7 +873,7 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 	coro_send_doc(socket, join_lobby_response, yield);
 
 	boost::asio::spawn(io_service_,
-		[this, socket, new_player](boost::asio::yield_context yield) { handle_player(yield, socket, new_player); }
+		[this, socket, new_player](boost::asio::yield_context yield) { handle_player(std::move(yield), socket, new_player); }
 #if BOOST_VERSION >= 108000
 		, [](const std::exception_ptr& e) { if (e) std::rethrow_exception(e); }
 #endif

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -281,7 +281,7 @@ void unit_filter_compound::create_child(const vconfig& c, F func)
 }
 
 template<typename C, typename F>
-void unit_filter_compound::create_attribute(const config::attribute_value v, C conv, F func)
+void unit_filter_compound::create_attribute(const config::attribute_value& v, C conv, F func)
 {
 	if(v.blank()) {
 	}

--- a/src/units/filter.hpp
+++ b/src/units/filter.hpp
@@ -84,7 +84,7 @@ namespace unit_filter_impl
 		unit_filter_compound(const vconfig& cfg);
 
 		template<typename C, typename F>
-		void create_attribute(const config::attribute_value c, C conv, F func);
+		void create_attribute(const config::attribute_value& c, C conv, F func);
 		template<typename F>
 		void create_child(const vconfig& c, F func);
 


### PR DESCRIPTION
Specifically, this redeclares some parameters as const references when those parameters are only used in a const way. It also removes std::move from being used on those parameters as you cannot move a const ref. Finally, it also adds std::move when necessary.

I'm not sure why these got missed but they appear as errors on my own machine.