### PR TITLE
GUI/Events: Touch: double tap movement/single tap select

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
    * Updated translations: Ancient Greek, Arabic, Bengali, British English, Chinese (Simplified), Finnish, Hungarian
 ### Units
 ### User interface
+   * On touch devices, double tap no longer shows context menu. It can still be accessed via long press. Single tap selects the unit. Another single tap on a hex shows hover info, which was previously not available. Single tap select followed by double tap on a hex moves the unit. Dragging now indicates the path and defense.
 ### WML Engine
 ### Miscellaneous and Bug Fixes
 

--- a/data/core/hotkeys.cfg
+++ b/data/core/hotkeys.cfg
@@ -46,6 +46,13 @@
     # Which means "touch"
     mouse=255
 [/hotkey]
+[hotkey]
+    button=1
+    click=2
+    command="selectmoveaction"
+    # Which means "touch"
+    mouse=255
+[/hotkey]
 
 [hotkey]
     command=aiformula

--- a/data/schema/core/config.cfg
+++ b/data/schema/core/config.cfg
@@ -242,6 +242,7 @@
 	{SIMPLE_KEY key string}
 	{SIMPLE_KEY button string}
 	{SIMPLE_KEY mouse string}
+	{DEFAULT_KEY click int 1}
 	{DEFAULT_KEY ctrl bool no}
 	{DEFAULT_KEY alt bool no}
 	{DEFAULT_KEY cmd bool no}

--- a/src/controller_base.cpp
+++ b/src/controller_base.cpp
@@ -35,7 +35,6 @@ static lg::log_domain log_display("display");
 #define ERR_DP LOG_STREAM(err, log_display)
 
 using namespace std::chrono_literals;
-static const auto long_touch_duration = gui2::settings::popup_show_delay;
 
 controller_base::controller_base()
 	: game_config_(game_config_manager::get()->game_config())
@@ -178,12 +177,8 @@ void controller_base::handle_event(const SDL_Event& event)
 			int y = event.button.y;
 
 			if(long_touch_timer_ == 0) {
-				long_touch_timer_ = gui2::add_timer(long_touch_duration,
+				long_touch_timer_ = gui2::add_timer(gui2::settings::popup_show_delay,
 					std::bind(&controller_base::long_touch_callback, this, x, y));
-			}
-
-			if(event.button.clicks == 2) {
-				show_menu(get_display().get_theme().context_menu(), { x, y }, true);
 			}
 		}
 

--- a/src/hotkey/hotkey_command.cpp
+++ b/src/hotkey/hotkey_command.cpp
@@ -81,7 +81,7 @@ constexpr std::array<hotkey_command_temp, HOTKEY_NULL - 1> master_hotkey_list {{
 	{ HOTKEY_DESELECT_HEX, "deselecthex", N_("Deselect Hex"), false, scope_game, HKCAT_MAP, "" },
 	{ HOTKEY_MOVE_ACTION, "moveaction", N_("Move/Attack"), false, scope_game, HKCAT_UNITS, "" },
 	{ HOTKEY_SELECT_AND_ACTION, "selectmoveaction", N_("Select/Move/Attack"), false, scope_game, HKCAT_UNITS, "" },
-	{ HOTKEY_TOUCH_HEX, "touchhex", N_("Touch"), false, scope_game, HKCAT_UNITS, "" },
+	{ HOTKEY_TOUCH_HEX, "touchhex", N_("Touch Hex"), false, scope_game, HKCAT_UNITS, "" },
 	{ HOTKEY_ANIMATE_MAP, "animatemap", N_("Animate Map"), false, scope_game | scope_editor, HKCAT_MAP, "" },
 	{ HOTKEY_CYCLE_UNITS, "cycle", N_("Next Unit"), false, scope_game, HKCAT_UNITS, "" },
 	{ HOTKEY_CYCLE_BACK_UNITS, "cycleback", N_("Previous Unit"), false, scope_game, HKCAT_UNITS, "" },

--- a/src/hotkey/hotkey_item.hpp
+++ b/src/hotkey/hotkey_item.hpp
@@ -299,7 +299,7 @@ public:
 	/**
 	 * Initialise new instance of this class that has no button associated with is.
 	 */
-	hotkey_mouse() : hotkey_base(), button_ (0)
+	hotkey_mouse() : hotkey_base(), button_(0), clicks_(1)
 	{}
 
 	/**
@@ -311,13 +311,20 @@ public:
 		return button_ != 0;
 	}
 
-	/* new functionality for this class */
+	/** Sets the mouse button for this hotkey */
 	void set_button(int button)
 	{
 		button_ = button;
 	}
+
+	/** Sets the number of mouse clicks needed for this hotkey */
+	void set_clicks(int clicks)
+	{
+		clicks_ = clicks;
+	}
 protected:
 	int button_;
+	int clicks_;
 
 	virtual void save_helper(config& cfg) const;
 	virtual const std::string get_name_helper() const;

--- a/src/mouse_events.cpp
+++ b/src/mouse_events.cpp
@@ -1121,8 +1121,6 @@ void mouse_handler::touch_action(const map_location touched_hex, bool browse)
 
 	if (touched_hex.valid() && unit.valid() && !unit->get_hidden()) {
 		select_or_action(browse);
-	} else {
-		deselect_hex();
 	}
 }
 


### PR DESCRIPTION
Touch behavior changes:
* Double tap no longer shows context menu. It can still be accessed via long press.
* Single tap selects the unit. Another single tap on a hex shows hover info, which was previously not available.
* Single tap select followed by double tap on a hex moves the unit.
* Dragging now properly indicates the path and defense.

Also:
* mouse [hotkey]-s now support specifying the number of clicks.
* user visible mouse [hotkey] names (in Hotkey Preferences) are improved and will show number of clicks when >1. (i.e., left mouse instead of mouse 1)
* fixes long press delay accidentally being zero.