### PR TITLE
 fix #10496 OOS when using DSU

### DIFF
--- a/src/replay_helper.cpp
+++ b/src/replay_helper.cpp
@@ -117,10 +117,11 @@ config replay_helper::get_attack(const map_location& a, const map_location& b,
 /**
  * Records that the player has toggled automatic shroud updates.
  */
-config replay_helper::get_auto_shroud(bool turned_on)
+config replay_helper::get_auto_shroud(bool turned_on, bool block_undo)
 {
 	config child;
 	child["active"] = turned_on;
+	child["block_undo"] = block_undo;
 	return child;
 }
 

--- a/src/replay_helper.hpp
+++ b/src/replay_helper.hpp
@@ -37,7 +37,7 @@ public:
 		const std::string& defender_type_id, int attacker_lvl,
 		int defender_lvl, const std::size_t turn, const time_of_day &t);
 
-	static config get_auto_shroud(bool turned_on);
+	static config get_auto_shroud(bool turned_on, bool block_undo = true);
 
 	static config get_update_shroud();
 

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -339,7 +339,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(auto_shroud, child, /*spectator*/)
 	bool active = child["active"].to_bool();
 	bool block_undo = child["block_undo"].to_bool();
 	if(active && !current_team.auto_shroud_updates()) {
-		resources::undo_stack->commit_vision();
+		block_undo |= resources::undo_stack->commit_vision();
 	}
 	current_team.set_auto_shroud_updates(active);
 	resources::undo_stack->add_auto_shroud(active);

--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -337,12 +337,14 @@ SYNCED_COMMAND_HANDLER_FUNCTION(auto_shroud, child, /*spectator*/)
 	team &current_team = resources::controller->current_team();
 
 	bool active = child["active"].to_bool();
+	bool block_undo = child["block_undo"].to_bool();
 	if(active && !current_team.auto_shroud_updates()) {
 		resources::undo_stack->commit_vision();
 	}
 	current_team.set_auto_shroud_updates(active);
-	if(resources::undo_stack->can_undo()) {
-		resources::undo_stack->add_auto_shroud(active);
+	resources::undo_stack->add_auto_shroud(active);
+	if(block_undo) {
+		synced_context::block_undo();
 	}
 	return true;
 }


### PR DESCRIPTION
the old code tried to prevent the creation of a dummy undo stack entry for toggling shroud updated if there are no elements in te undo stack before. However the old way of doing this resulted in the action being removed from the replay recorder aswell , leading to OOS.


Now we just always block undo in this case.

The optional paramter in get_auto_shroud does in theory allow us to make it undoable again later in a save way.