### PR TITLE
(1.18) Implement <img> scale= attribute into the Help system markup and use it for unit portraits

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
    * Updated translations: Arabic, Bengali, Bulgarian, Chinese (Simplified), Czech, Finnish, Italian, Japanese
 ### Units
 ### User interface
+   * Fixed an issue with the Help browser over-scaling portraits up on configurations with a pixel scale higher than 1 (e.g. macOS and Retina screens), causing blurry rendering and lacking enough room for text.
 ### WML Engine
 ### Miscellaneous and Bug Fixes
    * Fix failure to build with recent versions of Visual Studio due to missing `<chrono>` include.

--- a/src/help/help_text_area.hpp
+++ b/src/help/help_text_area.hpp
@@ -127,7 +127,7 @@ private:
 
 	/** Add an image item with the specified attributes. */
 	void add_img_item(const std::string& path, const std::string& alignment, const bool floating,
-					  const bool box);
+					  const bool box, const int target_scale);
 
 	/** Move the current input point to the next line. */
 	void down_one_line();

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -326,16 +326,20 @@ std::string unit_topic_generator::operator()() const {
 
 	// without this, scaling down (SCALE_INTO below) and then scaling back up due to the pixel multiplier leads to ugly results
 	// can't use the preferences value since it may be different than the actual value
-	sz *= video::get_pixel_scale();
+	const auto scale = video::get_pixel_scale();
+	sz *= scale;
 
 	// TODO: figure out why the second checks don't match but the last does
 	if (has_male_portrait) {
-		ss << "<img>src='" << male_portrait << "~FL(horiz)~SCALE_INTO(" << sz << ',' << sz << ")' box='no' align='right' float='yes'</img> ";
+		ss << "<img>src='" << male_portrait << "~FL(horiz)~SCALE_INTO("
+		   << sz << ',' << sz << ")' box='no' align='right' float='yes' "
+		   << "scale='" << scale << "' </img>";
 	}
 
-
 	if (has_female_portrait) {
-		ss << "<img>src='" << female_portrait << "~FL(horiz)~SCALE_INTO(" << sz << ',' << sz << ")' box='no' align='right' float='yes'</img> ";
+		ss << "<img>src='" << female_portrait << "~FL(horiz)~SCALE_INTO("
+		   << sz << ',' << sz << ")' box='no' align='right' float='yes' "
+		   << "scale='" << scale << "' </img>";
 	}
 
 	ss << "\n\n\n";


### PR DESCRIPTION
Firstly, this patch adds an `<img> scale=` attribute that allows the user to express rendering intent for images that have been transformed via `~SCALE_INTO()` and similar IPFs. When this attribute is used, the UI shrinks the image's draw size accordingly so that the final result does not get upscaled according to the screen's pixel scale *again*, which can result in excessively blurry images on high pixel density screens (e.g. Apple Retina).

Secondly, this makes the unit type page generator convey the scale information in `<img>`, since it's the generator and not the rendering code that's currently in charge of picking the correct numbers for scaling portraits up according to the display device's properties.

This all fixes a major issue on high pixel density screens where the previous fixes for portrait upscaling quality and extents would cause the portraits to be upscaled again on render, resulting in incredibly blurry results (undermining the intent of the original fix) and a massive lack of room for the unit description text due to half the dialog being occupied by the portrait.

(Tested on a 2021 16" MacBook Pro, both on the native panel and an external 1080p display. Additional testing would be very much welcome.)

### Before
<img width="1455" alt="Screenshot 2025-05-12 at 10 57 09" src="https://github.com/user-attachments/assets/2dd96c80-17b3-408e-a2be-5055755a827a" />

### After
<img width="1455" alt="Screenshot 2025-05-12 at 10 56 34" src="https://github.com/user-attachments/assets/638aaa98-02e5-48b3-b814-5b0c56a0c2d3" />