### PR TITLE
Allow checking multiple [filter_adjacent/location] in the same ability

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/multiple_filter_adjacent_active.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/multiple_filter_adjacent_active.cfg
@@ -1,0 +1,54 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[filter_adjacent]adjacent,count=
+##
+# Actions:
+# Give Alice an ability specialX, which is only active if one adjacent unit is bob with another [filter_adjacent] who don't match.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX should be active because one [filter_adjacent] only is needed for validate the checking.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "multiple_filter_adjacent_active" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one of the adjacents units is bob"
+                        value=100
+                        apply_to=self
+                        [filter_adjacent]
+                            adjacent=n,ne
+                            count=1-3
+                            id=loki
+                        [/filter_adjacent]
+                        [filter_adjacent]
+                            adjacent=n,ne,se,s,sw,nw
+                            count=1-6
+                            id=bob
+                        [/filter_adjacent]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [have_unit]
+                ability_id_active=specialX
+            [/have_unit]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/multiple_filter_adjacent_inactive.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/multiple_filter_adjacent_inactive.cfg
@@ -1,0 +1,56 @@
+#textdomain wesnoth-test
+
+#####
+# API(s) being tested: ability[filter_adjacent]adjacent,count=
+##
+# Actions:
+# Give Alice an ability specialX, which is only active if one adjacent unit is Loki.
+# Test whether the ability is active.
+##
+# Expected end state:
+# specialX shouldn't be active.
+#####
+{COMMON_KEEP_A_B_C_D_UNIT_TEST "multiple_filter_adjacent_inactive" (
+    [event]
+        name=start
+
+        [object]
+            silent=yes
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [damage]
+                        id=specialX
+                        name=_ "specialX"
+                        description=_ "specialX is active if and only if one of the adjacents units is Loki"
+                        value=100
+                        apply_to=self
+                        [filter_adjacent]
+                            adjacent=n,ne,se,s,sw,nw
+                            count=1-6
+                            id=Loki
+                        [/filter_adjacent]
+                        [filter_adjacent]
+                            adjacent=n,ne,se,s,sw,nw
+                            count=1-6
+                            id=Hela
+                        [/filter_adjacent]
+                    [/damage]
+                [/abilities]
+            [/effect]
+            [filter]
+                id=alice
+            [/filter]
+        [/object]
+
+        {ASSERT (
+            [not]
+                [have_unit]
+                    ability_id_active=specialX
+                [/have_unit]
+            [/not]
+        )}
+
+        {SUCCEED}
+    [/event]
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -421,6 +421,8 @@
 0 filter_adjacent_location_count_zero_inactive
 0 filter_adjacent_active
 0 filter_adjacent_inactive
+0 multiple_filter_adjacent_active
+0 multiple_filter_adjacent_inactive
 0 filter_adjacent_student_active
 0 filter_adjacent_student_inactive
 0 filter_adjacent_direction_active


### PR DESCRIPTION
Until now, using multiple filters required all filters to match for the ability to be active, but if we have [filter_adjacent] race,count=elf,2 and [filter_adjacent] race,count=human,3, we cannot use [filter_adjacent] race,count=elf,2 or race,count=human,3 because count is not part of the standard filtering and cannot be encoded in an [and/or/not] subtag, hence the idea of multiple filters.