### PR TITLE
Editor/Edit Side: don't add/write game default base_income

### DIFF
--- a/data/gui/themes/default/dialogs/editor_edit_side.cfg
+++ b/data/gui/themes/default/dialogs/editor_edit_side.cfg
@@ -341,7 +341,7 @@
 									id = "income"
 									definition = "default"
 									best_slider_length = 200
-									minimum_value = -2
+									minimum_value = 0
 									maximum_value = 20
 									step_size = 1
 								[/slider]

--- a/src/ai/default/ca.cpp
+++ b/src/ai/default/ca.cpp
@@ -23,6 +23,7 @@
 #include "ai/manager.hpp"
 #include "ai/composite/rca.hpp"
 #include "game_board.hpp"
+#include "game_config.hpp"
 #include "game_data.hpp"
 #include "log.hpp"
 #include "map/map.hpp"

--- a/src/ai/lua/engine_lua.cpp
+++ b/src/ai/lua/engine_lua.cpp
@@ -30,6 +30,7 @@
 #include "resources.hpp"
 #include "ai/lua/core.hpp"
 #include "ai/lua/lua_object.hpp"
+#include "game_config.hpp"
 #include "game_board.hpp"
 #include "scripting/game_lua_kernel.hpp"
 #include "units/unit.hpp"

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -21,6 +21,7 @@
 #include "editor/action/action.hpp"
 #include "filesystem.hpp"
 #include "formula/string_utils.hpp"
+#include "game_config.hpp"
 #include "gettext.hpp"
 #include "gui/dialogs/message.hpp"
 #include "gui/dialogs/transient_message.hpp"
@@ -43,7 +44,7 @@ editor_team_info::editor_team_info(const team& t)
 	, name(t.user_team_name())
 	, recruit_list(utils::join(t.recruits(), ","))
 	, gold(t.gold())
-	, income(t.base_income())
+	, income(t.base_income() - game_config::base_income)
 	, village_income(t.village_gold())
 	, village_support(t.village_support())
 	, fog(t.uses_fog())
@@ -495,7 +496,7 @@ void map_context::load_scenario()
 			teams_.back().set_recruits(utils::split_set(side["recruit"].str(), ','));
 		}
 	}
-
+	
 	tod_manager_.reset(new tod_manager(scenario));
 
 	auto event = scenario.find_child("event", "id", "editor_event-start");
@@ -792,7 +793,7 @@ config map_context::to_config()
 		side["share_vision"] = team_shared_vision::get_string(team.share_vision());
 
 		side["gold"] = team.gold();
-		side["income"] = team.base_income();
+		side["income"] = team.base_income() - game_config::base_income;
 
 		for(const map_location& village : team.villages()) {
 			village.write(side.add_child("village"));

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -21,7 +21,6 @@
 #include "editor/action/action.hpp"
 #include "filesystem.hpp"
 #include "formula/string_utils.hpp"
-#include "game_config.hpp"
 #include "gettext.hpp"
 #include "gui/dialogs/message.hpp"
 #include "gui/dialogs/transient_message.hpp"
@@ -44,7 +43,7 @@ editor_team_info::editor_team_info(const team& t)
 	, name(t.user_team_name())
 	, recruit_list(utils::join(t.recruits(), ","))
 	, gold(t.gold())
-	, income(t.base_income() - game_config::base_income)
+	, income(t.raw_income())
 	, village_income(t.village_gold())
 	, village_support(t.village_support())
 	, fog(t.uses_fog())
@@ -329,7 +328,7 @@ void map_context::set_side_setup(editor_team_info& info)
 	t.have_leader(!info.no_leader);
 	t.change_controller(info.controller);
 	t.set_gold(info.gold);
-	t.set_base_income(info.income);
+	t.set_raw_income(info.income);
 	t.set_hidden(info.hidden);
 	t.set_fog(info.fog);
 	t.set_shroud(info.shroud);
@@ -496,7 +495,7 @@ void map_context::load_scenario()
 			teams_.back().set_recruits(utils::split_set(side["recruit"].str(), ','));
 		}
 	}
-	
+
 	tod_manager_.reset(new tod_manager(scenario));
 
 	auto event = scenario.find_child("event", "id", "editor_event-start");
@@ -793,7 +792,7 @@ config map_context::to_config()
 		side["share_vision"] = team_shared_vision::get_string(team.share_vision());
 
 		side["gold"] = team.gold();
-		side["income"] = team.base_income() - game_config::base_income;
+		side["income"] = team.raw_income();
 
 		for(const map_location& village : team.villages()) {
 			village.write(side.add_child("village"));

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -43,7 +43,7 @@ editor_team_info::editor_team_info(const team& t)
 	, name(t.user_team_name())
 	, recruit_list(utils::join(t.recruits(), ","))
 	, gold(t.gold())
-	, income(t.raw_income())
+	, income(t.base_income())
 	, village_income(t.village_gold())
 	, village_support(t.village_support())
 	, fog(t.uses_fog())
@@ -328,7 +328,7 @@ void map_context::set_side_setup(editor_team_info& info)
 	t.have_leader(!info.no_leader);
 	t.change_controller(info.controller);
 	t.set_gold(info.gold);
-	t.set_raw_income(info.income);
+	t.set_base_income(info.income);
 	t.set_hidden(info.hidden);
 	t.set_fog(info.fog);
 	t.set_shroud(info.shroud);

--- a/src/gui/dialogs/gamestate_inspector.cpp
+++ b/src/gui/dialogs/gamestate_inspector.cpp
@@ -25,6 +25,7 @@
 #include "gui/widgets/window.hpp"
 
 #include "desktop/clipboard.hpp"
+#include "game_config.hpp"
 #include "serialization/markup.hpp"
 #include "game_events/manager.hpp"
 #include "serialization/parser.hpp" // for write()

--- a/src/team.cpp
+++ b/src/team.cpp
@@ -23,6 +23,7 @@
 #include "ai/manager.hpp"
 #include "color.hpp"
 #include "formula/string_utils.hpp"     // for VGETTEXT
+#include "game_config.hpp"
 #include "game_data.hpp"
 #include "game_events/pump.hpp"
 #include "lexical_cast.hpp"
@@ -409,6 +410,16 @@ void team::write(config& cfg) const
 
 	cfg["countdown_time"] = countdown_time_;
 	cfg["action_bonus_count"] = action_bonus_count_;
+}
+
+int team::base_income() const
+{
+	return info_.income + game_config::base_income;
+}
+
+void team::set_base_income(int amount)
+{
+	info_.income = amount - game_config::base_income;
 }
 
 void team::fix_villages(const gamemap &map)

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -18,7 +18,6 @@
 #include "color_range.hpp"
 #include "config.hpp"
 #include "defeat_condition.hpp"
-#include "game_config.hpp"
 #include "game_events/fwd.hpp"
 #include "map/location.hpp"
 #include "recall_list_manager.hpp"
@@ -181,7 +180,7 @@ public:
 	int gold() const { return info_.gold; }
 	int start_gold() const { return info_.start_gold; }
 	int raw_income() const { return info_.income; }
-	int base_income() const { return info_.income + game_config::base_income; }
+	int base_income() const;
 	int village_gold() const { return info_.income_per_village; }
 	int recall_cost() const { return info_.recall_cost; }
 	void set_village_gold(int income) { info_.income_per_village = income; }
@@ -200,7 +199,7 @@ public:
 	void set_start_gold(const int amount) { info_.start_gold = amount; }
 	void spend_gold(const int amount) { info_.gold -= amount; }
 	void set_raw_income(int amount) { info_.income = amount; }
-	void set_base_income(int amount) { info_.income = amount - game_config::base_income; }
+	void set_base_income(int amount);
 	std::chrono::milliseconds countdown_time() const { return countdown_time_; }
 	void set_countdown_time(const std::chrono::milliseconds& amount) const { countdown_time_ = amount; }
 	int action_bonus_count() const { return action_bonus_count_; }

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -179,35 +179,35 @@ public:
 	int side() const { return info_.side; }
 	int gold() const { return info_.gold; }
 	int start_gold() const { return info_.start_gold; }
-	
+
 	/**
 	 * @return The income for this side exactly as defined in the [side] tag.
 	 */
 	int raw_income() const { return info_.income; }
-	
+
 	/**
 	 * @return The income for this side as defined in the [side] tag
 	 *         with base income from [game_config] added.
 	 */
 	int base_income() const;
-	
+
 	int village_gold() const { return info_.income_per_village; }
 	int recall_cost() const { return info_.recall_cost; }
 	void set_village_gold(int income) { info_.income_per_village = income; }
 	void set_recall_cost(int cost) { info_.recall_cost = cost; }
 	int total_income() const { return base_income() + static_cast<int>(villages_.size()) * info_.income_per_village; }
-	
+
 	/**
 	 *  @return The number of unit levels each village can support,
 	 *          i.e. how much upkeep each village can bear.
 	 */
 	int village_support() const { return info_.support_per_village; }
-	
+
 	/**
 	 *  @param support   The number of unit levels each village can support
 	 */
 	void set_village_support(int support) { info_.support_per_village = support; }
-	
+
 	/**
 	 *  @return Calculated total support capacity, based on support_per_village.
 	 */
@@ -217,14 +217,14 @@ public:
 	void set_gold(int amount) { info_.gold = amount; }
 	void set_start_gold(const int amount) { info_.start_gold = amount; }
 	void spend_gold(const int amount) { info_.gold -= amount; }
-	
+
 	/**
 	 *  Sets the income of this side to the given value.
 	 *  Base income from `[game_config]` is not added.
 	 *  @param amount   The income amount
 	 */
 	void set_raw_income(int amount) { info_.income = amount; }
-	
+
 	/**
 	 *  Sets the income of this side to the given value with
 	 *  base income from `[game_config]` added to it.

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -179,26 +179,57 @@ public:
 	int side() const { return info_.side; }
 	int gold() const { return info_.gold; }
 	int start_gold() const { return info_.start_gold; }
+	
+	/**
+	 * @return The income for this side exactly as defined in the [side] tag.
+	 */
 	int raw_income() const { return info_.income; }
+	
+	/**
+	 * @return The income for this side as defined in the [side] tag
+	 *         with base income from [game_config] added.
+	 */
 	int base_income() const;
+	
 	int village_gold() const { return info_.income_per_village; }
 	int recall_cost() const { return info_.recall_cost; }
 	void set_village_gold(int income) { info_.income_per_village = income; }
 	void set_recall_cost(int cost) { info_.recall_cost = cost; }
 	int total_income() const { return base_income() + static_cast<int>(villages_.size()) * info_.income_per_village; }
-	/** @return The number of unit levels each village can support,
-	    i.e. how much upkeep each village can bear. */
+	
+	/**
+	 *  @return The number of unit levels each village can support,
+	 *          i.e. how much upkeep each village can bear.
+	 */
 	int village_support() const { return info_.support_per_village; }
-	/** @param support The number of unit levels each village can support */
+	
+	/**
+	 *  @param support   The number of unit levels each village can support
+	 */
 	void set_village_support(int support) { info_.support_per_village = support; }
-	/** Calculate total support capacity, based on support_per_village. */
+	
+	/**
+	 *  @return Calculated total support capacity, based on support_per_village.
+	 */
 	int support() const { return static_cast<int>(villages_.size()) * village_support(); }
 	void new_turn() { info_.gold += total_income(); }
 	void get_shared_maps();
 	void set_gold(int amount) { info_.gold = amount; }
 	void set_start_gold(const int amount) { info_.start_gold = amount; }
 	void spend_gold(const int amount) { info_.gold -= amount; }
+	
+	/**
+	 *  Sets the income of this side to the given value.
+	 *  Base income from `[game_config]` is not added.
+	 *  @param amount   The income amount
+	 */
 	void set_raw_income(int amount) { info_.income = amount; }
+	
+	/**
+	 *  Sets the income of this side to the given value with
+	 *  base income from `[game_config]` added to it.
+	 *  @param amount   The income amount
+	 */
 	void set_base_income(int amount);
 	std::chrono::milliseconds countdown_time() const { return countdown_time_; }
 	void set_countdown_time(const std::chrono::milliseconds& amount) const { countdown_time_ = amount; }

--- a/src/team.hpp
+++ b/src/team.hpp
@@ -180,6 +180,7 @@ public:
 	int side() const { return info_.side; }
 	int gold() const { return info_.gold; }
 	int start_gold() const { return info_.start_gold; }
+	int raw_income() const { return info_.income; }
 	int base_income() const { return info_.income + game_config::base_income; }
 	int village_gold() const { return info_.income_per_village; }
 	int recall_cost() const { return info_.recall_cost; }
@@ -198,6 +199,7 @@ public:
 	void set_gold(int amount) { info_.gold = amount; }
 	void set_start_gold(const int amount) { info_.start_gold = amount; }
 	void spend_gold(const int amount) { info_.gold -= amount; }
+	void set_raw_income(int amount) { info_.income = amount; }
 	void set_base_income(int amount) { info_.income = amount - game_config::base_income; }
 	std::chrono::milliseconds countdown_time() const { return countdown_time_; }
 	void set_countdown_time(const std::chrono::milliseconds& amount) const { countdown_time_ = amount; }

--- a/src/terrain/filter.cpp
+++ b/src/terrain/filter.cpp
@@ -18,6 +18,7 @@
 #include "config.hpp"
 #include "display_context.hpp"
 #include "filter_context.hpp"
+#include "game_config.hpp"
 #include "game_data.hpp"
 #include "log.hpp"
 #include "map/map.hpp"


### PR DESCRIPTION
Resolves #10123

Reasoning given in https://github.com/wesnoth/wesnoth/issues/10123#issuecomment-2991271494, quoted here:

> 
> This is where the `+2` comes from:
> https://github.com/wesnoth/wesnoth/blob/a1d3e10e75b6695dc8466360168525a1bb47d743/src/team.hpp#L183
> 
> (game's base income is `2`, which gets added to the value loaded from the file)
> 
> `base_income()`'s retval is used for the `editor_team_info` constructor here:
> https://github.com/wesnoth/wesnoth/blob/a1d3e10e75b6695dc8466360168525a1bb47d743/src/editor/map/map_context.cpp#L46
> 
> Which in turn gets used in the Edit Side dialog, so when you save it it's income from saved scenario file + base income of game.