### PR TITLE
Floating label cleanup and optimization

### DIFF
--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -20,6 +20,7 @@
 #include "font/standard_colors.hpp"
 #include "font/text.hpp"
 #include "log.hpp"
+#include "serialization/chrono.hpp"
 #include "video.hpp"
 
 #include <map>
@@ -238,21 +239,16 @@ point floating_label::get_pos(const clock::time_point& time)
 	};
 }
 
-uint8_t floating_label::get_alpha(const clock::time_point& time)
+uint8_t floating_label::get_alpha(const clock::time_point& time) const
 {
 	if(lifetime_ >= 0ms && fadeout_ > 0ms) {
 		auto time_alive = get_time_alive(time);
-		if(time_alive >= lifetime_ && tex_ != nullptr) {
-			// fade out moving floating labels
-			int alpha_sub = 255 * (time_alive - lifetime_) / fadeout_;
-			if (alpha_sub >= 255) {
-				return 0;
-			} else {
-				return 255 - alpha_sub;
-			}
+		if(time_alive >= lifetime_) {
+			double progress = chrono::normalize_progress(time_alive - lifetime_, fadeout_);
+			return float_to_color(1.0 - progress);
 		}
 	}
-	return 255;
+	return ALPHA_OPAQUE;
 }
 
 int add_floating_label(const floating_label& flabel)

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -277,9 +277,9 @@ void move_floating_label(int handle, double xmove, double ymove)
 
 void scroll_floating_labels(double xmove, double ymove)
 {
-	for(label_map::iterator i = labels.begin(); i != labels.end(); ++i) {
-		if(i->second.scroll() == ANCHOR_LABEL_MAP) {
-			i->second.move(xmove, ymove);
+	for(auto& [id, label] : labels) {
+		if(label.scroll() == ANCHOR_LABEL_MAP) {
+			label.move(xmove, ymove);
 		}
 	}
 }
@@ -313,12 +313,12 @@ void show_floating_label(int handle, bool value)
 	}
 }
 
-SDL_Rect get_floating_label_rect(int handle)
+rect get_floating_label_rect(int handle)
 {
 	const label_map::iterator i = labels.find(handle);
 	if(i != labels.end()) {
 		if (i->second.create_texture()) {
-			SDL_Point size = i->second.get_draw_size();
+			point size = i->second.get_draw_size();
 			return {0, 0, size.x, size.y};
 		}
 	}

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -224,9 +224,9 @@ void floating_label::set_lifetime(const std::chrono::milliseconds& lifetime, con
 	time_start_	= std::chrono::steady_clock::now();
 }
 
-std::chrono::milliseconds floating_label::get_time_alive(const clock::time_point& current_time) const
+auto floating_label::get_time_alive(const clock::time_point& current_time) const -> clock::duration
 {
-	return std::chrono::duration_cast<std::chrono::milliseconds>(current_time - time_start_);
+	return current_time - time_start_;
 }
 
 point floating_label::get_pos(const clock::time_point& time) const
@@ -235,7 +235,7 @@ point floating_label::get_pos(const clock::time_point& time) const
 	double new_y = ypos_;
 
 	if(xmove_ != 0.0 || ymove_ != 0.0) {
-		auto time_alive = get_time_alive(time);
+		auto time_alive = std::chrono::duration_cast<std::chrono::milliseconds>(get_time_alive(time));
 		new_x += time_alive.count() * xmove_;
 		new_y += time_alive.count() * ymove_;
 	}

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -26,6 +26,8 @@
 #include <set>
 #include <stack>
 
+#include <boost/algorithm/string/trim.hpp>
+
 static lg::log_domain log_font("font");
 #define DBG_FT LOG_STREAM(debug, log_font)
 #define LOG_FT LOG_STREAM(info, log_font)
@@ -55,7 +57,7 @@ floating_label::floating_label(const std::string& text)
 	, alpha_(0)
 	, fadeout_(0)
 	, time_start_()
-	, text_(text)
+	, text_(boost::trim_copy(text))
 	, font_size_(SIZE_SMALL)
 	, color_(NORMAL_COLOR)
 	, bgcolor_(0, 0, 0, SDL_ALPHA_TRANSPARENT)
@@ -134,12 +136,7 @@ bool floating_label::create_texture()
 		.set_characters_per_line(0)
 		.set_add_outline(bgcolor_.a == 0);
 
-	// ignore last '\n'
-	if(!text_.empty() && *(text_.rbegin()) == '\n') {
-		text.set_text(std::string(text_.begin(), text_.end() - 1), use_markup_);
-	} else {
-		text.set_text(text_, use_markup_);
-	}
+	text.set_text(text_, use_markup_);
 
 	tex_ = text.render_and_get_texture();
 	if(!tex_) {

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -166,8 +166,7 @@ void floating_label::update(const clock::time_point& time)
 		return;
 	}
 
-	point new_pos = get_pos(time);
-	rect draw_loc {new_pos.x, new_pos.y, tex_.w(), tex_.h()};
+	rect draw_loc{get_pos(time), tex_.draw_size()};
 
 	uint8_t new_alpha = get_alpha(time);
 
@@ -230,13 +229,19 @@ std::chrono::milliseconds floating_label::get_time_alive(const clock::time_point
 	return std::chrono::duration_cast<std::chrono::milliseconds>(current_time - time_start_);
 }
 
-point floating_label::get_pos(const clock::time_point& time)
+point floating_label::get_pos(const clock::time_point& time) const
 {
-	auto time_alive = get_time_alive(time);
-	return {
-		static_cast<int>(time_alive.count() * xmove_ + xpos(tex_.w())),
-		static_cast<int>(time_alive.count() * ymove_ + ypos_)
-	};
+	double new_x = xpos(tex_.w());
+	double new_y = ypos_;
+
+	if(xmove_ != 0.0 || ymove_ != 0.0) {
+		auto time_alive = get_time_alive(time);
+		new_x += time_alive.count() * xmove_;
+		new_y += time_alive.count() * ymove_;
+	}
+
+	// TODO: return a floating point point
+	return {static_cast<int>(new_x), static_cast<int>(new_y)};
 }
 
 uint8_t floating_label::get_alpha(const clock::time_point& time) const

--- a/src/floating_label.cpp
+++ b/src/floating_label.cpp
@@ -167,8 +167,15 @@ void floating_label::update(const clock::time_point& time)
 	}
 
 	rect draw_loc{get_pos(time), tex_.draw_size()};
-
 	uint8_t new_alpha = get_alpha(time);
+
+	// Nothing has changed
+	// FIXME: we consider border too since otherwise we get flickering under floating
+	// labels with a background (see bug #7700). This isn't ideal for chat messages or
+	// tooltips, but it optimizes the usual case (map labels).
+	if(screen_loc_ == draw_loc && alpha_ == new_alpha && border_ == 0) {
+		return;
+	}
 
 	// Invalidate former draw loc
 	draw_manager::invalidate_region(get_bg_rect(screen_loc_));

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -18,7 +18,6 @@
 #include "color.hpp"
 #include "sdl/point.hpp"
 #include "sdl/rect.hpp"
-#include "sdl/surface.hpp"
 #include "sdl/texture.hpp"
 
 #include <chrono>
@@ -54,12 +53,12 @@ public:
 		xpos_ = xpos;
 		ypos_ = ypos;
 	}
-	// set the amount to move the text each frame
+	// set the amount to move the text each millisecond
 	void set_move(double xmove, double ymove){
 		xmove_ = xmove;
 		ymove_ = ymove;
 	}
-	// set the number of frames to display the text for, or -1 to display until removed
+	// set the number of milliseconds to display the text for, or -1 to display until removed
 	void set_lifetime(const std::chrono::milliseconds& lifetime, const std::chrono::milliseconds& fadeout = std::chrono::milliseconds{100});
 	void set_color(const color_t& color) {color_ = color;}
 	void set_bg_color(const color_t& bg_color) {
@@ -93,7 +92,7 @@ public:
 	void clear_texture();
 
 	/** Return the size of the label in drawing coordinates */
-	SDL_Point get_draw_size() const
+	point get_draw_size() const
 	{
 		return get_bg_rect({0, 0, tex_.w(), tex_.h()}).size();
 	}
@@ -128,7 +127,7 @@ private:
 	double xpos_, ypos_, xmove_, ymove_;
 	std::chrono::milliseconds lifetime_;
 	int width_, height_;
-	SDL_Rect clip_rect_;
+	rect clip_rect_;
 	bool visible_;
 	font::ALIGN align_;
 	int border_;
@@ -158,7 +157,8 @@ void remove_floating_label(int handle, const std::chrono::milliseconds& fadeout 
 /** hides or shows a floating label */
 void show_floating_label(int handle, bool show);
 
-SDL_Rect get_floating_label_rect(int handle);
+// TODO: refactor out. This only gives size, not position
+rect get_floating_label_rect(int handle);
 void draw_floating_labels();
 void update_floating_labels();
 

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -113,7 +113,7 @@ private:
 
 	std::chrono::milliseconds get_time_alive(const clock::time_point& current_time) const;
 	int xpos(std::size_t width) const;
-	point get_pos(const clock::time_point& time);
+	point get_pos(const clock::time_point& time) const;
 	uint8_t get_alpha(const clock::time_point& time) const;
 	rect get_bg_rect(const rect& text_rect) const;
 	texture tex_;

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -114,7 +114,7 @@ private:
 	std::chrono::milliseconds get_time_alive(const clock::time_point& current_time) const;
 	int xpos(std::size_t width) const;
 	point get_pos(const clock::time_point& time);
-	uint8_t get_alpha(const clock::time_point& time);
+	uint8_t get_alpha(const clock::time_point& time) const;
 	rect get_bg_rect(const rect& text_rect) const;
 	texture tex_;
 	rect screen_loc_;

--- a/src/floating_label.hpp
+++ b/src/floating_label.hpp
@@ -111,7 +111,7 @@ public:
 
 private:
 
-	std::chrono::milliseconds get_time_alive(const clock::time_point& current_time) const;
+	clock::duration get_time_alive(const clock::time_point& current_time) const;
 	int xpos(std::size_t width) const;
 	point get_pos(const clock::time_point& time) const;
 	uint8_t get_alpha(const clock::time_point& time) const;

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -611,7 +611,7 @@ void game_display::float_label(const map_location& loc, const std::string& text,
 	flabel.set_color(color);
 	flabel.set_position(loc_rect.center().x, loc_rect.y); // middle of top edge
 	flabel.set_move(0, -pixels_per_millisecond); // moving up
-	flabel.set_lifetime(std::chrono::round<std::chrono::milliseconds>(lifetime));
+	flabel.set_lifetime(0ms, std::chrono::round<std::chrono::milliseconds>(lifetime));
 	flabel.set_scroll_mode(font::ANCHOR_LABEL_MAP);
 
 	font::add_floating_label(flabel);

--- a/src/game_display.cpp
+++ b/src/game_display.cpp
@@ -600,12 +600,18 @@ void game_display::float_label(const map_location& loc, const std::string& text,
 
 	rect loc_rect = get_location_rect(loc);
 
+	using namespace std::chrono_literals;
+	const auto lifetime = 1s / turbo_speed();
+
+	// Base speed is 100 pixels per second, taken in milliseconds
+	const double pixels_per_millisecond = 0.1 * turbo_speed() * get_zoom_factor();
+
 	font::floating_label flabel(text);
 	flabel.set_font_size(int(font::SIZE_FLOAT_LABEL * get_zoom_factor()));
 	flabel.set_color(color);
 	flabel.set_position(loc_rect.center().x, loc_rect.y); // middle of top edge
-	flabel.set_move(0, -0.1 * turbo_speed() * get_zoom_factor());
-	flabel.set_lifetime(std::chrono::milliseconds{static_cast<int>(1000 / turbo_speed())});
+	flabel.set_move(0, -pixels_per_millisecond); // moving up
+	flabel.set_lifetime(std::chrono::round<std::chrono::milliseconds>(lifetime));
 	flabel.set_scroll_mode(font::ANCHOR_LABEL_MAP);
 
 	font::add_floating_label(flabel);


### PR DESCRIPTION
Covers a bunch of misc changes to floating labels. Notably:
- Fixes damage floating labels not fading out over their whole duration
- Avoid calculating movement delta if no delta was specified (it had ended up as a multiplication by 0)
- Partially readds an early-exit optimization that was lost in the process of fixing #7700