### PR TITLE
Units Dialog: support marking units as favorite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
    * Updated translations: British English, Czech, Esperanto, Finnish, Italian
 ### Units
 ### User interface
+   * It is now possible to mark certain units as favorite in Unit List and Recall dialogs. Units can be sorted by whether they are favorite or not.
 ### WML Engine
 ### Miscellaneous and Bug Fixes
 

--- a/data/gui/themes/default/dialogs/units_dialog.cfg
+++ b/data/gui/themes/default/dialogs/units_dialog.cfg
@@ -14,6 +14,21 @@
 					grow_factor = 1
 					horizontal_grow = true
 
+					# No border by design
+					[toggle_button]
+						id = "unit_favorite"
+						definition = "listbox_header"
+						linked_group = "favorite"
+
+						#po: Filled five pointed star, used as favorite unit marker
+						label = _ "★"
+					[/toggle_button]
+				[/column]
+
+				[column]
+					grow_factor = 1
+					horizontal_grow = true
+
 					[spacer]
 						definition = "default"
 						linked_group = "image"
@@ -153,6 +168,18 @@
 									horizontal_grow = true
 									vertical_alignment = "center"
 
+									[label]
+										id = "unit_favorite"
+										linked_group = "favorite"
+									[/label]
+								[/column]
+
+								[column]
+									border = "all"
+									border_size = 5
+									horizontal_grow = true
+									vertical_alignment = "center"
+
 									[image]
 										id = "unit_image"
 										linked_group = "image"
@@ -281,6 +308,11 @@
 		horizontal_placement = "center"
 
 		maximum_height = (max(750, screen_height * 3 / 5))
+
+		[linked_group]
+			id = "favorite"
+			fixed_width = true
+		[/linked_group]
 
 		[linked_group]
 			id = "image"
@@ -525,6 +557,20 @@
 									id = "rename"
 									definition = "default"
 									label = _ "Rename"
+								[/button]
+							[/column]
+
+							[column]
+								grow_factor = 1
+								border = "all"
+								border_size = 5
+								[button]
+									id = "mark_favorite"
+									definition = "default"
+
+									#po: Filled five pointed star, used as favorite unit marker
+									label = _ "★"
+									tooltip = _ "Mark/unmark the selected unit as favorite"
 								[/button]
 							[/column]
 						[/row]

--- a/src/gui/dialogs/units_dialog.hpp
+++ b/src/gui/dialogs/units_dialog.hpp
@@ -110,6 +110,12 @@ public:
 		return *this;
 	}
 
+	units_dialog& set_show_favorite(bool show = true)
+	{
+		show_mark_favorite_ = show;
+		return *this;
+	}
+
 	units_dialog& set_show_variations(bool show = true)
 	{
 		show_variations_ = show;
@@ -230,6 +236,7 @@ private:
 
 	bool show_rename_;
 	bool show_dismiss_;
+	bool show_mark_favorite_;
 	bool show_variations_;
 
 	std::pair<std::string, sort_order::type> sort_order_;
@@ -254,6 +261,7 @@ private:
 	// FIXME only thing needing team
 	void dismiss_unit(std::vector<unit_const_ptr>& unit_list, const team& team);
 	void rename_unit(std::vector<unit_const_ptr>& unit_list);
+	void toggle_favorite(std::vector<unit_const_ptr>& unit_list);
 
 	void show_list(listbox& list);
 	void show_help() const;

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -143,7 +143,8 @@ namespace
 		"flag_rgb",
 		"language_name",
 		"image",
-		"image_icon"
+		"image_icon",
+		"favorite"
 	};
 
 	void warn_unknown_attribute(const config::const_attr_itors& cfg)
@@ -305,6 +306,7 @@ unit::unit(const unit& o)
 	, interrupted_move_(o.interrupted_move_)
 	, is_fearless_(o.is_fearless_)
 	, is_healthy_(o.is_healthy_)
+	, is_favorite_(o.is_favorite_)
 	, modification_descriptions_(o.modification_descriptions_)
 	, anim_comp_(new unit_animation_component(*this, *o.anim_comp_))
 	, hidden_(o.hidden_)
@@ -387,6 +389,7 @@ unit::unit(unit_ctor_t)
 	, interrupted_move_()
 	, is_fearless_(false)
 	, is_healthy_(false)
+	, is_favorite_(false)
 	, modification_descriptions_()
 	, anim_comp_(new unit_animation_component(*this))
 	, hidden_(false)
@@ -419,16 +422,18 @@ void unit::init(const config& cfg, bool use_traits, const vconfig* vcfg)
 	role_ = cfg["role"].str();
 	//, facing_(map_location::direction::indeterminate)
 	//, anim_comp_(new unit_animation_component(*this))
-	hidden_ = cfg["hidden"].to_bool(false);
+	hidden_ = cfg["hidden"].to_bool();
 	random_traits_ = true;
 	generate_name_ = true;
-	side_ = cfg["side"].to_int();
 
+	side_ = cfg["side"].to_int();
 	if(side_ <= 0) {
 		side_ = 1;
 	}
-
 	validate_side(side_);
+
+	is_favorite_ = cfg["favorite"].to_bool();
+
 	underlying_id_ = n_unit::unit_id(cfg["underlying_id"].to_size_t());
 	set_underlying_id(resources::gameboard ? resources::gameboard->unit_id_manager() : n_unit::id_manager::global_instance());
 
@@ -1595,6 +1600,8 @@ void unit::write(config& cfg, bool write_all) const
 	cfg["gender"] = gender_string(gender_);
 	cfg["variation"] = variation_;
 	cfg["role"] = role_;
+
+	cfg["favorite"] = is_favorite_;
 
 	config status_flags;
 	for(const std::string& state : get_states()) {

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -2098,6 +2098,16 @@ private:
 
 	bool is_fearless_, is_healthy_;
 
+	// Unit list/recall list favorite unit marking
+	bool is_favorite_;
+
+public:
+	bool favorite() const { return is_favorite_; }
+
+	void set_favorite(bool favorite) { is_favorite_ = favorite; }
+
+private:
+
 	utils::string_map modification_descriptions_;
 
 	// Animations:


### PR DESCRIPTION
Resolves #7733

Adds a new button to the Units List and Recall dialog using which units can be marked as favorite. Favorite unis are shown (for now) with a white filled star in the leading column, while rest are shown with unfilled white star.

![Screenshot from 2025-05-19 10-01-47](https://github.com/user-attachments/assets/11bc58ea-2cbe-4838-9e90-514614670ef1)
![Screenshot from 2025-05-19 10-01-24](https://github.com/user-attachments/assets/0b767545-eba6-4f2a-9777-1972f44f1cec)
