### PR TITLE
Lua jailbreak catch

### DIFF
--- a/data/test/scenarios/lua_tests/gui/show_dialog.cfg
+++ b/data/test/scenarios/lua_tests/gui/show_dialog.cfg
@@ -1,0 +1,53 @@
+
+{GENERIC_UNIT_TEST "lua_gui_show_dialog" (
+    [event]
+        name = prestart
+        [lua]
+            code=<<
+                T = wml.tag
+
+                function _G.do_nothing() end
+
+                _G.delay_dialog = {
+                  T.tooltip { id = "tooltip_large" },
+                  T.helptip { id = "tooltip_large" },
+                  T.grid { T.row {
+                    T.column { T.grid {
+                      T.row { T.column { T.grid {
+                        T.row {
+                            T.column {
+                                T.button { id = "ok", label = "I have seen my leader now" }
+                            }
+                        }
+                      } } }
+                    } },
+                    T.column { T.image { id = "the_image" } }
+                  } }
+                }
+
+
+                -- correct: delay_dialog[3][2][1][2][1][2][1][2][1][2][1][2][1][2]
+                if true then
+                table.insert(delay_dialog[3][2][1][2][1][2][1][2][1][2][1][2], T.row {
+                    T.column {
+                        T.label { id = "other", label = "other" }
+                    }
+                })
+                end
+
+                -- this exits the scenario if lua_jailbreak_exception is not cleared
+                gui.show_dialog(_G.delay_dialog, do_nothing, do_nothing)
+                -- instead, we want it to stop executing this tag, but then continue the scenario
+
+                -- should not reach this
+                unit_test.fail()
+            >>
+        [/lua]
+    [/event]
+    [event]
+        name = start
+        [endlevel]
+            result=victory
+        [/endlevel]
+    [/event]
+)}

--- a/src/lua_jailbreak_exception.cpp
+++ b/src/lua_jailbreak_exception.cpp
@@ -16,6 +16,7 @@
 #include "lua_jailbreak_exception.hpp"
 
 #include <cassert>
+#include <typeinfo>
 
 int lua_jailbreak_exception::jail_depth = 0;
 lua_jailbreak_exception *lua_jailbreak_exception::jailbreak_exception = nullptr;
@@ -33,6 +34,21 @@ void lua_jailbreak_exception::store() const noexcept
 	}
 
 	jailbreak_exception = this->clone();
+}
+
+void lua_jailbreak_exception::caught() const noexcept
+{
+	assert(jail_depth != 0);
+	// At jail_depth 0, the exception would already have been cleared.
+	// This assert may alternatively become an early return,
+	// if this method is called in places that may or may not have a lua stack.
+
+	assert(jailbreak_exception);
+	// jailbreak_exception should be a clone of this, but we don't have
+	// operator==, or even any members to compare.
+	assert(typeid(*jailbreak_exception) == typeid(*this));
+
+	clear();
 }
 
 void lua_jailbreak_exception::rethrow()

--- a/src/lua_jailbreak_exception.hpp
+++ b/src/lua_jailbreak_exception.hpp
@@ -34,6 +34,9 @@ public:
 	/** Stores a copy the current exception to be rethrown. */
 	void store() const noexcept;
 
+	/** Clears the rethrow mechanism of this exception. */
+	void caught() const noexcept;
+
 	/**
 	 * Rethrows the stored exception.
 	 *

--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -53,9 +53,17 @@ static lg::log_domain log_scripting_lua("scripting/lua");
 int intf_show_dialog(lua_State* L)
 {
 	config def_cfg = luaW_checkconfig(L, 1);
-	gui2::builder_window::window_resolution def(def_cfg);
-
-	auto wp = std::make_unique<gui2::window>(def);
+	std::unique_ptr<gui2::window> wp;
+	try {
+		gui2::builder_window::window_resolution def(def_cfg);
+		wp = std::make_unique<gui2::window>(def);
+	} catch (const wml_exception& error) {
+		error.caught();
+		error.show();
+		// luaL_argerror is effectively a throw statement
+		// It exits the current lua context, but returns control to its caller
+		return luaL_argerror(L, 1, error.dev_message.c_str());
+	}
 
 	if(!lua_isnoneornil(L, 2)) {
 		lua_pushvalue(L, 2);

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -301,6 +301,7 @@
 0 test_scoped_scalar
 0 as_text
 0 test_lua_version_api
+12 lua_gui_show_dialog
 #
 # Pathfinding
 #


### PR DESCRIPTION
Add API to `lua_jailbreak_exception` to clear the rethrow mechanism. Use this API to stop lua `intf_show_dialog` from ~crashing the game~ _exiting scenarios_. Add a unit test for this.

Fixes #9178.