### PR TITLE
Save Index: fix dangling reference when index file does not exist

### DIFF
--- a/src/save_index.hpp
+++ b/src/save_index.hpp
@@ -130,7 +130,6 @@ private:
 	/** Deletes non-existent save files from the index. */
 	void clean_up_index();
 
-	bool loaded_;
 	config data_;
 	std::map<std::string, std::chrono::system_clock::time_point> modified_;
 	const std::string dir_;


### PR DESCRIPTION
If the save_index file did not exist when opening the Load Game dialog, the game could crash with a read access exception. When I first added the do-not-load-if-file-does-not-exist logic (691f9256ce134c731682d4635242b66be1824c44), I neglected to also set `loaded_` to true if the file was not found. Since `data()` had side effects - reading from the index file and setting the data_ member - the next time it was called, if the file *did* exist, this would result in a redundant read.

Prior to 02818082186faf78adc06c9378a08b57eda05511, this redundant read was no issue. `io::read_gz` took an input parameter, and if the file it was attempting to read was empty, it simply returned and did not touch the input. Once `read_gz` returned a config, however, the flaw in the original logic revealed itself. The dialog would try to get the first save's summary config, which would query the save index. The had not yet performed lazy initialization, so data() would try to load the index file and fail, since it did not exist. A new [save] child was added to the data_ config, the save file loaded, and a summary generated. The index would attempt to write the updated config back to disk and return the newly added [save] child.

Yet write_save_config *also* called data() rather than using the data_ member directly. Here, since loaded_ was still false and the index file now *did* exist (it was created in by opening a file ostream immediately prior to calling data()), the empty file was loaded from disk and data_ assigned an empty config. The child config reference was now dangling, since it was a reference into the now-empty class member.

Again, this step, though erroneous and extraneous, was a no-op before I changed the signature of read_gz to return a config. The proper fix is to set loaded_ to true even if the index file does not exist. I decided to go further and simply get rid of the lazy loading mechanism entirely, populating data_ directly in the ctor. We don't create save_index_class objects often enough for this to matter (the one managing the default save dir is kept as a static instance, for one). It also resolves the frankly bad design wherein a getter called from a write-to-disk function could first clobber its payload by reading from the target file.