### PR TITLE
Fix [terrain_defaults] default value not being used

### DIFF
--- a/src/formula/variant.cpp
+++ b/src/formula/variant.cpp
@@ -288,23 +288,23 @@ variant variant::get_member(const std::string& name) const
 	return variant();
 }
 
-int variant::as_int() const
+int variant::as_int(int fallback) const
 {
-	if(is_null())    { return 0; }
+	if(is_null())    { return fallback; }
 	if(is_decimal()) { return as_decimal() / 1000; }
 
 	must_be(formula_variant::type::integer);
 	return value_cast<variant_int>()->get_numeric_value();
 }
 
-int variant::as_decimal() const
+int variant::as_decimal(int fallback) const
 {
 	if(is_decimal()) {
 		return value_cast<variant_decimal>()->get_numeric_value();
 	} else if(is_int()) {
 		return value_cast<variant_int>()->get_numeric_value() * 1000;
 	} else if(is_null()) {
-		return 0;
+		return fallback;
 	}
 
 	throw type_error(was_expecting("an integer or a decimal", *this));

--- a/src/formula/variant.hpp
+++ b/src/formula/variant.hpp
@@ -67,10 +67,17 @@ public:
 	bool is_string()   const { return type() == formula_variant::type::string; }
 	bool is_map()      const { return type() == formula_variant::type::map; }
 
-	int as_int() const;
+	/**
+	 * Returns the variant's value as an integer.
+	 * If @ref is_null() is true, returns @a fallback.
+	 */
+	int as_int(int fallback = 0) const;
 
-	/** Returns variant's internal representation of decimal number: ie, 1.234 is represented as 1234 */
-	int as_decimal() const;
+	/**
+	 * Returns the variant's internal representation of decimal number: ie, 1.234 is represented as 1234.
+	 * If @ref is_null() is true, returns @a fallback.
+	 */
+	int as_decimal(int fallback = 0) const;
 
 	/** Returns a boolean state of the variant value. The implementation is type-dependent. */
 	bool as_bool() const;

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -29,7 +29,6 @@
 #include "units/animation.hpp"
 #include "units/unit.hpp"
 
-#include "gui/auxiliary/typed_formula.hpp"
 #include "gui/dialogs/loading_screen.hpp"
 
 #include <boost/range/algorithm_ext/erase.hpp>
@@ -899,7 +898,7 @@ void patch_movetype(movetype& mt,
 		// before the formula is evaluated.
 		std::list<config> config_copies;
 
-		gui2::typed_formula<int> formula(formula_str, default_val);
+		auto formula = wfl::formula(formula_str);
 		wfl::map_formula_callable original;
 
 		// These three need to follow movetype's fallback system, where values for
@@ -936,7 +935,7 @@ void patch_movetype(movetype& mt,
 		}
 
 		try {
-			temp_cfg[new_key] = formula(original);
+			temp_cfg[new_key] = formula.evaluate(original).as_int(default_val);
 		} catch(const wfl::formula_error&) {
 			ERR_CF << "Error evaluating movetype formula: " << formula_str;
 			return;


### PR DESCRIPTION
Essentially, typed_formula was the wrong tool for this job. The default was only used if no input was provided, not if the formula itself evaluated to null.