### PR TITLE
Simplify and consolidate save loading paths

### DIFF
--- a/src/game_launcher.cpp
+++ b/src/game_launcher.cpp
@@ -661,33 +661,6 @@ savegame::load_game_metadata game_launcher::extract_load_data()
 	return std::exchange(load_data_, utils::nullopt).value();
 }
 
-bool game_launcher::load_prepared_game()
-{
-	auto load_data = extract_load_data();
-	savegame::set_gamestate(state_, load_data);
-
-	play_replay_ = load_data.show_replay;
-
-	// in case show_replay && is_start_of_scenario
-	// there won't be any turns to replay, but the
-	// user gets to watch the intro sequence again ...
-	if(load_data.show_replay && !state_.is_start_of_scenario()) {
-		state_.statistics().clear_current_scenario();
-	}
-
-	if(load_data.cancel_orders) {
-		state_.cancel_orders();
-	}
-
-	try {
-		game_config_manager::get()->load_game_config_for_game(state_.classification(), state_.get_scenario_id());
-	} catch(const config::error&) {
-		return false;
-	}
-
-	return true;
-}
-
 bool game_launcher::load_game()
 {
 	DBG_GENERAL << "Current campaign type: " << campaign_type::get_string(state_.classification().type);
@@ -728,6 +701,33 @@ bool game_launcher::load_game()
 
 	// If the player canceled loading, we won't have any load data at this point
 	return has_load_data() && load_prepared_game();
+}
+
+bool game_launcher::load_prepared_game()
+{
+	auto load_data = extract_load_data();
+	savegame::set_gamestate(state_, load_data);
+
+	play_replay_ = load_data.show_replay;
+
+	// in case show_replay && is_start_of_scenario
+	// there won't be any turns to replay, but the
+	// user gets to watch the intro sequence again ...
+	if(load_data.show_replay && !state_.is_start_of_scenario()) {
+		state_.statistics().clear_current_scenario();
+	}
+
+	if(load_data.cancel_orders) {
+		state_.cancel_orders();
+	}
+
+	try {
+		game_config_manager::get()->load_game_config_for_game(state_.classification(), state_.get_scenario_id());
+	} catch(const config::error&) {
+		return false;
+	}
+
+	return true;
 }
 
 bool game_launcher::new_campaign()

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -89,7 +89,7 @@ public:
 	unit_test_result unit_test();
 
 	bool has_load_data() const;
-	bool load_game();
+	bool load_game_prompt();
 	bool load_prepared_game();
 	void set_test(const std::string& id);
 
@@ -155,6 +155,6 @@ private:
 	bool jump_to_multiplayer_;
 	jump_to_campaign_info jump_to_campaign_;
 
-	bool jump_to_editor_;
+	utils::optional<std::string> jump_to_editor_;
 	utils::optional<savegame::load_game_metadata> load_data_;
 };

--- a/src/game_launcher.hpp
+++ b/src/game_launcher.hpp
@@ -90,6 +90,7 @@ public:
 
 	bool has_load_data() const;
 	bool load_game();
+	bool load_prepared_game();
 	void set_test(const std::string& id);
 
 	/** Return the ID of the campaign to jump to (skipping the main menu). */
@@ -127,6 +128,12 @@ private:
 	 * Wesnoth is running multiple unit tests, this gets called once per test.
 	 */
 	unit_test_result single_unit_test();
+
+	/**
+	 * Returns the load_game_metadata object stored in load_data_.
+	 * After this function returns, load_data_ will contain no value.
+	 */
+	savegame::load_game_metadata extract_load_data();
 
 	const commandline_options& cmdline_opts_;
 

--- a/src/gui/dialogs/game_load.cpp
+++ b/src/gui/dialogs/game_load.cpp
@@ -22,6 +22,7 @@
 #include "formatter.hpp"
 #include "formula/string_utils.hpp"
 #include "game_config.hpp"
+#include "game_config_manager.hpp"
 #include "gettext.hpp"
 #include "gui/auxiliary/field.hpp"
 #include "gui/dialogs/game_delete.hpp"
@@ -56,7 +57,7 @@ namespace gui2::dialogs
 
 REGISTER_DIALOG(game_load)
 
-bool game_load::execute(const game_config_view& cache_config, savegame::load_game_metadata& data)
+bool game_load::execute(savegame::load_game_metadata& data)
 {
 	if(savegame::save_index_class::default_saves_dir()->get_saves_list().empty()) {
 		bool found_files = false;
@@ -74,10 +75,10 @@ bool game_load::execute(const game_config_view& cache_config, savegame::load_gam
 		}
 	}
 
-	return game_load(cache_config, data).show();
+	return game_load(data).show();
 }
 
-game_load::game_load(const game_config_view& cache_config, savegame::load_game_metadata& data)
+game_load::game_load(savegame::load_game_metadata& data)
 	: modal_dialog(window_id())
 	, filename_(data.filename)
 	, save_index_manager_(data.manager)
@@ -86,7 +87,7 @@ game_load::game_load(const game_config_view& cache_config, savegame::load_game_m
 	, cancel_orders_(register_bool("cancel_orders", true, data.cancel_orders))
 	, summary_(data.summary)
 	, games_()
-	, cache_config_(cache_config)
+	, cache_config_(game_config_manager::get()->game_config())
 {
 }
 
@@ -254,7 +255,7 @@ void game_load::display_savegame_internal(const savegame::save_info& game)
 	toggle_button& cancel_orders_toggle     = dynamic_cast<toggle_button&>(*cancel_orders_->get_widget());
 	toggle_button& change_difficulty_toggle = dynamic_cast<toggle_button&>(*change_difficulty_->get_widget());
 
-	const bool is_replay = savegame::loadgame::is_replay_save(summary_);
+	const bool is_replay = savegame::is_replay_save(summary_);
 	const bool is_scenario_start = summary_["turn"].empty();
 
 	// Always toggle show_replay on if the save is a replay
@@ -374,7 +375,7 @@ void game_load::evaluate_summary_string(std::stringstream& str, const config& cf
 
 	str << "\n";
 
-	if(savegame::loadgame::is_replay_save(cfg_summary)) {
+	if(savegame::is_replay_save(cfg_summary)) {
 		str << _("Replay");
 	} else if(!cfg_summary["turn"].empty()) {
 		str << _("Turn") << " " << cfg_summary["turn"];

--- a/src/gui/dialogs/game_load.hpp
+++ b/src/gui/dialogs/game_load.hpp
@@ -28,9 +28,9 @@ namespace gui2::dialogs
 class game_load : public modal_dialog
 {
 public:
-	game_load(const game_config_view& cache_config, savegame::load_game_metadata& data);
+	game_load(savegame::load_game_metadata& data);
 
-	static bool execute(const game_config_view& cache_config, savegame::load_game_metadata& data);
+	static bool execute(savegame::load_game_metadata& data);
 
 private:
 	virtual void pre_show() override;

--- a/src/gui/dialogs/multiplayer/mp_create_game.cpp
+++ b/src/gui/dialogs/multiplayer/mp_create_game.cpp
@@ -870,15 +870,14 @@ void mp_create_game::update_map_settings()
 
 void mp_create_game::load_game_callback()
 {
-	savegame::loadgame load(savegame::save_index_class::default_saves_dir(), create_engine_.get_state());
-
-	if(!load.load_multiplayer_game()) {
+	auto load_data = savegame::load_interactive_for_multiplayer();
+	if(!load_data) {
 		return;
 	}
 
-	load.set_gamestate();
+	savegame::set_gamestate(create_engine_.get_state(), load_data.value());
 
-	if(load.data().cancel_orders) {
+	if(load_data->cancel_orders) {
 		create_engine_.get_state().cancel_orders();
 	}
 

--- a/src/gui/dialogs/title_screen.cpp
+++ b/src/gui/dialogs/title_screen.cpp
@@ -281,11 +281,11 @@ void title_screen::init_callbacks()
 	// Load game
 	//
 	register_button("load", hotkey::HOTKEY_LOAD_GAME, [this]() {
-		if(game_.load_game()) {
+		if(game_.load_game_prompt()) {
 			// Suspend drawing of the title screen,
 			// so it doesn't flicker in between loading screens.
 			hide();
-			set_retval(LAUNCH_GAME);
+			set_retval(LOAD_GAME);
 		}
 	});
 

--- a/src/gui/dialogs/title_screen.hpp
+++ b/src/gui/dialogs/title_screen.hpp
@@ -47,6 +47,8 @@ public:
 	enum result {
 		// Window was resized, so needs redrawing
 		REDRAW_BACKGROUND = 0, // Needs to be 0, the value of gui2::retval::NONE
+		// Load and begin playing a saved game
+		LOAD_GAME,
 		// Start playing a single-player game, such as the tutorial or a campaign
 		LAUNCH_GAME,
 		// Connect to an MP server

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -229,7 +229,7 @@ bool play_controller::hotkey_handler::do_execute_command(const hotkey::ui_comman
 
 	if(balg::starts_with(cmd.id, quickreplay_prefix)) {
 		std::string savename = cmd.id.substr(quickreplay_prefix.size());
-		// Load the game by throwing load_game_exception
+		// Load the game by throwing reset_gamestate_exception
 		load_autosave(savename, true);
 	}
 
@@ -508,5 +508,4 @@ hotkey::action_state play_controller::hotkey_handler::get_action_state(const hot
 
 void play_controller::hotkey_handler::load_autosave(const std::string& filename, bool)
 {
-	throw savegame::load_game_exception({savegame::save_index_class::default_saves_dir(), filename});
 }

--- a/src/hotkey/hotkey_handler.cpp
+++ b/src/hotkey/hotkey_handler.cpp
@@ -506,6 +506,6 @@ hotkey::action_state play_controller::hotkey_handler::get_action_state(const hot
 	}
 }
 
-void play_controller::hotkey_handler::load_autosave(const std::string& filename, bool)
+void play_controller::hotkey_handler::load_autosave(const std::string&, bool)
 {
 }

--- a/src/play_controller.cpp
+++ b/src/play_controller.cpp
@@ -935,8 +935,7 @@ void play_controller::save_map()
 
 void play_controller::load_game()
 {
-	savegame::loadgame load(savegame::save_index_class::default_saves_dir(), saved_game_);
-	load.load_game_ingame();
+	savegame::load_interactive_by_exception();
 }
 
 void play_controller::undo()

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -777,9 +777,10 @@ void saved_game::swap(saved_game& other)
 	std::swap(starting_point_type_, other.starting_point_type_);
 }
 
-void saved_game::set_data(config&& cfg)
+void saved_game::set_data(config&& input_cfg)
 {
 	log_scope("read_game");
+	config cfg = std::move(input_cfg);
 
 	if(auto caryover_sides = cfg.optional_child("carryover_sides")) {
 		carryover_.swap(*caryover_sides);

--- a/src/saved_game.cpp
+++ b/src/saved_game.cpp
@@ -145,7 +145,7 @@ saved_game::saved_game(config cfg)
 	, statistics_()
 	, skip_story_(false)
 {
-	set_data(cfg);
+	set_data(std::move(cfg));
 }
 
 saved_game::saved_game(const saved_game& state)
@@ -777,7 +777,7 @@ void saved_game::swap(saved_game& other)
 	std::swap(starting_point_type_, other.starting_point_type_);
 }
 
-void saved_game::set_data(config& cfg)
+void saved_game::set_data(config&& cfg)
 {
 	log_scope("read_game");
 
@@ -826,8 +826,6 @@ void saved_game::set_data(config& cfg)
 
 	classification_ = game_classification{ cfg };
 	mp_settings_ = { cfg.child_or_empty("multiplayer") };
-
-	cfg.clear();
 }
 
 void saved_game::clear()

--- a/src/saved_game.hpp
+++ b/src/saved_game.hpp
@@ -44,8 +44,7 @@ public:
 	saved_game& operator=(const saved_game& other) = delete;
 	saved_game& operator=(saved_game&& other);
 	void swap(saved_game& other);
-	/** destroys the passed config. */
-	void set_data(config& cfg);
+	void set_data(config&& cfg);
 	void clear();
 	/** writes the config information into a stream (file) */
 	void write_config(config_writer& out) const;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -140,7 +140,7 @@ void load_interactive_by_exception()
 
 utils::optional<load_game_metadata> load_interactive()
 {
-	// FIXME: game_load dialog should initialize its own manager
+	// FIXME: game_load dialog should initialize its own manager pointer
 	load_game_metadata load_data{ save_index_class::default_saves_dir() };
 
 	if(!gui2::dialogs::game_load::execute(load_data)) {
@@ -226,7 +226,7 @@ bool check_version_compatibility(const version_info& save_version)
 // TODO: reduce code duplication with load_interactive
 utils::optional<load_game_metadata> load_interactive_for_multiplayer()
 {
-	// FIXME: game_load dialog should initialize its own manager
+	// FIXME: game_load dialog should initialize its own manager pointer
 	load_game_metadata load_data{ save_index_class::default_saves_dir() };
 
 	if(!gui2::dialogs::game_load::execute(load_data)) {
@@ -252,8 +252,6 @@ utils::optional<load_game_metadata> load_interactive_for_multiplayer()
 		return utils::nullopt;
 	}
 
-	// Since we want to verify game classification and version compatibility before setting the
-	// gamestate, we can't make use of the game_classification object owned by the gamestate.
 	const auto metadata = game_classification{load_data.load_config};
 
 	if(!metadata.is_multiplayer()) {
@@ -272,7 +270,7 @@ utils::optional<load_game_metadata> load_interactive_for_multiplayer()
 void set_gamestate(saved_game& gamestate, load_game_metadata& load_data)
 {
 	gamestate.set_data(std::exchange(load_data.load_config, {}));
-	gamestate.unify_controllers(); // TODO: check if this is the right replacement for the thing
+	gamestate.unify_controllers();
 }
 
 savegame::savegame(saved_game& gamestate, const compression::format compress_saves, const std::string& title)

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -96,9 +96,10 @@ private:
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(load_game_exception)
 };
 
-inline bool is_replay_save(const config& cfg)
+/** @note This function expects a save_index summary config */
+inline bool is_replay_save(const config& summary)
 {
-	return cfg["replay"].to_bool() && !cfg["snapshot"].to_bool(true);
+	return summary["replay"].to_bool() && !summary["snapshot"].to_bool(true);
 }
 
 utils::optional<load_game_metadata> load_interactive();

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -96,51 +96,25 @@ private:
 	IMPLEMENT_LUA_JAILBREAK_EXCEPTION(load_game_exception)
 };
 
-/** The class for loading a savefile. */
-class loadgame
+inline bool is_replay_save(const config& cfg)
 {
-public:
-	loadgame(const std::shared_ptr<save_index_class>& index, saved_game& gamestate);
-	virtual ~loadgame() {}
+	return cfg["replay"].to_bool() && !cfg["snapshot"].to_bool(true);
+}
 
-	/* In any of the following three function, a bool value of false indicates
-	   some failure or abort of the load process */
+utils::optional<load_game_metadata> load_interactive();
+utils::optional<load_game_metadata> load_interactive_for_multiplayer();
 
-	/** Load a game without providing any information. */
-	bool load_game_ingame();
-	/** Load a game with pre-setting information for the load-game dialog. */
-	bool load_game();
-	/** Loading a game from within the multiplayer-create dialog. */
-	bool load_multiplayer_game();
-	/** Generate the gamestate out of the loaded game config. */
-	void set_gamestate();
+/**
+ * In-game load wrapper for @ref load_interactive.
+ *
+ * If load_interactive returns a valid load_game_metadata object,
+ * load_game_exception will be thrown with said object as its payload.
+ * Otherwise, no exception is thrown.
+ */
+void load_interactive_by_exception();
 
-	// Getter-methods
-	load_game_metadata& data()
-	{
-		return load_data_;
-	}
+void set_gamestate(saved_game& gamestate, load_game_metadata& load_data);
 
-	/** GUI Dialog sequence which confirms attempts to load saves from previous game versions. */
-	static bool check_version_compatibility(const version_info& version);
-
-	static bool is_replay_save(const config& cfg)
-	{
-		return cfg["replay"].to_bool() && !cfg["snapshot"].to_bool(true);
-	}
-
-private:
-	/** Display the difficulty dialog. */
-	bool show_difficulty_dialog();
-	/** Copy era information into the snapshot. */
-	void copy_era(config& cfg);
-
-	const game_config_view& game_config_;
-
-	saved_game& gamestate_; /** Primary output information. */
-
-	load_game_metadata load_data_;
-};
 /**
  * The base class for all savegame stuff.
  * This should not be used directly, as it does not directly produce usable saves.

--- a/src/savegame.hpp
+++ b/src/savegame.hpp
@@ -74,6 +74,9 @@ struct load_game_metadata
 
 	/** Config information of the savefile to be loaded. */
 	config load_config {};
+
+	/** Reads the savefile @ref filename and stores the result in @ref load_config. */
+	void read_file();
 };
 
 /**
@@ -106,10 +109,10 @@ utils::optional<load_game_metadata> load_interactive();
 utils::optional<load_game_metadata> load_interactive_for_multiplayer();
 
 /**
- * In-game load wrapper for @ref load_interactive.
+ * @ref load_interactive wrapper for in-game save loading.
  *
- * If load_interactive returns a valid load_game_metadata object,
- * load_game_exception will be thrown with said object as its payload.
+ * If load_interactive returns a load_game_metadata object,
+ * throws load_game_exception with said object as its payload.
  * Otherwise, no exception is thrown.
  */
 void load_interactive_by_exception();

--- a/src/tests/gui/test_gui2.cpp
+++ b/src/tests/gui/test_gui2.cpp
@@ -989,7 +989,6 @@ template<>
 struct dialog_tester<game_load>
 {
 	config cfg;
-	game_config_view view;
 	// It would be good to have a test directory instead of using the same directory as the player,
 	// however this code will support that - default_saves_dir() will respect --userdata-dir.
 	savegame::load_game_metadata data{savegame::save_index_class::default_saves_dir()};
@@ -999,10 +998,8 @@ struct dialog_tester<game_load>
 	}
 	game_load* create()
 	{
-		view = game_config_view::wrap(cfg);
-		return new game_load(view, data);
+		return new game_load(data);
 	}
-
 };
 
 template<>

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -906,7 +906,7 @@ static int do_gameloop(commandline_options& cmdline_opts)
 		cursor::set(cursor::NORMAL);
 
 		// If loading a game, skip the titlescreen entirely
-		if(game->has_load_data() && game->load_game()) {
+		if(game->has_load_data() && game->load_prepared_game()) {
 			game->launch_game(game_launcher::reload_mode::RELOAD_DATA);
 			continue;
 		}

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -728,6 +728,26 @@ static void check_fpu()
 }
 #endif
 
+/** Gets the appropriate action code for the current iteration of the game loop. */
+static int get_gameloop_action(game_launcher& game)
+{
+	// If loading a game, skip the titlescreen entirely
+	if(game.has_load_data()) {
+		return title_screen::LOAD_GAME;
+	}
+
+	title_screen dlg{game};
+
+	// Allows re-layout on resize.
+	// Since RELOAD_UI is not checked here, it causes
+	// the dialog to be closed and reshown with changes.
+	while(dlg.get_retval() == title_screen::REDRAW_BACKGROUND) {
+		dlg.show();
+	}
+
+	return dlg.get_retval();
+}
+
 /**
  * Setups the game environment and enters
  * the titlescreen or game loops.
@@ -905,26 +925,7 @@ static int do_gameloop(commandline_options& cmdline_opts)
 
 		cursor::set(cursor::NORMAL);
 
-		// If loading a game, skip the titlescreen entirely
-		if(game->has_load_data() && game->load_prepared_game()) {
-			game->launch_game(game_launcher::reload_mode::RELOAD_DATA);
-			continue;
-		}
-
-		int retval;
-		{ // scope to not keep the title screen alive all game
-			title_screen dlg(*game);
-
-			// Allows re-layout on resize.
-			// Since RELOAD_UI is not checked here, it causes
-			// the dialog to be closed and reshown with changes.
-			while(dlg.get_retval() == title_screen::REDRAW_BACKGROUND) {
-				dlg.show();
-			}
-			retval = dlg.get_retval();
-		}
-
-		switch(retval) {
+		switch(get_gameloop_action(*game)) {
 		case title_screen::QUIT_GAME:
 			LOG_GENERAL << "quitting game...";
 			return 0;
@@ -947,6 +948,11 @@ static int do_gameloop(commandline_options& cmdline_opts)
 		case title_screen::MAP_EDITOR:
 			game->start_editor();
 			break;
+		case title_screen::LOAD_GAME:
+			if(!game->load_prepared_game()) {
+				break;
+			}
+			[[fallthrough]];
 		case title_screen::LAUNCH_GAME:
 			game->launch_game(game_launcher::reload_mode::RELOAD_DATA);
 			break;


### PR DESCRIPTION
While working on #10451, I noticed that errors for saves weren't being displayed in-game. That was because b007b5a8d09980e10c5e7192f5620319e0d88edf made it so we checked the save index for save validity in order to avoid loading the actual save file twice - once to validate it before load_game_exception was thrown and once in the titlescreen loop to actually load the damn thing.

All in-game loading (autosaves and interactive) now reads the save file to check its validity and surface any errors *before* throwing load_game_exception. The load_game_metadata  payload is likewise now expected to contain the parsed save config. The autosave loader path has been adjusted to pass the loaded payload along with its exception. (Thankfully, gfgtdf's work already made this trivial.) Conversely, the interactive load path in game_launcher will assert if load data has already been provided.

The titlescreen loop has been simplified. Previously, we had two "load" paths: The first through the interactive Load Game menu on the titlescreen, which would load the save, reload the game config, and update the gamestate config before dismissing the titlescreen and entering a game. The second was through a load game exception, which would skip the titlescreen by updating the gamestate config and immediately launching the game. Both paths have now been unified. In the former case, the save is selected and its config loaded (to allow for any errors), before passing off to the game launcher to apply said config and launch the game. This means we aren't invoking the loading screen twice.

game_launcher::goto_editor was using the load_data payload when it had no reason to do so. The only piece of info actually needed was the filename, then passed on to the editor. Replaced the jump-to-editor flag with an optional string. The string may be empty, but that's a valid value for the editor.

The `savegame::loadgame` class has been removed and its constituent functionality made free-standing. There was really no reason to be a class, and its nature as such only made tracking the provenance of data and who was modifying what and when extremely difficulty. We now have `load_interactive`, `load_interactive_for_multiplayer`, and `load_interactive_by_exception`. (The last simply wraps the first). Each creates and return (or throws) its own load_game_metadata object.

The other two members of the loadgame class were similarly unnecessary. The game_config_view reference mostly existed to be passed to the Load Game dialog (it had one use in show_difficulty_dialog). The former has been removed; the game_config_manager is now queried when creating the dialog rather than passing the object in. The latter was turned into a local variable.

Finally, the gamestate (saved_game) reference. This is now handled by savegame::set_gamestate in order to make it extremely clear when the gamestate is being modified. Likewise, we no longer manually set the gamestate's game_classification object as part of the validation checks. We can just as easily query the version directly rather than relying on a temp object which will be later overwritten by set_state. `load_interactive_for_multiplayer` does still create its own game_classification object, but in that case, we need it for two checks. Would be good to dispense with that at some point...

Several early return checks has been removed, notable "is manager null" and "is filename empty". Neither of these should arise in the regular course of events. show_difficulty_dialog now writes the new difficulty value directly to the load config rather than leaving that to be handled separately.

One change I'm unsure about is calling `unify_controllers` in `set_gamestate` unconditionally. Years ago, @gfgtdf added code (see #1762) to strip `is_local` from the side tags in the load config. `unify_controllers` has since evolved to perform the same cleanup on the `starting_point_` config side tags. I am unsure whether simply calling `unify_controllers` unconditionally will strip the key from the right set of side_tags to not reintroduce the crash from #1762, considering `starting_point_` is read either from `[snapshot]` or `[scenario]`...