### PR TITLE
TRoW: improve {ABILITY_DISTRACT} description

### DIFF
--- a/data/campaigns/The_Rise_Of_Wesnoth/utils/trow-abilities.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/utils/trow-abilities.cfg
@@ -4,8 +4,8 @@
     [skirmisher]
         id=distract
         name= _ "distract"
-        description= _ "Allies adjacent to this unit are not affected by enemy Zone of Control."
-        special_note=_"This unit is capable of distracting opponents, allowing adjacent allies to ignore enemy Zone of Control."
+        description= _ "Allies adjacent to this unit are not affected by enemy Zones of Control."
+        special_note=_"This unit is capable of distracting opponents, allowing adjacent allies to ignore enemy Zones of Control."
         affect_self=no
         affect_allies=yes
         [affect_adjacent]


### PR DESCRIPTION
The description for TRoW's {ABILITY_DISTRACT} is a little confusing, and could be read to imply that adjacent enemies have their ZoC disabled.

This change to the description should hopefully be more clear.