### PR TITLE
Reduce copying of preproc_define and tidy up config cache

### DIFF
--- a/boost_test_schedule
+++ b/boost_test_schedule
@@ -84,7 +84,6 @@ test_config/add_child_NonEmptyThis_newOrExistingKey_lOrRValue_AppendAndReturnNew
 test_preproc_defines
 test_config_cache_defaults
 config_cache/test_load_config
-config_cache/test_non_clean_config_loading
 config_cache/test_macrosubstitution
 config_cache/test_transaction
 config_cache/test_define_loading

--- a/src/addon/manager_ui.cpp
+++ b/src/addon/manager_ui.cpp
@@ -287,9 +287,7 @@ bool ad_hoc_addon_fetch_session(const std::vector<std::string>& addon_ids)
 				// if _info.cfg exists, compare the local vs remote add-on versions to determine whether a download is needed
 				if(filesystem::file_exists(info_cfg)) {
 					game_config::config_cache& cache = game_config::config_cache::instance();
-					config info;
-					cache.get_config(info_cfg, info);
-					version_info installed_addon_version(info.child_or_empty("info")["version"]);
+					version_info installed_addon_version(cache.get_config(info_cfg).child_or_empty("info")["version"]);
 
 					// if the installed version is outdated, download the most recent version from the add-ons server
 					if(installed_addon_version >= addon.current_version) {

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -399,9 +399,6 @@ bool config_cache::delete_cache_files(const std::vector<std::string>& paths,
 	return status;
 }
 
-config_cache_transaction::state config_cache_transaction::state_ = FREE;
-config_cache_transaction* config_cache_transaction::active_ = nullptr;
-
 config_cache_transaction::config_cache_transaction()
 	: define_filenames_()
 	, active_map_()

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -447,15 +447,18 @@ preproc_map& config_cache_transaction::get_active_map(const preproc_map& defines
 void config_cache_transaction::add_defines_map_diff(preproc_map& new_map)
 {
 	switch(get_state()) {
-	case ACTIVE:
-		// First, remove all duplicate defines from the input map
-		for(const auto& [key, define] : active_map_) {
-			new_map.erase(key);
-		}
+	case ACTIVE: {
+		preproc_map temp;
+		std::set_difference(new_map.begin(),
+				new_map.end(),
+				active_map_.begin(),
+				active_map_.end(),
+				std::insert_iterator(temp, temp.begin()));
 
-		// Then copy the remaining unique defines back to the active map
-		active_map_.insert(new_map.begin(), new_map.end());
+		active_map_.insert(temp.begin(), temp.end());
+		std::swap(temp, new_map);
 		break;
+	}
 
 	case LOCKED:
 		new_map.clear();

--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -42,18 +42,18 @@ namespace
 void add_builtin_defines(preproc_map& target)
 {
 #ifdef __APPLE__
-	target["APPLE"] = preproc_define();
+	target.try_emplace("APPLE");
 #endif
 
 #ifdef __ANDROID__
-	target["ANDROID"] = preproc_define();
+	target.try_emplace("ANDROID");
 #endif
 
 #if defined(MOUSE_TOUCH_EMULATION) || defined(TARGET_OS_IPHONE)
-	target["IPHONEOS"] = preproc_define();
+	target.try_emplace("IPHONEOS");
 #endif
 
-	target["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
+	target.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 }
 
 }
@@ -83,7 +83,6 @@ const preproc_map& config_cache::get_preproc_map() const
 void config_cache::clear_defines()
 {
 	LOG_CACHE << "Clearing defines map!";
-
 	defines_map_.clear();
 
 	//
@@ -93,9 +92,9 @@ void config_cache::clear_defines()
 	add_builtin_defines(defines_map_);
 }
 
-void config_cache::get_config(const std::string& file_path, config& cfg, abstract_validator* validator)
+config config_cache::get_config(const std::string& file_path, abstract_validator* validator)
 {
-	load_configs(file_path, cfg, validator);
+	return load_configs(file_path, validator);
 }
 
 void config_cache::write_file(const std::string& file_path, const config& cfg)
@@ -123,9 +122,9 @@ void config_cache::write_file(const std::string& file_path, const preproc_map& d
 	}
 }
 
-void config_cache::read_file(const std::string& file_path, config& cfg)
+config config_cache::read_file(const std::string& file_path)
 {
-	cfg = io::read_gz(*filesystem::istream_file(file_path));
+	return io::read_gz(*filesystem::istream_file(file_path));
 }
 
 preproc_map& config_cache::make_copy_map()
@@ -142,10 +141,9 @@ void config_cache::add_defines_map_diff(preproc_map& defines_map)
 	return config_cache_transaction::instance().add_defines_map_diff(defines_map);
 }
 
-void config_cache::read_configs(const std::string& file_path, config& cfg, preproc_map& defines_map, abstract_validator* validator)
+config config_cache::read_configs(const std::string& file_path, preproc_map& defines_map, abstract_validator* validator)
 {
-	//read the file and then write to the cache
-	cfg = io::read(*preprocess_file(file_path, &defines_map), validator);
+	return io::read(*preprocess_file(file_path, &defines_map), validator);
 }
 
 void config_cache::read_cache(const std::string& file_path, config& cfg, abstract_validator* validator)
@@ -157,19 +155,17 @@ void config_cache::read_cache(const std::string& file_path, config& cfg, abstrac
 
 	bool is_valid = true;
 
-	for(const preproc_map::value_type& d : defines_map_) {
+	for(const auto& [key, define] : defines_map_) {
 		//
 		// Only WESNOTH_VERSION is allowed to be non-empty.
 		//
-		if((!d.second.value.empty() || !d.second.arguments.empty()) &&
-		   d.first != "WESNOTH_VERSION")
-		{
+		if((!define.value.empty() || !define.arguments.empty()) && key != "WESNOTH_VERSION") {
 			is_valid = false;
-			ERR_CACHE << "Invalid preprocessor define: " << d.first;
+			ERR_CACHE << "Invalid preprocessor define: " << key;
 			break;
 		}
 
-		defines_string << " " << d.first;
+		defines_string << " " << key;
 	}
 
 	// Do cache check only if define map is valid and
@@ -188,10 +184,8 @@ void config_cache::read_cache(const std::string& file_path, config& cfg, abstrac
 		if(!force_valid_cache_ && !fake_invalid_cache_) {
 			try {
 				if(filesystem::file_exists(fname_checksum)) {
-					config checksum_cfg;
-
 					DBG_CACHE << "Reading checksum: " << fname_checksum;
-					read_file(fname_checksum, checksum_cfg);
+					config checksum_cfg = read_file(fname_checksum);
 
 					dir_checksum = filesystem::file_tree_checksum(checksum_cfg);
 				}
@@ -213,7 +207,7 @@ void config_cache::read_cache(const std::string& file_path, config& cfg, abstrac
 			log_scope("read cache");
 
 			try {
-				read_file(fname + extension,cfg);
+				cfg = read_file(fname + extension);
 				const std::string define_file = fname + ".define" + extension;
 
 				if(filesystem::file_exists(define_file)) {
@@ -238,7 +232,7 @@ void config_cache::read_cache(const std::string& file_path, config& cfg, abstrac
 
 		preproc_map copy_map(make_copy_map());
 
-		read_configs(file_path, cfg, copy_map, validator);
+		cfg = read_configs(file_path, copy_map, validator);
 		add_defines_map_diff(copy_map);
 
 		try {
@@ -259,45 +253,42 @@ void config_cache::read_cache(const std::string& file_path, config& cfg, abstrac
 	LOG_CACHE << "Loading plain config instead of cache";
 
 	preproc_map copy_map(make_copy_map());
-	read_configs(file_path, cfg, copy_map, validator);
+	cfg = read_configs(file_path, copy_map, validator);
 	add_defines_map_diff(copy_map);
 }
 
 void config_cache::read_defines_file(const std::string& file_path)
 {
-	config cfg;
-	read_file(file_path, cfg);
-
 	DBG_CACHE << "Reading cached defines from: " << file_path;
+	config file_cfg = read_file(file_path);
 
-	// use static preproc_define::read_pair(config) to make a object
-	// and pass that object config_cache_transaction::insert_to_active method
-	for(const auto [key, cfg] : cfg.all_children_view()) {
-		config_cache_transaction::instance().insert_to_active(preproc_define::read_pair(cfg));
+	for(const auto [key, cfg] : file_cfg.all_children_view()) {
+		preproc_define::insert(config_cache_transaction::instance().get_active_map(defines_map_), cfg);
 	}
 }
 
 void config_cache::read_defines_queue()
 {
-	const std::vector<std::string>& files = config_cache_transaction::instance().get_define_files();
-
-	for(const std::string &p : files) {
+	for(const std::string& p : config_cache_transaction::instance().get_define_files()) {
 		read_defines_file(p);
 	}
 }
 
-void config_cache::load_configs(const std::string& config_path, config& cfg, abstract_validator* validator)
+config config_cache::load_configs(const std::string& config_path, abstract_validator* validator)
 {
 	// Make sure that we have fake transaction if no real one is going on
 	fake_transaction fake;
+	config cfg;
 
-	if (use_cache_) {
+	if(use_cache_) {
 		read_cache(config_path, cfg, validator);
 	} else {
 		preproc_map copy_map(make_copy_map());
-		read_configs(config_path, cfg, copy_map, validator);
+		cfg = read_configs(config_path, copy_map, validator);
 		add_defines_map_diff(copy_map);
 	}
+
+	return cfg;
 }
 
 void config_cache::set_force_invalid_cache(bool force)
@@ -323,13 +314,12 @@ void config_cache::recheck_filetree_checksum()
 void config_cache::add_define(const std::string& define)
 {
 	DBG_CACHE << "adding define: " << define;
-	defines_map_[define] = preproc_define();
+	defines_map_.try_emplace(define);
 
 	if(config_cache_transaction::is_active()) {
 		// we have to add this to active map too
-		config_cache_transaction::instance().get_active_map(defines_map_).emplace(define, preproc_define());
+		config_cache_transaction::instance().get_active_map(defines_map_).try_emplace(define);
 	}
-
 }
 
 void config_cache::remove_define(const std::string& define)
@@ -454,52 +444,26 @@ preproc_map& config_cache_transaction::get_active_map(const preproc_map& defines
 	return active_map_;
 }
 
-namespace
-{
-
-bool compare_define(const preproc_map::value_type& a, const preproc_map::value_type& b)
-{
-	if(a.first < b.first) {
-		return true;
-	}
-
-	if(b.first < a.first) {
-		return false;
-	}
-
-	if(a.second < b.second) {
-		return true;
-	}
-
-	return false;
-}
-
-} // end anonymous namespace
-
 void config_cache_transaction::add_defines_map_diff(preproc_map& new_map)
 {
-	if(get_state() == ACTIVE) {
-		preproc_map temp;
-		std::set_difference(new_map.begin(),
-				new_map.end(),
-				active_map_.begin(),
-				active_map_.end(),
-				std::insert_iterator<preproc_map>(temp,temp.begin()),
-				&compare_define);
-
-		for(const preproc_map::value_type &def : temp) {
-			insert_to_active(def);
+	switch(get_state()) {
+	case ACTIVE:
+		// First, remove all duplicate defines from the input map
+		for(const auto& [key, define] : active_map_) {
+			new_map.erase(key);
 		}
 
-		temp.swap(new_map);
-	} else if (get_state() == LOCKED) {
-		new_map.clear();
-	}
-}
+		// Then copy the remaining unique defines back to the active map
+		active_map_.insert(new_map.begin(), new_map.end());
+		break;
 
-void config_cache_transaction::insert_to_active(const preproc_map::value_type& def)
-{
-	active_map_[def.first] = def.second;
+	case LOCKED:
+		new_map.clear();
+		break;
+
+	default:
+		break;
+	}
 }
 
 }

--- a/src/config_cache.hpp
+++ b/src/config_cache.hpp
@@ -162,10 +162,12 @@ private:
 	void write_file(const std::string& file, const config& cfg);
 	void write_file(const std::string& file, const preproc_map& defines);
 
-	void read_cache(const std::string& path, config& cfg, abstract_validator* validator = nullptr);
+	config read_cache(const std::string& path, abstract_validator* validator = nullptr);
 
+	config read_configs(const std::string& path, abstract_validator* validator);
 	config read_configs(const std::string& path, preproc_map& defines, abstract_validator* validator = nullptr);
 	config load_configs(const std::string& path, abstract_validator* validator = nullptr);
+
 	void read_defines_queue();
 	void read_defines_file(const std::string& path);
 

--- a/src/config_cache.hpp
+++ b/src/config_cache.hpp
@@ -105,10 +105,9 @@ public:
 	/**
 	 * Gets a config object from given @a path.
 	 * @param path file to load. Should be _main.cfg.
-	 * @param cfg config object that is written to. Should be empty on entry.
 	 * @param validator the WML schema validator, if provided.
 	 */
-	void get_config(const std::string& path, config& cfg, abstract_validator* validator = nullptr);
+	config get_config(const std::string& path, abstract_validator* validator = nullptr);
 
 	/**
 	 * Clear stored defines map to default values
@@ -159,14 +158,14 @@ private:
 
 	std::string cache_file_prefix_;
 
-	void read_file(const std::string& file, config& cfg);
+	config read_file(const std::string& file);
 	void write_file(const std::string& file, const config& cfg);
 	void write_file(const std::string& file, const preproc_map& defines);
 
 	void read_cache(const std::string& path, config& cfg, abstract_validator* validator = nullptr);
 
-	void read_configs(const std::string& path, config& cfg, preproc_map& defines, abstract_validator* validator = nullptr);
-	void load_configs(const std::string& path, config& cfg, abstract_validator* validator = nullptr);
+	config read_configs(const std::string& path, preproc_map& defines, abstract_validator* validator = nullptr);
+	config load_configs(const std::string& path, abstract_validator* validator = nullptr);
 	void read_defines_queue();
 	void read_defines_file(const std::string& path);
 
@@ -206,12 +205,6 @@ public:
 	 * Lock the transaction so no more macros are added
 	 */
 	void lock();
-
-	/**
-	 * Used to let std::for_each insert new defines to active_map
-	 * map to active
-	 */
-	void insert_to_active(const preproc_map::value_type& def);
 
 	enum state
 	{

--- a/src/config_cache.hpp
+++ b/src/config_cache.hpp
@@ -164,7 +164,8 @@ private:
 
 	config read_cache(const std::string& path, abstract_validator* validator = nullptr);
 
-	config read_configs(const std::string& path, abstract_validator* validator);
+	std::pair<config, preproc_map> read_configs(const std::string& path, abstract_validator* validator);
+
 	config read_configs(const std::string& path, preproc_map& defines, abstract_validator* validator = nullptr);
 	config load_configs(const std::string& path, abstract_validator* validator = nullptr);
 

--- a/src/config_cache.hpp
+++ b/src/config_cache.hpp
@@ -221,8 +221,8 @@ private:
 	friend class config_cache;
 	friend class fake_transaction;
 
-	static state state_;
-	static config_cache_transaction* active_;
+	static inline state state_ = FREE;
+	static inline config_cache_transaction* active_ = nullptr;
 
 	std::vector<std::string> define_filenames_;
 	preproc_map active_map_;

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -832,7 +832,7 @@ void map_context::save_schedule(const std::string& schedule_id, const std::strin
 			/* If exists, read the schedule.cfg
 			 * and insert [editor_times] block at correct place */
 			preproc_map editor_map;
-			editor_map["EDITOR"] = preproc_define("true");
+			editor_map.try_emplace("EDITOR");
 			schedule = io::read(*preprocess_file(schedule_path, &editor_map));
 		}
 	} catch(const filesystem::io_exception& e) {

--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -212,8 +212,7 @@ void game_config_manager::load_game_config(bool reload_everything, const game_cl
 			achievements_.reload();
 
 			// Load mainline cores definition file.
-			config cores_cfg;
-			cache_.get_config(game_config::path + "/data/cores.cfg", cores_cfg);
+			config cores_cfg = cache_.get_config(game_config::path + "/data/cores.cfg");
 
 			// Append the $user_campaign_dir/*/cores.cfg files to the cores.
 			std::vector<std::string> user_dirs;
@@ -227,9 +226,7 @@ void game_config_manager::load_game_config(bool reload_everything, const game_cl
 			for(const std::string& umc : user_dirs) {
 				const std::string cores_file = umc + "/cores.cfg";
 				if(filesystem::file_exists(cores_file)) {
-					config cores;
-					cache_.get_config(cores_file, cores);
-					cores_cfg.append(cores);
+					cores_cfg.append(cache_.get_config(cores_file));
 				}
 			}
 
@@ -314,7 +311,7 @@ void game_config_manager::load_game_config(bool reload_everything, const game_cl
 				validator->set_create_exceptions(false); // Don't crash if there's an error, just go ahead anyway
 			}
 
-			cache_.get_config(filesystem::get_wml_location(wml_tree_root).value(), game_config_, validator.get());
+			game_config_ = cache_.get_config(filesystem::get_wml_location(wml_tree_root).value(), validator.get());
 			game_config_.append(valid_cores);
 
 			main_transaction.lock();
@@ -524,10 +521,7 @@ void game_config_manager::load_addons_cfg()
 			}
 		} else if(filesystem::file_exists(info_cfg)) {
 			// Addon server-generated info can be fetched from cache.
-			config temp;
-			cache_.get_config(info_cfg, temp);
-
-			metadata = temp.child_or_empty("info");
+			metadata = cache_.get_config(info_cfg).child_or_empty("info");
 		}
 
 		std::string using_core = metadata["core"];
@@ -558,8 +552,7 @@ void game_config_manager::load_addons_cfg()
 			loading_screen::spin();
 
 			// Load this addon from the cache to a config.
-			config umc_cfg;
-			cache_.get_config(main_cfg, umc_cfg, validator.get());
+			config umc_cfg = cache_.get_config(main_cfg, validator.get());
 
 			static const std::set<std::string> tags_with_addon_id {
 				"era",

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -36,7 +36,7 @@ config read_and_validate(const std::string& path)
 try {
 	preproc_map defines;
 #ifdef __ANDROID__
-	defines["ANDROID"] = preproc_define();
+	defines.try_emplace("ANDROID");
 #endif
 	schema_validation::schema_validator validator{filesystem::get_wml_location("schema/gui.cfg").value()};
 	return io::read(*preprocess_file(path, &defines), &validator);

--- a/src/scripting/lua_wml.cpp
+++ b/src/scripting/lua_wml.cpp
@@ -67,7 +67,7 @@ static int intf_load_wml(lua_State* L)
 			std::string define = lua_tostring(L, -1);
 			lua_pop(L, 1);
 			if(!define.empty()) {
-				defines_map.emplace(define, preproc_define(define));
+				defines_map.try_emplace(define, define);
 			}
 		}
 	} else if(!lua_isnoneornil(L, 2)) {

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -657,6 +657,13 @@ class preprocessor_data : public preprocessor
 			macro_parens  // Processing a parenthesized macro argument
 		};
 
+		token_desc(token_type type, const int stack_pos, const int linenum)
+			: type(type)
+			, stack_pos(stack_pos)
+			, linenum(linenum)
+		{
+		}
+
 		token_type type;
 
 		/** Starting position in #strings_ of the delayed text for this chunk. */

--- a/src/serialization/preprocessor.cpp
+++ b/src/serialization/preprocessor.cpp
@@ -226,12 +226,9 @@ void preproc_define::read(const config& cfg)
 	}
 }
 
-preproc_map::value_type preproc_define::read_pair(const config& cfg)
+void preproc_define::insert(preproc_map& map, const config& cfg)
 {
-	preproc_define second;
-	second.read(cfg);
-
-	return preproc_map::value_type(cfg["name"], second);
+	map.try_emplace(cfg["name"], cfg);
 }
 
 std::ostream& operator<<(std::ostream& stream, const preproc_define& def)
@@ -659,13 +656,6 @@ class preprocessor_data : public preprocessor
 			macro_chunk,  // Processing inside a chunk of a macro call (stop on space or '(')
 			macro_parens  // Processing a parenthesized macro argument
 		};
-
-		token_desc(token_type type, const int stack_pos, const int linenum)
-			: type(type)
-			, stack_pos(stack_pos)
-			, linenum(linenum)
-		{
-		}
 
 		token_type type;
 
@@ -1311,9 +1301,9 @@ bool preprocessor_data::get_chunk()
 				}
 
 				buffer.erase(buffer.end() - 7, buffer.end());
-				(*parent_.defines_)[symbol]
-						= preproc_define(buffer, items, optargs, parent_.textdomain_, linenum, parent_.location_,
-						deprecation_detail, deprecation_level, deprecation_version);
+				(*parent_.defines_).insert_or_assign(symbol,
+						preproc_define(buffer, items, optargs, parent_.textdomain_, linenum, parent_.location_,
+						deprecation_detail, deprecation_level, deprecation_version));
 
 				LOG_PREPROC << "defining macro " << symbol << " (location " << get_location(parent_.location_) << ")";
 			}

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -35,24 +35,16 @@ typedef std::map<std::string, struct preproc_define> preproc_map;
 
 struct preproc_define
 {
-	preproc_define()
-		: value()
-		, arguments()
-		, optional_arguments()
-		, textdomain()
-		, linenum(0)
-		, location()
-	{
-	}
+	preproc_define() = default;
 
 	explicit preproc_define(const std::string& val)
 		: value(val)
-		, arguments()
-		, optional_arguments()
-		, textdomain()
-		, linenum(0)
-		, location()
 	{
+	}
+
+	explicit preproc_define(const config& cfg)
+	{
+		read(cfg);
 	}
 
 	preproc_define(const std::string& val,
@@ -67,11 +59,11 @@ struct preproc_define
 		, arguments(args)
 		, optional_arguments(optargs)
 		, textdomain(domain)
-		, linenum(line)
 		, location(loc)
 		, deprecation_message(dep_msg)
-		, deprecation_level(dep_lvl)
 		, deprecation_version(dep_ver)
+		, deprecation_level(dep_lvl)
+		, linenum(line)
 	{
 	}
 
@@ -83,15 +75,15 @@ struct preproc_define
 
 	std::string textdomain;
 
-	int linenum;
-
 	std::string location;
 
 	std::string deprecation_message;
 
+	version_info deprecation_version;
+
 	utils::optional<DEP_LEVEL> deprecation_level;
 
-	version_info deprecation_version;
+	int linenum{0};
 
 	bool is_deprecated() const {
 		return deprecation_level.has_value();
@@ -104,7 +96,7 @@ struct preproc_define
 	void read(const config&);
 	void read_argument(const config&);
 
-	static preproc_map::value_type read_pair(const config&);
+	static void insert(preproc_map&, const config&);
 
 	bool operator==(const preproc_define&) const;
 

--- a/src/serialization/tokenizer.hpp
+++ b/src/serialization/tokenizer.hpp
@@ -39,11 +39,6 @@ constexpr int END_STANDARD_ASCII = 128;
  */
 struct token
 {
-	token() :
-		type(END),
-		value()
-	{}
-
 	/**
 	 * used for a token's type field
 	 */
@@ -85,7 +80,7 @@ struct token
 		DOLLAR = '$',
 	};
 
-	token_type type;
+	token_type type{END};
 	/** the token's value, can be either a single character or multiple characters */
 	std::string value;
 };

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -144,16 +144,16 @@ struct test_gui2_fixture {
 	: config_manager()
 	, dummy_args({"wesnoth", "--noaddons"})
 	{
-		/** The main config, which contains the entire WML tree. */
-		game_config_view game_config_view_ = game_config_view::wrap(main_config);
 		config_manager.reset(new game_config_manager(dummy_args));
-
 		game_config::config_cache& cache = game_config::config_cache::instance();
 
 		cache.clear_defines();
 		cache.add_define("EDITOR");
 		cache.add_define("MULTIPLAYER");
-		cache.get_config(game_config::path +"/data", main_config);
+
+		/** The main config, which contains the entire WML tree. */
+		main_config = cache.get_config(game_config::path +"/data");
+		game_config_view game_config_view_ = game_config_view::wrap(main_config);
 
 		const filesystem::binary_paths_manager bin_paths_manager(game_config_view_);
 

--- a/src/tests/test_config_cache.cpp
+++ b/src/tests/test_config_cache.cpp
@@ -29,21 +29,17 @@
 
 #include <functional>
 
-
 static preproc_map setup_test_preproc_map()
 {
 	preproc_map defines_map;
 
 #if defined(__APPLE__)
-	defines_map["APPLE"] = preproc_define();
+	defines_map.try_emplace("APPLE");
 #endif
 
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	return defines_map;
-
 }
-
 
 /**
  * Used to make distinct singleton for testing it
@@ -98,7 +94,7 @@ BOOST_AUTO_TEST_CASE( test_preproc_defines )
 	// scoped
 	{
 		test_scoped_define test("TEST");
-		defines_map["TEST"] = preproc_define();
+		defines_map.try_emplace("TEST");;
 
 		BOOST_CHECK_EQUAL_COLLECTIONS(test_defines.begin(),test_defines.end(),
 				defines_map.begin() ,defines_map.end());
@@ -111,7 +107,7 @@ BOOST_AUTO_TEST_CASE( test_preproc_defines )
 
 	// Manual add define
 	cache.add_define("TEST");
-	defines_map["TEST"] = preproc_define();
+	defines_map.try_emplace("TEST");;
 	BOOST_CHECK_EQUAL_COLLECTIONS(test_defines.begin(),test_defines.end(),
 			defines_map.begin() ,defines_map.end());
 

--- a/src/tests/test_config_cache.cpp
+++ b/src/tests/test_config_cache.cpp
@@ -147,44 +147,18 @@ static config setup_test_config()
 
 BOOST_AUTO_TEST_CASE( test_load_config )
 {
-
 	config test_config = setup_test_config();
-	config cached_config;
-	cache.get_config(test_data_path, cached_config);
+	config cached_config = cache.get_config(test_data_path);
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 
 	config &child = test_config.add_child("test_key2");
 	child["define"] = t_string("testing translation reset.", GETTEXT_DOMAIN);
 
-
 	test_scoped_define test_define_def("TEST_DEFINE");
-	cached_config.clear();
-	cache.get_config(test_data_path, cached_config);
+	cached_config = cache.get_config(test_data_path);
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 
 	BOOST_CHECK_EQUAL(test_config.mandatory_child("test_key2")["define"].str(), cached_config.mandatory_child("test_key2")["define"].str());
-}
-
-BOOST_AUTO_TEST_CASE( test_non_clean_config_loading )
-{
-
-	config test_config = setup_test_config();
-
-	// Test clean load first
-	{
-		config cfg;
-		cache.get_config(test_data_path, cfg);
-		BOOST_CHECK_EQUAL(test_config, cfg);
-	}
-
-	// test non-clean one then
-	{
-		config cfg;
-		config &child = cfg.add_child("junk_data");
-		child["some_junk"] = "hah";
-		cache.get_config(test_data_path, cfg);
-		BOOST_CHECK_EQUAL(test_config, cfg);
-	}
 }
 
 BOOST_AUTO_TEST_CASE( test_macrosubstitution )
@@ -200,16 +174,12 @@ BOOST_AUTO_TEST_CASE( test_macrosubstitution )
 	test_scoped_define macro("TEST_MACRO");
 
 	// Without cache
-	config cached_config;
-	cache.get_config(test_data_path, cached_config);
+	config cached_config = cache.get_config(test_data_path);
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 
 	// With cache
-	cached_config.clear();
-	cache.get_config(test_data_path, cached_config);
+	cached_config = cache.get_config(test_data_path);
 	BOOST_CHECK_EQUAL(test_config, cached_config);
-
-
 }
 
 BOOST_AUTO_TEST_CASE( test_transaction )
@@ -228,8 +198,7 @@ BOOST_AUTO_TEST_CASE( test_transaction )
 
 	game_config::config_cache_transaction transaction;
 
-	config cached_config;
-	cache.get_config(test_data_path, cached_config);
+	config cached_config = cache.get_config(test_data_path);
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 
 	transaction.lock();
@@ -240,8 +209,7 @@ BOOST_AUTO_TEST_CASE( test_transaction )
 	(*child)["define"] = "transaction";
 	child = &umc_config.add_child("test_key4");
 	(*child)["defined"] = "parameter";
-	cached_config.clear();
-	cache.get_config("data/test/test/umc.cfg", cached_config);
+	cached_config = cache.get_config("data/test/test/umc.cfg");
 	BOOST_CHECK_EQUAL(umc_config, cached_config);
 }
 
@@ -262,8 +230,7 @@ BOOST_AUTO_TEST_CASE( test_define_loading )
 
 	game_config::config_cache_transaction transaction;
 
-	config cached_config;
-	cache.get_config(test_data_path, cached_config);
+	config cached_config = cache.get_config(test_data_path);
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 
 	transaction.lock();
@@ -276,8 +243,7 @@ BOOST_AUTO_TEST_CASE( test_define_loading )
 	(*child)["define"] = "transaction";
 	child = &umc_config.add_child("test_key4");
 	(*child)["defined"] = "parameter";
-	cached_config.clear();
-	cache.get_config("data/test/test/umc.cfg", cached_config);
+	cached_config = cache.get_config("data/test/test/umc.cfg");
 	BOOST_CHECK_EQUAL(umc_config, cached_config);
 	cache.set_force_invalid_cache(false);
 }
@@ -288,12 +254,10 @@ BOOST_AUTO_TEST_CASE( test_lead_spaces_loading )
 	test_config.add_child("test_lead_space")["space"] = "empty char in middle";
 	// Force reload of cache
 	cache.set_force_invalid_cache(true);
-	config cached_config;
-	cache.get_config("data/test/test/leading_space.cfg", cached_config);
+	config cached_config = cache.get_config("data/test/test/leading_space.cfg");
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 	cache.set_force_invalid_cache(false);
-	cached_config.clear();
-	cache.get_config("data/test/test/leading_space.cfg", cached_config);
+	cached_config = cache.get_config("data/test/test/leading_space.cfg");
 	BOOST_CHECK_EQUAL(test_config, cached_config);
 }
 
@@ -302,13 +266,12 @@ BOOST_AUTO_TEST_CASE( test_lead_spaces_loading )
 BOOST_AUTO_TEST_CASE( test_performance )
 {
 	test_scoped_define mp("MULTIPLAYER");
-	config cfg_ref;
 //	cache.set_force_invalid_cache(true);
-	cache.get_config("data/", cfg_ref);
+	config cfg_ref = cache.get_config("data/");
 //	cache.set_force_invalid_cache(false);
 	for (int i=0; i < 3; ++i)
 	{
-		cache.get_config("data/");
+		cfg_ref = cache.get_config("data/");
 	}
 }
 #endif

--- a/src/tests/test_filesystem.cpp
+++ b/src/tests/test_filesystem.cpp
@@ -145,14 +145,14 @@ BOOST_AUTO_TEST_CASE( test_fs_enum )
 
 BOOST_AUTO_TEST_CASE( test_fs_binary_path )
 {
-	config main_config;
-	game_config_view game_config_view_ = game_config_view::wrap(main_config);
 	game_config::config_cache& cache = game_config::config_cache::instance();
 
 	cache.clear_defines();
 	cache.add_define("EDITOR");
 	cache.add_define("MULTIPLAYER");
-	cache.get_config(game_config::path +"/data", main_config);
+
+	config main_config = cache.get_config(game_config::path + "/data");
+	game_config_view game_config_view_ = game_config_view::wrap(main_config);
 
 	const filesystem::binary_paths_manager bin_paths_manager(game_config_view_);
 

--- a/src/tests/utils/game_config_manager_tests.cpp
+++ b/src/tests/utils/game_config_manager_tests.cpp
@@ -69,13 +69,12 @@ namespace test_utils {
 			translation::bind_textdomain("wesnoth-lib", intl_dir.c_str(), "UTF-8");
 			translation::set_default_textdomain("wesnoth");
 
-
 			font::load_font_config();
 			gui2::init();
 			gui2::switch_theme("default");
 			load_language_list();
 			game_config::config_cache::instance().add_define("TEST");
-			game_config::config_cache::instance().get_config(game_config::path + "/data/test/", cfg_);
+			cfg_ = game_config::config_cache::instance().get_config(game_config::path + "/data/test/");
 			::init_textdomains(game_config_view_);
 			const std::vector<language_def>& languages = get_languages();
 			auto English = utils::ranges::find(languages, "en_US", &language_def::localename);
@@ -89,7 +88,6 @@ namespace test_utils {
 			hotkey::load_default_hotkeys(game_config_view_);
 			paths_manager_.set_paths(game_config_view_);
 			font::load_font_config();
-
 		}
 
 		static config& get_config_static()

--- a/src/tests/wml/schema/test_schema_validator.cpp
+++ b/src/tests/wml/schema/test_schema_validator.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(test_super_cycle)
 
 	// See: wesnoth.cpp > handle_validate_command
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 
@@ -58,8 +58,8 @@ BOOST_AUTO_TEST_CASE(test_super_cycle_only_if_used)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(test_super_cycle_crashes_on_unknown_key)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 
@@ -96,8 +96,8 @@ BOOST_AUTO_TEST_CASE(test_super_missing)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 
@@ -116,8 +116,8 @@ BOOST_AUTO_TEST_CASE(test_super_missing_only_if_used)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
@@ -133,8 +133,8 @@ BOOST_AUTO_TEST_CASE(test_super_mandatory)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
@@ -150,8 +150,8 @@ BOOST_AUTO_TEST_CASE(test_super_mandatory_missing)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 	BOOST_CHECK_EXCEPTION(io::read(*stream, &validator), wml_exception, [](const wml_exception& e) {
@@ -169,8 +169,8 @@ BOOST_AUTO_TEST_CASE(test_super_cycle_mandatory)
 	validator.set_create_exceptions(true);
 
 	preproc_map defines_map;
-	defines_map["WESNOTH_VERSION"] = preproc_define(game_config::wesnoth_version.str());
-	defines_map["SCHEMA_VALIDATION"] = preproc_define();
+	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
+	defines_map.try_emplace("SCHEMA_VALIDATION");
 
 	auto stream = preprocess_file(config_path, &defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));


### PR DESCRIPTION
- Prefer return values over input parameters in the config cache. The test_non_clean_config_loading test has likewise been removed since `config_cache::get_config` no longer takes an input parameter.
- Remove unnecessary default ctors or use defaulted ones
- Use in-place construction for preproc_defines. Especially no need to create default objects only to assign them to default objects.) Subscript lookup for define maps has been replaced either with try_emplace or insert_or_assign`.
- Slightly optimize `preproc_define` size (saves 8 bytes)
- Replace `preproc_define::read_pair` with a new in-place construction helper (`preproc_define::insert`).
- ~Optimize `config_cache::transaction::add_defines_map_diff`. Remove an unnecessary copy by erasing duplicates from the input map before copying to the active map rather than going through an intermediate temp object.~
- Remove `config_cache_transaction::insert_to_active`. One use was superseded by the above change, the other by the new `preproc_define::insert` helper. The old implementation was also making an unnecessary value copy instead of simply inserting the value_type parameter. (Note that using `get_active_map` instead of straight map insertion results in defines being copied from the input map to the active map if the latter is empty, but I don’t see harm in doing so, given we expect that wherever else the accessor is used).