### PR TITLE
Fix command line and some keyboard shortcuts no longer work

### DIFF
--- a/src/gui/widgets/text_box_base.cpp
+++ b/src/gui/widgets/text_box_base.cpp
@@ -687,14 +687,18 @@ void text_box_base::signal_handler_sdl_key_down(const event::ui_event event,
 void text_box_base::signal_handler_receive_keyboard_focus(const event::ui_event event)
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
+#ifdef __ANDROID__
 	SDL_StartTextInput();
+#endif
 	set_state(FOCUSED);
 }
 
 void text_box_base::signal_handler_lose_keyboard_focus(const event::ui_event event)
 {
 	DBG_GUI_E << LOG_HEADER << ' ' << event << ".";
+#ifdef __ANDROID__
 	SDL_StopTextInput();
+#endif
 	set_state(ENABLED);
 }
 


### PR DESCRIPTION
~~This reverts commit e503658256fa4ab07d9a7fbbc5bb2cb353638585.~~

Fixes https://github.com/wesnoth/wesnoth/issues/10361 issue by adding `ifdef` guard around `SDL_Start/StopTextInput()` introduced in e503658256fa4ab07d9a7fbbc5bb2cb353638585.