### PR TITLE
Add util for container lookup with projections

### DIFF
--- a/src/about.cpp
+++ b/src/about.cpp
@@ -20,6 +20,7 @@
 #include "game_config_view.hpp"
 #include "gettext.hpp"
 #include "serialization/string_utils.hpp"
+#include "utils/general.hpp"
 
 #include <map>
 
@@ -98,8 +99,7 @@ const credits_data& get_credits_data()
 
 utils::optional<credits_data::const_iterator> get_campaign_credits(const std::string& campaign)
 {
-	const credits_data::const_iterator res = std::find_if(parsed_credits_data.begin(), parsed_credits_data.end(),
-		[&campaign](const credits_group& group) { return group.id == campaign; });
+	const auto res = utils::ranges::find(parsed_credits_data, campaign, &credits_group::id);
 	return res != parsed_credits_data.end() ? utils::make_optional(res) : utils::nullopt;
 }
 

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -99,7 +99,7 @@ const credits_data& get_credits_data()
 
 utils::optional<credits_data::const_iterator> get_campaign_credits(const std::string& campaign)
 {
-	const auto res = utils::ranges::find(parsed_credits_data, campaign, &credits_group::id);
+	const auto res = utils::ranges::find(get_credits_data(), campaign, &credits_group::id);
 	return res != parsed_credits_data.end() ? utils::make_optional(res) : utils::nullopt;
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -782,17 +782,11 @@ optional_config config::find_child(config_key_type key, const std::string& name,
 	const child_map::iterator i = children_.find(key);
 	if(i == children_.end()) {
 		DBG_CF << "Key ‘" << name << "’ value ‘" << value << "’ pair not found as child of key ‘" << key << "’.";
-
-
 		return utils::nullopt;
 	}
 
-	const child_list::iterator j = std::find_if(i->second.begin(), i->second.end(),
-		[&](const std::unique_ptr<config>& pcfg) {
-			const config& cfg = *pcfg;
-			return cfg[name] == value;
-		}
-	);
+	const child_list::iterator j = utils::ranges::find(i->second, value,
+		[&](const std::unique_ptr<config>& pcfg) { return (*pcfg)[name]; });
 
 	if(j != i->second.end()) {
 		return **j;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -118,7 +118,8 @@ static int get_zoom_levels_index(unsigned int zoom_level)
 void display::add_overlay(const map_location& loc, overlay&& ov)
 {
 	std::vector<overlay>& overlays = get_overlays()[loc];
-	auto pos = utils::ranges::find(overlays, ov.z_order, &overlay::z_order);
+	auto pos = std::find_if(overlays.begin(), overlays.end(),
+		[new_order = ov.z_order](const overlay& existing) { return existing.z_order > new_order; });
 
 	auto inserted = overlays.emplace(pos, std::move(ov));
 	if(const std::string& halo = inserted->halo; !halo.empty()) {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -118,8 +118,7 @@ static int get_zoom_levels_index(unsigned int zoom_level)
 void display::add_overlay(const map_location& loc, overlay&& ov)
 {
 	std::vector<overlay>& overlays = get_overlays()[loc];
-	auto pos = std::find_if(overlays.begin(), overlays.end(),
-		[new_order = ov.z_order](const overlay& existing) { return existing.z_order > new_order; });
+	auto pos = utils::ranges::find(overlays, ov.z_order, &overlay::z_order);
 
 	auto inserted = overlays.emplace(pos, std::move(ov));
 	if(const std::string& halo = inserted->halo; !halo.empty()) {

--- a/src/formula/function_gamestate.cpp
+++ b/src/formula/function_gamestate.cpp
@@ -159,7 +159,7 @@ DEFINE_WFL_FUNCTION(defense_on, 2, 2)
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
 		auto iter = utils::ranges::find(tdata->map(), id,
-			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
+			[](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -207,7 +207,7 @@ DEFINE_WFL_FUNCTION(chance_to_hit, 2, 2)
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
 		auto iter = utils::ranges::find(tdata->map(), id,
-			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
+			[](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -255,7 +255,7 @@ DEFINE_WFL_FUNCTION(movement_cost, 2, 2)
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
 		auto iter = utils::ranges::find(tdata->map(), id,
-			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
+			[](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -303,7 +303,7 @@ DEFINE_WFL_FUNCTION(vision_cost, 2, 2)
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
 		auto iter = utils::ranges::find(tdata->map(), id,
-			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
+			[](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -351,7 +351,7 @@ DEFINE_WFL_FUNCTION(jamming_cost, 2, 2)
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
 		auto iter = utils::ranges::find(tdata->map(), id,
-			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
+			[](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}

--- a/src/formula/function_gamestate.cpp
+++ b/src/formula/function_gamestate.cpp
@@ -158,9 +158,8 @@ DEFINE_WFL_FUNCTION(defense_on, 2, 2)
 		ter = t_translation::read_terrain_code(loc_var.as_string());
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
-		auto iter = std::find_if(tdata->map().begin(), tdata->map().end(), [id](const std::pair<t_translation::terrain_code, terrain_type>& p) {
-			return id == p.second.id();
-		});
+		auto iter = utils::ranges::find(tdata->map(), id,
+			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -207,9 +206,8 @@ DEFINE_WFL_FUNCTION(chance_to_hit, 2, 2)
 		ter = t_translation::read_terrain_code(loc_var.as_string());
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
-		auto iter = std::find_if(tdata->map().begin(), tdata->map().end(), [id](const std::pair<t_translation::terrain_code, terrain_type>& p) {
-			return id == p.second.id();
-		});
+		auto iter = utils::ranges::find(tdata->map(), id,
+			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -256,9 +254,8 @@ DEFINE_WFL_FUNCTION(movement_cost, 2, 2)
 		ter = t_translation::read_terrain_code(loc_var.as_string());
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
-		auto iter = std::find_if(tdata->map().begin(), tdata->map().end(), [id](const std::pair<t_translation::terrain_code, terrain_type>& p) {
-			return id == p.second.id();
-		});
+		auto iter = utils::ranges::find(tdata->map(), id,
+			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -305,9 +302,8 @@ DEFINE_WFL_FUNCTION(vision_cost, 2, 2)
 		ter = t_translation::read_terrain_code(loc_var.as_string());
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
-		auto iter = std::find_if(tdata->map().begin(), tdata->map().end(), [id](const std::pair<t_translation::terrain_code, terrain_type>& p) {
-			return id == p.second.id();
-		});
+		auto iter = utils::ranges::find(tdata->map(), id,
+			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}
@@ -354,9 +350,8 @@ DEFINE_WFL_FUNCTION(jamming_cost, 2, 2)
 		ter = t_translation::read_terrain_code(loc_var.as_string());
 	} else if(auto tc = loc_var.try_convert<terrain_callable>()) {
 		const std::string id = tc->get_value("id").as_string();
-		auto iter = std::find_if(tdata->map().begin(), tdata->map().end(), [id](const std::pair<t_translation::terrain_code, terrain_type>& p) {
-			return id == p.second.id();
-		});
+		auto iter = utils::ranges::find(tdata->map(), id,
+			[id](const std::pair<t_translation::terrain_code, terrain_type>& p) { return p.second.id(); });
 		if(iter == tdata->map().end()) {
 			return variant();
 		}

--- a/src/game_initialization/flg_manager.cpp
+++ b/src/game_initialization/flg_manager.cpp
@@ -435,10 +435,8 @@ void flg_manager::update_choosable_genders()
 void flg_manager::select_default_faction()
 {
 	const std::string& default_faction = original_faction_;
-	auto default_faction_it = std::find_if(choosable_factions_.begin(), choosable_factions_.end(),
-		[&default_faction](const config* faction) {
-			return (*faction)["id"] == default_faction;
-		});
+	auto default_faction_it = utils::ranges::find(choosable_factions_, default_faction,
+		[](const config* faction) { return (*faction)["id"]; });
 
 	if(default_faction_it != choosable_factions_.end()) {
 		set_current_faction(std::distance(choosable_factions_.begin(), default_faction_it));

--- a/src/game_initialization/singleplayer.cpp
+++ b/src/game_initialization/singleplayer.cpp
@@ -82,9 +82,8 @@ bool select_campaign(saved_game& state, jump_to_campaign_info jump_to_campaign)
 			// if we should quit the game or return to the main menu
 
 			// Checking for valid campaign name
-			const auto campaign = std::find_if(campaigns.begin(), campaigns.end(), [&jump_to_campaign](const ng::create_engine::level_ptr& level) {
-				return level->data()["id"] == jump_to_campaign.campaign_id;
-			});
+			const auto campaign = utils::ranges::find(campaigns, jump_to_campaign.campaign_id,
+				[](const ng::create_engine::level_ptr& level) { return level->data()["id"]; });
 
 			// Didn't find a campaign with that id
 			if(campaign == campaigns.end()) {

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -469,8 +469,7 @@ void addon_manager::pre_show()
 		const sort_order::type saved_order_direction = prefs::get().addon_manager_saved_order_direction();
 
 		if(!saved_order_name.empty()) {
-			auto order_it = std::find_if(all_orders_.begin(), all_orders_.end(),
-				[&saved_order_name](const addon_order& order) {return order.as_preference == saved_order_name;});
+			auto order_it = utils::ranges::find(all_orders_, saved_order_name, &addon_order::as_preference);
 			if(order_it != all_orders_.end()) {
 				int index = 2 * (std::distance(all_orders_.begin(), order_it));
 				addon_list::addon_sort_func func;
@@ -655,11 +654,8 @@ boost::dynamic_bitset<> addon_manager::get_name_filter_visibility() const
 
 	for(const auto& a : addons_)
 	{
-		const config& addon_cfg = *std::find_if(addon_cfgs.begin(), addon_cfgs.end(),
-			[&a](const config& cfg)
-		{
-			return cfg["name"] == a.first;
-		});
+		const config& addon_cfg = *utils::ranges::find(addon_cfgs, a.first,
+			[](const config& cfg) { return cfg["name"]; });
 
 		res.push_back(filter(addon_cfg));
 	}
@@ -734,11 +730,8 @@ boost::dynamic_bitset<> addon_manager::get_type_filter_visibility() const
 
 		for(const auto& a : addons_) {
 			int index = std::distance(type_filter_types_.begin(),
-				std::find_if(type_filter_types_.begin(), type_filter_types_.end(),
-					[&a](const std::pair<ADDON_TYPE, std::string>& entry) {
-						return entry.first == a.second.type;
-					})
-				);
+				utils::ranges::find(type_filter_types_, a.second.type,
+					[](const std::pair<ADDON_TYPE, std::string>& entry) { return entry.first; }));
 			res.push_back(toggle_states[index]);
 		}
 		return res;
@@ -824,8 +817,7 @@ void addon_manager::order_addons()
 void addon_manager::on_order_changed(unsigned int sort_column, sort_order::type order)
 {
 	menu_button& order_menu = find_widget<menu_button>("order_dropdown");
-	auto order_it = std::find_if(all_orders_.begin(), all_orders_.end(),
-		[sort_column](const addon_order& order) {return order.column_index == static_cast<int>(sort_column);});
+	auto order_it = utils::ranges::find(all_orders_, static_cast<int>(sort_column), &addon_order::column_index);
 	int index = 2 * (std::distance(all_orders_.begin(), order_it));
 	if(order == sort_order::type::descending) {
 		++index;

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -537,8 +537,7 @@ void mp_create_game::sync_with_depcheck()
 			selected_game_index_ = new_level_index;
 
 			auto iter = utils::ranges::find(level_types_, new_level_type, &level_type_info::first);
-			auto& game_types_list = find_widget<menu_button>("game_types");
-			game_types_list.set_value(std::distance(level_types_.begin(), iter));
+			find_widget<menu_button>("game_types").set_value(std::distance(level_types_.begin(), iter));
 
 			if(different_type) {
 				display_games_of_type(new_level_type, create_engine_.current_level().id());

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -281,9 +281,8 @@ void mp_create_game::pre_show()
 
 	// Helper to make sure the initially selected level type is valid
 	auto get_initial_type_index = [this]()->int {
-		const auto index = std::find_if(level_types_.begin(), level_types_.end(), [](level_type_info& info) {
-			return info.first == *level_type::get_enum(prefs::get().mp_level_type());
-		});
+		const auto index = utils::ranges::find(level_types_,
+			level_type::get_enum(prefs::get().mp_level_type()).value(), &level_type_info::first);
 
 		if(index != level_types_.end()) {
 			return std::distance(level_types_.begin(), index);
@@ -537,13 +536,7 @@ void mp_create_game::sync_with_depcheck()
 			create_engine_.set_current_level(new_level_index);
 			selected_game_index_ = new_level_index;
 
-#ifdef __cpp_lib_ranges
-			auto iter = std::ranges::find(level_types_, new_level_type, &level_type_info::first);
-#else
-			auto iter = std::find_if(level_types_.begin(), level_types_.end(),
-				[type = new_level_type](const level_type_info& info) { return info.first == type; });
-#endif
-
+			auto iter = utils::ranges::find(level_types_, new_level_type, &level_type_info::first);
 			auto& game_types_list = find_widget<menu_button>("game_types");
 			game_types_list.set_value(std::distance(level_types_.begin(), iter));
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -393,10 +393,7 @@ void title_screen::update_static_labels()
 		const auto& boost_name = boost::algorithm::erase_first_copy(locale.name(), ".UTF-8");
 		const auto& langs = get_languages(true);
 
-		auto lang_def = std::find_if(langs.begin(), langs.end(), [&](language_def const& lang) {
-			return lang.localename == boost_name;
-		});
-
+		auto lang_def = utils::ranges::find(langs, boost_name, &language_def::localename);
 		if(lang_def != langs.end()) {
 			lang_button->set_label(lang_def->language.str());
 		} else if(boost_name == "c" || boost_name == "C") {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -155,8 +155,8 @@ void switch_theme(const std::string& theme_id)
 	if(theme_id.empty() || theme_id == "default") {
 		current_gui = default_gui;
 	} else {
-		current_gui = std::find_if(guis.begin(), guis.end(),
-			[&](const auto& theme) { return theme.first == theme_id; });
+		current_gui = utils::ranges::find(guis, theme_id,
+			[&](const auto& theme) { return theme.first; });
 
 		if(current_gui == guis.end()) {
 			ERR_GUI_P << "Missing [gui] definition for '" << theme_id << "'";

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -332,9 +332,7 @@ void addon_list::select_addon(const std::string& id)
 {
 	listbox& list = get_listbox();
 
-	auto iter = std::find_if(addon_vector_.begin(), addon_vector_.end(),
-		[&id](const addon_info* a) { return a->id == id; }
-	);
+	auto iter = utils::ranges::find(addon_vector_, id, &addon_info::id);
 
 	// Corner case: if you publish an addon with an out-of-folder .pbl file and
 	// delete it locally before deleting it from the server, the game will try

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -454,9 +454,8 @@ lobby_chat_window* chatbox::find_or_create_window(const std::string& name,
 
 void chatbox::close_window_button_callback(std::string room_name, bool& handled, bool& halt)
 {
-	const int index = std::distance(open_windows_.begin(), std::find_if(open_windows_.begin(), open_windows_.end(),
-		[&room_name](const lobby_chat_window& room) { return room.name == room_name; }
-	));
+	const int index = std::distance(open_windows_.begin(),
+		utils::ranges::find(open_windows_, room_name, &lobby_chat_window::name));
 
 	close_window(index);
 

--- a/src/gui/widgets/chatbox.cpp
+++ b/src/gui/widgets/chatbox.cpp
@@ -452,12 +452,10 @@ lobby_chat_window* chatbox::find_or_create_window(const std::string& name,
 	return &open_windows_.back();
 }
 
-void chatbox::close_window_button_callback(std::string room_name, bool& handled, bool& halt)
+void chatbox::close_window_button_callback(const std::string& room_name, bool& handled, bool& halt)
 {
-	const int index = std::distance(open_windows_.begin(),
-		utils::ranges::find(open_windows_, room_name, &lobby_chat_window::name));
-
-	close_window(index);
+	close_window(std::distance(open_windows_.begin(),
+		utils::ranges::find(open_windows_, room_name, &lobby_chat_window::name)));
 
 	handled = halt = true;
 }

--- a/src/gui/widgets/chatbox.hpp
+++ b/src/gui/widgets/chatbox.hpp
@@ -227,7 +227,7 @@ public:
 	 */
 	lobby_chat_window* find_or_create_window(const std::string& name, const bool whisper, const bool open_new, const bool allow_close, const std::string& initial_text);
 
-	void close_window_button_callback(std::string room_name, bool& handled, bool& halt);
+	void close_window_button_callback(const std::string& room_name, bool& handled, bool& halt);
 
 	void process_message(const ::config& data, bool whisper = false);
 

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -65,8 +65,7 @@ std::pair<std::shared_ptr<tree_view_node>, int> tree_view::remove_node(tree_view
 	const point node_size = node->get_size();
 
 	tree_view_node::node_children_vector& siblings = node->parent_node_->children_;
-
-	auto node_itor = std::find_if(siblings.begin(), siblings.end(), [node](const auto& c) { return c.get() == node; });
+	auto node_itor = utils::ranges::find(siblings, node, [node](const auto& c) { return c.get(); });
 
 	assert(node_itor != siblings.end());
 

--- a/src/gui/widgets/tree_view.cpp
+++ b/src/gui/widgets/tree_view.cpp
@@ -65,8 +65,8 @@ std::pair<std::shared_ptr<tree_view_node>, int> tree_view::remove_node(tree_view
 	const point node_size = node->get_size();
 
 	tree_view_node::node_children_vector& siblings = node->parent_node_->children_;
-	auto node_itor = utils::ranges::find(siblings, node, [node](const auto& c) { return c.get(); });
 
+	auto node_itor = utils::ranges::find(siblings, node, [](const auto& c) { return c.get(); });
 	assert(node_itor != siblings.end());
 
 	auto old_node = std::move(*node_itor);

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -180,7 +180,7 @@ public:
 	auto get_node_definition(const std::string& id) const
 	{
 		const auto def = utils::ranges::find(node_definitions_, id, &node_definition::id);
-		return def != node_definitions_.end() ? utils::optional(def) : utils::nullopt;
+		return def != node_definitions_.end() ? utils::make_optional(def) : utils::nullopt;
 	}
 
 private:

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -177,7 +177,7 @@ public:
 	static const std::string& type();
 
 	/** Optionally returns the node definition with the given id, or nullopt if not found. */
-	auto get_node_definition(const std::string& id) const
+	utils::optional<decltype(node_definitions_)::const_iterator> get_node_definition(const std::string& id) const
 	{
 		const auto def = utils::ranges::find(node_definitions_, id, &node_definition::id);
 		return def != node_definitions_.end() ? utils::make_optional(def) : utils::nullopt;

--- a/src/gui/widgets/tree_view.hpp
+++ b/src/gui/widgets/tree_view.hpp
@@ -177,11 +177,10 @@ public:
 	static const std::string& type();
 
 	/** Optionally returns the node definition with the given id, or nullopt if not found. */
-	utils::optional<decltype(node_definitions_)::const_iterator> get_node_definition(const std::string& id) const
+	auto get_node_definition(const std::string& id) const
 	{
-		const auto def = std::find_if(
-			node_definitions_.begin(), node_definitions_.end(), [&id](const auto& d) { return d.id == id; });
-		return def != node_definitions_.end() ? utils::make_optional(def) : utils::nullopt;
+		const auto def = utils::ranges::find(node_definitions_, id, &node_definition::id);
+		return def != node_definitions_.end() ? utils::optional(def) : utils::nullopt;
 	}
 
 private:

--- a/src/menu_events.cpp
+++ b/src/menu_events.cpp
@@ -1644,21 +1644,6 @@ void console_handler::do_theme()
 	prefs::get().show_theme_dialog();
 }
 
-struct save_id_matches
-{
-	save_id_matches(const std::string& save_id)
-		: save_id_(save_id)
-	{
-	}
-
-	bool operator()(const team& t) const
-	{
-		return t.save_id() == save_id_;
-	}
-
-	std::string save_id_;
-};
-
 void console_handler::do_control()
 {
 	// :control <side> <nick>
@@ -1678,7 +1663,7 @@ void console_handler::do_control()
 		side_num = lexical_cast<unsigned int>(side);
 	} catch(const bad_lexical_cast&) {
 		const auto& teams = menu_handler_.pc_.get_teams();
-		const auto it_t = std::find_if(teams.begin(), teams.end(), save_id_matches(side));
+		const auto it_t = utils::ranges::find(teams, side, &team::save_id);
 
 		if(it_t == teams.end()) {
 			utils::string_map symbols;

--- a/src/recall_list_manager.cpp
+++ b/src/recall_list_manager.cpp
@@ -22,14 +22,12 @@
 #include <string>
 #include <vector>
 
-
 /**
  * Used to find units in vectors by their ID.
  */
 unit_ptr recall_list_manager::find_if_matches_id(const std::string &unit_id)
 {
-	std::vector<unit_ptr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[&unit_id](const unit_ptr & ptr) { return ptr->id() == unit_id; });
+	auto it = utils::ranges::find(recall_list_, unit_id, &unit::id);
 	if (it != recall_list_.end()) {
 		return *it;
 	} else {
@@ -42,8 +40,7 @@ unit_ptr recall_list_manager::find_if_matches_id(const std::string &unit_id)
  */
 unit_const_ptr recall_list_manager::find_if_matches_id(const std::string &unit_id) const
 {
-	std::vector<unit_ptr >::const_iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[&unit_id](const unit_ptr & ptr) { return ptr->id() == unit_id; });
+	auto it = utils::ranges::find(recall_list_, unit_id, &unit::id);
 	if (it != recall_list_.end()) {
 		return *it;
 	} else {
@@ -73,16 +70,13 @@ void recall_list_manager::add(const unit_ptr & ptr, int pos)
 
 std::size_t recall_list_manager::find_index(const std::string & unit_id) const
 {
-	std::vector<unit_ptr >::const_iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[&unit_id](const unit_ptr & ptr) { return ptr->id() == unit_id; });
-
+	auto it = utils::ranges::find(recall_list_, unit_id, &unit::id);
 	return std::distance(recall_list_.begin(), it);
 }
 
 unit_ptr recall_list_manager::extract_if_matches_id(const std::string &unit_id, int * pos)
 {
-	std::vector<unit_ptr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[&unit_id](const unit_ptr & ptr) { return ptr->id() == unit_id; });
+	auto it = utils::ranges::find(recall_list_, unit_id, &unit::id);
 	if (it != recall_list_.end()) {
 		unit_ptr ret = *it;
 		if(pos) {
@@ -97,8 +91,7 @@ unit_ptr recall_list_manager::extract_if_matches_id(const std::string &unit_id, 
 
 unit_ptr recall_list_manager::find_if_matches_underlying_id(std::size_t uid)
 {
-	std::vector<unit_ptr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[uid](const unit_ptr & ptr) { return ptr->underlying_id() == uid; });
+	auto it = utils::ranges::find(recall_list_, uid, &unit::underlying_id);
 	if (it != recall_list_.end()) {
 		return *it;
 	} else {
@@ -108,8 +101,7 @@ unit_ptr recall_list_manager::find_if_matches_underlying_id(std::size_t uid)
 
 unit_const_ptr recall_list_manager::find_if_matches_underlying_id(std::size_t uid) const
 {
-	std::vector<unit_ptr >::const_iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[uid](const unit_ptr & ptr) { return ptr->underlying_id() == uid; });
+	auto it = utils::ranges::find(recall_list_, uid, &unit::underlying_id);
 	if (it != recall_list_.end()) {
 		return *it;
 	} else {
@@ -124,8 +116,7 @@ void recall_list_manager::erase_by_underlying_id(std::size_t uid)
 
 unit_ptr recall_list_manager::extract_if_matches_underlying_id(std::size_t uid)
 {
-	std::vector<unit_ptr >::iterator it = std::find_if(recall_list_.begin(), recall_list_.end(),
-		[uid](const unit_ptr & ptr) { return ptr->underlying_id() == uid; });
+	auto it = utils::ranges::find(recall_list_, uid, &unit::underlying_id);
 	if (it != recall_list_.end()) {
 		unit_ptr ret = *it;
 		recall_list_.erase(it);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -108,6 +108,7 @@
 #include "units/map.hpp"                // for unit_map, etc
 #include "units/ptr.hpp"                // for unit_const_ptr, unit_ptr
 #include "units/types.hpp"              // for unit_type_data, unit_types, etc
+#include "utils/general.hpp"
 #include "utils/scope_exit.hpp"
 #include "variable.hpp"                 // for vconfig, etc
 #include "variable_info.hpp"
@@ -1004,9 +1005,7 @@ SCHEDULE_GETTER("time_of_day", std::string) {
 
 SCHEDULE_SETTER("time_of_day", std::string) {
 	const auto& times = sched.area_index < 0 ? sched.tod_man().times() : sched.tod_man().times(sched.area_index);
-	auto iter = std::find_if(times.begin(), times.end(), [&value](const time_of_day& tod) {
-		return tod.id == value;
-	});
+	auto iter = utils::ranges::find(times, value, &time_of_day::id);
 	if(iter == times.end()) {
 		std::ostringstream err;
 		err << "invalid time of day ID for ";

--- a/src/serialization/schema_validator.cpp
+++ b/src/serialization/schema_validator.cpp
@@ -318,12 +318,12 @@ void schema_validator::detect_link_cycles(const std::string& filename) {
 	boost::depth_first_search(link_graph,
 		boost::visitor(utils::back_edge_detector([&](const link_graph_t::edge_descriptor edge) {
 			const auto source = utils::ranges::find(link_map, boost::source(edge, link_graph),
-				[&](const auto& link) { return link.second; });
+				[](const auto& link) { return link.second; });
 
 			assert(source != link_map.end());
 
 			const auto target = utils::ranges::find(link_map, boost::target(edge, link_graph),
-				[&](const auto& link) { return link.second; });
+				[](const auto& link) { return link.second; });
 
 			assert(target != link_map.end());
 

--- a/src/serialization/schema_validator.cpp
+++ b/src/serialization/schema_validator.cpp
@@ -317,13 +317,13 @@ void schema_validator::detect_link_cycles(const std::string& filename) {
 
 	boost::depth_first_search(link_graph,
 		boost::visitor(utils::back_edge_detector([&](const link_graph_t::edge_descriptor edge) {
-			const auto source = std::find_if(link_map.begin(), link_map.end(),
-				[&](const auto& link) { return link.second == boost::source(edge, link_graph); });
+			const auto source = utils::ranges::find(link_map, boost::source(edge, link_graph),
+				[&](const auto& link) { return link.second; });
 
 			assert(source != link_map.end());
 
-			const auto target = std::find_if(link_map.begin(), link_map.end(),
-				[&](const auto& link) { return link.second == boost::target(edge, link_graph); });
+			const auto target = utils::ranges::find(link_map, boost::target(edge, link_graph),
+				[&](const auto& link) { return link.second; });
 
 			assert(target != link_map.end());
 
@@ -592,13 +592,13 @@ void schema_validator::detect_derivation_cycles()
 {
 	boost::depth_first_search(derivation_graph_,
 		boost::visitor(utils::back_edge_detector([&](const derivation_graph_t::edge_descriptor edge) {
-			const auto source = std::find_if(derivation_map_.begin(), derivation_map_.end(),
-				[&](const auto& derivation) { return derivation.second == boost::source(edge, derivation_graph_); });
+			const auto source = utils::ranges::find(derivation_map_, boost::source(edge, derivation_graph_),
+				[](const auto& derivation) { return derivation.second; });
 
 			assert(source != derivation_map_.end());
 
-			const auto target = std::find_if(derivation_map_.begin(), derivation_map_.end(),
-				[&](const auto& derivation) { return derivation.second == boost::target(edge, derivation_graph_); });
+			const auto target = utils::ranges::find(derivation_map_, boost::target(edge, derivation_graph_),
+				[](const auto& derivation) { return derivation.second; });
 
 			assert(target != derivation_map_.end());
 

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -20,6 +20,7 @@
 #include "random.hpp"
 #include "serialization/string_utils.hpp"
 #include "sound_music_track.hpp"
+#include "utils/general.hpp"
 #include "utils/rate_counter.hpp"
 
 #include <SDL2/SDL.h>
@@ -180,9 +181,8 @@ std::shared_ptr<sound::music_track> previous_track;
 
 std::vector<std::shared_ptr<sound::music_track>>::const_iterator find_track(const sound::music_track& track)
 {
-	return std::find_if(current_track_list.begin(), current_track_list.end(),
-		[&track](const std::shared_ptr<const sound::music_track>& ptr) { return *ptr == track; }
-	);
+	return utils::ranges::find(current_track_list, track,
+		[](const std::shared_ptr<const sound::music_track>& ptr) { return *ptr; });
 }
 
 } // end anon namespace

--- a/src/tests/utils/game_config_manager_tests.cpp
+++ b/src/tests/utils/game_config_manager_tests.cpp
@@ -29,17 +29,13 @@
 #include "hotkey/hotkey_item.hpp"
 #include "language.hpp"
 #include "units/types.hpp"
+#include "utils/general.hpp"
 
 #include "gui/gui.hpp"
 
 #include <clocale>
 
 namespace test_utils {
-
-	static bool match_english(const language_def& def)
-	{
-		return def.localename == "en_US";
-	}
 
 	class game_config_manager {
 		config cfg_;
@@ -82,9 +78,7 @@ namespace test_utils {
 			game_config::config_cache::instance().get_config(game_config::path + "/data/test/", cfg_);
 			::init_textdomains(game_config_view_);
 			const std::vector<language_def>& languages = get_languages();
-			std::vector<language_def>::const_iterator English = std::find_if(languages.begin(),
-					languages.end(),
-					match_english); // Using German because the most active translation
+			auto English = utils::ranges::find(languages, "en_US", &language_def::localename);
 			::set_language(*English);
 
 			unit_types.set_config(game_config_view_.merged_children_view("units"));

--- a/src/utils/general.hpp
+++ b/src/utils/general.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <functional>
 #include <string>
 
 namespace utils

--- a/src/utils/general.hpp
+++ b/src/utils/general.hpp
@@ -99,7 +99,7 @@ std::string get_unknown_exception_type();
 /**
  * Convenience wrapper for using std::remove_if on a container.
  *
- * todoc++20 use C++20's std::erase_if instead. The C++20 function returns the number of elements
+ * @todo c++20 use C++20's std::erase_if instead. The C++20 function returns the number of elements
  * removed; this one could do that but it seems unnecessary to add it unless something is using it.
  */
 template<typename Container, typename Predicate>
@@ -125,6 +125,7 @@ std::size_t erase(Container& container, const Value& value)
 /**
  * Convenience wrapper for using std::sort on a container.
  *
+ * @todo C++20: use std::ranges::sort
  */
 template<typename Container, typename Predicate>
 void sort_if(Container& container, const Predicate& predicate)
@@ -134,7 +135,6 @@ void sort_if(Container& container, const Predicate& predicate)
 
 /**
  * Convenience wrapper for using find on a container without needing to comare to end()
- *
  */
 template<typename Container, typename Value>
 auto* find(Container& container, const Value& value)
@@ -142,5 +142,40 @@ auto* find(Container& container, const Value& value)
 	auto res = container.find(value);
 	return (res == container.end()) ? nullptr : &*res;
 }
+
+/**
+ * Conveniences wrapper for range algorithms.
+ *
+ * @todo C++20: use std::ranges
+ */
+namespace ranges
+{
+namespace implementation
+{
+struct identity
+{
+	template<typename T>
+	constexpr T&& operator()(T&& t) const noexcept
+	{
+		return std::forward<T>(t);
+	}
+};
+
+} // namespace implementation
+
+template<typename Container, typename Value, typename Projection = implementation::identity>
+auto find(Container& container, const Value& value, const Projection& projection = {})
+{
+	auto end = container.end();
+	for(auto iter = container.begin(); iter != end; ++iter) {
+		if(std::invoke(projection, *iter) == value) {
+			return iter;
+		}
+	}
+
+	return end;
+}
+
+} // namespace ranges
 
 } // namespace utils

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -28,6 +28,7 @@
 #include "resources.hpp"
 #include "units/unit.hpp"
 #include "units/map.hpp"
+#include "utils/general.hpp"
 #include "team.hpp"
 
 static lg::log_domain log_engine("engine");
@@ -568,8 +569,7 @@ void scoped_recall_unit::activate()
 	assert(resources::gameboard);
 
 	const std::vector<team>& teams = resources::gameboard->teams();
-
-	std::vector<team>::const_iterator team_it = std::find_if(teams.begin(), teams.end(), [&](const team& t) { return t.save_id_or_number() == player_; });
+	auto team_it = utils::ranges::find(teams, player_, &team::save_id_or_number);
 
 	if(team_it != teams.end()) {
 		if(team_it->recall_list().size() > recall_index_) {


### PR DESCRIPTION
This adds a new `utils::ranges::find` helper function modeled after C++20's `ranges::find`. Unlike the latter, it only accepts lvalue references (you can't have a "borrowed range"), but for most cases the syntax is equivalent to `ranges::find`. The most useful part is the projection argument, which significantly simplifies existing uses of `std::find_if`. The C++20 version proper should be a drop-in replacement once we bump our minimums.