### PR TITLE
Simple WML: remove unused function with infinite loop

### DIFF
--- a/src/server/common/simple_wml.cpp
+++ b/src/server/common/simple_wml.cpp
@@ -549,16 +549,6 @@ void node::remove_ordered_child(int child_map_index, int child_list_index)
 	assert(erase_count == 1);
 }
 
-void node::insert_ordered_child_list(int child_map_index)
-{
-	std::vector<node_pos>::iterator i = ordered_children_.begin();
-	while(i != ordered_children_.end()) {
-		if(i->child_map_index >= child_map_index) {
-			i->child_map_index++;
-		}
-	}
-}
-
 void node::remove_ordered_child_list(int child_map_index)
 {
 	std::vector<node_pos>::iterator i = ordered_children_.begin();

--- a/src/server/common/simple_wml.hpp
+++ b/src/server/common/simple_wml.hpp
@@ -225,7 +225,6 @@ private:
 
 	void insert_ordered_child(int child_map_index, int child_list_index);
 	void remove_ordered_child(int child_map_index, int child_list_index);
-	void insert_ordered_child_list(int child_map_index);
 	void remove_ordered_child_list(int child_map_index);
 
 	void check_ordered_children() const;


### PR DESCRIPTION
Added in 2f95e5b43d47bebed3fdf636e867ea7458a56f94 and unchanged since. Was unused then, unused now, doesn't actually seem to insert anything, and is an infinite loop.