### PR TITLE
using [defense] instead of parry with defense_weight=0

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
@@ -63,9 +63,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 2}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     [attack]
         name=glaive
@@ -78,9 +77,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/champion-defend2.png" "units/quenoth/champion-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
@@ -53,9 +53,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/fighter-defend-2.png" "units/quenoth/fighter-defend-1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
@@ -68,9 +68,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/flanker-defend2.png" "units/quenoth/flanker-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
@@ -69,9 +69,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 20}
         [/specials]
-        parry=20
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/ranger-defend2.png" "units/quenoth/ranger-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
@@ -62,9 +62,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 2}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     [attack]
         name=glaive
@@ -77,9 +76,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/warrior-defend-2.png" "units/quenoth/warrior-defend-1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -667,6 +667,22 @@ _ "At the start of the turn this unit increases movement points of surrounding u
     [/dummy]
 #enddef
 
+#define STR_PARRYING_10
+_ "This unit sees its defense reinforced by 10% when this weapon is used in offense"#enddef
+
+#define STR_PARRYING_20
+_ "This unit sees its defense reinforced by 20% when this weapon is used in offense"#enddef
+
+#define WEAPON_SPECIAL_PARRYING VALUE
+    [defense]
+        id=parrying{VALUE}
+        name=_"parrying: " + "{VALUE}"
+        description={STR_PARRYING_{VALUE}}
+        add={VALUE}
+        active_on=offense
+    [/defense]
+#enddef
+
 # These are all direct clones of the mainline healing abilities, except that
 # they are set to exclude units suffering from dehydration. Dehydration is only
 # delayed by healers, so they must not actually heal a dehydrated unit any


### PR DESCRIPTION
Since these attacks almost all have the firststrike special, it makes no sense to cancel them in defense now that another solution exists.