### PR TITLE
apply the 'neutral' alignment to the fire scepter and align the power of the attacks with those of the scepter when it is held by Li'sar

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/units/Commander.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Commander.cfg
@@ -109,11 +109,12 @@
             description= _"sceptre of fire"
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
             icon=attacks/fireball.png
-            damage=16
+            damage=14
             number=4
         [/attack]
         {DEFENSE_ANIM_FILTERED "units/konrad-commander-scepter-defend.png" "units/konrad-commander-scepter.png" {SOUND_LIST:HUMAN_HIT} (

--- a/data/campaigns/Heir_To_The_Throne/units/Fighter.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Fighter.cfg
@@ -65,11 +65,12 @@
             description= _"sceptre of fire"
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
             icon=attacks/fireball.png
-            damage=12
+            damage=11
             number=3
         [/attack]
         [attack_anim]

--- a/data/campaigns/Heir_To_The_Throne/units/Lord.cfg
+++ b/data/campaigns/Heir_To_The_Throne/units/Lord.cfg
@@ -132,11 +132,12 @@
             description= _"sceptre of fire"
             type=fire
             range=ranged
+            alignment=neutral
             [specials]
                 {WEAPON_SPECIAL_MAGICAL}
             [/specials]
             icon=attacks/fireball.png
-            damage=18
+            damage=16
             number=4
         [/attack]
         [attack_anim]


### PR DESCRIPTION

I know I've already tried to sell the concept in another PR but here's an argument that might be more relevant ; Konrad is alignment lawful and Li'sar neutral, but the Scepter of Fire is so powerful that for them the difficulty comes more from keeping control in combat than trying to go to the maximum unlike the sword which comes from training, or from the magical mastery of mage which also comes with years of practice. For me, the fact that the Scepter attack is of reduced power at level 1 comes from the fact that the wearer lacks confidence and unconsciously restrains the power of the artifact. In the end, I consider that the alignment does not come into play because Konrad should not be more comfortable during the day than at night to handle what is a monster of power.