### PR TITLE
Fix non-permanent bans not actually working

### DIFF
--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -884,7 +884,7 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 		}
 		else
 		{
-			ERR_SQL << "Unsupported parameter type in SQL query: " << typeid(param).name() << " at position " << i;
+			ERR_SQL << "Unsupported parameter type in SQL query at position " << i;
 		}
 		i++;
 	}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -884,7 +884,7 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 		}
 		else
 		{
-			ERR_SQL << "Unsupported parameter type in SQL query at position " << i;
+			throw mariadb::exception::base("Unsupported parameter type in SQL query at position " + std::to_string(i));
 		}
 		i++;
 	}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -866,6 +866,10 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 		{
 			stmt->set_signed32(i, std::get<int>(param));
 		}
+		else if(std::holds_alternative<long>(param))
+		{
+			stmt->set_signed64(i, std::get<long>(param));
+		}
 		else if(std::holds_alternative<unsigned long long>(param))
 		{
 			stmt->set_signed64(i, std::get<unsigned long long>(param));
@@ -877,6 +881,10 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 		else if(std::holds_alternative<const char*>(param))
 		{
 			stmt->set_string(i, std::get<const char*>(param));
+		}
+		else
+		{
+			ERR_SQL << "Unsupported parameter type in SQL query: " << typeid(param).name() << " at position " << i;
 		}
 		i++;
 	}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -884,7 +884,7 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 		}
 		else
 		{
-			throw mariadb::exception::base("Unsupported parameter type in SQL query at position " + std::to_string(i));
+			throw mariadb::exception::base("Unsupported parameter type in SQL query at position " + std::to_string(i) + " for sql: " + sql);
 		}
 		i++;
 	}

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -864,7 +864,7 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 	for(const auto& param : params)
 	{
 		std::visit([&](const auto& p) {
-			using T = std::remove_cvref_t<decltype(p)>;
+			using T = std::remove_cv_t<std::remove_reference_t<decltype(p)>>;
 			if constexpr (std::is_same_v<T, bool>) {
 				stmt->set_boolean(i, p);
 			} else if constexpr (std::is_same_v<T, int>) {

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -861,7 +861,7 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 	unsigned i = 0;
 	for(const auto& param : params)
 	{
-		std::visit([&](const auto& p) {
+		std::visit([&i, &stmt](const auto& p) {
 			using T = std::remove_cv_t<std::remove_reference_t<decltype(p)>>;
 			if constexpr (std::is_same_v<T, bool>) {
 				stmt->set_boolean(i, p);

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -21,6 +21,8 @@
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
 
+#include <type_traits>
+
 static lg::log_domain log_sql_handler("sql_executor");
 #define ERR_SQL LOG_STREAM(err, log_sql_handler)
 #define WRN_SQL LOG_STREAM(warn, log_sql_handler)
@@ -851,6 +853,9 @@ unsigned long long dbconn::modify_get_id(const mariadb::connection_ref& connecti
 	}
 }
 
+template<class T>
+inline constexpr bool always_false_v = false;
+
 mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
 	mariadb::statement_ref stmt = connection->create_statement(sql);
@@ -858,34 +863,24 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 	unsigned i = 0;
 	for(const auto& param : params)
 	{
-		if(std::holds_alternative<bool>(param))
-		{
-			stmt->set_boolean(i, std::get<bool>(param));
-		}
-		else if(std::holds_alternative<int>(param))
-		{
-			stmt->set_signed32(i, std::get<int>(param));
-		}
-		else if(std::holds_alternative<long>(param))
-		{
-			stmt->set_signed64(i, std::get<long>(param));
-		}
-		else if(std::holds_alternative<unsigned long long>(param))
-		{
-			stmt->set_signed64(i, std::get<unsigned long long>(param));
-		}
-		else if(std::holds_alternative<std::string>(param))
-		{
-			stmt->set_string(i, std::get<std::string>(param));
-		}
-		else if(std::holds_alternative<const char*>(param))
-		{
-			stmt->set_string(i, std::get<const char*>(param));
-		}
-		else
-		{
-			throw mariadb::exception::base("Unsupported parameter type in SQL query at position " + std::to_string(i) + " for sql: " + sql);
-		}
+		std::visit([&](const auto& p) {
+			using T = std::remove_cvref_t<decltype(p)>;
+			if constexpr (std::is_same_v<T, bool>) {
+				stmt->set_boolean(i, p);
+			} else if constexpr (std::is_same_v<T, int>) {
+				stmt->set_signed32(i, p);
+			} else if constexpr (std::is_same_v<T, long>) {
+				stmt->set_signed64(i, p);
+			} else if constexpr (std::is_same_v<T, unsigned long long>) {
+				stmt->set_signed64(i, p);
+			} else if constexpr (std::is_same_v<T, std::string>) {
+				stmt->set_string(i, p);
+			} else if constexpr (std::is_same_v<T, const char*>) {
+				stmt->set_string(i, p);
+			} else {
+				static_assert(always_false_v<T>, "Unsupported parameter type in SQL query");
+			}
+		}, param);
 		i++;
 	}
 

--- a/src/server/common/dbconn.cpp
+++ b/src/server/common/dbconn.cpp
@@ -20,6 +20,7 @@
 #include "serialization/parser.hpp"
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
+#include "utils/general.hpp"
 
 #include <type_traits>
 
@@ -853,9 +854,6 @@ unsigned long long dbconn::modify_get_id(const mariadb::connection_ref& connecti
 	}
 }
 
-template<class T>
-inline constexpr bool always_false_v = false;
-
 mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, const std::string& sql, const sql_parameters& params)
 {
 	mariadb::statement_ref stmt = connection->create_statement(sql);
@@ -878,7 +876,7 @@ mariadb::statement_ref dbconn::query(const mariadb::connection_ref& connection, 
 			} else if constexpr (std::is_same_v<T, const char*>) {
 				stmt->set_string(i, p);
 			} else {
-				static_assert(always_false_v<T>, "Unsupported parameter type in SQL query");
+				static_assert(utils::dependent_false_v<T>, "Unsupported parameter type in SQL query");
 			}
 		}, param);
 		i++;

--- a/src/server/common/dbconn.hpp
+++ b/src/server/common/dbconn.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <unordered_map>
 
+// make sure to update dbconn::query() as well when changing these listed values
 typedef std::vector<std::variant<bool, int, long, unsigned long long, std::string, const char*>> sql_parameters;
 
 /**

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -961,7 +961,7 @@ template<class SocketPtr> bool server::is_login_allowed(boost::asio::yield_conte
 		auth_ban = user_handler_->user_is_banned(username, client_address(socket));
 	}
 
-	if(auth_ban.type) {
+	if(auth_ban.type != user_handler::BAN_NONE) {
 		std::string ban_type_desc;
 		std::string ban_reason;
 		const char* msg_numeric;


### PR DESCRIPTION
time_t ends up being a long while we only have if-blocks for int and unsigned long long. so the parameter doesn't get set at all, and somehow mariadbpp runs the query without all the required parameters being set.