### PR TITLE
Swift trait added

### DIFF
--- a/data/core/macros/traits.cfg
+++ b/data/core/macros/traits.cfg
@@ -129,6 +129,7 @@ Elemental units generally have elemental as their only trait. Since elemental un
     # Units with trait Strong get a +1 increment in hitpoints and melee damage.
     [trait]
         id=strong
+        exclude_traits=swift
         male_name= _ "strong"
         female_name= _ "female^strong"
         help_text= _ "<italic>text='Strong'</italic> units do 1 more damage for every successful strike in melee combat, and have 1 additional hitpoint." + _ "
@@ -371,6 +372,28 @@ Dim is a trait all too common in goblins and other lesser species. There are rea
             apply_to=attack
             range=melee
             increase_damage=-1
+        [/effect]
+    [/trait]
+#enddef
+
+#define TRAIT_SWIFT
+    # Units with trait Swift get a +1 increment in melee Strikes but do 1 damage less.
+    # This trait is meant to be for light units: elves, saurians, & outlaw Humans. It can also be used for fencer line, or even other human lines. 
+    # But it is over powered for Drakes, orcs, Dwarves, Heavy Infantry line, and cavalry; these should be excluded
+    # the trait is never used for now.
+    [trait]
+        id=swift
+        exclude_traits=strong
+        male_name= _ "swift"
+        female_name= _ "female^swift"
+        help_text= _ "<italic>text='swift'</italic> units do 1 more strike in melee combat, but do 1 less damage." + _ "
+
+While useful for any close-combat unit, swift is most effective for units who have a low number of swings such as the orc fighter. when only one strike is a killing blow, Swift units can be very useful & reliable to ensure the kill."
+        [effect]
+            apply_to=attack
+            range=melee
+            increase_damage=-1
+            increase_attacks=1
         [/effect]
     [/trait]
 #enddef


### PR DESCRIPTION
Added Swift Trait. It might be useful for some campaigns or scenarios.

trait is still unused.

Here is the description:
    # Units with trait Swift get a +1 increment in melee Strikes but do 1 less damage..
    # This trait is meant to be for light units: elves,  saurians, & outlaw humans. Can also be used for fencer line, or even other human lines. 
    # But it is over powered for Drakes, orcs, Dwarves, Heavy Infantry line, and cavalry; these should be excluded
    # the trait is never used, for now.