### PR TITLE
SotA: Update terrain

### DIFF
--- a/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/utils/sota-utils.cfg
@@ -942,7 +942,7 @@
             [terrain]
                 x=7
                 y="$(9+{OFFSET})"
-                terrain=^Zrlp
+                terrain=^rlpS
                 layer=overlay
             [/terrain]
             [set_variable]


### PR DESCRIPTION
Closes #10299

I can see how this was missed in #5189 but I don't (yet) see the error message logged in #10299. 1.18 is also affected so it could be back-ported.