### PR TITLE
[1.18] Make the Load Game dialog see other-version save files from 1.19

### DIFF
--- a/changelog_entries/other_version_savefiles.md
+++ b/changelog_entries/other_version_savefiles.md
@@ -1,0 +1,2 @@
+### User interface
+  * The load-game dialog can now see the directories used by the development version (1.19.2 and later)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -955,12 +955,18 @@ std::vector<other_version_dir> find_other_version_saves_dirs()
 		//
 
 #if defined(_WIN32)
-		path = get_user_data_path().parent_path() / ("Wesnoth" + suffix) / "saves";
+		path = get_user_data_path().parent_path() / ("Wesnoth" + suffix);
 #elif defined(_X11)
-		path = get_user_data_path().parent_path() / suffix / "saves";
+		path = get_user_data_path().parent_path() / suffix;
 #elif defined(__APPLE__)
-		path = get_user_data_path().parent_path() / ("Wesnoth_" + suffix) / "saves";
+		path = get_user_data_path().parent_path() / ("Wesnoth_" + suffix);
 #endif
+
+		// 1.19.2 added get_sync_dir() and changed the path to the save directory.
+		if(minor >= 19) {
+			path /= "sync";
+		}
+		path /= "saves";
 
 		if(bfs::exists(path)) {
 			result.emplace_back(suffix, path.string());


### PR DESCRIPTION
If there are save directories for other versions of Wesnoth, there's a drop-down list in the Load Game dialog to see those other directories.

This adapts 1.18 for commit 80fe9ba84ddb507f0212c445e4af9bb163e94bb3, so that 1.18 will see the save directory of 1.19.2 onwards.

Previously, 1.18 would show the directory that 1.19.0 and 1.19.1 used.

I'm planning to forward-port this as-is to 1.19, I think the technical debt of hardcoding the directory name "sync" in this place is balanced by this being a place where some cross-version debt is to be expected.