### PR TITLE
Fix move behavior of enable_lua_ptr<T>

### DIFF
--- a/boost_test_schedule
+++ b/boost_test_schedule
@@ -186,6 +186,7 @@ test_lexical_arethmetic_signed<double>
 test_lexical_arethmetic_signed<long double>
 test_lexical_cast_bool
 test_lexical_cast_result
+test_lua_ptr
 test_map_location/map_location_characterization_test_radial_mode
 test_map_location/reality_check_vector_negation
 test_map_location/reality_check_get_direction

--- a/src/tests/test_lua_ptr.cpp
+++ b/src/tests/test_lua_ptr.cpp
@@ -33,11 +33,27 @@ BOOST_AUTO_TEST_CASE(test_lua_ptr) {
 	BOOST_CHECK(ptr);
 	BOOST_CHECK_EQUAL(ptr.get_ptr(), &obj);
 	{
-		auto obj_moved = std::move(obj);
+		// test move constructor
+		auto obj2 = std::move(obj);
 		BOOST_CHECK(ptr);
-		BOOST_CHECK_EQUAL(ptr.get_ptr(), &obj_moved);
+		BOOST_CHECK_EQUAL(ptr.get_ptr(), &obj2);
 		BOOST_CHECK_EQUAL(ptr->value, "test");
+
+		// NOLINTNEXTLINE(bugprone-use-after-move)
+		lua_ptr<dummy_object> ptr_from_moved_object(obj);
+		BOOST_CHECK(!ptr_from_moved_object);
+
+		// test move assignment
+		dummy_object obj3{"different"};
+		obj3 = std::move(obj2);
+		BOOST_CHECK(ptr);
+		BOOST_CHECK_EQUAL(ptr.get_ptr(), &obj3);
+		BOOST_CHECK_EQUAL(ptr->value, "test");
+
 		vec.clear();
+		BOOST_CHECK(ptr);
+		BOOST_CHECK_EQUAL(ptr->value, "test");
+		BOOST_CHECK(!ptr_from_moved_object);
 	}
 	BOOST_CHECK(!ptr);
 }


### PR DESCRIPTION
The move assignment didn't return a value, however it was also unused, GCC started giving warnings when the test was changed to use it.

Thanks to Nanamuru for finding this, it's one of the bugs found by static analysis and reported in #10386.

@gfgtdf I'm opening this as a draft, because I've added comments about what I think this code does, but I'd like your confirmation that I've understood it correctly.