### PR TITLE
Remove unnecessary differences between Bone Knight and Skeleton Rider unit descriptions

### DIFF
--- a/data/core/units/undead/Skele_Bone_Knight.cfg
+++ b/data/core/units/undead/Skele_Bone_Knight.cfg
@@ -57,7 +57,7 @@
     {AMLA_DEFAULT}
     cost=26
     usage=scout
-    description= _ "Once great warriors across the plains, these mounted riders atop their skeletal horses were raised from the ground by unholy magic to spread fear and destruction."
+    description= _ "Once great warriors thundering across the plains, these mounted riders atop their skeletal horses were raised from the grave by unholy magic to spread fear and destruction."
     die_sound=skeleton-big-die.ogg
     [abilities]
         {ABILITY_SUBMERGE}


### PR DESCRIPTION
Ideally both descriptions should be different, but two slightly different words between these are unnecessary and it feels like one may have been updated without updating the other at some point.