### PR TITLE
MP/Faction Select: add listbox sorter for faction names

### DIFF
--- a/data/gui/themes/default/dialogs/mp_faction_select.cfg
+++ b/data/gui/themes/default/dialogs/mp_faction_select.cfg
@@ -8,6 +8,36 @@
 		id = "faction_list"
 		definition = "default"
 
+		[header]
+
+			[row]
+
+				[column]
+					border = "left,right"
+					border_size = 1 # Matches image widget border
+
+					[spacer]
+						definition = "default"
+						linked_group = "image"
+					[/spacer]
+
+				[/column]
+
+				[column]
+					grow_factor = 1
+					horizontal_grow = true
+
+					[toggle_button]
+						id = "sort_0"
+						definition = "listbox_header"
+						label = _ "Name"
+					[/toggle_button]
+				[/column]
+
+			[/row]
+
+		[/header]
+
 		[list_definition]
 			[row]
 				[column]

--- a/data/schema/core/addons.cfg
+++ b/data/schema/core/addons.cfg
@@ -262,7 +262,7 @@
 	{SIMPLE_KEY disallow_scenario string_list}
 	{SIMPLE_KEY ignore_incompatible_scenario string_list}
 	{SIMPLE_KEY require_era bool}
-	{DEFAULT_KEY auto_sort bool yes}
+	{DEFAULT_KEY auto_sort sort_order ascending}
 	{DEFAULT_KEY hide_help bool no}
 	{DEFAULT_KEY type addon_type mp}
 	{LINK_TAG "multiplayer_side"}

--- a/data/schema/game_config.cfg
+++ b/data/schema/game_config.cfg
@@ -519,6 +519,10 @@
         name="theme_action"
         value="checkbox|radiobox|image|turbo"
     [/type]
+    [type]
+        name="sort_order"
+        value="none|ascending|descending"
+    [/type]
     [tag]
         name="root"
         min=1

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -60,27 +60,6 @@ const std::set<std::string> children_to_swap {
 	"ai"
 };
 
-void sort_faction_options(std::vector<const config*>& factions)
-{
-	// Since some eras have multiple random options we can't just
-	// assume there is only one random faction on top of the list.
-	std::sort(factions.begin(), factions.end(), [](const config* lhs, const config* rhs) {
-		bool lhs_rand = (*lhs)["random_faction"].to_bool();
-		bool rhs_rand = (*rhs)["random_faction"].to_bool();
-
-		// Random factions always first.
-		if(lhs_rand && !rhs_rand) {
-			return true;
-		}
-
-		if(!lhs_rand && rhs_rand) {
-			return false;
-		}
-
-		return translation::compare((*lhs)["name"].str(), (*rhs)["name"].str()) < 0;
-	});
-}
-
 } // end anon namespace
 
 namespace ng {
@@ -194,10 +173,6 @@ connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_
 	// Selected era's factions.
 	for(const config& ms : era_config.child_range("multiplayer_side")) {
 		era_factions_.push_back(&ms);
-	}
-
-	if(era_config["auto_sort"].to_bool(true)) {
-		sort_faction_options(era_factions_);
 	}
 
 	game_config::add_color_info(game_config_view::wrap(scenario()));

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -180,7 +180,8 @@ connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_
 	// Create side engines.
 	int index = 0;
 	for(const config& s : sides) {
-		side_engines_.emplace_back(new side_engine(s, *this, index++));
+		auto engine = side_engines_.emplace_back(new side_engine(s, *this, index++));
+		engine->flg().set_faction_sort_order(era_config); // TODO: unify with flg construction
 	}
 
 	if(first_scenario_) {

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -175,7 +175,7 @@ connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_
 	// Create side engines.
 	int index = 0;
 	for(const config& s : sides) {
-		auto engine = side_engines_.emplace_back(new side_engine(s, *this, index++));
+		side_engines_.emplace_back(new side_engine(s, *this, index++));
 	}
 
 	if(first_scenario_) {

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -65,7 +65,7 @@ const std::set<std::string> children_to_swap {
 namespace ng {
 
 connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_game_metadata* metadata)
-	: level_()
+	: level_(mp::initial_level_config(state))
 	, state_(state)
 	, params_(state.mp_settings())
 	, default_controller_(metadata ? CNTR_NETWORK : CNTR_LOCAL)
@@ -75,13 +75,8 @@ connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_
 	, side_engines_()
 	, era_factions_()
 	, team_data_()
+	, era_info_(level_.mandatory_child("era"))
 {
-	// Initial level config from the mp_game_settings.
-	level_ = mp::initial_level_config(state_);
-	if(level_.empty()) {
-		return;
-	}
-
 	const config& era_config = level_.mandatory_child("era");
 
 	const bool is_mp = state_.classification().is_normal_mp_game();
@@ -181,7 +176,6 @@ connect_engine::connect_engine(saved_game& state, const bool first_scenario, mp_
 	int index = 0;
 	for(const config& s : sides) {
 		auto engine = side_engines_.emplace_back(new side_engine(s, *this, index++));
-		engine->flg().set_faction_sort_order(era_config); // TODO: unify with flg construction
 	}
 
 	if(first_scenario_) {

--- a/src/game_initialization/connect_engine.cpp
+++ b/src/game_initialization/connect_engine.cpp
@@ -816,7 +816,7 @@ side_engine::side_engine(const config& cfg, connect_engine& parent_engine, const
 	, ai_algorithm_()
 	, chose_random_(cfg["chose_random"].to_bool(false))
 	, disallow_shuffle_(cfg["disallow_shuffle"].to_bool(false))
-	, flg_(parent_.era_factions_, cfg_, parent_.force_lock_settings_, parent_.params_.use_map_settings, parent_.params_.saved_game == saved_game_mode::type::midgame)
+	, flg_(parent_.era_info_, parent_.era_factions_, cfg_, parent_.force_lock_settings_, parent_.params_.use_map_settings, parent_.params_.saved_game == saved_game_mode::type::midgame)
 	, allow_changes_(parent_.params_.saved_game != saved_game_mode::type::midgame && !(flg_.choosable_factions().size() == 1 && flg_.choosable_leaders().size() == 1 && flg_.choosable_genders().size() == 1))
 	, waiting_to_choose_faction_(allow_changes_)
 	, color_options_(game_config::default_colors)

--- a/src/game_initialization/connect_engine.hpp
+++ b/src/game_initialization/connect_engine.hpp
@@ -136,6 +136,8 @@ private:
 	std::vector<const config*> era_factions_;
 	std::vector<team_data_pod> team_data_;
 
+	ng::era_metadata era_info_;
+
 	std::set<std::string>& connected_users_rw();
 };
 

--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -54,6 +54,7 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 	, current_gender_("null")
 	, default_leader_type_("")
 	, default_leader_gender_("")
+	, faction_sorting_mode_(sort_order::type::ascending)
 {
 	std::string leader_id = side["id"];
 	bool found_leader;
@@ -547,6 +548,12 @@ const config& flg_manager::get_default_faction(const config& cfg)
 	} else {
 		return cfg;
 	}
+}
+
+void flg_manager::set_faction_sort_order(const config& era_config)
+{
+	auto direction = sort_order::get_enum(era_config["auto_sort"].str());
+	faction_sorting_mode_ = direction.value_or(faction_sorting_mode_);
 }
 
 } // end namespace ng

--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -31,10 +31,15 @@ static lg::log_domain log_mp_connect_engine("mp/connect/engine");
 
 namespace ng
 {
+era_metadata::era_metadata(const config& cfg)
+	: faction_sort_order(sort_order::get_enum(cfg["auto_sort"].str()).value_or(sort_order::type::ascending))
+{
+}
 
-flg_manager::flg_manager(const std::vector<const config*>& era_factions,
+flg_manager::flg_manager(const era_metadata& era_info, const std::vector<const config*>& era_factions,
 		const config& side, const bool lock_settings, const bool use_map_settings, const bool saved_game)
-	: era_factions_(era_factions)
+	: era_info_(era_info)
+	, era_factions_(era_factions)
 	, side_num_(side["side"].to_int())
 	, faction_from_recruit_(side["faction_from_recruit"].to_bool())
 	, original_faction_(get_default_faction(side)["faction"].str())
@@ -54,7 +59,6 @@ flg_manager::flg_manager(const std::vector<const config*>& era_factions,
 	, current_gender_("null")
 	, default_leader_type_("")
 	, default_leader_gender_("")
-	, faction_sorting_mode_(sort_order::type::ascending)
 {
 	std::string leader_id = side["id"];
 	bool found_leader;
@@ -548,12 +552,6 @@ const config& flg_manager::get_default_faction(const config& cfg)
 	} else {
 		return cfg;
 	}
-}
-
-void flg_manager::set_faction_sort_order(const config& era_config)
-{
-	auto direction = sort_order::get_enum(era_config["auto_sort"].str());
-	faction_sorting_mode_ = direction.value_or(faction_sorting_mode_);
 }
 
 } // end namespace ng

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include "gui/sort_order.hpp"
+
 #include <string>
 #include <vector>
 
@@ -80,6 +82,15 @@ public:
 	bool leader_lock() const
 		{ return leader_lock_; }
 
+	/** Sets the faction list ordering from the [era] config. */
+	void set_faction_sort_order(const config& era_config);
+
+	/** The order the faction list should be sorted by default in Faction Select. */
+	sort_order::type faction_sort_order() const
+	{
+		return faction_sorting_mode_;
+	}
+
 private:
 	flg_manager(const flg_manager&) = delete;
 	flg_manager& operator=(const flg_manager&) = delete;
@@ -131,6 +142,8 @@ private:
 
 	std::string default_leader_type_;
 	std::string default_leader_gender_;
+
+	sort_order::type faction_sorting_mode_;
 
 	static const config& get_default_faction(const config& cfg);
 };

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -27,11 +27,22 @@ namespace ng {
 
 const std::string random_enemy_picture("units/random-dice.png");
 
+// TODO: use this for more [era] stuff
+// TODO: move this somewhere more general
+struct era_metadata
+{
+	/** Parses an [era] tag. */
+	explicit era_metadata(const config& cfg);
+
+	/** The order to display factions when a player selects their leader. */
+	sort_order::type faction_sort_order;
+};
+
 /** FLG stands for faction, leader and gender. */
 class flg_manager
 {
 public:
-	flg_manager(const std::vector<const config*>& era_factions,
+	flg_manager(const era_metadata& era_info, const std::vector<const config*>& era_factions,
 		const config& side, bool lock_settings, bool use_map_settings, bool saved_game);
 
 	void set_current_faction(const unsigned index);
@@ -82,13 +93,9 @@ public:
 	bool leader_lock() const
 		{ return leader_lock_; }
 
-	/** Sets the faction list ordering from the [era] config. */
-	void set_faction_sort_order(const config& era_config);
-
-	/** The order the faction list should be sorted by default in Faction Select. */
-	sort_order::type faction_sort_order() const
+	const era_metadata& get_era_info() const
 	{
-		return faction_sorting_mode_;
+		return era_info_;
 	}
 
 private:
@@ -112,6 +119,8 @@ private:
 	int leader_index(const std::string& leader) const;
 	/** returns -1 if no gender with that name was found */
 	int gender_index(const std::string& gender) const;
+
+	const era_metadata& era_info_;
 
 	const std::vector<const config*>& era_factions_;
 
@@ -142,8 +151,6 @@ private:
 
 	std::string default_leader_type_;
 	std::string default_leader_gender_;
-
-	sort_order::type faction_sorting_mode_;
 
 	static const config& get_default_faction(const config& cfg);
 };

--- a/src/game_initialization/flg_manager.hpp
+++ b/src/game_initialization/flg_manager.hpp
@@ -93,7 +93,7 @@ public:
 	bool leader_lock() const
 		{ return leader_lock_; }
 
-	const era_metadata& get_era_info() const
+	const era_metadata& era_info() const
 	{
 		return era_info_;
 	}

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -45,6 +45,8 @@ struct faction_sorter
 };
 
 #ifdef __cpp_impl_three_way_comparison
+
+/** Must be defined in the same namespace for ADL reasons. */
 auto operator<=>(const faction_sorter& lhs, const faction_sorter& rhs)
 {
 	// Since some eras have multiple random options we can't just

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -76,38 +76,22 @@ auto operator<=>(const faction_sorter& lhs, const faction_sorter& rhs)
 
 bool operator<(const faction_sorter& lhs, const faction_sorter& rhs)
 {
-	// Since some eras have multiple random options we can't just
-	// assume there is only one random faction on top of the list.
 	bool lhs_rand = (*lhs.cfg)["random_faction"].to_bool();
 	bool rhs_rand = (*rhs.cfg)["random_faction"].to_bool();
 
-	// Random factions always first.
-	if(lhs_rand && !rhs_rand) {
-		return true;
-	}
-
-	if(!lhs_rand && rhs_rand) {
-		return false;
-	}
+	if(lhs_rand && !rhs_rand) return true;
+	if(!lhs_rand && rhs_rand) return false;
 
 	return translation::compare((*lhs.cfg)["name"].str(), (*rhs.cfg)["name"].str()) < 0;
 }
 
 bool operator>(const faction_sorter& lhs, const faction_sorter& rhs)
 {
-	// Since some eras have multiple random options we can't just
-	// assume there is only one random faction on top of the list.
 	bool lhs_rand = (*lhs.cfg)["random_faction"].to_bool();
 	bool rhs_rand = (*rhs.cfg)["random_faction"].to_bool();
 
-	// Random factions always first.
-	if(lhs_rand && !rhs_rand) {
-		return false;
-	}
-
-	if(!lhs_rand && rhs_rand) {
-		return true;
-	}
+	if(lhs_rand && !rhs_rand) return false;
+	if(!lhs_rand && rhs_rand) return true;
 
 	return translation::compare((*lhs.cfg)["name"].str(), (*rhs.cfg)["name"].str()) > 0;
 }
@@ -186,7 +170,7 @@ void faction_select::pre_show()
 
 	list.select_row(flg_manager_.current_faction_index());
 	list.set_sorters([this](std::size_t i) { return faction_sorter{flg_manager_.choosable_factions()[i]}; });
-	list.set_active_sorter("sort_0", sort_order::type::ascending, true);
+	list.set_active_sorter("sort_0", flg_manager_.faction_sort_order(), true);
 
 	on_faction_select();
 }

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -29,10 +29,91 @@
 #include "preferences/preferences.hpp" // for encountered_units
 #include "units/types.hpp"
 
+#ifdef __cpp_impl_three_way_comparison
+#include <compare>
+#endif
 #include <functional>
 
 namespace gui2::dialogs
 {
+namespace
+{
+/** Wrapper type to allow custom sorting for faction names. */
+struct faction_sorter
+{
+	const config* cfg;
+};
+
+#ifdef __cpp_impl_three_way_comparison
+auto operator<=>(const faction_sorter& lhs, const faction_sorter& rhs)
+{
+	// Since some eras have multiple random options we can't just
+	// assume there is only one random faction on top of the list.
+	bool lhs_rand = (*lhs.cfg)["random_faction"].to_bool();
+	bool rhs_rand = (*rhs.cfg)["random_faction"].to_bool();
+
+	// Random factions always first.
+	if(lhs_rand && !rhs_rand) {
+		return std::strong_ordering::less;
+	}
+
+	if(!lhs_rand && rhs_rand) {
+		return std::strong_ordering::greater;
+	}
+
+	std::string lhs_name = (*lhs.cfg)["name"];
+	std::string rhs_name = (*rhs.cfg)["name"];
+
+	// TODO C++20: define three-way comparison for t_string?
+	auto cmp = translation::compare(lhs_name, rhs_name);
+	if(cmp < 0) return std::strong_ordering::less;
+	if(cmp > 0) return std::strong_ordering::greater;
+
+	return std::strong_ordering::equal;
+}
+
+#else // TODO: remove block below as soon as humanly possible
+
+bool operator<(const faction_sorter& lhs, const faction_sorter& rhs)
+{
+	// Since some eras have multiple random options we can't just
+	// assume there is only one random faction on top of the list.
+	bool lhs_rand = (*lhs.cfg)["random_faction"].to_bool();
+	bool rhs_rand = (*rhs.cfg)["random_faction"].to_bool();
+
+	// Random factions always first.
+	if(lhs_rand && !rhs_rand) {
+		return true;
+	}
+
+	if(!lhs_rand && rhs_rand) {
+		return false;
+	}
+
+	return translation::compare((*lhs.cfg)["name"].str(), (*rhs.cfg)["name"].str()) < 0;
+}
+
+bool operator>(const faction_sorter& lhs, const faction_sorter& rhs)
+{
+	// Since some eras have multiple random options we can't just
+	// assume there is only one random faction on top of the list.
+	bool lhs_rand = (*lhs.cfg)["random_faction"].to_bool();
+	bool rhs_rand = (*rhs.cfg)["random_faction"].to_bool();
+
+	// Random factions always first.
+	if(lhs_rand && !rhs_rand) {
+		return false;
+	}
+
+	if(!lhs_rand && rhs_rand) {
+		return true;
+	}
+
+	return translation::compare((*lhs.cfg)["name"].str(), (*rhs.cfg)["name"].str()) > 0;
+}
+#endif
+
+} // namespace
 
 REGISTER_DIALOG(faction_select)
 
@@ -104,6 +185,8 @@ void faction_select::pre_show()
 	}
 
 	list.select_row(flg_manager_.current_faction_index());
+	list.set_sorters([this](std::size_t i) { return faction_sorter{flg_manager_.choosable_factions()[i]}; });
+	list.set_active_sorter("sort_0", sort_order::type::ascending, true);
 
 	on_faction_select();
 }

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -172,7 +172,7 @@ void faction_select::pre_show()
 
 	list.select_row(flg_manager_.current_faction_index());
 	list.set_sorters([this](std::size_t i) { return faction_sorter{flg_manager_.choosable_factions()[i]}; });
-	list.set_active_sorter("sort_0", flg_manager_.get_era_info().faction_sort_order, true);
+	list.set_active_sorter("sort_0", flg_manager_.era_info().faction_sort_order, true);
 
 	on_faction_select();
 }

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -54,12 +54,8 @@ auto operator<=>(const faction_sorter& lhs, const faction_sorter& rhs)
 	bool lhs_rand = (*lhs.cfg)["random_faction"].to_bool();
 	bool rhs_rand = (*rhs.cfg)["random_faction"].to_bool();
 
-	// Random factions always first.
-	if(lhs_rand && !rhs_rand) {
-		return std::strong_ordering::less;
-	}
-
-	if(!lhs_rand && rhs_rand) {
+	// Group random factions together.
+	if(lhs_rand <=> rhs_rand != 0) {
 		return std::strong_ordering::greater;
 	}
 
@@ -97,6 +93,7 @@ bool operator>(const faction_sorter& lhs, const faction_sorter& rhs)
 
 	return translation::compare((*lhs.cfg)["name"].str(), (*rhs.cfg)["name"].str()) > 0;
 }
+
 #endif
 
 } // namespace

--- a/src/gui/dialogs/multiplayer/faction_select.cpp
+++ b/src/gui/dialogs/multiplayer/faction_select.cpp
@@ -172,7 +172,7 @@ void faction_select::pre_show()
 
 	list.select_row(flg_manager_.current_faction_index());
 	list.set_sorters([this](std::size_t i) { return faction_sorter{flg_manager_.choosable_factions()[i]}; });
-	list.set_active_sorter("sort_0", flg_manager_.faction_sort_order(), true);
+	list.set_active_sorter("sort_0", flg_manager_.get_era_info().faction_sort_order, true);
 
 	on_faction_select();
 }

--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -314,6 +314,7 @@ bool mp_join_game::show_flg_select(int side_num, bool first_time)
 		const saved_game_mode::type saved_game = saved_game_mode::get_enum(level_.mandatory_child("multiplayer")["savegame"].str()).value_or(saved_game_mode::type::no);
 
 		ng::flg_manager flg(era_factions, *side_choice, lock_settings, use_map_settings, saved_game == saved_game_mode::type::midgame);
+		flg.set_faction_sort_order(*era); // TODO: unify with flg construction
 
 		{
 			gui2::dialogs::faction_select flg_dialog(flg, color, side_num);

--- a/src/gui/dialogs/multiplayer/mp_join_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_join_game.cpp
@@ -313,8 +313,8 @@ bool mp_join_game::show_flg_select(int side_num, bool first_time)
 		const bool use_map_settings = level_.mandatory_child("multiplayer")["mp_use_map_settings"].to_bool();
 		const saved_game_mode::type saved_game = saved_game_mode::get_enum(level_.mandatory_child("multiplayer")["savegame"].str()).value_or(saved_game_mode::type::no);
 
-		ng::flg_manager flg(era_factions, *side_choice, lock_settings, use_map_settings, saved_game == saved_game_mode::type::midgame);
-		flg.set_faction_sort_order(*era); // TODO: unify with flg construction
+		const auto era_info = ng::era_metadata(*era);
+		ng::flg_manager flg(era_info, era_factions, *side_choice, lock_settings, use_map_settings, saved_game == saved_game_mode::type::midgame);
 
 		{
 			gui2::dialogs::faction_select flg_dialog(flg, color, side_num);

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -1378,11 +1378,12 @@ struct dialog_tester<faction_select>
 {
 	config era_cfg, side_cfg;
 	std::vector<const config*> eras;
+	ng::era_metadata era;
 	ng::flg_manager flg;
 	std::string color;
 	dialog_tester()
-		: era_cfg(), side_cfg(), eras(1, &era_cfg) // TODO: Add an actual era definition
-		, flg(eras, side_cfg, false, false, false)
+		: era_cfg(), side_cfg(), eras(1, &era_cfg), era(era_cfg) // TODO: Add an actual era definition
+		, flg(era, eras, side_cfg, false, false, false)
 		, color("teal")
 	{}
 	faction_select* create() {


### PR DESCRIPTION
Resolves #10338. Sorting is no longer done internally on the host, but is now a purely cosmetic operation for anyone selecting a faction. [era] auto_sort has been upgraded from a bool to now accept "none", "ascending", or "descending".