### PR TITLE
use std::from_chars for the integer variants (issue #10009)

### DIFF
--- a/src/utils/charconv.hpp
+++ b/src/utils/charconv.hpp
@@ -58,9 +58,9 @@ namespace utils::charconv
 	}
 
 	template<typename T>
-	std::enable_if_t<std::is_integral_v<T>, from_chars_result> from_chars(const char* first, const char* last, T& value, int base = 10 )
+	std::enable_if_t<std::is_integral_v<T>, std::from_chars_result> from_chars(const char* first, const char* last, T& value, int base = 10 )
 	{
-		return charconv_impl::from_chars(first, last, value, base);
+		return std::from_chars(first, last, value, base);
 	}
 
 #ifndef USE_FALLBACK_CHARCONV

--- a/src/utils/charconv.hpp
+++ b/src/utils/charconv.hpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <assert.h>
 #include <cctype>
+#include <charconv>
 #include <string_view>
 #include <string>
 #include <stdexcept>
@@ -40,7 +41,6 @@
 #include <boost/charconv.hpp>
 namespace charconv_impl = boost::charconv;
 #else
-#include <charconv>
 namespace charconv_impl = std;
 #endif
 


### PR DESCRIPTION
boost::charconv::from_chars with integers is broken on boost 1.85 (fixed in boost 1.86)

however for the floating point variants we still need boost on some compilers since those are sometimes missing/incomplete on std