### PR TITLE
Consistently format achievements

### DIFF
--- a/data/campaigns/Eastern_Invasion/achievements.cfg
+++ b/data/campaigns/Eastern_Invasion/achievements.cfg
@@ -30,47 +30,47 @@ data/core/images#enddef
     #
 
     {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(84,84)~BLIT({CORE_PATH}/scenery/trapdoor-open.png,8,8)"
-    "ei_S01"    _"Scenario 1: Tactical Withdrawal"            _"Complete the ‘<i>Eastern Invasion</i>’ scenario with at least 10 surviving units."}
+    "ei_S01"    _"Scenario 1: Tactical Withdrawal"            _"Complete the <i>Eastern Invasion</i> scenario with at least 10 surviving units."}
     {ACHIEVEMENT {CORE_PATH}/attacks/foot-shoe.png
-    "ei_S02"    _"Scenario 2: Speedrun"                       _"Complete ‘<i>The Escape Tunnel</i>’ before the undead arrive."}
+    "ei_S02"    _"Scenario 2: Speedrun"                       _"Complete <i>The Escape Tunnel</i> before the undead arrive."}
     {ACHIEVEMENT {CORE_PATH}/icons/amla-default.png
-    "ei_S03"    _"Scenario 3: Merciful"                       _"Complete ‘<i>An Unexpected Appearance</i>’ without killing Mal-Tar, the dark adept."}
+    "ei_S03"    _"Scenario 3: Merciful"                       _"Complete <i>An Unexpected Appearance</i> without killing Mal-Tar, the dark adept."}
     {ACHIEVEMENT {CORE_PATH}/attacks/torch.png
-    "ei_S04a"   _"Scenario 4a: Scorched Earth"                _"Defeat both the bandit and elven leaders in ‘<i>Elven Interlude</i>’."}
+    "ei_S04a"   _"Scenario 4a: Scorched Earth"                _"Defeat both the bandit and elven leaders in <i>Elven Interlude</i>."}
     {ACHIEVEMENT {PATH}/coins_gold.png
-    "ei_S04b"   _"Scenario 4b: Mercenary"                     _"Recruit the dunefolk in ‘<i>Ill Humours</i>’."}
+    "ei_S04b"   _"Scenario 4b: Mercenary"                     _"Recruit the dunefolk in <i>Ill Humours</i>."}
     {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(84,84)~BLIT({CORE_PATH}/units/human-loyalists/knight/knight.png~RC(magenta>white),1,5)~BLIT(data/campaigns/Eastern_Invasion/images/items/horse-cage.png,8,10)"
-    "ei_S04c"   _"Scenario 4c: No (Horse)Man Left Behind"     _"Rescue all 6 prisoners from ‘<i>Mal Ravanal’s Capital</i>’."}
+    "ei_S04c"   _"Scenario 4c: No (Horse)Man Left Behind"     _"Rescue all 6 prisoners from <i>Mal Ravanal’s Capital</i>."}
     {ACHIEVEMENT {CORE_PATH}/icons/hat-huntsman.png
-    "ei_S05"    _"Scenario 5: Folk Hero"                      _"Complete ‘<i>Northern Outpost</i>’ without any peasants dying."}
+    "ei_S05"    _"Scenario 5: Folk Hero"                      _"Complete <i>Northern Outpost</i> without any peasants dying."}
     {ACHIEVEMENT {PATH}/drowning.png
-    "ei_S06a"   _"Scenario 6a: A Little Help Here?"           _"Defeat the necromancer in ‘<i>Undead Crossing</i>’ before rescuing Dolburras."}
+    "ei_S06a"   _"Scenario 6a: A Little Help Here?"           _"Defeat the necromancer in <i>Undead Crossing</i> before rescuing Dolburras."}
     {ACHIEVEMENT {PATH}/ninja.png
-    "ei_S06b"   _"Scenario 6b: Ninja"                         _"Complete ‘<i>Soradoc</i>’ without killing any enemy leaders."}
+    "ei_S06b"   _"Scenario 6b: Ninja"                         _"Complete <i>Soradoc</i> without killing any enemy leaders."}
     {ACHIEVEMENT {PATH}/ogre.png
-    "ei_S07a"   _"Scenario 7a: Ogre Rights Advocate"          _"Refuse to enslave any ogres in ‘<i>Capturing the Ogres</i>’."}
+    "ei_S07a"   _"Scenario 7a: Ogre Rights Advocate"          _"Refuse to enslave any ogres in <i>Capturing the Ogres</i>."}
     {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(72,72)~BLIT({CORE_PATH}/units/dwarves/berserker/berserker-attack-8.png,-2,-2)"
-    "ei_S07b"   _"Scenario 7b: Frenzied"                      _"Kill 5 enemy leaders in ‘<i>Ogre Crossing</i>’."}
+    "ei_S07b"   _"Scenario 7b: Frenzied"                      _"Kill 5 enemy leaders in <i>Ogre Crossing</i>."}
     {ACHIEVEMENT {CORE_PATH}/attacks/battleaxe.png
-    "ei_S08"    _"Scenario 8: And My Axe"                     _"Ally with the dwarves in ‘<i>Xenophobia</i>’."}
+    "ei_S08"    _"Scenario 8: And My Axe"                     _"Ally with the dwarves in <i>Xenophobia</i>."}
     {ACHIEVEMENT {CORE_PATH}/attacks/cleaver.png
-    "ei_S09"    _"Scenario 9: Guuuh..."                       _"Recruit the wild ogres in ‘<i>Castle in the Ice</i>’."}
+    "ei_S09"    _"Scenario 9: Guuuh..."                       _"Recruit the wild ogres in <i>Castle in the Ice</i>."}
     {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(72,72)~BLIT({CORE_PATH}/units/undead/zombie.png~RC(magenta>white),-2,-2)"
-    "ei_S10"    _"Scenario 10: Brains"                        _"Find the legendary Staff of Power in ‘<i>Dark Sanctuary</i>’."}
+    "ei_S10"    _"Scenario 10: Brains"                        _"Find the legendary Staff of Power in <i>Dark Sanctuary</i>."}
     {ACHIEVEMENT {CORE_PATH}/icons/ring_gold.png
-    "ei_S11"    _"Scenario 11: And In The Darkness Bind Them" _"Find the Ring of Invisibility in ‘<i>Captured</i>’."}
+    "ei_S11"    _"Scenario 11: And In The Darkness Bind Them" _"Find the Ring of Invisibility in <i>Captured</i>."}
     {ACHIEVEMENT {PATH}/planb.png
-    "ei_S12"    _"Scenario 12: Plan B"                        _"Complete ‘<i>Evacuation</i>’ by defeating all enemy leaders."}
+    "ei_S12"    _"Scenario 12: Plan B"                        _"Complete <i>Evacuation</i> by defeating all enemy leaders."}
     {ACHIEVEMENT {CORE_PATH}/attacks/sword-holy.png
-    "ei_S13"    _"Scenario 13: Oath of Redemption"            _"Recruit Gaennell, the dark adept, in ‘<i>Spoils of War</i>’."}
+    "ei_S13"    _"Scenario 13: Oath of Redemption"            _"Recruit Gaennell, the dark adept, in <i>Spoils of War</i>."}
     {ACHIEVEMENT {CORE_PATH}/icons/book.png
-    "ei_S14"    _"Scenario 14: Historian"                     _"Read the story of the Clans’ defeat in ‘<i>The Drowned Plains</i>’."}
+    "ei_S14"    _"Scenario 14: Historian"                     _"Read the story of the Clans’ defeat in <i>The Drowned Plains</i>."}
     {ACHIEVEMENT {CORE_PATH}/icons/helmet_frogmouth.png
-    "ei_S16"    _"Scenario 16: Alternate History"             _"Complete ‘<i>Eleventh Hour</i>’ with no recalling and no droppable items."}
+    "ei_S16"    _"Scenario 16: Alternate History"             _"Complete <i>Eleventh Hour</i> with no recalling and no droppable items."}
     {ACHIEVEMENT {PATH}/pacifist.png
-    "ei_S17a"   _"Scenario 17a: Pacifist"                     _"Kill no enemies before defeating Mal-Ravanal in ‘<i>The Duel</i>’."}
+    "ei_S17a"   _"Scenario 17a: Pacifist"                     _"Kill no enemies before defeating Mal-Ravanal in <i>The Duel</i>."}
     {ACHIEVEMENT {PATH}/skull.png
-    "ei_S17b"   _"Scenario 17b: Warmonger"                    _"Kill all enemies before defeating Mal-Ravanal in ‘<i>All-In</i>’."}
+    "ei_S17b"   _"Scenario 17b: Warmonger"                    _"Kill all enemies before defeating Mal-Ravanal in <i>All-In</i>."}
     {ACHIEVEMENT "{CORE_PATH}/attacks/blank-attack.png~SCALE(76,76)~BLIT({CORE_PATH}/units/orcs/sovereign-attack-5.png,2,7)"
     "ei_S99"    _"Scenario 99: Haw, Haw, Haw"                 _"Complete the secret bonus scenario."}
 [/achievement_group]

--- a/data/campaigns/Liberty/achievements.cfg
+++ b/data/campaigns/Liberty/achievements.cfg
@@ -27,7 +27,7 @@
         id="liberty_hunter"
         #po: this is the achievement for the scenario The Hunters
         name=_"Perfect Hunter"
-        description=_"Complete <i>The Hunters</i> with no losses"
+        description=_"Complete <i>The Hunters</i> with no losses."
         icon="data/core/images/attacks/blowgun.png"
         icon_completed="data/core/images/attacks/blowgun.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-8-grey.png",0,0)"
     [/achievement]

--- a/data/campaigns/The_Deceivers_Gambit/achievements.cfg
+++ b/data/campaigns/The_Deceivers_Gambit/achievements.cfg
@@ -18,24 +18,24 @@ data/campaigns/The_Deceivers_Gambit/images/icons#enddef
     display_name=_"The Deceiver’s Gambit"
     content_for=the_deceivers_gambit
 
-    {ACHIEVEMENT {PATH}/animate-fire.png      "tdg_s00"    _"Scenario 0: Sandbagger"             _"Blast the fire elementals in ‘<i>Graduation</i>’."} #po: "sandbagging" means to deliberately underperform
-    {ACHIEVEMENT icons/amla-default.png       "tdg_s01"    _"Scenario 1: Goblinitarian"          _"Complete ‘<i>Stirrings of War</i>’ without killing any goblin spearmen."} #po: portmanteau of "goblin" and "humanitarian"
-    {ACHIEVEMENT attacks/frenzy.png           "tdg_s02"    _"Scenario 2: Bloodthirsty"           _"Complete the hidden victory condition in ‘<i>Fort Garard</i>'"}
-    {ACHIEVEMENT {PATH}/mellon.png            "tdg_s03"    _"Scenario 3: Mellon"                 _"Complete ‘<i>The Ambassador</i>’ without any of your units dying."} #po: "Mellon" is a Lord of the Rings reference
-    {ACHIEVEMENT attacks/waterspray.png       "tdg_s04"    _"Scenario 4: Gurgle gurgle"          _"Drown the silverback in ‘<i>The Sylvan Seer</i>’."}
-    {ACHIEVEMENT {PATH}/hook.png              "tdg_s05"    _"Scenario 5: Hook, Line, and Sinker" _"Defeat both enemy leaders in ‘<i>The Deceiver</i>’ before Garard does."}
-    {ACHIEVEMENT {PATH}/royal-privilege.png   "tdg_s06"    _"Scenario 6: Royal Privilege"        _"Complete ‘<i>Ring of Swords</i>’ with Garard at full hp."}
-    {ACHIEVEMENT {PATH}/time-dilation.png     "tdg_s07"    _"Scenario 7: On the Clock"           _"Complete ‘<i>The Great River</i>’ in 20 turns or less."}
-    {ACHIEVEMENT {PATH}/mist-monster.png      "tdg_s08"    _"Scenario 8: Monster in the Mist"    _"Complete ‘<i>Ruins of Saurgrath</i>’ on the same turn you’re first spotted."}
-    {ACHIEVEMENT {PATH}/bomb.png              "tdg_s09"    _"Scenario 9: Sapper"                 _"Complete ‘<i>Omaranth</i>’ before turns run out."}
+    {ACHIEVEMENT {PATH}/animate-fire.png      "tdg_s00"    _"Scenario 0: Sandbagger"             _"Blast the fire elementals in <i>Graduation</i>."} #po: "sandbagging" means to deliberately underperform
+    {ACHIEVEMENT icons/amla-default.png       "tdg_s01"    _"Scenario 1: Goblinitarian"          _"Complete <i>Stirrings of War</i> without killing any goblin spearmen."} #po: portmanteau of "goblin" and "humanitarian"
+    {ACHIEVEMENT attacks/frenzy.png           "tdg_s02"    _"Scenario 2: Bloodthirsty"           _"Complete the hidden victory condition in <i>Fort Garard</i>."}
+    {ACHIEVEMENT {PATH}/mellon.png            "tdg_s03"    _"Scenario 3: Mellon"                 _"Complete <i>The Ambassador</i> without any of your units dying."} #po: "Mellon" is a Lord of the Rings reference
+    {ACHIEVEMENT attacks/waterspray.png       "tdg_s04"    _"Scenario 4: Gurgle gurgle"          _"Drown the silverback in <i>The Sylvan Seer</i>."}
+    {ACHIEVEMENT {PATH}/hook.png              "tdg_s05"    _"Scenario 5: Hook, Line, and Sinker" _"Defeat both enemy leaders in <i>The Deceiver</i> before Garard does."}
+    {ACHIEVEMENT {PATH}/royal-privilege.png   "tdg_s06"    _"Scenario 6: Royal Privilege"        _"Complete <i>Ring of Swords</i> with Garard at full hp."}
+    {ACHIEVEMENT {PATH}/time-dilation.png     "tdg_s07"    _"Scenario 7: On the Clock"           _"Complete <i>The Great River</i> in 20 turns or less."}
+    {ACHIEVEMENT {PATH}/mist-monster.png      "tdg_s08"    _"Scenario 8: Monster in the Mist"    _"Complete <i>Ruins of Saurgrath</i> on the same turn you’re first spotted."}
+    {ACHIEVEMENT {PATH}/bomb.png              "tdg_s09"    _"Scenario 9: Sapper"                 _"Complete <i>Omaranth</i> before turns run out."}
 
     {ACHIEVEMENT "data/core/images/attacks/blank-attack.png~SCALE(84,84)~BLIT(data/core/images/units/undead-spirit/ghost-base.png~RC(magenta>white),0,0)"
-    "tdg_s10"    _"Scenario 10: Army of the Dead"      _"Command four ghosts at once in ‘<i>Houses of the Dead</i>’."}
+    "tdg_s10"    _"Scenario 10: Army of the Dead"      _"Command four ghosts at once in <i>Houses of the Dead</i>."}
 
-    {ACHIEVEMENT {PATH}/combined-arms.png     "tdg_s11"    _"Scenario 11: Combined Arms"         _"Complete ‘<i>Clan Blackcrest</i>’ in 10 turns or less."}
-    {ACHIEVEMENT attacks/torch.png            "tdg_s12"    _"Scenario 12: Scorched Earth"        _"Destroy all villages in ‘<i>The Traitor</i>’."}
-    {ACHIEVEMENT attacks/saber-human.png      "tdg_s13"    _"Scenario 13: Stand Fast"            _"Defeat all enemy leaders in ‘<i>Revelry, Revisited</i>’."}
-    {ACHIEVEMENT {PATH}/armchair-general.png  "tdg_s14"    _"Scenario 14: Armchair General"      _"Complete the first phase of ‘<i>Long Live the Queen</i>’ without moving Delfador."}
+    {ACHIEVEMENT {PATH}/combined-arms.png     "tdg_s11"    _"Scenario 11: Combined Arms"         _"Complete <i>Clan Blackcrest</i> in 10 turns or less."}
+    {ACHIEVEMENT attacks/torch.png            "tdg_s12"    _"Scenario 12: Scorched Earth"        _"Destroy all villages in <i>The Traitor</i>."}
+    {ACHIEVEMENT attacks/saber-human.png      "tdg_s13"    _"Scenario 13: Stand Fast"            _"Defeat all enemy leaders in <i>Revelry, Revisited</i>."}
+    {ACHIEVEMENT {PATH}/armchair-general.png  "tdg_s14"    _"Scenario 14: Armchair General"      _"Complete the first phase of <i>Long Live the Queen</i> without moving Delfador."}
 [/achievement_group]
 
 #undef ACHIEVEMENT

--- a/data/campaigns/The_Hammer_of_Thursagan/achievements.cfg
+++ b/data/campaigns/The_Hammer_of_Thursagan/achievements.cfg
@@ -6,7 +6,7 @@
     [achievement]
         id="gryphon_hunter"
         name=_"Gryphon Hunter"
-        description=_"Kill the Gryphon leader in High Pass"
+        description=_"Kill the Gryphon leader in <i>High Pass</i>."
         hidden=yes
         icon="data/core/images/units/monsters/gryphon.png"
         icon_completed="data/core/images/units/monsters/gryphon.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
@@ -14,14 +14,14 @@
     [achievement]
         id="conqueror_of_the_forest"
         name=_"Conqueror of the Forest"
-        description=_"Defeat an enemy leader in Forbidden Forest"
+        description=_"Defeat an enemy leader in <i>Forbidden Forest</i>."
         icon="data/core/images/units/woses/wose-die-fall-5.png"
         icon_completed="data/core/images/units/woses/wose-die-fall-5.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-8-grey.png",0,0)"
     [/achievement]
     [achievement]
         id="new_thursagan"
         name=_"New Thursagan"
-        description=_"Complete The Underlevels on challenging difficulty"
+        description=_"Complete <i>The Underlevels</i> on challenging difficulty."
         icon="data/core/images/items/hammer-runic.png"
         icon_completed="data/core/images/items/hammer-runic.png~SCALE(72,72)~BLIT("data/core/images/misc/achievement-frames/frame-3-red.png",0,0)"
     [/achievement]


### PR DESCRIPTION
- Remove single quotes around scenario names. Some campaigns use them, some don't. IMO it looks cleaner without, since they names are already italicized. (TDG S2 wasn't using the proper typographic closing quote either)
- End all descriptions with periods. Again, I don't mind either way, but it should be consistent.
- Italicize all scenario names