### PR TITLE
GUI2/Textboxes: fix virtual keyboard not appearing

### DIFF
--- a/src/gui/widgets/multiline_text.cpp
+++ b/src/gui/widgets/multiline_text.cpp
@@ -415,7 +415,7 @@ void multiline_text::signal_handler_left_button_down(const event::ui_event event
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
 
-	get_window()->keyboard_capture(this);
+	get_window()->capture_and_show_keyboard(this);
 	get_window()->mouse_capture();
 
 	point mouse_pos = get_mouse_position();

--- a/src/gui/widgets/text_box.cpp
+++ b/src/gui/widgets/text_box.cpp
@@ -363,7 +363,7 @@ void text_box::signal_handler_left_button_down(const event::ui_event event,
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
 
-	get_window()->keyboard_capture(this);
+	get_window()->capture_and_show_keyboard(this);
 	get_window()->mouse_capture();
 
 	handle_mouse_selection(get_mouse_position(), true);

--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -301,13 +301,6 @@ void text_box_base::set_state(const state_t state)
 {
 	if(state != state_) {
 		state_ = state;
-#ifdef __ANDROID__
-		if (state_ == state_t::FOCUSED) {
-			SDL_StartTextInput();
-		} else {
-			SDL_StopTextInput();
-		}
-#endif
 		queue_redraw();
 	}
 }
@@ -694,14 +687,14 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 void text_box_base::signal_handler_receive_keyboard_focus(const event::ui_event event)
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
-
+	SDL_StartTextInput();
 	set_state(FOCUSED);
 }
 
 void text_box_base::signal_handler_lose_keyboard_focus(const event::ui_event event)
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
-
+	SDL_StopTextInput();
 	set_state(ENABLED);
 }
 
@@ -709,7 +702,7 @@ void text_box_base::signal_handler_mouse_enter(const event::ui_event event,
 											   bool& handled)
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
-
+	
 	if(state_ != FOCUSED) {
 		set_state(HOVERED);
 	}

--- a/src/gui/widgets/window.cpp
+++ b/src/gui/widgets/window.cpp
@@ -1204,7 +1204,12 @@ void window::keyboard_capture(widget* widget)
 #ifndef __ANDROID__
 	event_distributor_->keyboard_capture(widget);
 #endif
+}
 
+void window::capture_and_show_keyboard(widget* widget)
+{
+	assert(event_distributor_);
+	event_distributor_->keyboard_capture(widget);
 }
 
 void window::add_to_keyboard_chain(widget* widget)

--- a/src/gui/widgets/window.hpp
+++ b/src/gui/widgets/window.hpp
@@ -701,6 +701,7 @@ public:
 	// dispatcher. Chaining probably should remain exclusive to windows.
 	void mouse_capture(const bool capture = true);
 	void keyboard_capture(widget* widget);
+	void capture_and_show_keyboard(widget* widget);
 
 	/**
 	 * Adds the widget to the keyboard chain.


### PR DESCRIPTION
`window::keyboard_capture()` behavior is changed so that it is no-op for Android, but taping the textbox still works.