### PR TITLE
GUI2/Network Transmission: refinements

### DIFF
--- a/src/gui/dialogs/network_transmission.cpp
+++ b/src/gui/dialogs/network_transmission.cpp
@@ -25,8 +25,6 @@
 
 namespace gui2::dialogs
 {
-using namespace std::chrono_literals;
-
 REGISTER_DIALOG(network_transmission)
 
 void network_transmission::pump_monitor::process()
@@ -54,7 +52,6 @@ void network_transmission::pump_monitor::process()
 
 	if(connection_->finished()) {
 		window_->set_retval(retval::OK);
-		window_ = nullptr;
 	}
 }
 
@@ -87,6 +84,9 @@ void network_transmission::pre_show()
 
 void network_transmission::post_show()
 {
+	// In case we close the dialog before transmission is complete
+	pump_monitor_.window_ = nullptr;
+
 	if(get_retval() == retval::CANCEL) {
 		connection_->cancel();
 	}

--- a/src/gui/dialogs/network_transmission.hpp
+++ b/src/gui/dialogs/network_transmission.hpp
@@ -18,7 +18,6 @@
 #include "events.hpp"
 #include "gui/dialogs/modal_dialog.hpp"
 #include "network_asio.hpp"
-#include "utils/optional_reference.hpp"
 
 namespace gui2::dialogs
 {
@@ -54,11 +53,11 @@ private:
 		virtual void process();
 
 		pump_monitor(connection_data*& connection)
-			: connection_(connection), window_()
+			: connection_(connection), window_(nullptr)
 		{
 		}
 
-		utils::optional_reference<window> window_;
+		window* window_;
 	} pump_monitor_;
 
 public:


### PR DESCRIPTION
- Remove unnecessary invalidate_layout call
- Fix progress bar sometimes not filling up when completed
- Allow final progress stage to display
- Use a pointer instead of optional_reference