### PR TITLE
SotBE: Add AMLAs for Orcish, Wolf, Troll and Saurian units.

### DIFF
--- a/changelog_entries/sotbe_amla.md
+++ b/changelog_entries/sotbe_amla.md
@@ -1,5 +1,5 @@
 ### Campaigns
    * Son of the Black Eye
-     * Player units now have access to customized AMLA.
+     * Units now have access to customized AMLA.
      * Units granted AMLA: Orcish Sovereign, Great Troll, Orcish Warlord, Orcish Slurbow, Direwolf Rider, Goblin Pillager, Troll Warrior, Troll Rocklobber, Orcish Nightblade, Saurian Flanker, Saurian Javelineer, Saurian Seer, Saurian Prophet
      * Please note that the AMLAs are only active inside the campaign.

--- a/changelog_entries/sotbe_amla.md
+++ b/changelog_entries/sotbe_amla.md
@@ -1,0 +1,5 @@
+### Campaigns
+   * Son of the Black Eye
+     * Player units now have access to customized AMLA.
+     * Units granted AMLA: Orcish Sovereign, Great Troll, Orcish Warlord, Orcish Slurbow, Direwolf Rider, Goblin Pillager, Troll Warrior, Troll Rocklobber, Orcish Nightblade, Saurian Flanker, Saurian Javelineer, Saurian Seer, Saurian Prophet
+     * Please note that the AMLAs are only active inside the campaign.

--- a/data/campaigns/Son_Of_The_Black_Eye/_main.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/_main.cfg
@@ -74,6 +74,10 @@
     [/about]
 
     {ENABLE_SAURIAN_SPEARTHROWER}
+
+    [load_resource]
+        id=sotbe_resource_amla_system
+    [/load_resource]
 [/campaign]
 
 #ifdef CAMPAIGN_SON_OF_THE_BLACK_EYE

--- a/data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/utils/1-amla.cfg
@@ -1,0 +1,339 @@
+#textdomain wesnoth-sotbe
+
+# --------------------------------
+# Common AMLA defines here
+# --------------------------------
+
+#define SOTBE_AMLA_EFFECTS_HEAL
+    [effect]
+        apply_to=hitpoints
+        heal_full=yes
+    [/effect]
+    [effect]
+        apply_to=status
+        remove=poisoned
+    [/effect]
+    [effect]
+        apply_to=status
+        remove=slowed
+    [/effect]
+#enddef
+
+#define SOTBE_AMLA_HP_BOOST
+    [advancement]
+        id=wol_amla_hitpoints
+        description= _ "Endurance: +8 HP (Hitpoints)"
+
+        strict_amla=yes
+        major_amla=yes
+        max_times=100
+        image="icons/amla-default.png"
+
+        [effect]
+            apply_to=hitpoints
+            increase_total=8
+        [/effect]
+
+        {SOTBE_AMLA_EFFECTS_HEAL}
+    [/advancement]
+#enddef
+
+#define SOTBE_AMLA_GENERIC_DAMAGE _ATTACK_FILTER _ATTACK_NAME_STR _DAMAGE_NUM _ATTACK_NAME_DESC_STR _ICON_IMG_STR
+    [advancement]
+        id=sotbe_amla_damage{_DAMAGE_NUM}_{_ATTACK_NAME_STR}
+        description={_ATTACK_NAME_DESC_STR}
+
+        strict_amla=yes
+        major_amla=yes
+        max_times=100
+        image={_ICON_IMG_STR}
+
+        [effect]
+            apply_to=attack
+            {_ATTACK_FILTER}
+            increase_damage={_DAMAGE_NUM}
+        [/effect]
+
+        {SOTBE_AMLA_EFFECTS_HEAL}
+    [/advancement]
+#enddef
+
+# Orcish Warlord
+#define SOTBE_AMLA_SET_ORCISH_WARLORD
+    [modify_unit_type]
+        type="Orcish Warlord"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=greatsword
+            range=melee
+        ) (greatsword) (1) (_"Melee: greatsword +1 damage") ("attacks/greatsword-orcish.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=bow
+            range=ranged
+        ) (bow) (1) (_"Ranged: bow +1 damage") ("attacks/bow-orcish.png")}
+    [/modify_unit_type]
+#enddef
+
+# Orcish Slurbow
+#define SOTBE_AMLA_SET_ORCISH_SLURBOW
+    [modify_unit_type]
+        type="Orcish Slurbow"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=short sword
+            range=melee
+            type=blade
+        ) ("short_sword") (1) (_"Melee: short sword +1 damage") ("attacks/sword-orcish.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=crossbow
+            type=pierce
+            range=ranged
+        ) ("crossbow") (1) (_"Ranged: crossbow (pierce) +1 damage") ("attacks/crossbow-orcish.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=crossbow
+            type=fire
+            range=ranged
+        ) ("crossbow") (2) (_"Ranged: crossbow (fire) +2 damage") ("attacks/crossbow-orcish.png")}
+    [/modify_unit_type]
+#enddef
+
+# Direwolf Rider
+#define SOTBE_AMLA_SET_DIREWOLF_RIDER
+    [modify_unit_type]
+        type="Direwolf Rider"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=fangs
+            range=melee
+        ) ("fangs") (1) (_"Melee: fangs +1 damage") ("attacks/fangs-animal.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=claws
+            range=melee
+        ) ("claws") (1) (_"Melee: claws +1 damage") ("attacks/claws-animal.png")}
+    [/modify_unit_type]
+#enddef
+
+# Goblin Pillager
+#define SOTBE_AMLA_SET_GOBLIN_PILLAGER
+    [modify_unit_type]
+        type="Goblin Pillager"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=fangs
+            range=melee
+        ) ("fangs") (1) (_"Melee: fangs +1 damage") ("attacks/fangs-animal.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=torch
+            range=melee
+        ) ("torch") (1) (_"Melee: torch +1 damage") ("attacks/torch.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=net
+            range=ranged
+        ) ("net") (1) (_"Ranged: net +1 damage") ("attacks/net.png")}
+    [/modify_unit_type]
+#enddef
+
+# Troll Warrior
+#define SOTBE_AMLA_SET_TROLL_WARRIOR
+    [modify_unit_type]
+        type="Troll Warrior"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=hammer
+            range=melee
+        ) ("hammer") (2) (_"Melee: hammer +2 damage") ("attacks/hammer-troll.png")}
+    [/modify_unit_type]
+#enddef
+
+# Troll Rocklobber
+#define SOTBE_AMLA_SET_TROLL_ROCKLOBBER
+    [modify_unit_type]
+        type="Troll Rocklobber"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=fist
+            range=melee
+        ) ("fist") (2) (_"Melee: fist +2 damage") ("attacks/fist-troll.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=sling
+            range=ranged
+        ) ("sling") (4) (_"Melee: sling +4 damage") ("attacks/sling.png")}
+    [/modify_unit_type]
+#enddef
+
+# Great Troll
+#define SOTBE_AMLA_SET_GREAT_TROLL
+    [modify_unit_type]
+        type="Great Troll"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=hammer
+            range=melee
+        ) ("hammer") (1) (_"Melee: hammer +1 damage") ("attacks/hammer-troll.png")}
+    [/modify_unit_type]
+#enddef
+
+# Orcish Sovereign
+#define SOTBE_AMLA_SET_ORCISH_SOVEREIGN
+    [modify_unit_type]
+        type="Orcish Sovereign"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=greatsword
+            range=melee
+        ) (greatsword) (1) (_"Melee: greatsword +1 damage") ("attacks/greatsword-orcish.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=crossbow
+            range=ranged
+        ) (crossbow) (1) (_"Ranged: crossbow +1 damage") ("attacks/crossbow-orcish.png")}
+    [/modify_unit_type]
+#enddef
+
+# Orcish Nightblade
+#define SOTBE_AMLA_SET_ORCISH_NIGHTBLADE
+    [modify_unit_type]
+        type="Orcish Nightblade"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=blade
+            type=blade
+            range=melee
+        ) ("blade") (2) (_"Melee: blade +2 damage") ("attacks/dagger-orcish.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=kick
+            type=impact
+            range=melee
+        ) ("kick") (2) (_"Melee: kick +2 damage") ("attacks/foot-boot.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=throwing knives
+            range=ranged
+        ) ("throwing-knives") (1) (_"Ranged: throwing knives +1 damage") ("attacks/dagger-thrown-poison-orcish.png")}
+    [/modify_unit_type]
+#enddef
+
+# Saurian Flanker
+#define SOTBE_AMLA_SET_SAURIAN_FLANKER
+    [modify_unit_type]
+        type="Saurian Flanker"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=spear
+            range=melee
+        ) ("spear") (1) (_"Melee: +1 spear damage") ("attacks/spear.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=spear
+            range=ranged
+        ) ("spear") (1) (_"Ranged: +1 spear damage") ("attacks/spear-thrown.png")}
+    [/modify_unit_type]
+#enddef
+
+# Saurian Javelineer
+#define SOTBE_AMLA_SET_SAURIAN_JAVELINEER
+    [modify_unit_type]
+        type="Saurian Javelineer"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=spear
+            range=melee
+        ) ("spear") (1) (_"Melee: +1 spear damage") ("attacks/spear.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=spear
+            range=ranged
+        ) ("spear") (1) (_"Ranged: +1 spear damage") ("attacks/spear-thrown.png")}
+    [/modify_unit_type]
+#enddef
+
+# Saurian Prophet
+#define SOTBE_AMLA_SET_SAURIAN_PROPHET
+    [modify_unit_type]
+        type="Saurian Prophet"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=staff
+            range=melee
+        ) ("staff") (1) (_"Melee: staff +1 damage") ("attacks/staff-magic.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=curse
+            range=ranged
+        ) ("curse") (1) (_"Ranged: curse +1 damage") ("attacks/curse.png")}
+    [/modify_unit_type]
+#enddef
+
+# Saurian Seer
+#define SOTBE_AMLA_SET_SAURIAN_SEER
+    [modify_unit_type]
+        type="Saurian Seer"
+
+        {SOTBE_AMLA_HP_BOOST}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=staff
+            range=melee
+        ) ("staff") (1) (_"Melee: staff +1 damage") ("attacks/staff-magic.png")}
+
+        {SOTBE_AMLA_GENERIC_DAMAGE (
+            name=curse
+            range=ranged
+        ) ("curse") (1) (_"Ranged: curse +1 damage") ("attacks/curse.png")}
+    [/modify_unit_type]
+#enddef
+
+# define resource here
+[resource]
+    id=sotbe_resource_amla_system
+
+    {SOTBE_AMLA_SET_ORCISH_SOVEREIGN}
+    {SOTBE_AMLA_SET_GREAT_TROLL}
+
+    {SOTBE_AMLA_SET_ORCISH_WARLORD}
+    {SOTBE_AMLA_SET_ORCISH_SLURBOW}
+    {SOTBE_AMLA_SET_ORCISH_NIGHTBLADE}
+
+    {SOTBE_AMLA_SET_TROLL_WARRIOR}
+    {SOTBE_AMLA_SET_TROLL_ROCKLOBBER}
+
+    {SOTBE_AMLA_SET_DIREWOLF_RIDER}
+    {SOTBE_AMLA_SET_GOBLIN_PILLAGER}
+
+    {SOTBE_AMLA_SET_SAURIAN_FLANKER}
+    {SOTBE_AMLA_SET_SAURIAN_JAVELINEER}
+    {SOTBE_AMLA_SET_SAURIAN_PROPHET}
+    {SOTBE_AMLA_SET_SAURIAN_SEER}
+[/resource]


### PR DESCRIPTION
- SotBE: Add AMLAs for Orcish, Wolf, Troll and Saurian units.
- AMLAs tailored and fine-tuned in line with those in TSG, TDG, and EI.
- Each AMLA costs 120-150 XP for a level 3 unit, and 80-100 XP for a level 2 unit. 120 and 80 if unit has intelligent.
- On testing, it has been seen that most player units can earn at most one AMLA or 2 AMLA if heavily recalled and used in scenarios. 
- Hero units like Kapou'e and Gruu have a chance of earning a 3rd AMLA as they always available in every scenario.