### PR TITLE
Menu Events: rework recruit validation

### DIFF
--- a/src/actions/create.cpp
+++ b/src/actions/create.cpp
@@ -57,7 +57,7 @@ static lg::log_domain log_engine("engine");
 
 namespace actions {
 
-const std::set<std::string> get_recruits(int side, const map_location &recruit_loc)
+std::set<std::string> get_recruits(int side, const map_location &recruit_loc)
 {
 	const team & current_team = resources::gameboard->get_team(side);
 

--- a/src/actions/create.hpp
+++ b/src/actions/create.hpp
@@ -129,7 +129,7 @@ std::string find_recall_location(const int side, map_location& recall_location, 
  * @param recruit_location the hex field being part of the castle the player wants to recruit on or from.
  * @return a set of units that can be recruited either by the leader on @a recruit_location or by leaders on keeps connected by castle tiles to @a recruit_location.
  */
-const std::set<std::string> get_recruits(int side, const map_location &recruit_location);
+std::set<std::string> get_recruits(int side, const map_location &recruit_location);
 
 /**
  * Gets the recallable units for a side, restricted by that side's leaders' personal abilities to recall on or from a specific hex field.

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -266,43 +266,46 @@ void menu_handler::recruit(int side_num, const map_location& last_hex)
 {
 	std::map<const unit_type*, t_string> err_msgs_map;
 	std::vector<const unit_type*> recruit_list;
-	std::set<std::string> recruits = actions::get_recruits(side_num, last_hex);
 	std::vector<t_string> unknown_units;
+
+	// Required for purse checks
 	team& current_team = board().get_team(side_num);
+	const int reserved_gold = unit_helper::planned_gold_spent(side_num);
 
-	int selected = -1, i = 0;
+	std::size_t selected_index = -1, i = 0;
 
-	for(const auto& recruit : recruits) {
+	for(const auto& recruit : actions::get_recruits(side_num, last_hex)) {
 		const unit_type* type = unit_types.find(recruit);
-		if(!type) {
+
+		if(type) {
+			recruit_list.push_back(type);
+		} else {
 			ERR_NG << "could not find unit '" << recruit << "'";
 			unknown_units.emplace_back(recruit);
 			continue;
 		}
 
-		map_location ignored;
-		map_location recruit_hex = last_hex;
-		t_string err_msg = unit_helper::recruit_message(type->id(), recruit_hex, ignored, current_team);
-		if (!err_msg.empty()) {
-			err_msgs_map[type] = err_msg;
+		// Empty if validation passes
+		err_msgs_map[type] = unit_helper::check_recruit_purse(type->cost(), current_team.gold(), reserved_gold);
+
+		// Save index of last selected item
+		if(type->id() == last_recruit) {
+			selected_index = i;
 		}
-		recruit_list.push_back(type);
-		if (type->id() == last_recruit) {
-			selected = i;
-		}
+
 		i++;
 	}
 
 	if(!unknown_units.empty()) {
-		auto unknown_ids = utils::format_conjunct_list("", unknown_units);
 		// TRANSLATORS: An error that should never happen, might happen when loading an old savegame. If there are
 		// any units that the player can recruit then their standard recruitment dialog will be shown after this
 		// error message, otherwise they'll get the "You have no units available to recruit." error after this one.
-		const auto message = VNGETTEXT("Error: there’s an unknown unit type on your recruit list: $unknown_ids",
+		gui2::show_transient_message("", VNGETTEXT(
+			"Error: there’s an unknown unit type on your recruit list: $unknown_ids",
 			"Error: there are several unknown unit types on your recruit list: $unknown_ids",
 			unknown_units.size(),
-			utils::string_map { { "unknown_ids", unknown_ids }});
-		gui2::show_transient_message("", message);
+			{{ "unknown_ids", utils::format_conjunct_list("", unknown_units) }}
+		));
 	}
 
 	if(recruit_list.empty()) {
@@ -310,48 +313,58 @@ void menu_handler::recruit(int side_num, const map_location& last_hex)
 		return;
 	}
 
-	const auto& dlg = units_dialog::build_recruit_dialog(recruit_list, err_msgs_map, current_team);
-	dlg->set_selected_index(selected);
+	auto dlg = units_dialog::build_recruit_dialog(recruit_list, err_msgs_map, current_team);
+	dlg->set_selected_index(selected_index);
 	dlg->show();
-	const auto& type = recruit_list[dlg->get_selected_index()];
+
+	const unit_type* type = recruit_list[dlg->get_selected_index()];
 	last_recruit = type->id();
 
-	if((dlg->get_retval() == gui2::retval::OK) && dlg->is_selected()) {
-		map_location recruit_hex = last_hex;
-		do_recruit(type->id(), side_num, recruit_hex);
+	if(dlg->get_retval() == gui2::retval::OK && dlg->is_selected()) {
+		do_recruit(type->id(), side_num, last_hex);
 	}
 }
 
 void menu_handler::repeat_recruit(int side_num, const map_location& last_hex)
 {
-	const std::string& last_recruit = board().get_team(side_num).last_recruit();
-	if(!last_recruit.empty()) {
-		map_location recruit_hex = last_hex;
-		do_recruit(last_recruit, side_num, recruit_hex);
+	team& recruiter = board().get_team(side_num);
+	const std::string& last_recruit = recruiter.last_recruit();
+	if(last_recruit.empty()) return;
+
+	std::string error = unit_helper::check_recruit_purse(
+		unit_types.find(last_recruit)->cost(), recruiter.gold(), unit_helper::planned_gold_spent(side_num));
+
+	if(error.empty()) {
+		do_recruit(last_recruit, side_num, last_hex);
+	} else {
+		gui2::show_transient_message("", error);
 	}
 }
 
-bool menu_handler::do_recruit(const std::string& name, int side_num, map_location& loc)
+bool menu_handler::do_recruit(const std::string& type, int side_num, const map_location& target_hex)
 {
-	map_location recruited_from = map_location::null_location();
-	team& current_team = board().get_team(side_num);
-	const auto& res = unit_helper::recruit_message(name, loc, recruited_from, current_team);
+	if(auto wb = pc_.get_whiteboard()) {
+		if(wb->save_recruit(type, side_num, target_hex)) {
+			return false;
+		}
+	}
 
-	if(res.empty() && (!pc_.get_whiteboard() || !pc_.get_whiteboard()->save_recruit(name, side_num, loc))) {
-		// MP_COUNTDOWN grant time bonus for recruiting
-		current_team.set_action_bonus_count(1 + current_team.action_bonus_count());
-		current_team.last_recruit(name);
+	team& recruiter = board().get_team(side_num);
+	const events::command_disabler disable_commands;
+	const auto [err, dst, src] = unit_helper::validate_recruit_target(type, side_num, target_hex);
 
-		// Do the recruiting.
-		synced_context::run_and_throw("recruit", replay_helper::get_recruit(name, loc, recruited_from));
-		return true;
-	} else if(res.empty()) {
-		return false;
-	} else {
-		gui2::show_transient_message("", res);
+	if(!err.empty()) {
+		gui2::show_transient_message("", err);
 		return false;
 	}
 
+	// MP_COUNTDOWN grant time bonus for recruiting
+	recruiter.set_action_bonus_count(1 + recruiter.action_bonus_count());
+	recruiter.last_recruit(type);
+
+	// Do the recruiting.
+	synced_context::run_and_throw("recruit", replay_helper::get_recruit(type, dst, src));
+	return true;
 }
 
 void menu_handler::recall(int side_num, const map_location& last_hex)

--- a/src/menu_events.hpp
+++ b/src/menu_events.hpp
@@ -114,7 +114,7 @@ public:
 			mouse_handler& mousehandler);
 
 	/** @return Whether or not the recruit was successful */
-	bool do_recruit(const std::string& name, int side_num, map_location& target_hex);
+	bool do_recruit(const std::string& type, int side_num, const map_location& target_hex);
 	bool do_speak();
 	void do_search(const std::string& new_search);
 	void do_command(const std::string& str);

--- a/src/units/helper.cpp
+++ b/src/units/helper.cpp
@@ -164,55 +164,36 @@ std::string format_movement_string(const int moves_left, const int moves_max, bo
 	}
 }
 
-// TODO: Return multiple strings here, in case more than one error applies? For
-// example, if you start AOI S5 with 0GP and recruit a Mage, two reasons apply,
-// leader not on keep (extrarecruit=Mage) and not enough gold.
-t_string recruit_message(
-	const std::string& type_id,
-	map_location& target_hex,
-	map_location& recruited_from,
-	const team& current_team)
+int planned_gold_spent(int side_num)
 {
-	const unit_type* u_type = unit_types.find(type_id);
-	if(u_type == nullptr) {
-		return _("Internal error. Please report this as a bug! Details:\n")
-			+ "unit_helper::recruit_message: u_type == nullptr for " + type_id;
-	}
+	wb::future_map future; // FIXME: why not future_map_if_active?
+	auto wb = resources::controller->get_whiteboard();
+	return wb ? wb->get_spent_gold_for(side_num) : 0;
+}
 
-	// search for the unit to be recruited in recruits
-	if(!utils::contains(actions::get_recruits(current_team.side(), target_hex), type_id)) {
-		return VGETTEXT("You cannot recruit a $unit_type_name at this time.",
-				utils::string_map{{ "unit_type_name", u_type->type_name() }});
-	}
-
-	// TODO take a wb::future_map RAII as units_dialog does
-	int wb_gold = 0;
-	{
-		wb::future_map future;
-		wb_gold = (resources::controller->get_whiteboard()
-			? resources::controller->get_whiteboard()->get_spent_gold_for(current_team.side())
-			: 0);
-	}
-	if(u_type->cost() > current_team.gold() - wb_gold)
-	{
-		if(wb_gold > 0)
+std::string check_recruit_purse(int unit_cost, int current_purse, int investments)
+{
+	if(unit_cost > (current_purse - investments)) {
+		return investments > 0
 			// TRANSLATORS: "plan" refers to Planning Mode
-			return _("At this point in your plan, you will not have enough gold to recruit this unit.");
-		else
-			return _("You do not have enough gold to recruit this unit.");
-	}
-
-	const events::command_disabler disable_commands;
-
-	{
-		wb::future_map_if_active future; /* start planned unit map scope if in planning mode */
-		std::string msg = actions::find_recruit_location(current_team.side(), target_hex, recruited_from, type_id);
-		if(!msg.empty()) {
-			return msg;
+			? _("At this point in your plan, you will not have enough gold to recruit this unit.")
+			: _("You do not have enough gold to recruit this unit.");
 		}
-	} // end planned unit map scope
 
-	return {};
+	return "";
 }
 
+std::tuple<std::string, map_location, map_location> validate_recruit_target(
+	const std::string& type, int side_number, const map_location& target_hex)
+{
+	// start planned unit map scope if in planning mode
+	wb::future_map_if_active future;
+
+	map_location recruit_to = target_hex;
+	map_location recruit_from; // Populated below
+
+	std::string msg = actions::find_recruit_location(side_number, recruit_to, recruit_from, type);
+	return std::tuple(msg, recruit_to, recruit_from);
 }
+
+} // unit_helper

--- a/src/units/helper.hpp
+++ b/src/units/helper.hpp
@@ -101,11 +101,21 @@ std::string format_level_string(const int level, bool recallable);
  */
 std::string format_movement_string(const int moves_left, const int moves_max, const bool active = true);
 
-/** @return If the recruit is possible, an empty optional and set @a recruited_from;
-	otherwise, return an error message string describing the reason. */
-t_string recruit_message(
-	const std::string& type_id,
-	map_location& target_hex,
-	map_location& recruited_from,
-	const team& current_team);
-}
+/** @returns the amount of gold tied up in the given side's planned actions. */
+int planned_gold_spent(int side_num);
+
+/** @returns an error message if the given unit cost is unaffordable. */
+std::string check_recruit_purse(int unit_cost, int current_purse, int investments);
+
+/**
+ * Verifies that @a target_hex is a valid recruit location for the given side.
+ *
+ * @returns a tuple consisting of
+ * - any applicable error message
+ * - the valid recruit target hex
+ * - the valid recruit source hex
+ */
+std::tuple<std::string, map_location, map_location> validate_recruit_target(
+	const std::string& type, int side_number, const map_location& target_hex);
+
+} // namespace unit_helper


### PR DESCRIPTION
This splits `unit_helper::recruit_message` into several smaller functions. Previously, both `recruit` and `do_recruit` ran all validation checks, which was unnecessary (we know we have a valid unit type in `do_recruit`, for instance, or that it's a valid recruit).

Error handling is now done in two stages:
- `recruit` and `repeat_recruit` handle the pre-action checks. Can we afford the unit, is it a valid type, etc.
- `do_recruit` assumes we have a valid type and now checks the requested recruit location.

The interface is much simpler now. We avoid calculating whiteboard gold for every unit checked in `recruit`, and get rid of the mutable references being passed around everywhere which necessitated unnecessary copies and made it very unclear what was modifying what (it also meant the error message function had side effects!)

We now have:
- `planned_gold_spent`: gives our "whiteboard gold". Splitting this off avoids recalculating it for every recruit checked
- `check_recruit_purse`: performs the actual "have enough gold" check. I'll add a version for recall separately.
- `validate_recruit_target`: This is now handled in `do_recruit`. We know we have a valid type that we can afford, now let's check locations. The mutable location references have been removed. This function returns a tuple with any error message regarding the target hex, the valid target, and the valid source.

Also moves the `command_disabler` to `do_recruit`. I *think* this is the right place for it, given the context of the recall function.