### PR TITLE
[Units] Huntsman & Ranger balance adjustments

### DIFF
--- a/data/core/units/humans/Woodsman_Huntsman.cfg
+++ b/data/core/units/humans/Woodsman_Huntsman.cfg
@@ -6,7 +6,7 @@
     race=human
     image="units/human-outlaws/huntsman.png"
     profile=portraits/humans/huntsman.webp
-    hitpoints=53
+    hitpoints=57
     movement_type=smallfoot
     movement=5
     experience=150
@@ -31,9 +31,6 @@ Master hunters are employed by any group living in or passing through wild count
         forest=40
         swamp_water=40
     [/defense]
-    [abilities]
-        {ABILITY_SWAMP_LURK}
-    [/abilities]
     [attack]
         name=dagger
         description= _ "dagger"

--- a/data/core/units/humans/Woodsman_Ranger.cfg
+++ b/data/core/units/humans/Woodsman_Ranger.cfg
@@ -25,9 +25,7 @@ The presence of these men troubles the more authoritarian of rulers; they are an
 
     # Rangers are almost like human elves
     # same frozen/sand defense as the Elvish Avenger
-    # reduced castle defense reflecting their "wild-ness"
     [defense]
-        castle=50
         forest=40
         frozen=70
         hills=40


### PR DESCRIPTION
This PR introduces the following changes:

Huntsman:

-HP increased from 53 > 57 (pre-nerf value from 1.16)

-Swamp Lurk ability removed

Reasoning:

[hides] abilities massively affect the balance and gameplay of scenarios. In wesnoth balance, even a difference in resistances can majorly impact existing content (example - the now-partially-reverted arcane resistance, where the arcane rework affected most units in the game to some degree.).

Adding Swamp Lurk to the Huntsman is a very drastic change: despite the 2 MP cost in swamp, it enables stealth-based leaderkills on swamp-heavy maps that were previously impossible. And it is important to remember that the swamp tiles don't have to be consecutive to trick the AI - if it's a few swamp puddles with mostly flat in-between, even with 2mpcost swamp it is trivial to exploit.

And on the flipside, swamp scenarios with huntsmen as enemies suddenly become more difficult in an way that goes entirely against how the unit is normally designed (fully-visible DPS unit), it's like if you took a scenario where you fight loyalists in a forest, and then you swap every master bowman for an elvish avenger.



Ranger:

-castle defense 50% > 60%

Reasoning:

I believe the castle defense nerf is both mechanically an unnecessary decision (the unit was below-average before, it did not need nerfs to compensate the buffs he was given), and thematically doesn't hold water - the Ranger may be more 'wild' than the average human, yes, but he's not a feral animal. Even skeletons have 60% castle defense, even wolves, actual straight-up animals have 60% castle defense. The castle provides defense because it has walls, not because you can socialize well in it.



While I respect the initial idea that the lvl3s in the Poacher line were underpowered and deserved buffs, I believe PR #9582 overstepped beyond what was reasonably necessary to make the units viable.