### PR TITLE
Change mistaken call to active_view::origin back to active_view::size

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -326,7 +326,7 @@ bool update_framebuffer()
 		// Translate active_area into display coordinates as input_area_
 		input_area_ = {
 			(active_area.origin() * wsize) / osize,
-			(active_area.origin() * wsize) / osize
+			(active_area.size() * wsize) / osize
 		};
 		LOG_DP << "input area: " << input_area_;
 	}


### PR DESCRIPTION
This also prevents a divide-by-zero crash in `sdl::get_mouse_state()` if the `active_view`'s origin is at (0, 0).