### PR TITLE
Import the different unit comparisons into the utils class functions.

### DIFF
--- a/src/utils/config_filters.cpp
+++ b/src/utils/config_filters.cpp
@@ -152,3 +152,23 @@ bool utils::config_filters::bool_or_empty(const config& filter, const config& cf
 	}
 	return is_matches;
 }
+
+bool utils::unit_filters::same_unit(const unit& self, const unit& unit)
+{
+	return (self.get_location() == unit.get_location() || self.id() == unit.id());
+}
+
+bool utils::unit_filters::distant_unit_match(const unit& self, const unit& unit)
+{
+	return (unit.has_ability_distant() && !unit.incapacitated() && !same_unit(self, unit) && self.id() != unit.id());
+}
+
+bool utils::unit_filters::distant_unit_match(const unit& self, const unit& unit, const std::string& tag_name)
+{
+	return (distant_unit_match(self, unit) && unit.affect_distant(tag_name));
+}
+
+bool utils::unit_filters::distant_halo_unit_match(const unit& self, const unit& unit)
+{
+	return (distant_unit_match(self, unit) && unit.has_ability_distant_image());
+}

--- a/src/utils/config_filters.hpp
+++ b/src/utils/config_filters.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "config.hpp"
+#include "units/unit.hpp"
 
 /**
  * Utility functions for implementing [filter], [filter_ability], [filter_weapon], etc.
@@ -69,3 +70,31 @@ bool set_includes_if_present(const config& filter, const config& cfg, const std:
 bool bool_or_empty(const config& filter, const config& cfg, const std::string& attribute);
 
 } // namespace utils::config_filters
+
+/**
+ * Utility functions for for checking units variables like get_location(), id(), has_ability_distant().
+ */
+namespace utils::unit_filters
+{
+
+/**
+ * This function return true if locations checked are the same, or if units have same id.
+ */
+bool same_unit(const unit& self, const unit& unit);
+
+/**
+ * This function return true if same_unit() don't match, unit not incapacitated, and unit have has_ability_distant() variable.
+ */
+bool distant_unit_match(const unit& self, const unit& unit);
+
+/**
+ * This function return true if distant_unit_match() true and, unit have affect_distant() variable.
+ */
+bool distant_unit_match(const unit& self, const unit& unit, const std::string& tag_name);
+
+/**
+ * This function return true if distant_unit_match() true and, unit have has_ability_distant_image() variable.
+ */
+bool distant_halo_unit_match(const unit& self, const unit& unit);
+
+} // namespace utils::unit_filters


### PR DESCRIPTION
This will avoid duplicating each check for affect_adjacent in all the functions involved.