### PR TITLE
 Compare units directly instead of locations 

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -476,7 +476,7 @@ static bool ability_active_adjacent_helper(const unit& self, bool illuminates, c
 		for(const unit& u : units) {
 			const map_location& from_loc = u.get_location();
 			std::size_t distance = distance_between(from_loc, loc);
-			if(from_loc == loc || distance > radius || !ufilt(u, self)) {
+			if(&u == &self || distance > radius || !ufilt(u, self)) {
 				continue;
 			}
 			int dir = 0;

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -137,7 +137,7 @@ struct unit_filter_adjacent : public unit_filter_base
 		for(const unit& u : units) {
 			const map_location& from_loc = u.get_location();
 			std::size_t distance = distance_between(from_loc, args.loc);
-			if(from_loc == args.loc || distance > radius || !child_.matches(unit_filter_args{u, from_loc, &args.u, args.fc, args.use_flat_tod} )) {
+			if(&u == &args.u || distance > radius || !child_.matches(unit_filter_args{u, from_loc, &args.u, args.fc, args.use_flat_tod} )) {
 				continue;
 			}
 			int dir = 0;


### PR DESCRIPTION
I didn't know how to do it anymore, and in a panic, I resorted to using locations, but comparing unit variables seems more robust to me.