### PR TITLE
Hotkey/Handler: optimize menu list generation

### DIFF
--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -407,9 +407,9 @@ void foreach_autosave(int turn, saved_game& sg, F func)
 	auto starting = savegame::scenariostart_savegame(sg, compression_format);
 
 	for(; turn >= 0; --turn) {
-		const std::string name = turn == 0
-			: starting.create_filename()
+		const std::string name = turn > 0
 			? autosave.create_filename(turn);
+			: starting.create_filename();
 
 		if(savegame::save_game_exists(name, compression_format)) {
 			func(turn, name + compression::format_extension(compression_format));

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -389,16 +389,16 @@ static void foreach_autosave(int current_turn, saved_game& sg, F func)
 	auto starting = savegame::scenariostart_savegame(sg, compression_format);
 
 	// Generate a list of turn numbers from n to 0, descending
-	auto turn_range = std::vector<int>(current_turn);
+	auto turn_range = std::vector<int>(current_turn + 1);
 	std::iota(turn_range.rbegin(), turn_range.rend(), 0);
 
 	// Make sure list doesn't get too long: keep top two, midpoint and bottom.
 	auto filtered = turn_range | utils::views::filter([&](int turn) {
 		return turn == 0
-			|| turn == 1
+			|| turn == current_turn
+			|| turn == current_turn - 1
 			|| turn == current_turn / 3
-			|| turn == current_turn * 2 / 3
-			|| turn == current_turn;
+			|| turn == current_turn * 2 / 3;
 	});
 
 	for(int turn : filtered) {
@@ -412,7 +412,7 @@ static void foreach_autosave(int current_turn, saved_game& sg, F func)
 	}
 }
 
-void play_controller::hotkey_handler::expand_autosaves(std::vector<config>& items)
+void play_controller::hotkey_handler::expand_autosaves(std::vector<config>& items) const
 {
 	foreach_autosave(play_controller_.turn(), saved_game_, [&](int turn, const std::string& filename) {
 		// TODO: should this use variable substitution instead?
@@ -421,7 +421,7 @@ void play_controller::hotkey_handler::expand_autosaves(std::vector<config>& item
 	});
 }
 
-void play_controller::hotkey_handler::expand_quickreplay(std::vector<config>& items)
+void play_controller::hotkey_handler::expand_quickreplay(std::vector<config>& items) const
 {
 	foreach_autosave(play_controller_.turn(), saved_game_, [&](int turn, const std::string& filename) {
 		// TODO: should this use variable substitution instead?

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -408,7 +408,7 @@ void foreach_autosave(int turn, saved_game& sg, F func)
 
 	for(; turn >= 0; --turn) {
 		const std::string name = turn > 0
-			? autosave.create_filename(turn);
+			? autosave.create_filename(turn)
 			: starting.create_filename();
 
 		if(savegame::save_game_exists(name, compression_format)) {

--- a/src/hotkey/hotkey_handler.hpp
+++ b/src/hotkey/hotkey_handler.hpp
@@ -56,13 +56,13 @@ private:
 	typedef std::shared_ptr<const game_events::wml_menu_item> const_item_ptr;
 
 	// Expand AUTOSAVES in the menu items, setting the real savenames.
-	void expand_autosaves(std::vector<config>& items, int i);
-	void expand_quickreplay(std::vector<config>& items, int i);
+	void expand_autosaves(std::vector<config>& items);
+	void expand_quickreplay(std::vector<config>& items);
 
 	/**
 	 * Replaces "wml" in @a items with all active WML menu items for the current field.
 	 */
-	void expand_wml_commands(std::vector<config>& items, int i);
+	void expand_wml_commands(std::vector<config>& items);
 
 protected:
 	bool browse() const;

--- a/src/hotkey/hotkey_handler.hpp
+++ b/src/hotkey/hotkey_handler.hpp
@@ -56,8 +56,8 @@ private:
 	typedef std::shared_ptr<const game_events::wml_menu_item> const_item_ptr;
 
 	// Expand AUTOSAVES in the menu items, setting the real savenames.
-	void expand_autosaves(std::vector<config>& items);
-	void expand_quickreplay(std::vector<config>& items);
+	void expand_autosaves(std::vector<config>& items) const;
+	void expand_quickreplay(std::vector<config>& items) const;
 
 	/**
 	 * Replaces "wml" in @a items with all active WML menu items for the current field.


### PR DESCRIPTION
Instead of constructing an intermediate list whose special members (wml items, autosaves, etc) are then expanded, simply append the expanded items on the initial pass.

Also optimizes the case where a large number of configs would be constructed for long games, only to be pruned.