### PR TITLE
New Overwatch Ability

### DIFF
--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -413,3 +413,147 @@ Enemy units cannot see this unit while it is in swamp, except if they have units
         special_note={INTERNAL:SPECIAL_NOTES_FEEDING}
     [/dummy]
 #enddef
+
+#define ABILITY_OVERWATCH SLOWED POISONED
+    [dummy]
+        id = overwatch
+        name = _"overwatch"
+        description= _ "Unit with this ability attacks enemy unit that enters hex next to this unit using ranged attack once per turn."
+        [filter_self]
+            formula = "(self.wml_vars.overwatch_used != 1)"
+        [/filter_self]
+        {ABILITY_OVERWATCH_EVENTS {SLOWED} {POISONED}}
+    [/dummy]
+#enddef
+
+#define ABILITY_OVERWATCH_EVENTS SLOWED POISONED
+    # currently supports only slowed and poisoned statuses because of harm_unit limitations.
+    [event]
+        name = enter hex
+
+        id = overwatch
+        first_time_only = no
+
+        [filter]
+            [filter_adjacent]
+                ability_id_active = overwatch
+                is_enemy = yes
+            [/filter_adjacent]
+        [/filter]
+
+        [store_unit]
+            [filter]
+                [filter_adjacent]
+                    find_in = unit
+                    is_enemy = yes
+                [/filter_adjacent]
+                [and]
+                    [filter_ability]
+                        id = overwatch
+                        active = yes
+                    [/filter_ability]
+                [/and]
+            [/filter]
+            variable = overwatch_hitting_units
+        [/store_unit]
+
+        [foreach]
+            array = overwatch_hitting_units
+            variable = overwatch_hitting_unit
+            [do]
+                [foreach]
+                    array = overwatch_hitting_unit.attack
+                    [do]
+                        [if]
+                            [variable]
+                                name = this_item.range
+                                equals = ranged
+                            [/variable]
+                            [then]
+                                [set_variables]
+                                    name = overwatch_attack
+                                    mode = replace
+                                    to_variable = this_item
+                                [/set_variables]
+                                [break]
+                                [/break]
+                            [/then]
+                        [/if]
+                    [/do]
+                [/foreach]
+                [repeat]
+                    times = $overwatch_attack.number
+                    [do]
+                        [set_variable]
+                            name = overwatch_hit_roll
+                            rand = 1..100
+                        [/set_variable]
+                        [store_unit_defense_on]
+                            find_in = unit
+                            variable = overwatch_miss_chance
+                        [/store_unit_defense_on]
+                        [if]
+                            [variable]
+                                name = overwatch_hit_roll
+                                greater_than = $overwatch_miss_chance
+                            [/variable]
+                            [then]
+                                [harm_unit]
+                                    [filter]
+                                        find_in = unit
+                                    [/filter]
+                                    [filter_second]
+                                        find_in = overwatch_hitting_unit
+                                    [/filter_second]
+                                    amount = $overwatch_attack.damage
+                                    damage_type = $overwatch_attack.type
+                                    alignment = $overwatch_hitting_unit.alignment
+                                    kill = yes
+                                    experience = kill
+                                    fire_event = yes
+                                    slowed = {SLOWED}
+                                    poisoned = {POISONED}
+                                    animate = yes
+                                    [primary_attack]
+                                        name = $overwatch_attack.name
+                                    [/primary_attack]
+                                [/harm_unit]
+                            [/then]
+                            [else]
+                                # this is here entierly for visual clarity (and bug testing).
+                                [harm_unit]
+                                    [filter]
+                                        find_in = unit
+                                    [/filter]
+                                    [filter_second]
+                                        find_in = overwatch_hitting_unit
+                                    [/filter_second]
+                                    amount = 0
+                                    kill = yes
+                                    experience = no
+                                    fire_event = yes
+                                    animate = yes
+                                    [primary_attack]
+                                        name = $overwatch_attack.name
+                                    [/primary_attack]
+                                [/harm_unit]
+                            [/else]
+                        [/if]
+                    [/do]
+                [/repeat]
+                [modify_unit]
+                    [filter]
+                        find_in = overwatch_hitting_unit
+                    [/filter]
+
+                    [set_variable]
+                        name = overwatch_used
+                        value = 1
+                    [/set_variable]
+                [/modify_unit]
+            [/do]
+        [/foreach]
+
+        {CLEAR_VARIABLE overwatch_hit_units,overwatch_miss_chance,overwatch_hit_roll,overwatch_used}
+    [/event]
+#enddef


### PR DESCRIPTION
New ability for future use in Dunefolk faction and very likely in UtBS campaign. 

This is still quiet prototype but working ability, with some choices still to be made, currently it simply filters for a ranged weapon and takes its stats. Alternate solution might involve creating a dummy weapon special just for this ability that would allow for deliberate selection of attack used and improve visibility. However it would also clutter the game a bit with a special that basically serves as an advanced filter. So neither of the two solutions is imo perfect. 

Additionally the ability currently uses additional `harm_unit ` as animation trigger for some extra visibility for players to know better if the ability triggered and was disabled or not, which might not necessarily be a perfect solution in this case. 

Finally, no other core ability is actually written fully in WML (I think) and this is, right now it is all in one file but splitting events of it into another file seems like something that should be done, but right now this is mostly for code review anyway.