### PR TITLE
Android/InitActivity: add userdata import/export functionality (#10326)

### DIFF
--- a/packaging/android/app/build.gradle
+++ b/packaging/android/app/build.gradle
@@ -62,5 +62,6 @@ android {
 
     dependencies {
         implementation "androidx.core:core:1.16.0"
+        implementation "androidx.documentfile:documentfile:1.1.0"
     }
 }

--- a/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/IOUtils.java
+++ b/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/IOUtils.java
@@ -1,0 +1,68 @@
+package org.wesnoth.Wesnoth;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+import android.webkit.MimeTypeMap;
+import androidx.documentfile.provider.DocumentFile;
+
+public class IOUtils {
+	public static void copyStreamNoClose(InputStream in, OutputStream out) throws IOException {
+		byte[] buffer = new byte[8192];
+		int length;
+		while ((length = in.read(buffer)) > 0) {
+			out.write(buffer, 0, length);
+		}
+	}
+
+	public static void copyStream(InputStream in, OutputStream out) throws IOException {
+		copyStreamNoClose(in, out);
+		out.close();
+		in.close();
+	}
+	
+	public static void copyFolderToTree(Context context, File sourceDir, Uri treeUri) {
+		DocumentFile targetRoot = DocumentFile.fromTreeUri(context, treeUri);
+		if (targetRoot == null) return;
+		
+		copyRecursive(context, sourceDir, targetRoot);
+	}
+
+	private static void copyRecursive(Context context, File source, DocumentFile targetParent) {
+		if (source.isDirectory()) {
+			DocumentFile newDir = targetParent.findFile(source.getName());
+			if (newDir == null || !newDir.isDirectory()) {
+				newDir = targetParent.createDirectory(source.getName());
+			}
+
+			for (File child : source.listFiles()) {
+				copyRecursive(context, child, newDir);
+			}
+		} else {
+			try {
+				DocumentFile existingFile = targetParent.findFile(source.getName());
+				if (existingFile != null && existingFile.isFile()) {
+					existingFile.delete();
+				}
+
+				DocumentFile newFile = targetParent.createFile(getMimeType(source.getName()), source.getName());
+				copyStream(
+					new FileInputStream(source),
+					context.getContentResolver().openOutputStream(newFile.getUri()));
+			} catch (IOException ioe) {
+				Log.e("Import/Export copy", "IO error", ioe);
+			}
+		}
+	}
+	
+	private static String getMimeType(String filename) {
+		String ext = filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+		return MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
+	}
+}

--- a/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/IOUtils.java
+++ b/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/IOUtils.java
@@ -40,14 +40,17 @@ public class IOUtils {
 		
 		copyRecursive(context, source, targetDir);
 	}
-	
+
 	private static void copyRecursive(Context context, DocumentFile source, DocumentFile targetParent) {
 		final String sourceName = source.getName();
-		
+
 		if (source.isDirectory()) {
 			DocumentFile newDir = targetParent.findFile(sourceName);
 			if (newDir == null || !newDir.isDirectory()) {
 				newDir = targetParent.createDirectory(sourceName);
+				if (newDir == null) {
+					return;
+				}
 			}
 
 			for (DocumentFile child : source.listFiles()) {
@@ -61,9 +64,18 @@ public class IOUtils {
 				}
 
 				DocumentFile newFile = targetParent.createFile(getMimeType(sourceName), sourceName);
-				copyStream(
-					context.getContentResolver().openInputStream(source.getUri()),
-					context.getContentResolver().openOutputStream(newFile.getUri()));
+				if (newFile == null) {
+					return;
+				}
+
+				InputStream in = context.getContentResolver().openInputStream(source.getUri());
+				OutputStream out = context.getContentResolver().openOutputStream(newFile.getUri());
+
+				if (in == null || out == null) {
+					return;
+				}
+
+				copyStream(in, out);
 			} catch (IOException ioe) {
 				Log.e("Import/Export copy", "IO error", ioe);
 			}

--- a/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/InitActivity.java
+++ b/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/InitActivity.java
@@ -310,7 +310,7 @@ public class InitActivity extends Activity {
 	private void initializeAssetsFromZip(Uri uri) {
 		Executors.newSingleThreadExecutor().execute(() -> {
 			runOnUiThread(() -> showProgressScreen());
-			
+
 			Properties status = initStatusFile(dataDir);
 
 			if (unpackArchive(uri, dataDir, "Core")) {

--- a/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/InitActivity.java
+++ b/packaging/android/app/src/main/java/org/wesnoth/Wesnoth/InitActivity.java
@@ -372,14 +372,14 @@ public class InitActivity extends Activity {
 		new AlertDialog.Builder(this)
 			.setTitle("Import/Export User Data")
 			.setMessage("This allows you to import/export your userdata folder, which contains your add-ons, game saves, logs and so on. Intended for advanced users and UMC creators.")
-			.setPositiveButton("Import", (dialog, which) -> {
+			.setPositiveButton("Import", (dialog, which) ->
 				// Open directory picker to select import destination
-				startActivityForResult(new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE), 3);
-			})
-			.setNegativeButton("Export", (dialog, which) -> {
+				startActivityForResult(new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE), 3)
+			)
+			.setNegativeButton("Export", (dialog, which) ->
 				// Open directory picker to select export destination
-				startActivityForResult(new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE), 4);
-			})
+				startActivityForResult(new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE), 4)
+			)
 			.setNeutralButton("Cancel", null)
 			.setCancelable(false)
 			.show();
@@ -388,13 +388,15 @@ public class InitActivity extends Activity {
 	private void importUserData(Uri uri) {
 		Toast.makeText(this, "Importing...", Toast.LENGTH_SHORT).show();
 		Executors.newSingleThreadExecutor().execute(() -> {
+			runOnUiThread(()-> showProgressScreen());
 			DocumentFile targetDir = DocumentFile.fromTreeUri(this, uri);
 			for (DocumentFile child : targetDir.listFiles()) {
 				if (!child.getName().equals("gamedata")) {
-					runOnUiThread(()-> Toast.makeText(this, "Importing " + child.getName(), Toast.LENGTH_SHORT).show());
+					runOnUiThread(()-> updateProgress("Importing " + child.getName(), 0));
 					IOUtils.copyRecursive(this, child, getExternalFilesDir(null));
 				}
 			}
+			runOnUiThread(()-> showLaunchScreen());
 			runOnUiThread(()-> Toast.makeText(this, "Imported!", Toast.LENGTH_SHORT).show());
 		});
 	}
@@ -402,12 +404,14 @@ public class InitActivity extends Activity {
 	private void exportUserData(Uri uri) {
 		Toast.makeText(this, "Exporting...", Toast.LENGTH_SHORT).show();
 		Executors.newSingleThreadExecutor().execute(() -> {
+			runOnUiThread(()-> showProgressScreen());
 			for (File child : getExternalFilesDir(null).listFiles()) {
 				if (!child.getName().equals("gamedata")) {
-					runOnUiThread(()-> Toast.makeText(this, "Exporting " + child.getName(), Toast.LENGTH_SHORT).show());
+					runOnUiThread(()-> updateProgress("Exporting " + child.getName(), 0));
 					IOUtils.copyRecursive(this, child, uri);
 				}
 			}
+			runOnUiThread(()-> showLaunchScreen());
 			runOnUiThread(()-> Toast.makeText(this, "Exported!", Toast.LENGTH_SHORT).show());
 		});
 	}

--- a/packaging/android/app/src/main/res/menu/main_menu.xml
+++ b/packaging/android/app/src/main/res/menu/main_menu.xml
@@ -1,10 +1,14 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/mnuClear"
-        android:title="Clear Data"
+        android:title="Clear Gamedata"
         android:showAsAction="never"/>
     <item
         android:id="@+id/mnuLocalInstall"
-        android:title="Install Data from ZIP"
+        android:title="Install Gamedata ZIP"
+        android:showAsAction="never"/>
+    <item
+        android:id="@+id/mnuImportExport"
+        android:title="Import/Export Userdata"
         android:showAsAction="never"/>
 </menu>


### PR DESCRIPTION
Adds a new menu item to the setting menu in the Android splash screen/launcher activity that allows import/export of Wesnoth userdata folders.

TODO
- [x] Export
- [x] Import
~~- [ ] Custom userdata folder~~ (Will attempt in a future PR if possible)

<img width="1600" height="720" alt="Screenshot_20250722-172322" src="https://github.com/user-attachments/assets/8e615626-dcb1-43a2-ae9a-bc2182ea92ac" />
<img width="1600" height="720" alt="Screenshot_20250722-172327" src="https://github.com/user-attachments/assets/3cc6443a-251d-4f36-846a-27bf4e8ca5a4" />
