### PR TITLE
Unit Type: delete copy, default ctors

### DIFF
--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -53,7 +53,6 @@ static lg::log_domain log_unit("unit");
 unit_type::unit_type(default_ctor_t, const config& cfg, const std::string & parent_id)
 	: cfg_(nullptr)
 	, built_cfg_()
-	, has_cfg_build_()
 	, id_(cfg.has_attribute("id") ? cfg["id"].str() : parent_id)
 	, debug_id_()
 	, parent_id_(!parent_id.empty() ? parent_id : id_)
@@ -105,22 +104,17 @@ unit_type::unit_type(default_ctor_t, const config& cfg, const std::string & pare
 	check_id(id_);
 	check_id(parent_id_);
 }
+
 unit_type::unit_type(const config& cfg, const std::string & parent_id)
 	: unit_type(default_ctor_t(), cfg, parent_id)
 {
 	cfg_ = &cfg;
-
 }
 
 unit_type::unit_type(config&& cfg, const std::string & parent_id)
 	: unit_type(default_ctor_t(), cfg, parent_id)
 {
 	built_cfg_ = std::make_unique<config>(std::move(cfg));
-}
-
-
-unit_type::~unit_type()
-{
 }
 
 unit_type::ability_metadata::ability_metadata(const config& cfg)

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -50,56 +50,7 @@ static lg::log_domain log_unit("unit");
 
 /* ** unit_type ** */
 
-unit_type::unit_type(const unit_type& o)
-	: cfg_(o.cfg_)
-	, id_(o.id_)
-	, debug_id_(o.debug_id_)
-	, parent_id_(o.parent_id_)
-	, base_unit_id_(o.base_unit_id_)
-	, type_name_(o.type_name_)
-	, description_(o.description_)
-	, hitpoints_(o.hitpoints_)
-	, hp_bar_scaling_(o.hp_bar_scaling_)
-	, xp_bar_scaling_(o.xp_bar_scaling_)
-	, level_(o.level_)
-	, recall_cost_(o.recall_cost_)
-	, movement_(o.movement_)
-	, vision_(o.vision_)
-	, jamming_(o.jamming_)
-	, max_attacks_(o.max_attacks_)
-	, cost_(o.cost_)
-	, usage_(o.usage_)
-	, undead_variation_(o.undead_variation_)
-	, image_(o.image_)
-	, icon_(o.icon_)
-	, small_profile_(o.small_profile_)
-	, profile_(o.profile_)
-	, flag_rgb_(o.flag_rgb_)
-	, num_traits_(o.num_traits_)
-	, variations_(o.variations_)
-	, default_variation_(o.default_variation_)
-	, variation_name_(o.variation_name_)
-	, race_(o.race_)
-	, abilities_(o.abilities_)
-	, adv_abilities_(o.adv_abilities_)
-	, zoc_(o.zoc_)
-	, hide_help_(o.hide_help_)
-	, do_not_list_(o.do_not_list_)
-	, advances_to_(o.advances_to_)
-	, advancements_(o.advancements_)
-	, experience_needed_(o.experience_needed_)
-	, alignment_(o.alignment_)
-	, movement_type_(o.movement_type_)
-	, possible_traits_(o.possible_traits_)
-	, genders_(o.genders_)
-	, animations_(o.animations_)
-	, build_status_(o.build_status_)
-{
-	gender_types_[0].reset(gender_types_[0] != nullptr ? new unit_type(*o.gender_types_[0]) : nullptr);
-	gender_types_[1].reset(gender_types_[1] != nullptr ? new unit_type(*o.gender_types_[1]) : nullptr);
-}
-
-unit_type::unit_type(defaut_ctor_t, const config& cfg, const std::string & parent_id)
+unit_type::unit_type(default_ctor_t, const config& cfg, const std::string & parent_id)
 	: cfg_(nullptr)
 	, built_cfg_()
 	, has_cfg_build_()
@@ -155,14 +106,14 @@ unit_type::unit_type(defaut_ctor_t, const config& cfg, const std::string & paren
 	check_id(parent_id_);
 }
 unit_type::unit_type(const config& cfg, const std::string & parent_id)
-	: unit_type(defaut_ctor_t(), cfg, parent_id)
+	: unit_type(default_ctor_t(), cfg, parent_id)
 {
 	cfg_ = &cfg;
 
 }
 
 unit_type::unit_type(config&& cfg, const std::string & parent_id)
-	: unit_type(defaut_ctor_t(), cfg, parent_id)
+	: unit_type(default_ctor_t(), cfg, parent_id)
 {
 	built_cfg_ = std::make_unique<config>(std::move(cfg));
 }

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -117,6 +117,10 @@ unit_type::unit_type(config&& cfg, const std::string & parent_id)
 	built_cfg_ = std::make_unique<config>(std::move(cfg));
 }
 
+unit_type::~unit_type()
+{
+}
+
 unit_type::ability_metadata::ability_metadata(const config& cfg)
 	: id(cfg["id"])
 	, name(cfg["name"].t_str())

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -42,8 +42,8 @@ typedef std::map<std::string, movetype> movement_type_map;
 class unit_type
 {
 private:
-	struct defaut_ctor_t {};
-	unit_type(defaut_ctor_t, const config& cfg, const std::string& parent_id);
+	struct default_ctor_t {};
+	unit_type(default_ctor_t, const config& cfg, const std::string& parent_id);
 
 public:
 	using error = unit_type_error;
@@ -60,9 +60,14 @@ public:
 	 * @note @a cfg is copied
 	 */
 	explicit unit_type(config&& cfg, const std::string& parent_id="");
-	unit_type();
-	unit_type(const unit_type& o);
-	unit_type(unit_type&& o) = default;
+
+	unit_type() = delete;
+
+	unit_type(const unit_type&) = delete;
+	unit_type& operator=(const unit_type&) = delete;
+
+	unit_type(unit_type&&) noexcept = default;
+	unit_type& operator=(unit_type&&) noexcept = default;
 
 	~unit_type();
 

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -61,15 +61,11 @@ public:
 	 */
 	explicit unit_type(config&& cfg, const std::string& parent_id="");
 
-	unit_type() = delete;
-
 	unit_type(const unit_type&) = delete;
 	unit_type& operator=(const unit_type&) = delete;
 
 	unit_type(unit_type&&) noexcept = default;
 	unit_type& operator=(unit_type&&) noexcept = default;
-
-	~unit_type();
 
 	/**
 	 * Records the status of the lazy building of unit types.
@@ -319,7 +315,6 @@ private:
 	const config* cfg_;
 	friend class unit_type_data;
 	mutable std::unique_ptr<config> built_cfg_;
-	mutable bool has_cfg_build_;
 	mutable attack_list attacks_cache_;
 
 	std::string id_;

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -316,8 +316,6 @@ private:
 	void fill_variations_and_gender();
 	std::unique_ptr<unit_type> create_sub_type(const config& var_cfg, bool default_inherit);
 
-	unit_type& operator=(const unit_type& o) = delete;
-
 	const config* cfg_;
 	friend class unit_type_data;
 	mutable std::unique_ptr<config> built_cfg_;

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -67,6 +67,8 @@ public:
 	unit_type(unit_type&&) noexcept = default;
 	unit_type& operator=(unit_type&&) noexcept = default;
 
+	~unit_type();
+
 	/**
 	 * Records the status of the lazy building of unit types.
 	 * These are in order of increasing levels of being built.


### PR DESCRIPTION
#10053 inadvertently added a variable which copied a unit_type. This would have been caught had the copy ctor been deleted 
(as copy assignment already is). Since these aren't objects we'll be passing around, better to delete both to catch such cases in future. Ironically, the only place that actually used the unit_type copy ctor was the unit_type copy ctor itself (and the code for copying the gender variations looks broken anyway - it was checking whether the wrong variable was non-null!)

Also added a default definition of the move assignment operator (we already had a move ctor), and deleted the default ctor (unimplemented) ~~and dtor (empty~~).