### PR TITLE
Lower Drake Arcane Resistance

### DIFF
--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -133,6 +133,6 @@
         impact=80
         fire=50
         cold=150
-        arcane=110
+        arcane=130
     [/resistance]
 #enddef

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -1585,7 +1585,7 @@ The life span of the wose is unknown, although the most ancient members of this 
             impact=70
             fire=50
             cold=150
-            arcane=110
+            arcane=130
         [/resistance]
     [/movetype]
 


### PR DESCRIPTION
Reducing the arcane resistance of Drakes by 20%, from -10% to -30%.
- It will apply to all Drakes
- Drakes are magically beings aswell as skeletons
- for consistency with https://github.com/wesnoth/wesnoth/pull/10275