### PR TITLE
Make the Load Game dialog for 1.19 and 1.20 see each other's save files

### DIFF
--- a/changelog_entries/other_version_savefiles.md
+++ b/changelog_entries/other_version_savefiles.md
@@ -1,0 +1,2 @@
+### User interface
+  * Updated the load-game dialog support for other versions' files, ready for 1.20

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -945,12 +945,18 @@ std::vector<other_version_dir> find_other_version_saves_dirs()
 		//
 
 #if defined(_WIN32)
-		path = get_user_data_path().parent_path() / ("Wesnoth" + suffix) / "saves";
+		path = get_user_data_path().parent_path() / ("Wesnoth" + suffix);
 #elif defined(_X11)
-		path = get_user_data_path().parent_path() / suffix / "saves";
+		path = get_user_data_path().parent_path() / suffix;
 #elif defined(__APPLE__)
-		path = get_user_data_path().parent_path() / ("Wesnoth_" + suffix) / "saves";
+		path = get_user_data_path().parent_path() / ("Wesnoth_" + suffix);
 #endif
+
+		// 1.19.2 added get_sync_dir() and changed the path to the save directory.
+		if(minor >= 19) {
+			path /= "sync";
+		}
+		path /= "saves";
 
 		if(bfs::exists(path)) {
 			result.emplace_back(suffix, path.string());


### PR DESCRIPTION
If there are save directories for other versions of Wesnoth, there's a drop-down list in the Load Game dialog to see those other directories.

That directory moved in 80fe9ba84ddb507f0212c445e4af9bb163e94bb3, this adapts so that the feature will continue working when 1.19 is an old version. The code is the same as 1.18's implementation, I think the technical debt of hardcoding the directory name "sync" in this place is balanced by this being a place where some cross-version debt is to be expected.

This is a simple forward-port of #10474.