### PR TITLE
Skeletal Dragon image_icon

### DIFF
--- a/data/core/units/monsters/Skeletal_Dragon.cfg
+++ b/data/core/units/monsters/Skeletal_Dragon.cfg
@@ -5,7 +5,7 @@
     #not 'race=monster', because we need the not_living attribute
     race=undead
     image="units/monsters/skeletal-dragon/skeletal-dragon.png"
-    image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(0,0,160,160)"
+    image_icon="units/monsters/skeletal-dragon/skeletal-dragon.png~CROP(103,68,72,72)"
     hitpoints=98
     movement_type=undeadfly
     movement=5


### PR DESCRIPTION
> Not centered but it should use image_icon or similar. (#10391)

We could use a different cropping for the image_icon. Cropped in a way that one doesn't see the wings, with 72x72. Merging?

<img width="836" height="757" alt="list" src="https://github.com/user-attachments/assets/afb82589-eb7d-48f8-bb8c-e35a260a4b02" />
<img width="823" height="259" alt="dialogue" src="https://github.com/user-attachments/assets/6a90c384-1515-4d3f-bb57-b94fdb89afe8" />

It's cropped to 72x72, but the attack dialogue will use 144x144.