### PR TITLE
fix id=poison can poison opponent same if in another type of special

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/poison_id_no_work.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/poison_id_no_work.cfg
@@ -1,0 +1,56 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: specials with id=poison
+##
+# Actions:
+# Give the leaders a special with id=poison
+# Have side 1's leader attack side 2's leader with their first weapon
+##
+# Expected end state:
+# Side's 2 leader wasn't poisoned
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "poison_id_no_work" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+                id=alice
+            [/filter]
+            [effect]
+                apply_to=attack
+                [set_specials]
+                    mode=append
+                    [attacks]
+                        value=1
+                    [/attacks]
+                    [damage]
+                        value=1
+                    [/damage]
+                    [chance_to_hit]
+                        id=poison
+                        value=100
+                    [/chance_to_hit]
+                [/set_specials]
+            [/effect]
+        [/modify_unit]
+
+        [test_do_attack_by_id]
+            attacker=alice
+            defender=bob
+            weapon=0
+        [/test_do_attack_by_id]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    side=2
+                    status = "poisoned"
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -182,7 +182,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id or special_type instead");
 		bool found = false;
 		for(auto& special : filter_special) {
-			if(attack.has_special(special, true)) {
+			if(attack.has_special(special, true, true)) {
 				found = true;
 				break;
 			}
@@ -208,7 +208,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 		deprecated_message("special_active=", DEP_LEVEL::PREEMPTIVE, {1, 17, 0}, "Please use special_id_active or special_type_active instead");
 		bool found = false;
 		for(auto& special : filter_special_active) {
-			if(attack.has_special(special, false)) {
+			if(attack.has_special(special, false, true)) {
 				found = true;
 				break;
 			}
@@ -232,7 +232,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type) {
-			if(attack.has_special(special, true, false)) {
+			if(attack.has_special(special, true)) {
 				found = true;
 				break;
 			}
@@ -244,7 +244,7 @@ static bool matches_simple_filter(const attack_type & attack, const config & fil
 	if(!filter_special_type_active.empty()) {
 		bool found = false;
 		for(auto& special : filter_special_type_active) {
-			if(attack.has_special_or_ability(special, false)) {
+			if(attack.has_special_or_ability(special)) {
 				found = true;
 				break;
 			}

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -81,7 +81,7 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool has_special(const std::string& special, bool simple_check=false, bool special_id=true, bool special_tags=true) const;
+	bool has_special(const std::string& special, bool simple_check = false, bool special_id = false, bool special_tags = true) const;
 	unit_ability_list get_specials(const std::string& special) const;
 	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
 	std::string weapon_specials() const;
@@ -124,14 +124,14 @@ public:
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool has_weapon_ability(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool has_weapon_ability(const std::string& special, bool special_id = false, bool special_tags = true) const;
 	/** used for abilities used like weapon and true specials
 	 * @return True if the ability @a special is active.
 	 * @param special The special being checked.
 	 * @param special_id If true, match @a special against the @c id of special tags.
 	 * @param special_tags If true, match @a special against the tag name of special tags.
 	 */
-	bool has_special_or_ability(const std::string& special, bool special_id=true, bool special_tags=true) const;
+	bool has_special_or_ability(const std::string& special, bool special_id = false, bool special_tags = true) const;
 	/**
 	 * Returns true if this is a dummy attack_type, for example the placeholder that the unit_attack dialog
 	 * uses when a defender has no weapon for a given range.

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -372,6 +372,7 @@
 0 backstab_inactive_with_bobs_ally_behind_bob
 0 reflexive_drains
 0 reflexive_poison
+0 poison_id_no_work
 0 reflexive_slow
 0 replace_special_with_filter_in_attack_event_active
 0 replace_special_with_filter_in_attack_event_inactive


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/10225 issue. if for example, someone has fun giving a special [chance_to_hit] an id=poison, then the target will be poisoned once hit, this PR solves this problem