### PR TITLE
add_overlay extended

### DIFF
--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -24,6 +24,7 @@ local function add_overlay(x, y, cfg)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
 			redraw = cfg.redraw,
 			name = cfg.name,
@@ -36,14 +37,20 @@ end
 ---@param x integer
 ---@param y integer
 ---@param name? string
-function wesnoth.interface.remove_item(x, y, name)
+---@param do_partial_string_match boolean
+function wesnoth.interface.remove_item(x, y, name, do_partial_string_match)
 	local items = scenario_items:get(x, y)
 	if not items then return end
-	wesnoth.interface.remove_hex_overlay(x, y, name)
+	wesnoth.interface.remove_hex_overlay(x, y, name, do_partial_string_match)
 	if name then
 		for i = #items,1,-1 do
 			local item = items[i]
-			if item.image == name or item.halo == name or item.name == name then
+			if (item.image == name or item.halo == name or item.name == name) or 
+				(do_partial_string_match and 
+				((type(item.image) == "string" and string.find(item.image, name, 1, true)) or 
+				(type(item.halo) == "string" and string.find(item.halo, name, 1, true)) or 
+				(type(item.name) == "string" and string.find(item.name, name, 1, true))))
+				then
 				table.remove(items, i)
 			end
 		end
@@ -136,7 +143,7 @@ end
 function wml_actions.remove_item(cfg)
 	local locs = wesnoth.map.find(cfg)
 	for i, loc in ipairs(locs) do
-		wesnoth.interface.remove_item(loc[1], loc[2], cfg.image)
+		wesnoth.interface.remove_item(loc[1], loc[2], cfg.image , cfg.do_partial_string_match)
 	end
 end
 

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -46,10 +46,10 @@ function wesnoth.interface.remove_item(x, y, name, do_partial_string_match)
 	if name then
 		for i = #items,1,-1 do
 			local item = items[i]
-			if (item.image == name or item.halo == name or item.name == name) or 
-				(do_partial_string_match and 
-				((type(item.image) == "string" and string.find(item.image, name, 1, true)) or 
-				(type(item.halo) == "string" and string.find(item.halo, name, 1, true)) or 
+			if (item.image == name or item.halo == name or item.name == name) or
+				(do_partial_string_match and
+				((type(item.image) == "string" and string.find(item.image, name, 1, true)) or
+				(type(item.halo) == "string" and string.find(item.halo, name, 1, true)) or
 				(type(item.name) == "string" and string.find(item.name, name, 1, true))))
 				then
 				table.remove(items, i)

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -29,6 +29,7 @@ local function add_overlay(x, y, cfg)
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
+			drawing_layer = cfg.drawing_layer,
 			wml.tag.variables(wml.get_child(cfg, "variables") or {}),
 		})
 end

--- a/data/schema/core/actionwml.cfg
+++ b/data/schema/core/actionwml.cfg
@@ -855,6 +855,7 @@
 		super="$filter_location"
 		{INSERT_TAG}
 		{SIMPLE_KEY image string}
+		{SIMPLE_KEY do_partial_string_match s_bool no}
 	[/tag]
 	[tag]
 		name="print"

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -135,7 +135,7 @@ namespace
 		{
 			return src_w > 0 && src_h > 0;
 		}
-	};	
+	};
 
 	// Constants for hex geometry
 	static constexpr int HEX_W = 72; // hex width in px
@@ -317,7 +317,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 			std::vector<overlay>& overlays = get_overlays()[loc];
 			auto pos = std::find_if(overlays.begin(), overlays.end(),
 				[new_order = ov.z_order](const overlay& existing) { return existing.z_order > new_order; });
-			auto inserted = overlays.emplace(pos, std::move(ov));
+			overlays.emplace(pos, std::move(ov));
 			return;
 		} else {
 			if(!ov.image.empty()) {
@@ -3032,7 +3032,7 @@ void display::draw_overlays_at(const map_location& loc)
 			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos 
 				? image::get_lighted_texture(ov.image, lt)														
 				: image::get_texture(ov.image, image::HEXED);
-		} 
+		}
 
 		// Base submerge value for the terrain at this location
 		const double ter_sub = context().map().get_terrain_info(loc).unit_submerge();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -3024,10 +3024,13 @@ void display::draw_overlays_at(const map_location& loc)
 		texture tex;
 		if(ov.is_animated) {
 			const image::locator& frame = ov.anim.get_current_frame();
-			tex = image::get_texture(frame, image::HEXED);
-		} else { //old code
-			tex = ov.image.find("~NO_TOD_SHIFT()") == std::string::npos
-				? image::get_lighted_texture(ov.image, lt)
+			// Check the animation frame for the NO_TOD modifier, just like the static image.
+			tex = frame.get_modifications().find("NO_TOD_SHIFT") == std::string::npos
+				? image::get_lighted_texture(frame, lt)
+				: image::get_texture(frame, image::HEXED);
+		} else { // old code
+			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos 
+				? image::get_lighted_texture(ov.image, lt)														
 				: image::get_texture(ov.image, image::HEXED);
 		} 
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -170,8 +170,13 @@ public:
 	/** remove_overlay will remove all overlays on a tile. */
 	void remove_overlay(const map_location& loc);
 
-	/** remove_single_overlay will remove a single overlay from a tile */
-	void remove_single_overlay(const map_location& loc, const std::string& toDelete);
+	/**
+	 * remove_single_overlay will remove a single overlay from a tile.
+	 * - @param loc The location of the tile.
+	 * - @param toDelete The name or partial name of the overlay to delete.
+	 * - @param do_partial_string True to perform a partial string match, false for an exact match.
+	 */
+	void remove_single_overlay(const map_location& loc, const std::string& toDelete, bool do_partial_string);
 
 	/**
 	 * Updates internals that cache map size. This should be called when the map

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -15,7 +15,9 @@
 
 #pragma once
 
+#include "display.hpp"
 #include "halo.hpp"
+#include "drawing_layer.hpp"
 
 struct overlay
 {
@@ -24,7 +26,9 @@ struct overlay
 			const std::string& halo_img,
 			const std::string& overlay_team_name,
 			const std::string& item_id,
+			const std::string& drawing_layer,
 			const bool fogged,
+			const bool multihex,
 			float submerge,
 			float item_z_order = 0)
 		: image(img)
@@ -32,8 +36,10 @@ struct overlay
 		, team_name(overlay_team_name)
 		, name()
 		, id(item_id)
+		, drawing_layer(drawing_layer)
 		, halo_handle()
 		, visible_in_fog(fogged)
+		, multihex(multihex)
 		, submerge(submerge)
 		, z_order(item_z_order)
 	{}
@@ -45,12 +51,13 @@ struct overlay
 		, team_name(cfg["team_name"])
 		, name(cfg["name"].t_str())
 		, id(cfg["id"])
+		, drawing_layer(cfg["drawing_layer"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
+		, multihex(cfg["multihex"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
 		, z_order(cfg["z_order"].to_double(0))
-	{
-	}
+	{}
 
 	std::string image;
 	std::string halo;
@@ -62,5 +69,17 @@ struct overlay
 	bool visible_in_fog;
 	float submerge;
 	float z_order;
+
+	// --- animation support ---
+	animated<image::locator> anim;
+	bool is_animated = false;
+
+	// --- multihex support ---
+	bool multihex;
+	std::vector<map_location> child_hexes;
+
+	// --- drawing layer support ---
+	std::string drawing_layer;
+
 
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -21,29 +21,31 @@
 
 struct overlay
 {
-
 	overlay(const std::string& img,
-			const std::string& halo_img,
-			const std::string& overlay_team_name,
-			const std::string& item_id,
-			const std::string& drawing_layer,
-			const bool fogged,
-			const bool multihex,
-			float submerge,
-			float item_z_order = 0)
+		const std::string& halo_img,
+		const std::string& overlay_team_name,
+		const std::string& item_id,
+		const std::string& drawing_layer,
+		const bool fogged,
+		const bool multihex,
+		float submerge,
+		float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
 		, name()
 		, id(item_id)
-		, drawing_layer(drawing_layer)
 		, halo_handle()
 		, visible_in_fog(fogged)
-		, multihex(multihex)
 		, submerge(submerge)
 		, z_order(item_z_order)
-	{}
-
+		, is_animated(false)
+		, multihex(multihex)
+		, is_child(false)
+		, child_hexes()
+		, drawing_layer(drawing_layer)
+	{
+	}
 
 	overlay(const config& cfg)
 		: image(cfg["image"])
@@ -51,13 +53,17 @@ struct overlay
 		, team_name(cfg["team_name"])
 		, name(cfg["name"].t_str())
 		, id(cfg["id"])
-		, drawing_layer(cfg["drawing_layer"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
-		, multihex(cfg["multihex"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
 		, z_order(cfg["z_order"].to_double(0))
-	{}
+		, is_animated(false)
+		, multihex(cfg["multihex"].to_bool())
+		, is_child(false)
+		, child_hexes()
+		, drawing_layer(cfg["drawing_layer"])
+	{
+	}
 
 	std::string image;
 	std::string halo;
@@ -81,6 +87,4 @@ struct overlay
 
 	// --- drawing layer support ---
 	std::string drawing_layer;
-
-
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -76,6 +76,7 @@ struct overlay
 
 	// --- multihex support ---
 	bool multihex;
+	bool is_child = false;
 	std::vector<map_location> child_hexes;
 
 	// --- drawing layer support ---

--- a/src/picture.cpp
+++ b/src/picture.cpp
@@ -627,7 +627,7 @@ static surface get_hexed(const locator& i_locator, bool skip_cache = false)
 		// if the image is too large in either dimension, crop it.
 		if(image->w > mask->w || image->h >= mask->h) {
 			// fill the crop surface with transparency
-			SDL_FillRect(fit, nullptr, SDL_MapRGBA(fit->format, 0, 0, 0, 0));
+			SDL_FillRect(fit, nullptr, SDL_MapRGBA(fit->format, 128, 128, 128, 0)); // changed rgb input from 0,0,0 to 128,128,128 .. seems like the average is needed to avoid lightening or darkening
 			// crop the input image to hexmask dimensions
 			int cutx = std::max(0, image->w - mask->w) / 2;
 			int cuty = std::max(0, image->h - mask->h) / 2;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4180,7 +4180,9 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["halo"],
 			team_name,
 			cfg["name"], // Name is treated as the ID
+			cfg["drawing_layer"],
 			cfg["visible_in_fog"].to_bool(true),
+			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),
 			cfg["z_order"].to_double(0)
 		));
@@ -4192,15 +4194,26 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
  * Removes an overlay from a tile.
  * - Arg 1: location.
  * - Arg 2: optional string.
+ * - Arg 3: optional bolean.
  */
 int game_lua_kernel::intf_remove_tile_overlay(lua_State *L)
 {
 	map_location loc = luaW_checklocation(L, 1);
 	char const *m = lua_tostring(L, 2);
+	bool do_partial_string = false;
+
+	// Check if the second argument is a string.
+	// If it is, then the third argument might be a boolean.
+	// If it's not a string, we check if the second argument is a boolean.
+	if(m) {
+		do_partial_string = lua_toboolean(L, 3);
+	} else {
+		do_partial_string = lua_toboolean(L, 2);
+	}
 
 	if (m) {
 		if (game_display_) {
-			game_display_->remove_single_overlay(loc, m);
+			game_display_->remove_single_overlay(loc, m, do_partial_string);
 		}
 	} else {
 		if (game_display_) {

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4194,7 +4194,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
  * Removes an overlay from a tile.
  * - Arg 1: location.
  * - Arg 2: optional string.
- * - Arg 3: optional bolean.
+ * - Arg 3: optional boolean.
  */
 int game_lua_kernel::intf_remove_tile_overlay(lua_State *L)
 {


### PR DESCRIPTION
First of. I am a novice to github and c++, no doubt  there will be rewrites needed. 

This is done in order to extend image placement functions to allow for: animations, multi-hex images and drawing layer inputs. All optional inputs.

This will give the content creators a lot more freedom in what they want their images to do.

Other changes:
Bug fix were cutting an image with an "image::HEXED" caused the image to darken.
Image removal is changed to allow for multi-hex removal.
Image removal also gets optional input to allow for a partial string match rather than a full one. This makes it simpler to remove an image when you don't know its full string, something that can happen with a lot of IPF modifications. (This is not needed for the rest of this code to work)

This is tested on Windows 10 and seems to work fine. No issues detected.

Call examples:

    //wml

    //add multihex animation
        [item]
	        x,y=105,158
	        image=data/add-ons/Animated_Weather_and_Scenery/images/weather/rain_heavy/00[01~20].png
	        multihex=yes
        [/item]
    
    //remove multihex animation from above
        [remove_item]
	        x,y=105,158
	        image=weather/rain_heavy
	        do_partial_string_match=yes
        [/remove_item]
    
    //lua
    
    //add great continent map on top of in-game terrain (see image below)
    //add " drawing_layer = "arrows" " in there and the image will be drawn at the arrow level (above the units)
        wesnoth.interface.add_hex_overlay(68, 57, { image = "data/add-ons/Animated_Weather_and_Scenery/images/great_continent.png", multihex = "yes"})

    //remove
        wesnoth.interface.remove_hex_overlay(68, 57, "ages/great_continent", true)

<img width="687" height="429" alt="image" src="https://github.com/user-attachments/assets/0cd693f3-4599-457f-b04a-c20ef1b95c17" />


Edit, this has CRLF line endings, I'm guessing if should be LF. I'll change over later.

Edit 2, it also occurs to me now that a multi-hex image may get 1-hex-size children that are fully transparent. I will weed these out next.

Edit 3, When removing the children overlays we accidentally clear the entire child hex of all overlays, not just the child. I will change this.

Edit 4, no need to recall make_overlay_crop() for every frame, 1 time per hex is enough. Will rework.

Edit 5, also missed to enable "drawing_layer" as input from WML code (only Lua atm). Will add.