### PR TITLE
regroup checks of unit for adjacent abilites in same function

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -220,7 +220,7 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 	// different from the central unit, that the ability is of the right type, detailed verification of each ability),
 	// if so return true.
 	for(const unit& u : units) {
-		if(!u.max_ability_radius() || u.incapacitated() || u.underlying_id() == underlying_id() || !u.max_ability_radius_type(tag_name)) {
+		if(!u.has_ability_adjacent(underlying_id()) || !u.max_ability_radius_type(tag_name)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -262,7 +262,7 @@ unit_ability_list unit::get_abilities(const std::string& tag_name, const map_loc
 	// different from the central unit, that the ability is of the right type, detailed verification of each ability),
 	// If so, add to unit_ability_list.
 	for(const unit& u : units) {
-		if(!u.max_ability_radius() || u.incapacitated() || u.underlying_id() == underlying_id() || !u.max_ability_radius_type(tag_name)) {
+		if(!u.has_ability_adjacent(underlying_id()) || !u.max_ability_radius_type(tag_name)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -643,7 +643,7 @@ std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_t
 	const unit_map& units = get_unit_map();
 
 	for(const unit& u : units) {
-		if(!u.max_ability_radius_image() || u.incapacitated() || u.underlying_id() == underlying_id()) {
+		if(!u.has_ability_adjacent(underlying_id(), true)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -940,7 +940,7 @@ std::vector<std::pair<t_string, t_string>> attack_type::abilities_special_toolti
 		}
 	}
 	for(const unit& u : get_unit_map()) {
-		if(!u.max_ability_radius() || u.incapacitated() || u.underlying_id() == self_->underlying_id()) {
+		if(!u.has_ability_adjacent(self_->underlying_id())) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -1112,7 +1112,7 @@ void attack_type::weapon_specials_impl_adj(
 	const unit_map& units = get_unit_map();
 	if(self){
 		for(const unit& u : units) {
-			if(!u.max_ability_radius() || u.incapacitated() || u.underlying_id() == self->underlying_id()) {
+			if(!u.has_ability_adjacent(self->underlying_id())) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();
@@ -1772,7 +1772,7 @@ bool attack_type::has_ability_impl(
 	}
 	const unit_map& units = get_unit_map();
 	for(const unit& u : units) {
-		if(!u.max_ability_radius() || u.incapacitated() || u.underlying_id() == self->underlying_id() || !u.max_ability_radius_type(special)) {
+		if(!u.has_ability_adjacent(self->underlying_id()) || !u.max_ability_radius_type(special)) {
 			continue;
 		}
 		const map_location& from_loc = u.get_location();
@@ -1859,7 +1859,7 @@ bool attack_type::special_distant_filtering_impl(
 	}
 	if(check_adjacent) {
 		for(const unit& u : units) {
-			if(!u.max_ability_radius() || u.incapacitated() || u.underlying_id() == self->underlying_id()) {
+			if(!u.has_ability_adjacent(self->underlying_id())) {
 				continue;
 			}
 			const map_location& from_loc = u.get_location();

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -420,7 +420,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 				}
 
 				for(const unit& unit : units) {
-					if(!unit.max_ability_radius() || unit.incapacitated() || unit.underlying_id() == args.u.underlying_id()) {
+					if(!unit.has_ability_adjacent(args.u.underlying_id())) {
 						continue;
 					}
 					const map_location& from_loc = unit.get_location();
@@ -805,7 +805,7 @@ void unit_filter_compound::fill(const vconfig& cfg)
 
 						if(c.get_parsed_config()["affect_adjacent"].to_bool(true)) {
 							for(const unit& unit : units) {
-								if(!unit.max_ability_radius() || unit.incapacitated() || unit.underlying_id() == args.u.underlying_id()) {
+								if(!unit.has_ability_adjacent(args.u.underlying_id())) {
 									continue;
 								}
 								const map_location& from_loc = unit.get_location();

--- a/src/units/unit.hpp
+++ b/src/units/unit.hpp
@@ -1910,6 +1910,16 @@ public:
 	 */
 	bool ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const;
 
+	/**
+	checks that the unit has an ability that has [affect_adjacent] and that it is not incapacitated or is not the same unit as the beneficiary.
+	 * @param underlying_id the identity of the beneficiary
+	 * @param is_image if true, check abilities with halo/overlay_image attribute and [affect_adjacent]
+	 */
+	bool has_ability_adjacent(const std::size_t& underlying_id, bool is_image = false) const
+	{
+		return((is_image ? max_ability_radius_image() : max_ability_radius()) && !incapacitated() && underlying_id_.value != underlying_id);
+	}
+
 
 private:
 


### PR DESCRIPTION
move check of incapacitated, comparaison of underlying_id() and ownership of ability with [affect_adjacent] in same function should make the code more readable.