### PR TITLE
Several woptipng improvements

### DIFF
--- a/utils/woptipng.py
+++ b/utils/woptipng.py
@@ -68,6 +68,19 @@ EXEC_EXIFTOOL = args.exiftool_path or shutil.which("exiftool")
 
 if os.name == "posix":
     os.nice(args.nice) # set niceness, not available on Windows
+elif os.name == "nt":
+    # after testing this script on Windows, instead of running correctly,
+    # the command prompt became full of error messages.
+    # This happens because the Windows kernel lacks the fork() method
+    # available in POSIX systems, so multiprocessing is done by spawning
+    # multiple Python interpreters.
+    # To work correctly, this requires that everything which isn't a class
+    # or function definition or a global variable to be guarded inside the
+    # if __name__ == "__main__" block.
+    # Until everything can be moved into that block, corrected and tested,
+    # the only option is to exit here.
+    print("This program cannot run on Windows yet.")
+    sys.exit(0)
 
 input_files=[]
 bad_input_files=[]


### PR DESCRIPTION
This PR aims to make the `woptipng` script useful once again.
Since we started embedding copyright information directly into PNG images with EXIF tags, the script became useless because the tools used internally remove the metadata to reduce the file size. At first I though that I had to use some more command line switches, then I decided to use `exiftool` to preserve the metadata.

These are the improvements I made:

* added support for the `oxipng` script from the upstream repository
* used `exiftool` to read a few interesting (for us) EXIF tags (Artist, Copyright and UserComment), so they're added back after every single run of the four internal tools
* added command line switches to specify the paths of those tools, which should allow running the script on Windows (and on Linux I was able to use the AppImage release of ImageMagick instead of the one in the repositories!)
* improved the help text, so users know where to obtain the required dependencies.

Let me know if you find any issues (especially on Windows) or have any ideas.