### PR TITLE
Wesnothd: avoid unnecessary copy of new player object

### DIFF
--- a/src/server/wesnothd/player.hpp
+++ b/src/server/wesnothd/player.hpp
@@ -70,7 +70,7 @@ public:
 	const std::set<int>& get_queues() const { return in_queues_; }
 
 private:
-	const std::string name_;
+	std::string name_;
 	std::string version_;
 	std::string source_;
 	simple_wml::node& cfg_;
@@ -79,8 +79,8 @@ private:
 
 	std::chrono::steady_clock::time_point flood_start_;
 	unsigned int messages_since_flood_start_;
-	const std::size_t MaxMessages;
-	const std::chrono::seconds TimePeriod;
+	std::size_t MaxMessages;
+	std::chrono::seconds TimePeriod;
 	STATUS status_;
 	bool moderator_;
 	unsigned long long login_id_;

--- a/src/server/wesnothd/player_connection.hpp
+++ b/src/server/wesnothd/player_connection.hpp
@@ -31,7 +31,7 @@ class player_record
 {
 public:
 	template<class SocketPtr>
-	player_record(const SocketPtr socket, const player& player)
+	player_record(const SocketPtr socket, player&& player)
 		: login_time(std::chrono::steady_clock::now())
 		, socket_(socket)
 		, player_(player)

--- a/src/server/wesnothd/player_connection.hpp
+++ b/src/server/wesnothd/player_connection.hpp
@@ -30,11 +30,11 @@ class game;
 class player_record
 {
 public:
-	template<class SocketPtr>
-	player_record(const SocketPtr socket, player&& player)
+	template<typename SocketPtr, typename... Args>
+	player_record(const SocketPtr socket, Args&&... args)
 		: login_time(std::chrono::steady_clock::now())
 		, socket_(socket)
-		, player_(std::move(player))
+		, player_(std::forward<Args>(args)...)
 		, game_()
 		, ip_address(client_address(socket))
 	{

--- a/src/server/wesnothd/player_connection.hpp
+++ b/src/server/wesnothd/player_connection.hpp
@@ -34,7 +34,7 @@ public:
 	player_record(const SocketPtr socket, player&& player)
 		: login_time(std::chrono::steady_clock::now())
 		, socket_(socket)
-		, player_(player)
+		, player_(std::move(player))
 		, game_()
 		, ip_address(client_address(socket))
 	{

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -840,7 +840,8 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 	}
 
 	simple_wml::node& player_cfg = games_and_users_list_.root().add_child("user");
-	wesnothd::player player_data {
+	auto [new_player, inserted] = player_connections_.emplace(
+		socket, wesnothd::player{
 			username,
 			player_cfg,
 			user_handler_ ? user_handler_->get_forum_id(username) : 0,
@@ -851,10 +852,8 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 			default_max_messages_,
 			default_time_period_,
 			is_moderator
-	};
-	bool inserted;
-	player_iterator new_player;
-	std::tie(new_player, inserted) = player_connections_.insert(player_connections::value_type(socket, player_data));
+		});
+
 	assert(inserted && "unexpected duplicate username");
 
 	simple_wml::document join_lobby_response;

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -841,18 +841,18 @@ void server::login_client(boost::asio::yield_context yield, SocketPtr socket)
 
 	simple_wml::node& player_cfg = games_and_users_list_.root().add_child("user");
 	auto [new_player, inserted] = player_connections_.emplace(
-		socket, wesnothd::player{
-			username,
-			player_cfg,
-			user_handler_ ? user_handler_->get_forum_id(username) : 0,
-			registered,
-			client_version,
-			client_source,
-			user_handler_ ? user_handler_->db_insert_login(username, client_address(socket), client_version) : 0,
-			default_max_messages_,
-			default_time_period_,
-			is_moderator
-		});
+		socket,
+		username,
+		player_cfg,
+		user_handler_ ? user_handler_->get_forum_id(username) : 0,
+		registered,
+		client_version,
+		client_source,
+		user_handler_ ? user_handler_->db_insert_login(username, client_address(socket), client_version) : 0,
+		default_max_messages_,
+		default_time_period_,
+		is_moderator
+	);
 
 	assert(inserted && "unexpected duplicate username");
 


### PR DESCRIPTION
- Use emplace when adding entry to player_connections_
- Remove const members from `player` to allow implicit move ctor to work
- Take `player` by rvalue reference in `player_record`