### PR TITLE
Add native toggle button support to WML menu items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 ### User interface
    * On touch devices, double tap no longer shows context menu. It can still be accessed via long press. Single tap selects the unit. Another single tap on a hex shows hover info, which was previously not available. Single tap select followed by double tap on a hex moves the unit. Dragging now indicates the path and defense.
 ### WML Engine
+   * Custom WML menu items now support an accompanying toggle button.
 ### Miscellaneous and Bug Fixes
 
 ## Version 1.19.13

--- a/src/game_events/menu_item.hpp
+++ b/src/game_events/menu_item.hpp
@@ -141,6 +141,16 @@ public:
 		return is_synced_;
 	}
 
+	bool is_toggle_item() const
+	{
+		return toggle_state_variable_.has_value();
+	}
+
+	std::string toggle_state_variable() const
+	{
+		return toggle_state_variable_.value();
+	}
+
 private:
 	/**
 	 * Updates *this based on @a vcfg.
@@ -163,6 +173,9 @@ private:
 
 	/** Controls the lifetime of the associate hotkey's hotkey_command. */
 	utils::optional<hotkey::wml_hotkey_record> hotkey_record_;
+
+	/** The name of WML variable which holds the menu item's toggle state. */
+	utils::optional<std::string> toggle_state_variable_;
 
 	/** The image to display in the menu next to this item's description. */
 	std::string image_;

--- a/src/game_events/wmi_manager.cpp
+++ b/src/game_events/wmi_manager.cpp
@@ -35,6 +35,26 @@ static lg::log_domain log_engine("engine");
 
 namespace game_events
 {
+namespace
+{
+/**
+ * If the given menu item is a toggle item, attempts to execute the given function on
+ * the item's toggle state variable. Invalid variable names are ignored.
+ */
+template<typename Func>
+void if_toggle_item(const wmi_manager::item_ptr& item, game_data& gamedata, Func func)
+{
+	if(item->is_toggle_item()) {
+		try {
+			func(gamedata.get_variable(item->toggle_state_variable()));
+		} catch(const invalid_variablename_exception&) {
+			// TODO: log a warning?
+		}
+	}
+}
+
+} // namespace
+
 wmi_manager::wmi_manager()
 	: wml_menu_items_()
 {
@@ -80,9 +100,7 @@ bool wmi_manager::fire_item(
 {
 	// Does this item exist?
 	item_ptr wmi = get_item(id);
-	if(!wmi) {
-		return false;
-	} else if(is_key_hold_repeat && !wmi->hotkey_repeat()) {
+	if(!wmi || (is_key_hold_repeat && !wmi->hotkey_repeat())) {
 		return false;
 	}
 
@@ -93,10 +111,15 @@ bool wmi_manager::fire_item(
 	gamedata.get_variable("y1") = hex.wml_y();
 	scoped_xy_unit highlighted_unit("unit", hex, units);
 
+	// Update toggle variable, if applicable, before running the event
+	if_toggle_item(wmi, gamedata, [](auto& state) { state = !state.to_bool(); });
+
 	// Can this item be shown?
 	if(wmi->can_show(hex, gamedata, fc)) {
 		wmi->fire_event(hex, gamedata);
 	}
+
+	// Restore old values
 	gamedata.get_variable("x1") = x1;
 	gamedata.get_variable("y1") = y1;
 	return true;
@@ -141,6 +164,9 @@ void wmi_manager::get_items(const map_location& hex,
 		// Allows variables to be substituted at invocation time
 		auto description = utils::interpolate_variables_into_string(item->menu_text(), gamedata);
 		items.emplace_back("id", item->hotkey_id(), "label", description, "icon", item->image());
+
+		// Write checkbox key separately; even an empty value manifests a toggle button.
+		if_toggle_item(item, gamedata, [&](auto& state) { items.back()["checkbox"] = state.to_bool(); });
 	}
 
 	// Restore old values


### PR DESCRIPTION
The TSG "enable tutorial hints" menu is implemented as two separate menu buttons, each displayed when the other is not. Given my recent context menu handling work, it's pretty simple to add native support for displaying a toggle button along with a custom WML menu item.

Currently, this adds a new [toggle] tag to [set_menu_item] with a solitary `state_variable` key. The variable specified here is read from to determine the toggle button's current state and flipped when "executing" the menu item's commands. While this works, it feels somewhat limiting and precludes more complex conditions. Do I want this key to hold the state itself, and leave state management to the player? What about exposing additional drop down menu functionality?

I'd like some feedback on the design. Pinging Dalas since his usecase inspired this.
<img width="318" height="106" alt="image" src="https://github.com/user-attachments/assets/8a1d61aa-ace4-4caf-bfab-6b4863ed08fe" />
