### PR TITLE
Log at most one "image won't be drawn" error per canvas

### DIFF
--- a/src/gui/core/canvas.cpp
+++ b/src/gui/core/canvas.cpp
@@ -244,6 +244,7 @@ image_shape::image_shape(const config& cfg, wfl::action_function_symbol_table& f
 	, resize_mode_(get_resize_mode(cfg["resize_mode"]))
 	, mirror_(cfg.get_old_attribute("mirror", "vertical_mirror", "image"))
 	, actions_formula_(cfg["actions"], &functions)
+	, failure_logged_(false)
 {
 	const std::string& debug = (cfg["debug"]);
 	if(!debug.empty()) {
@@ -272,7 +273,10 @@ void image_shape::draw(wfl::map_formula_callable& variables)
 	const std::string& name = image_name_(variables);
 
 	if(name.empty()) {
-		DBG_GUI_D << "Image: name is empty or contains invalid formula, will not be drawn.";
+		if(!failure_logged_) {
+			DBG_GUI_D << "Image: name is empty or contains invalid formula, will not be drawn.";
+			failure_logged_ = true;
+		}
 		return;
 	}
 
@@ -287,7 +291,10 @@ void image_shape::draw(wfl::map_formula_callable& variables)
 	texture tex = image::get_texture(image::locator(name), scale_quality);
 
 	if(!tex) {
-		ERR_GUI_D << "Image: '" << name << "' not found and won't be drawn.";
+		if(!failure_logged_) {
+			ERR_GUI_D << "Image: '" << name << "' not found and won't be drawn.";
+			failure_logged_ = true;
+		}
 		return;
 	}
 

--- a/src/gui/core/canvas_private.hpp
+++ b/src/gui/core/canvas_private.hpp
@@ -231,6 +231,11 @@ private:
 	// TODO: use a typed_formula?
 	wfl::formula actions_formula_;
 
+	/**
+	 * Prevents duplicate error logs when an image can't be loaded.
+	 */
+	bool failure_logged_;
+
 	static void dimension_validation(unsigned value, const std::string& name, const std::string& key);
 };
 


### PR DESCRIPTION
This was triggering for a broken Data URI in the list of add-ons, which declares itself as image/png but the data is image/webp. The whole Data URI was getting logged on every draw() call.

For formulas, this means that only the first failing filename or data URI will be reported, even if the formula changes to a different image. It seems unnecessary to add more logic; if the person who sees the log is the person who can fix the problem, then they're likely to either see a common pattern in a set of broken filenames, or to keep testing until everything is fixed.

Note: when testing this on the 1.19 add-ons server, you'll currently see two logs, which look like the same error. It's because Town of Arnsreach has a separate Resources add-on, and there's one log for each.