### PR TITLE
Use name_affected attributes in abilities for affected units.

### DIFF
--- a/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
+++ b/data/campaigns/Descent_Into_Darkness/utils/abilities.cfg
@@ -132,7 +132,9 @@
         id=did_shadow_veil
         name= _ "shadow veil"
         name_inactive= _ "shadow veil"
+        name_affected= _ "veiled by shadow"
         description= _ "Allied undead units within a 5 hex radius are hidden."
+        description_affected= _ "This undead unit is hidden by the veil of shadow."
         description_inactive= _ "Allied undead units within a 5 hex radius are hidden."
         affect_self=no
         affect_allies=yes

--- a/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
+++ b/data/campaigns/Heir_To_The_Throne/utils/abilities.cfg
@@ -5,8 +5,8 @@
         id=initiative
         name= _ "initiative"
         description= _ "All adjacent friendly units will strike first in melee combat, even when defending."
-        name_affected= _ "first strike"
-        description_affected= _ "When under initiative influence, this unit always strikes first when attacked by melee weapon, even if they are defending."
+        special_name_affected= _ "first strike"
+        special_description_affected= _ "When under initiative influence, this unit always strikes first when attacked by melee weapon, even if they are defending."
         special_note=_"This unit’s grasp of melee tactics allows adjacent allies to strike the first blow even when defending."
         affect_self=no
         affect_allies=yes

--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -972,10 +972,16 @@ no#endarg
 ""#endarg
 #arg DESCRIPTION_AFFECTED
 ""#endarg
+#arg ABILITY_NAME_AFFECTED
+""#endarg
+#arg ABILITY_DESCRIPTION_AFFECTED
+""#endarg
     [chance_to_hit]
         id={ID}
         name={NAME}
         {VALUE}
+        name_affected={ABILITY_NAME_AFFECTED}
+        description_affected={ABILITY_DESCRIPTION_AFFECTED}
         special_name_affected={NAME_AFFECTED}
         special_description_affected={DESCRIPTION_AFFECTED}
         cumulative=no
@@ -1507,8 +1513,8 @@ no#endarg
                 apply_to=new_ability
                 [abilities]
                     {ABILITIES_SPELLS skill_illusion () 2 (sub=10) self {FILTER_ENTHRALL_ATTACK} ENEMIES=yes NAME_AFFECTED=_"<span color='#DD6F6F'>dazed</span>" DESCRIPTION_AFFECTED=_"This unit is dazed, therefore non-magical attacks lose 10% accuracy"}
-                    {ABILITIES_SPELLS skill_illusion_defense () 2 (add=10) opponent {FILTER_ENTHRALL_DEFENSE_NO_MAGICAL} ENEMIES=yes}
-                    {ABILITIES_SPELLS skill_illusion_defense () 2 (add=10) opponent { FILTER_ENTHRALL_DEFENSE_MARKSMAN} ENEMIES=yes}
+                    {ABILITIES_SPELLS skill_illusion_defense () 2 (add=10) opponent {FILTER_ENTHRALL_DEFENSE_NO_MAGICAL} ENEMIES=yes ABILITY_NAME_AFFECTED=_"<span color='#DD6F6F'>parry: -10%</span>" ABILITY_DESCRIPTION_AFFECTED=_"This unit is dazed, it's lose 10% of parry except for magical attack"}
+                    {ABILITIES_SPELLS skill_illusion_defense () 2 (add=10) opponent {FILTER_ENTHRALL_DEFENSE_MARKSMAN} ENEMIES=yes}
                     {HALO_CAST illusion_aura "halo/terror/terrorCW-[21~45].png~O(0.07)~CS(252,174,30):100, halo/terror/terrorCW-[1~20].png~O(0.07)~CS(252,174,30):100"}
                     {HALO_CAST illusion_aura1 "halo/terror/terrorCCW-[1~45].png~O(0.07)~CS(225,225,0)~FL():175"}
                     {HALO_CAST illusion_aura2 "halo/terror/terrorCCW-[1~45].png~O(0.07)~CS(252,215,0):100"}

--- a/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/utils/spellcasting.cfg
@@ -976,8 +976,8 @@ no#endarg
         id={ID}
         name={NAME}
         {VALUE}
-        name_affected={NAME_AFFECTED}
-        description_affected={DESCRIPTION_AFFECTED}
+        special_name_affected={NAME_AFFECTED}
+        special_description_affected={DESCRIPTION_AFFECTED}
         cumulative=no
         affect_self={SELF}
         affect_allies={ALLIES}
@@ -1044,8 +1044,8 @@ no#endarg
         {GIVE_OBJECT_TO id=Delfador (id=skill_counterspell {EFFECT new_ability ([abilities]
         [disable]
             id=skill_counterspell
-            name_affected=_"<span color='#DD6F6F'>counterspelled</span>"
-            description_affected= _"Counterspell is nullifying this magical attack."
+            special_name_affected=_"<span color='#DD6F6F'>counterspelled</span>"
+            special_description_affected= _"Counterspell is nullifying this magical attack."
             cumulative=no
             affect_self=yes
             affect_allies=yes

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -1020,8 +1020,8 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
                     [/chance_to_hit]
                     [chance_to_hit]
                         id=self_dazed
-                        name_affected=_ "<span color='#DD6F6F'>accuracy: -10%</span>"
-                        description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
+                        special_name_affected=_ "<span color='#DD6F6F'>accuracy: -10%</span>"
+                        special_description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
                         sub=10
                         [filter_student]
                             [filter_weapon]
@@ -1041,8 +1041,8 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
                     [/chance_to_hit]
                     [chance_to_hit]
                         id=self_dazed
-                        name_affected=_ "<span color='#DD6F6F'>accuracy: -10%</span>"
-                        description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
+                        special_name_affected=_ "<span color='#DD6F6F'>accuracy: -10%</span>"
+                        special_description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
                         sub=10
                         [filter_base_value]
                             greater_than_equal_to=70

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -974,8 +974,8 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
                 [abilities]
                     [chance_to_hit]
                         id=enemy_dazed
-                        name=""
-                        description=""
+                        name_affected=_ "<span color='#DD6F6F'>parry: -10%</span>"
+                        description_affected=_ "Because this unit is dazed, its parry is decreased by 10% except for enemies magical attacks or marsksman"
                         add=10
                         apply_to=opponent
                         [filter_student]
@@ -998,8 +998,6 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
                     [/chance_to_hit]
                     [chance_to_hit]
                         id=enemy_dazed
-                        name=""
-                        description=""
                         add=10
                         apply_to=opponent
                         [filter_base_value]

--- a/data/schema/units/abilities.cfg
+++ b/data/schema/units/abilities.cfg
@@ -4,8 +4,8 @@
 		name={NAME}
 		max=infinite
 		super="units/unit_type/abilities/~generic~,units/unit_type/attack/specials/" + {NAME}
-		{SIMPLE_KEY name_affected t_string}
-		{SIMPLE_KEY description_affected t_string}
+		{SIMPLE_KEY special_name_affected t_string}
+		{SIMPLE_KEY special_description_affected t_string}
 		{FILTER_TAG "filter_student" unit {FILTER_TAG "filter_weapon" weapon ()}}
 		{FILTER_TAG "filter_adjacent_student" adjacent ()}
 		{FILTER_TAG "filter_adjacent_student_location" adjacent_location ()}
@@ -22,6 +22,9 @@
 	{SIMPLE_KEY female_name_inactive t_string}
 	{SIMPLE_KEY description t_string}
 	{SIMPLE_KEY description_inactive t_string}
+	{SIMPLE_KEY name_affected t_string}
+	{SIMPLE_KEY female_name_affected t_string}
+	{SIMPLE_KEY description_affected t_string}
 	{SIMPLE_KEY special_note t_string}
 	{SIMPLE_KEY affect_self bool}
 	{SIMPLE_KEY affect_allies bool}


### PR DESCRIPTION

This will allow the effect and description of the effect to appear in the sidebar, which can be more useful when the ability is used beyond radius 1.

Attributes in abilities used as weapons are renamed to avoid unwanted use.