### PR TITLE
Config Attribute Value: compare string-like types directly, remove heterogenous comparison for integers

### DIFF
--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -214,14 +214,14 @@ public:
 
 	template<typename T>
 	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
-	bool friend operator!=(const config_attribute_value& val, const T& str)
+	friend operator!=(const config_attribute_value& val, const T& str)
 	{
 		return !val.operator==(str);
 	}
 
 	template<typename T>
 	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
-	bool friend operator!=(const T &str, const config_attribute_value& val)
+	friend operator!=(const T &str, const config_attribute_value& val)
 	{
 		return !val.operator==(str);
 	}

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -213,9 +213,9 @@ public:
 
 	template<typename T>
 	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
-	friend operator!=(const config_attribute_value& val, const T& str)
+	operator!=(const T& comp) const
 	{
-		return !val.operator==(str);
+		return !operator==(comp);
 	}
 #endif
 

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -187,8 +187,7 @@ public:
 	}
 
 #ifdef __cpp_concepts
-	template<StringLike T>
-	bool operator==(const T& comp) const
+	bool operator==(const StringLike auto& comp) const
 	{
 		return apply_visitor([this, &comp]<typename V>(const V& value) {
 			if constexpr(StringLike<V>) {
@@ -215,13 +214,6 @@ public:
 	template<typename T>
 	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
 	friend operator!=(const config_attribute_value& val, const T& str)
-	{
-		return !val.operator==(str);
-	}
-
-	template<typename T>
-	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
-	friend operator!=(const T &str, const config_attribute_value& val)
 	{
 		return !val.operator==(str);
 	}

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -38,7 +38,6 @@
 #endif
 #include <iosfwd>
 #include <string>
-#include <utility>
 #include <vector>
 #include <type_traits>
 
@@ -173,6 +172,7 @@ public:
 
 	// Implicit conversions:
 	operator std::string() const { return str(); }
+	operator t_string() const { return t_str(); }
 
 	/** Tests for an attribute that was never set. */
 	bool blank() const;

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -38,6 +38,7 @@
 #endif
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 #include <type_traits>
 

--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -41,6 +41,18 @@
 #include <vector>
 #include <type_traits>
 
+#ifdef __cpp_concepts
+template<typename T>
+concept integer_type =
+	std::integral<T> &&
+	!std::same_as<T, char> &&
+	!std::same_as<T, char8_t> &&
+	!std::same_as<T, char16_t> &&
+	!std::same_as<T, char32_t> &&
+	!std::same_as<T, wchar_t> &&
+	!std::same_as<T, bool>;
+#endif
+
 /**
  * Variant for storing WML attributes.
  * The most efficient type is used when assigning a value. For instance,
@@ -187,7 +199,11 @@ public:
 	{
 		return apply_visitor([&comp]<typename V>(const V& value) {
 			if constexpr(std::equality_comparable_with<T, V>) {
-				return comp == value;
+				if constexpr(integer_type<T> && integer_type<V>) {
+					return std::cmp_equal(comp, value);
+				} else {
+					return comp == value;
+				}
 			} else {
 				return false;
 			}

--- a/src/preferences/preferences.cpp
+++ b/src/preferences/preferences.cpp
@@ -1562,7 +1562,7 @@ void prefs::add_game_preset(config&& preset_data)
 
 void prefs::remove_game_preset(int id)
 {
-	preferences_.remove_children(prefs_list::game_preset, [&id](const config& preset) {return preset["id"] == id;});
+	preferences_.remove_children(prefs_list::game_preset, [&id](const config& preset) { return preset["id"].to_int() == id; });
 }
 
 config::child_itors prefs::get_game_presets()

--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -298,7 +298,7 @@ static int intf_execute(lua_State* L)
 	}
 	try {
 		config data = luaW_serialize_function(L, FUNC);
-		if(data["params"] != 0) {
+		if(data["params"].to_int() != 0) {
 			lua_pushboolean(L, false);
 			lua_pushstring(L, "cannot execute function with parameters");
 			return 2;

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -223,6 +223,8 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 	BOOST_CHECK_EQUAL(c["x"], "test");
 	c["x"] = false;
 	BOOST_CHECK_EQUAL(c["x"], "no");
+	c["x"] = 9.87654321;
+	BOOST_CHECK_EQUAL(c["x"], "9.87654321");
 	c["x"] = "sfvsdgdsfg";
 	BOOST_CHECK_EQUAL(c["x"], std::string{"sfvsdgdsfg"});
 	BOOST_CHECK_EQUAL(c["x"], std::string_view{"sfvsdgdsfg"});
@@ -335,9 +337,9 @@ BOOST_AUTO_TEST_CASE(test_variable_info)
 		[tag1]
 		[/tag1]
 		*/
-		BOOST_CHECK_EQUAL(variable_access_const("tag1.length", nonempty).as_scalar(), 3);
-		BOOST_CHECK_EQUAL(variable_access_const("tag1.tag2.length", nonempty).as_scalar(), 0);
-		BOOST_CHECK_EQUAL(variable_access_const("tag1[1].tag2.length", nonempty).as_scalar(), 3);
+		BOOST_CHECK_EQUAL(variable_access_const("tag1.length", nonempty).as_scalar().to_int(), 3);
+		BOOST_CHECK_EQUAL(variable_access_const("tag1.tag2.length", nonempty).as_scalar().to_int(), 0);
+		BOOST_CHECK_EQUAL(variable_access_const("tag1[1].tag2.length", nonempty).as_scalar().to_int(), 3);
 		BOOST_CHECK_EQUAL(variable_access_const("tag1[1].tag2[2].atribute1", nonempty).as_scalar().to_int(), 88);
 		int count = 0;
 		for([[maybe_unused]] const config& child : variable_access_const("tag1", nonempty).as_array()) {

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -291,13 +291,13 @@ BOOST_AUTO_TEST_CASE(test_variable_info)
 		config c2;
 		variable_access_create access("a.b[0].c[1].d.e.f[2].g", c2);
 		access.as_scalar() = 84;
-		BOOST_CHECK_EQUAL(variable_access_const("a.length", c2).as_scalar(), 1);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.length", c2).as_scalar(), 1);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c.length", c2).as_scalar(), 2);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f.length", c2).as_scalar(), 3);
+		BOOST_CHECK_EQUAL(variable_access_const("a.length", c2).as_scalar().to_int(), 1);
+		BOOST_CHECK_EQUAL(variable_access_const("a.b.length", c2).as_scalar().to_int(), 1);
+		BOOST_CHECK_EQUAL(variable_access_const("a.b.c.length", c2).as_scalar().to_int(), 2);
+		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f.length", c2).as_scalar().to_int(), 3);
 		// we set g as a scalar
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f[2].g.length", c2).as_scalar(), 0);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f[2].g", c2).as_scalar(), 84);
+		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f[2].g.length", c2).as_scalar().to_int(), 0);
+		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f[2].g", c2).as_scalar().to_int(), 84);
 	}
 	{
 		config c2;

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -256,6 +256,11 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 
 BOOST_AUTO_TEST_CASE(test_variable_info)
 {
+	// Returns the integer value of the given variable in the config
+	const auto scalar_value = [](const std::string& var, const config& cfg) {
+		return variable_access_const{var, cfg}.as_scalar().to_int();
+	};
+
 	config c;
 	{
 		variable_access_const access("", c);
@@ -293,13 +298,13 @@ BOOST_AUTO_TEST_CASE(test_variable_info)
 		config c2;
 		variable_access_create access("a.b[0].c[1].d.e.f[2].g", c2);
 		access.as_scalar() = 84;
-		BOOST_CHECK_EQUAL(variable_access_const("a.length", c2).as_scalar().to_int(), 1);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.length", c2).as_scalar().to_int(), 1);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c.length", c2).as_scalar().to_int(), 2);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f.length", c2).as_scalar().to_int(), 3);
+		BOOST_CHECK_EQUAL(scalar_value("a.length", c2), 1);
+		BOOST_CHECK_EQUAL(scalar_value("a.b.length", c2), 1);
+		BOOST_CHECK_EQUAL(scalar_value("a.b.c.length", c2), 2);
+		BOOST_CHECK_EQUAL(scalar_value("a.b.c[1].d.e.f.length", c2), 3);
 		// we set g as a scalar
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f[2].g.length", c2).as_scalar().to_int(), 0);
-		BOOST_CHECK_EQUAL(variable_access_const("a.b.c[1].d.e.f[2].g", c2).as_scalar().to_int(), 84);
+		BOOST_CHECK_EQUAL(scalar_value("a.b.c[1].d.e.f[2].g.length", c2), 0);
+		BOOST_CHECK_EQUAL(scalar_value("a.b.c[1].d.e.f[2].g", c2), 84);
 	}
 	{
 		config c2;
@@ -337,10 +342,10 @@ BOOST_AUTO_TEST_CASE(test_variable_info)
 		[tag1]
 		[/tag1]
 		*/
-		BOOST_CHECK_EQUAL(variable_access_const("tag1.length", nonempty).as_scalar().to_int(), 3);
-		BOOST_CHECK_EQUAL(variable_access_const("tag1.tag2.length", nonempty).as_scalar().to_int(), 0);
-		BOOST_CHECK_EQUAL(variable_access_const("tag1[1].tag2.length", nonempty).as_scalar().to_int(), 3);
-		BOOST_CHECK_EQUAL(variable_access_const("tag1[1].tag2[2].atribute1", nonempty).as_scalar().to_int(), 88);
+		BOOST_CHECK_EQUAL(scalar_value("tag1.length", nonempty), 3);
+		BOOST_CHECK_EQUAL(scalar_value("tag1.tag2.length", nonempty), 0);
+		BOOST_CHECK_EQUAL(scalar_value("tag1[1].tag2.length", nonempty), 3);
+		BOOST_CHECK_EQUAL(scalar_value("tag1[1].tag2[2].atribute1", nonempty), 88);
 		int count = 0;
 		for([[maybe_unused]] const config& child : variable_access_const("tag1", nonempty).as_array()) {
 			++count;

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -215,29 +215,17 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 	BOOST_CHECK_EQUAL(x_str, "123456789123");
 
 // check heterogeneous comparison
-	c["x"] = 987654321;
-	BOOST_CHECK_EQUAL(c["x"], 987654321);
 	c["x"] = "1";
 	BOOST_CHECK_EQUAL(c["x"], "1");
 	c["x"] = 222;
 	BOOST_CHECK_EQUAL(c["x"], "222");
 	c["x"] = "test";
 	BOOST_CHECK_EQUAL(c["x"], "test");
-	c["x"] = "33333";
-	BOOST_CHECK_EQUAL(c["x"], 33333);
-	c["x"] = "yes";
-	BOOST_CHECK_EQUAL(c["x"], true);
 	c["x"] = false;
 	BOOST_CHECK_EQUAL(c["x"], "no");
-	c["x"] = 1.23456789;
-	BOOST_CHECK_EQUAL(c["x"], 1.23456789);
-	c["x"] = "9.87654321";
-	BOOST_CHECK_EQUAL(c["x"], 9.87654321);
 	c["x"] = "sfvsdgdsfg";
 	BOOST_CHECK_EQUAL(c["x"], std::string{"sfvsdgdsfg"});
 	BOOST_CHECK_EQUAL(c["x"], std::string_view{"sfvsdgdsfg"});
-	BOOST_CHECK_NE(c["x"], 0);
-	BOOST_CHECK_NE(c["x"], true);
 	BOOST_CHECK_NE(c["x"], "a random string");
 
 	// blank != "" test.

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -215,19 +215,27 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 	BOOST_CHECK_EQUAL(x_str, "123456789123");
 
 // check heterogeneous comparison
+	using namespace std::literals;
+
 	c["x"] = "1";
 	BOOST_CHECK_EQUAL(c["x"], "1");
 	c["x"] = 222;
 	BOOST_CHECK_EQUAL(c["x"], "222");
+	BOOST_CHECK_EQUAL(c["x"], "222"s);
 	c["x"] = "test";
-	BOOST_CHECK_EQUAL(c["x"], "test");
+	BOOST_CHECK_EQUAL(c["x"], "test"sv);
 	c["x"] = false;
 	BOOST_CHECK_EQUAL(c["x"], "no");
+	BOOST_CHECK_EQUAL(c["x"], "false");
 	c["x"] = 9.87654321;
 	BOOST_CHECK_EQUAL(c["x"], "9.87654321");
+	BOOST_CHECK_EQUAL(c["x"], t_string{"9.87654321"});
+	BOOST_CHECK_EQUAL(c["x"], config_attribute_value::create("9.87654321"));
 	c["x"] = "sfvsdgdsfg";
-	BOOST_CHECK_EQUAL(c["x"], std::string{"sfvsdgdsfg"});
-	BOOST_CHECK_EQUAL(c["x"], std::string_view{"sfvsdgdsfg"});
+	BOOST_CHECK_EQUAL(c["x"], "sfvsdgdsfg");
+	BOOST_CHECK_EQUAL(c["x"], "sfvsdgdsfg"s);
+	BOOST_CHECK_EQUAL(c["x"], "sfvsdgdsfg"sv);
+	BOOST_CHECK_EQUAL(c["x"], t_string{"sfvsdgdsfg"});
 	BOOST_CHECK_NE(c["x"], "a random string");
 
 	// blank != "" test.

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -231,11 +231,11 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 	BOOST_CHECK_EQUAL(c["x"], "no");
 	c["x"] = 1.23456789;
 	BOOST_CHECK_EQUAL(c["x"], 1.23456789);
-#if 1 // FIXME: this should work. it doesn't work. looks like it's getting stored as 9.8765432099999995
 	c["x"] = "9.87654321";
 	BOOST_CHECK_EQUAL(c["x"], 9.87654321);
-#endif
 	c["x"] = "sfvsdgdsfg";
+	BOOST_CHECK_EQUAL(c["x"], std::string{"sfvsdgdsfg"});
+	BOOST_CHECK_EQUAL(c["x"], std::string_view{"sfvsdgdsfg"});
 	BOOST_CHECK_NE(c["x"], 0);
 	BOOST_CHECK_NE(c["x"], true);
 	BOOST_CHECK_NE(c["x"], "a random string");


### PR DESCRIPTION
Also fixes comparison with std::string_view on the legacy codepath