### PR TITLE
Preprocessor: clean up preproc_map input handling

### DIFF
--- a/src/config_cache.cpp
+++ b/src/config_cache.cpp
@@ -150,7 +150,7 @@ std::pair<config, preproc_map> config_cache::read_configs(const std::string& fil
 
 config config_cache::read_configs(const std::string& file_path, preproc_map& defines_map, abstract_validator* validator)
 {
-	return io::read(*preprocess_file(file_path, &defines_map), validator);
+	return io::read(*preprocess_file(file_path, defines_map), validator);
 }
 
 config config_cache::read_cache(const std::string& file_path, abstract_validator* validator)

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -750,7 +750,7 @@ config map_context::to_config()
 
 	// [unit]s
 	preproc_map traits_map;
-	preprocess_file(game_config::path + "/data/core/macros/traits.cfg", &traits_map);
+	preprocess_file(game_config::path + "/data/core/macros/traits.cfg", traits_map);
 
 	for(const auto& unit : units_) {
 		config& u = event.add_child("unit");
@@ -776,8 +776,7 @@ config map_context::to_config()
 
 		config& mods = u.add_child("modifications");
 		if(unit.loyal()) {
-			config trait_loyal = io::read(preprocess_string("{TRAIT_LOYAL}", &traits_map, "wesnoth-help"));
-			mods.append(std::move(trait_loyal));
+			mods.append(io::read(preprocess_string("{TRAIT_LOYAL}", &traits_map, "wesnoth-help")));
 		}
 		//TODO this entire block could also be replaced by unit.write(u, true)
 		//however, the resultant config is massive and contains many attributes we don't need.
@@ -833,7 +832,7 @@ void map_context::save_schedule(const std::string& schedule_id, const std::strin
 			 * and insert [editor_times] block at correct place */
 			preproc_map editor_map;
 			editor_map.try_emplace("EDITOR");
-			schedule = io::read(*preprocess_file(schedule_path, &editor_map));
+			schedule = io::read(*preprocess_file(schedule_path, editor_map));
 		}
 	} catch(const filesystem::io_exception& e) {
 		utils::string_map symbols;

--- a/src/editor/map/map_context.cpp
+++ b/src/editor/map/map_context.cpp
@@ -776,7 +776,7 @@ config map_context::to_config()
 
 		config& mods = u.add_child("modifications");
 		if(unit.loyal()) {
-			mods.append(io::read(preprocess_string("{TRAIT_LOYAL}", &traits_map, "wesnoth-help")));
+			mods.append(io::read(*preprocess_string("{TRAIT_LOYAL}", "wesnoth-help", traits_map)));
 		}
 		//TODO this entire block could also be replaced by unit.write(u, true)
 		//however, the resultant config is massive and contains many attributes we don't need.

--- a/src/gui/dialogs/editor/edit_unit.cpp
+++ b/src/gui/dialogs/editor/edit_unit.cpp
@@ -60,12 +60,12 @@ editor_edit_unit::editor_edit_unit(const game_config_view& game_config, const st
 	, addon_id_(addon_id)
 {
 	//TODO some weapon specials can have args (PLAGUE_TYPE)
-	io::read(*preprocess_file(game_config::path+"/data/core/macros/weapon_specials.cfg", &specials_map_));
+	io::read(*preprocess_file(game_config::path+"/data/core/macros/weapon_specials.cfg", specials_map_));
 	for (const auto& x : specials_map_) {
 		specials_list_.emplace_back("label", x.first, "checkbox", false);
 	}
 
-	io::read(*preprocess_file(game_config::path+"/data/core/macros/abilities.cfg", &abilities_map_));
+	io::read(*preprocess_file(game_config::path+"/data/core/macros/abilities.cfg", abilities_map_));
 	for (const auto& x : abilities_map_) {
 		// Don't add any macros that have INTERNAL
 		if (x.first.find("INTERNAL") == std::string::npos) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -39,7 +39,7 @@ try {
 	defines.try_emplace("ANDROID");
 #endif
 	schema_validation::schema_validator validator{filesystem::get_wml_location("schema/gui.cfg").value()};
-	return io::read(*preprocess_file(path, &defines), &validator);
+	return io::read(*preprocess_file(path, defines), &validator);
 
 } catch(const utils::bad_optional_access&) {
 	FAIL("GUI2: schema/gui.cfg not found.");

--- a/src/scripting/lua_wml.cpp
+++ b/src/scripting/lua_wml.cpp
@@ -82,7 +82,7 @@ static int intf_load_wml(lua_State* L)
 	std::string wml_file = filesystem::get_wml_location(file).value();
 	filesystem::scoped_istream stream;
 	if(preprocess) {
-		stream = preprocess_file(wml_file, &defines_map);
+		stream = preprocess_file(wml_file, defines_map);
 	} else {
 		stream.reset(new std::ifstream(wml_file));
 	}

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -133,7 +133,8 @@ std::ostream& operator<<(std::ostream& stream, const preproc_map::value_type& de
  *
  * @returns                       The resulting preprocessed file data.
  */
-filesystem::scoped_istream preprocess_file(const std::string& fname, preproc_map* defines = nullptr);
+filesystem::scoped_istream preprocess_file(const std::string& fname, preproc_map& defines);
+filesystem::scoped_istream preprocess_file(const std::string& fname);
 
 /**
  * Function to use the WML preprocessor on a string.

--- a/src/serialization/preprocessor.hpp
+++ b/src/serialization/preprocessor.hpp
@@ -142,14 +142,11 @@ filesystem::scoped_istream preprocess_file(const std::string& fname);
  * @param defines                 A map of symbols defined.
  * @param contents                The string to be preprocessed.
  * @param textdomain              The textdomain to associate the contents.
- *                                Default: wesnoth
  *
  * @returns                       The resulting preprocessed string.
  */
-std::string preprocess_string(
-	const std::string& contents,
-	preproc_map* defines,
-	const std::string& textdomain = "wesnoth");
+filesystem::scoped_istream preprocess_string(const std::string& contents, const std::string& textdomain, preproc_map& defines);
+filesystem::scoped_istream preprocess_string(const std::string& contents, const std::string& textdomain);
 
 void preprocess_resource(
 	const std::string& res_name,

--- a/src/serialization/schema_validator.cpp
+++ b/src/serialization/schema_validator.cpp
@@ -277,7 +277,7 @@ bool schema_validator::read_config_file(const std::string& filename)
 			validator.reset(new schema_self_validator());
 		}
 		preproc_map preproc(game_config::config_cache::instance().get_preproc_map());
-		filesystem::scoped_istream stream = preprocess_file(filename, &preproc);
+		filesystem::scoped_istream stream = preprocess_file(filename, preproc);
 		cfg = io::read(*stream, validator.get());
 	} catch(const config::error& e) {
 		ERR_VL << "Failed to read file " << filename << ":\n" << e.what();

--- a/src/tests/utils/wml_equivalence.cpp
+++ b/src/tests/utils/wml_equivalence.cpp
@@ -54,11 +54,11 @@ private:
 	bfs::ofstream stream;
 };
 
-config preprocess_and_parse(const std::string& wml_str, preproc_map* macro_map)
+config preprocess_and_parse(const std::string& wml_str)
 {
 	tmp_file tmp_f;
 	tmp_f.set(wml_str);
-	auto b = preprocess_file(tmp_f.path.string(), macro_map);
+	auto b = preprocess_file(tmp_f.path.string());
 	return io::read(*b);
 }
 

--- a/src/tests/utils/wml_equivalence.hpp
+++ b/src/tests/utils/wml_equivalence.hpp
@@ -27,11 +27,10 @@
 /**
  * Make a syntax tree by preprocessing and parsing a WML string
  * @param[in]  wml_str    The string
- * @param[out] macro_map  Store preprocessor macros found by the preprocessor
  * @return                The syntax tree.
  * @warning Create and delete a temporary file at the current directory.
  */
-config preprocess_and_parse(const std::string& wml_str, preproc_map* macro_map = nullptr);
+config preprocess_and_parse(const std::string& wml_str);
 
 /**
  * Assert two WML strings are equivalent. The function performs two steps:

--- a/src/tests/wml/schema/test_schema_validator.cpp
+++ b/src/tests/wml/schema/test_schema_validator.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test_super_cycle)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 
 	BOOST_CHECK_EXCEPTION(io::read(*stream, &validator), wml_exception, [](const wml_exception& e) {
 		return boost::algorithm::contains(e.dev_message, "Inheritance cycle from other/second to main/first found");
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(test_super_cycle_only_if_used)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
 }
 
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(test_super_cycle_crashes_on_unknown_key)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 
 	BOOST_CHECK_EXCEPTION(io::read(*stream, &validator), wml_exception, [](const wml_exception& e) {
 		return boost::algorithm::contains(e.dev_message, "Invalid key 'unknown=' in tag [first]");
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(test_super_missing)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 
 	BOOST_CHECK_EXCEPTION(io::read(*stream, &validator), wml_exception, [](const wml_exception& e) {
 		return boost::algorithm::contains(e.dev_message, "Super not/here not found. Needed by other/second");
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(test_super_missing_only_if_used)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
 }
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(test_super_mandatory)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
 }
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(test_super_mandatory_missing)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 	BOOST_CHECK_EXCEPTION(io::read(*stream, &validator), wml_exception, [](const wml_exception& e) {
 		return boost::algorithm::contains(e.dev_message, "Missing key 'id=' in tag [campaign]");
 	});
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(test_super_cycle_mandatory)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 	defines_map.try_emplace("SCHEMA_VALIDATION");
 
-	auto stream = preprocess_file(config_path, &defines_map);
+	auto stream = preprocess_file(config_path, defines_map);
 	BOOST_CHECK_NO_THROW(io::read(*stream, &validator));
 }
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -181,7 +181,7 @@ static void handle_preprocess_string(const commandline_options& cmdline_opts)
 	PLAIN_LOG << "preprocessing specified string: " << *cmdline_opts.preprocess_source_string;
 	const utils::ms_optimer timer(
 		[](const auto& timer) { PLAIN_LOG << "preprocessing finished. Took " << timer << " ticks."; });
-	std::cout << preprocess_string(*cmdline_opts.preprocess_source_string, &defines_map) << std::endl;
+	std::cout << preprocess_string(*cmdline_opts.preprocess_source_string, "wesnoth", defines_map) << std::endl;
 	PLAIN_LOG << "added " << defines_map.size() << " defines.";
 }
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -178,11 +178,14 @@ static void handle_preprocess_string(const commandline_options& cmdline_opts)
 	defines_map.try_emplace("WESNOTH_VERSION", game_config::wesnoth_version.str());
 
 	// preprocess resource
+	PLAIN_LOG << "added " << defines_map.size() << " defines.";
 	PLAIN_LOG << "preprocessing specified string: " << *cmdline_opts.preprocess_source_string;
+
 	const utils::ms_optimer timer(
 		[](const auto& timer) { PLAIN_LOG << "preprocessing finished. Took " << timer << " ticks."; });
-	std::cout << preprocess_string(*cmdline_opts.preprocess_source_string, "wesnoth", defines_map) << std::endl;
-	PLAIN_LOG << "added " << defines_map.size() << " defines.";
+
+	const auto output_stream = preprocess_string(*cmdline_opts.preprocess_source_string, "wesnoth", defines_map);
+	std::cout << output_stream.get() << std::endl;
 }
 
 static void handle_preprocess_command(const commandline_options& cmdline_opts)

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -318,7 +318,7 @@ static int handle_validate_command(const std::string& file, abstract_validator& 
 
 	PLAIN_LOG << "Validating " << file << " against schema " << validator.name_;
 	lg::set_strict_severity(lg::severity::LG_ERROR);
-	io::read(*preprocess_file(file, &defines_map), &validator);
+	io::read(*preprocess_file(file, defines_map), &validator);
 	if(lg::broke_strict()) {
 		std::cout << "validation failed\n";
 	} else {


### PR DESCRIPTION
- Add preprocess_file and preprocess_string overloads taking a preproc_map reference instead of a defaulted pointer argument. No longer need to take the address of every defines map we pass in.
- Make preprocess_string return the stream to match preprocess_file
- Remove unused `default_defines_` member from from preprocessor_streambuf. Was added all the way back in 1e32e22ca9ba4f4be8726b908a76bdda4ba5f688 to serve as a local fallback for the defines pointer, but that functionality has long since been relegated to preprocessor_scope_helper (now called preprocessor_istream)
- Store defines as a reference in preprocessor_streambuf, since we know it's always valid.
- Use rdbuf over `std::ios::init` and remove a comment I added years ago which now proved to be incorrect.
- Expand preprocessor_istream functionality to make it usable in preprocess_string without duplicating code.