### PR TITLE
Simple WML: make use of unique_ptr

### DIFF
--- a/src/server/common/simple_wml.cpp
+++ b/src/server/common/simple_wml.cpp
@@ -37,10 +37,6 @@ std::size_t document::document_size_limit = 40000000;
 
 namespace {
 
-void debug_delete(node* n) {
-	delete n;
-}
-
 char* uncompress_buffer(const string_span& input, string_span* span)
 {
 	int nalloc = input.size();
@@ -260,7 +256,7 @@ node::node(document& doc, node* parent, const char** str, int depth) :
 
 			s = end + 1;
 
-			children_[list_index].second.push_back(new node(doc, this, str, depth+1));
+			children_[list_index].second.push_back(std::make_unique<node>(doc, this, str, depth+1));
 			ordered_children_.emplace_back(list_index, children_[list_index].second.size() - 1);
 			check_ordered_children();
 
@@ -365,11 +361,6 @@ node::node(document& doc, node* parent, const char** str, int depth) :
 
 node::~node()
 {
-	for(child_map::iterator i = children_.begin(); i != children_.end(); ++i) {
-		for(child_list::iterator j = i->second.begin(); j != i->second.end(); ++j) {
-			debug_delete(*j);
-		}
-	}
 }
 
 namespace {
@@ -461,7 +452,7 @@ node& node::add_child_at(const char* name, std::size_t index)
 	}
 
 	check_ordered_children();
-	list.insert(list.begin() + index, new node(*doc_, this));
+	list.insert(list.begin() + index, std::make_unique<node>(*doc_, this));
 	insert_ordered_child(list_index, index);
 
 	check_ordered_children();
@@ -476,7 +467,7 @@ node& node::add_child(const char* name)
 	const int list_index = get_children(name);
 	check_ordered_children();
 	child_list& list = children_[list_index].second;
-	list.push_back(new node(*doc_, this));
+	list.push_back(std::make_unique<node>(*doc_, this));
 	ordered_children_.emplace_back(list_index, list.size() - 1);
 	check_ordered_children();
 	return *list.back();
@@ -499,7 +490,6 @@ void node::remove_child(const string_span& name, std::size_t index)
 
 	remove_ordered_child(std::distance(children_.begin(), itor), index);
 
-	debug_delete(list[index]);
 	list.erase(list.begin() + index);
 
 	if(list.empty()) {
@@ -616,7 +606,7 @@ node* node::child(const char* name)
 	for(child_map::iterator i = children_.begin(); i != children_.end(); ++i) {
 		if(i->first == name) {
 			assert(i->second.empty() == false);
-			return i->second.front();
+			return i->second.front().get();
 		}
 	}
 
@@ -630,7 +620,7 @@ const node* node::child(const char* name) const
 			if(i->second.empty()) {
 				return nullptr;
 			} else {
-				return i->second.front();
+				return i->second.front().get();
 			}
 		}
 	}
@@ -979,7 +969,7 @@ document::document(char* buf, INIT_BUFFER_CONTROL control) :
 		buffers_.push_back(buf);
 	}
 	const char* cbuf = buf;
-	root_ = new node(*this, nullptr, &cbuf);
+	root_.reset(new node(*this, nullptr, &cbuf));
 
 	attach_list();
 }
@@ -996,7 +986,7 @@ document::document(const char* buf, INIT_STATE state) :
 		output_compressed();
 		output_ = nullptr;
 	} else {
-		root_ = new node(*this, nullptr, &buf);
+		root_.reset(new node(*this, nullptr, &buf));
 	}
 
 	attach_list();
@@ -1015,7 +1005,7 @@ document::document(string_span compressed_buf) :
 	output_ = uncompressed_buf.begin();
 	const char* cbuf = output_;
 	try {
-		root_ = new node(*this, nullptr, &cbuf);
+		root_.reset(new node(*this, nullptr, &cbuf));
 	} catch(...) {
 		ERR_SWML << "Caught exception creating a new simple_wml node: " << utils::get_unknown_exception_type();
 		delete [] buffers_.front();
@@ -1033,7 +1023,7 @@ document::~document()
 	}
 
 	buffers_.clear();
-	debug_delete(root_);
+	root_ = nullptr;
 
 	detach_list();
 }
@@ -1115,7 +1105,6 @@ string_span document::output_compressed(bool bzip2)
 void document::compress()
 {
 	output_compressed();
-	debug_delete(root_);
 	root_ = nullptr;
 	output_ = nullptr;
 	std::vector<char*> new_buffers;
@@ -1142,7 +1131,7 @@ void document::generate_root()
 
 	assert(root_ == nullptr);
 	const char* cbuf = output_;
-	root_ = new node(*this, nullptr, &cbuf);
+	root_.reset(new node(*this, nullptr, &cbuf));
 }
 
 std::unique_ptr<document> document::clone()
@@ -1167,8 +1156,7 @@ void document::clear()
 {
 	compressed_buf_ = string_span();
 	output_ = nullptr;
-	debug_delete(root_);
-	root_ = new node(*this, nullptr);
+	root_.reset(new node(*this, nullptr));
 	for(std::vector<char*>::iterator i = buffers_.begin(); i != buffers_.end(); ++i) {
 		delete [] *i;
 	}

--- a/src/server/common/simple_wml.hpp
+++ b/src/server/common/simple_wml.hpp
@@ -126,7 +126,7 @@ public:
 		string_span key;
 		string_span value;
 	};
-	typedef std::vector<node*> child_list;
+	typedef std::vector<std::unique_ptr<node>> child_list;
 
 	const string_span& operator[](const char* key) const;
 	const string_span& attr(const char* key) const {
@@ -305,7 +305,7 @@ private:
 	string_span compressed_buf_;
 	const char* output_;
 	std::vector<char*> buffers_;
-	node* root_;
+	std::unique_ptr<node> root_;
 
 	//linked list of documents for accounting purposes
 	void attach_list();

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -346,9 +346,9 @@ void game::start_game(player_iterator starter)
 	send_observerjoins();
 }
 
-bool game::send_taken_side(simple_wml::document& cfg, const simple_wml::node* side) const
+bool game::send_taken_side(simple_wml::document& cfg, const simple_wml::node& side) const
 {
-	const std::size_t side_index = (*side)["side"].to_int() - 1;
+	const std::size_t side_index = side["side"].to_int() - 1;
 
 	// Negative values are casted (int -> std::size_t) to very high values to this check will fail for them too.
 	if(side_index >= sides_.size()) {
@@ -360,7 +360,7 @@ bool game::send_taken_side(simple_wml::document& cfg, const simple_wml::node* si
 	}
 
 	// We expect that the host will really use our proposed side number. (He could do different...)
-	cfg.root().set_attr_dup("side", (*side)["side"]);
+	cfg.root().set_attr_dup("side", side["side"]);
 
 	// Tell the host which side the new player should take.
 	server.send_to_player(owner_, cfg);
@@ -383,20 +383,20 @@ bool game::take_side(player_iterator user)
 	// Check if we can figure out a fitting side.
 	const simple_wml::node::child_list& sides = get_sides_list();
 
-	for(const simple_wml::node* side : sides) {
+	for(const auto& side : sides) {
 		if(((*side)["controller"] == side_controller::human || (*side)["controller"] == side_controller::reserved)
 				&& (*side)["current_player"] == user->name().c_str()) {
 
-			if(send_taken_side(cfg, side)) {
+			if(send_taken_side(cfg, *side)) {
 				return true;
 			}
 		}
 	}
 
 	// If there was no fitting side just take the first available.
-	for(const simple_wml::node* side : sides) {
+	for(const auto& side : sides) {
 		if((*side)["controller"] == side_controller::human) {
-			if(send_taken_side(cfg, side)) {
+			if(send_taken_side(cfg, *side)) {
 				return true;
 			}
 		}
@@ -449,7 +449,7 @@ void game::update_side_data()
 
 		bool side_found = false;
 		for(unsigned side_index = 0; side_index < level_sides.size(); ++side_index) {
-			const simple_wml::node* side = level_sides[side_index];
+			const auto& side = level_sides[side_index];
 
 			if(side_index >= sides_.size() || sides_[side_index]) {
 				continue;
@@ -663,7 +663,7 @@ void game::describe_slots()
 	int num_sides = get_sides_list().size();
 	int i = 0;
 
-	for(const simple_wml::node* side : get_sides_list()) {
+	for(const auto& side : get_sides_list()) {
 		if(((*side)["allow_player"].to_bool(true) == false) || (*side)["controller"] == side_controller::none) {
 			num_sides--;
 		} else if(!sides_[i]) {
@@ -993,7 +993,7 @@ bool game::process_turn(simple_wml::document& data, player_iterator user)
 
 	const simple_wml::node::child_list& commands = turn->children("command");
 
-	for(simple_wml::node* command : commands) {
+	for(auto& command : commands) {
 		DBG_GAME << "game " << id_ << ", " << db_id_ << " received [" << (*command).first_child() << "] from player '" << username(user)
 				 << "'(" << ") during turn " << current_side_index_ + 1 << "," << current_turn_;
 		if(!is_legal_command(*command, user)) {
@@ -1096,7 +1096,7 @@ bool game::process_turn(simple_wml::document& data, player_iterator user)
 		return turn_ended;
 	}
 
-	for(simple_wml::node* command : commands) {
+	for(auto& command : commands) {
 		simple_wml::node* const speak = (*command).child("speak");
 		if(speak == nullptr) {
 			auto mdata = std::make_unique<simple_wml::document>();
@@ -1812,7 +1812,7 @@ void game::save_replay()
 	for(const auto& h : history_) {
 		const simple_wml::node::child_list& turn_list = h->root().children("turn");
 
-		for(const simple_wml::node* turn : turn_list) {
+		for(const auto& turn : turn_list) {
 			replay_commands += simple_wml::node_to_string(*turn);
 		}
 	}
@@ -1930,7 +1930,7 @@ std::string game::debug_sides_info() const
 
 	result << "\t\t level, server\n";
 
-	for(const simple_wml::node* s : sides) {
+	for(const auto& s : sides) {
 		result
 			<< "side " << (*s)["side"].to_int()
 			<< " :\t" << (*s)["controller"].to_string()

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -708,7 +708,7 @@ private:
 	 * @param side The side information to send.
 	 * @return True if the document was sent, false otherwise.
 	 */
-	bool send_taken_side(simple_wml::document& cfg, const simple_wml::node* side) const;
+	bool send_taken_side(simple_wml::document& cfg, const simple_wml::node& side) const;
 
 	/**
 	 * Figures out which side to take and tells that side to the game owner.

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -131,7 +131,8 @@ static bool make_delete_diff(const simple_wml::node& src,
 	}
 
 	const simple_wml::node::child_list& children = src.children(type);
-	const auto itor = std::find(children.begin(), children.end(), remove);
+	const auto itor = std::find_if(children.begin(), children.end(),
+		[remove](const auto& child_ptr) { return child_ptr.get() == remove; });
 
 	if(itor == children.end()) {
 		return false;
@@ -164,7 +165,8 @@ static bool make_change_diff(const simple_wml::node& src,
 	}
 
 	const simple_wml::node::child_list& children = src.children(type);
-	const auto itor = std::find(children.begin(), children.end(), item);
+	const auto itor = std::find_if(children.begin(), children.end(),
+		[item](const auto& child_ptr) { return child_ptr.get() == item; });
 
 	if(itor == children.end()) {
 		return false;
@@ -698,10 +700,10 @@ void server::dummy_player_updates(const boost::system::error_code& ec)
 	int size = games_and_users_list_.root().children("user").size();
 	LOG_SERVER << "player count: " << size;
 	if(size % 2 == 0) {
-		simple_wml::node* dummy_user = games_and_users_list_.root().children("user").at(size-1);
+		auto& dummy_user = games_and_users_list_.root().children("user").at(size-1);
 
 		simple_wml::document diff;
-		if(make_delete_diff(games_and_users_list_.root(), nullptr, "user", dummy_user, diff)) {
+		if(make_delete_diff(games_and_users_list_.root(), nullptr, "user", dummy_user.get(), diff)) {
 			send_to_lobby(diff);
 		}
 
@@ -1528,7 +1530,8 @@ void server::cleanup_game(game* game_ptr)
 
 	// Delete the game from the games_and_users_list_.
 	const simple_wml::node::child_list& games = gamelist->children("game");
-	const auto g = std::find(games.begin(), games.end(), game_ptr->description());
+	const auto g = std::find_if(games.begin(), games.end(),
+		[game_ptr](const auto& game) { return game.get() == game_ptr->description(); });
 
 	if(g != games.end()) {
 		const std::size_t index = std::distance(games.begin(), g);
@@ -1824,7 +1827,7 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		}
 
 		const simple_wml::node::child_list& mlist = data.children("modification");
-		for(const simple_wml::node* m : mlist) {
+		for(const auto& m : mlist) {
 			desc.add_child_at("modification", 0);
 			desc.child("modification")->set_attr_dup("id", m->attr("id"));
 			desc.child("modification")->set_attr_dup("name", m->attr("name"));
@@ -2040,13 +2043,13 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 					leaders.emplace_back(side.attr("type").to_string());
 				}
 				// add each [unit] in the side that has canrecruit=yes
-				for(const auto unit : side.children("unit")) {
+				for(const auto& unit : side.children("unit")) {
 					if(unit->attr("canrecruit") == "yes") {
 						leaders.emplace_back(unit->attr("type").to_string());
 					}
 				}
 				// add any [leader] specified for the side
-				for(const auto leader : side.children("leader")) {
+				for(const auto& leader : side.children("leader")) {
 					leaders.emplace_back(leader->attr("type").to_string());
 				}
 
@@ -2262,8 +2265,8 @@ void server::remove_player(player_iterator iter)
 	}
 
 	const simple_wml::node::child_list& users = games_and_users_list_.root().children("user");
-	const std::size_t index =
-		std::distance(users.begin(), std::find(users.begin(), users.end(), iter->info().config_address()));
+	const std::size_t index = std::distance(users.begin(), std::find_if(users.begin(), users.end(),
+		[address = iter->info().config_address()](const auto& user) { return user.get() == address; }));
 
 	// Notify other players in lobby
 	simple_wml::document diff;


### PR DESCRIPTION
Reduces manual memory management by using unique_ptr. Doesn't (yet) touch `document::buffers_` since that's a slightly more in-depth change.