### PR TITLE
Addon Info: remove extra escaping

### DIFF
--- a/src/addon/client.cpp
+++ b/src/addon/client.cpp
@@ -569,7 +569,8 @@ bool addons_client::try_fetch_addon(const addon_info & addon)
 	if(!(
 		download_addon(archive, addon.id, addon.display_title_full(), addon.current_version, !is_addon_installed(addon.id)) &&
 		install_addon(archive, addon)
-		)) {
+		))
+	{
 		const std::string& server_error = get_last_server_error();
 		if(!server_error.empty()) {
 			gui2::show_error_message(

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -154,11 +154,7 @@ void addon_info::write_minimal(config& cfg) const
 
 std::string addon_info::display_title() const
 {
-	if(title.empty()) {
-		return font::escape_text(make_addon_title(id));
-	} else {
-		return font::escape_text(title);
-	}
+	return title.empty() ? make_addon_title(id) : title;
 }
 
 addon_info_translation addon_info_translation::invalid = {false, "", ""};

--- a/src/addon/info.cpp
+++ b/src/addon/info.cpp
@@ -192,12 +192,7 @@ addon_info_translation addon_info::translated_info() const
 std::string addon_info::display_title_translated() const
 {
 	addon_info_translation info = translated_info();
-
-	if(info.valid()) {
-		return info.title;
-	}
-
-	return "";
+	return info.valid() ? info.title : "";
 }
 
 std::string addon_info::display_title_translated_or_original() const
@@ -209,20 +204,13 @@ std::string addon_info::display_title_translated_or_original() const
 std::string addon_info::description_translated() const
 {
 	addon_info_translation info = translated_info();
-
-	if(info.valid() && !info.description.empty()) {
-		return info.description;
-	}
-
-	return description;
+	return (info.valid() && !info.description.empty()) ? info.description : description;
 }
 
 std::string addon_info::display_title_full() const
 {
 	std::string local_title = display_title_translated();
-	if(local_title.empty())
-		return display_title();
-	return local_title + " (" + display_title() + ")";
+	return local_title.empty() ? display_title() : local_title + " (" + display_title() + ")";
 }
 
 std::string addon_info::display_icon() const
@@ -305,11 +293,7 @@ void read_addons_list(const config& cfg, addons_list& dest)
 
 std::string size_display_string(double size)
 {
-	if(size > 0.0) {
-		return utils::si_string(size, true, _("unit_byte^B"));
-	} else {
-		return "";
-	}
+	return size > 0.0 ? utils::si_string(size, true, _("unit_byte^B")) : "";
 }
 
 std::string make_addon_title(const std::string& id)

--- a/src/gui/dialogs/addon/manager.cpp
+++ b/src/gui/dialogs/addon/manager.cpp
@@ -876,7 +876,7 @@ void addon_manager::install_addon(const addon_info& addon)
 void addon_manager::uninstall_addon(const addon_info& addon)
 {
 	if(have_addon_pbl_info(addon.id) || have_addon_in_vcs_tree(addon.id)) {
-		show_error_message(
+		gui2::show_error_message(
 			_("The following add-on appears to have publishing or version control information stored locally, and will not be removed:")
 			+ " " +	addon.display_title_full());
 		return;

--- a/src/gui/widgets/addon_list.cpp
+++ b/src/gui/widgets/addon_list.cpp
@@ -18,6 +18,7 @@
 
 #include "addon/client.hpp"
 #include "color.hpp"
+#include "font/pango/escape.hpp"
 #include "formatter.hpp"
 #include "gettext.hpp"
 #include "gui/core/event/dispatcher.hpp"
@@ -90,7 +91,7 @@ std::string addon_list::colorize_addon_state_string(const std::string& str, ADDO
 		break;
 	}
 
-	return markup::span_color(colorname, str);
+	return markup::span_color(colorname, font::escape_text(str));
 }
 
 std::string addon_list::describe_status(const addon_tracking_info& info)
@@ -143,10 +144,10 @@ void addon_list::addon_action_wrapper(addon_op_func_t& func, const addon_info& a
 	}
 }
 
-const std::string addon_list::display_title_full_shift(const addon_info& addon) const
+const std::string addon_list::display_title_full_shift_markup(const addon_info& addon) const
 {
-	const std::string& local_title = addon.display_title_translated();
-	const std::string& display_title = addon.display_title();
+	const std::string& local_title = font::escape_text(addon.display_title_translated());
+	const std::string& display_title = font::escape_text(addon.display_title());
 	if(local_title.empty()) {
 		return display_title;
 	}
@@ -173,7 +174,7 @@ void addon_list::set_addons(const addons_list& addons)
 			item["label"] = addon.display_icon();
 			data.emplace("icon", item);
 
-			item["label"] = display_title_full_shift(addon);
+			item["label"] = display_title_full_shift_markup(addon);
 			data.emplace("name", item);
 		} else {
 			if(!addon.display_icon().empty()) {
@@ -181,8 +182,9 @@ void addon_list::set_addons(const addons_list& addons)
 				data.emplace("icon", item);
 			}
 
-			const std::string publish_name = markup::span_color(font::GOOD_COLOR, display_title_full_shift(addon));
-
+			const std::string publish_name = markup::span_color(
+				font::GOOD_COLOR,
+				display_title_full_shift_markup(addon));
 			item["label"] = publish_name;
 			data.emplace("name", item);
 		}
@@ -353,7 +355,7 @@ void addon_list::select_addon(const std::string& id)
 		grid* row = list.get_row_grid(i);
 
 		const label& name_label = row->find_widget<label>("name");
-		if(name_label.get_label().base_str() == display_title_full_shift(info)) {
+		if(name_label.get_label().base_str() == display_title_full_shift_markup(info)) {
 			list.select_row(i);
 		}
 	}

--- a/src/gui/widgets/addon_list.hpp
+++ b/src/gui/widgets/addon_list.hpp
@@ -44,7 +44,7 @@ public:
 	/** Special retval for the toggle panels in the addons list */
 	static const int DEFAULT_ACTION_RETVAL = 200;
 
-	const std::string display_title_full_shift(const addon_info& addon) const;
+	const std::string display_title_full_shift_markup(const addon_info& addon) const;
 
 	/** Sets the add-ons to show. */
 	void set_addons(const addons_list& addons);


### PR DESCRIPTION
Resolves #10466
The issue is caused by duplicate escaping in `addon_info::display_title`, which gets escaped again in the addon client (`client.cpp`).