### PR TITLE
Fix halo and hides display bug in abilities

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -199,11 +199,11 @@ int find_direction(const map_location& loc, const map_location& from_loc, std::s
 }
 
 /**
- * This function return true if units checked are the same, or own same id like in case of moves.
+ * This function return true if locations checked are the same, or if units have same id.
  */
 bool same_unit(const unit& u, const unit& unit)
 {
-	return (&u == &unit || u.id() == unit.id());
+	return (u.get_location() == unit.get_location() || u.id() == unit.id());
 }
 
 }

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -198,6 +198,14 @@ int find_direction(const map_location& loc, const map_location& from_loc, std::s
 	return 0;
 }
 
+/**
+ * This function return true if units checked are the same, or own same id like in case of moves.
+ */
+bool same_unit(const unit& u, const unit& unit)
+{
+	return (&u == &unit || u.id() == unit.id());
+}
+
 }
 
 bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc) const
@@ -220,7 +228,7 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 	// different from the central unit, that the ability is of the right type, detailed verification of each ability),
 	// if so return true.
 	for(const unit& u : units) {
-		if(!u.has_ability_distant() || u.incapacitated() || &u == this || !u.affect_distant(tag_name)) {
+		if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *this) || !u.affect_distant(tag_name)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -262,7 +270,7 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 	// different from the central unit, that the ability is of the right type, detailed verification of each ability),
 	// If so, add to unit_ability_list.
 	for(const unit& u : units) {
-		if(!u.has_ability_distant() || u.incapacitated() || &u == this || !u.affect_distant(tag_name)) {
+		if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *this) || !u.affect_distant(tag_name)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -476,7 +484,7 @@ static bool ability_active_adjacent_helper(const unit& self, bool illuminates, c
 		for(const unit& u : units) {
 			const map_location& from_loc = u.get_location();
 			std::size_t distance = distance_between(from_loc, loc);
-			if(&u == &self || distance > radius || !ufilt(u, self)) {
+			if(same_unit(u, self) || distance > radius || !ufilt(u, self)) {
 				continue;
 			}
 			int dir = 0;
@@ -645,7 +653,7 @@ std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_t
 	const unit_map& units = get_unit_map();
 
 	for(const unit& u : units) {
-		if(!u.has_ability_distant_image() || u.incapacitated() || &u == this) {
+		if(!u.has_ability_distant_image() || u.incapacitated() || same_unit(u, *this)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -941,7 +949,7 @@ std::vector<std::pair<t_string, t_string>> attack_type::abilities_special_toolti
 		}
 	}
 	for(const unit& u : get_unit_map()) {
-		if(!u.has_ability_distant() || u.incapacitated() || &u == self_.get()) {
+		if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *self_)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -1113,7 +1121,7 @@ void attack_type::weapon_specials_impl_adj(
 	const unit_map& units = get_unit_map();
 	if(self){
 		for(const unit& u : units) {
-			if(!u.has_ability_distant() || u.incapacitated() || &u == self.get()) {
+			if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *self)) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();
@@ -1785,7 +1793,7 @@ bool attack_type::has_special_or_ability(const std::string& special) const
 		}
 
 		for(const unit& u : units) {
-			if(!u.affect_distant(special) || u.incapacitated() || &u == self_.get()) {
+			if(!u.affect_distant(special) || u.incapacitated() || same_unit(u, *self_)) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();
@@ -1810,7 +1818,7 @@ bool attack_type::has_special_or_ability(const std::string& special) const
 		}
 
 		for(const unit& u : units) {
-			if(!u.affect_distant(special) || u.incapacitated() || &u == other_.get()) {
+			if(!u.affect_distant(special) || u.incapacitated() || same_unit(u, *other_)) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();
@@ -1890,7 +1898,7 @@ bool attack_type::has_filter_special_or_ability(const config& filter, bool simpl
 			}
 		}
 		for(const unit& u : units) {
-			if(!u.has_ability_distant() || u.incapacitated() || &u == self_.get()) {
+			if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *self_)) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();
@@ -1916,7 +1924,7 @@ bool attack_type::has_filter_special_or_ability(const config& filter, bool simpl
 		}
 
 		for(const unit& u : units) {
-			if(!u.has_ability_distant() || u.incapacitated() || &u == other_.get()) {
+			if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *other_)) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();
@@ -2179,7 +2187,7 @@ bool attack_type::has_special_or_ability_with_filter(const config & filter) cons
 		}
 		if(check_adjacent) {
 			for(const unit& u : units) {
-				if(!u.has_ability_distant() || u.incapacitated() || &u == self_.get()) {
+				if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *self_)) {
 					continue;
 				}
 				const map_location& from_loc = u.get_location();
@@ -2207,7 +2215,7 @@ bool attack_type::has_special_or_ability_with_filter(const config & filter) cons
 
 		if(check_adjacent) {
 			for(const unit& u : units) {
-				if(!u.has_ability_distant() || u.incapacitated() || &u == other_.get()) {
+				if(!u.has_ability_distant() || u.incapacitated() || same_unit(u, *other_)) {
 					continue;
 				}
 				const map_location& from_loc = u.get_location();

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -94,7 +94,7 @@ unit_const_ptr unit_filter::first_match_on_map() const {
 namespace {
 bool same_unit(const unit& u, const unit& unit)
 {
-	return (&u == &unit || u.id() == unit.id());
+	return (u.get_location() == unit.get_location() || u.id() == unit.id());
 }
 }
 

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -92,6 +92,13 @@ unit_const_ptr unit_filter::first_match_on_map() const {
 }
 
 namespace {
+bool same_unit(const unit& u, const unit& unit)
+{
+	return (&u == &unit || u.id() == unit.id());
+}
+}
+
+namespace {
 
 struct unit_filter_xy : public unit_filter_base
 {
@@ -137,7 +144,7 @@ struct unit_filter_adjacent : public unit_filter_base
 		for(const unit& u : units) {
 			const map_location& from_loc = u.get_location();
 			std::size_t distance = distance_between(from_loc, args.loc);
-			if(&u == &args.u || distance > radius || !child_.matches(unit_filter_args{u, from_loc, &args.u, args.fc, args.use_flat_tod} )) {
+			if(same_unit(u, args.u) || distance > radius || !child_.matches(unit_filter_args{u, from_loc, &args.u, args.fc, args.use_flat_tod} )) {
 				continue;
 			}
 			int dir = 0;
@@ -420,7 +427,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 				}
 
 				for(const unit& unit : units) {
-					if(!unit.has_ability_distant() || unit.incapacitated() || &unit == args.u.shared_from_this().get()) {
+					if(!unit.has_ability_distant() || unit.incapacitated() || same_unit(unit, args.u)) {
 						continue;
 					}
 					const map_location& from_loc = unit.get_location();
@@ -805,7 +812,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 
 						if(c.get_parsed_config()["affect_adjacent"].to_bool(true)) {
 							for(const unit& unit : units) {
-								if(!unit.has_ability_distant() || unit.incapacitated() || &unit == args.u.shared_from_this().get()) {
+								if(!unit.has_ability_distant() || unit.incapacitated() || same_unit(unit, args.u)) {
 									continue;
 								}
 								const map_location& from_loc = unit.get_location();


### PR DESCRIPTION
Fix https://github.com/wesnoth/wesnoth/issues/10364 issue

When a unit with the halo_image attribute [affect_adjacent] but with affect_self=no moves, it is likely to be illuminated by this halo, as it finds itself next to a temporary unit that is almost identical except for its location. This requires slightly complicating the verification with id if a simple comparison of unit is not sufficient.

same for [filter_adjacent] and [filter], if a unit with hides ability is invisible only when another unit of same race is adjacent, when unitmoves, it is 'hidden' because' adjacent to itself.