### PR TITLE
Addon Manager: select correct layer for controls (#10457)

### DIFF
--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -854,9 +854,13 @@ void addon_manager::install_addon(const addon_info& addon)
 {
 	addon_info versioned_addon = addon;
 	if(addon.id == find_widget<addon_list>("addons").get_selected_addon()->id) {
-		if (menu_button* list = find_widget<menu_button>("version_filter", false, false)) {
-			versioned_addon.current_version = list->get_value_string();
+		widget* parent = this;
+		if(stacked_widget* stk = find_widget<stacked_widget>("main_stack", false, false)) {
+			parent = stk->get_layer_grid(1);
 		}
+		// At this point the version list should always be found, so error if it's not there
+		menu_button& list = parent->find_widget<menu_button>("version_filter");
+		versioned_addon.current_version = list.get_value_string();
 	}
 
 	addons_client::install_result result = client_.install_addon_with_checks(addons_, versioned_addon);
@@ -1186,11 +1190,13 @@ void addon_manager::on_addon_select()
 void addon_manager::on_selected_version_change()
 {
 	widget* parent = this;
+	const addon_info* info = nullptr;
 	if(stacked_widget* stk = find_widget<stacked_widget>("main_stack", false, false)) {
-		parent = stk->get_layer_grid(0);
+		parent = stk->get_layer_grid(1);
+		info = stk->get_layer_grid(0)->find_widget<addon_list>("addons").get_selected_addon();
+	} else {
+		info = find_widget<addon_list>("addons").get_selected_addon();
 	}
-
-	const addon_info* info = parent->find_widget<addon_list>("addons").get_selected_addon();
 
 	if(info == nullptr) {
 		return;


### PR DESCRIPTION
Resolves #10457.
Fixes incorrect layer/parent being selected for some UI widgets, otherwise it can show the "widget not found" and return to title screen.

> The reason was incorrect stacked widget layer selection. The low-res version uses a stacked widget which put the add-on on layer zero and the details panel on layer one, while the high-res version puts them all on the parent container. During find_widget call, the correct layer/parent needs to be selected, otherwise it won't be able to find the version selection menu button.