### PR TITLE
TSG/TDG: remove "miss" text from missed attacks

### DIFF
--- a/data/campaigns/The_Deceivers_Gambit/_main.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/_main.cfg
@@ -106,24 +106,6 @@
     {GLOBAL__SPELLCASTING_EVENTS}
     {GLOBAL__ANIMATIONS_RECRUIT}
     {EXPERIENCE_MODIFIER_GLOBAL}
-
-    # include floating "miss" text to help beginners, like in TSG
-    [event]
-        name=attacker misses
-        first_time_only=no
-        [floating_text]
-            x,y=$second_unit.x,$second_unit.y
-            text=_"<span size='x-small'>Miss</span>"
-        [/floating_text]
-    [/event]
-    [event]
-        name=defender misses
-        first_time_only=no
-        [floating_text]
-            x,y=$unit.x,$unit.y
-            text=_"<span size='x-small'>Miss</span>"
-        [/floating_text]
-    [/event]
 #endif
 #enddef
 

--- a/data/campaigns/The_South_Guard/utils/sg_help.cfg
+++ b/data/campaigns/The_South_Guard/utils/sg_help.cfg
@@ -111,32 +111,6 @@ in the next scenario, so don’t delay!"
     #                                                                  UNITS AND ATTACKS
     #######################################################################################################################################################
     #############################
-    # HIGHLIGHT MISSES
-    #############################
-    # when I first started Wesnoth, it wasn't always clear why my units wouldn't deal any damage
-    # I noticed this same pattern in a couple of new players who I had try out this campaign
-    # hopefully this indicator helps make it a little more clear what's happening
-    # (and hopefully this doesn't make other campaigns without this indicator confusing)
-    [event]
-        name=attacker misses
-        first_time_only=no
-        {FILTER_CONDITION( {VARIABLE_CONDITIONAL enable_tutorial_elements equals yes} )}
-        [floating_text]
-            x,y=$second_unit.x,$second_unit.y
-            text=_"<span size='x-small'>Miss</span>"
-        [/floating_text]
-    [/event]
-    [event]
-        name=defender misses
-        first_time_only=no
-        {FILTER_CONDITION( {VARIABLE_CONDITIONAL enable_tutorial_elements equals yes} )}
-        [floating_text]
-            x,y=$unit.x,$unit.y
-            text=_"<span size='x-small'>Miss</span>"
-        [/floating_text]
-    [/event]
-
-    #############################
     # HEALERS CAN'T HEAL THEMSELVES
     #############################
     [event]


### PR DESCRIPTION
Made redundant after https://github.com/wesnoth/wesnoth/commit/ece4c2e432982515f98a9e1065d2b6f0eed36fb7