### PR TITLE
Change Sylph, Shyde, and Enchantress to be closer to 1.16

### DIFF
--- a/changelog_entries/sylph-shyde-enchantress.md
+++ b/changelog_entries/sylph-shyde-enchantress.md
@@ -1,0 +1,10 @@
+### Units
+  * Elvish Sylph:
+     * Now that most undead have had their arcane vulnerabilities increased to 40%, the Sylph's 1.18 buffs make her ludicrously strong against them. These changes bring most of her stats back down to 1.16, while leaving her slowing attacks unchanged.
+     * cost 135 -> 110, hitpoints 68 -> 60, faerie fire (ranged arcane) 13-5 -> 10-5.
+  * Elvish Enchantress:
+     * Same reasoning as the Sylph changes, but much smaller in magnitude.
+     * cost 62 -> 59, faerie fire (ranged arcane) 11-4 -> 10-4.
+  * Elvish Shyde:
+     * As a flying, slowing, magical healer with 6mp, the Shyde was powerful even before the numerous buffs she received in 1.18. This is a reversion to her 1.16 values.
+     * cost 58 -> 52, hitpoints 51 -> 46, entangle (ranged impact) 7-3 -> 6-3, thorns (ranged pierce) 10-3 -> 7-3, faerie touch (melee impact) 7-2 -> 6-2.

--- a/changelog_entries/sylph-shyde-enchantress.md
+++ b/changelog_entries/sylph-shyde-enchantress.md
@@ -1,10 +1,10 @@
 ### Units
   * Elvish Sylph:
      * Now that most undead have had their arcane vulnerabilities increased to 40%, the Sylph's 1.18 buffs make her ludicrously strong against them. These changes bring most of her stats back down to 1.16, while leaving her slowing attacks unchanged.
-     * cost 135 -> 110, hitpoints 68 -> 60, faerie fire (ranged arcane) 13-5 -> 10-5.
+     * cost 135 -> 110, hitpoints 68 -> 60, faerie fire 13-5 -> 10-5 (ranged arcane).
   * Elvish Enchantress:
      * Same reasoning as the Sylph changes, but much smaller in magnitude.
-     * cost 62 -> 57, faerie fire (ranged arcane) 11-4 -> 10-4.
+     * cost 62 -> 57, faerie fire 11-4 -> 10-4 (ranged arcane).
   * Elvish Shyde:
      * As a flying, slowing, magical healer with 6mp, the Shyde was powerful even before the numerous buffs she received in 1.18. This is a reversion to her 1.16 values.
-     * cost 58 -> 52, hitpoints 51 -> 46, entangle (ranged impact) 7-3 -> 6-3, thorns (ranged pierce) 10-3 -> 8-3, faerie touch (melee impact) 7-2 -> 6-2.
+     * cost 58 -> 52, hitpoints 51 -> 46, entangle 7-3 -> 6-3 (ranged impact), thorns 10-3 -> 8-3 (ranged pierce), faerie touch 7-2 -> 6-2 (melee impact).

--- a/changelog_entries/sylph-shyde-enchantress.md
+++ b/changelog_entries/sylph-shyde-enchantress.md
@@ -4,7 +4,7 @@
      * cost 135 -> 110, hitpoints 68 -> 60, faerie fire (ranged arcane) 13-5 -> 10-5.
   * Elvish Enchantress:
      * Same reasoning as the Sylph changes, but much smaller in magnitude.
-     * cost 62 -> 59, faerie fire (ranged arcane) 11-4 -> 10-4.
+     * cost 62 -> 57, faerie fire (ranged arcane) 11-4 -> 10-4.
   * Elvish Shyde:
      * As a flying, slowing, magical healer with 6mp, the Shyde was powerful even before the numerous buffs she received in 1.18. This is a reversion to her 1.16 values.
      * cost 58 -> 52, hitpoints 51 -> 46, entangle (ranged impact) 7-3 -> 6-3, thorns (ranged pierce) 10-3 -> 8-3, faerie touch (melee impact) 7-2 -> 6-2.

--- a/changelog_entries/sylph-shyde-enchantress.md
+++ b/changelog_entries/sylph-shyde-enchantress.md
@@ -7,4 +7,4 @@
      * cost 62 -> 59, faerie fire (ranged arcane) 11-4 -> 10-4.
   * Elvish Shyde:
      * As a flying, slowing, magical healer with 6mp, the Shyde was powerful even before the numerous buffs she received in 1.18. This is a reversion to her 1.16 values.
-     * cost 58 -> 52, hitpoints 51 -> 46, entangle (ranged impact) 7-3 -> 6-3, thorns (ranged pierce) 10-3 -> 7-3, faerie touch (melee impact) 7-2 -> 6-2.
+     * cost 58 -> 52, hitpoints 51 -> 46, entangle (ranged impact) 7-3 -> 6-3, thorns (ranged pierce) 10-3 -> 8-3, faerie touch (melee impact) 7-2 -> 6-2.

--- a/data/core/units/elves/Enchantress.cfg
+++ b/data/core/units/elves/Enchantress.cfg
@@ -14,7 +14,7 @@
     level=3
     alignment=neutral
     advances_to=Elvish Sylph
-    cost=62
+    cost=59
     usage=mixed fighter
     description= _ "In the context of Elven magic, the notion of enchanting is a little bit misleading since it almost always refers to manipulation of an object’s essence for the purpose of divination or insight. A favorite among the corresponding enchantresses is imbuing their natural surroundings with the breath of the arcane, yielding secret groves that exist at the juncture between the corporeal and ethereal worlds. These mysterious domains are kept by their equally enigmatic caretakers, who mostly keep to themselves away from prying eyes. Though rather reserved and unsociable, these elves are well-regarded by most of their kin and sometimes called upon for guidance especially in unusual or peculiar matters."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
@@ -48,7 +48,7 @@
         name=faerie fire
         description=_"faerie fire"
         type=arcane
-        damage=11
+        damage=10
         number=4
         range=ranged
         [specials]

--- a/data/core/units/elves/Enchantress.cfg
+++ b/data/core/units/elves/Enchantress.cfg
@@ -14,7 +14,7 @@
     level=3
     alignment=neutral
     advances_to=Elvish Sylph
-    cost=59
+    cost=57
     usage=mixed fighter
     description= _ "In the context of Elven magic, the notion of enchanting is a little bit misleading since it almost always refers to manipulation of an object’s essence for the purpose of divination or insight. A favorite among the corresponding enchantresses is imbuing their natural surroundings with the breath of the arcane, yielding secret groves that exist at the juncture between the corporeal and ethereal worlds. These mysterious domains are kept by their equally enigmatic caretakers, who mostly keep to themselves away from prying eyes. Though rather reserved and unsociable, these elves are well-regarded by most of their kin and sometimes called upon for guidance especially in unusual or peculiar matters."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}

--- a/data/core/units/elves/Shyde.cfg
+++ b/data/core/units/elves/Shyde.cfg
@@ -17,7 +17,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=58
+    cost=52
     usage=healer
     description= _ "As an elf maiden entwines herself more and more with nature, the essence of earth begins to transform her body. The butterfly wings that sprout on the back of a Shyde are a direct manifestation of her connection to the faerie, granting her their characteristic ethereal aura of both serenity and fear. Shydes are masters of the mundane, guided by a power which is little understood, yet greatly respected by others of their kind. Often mistaken for true faerie or ‘forest spirits’, these stewards of the forests epitomize their people’s mysterious connection with the natural order."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
@@ -33,7 +33,7 @@
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
         range=melee
-        damage=7
+        damage=6
         number=2
         range=melee
     [/attack]
@@ -44,7 +44,7 @@
         [specials]
             {WEAPON_SPECIAL_SLOW}
         [/specials]
-        damage=7
+        damage=6
         number=3
         range=ranged
         icon=attacks/entangle.png
@@ -56,7 +56,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=10
+        damage=8
         number=3
         range=ranged
     [/attack]

--- a/data/core/units/elves/Shyde.cfg
+++ b/data/core/units/elves/Shyde.cfg
@@ -9,7 +9,7 @@
     small_profile="portraits/elves/shyde.webp~CROP(110,60,390,390)"
     profile="portraits/elves/shyde.webp"
     halo=halo/elven/shyde-stationary-halo[1~6].png:150
-    hitpoints=51
+    hitpoints=46
     movement_type=woodlandfloat
     movement=6
     experience=150

--- a/data/core/units/elves/Sylph.cfg
+++ b/data/core/units/elves/Sylph.cfg
@@ -16,7 +16,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=85
+    cost=110
     usage=mixed fighter
     description= _ "Tremendously powerful in unfathomable ways, the sage-like Sylphs are masters of manipulating the bridge between the mundane and arcane worlds. Long years spent peering into the ethereal realm have eroded the ability of these elves to view the physical world; in return, they are granted an abstract sight, gaining the ability to view one or even several different aspects of reality’s essence. Like the many shards of a broken mirror, the myriad fractures of the material world reflect the light of the arcane through its many different facets. Careful practice allows one to follow these strands of light from pane to pane, observing how the outcome of physical reality evolves with each choice made of free will. While direct weaving of the connecting fabric is usually impossible to achieve, indirect manipulation is feasible by machination in the corporeal plane where the reflection of the arcane plane is strongest. The ability of a Sylph to locate these ‘reflection pools’ and steer them is one of her greatest — and most feared — abilities."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}

--- a/data/core/units/elves/Sylph.cfg
+++ b/data/core/units/elves/Sylph.cfg
@@ -8,7 +8,7 @@
     small_profile="portraits/elves/sylph.webp~CROP(26,30,420,420)"
     profile="portraits/elves/sylph.webp~RIGHT()"
     halo=halo/elven/shyde-stationary-halo[1~6].png:150
-    hitpoints=68
+    hitpoints=60
     movement_type=woodlandfloat
     movement=6
     experience=200
@@ -16,7 +16,7 @@
     alignment=neutral
     advances_to=null
     {AMLA_DEFAULT}
-    cost=135
+    cost=85
     usage=mixed fighter
     description= _ "Tremendously powerful in unfathomable ways, the sage-like Sylphs are masters of manipulating the bridge between the mundane and arcane worlds. Long years spent peering into the ethereal realm have eroded the ability of these elves to view the physical world; in return, they are granted an abstract sight, gaining the ability to view one or even several different aspects of reality’s essence. Like the many shards of a broken mirror, the myriad fractures of the material world reflect the light of the arcane through its many different facets. Careful practice allows one to follow these strands of light from pane to pane, observing how the outcome of physical reality evolves with each choice made of free will. While direct weaving of the connecting fabric is usually impossible to achieve, indirect manipulation is feasible by machination in the corporeal plane where the reflection of the arcane plane is strongest. The ability of a Sylph to locate these ‘reflection pools’ and steer them is one of her greatest — and most feared — abilities."
     die_sound={SOUND_LIST:ELF_FEMALE_HIT}
@@ -55,7 +55,7 @@
         [specials]
             {WEAPON_SPECIAL_MAGICAL}
         [/specials]
-        damage=13
+        damage=10
         number=5
         range=ranged
         icon=attacks/faerie-fire.png


### PR DESCRIPTION
The Elvish Sylph, Shyde, and Enchantress received massive buffs in 1.18. Those have been partially walked back in #8749, but these units still remain outliers in power at their respective levels - especially now that most undead have -40% arcane resist.

A dexterous Sylph, for example, is better than a Great Mage in almost every possible aspect - damage, movement, hitpoints, melee, support (slows), and defense.

This PR brings most of their stats back down to their 1.16 levels (or slightly stronger), but deliberately leaves the Sylph and Enchantress's slowing attacks unnerfed; I think those attacks are somewhat weak in comparison to their much more deadly arcane attacks.

Balance vote is in progress; will conclude in a few days.