### PR TITLE
Add commands for the host or a moderator to change the host of a game.

### DIFF
--- a/src/chat_command_handler.hpp
+++ b/src/chat_command_handler.hpp
@@ -82,6 +82,8 @@ protected:
 				" the server."), _("<nickname>"));
 		register_command("kick", &chat_command_handler::do_network_send_req_arg,
 			_("Kick a player or observer."), _("<nickname>"));
+		register_command("transfer_host", &chat_command_handler::do_network_send_req_arg,
+			_("Transfer host to another player."), _("<nickname>"));
 		register_command("mute", &chat_command_handler::do_network_send,
 			_("Mute an observer. Without an argument displays the mute status."), _("<nickname>"));
 		register_command("unmute", &chat_command_handler::do_network_send,

--- a/src/chat_command_handler.hpp
+++ b/src/chat_command_handler.hpp
@@ -82,7 +82,7 @@ protected:
 				" the server."), _("<nickname>"));
 		register_command("kick", &chat_command_handler::do_network_send_req_arg,
 			_("Kick a player or observer."), _("<nickname>"));
-		register_command("transfer_host", &chat_command_handler::do_network_send_req_arg,
+		register_command("transferhost", &chat_command_handler::do_network_send_req_arg,
 			_("Transfer host to another player."), _("<nickname>"));
 		register_command("mute", &chat_command_handler::do_network_send,
 			_("Mute an observer. Without an argument displays the mute status."), _("<nickname>"));

--- a/src/chat_events.cpp
+++ b/src/chat_events.cpp
@@ -88,7 +88,7 @@ void chat_handler::send_command(const std::string& cmd, const std::string& args 
 		data.add_child(cmd)["type"] = args;
 	}
 	else if (cmd == "ban" || cmd == "unban" || cmd == "kick"
-		|| cmd == "mute" || cmd == "unmute" || cmd == "transfer_host") {
+		|| cmd == "mute" || cmd == "unmute" || cmd == "transferhost") {
 		data.add_child(cmd)["username"] = args;
 	}
 	else if (cmd == "ping") {

--- a/src/chat_events.cpp
+++ b/src/chat_events.cpp
@@ -88,7 +88,7 @@ void chat_handler::send_command(const std::string& cmd, const std::string& args 
 		data.add_child(cmd)["type"] = args;
 	}
 	else if (cmd == "ban" || cmd == "unban" || cmd == "kick"
-		|| cmd == "mute" || cmd == "unmute") {
+		|| cmd == "mute" || cmd == "unmute" || cmd == "transfer_host") {
 		data.add_child(cmd)["username"] = args;
 	}
 	else if (cmd == "ping") {

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -913,9 +913,11 @@ void game::unban_user(const simple_wml::node& unban, player_iterator unbanner)
 }
 
 void game::transfer_host(const simple_wml::node& new_host, player_iterator requestor) {
-	if(requestor != owner_) {
-		send_server_message("You cannot transfer host: not the game host.", requestor);
-		return;
+	if(!requestor->info().is_moderator()) {
+		if(requestor != owner_) {
+			send_server_message("You cannot transfer host: not the game host.", requestor);
+			return;
+		}
 	}
 
 	const simple_wml::string_span& username = new_host["username"];

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -920,6 +920,12 @@ void game::transfer_host(const simple_wml::node& new_host, player_iterator reque
 		}
 	}
 
+	// TODO: In theory this operation should be possible, but transitioning between the host lobby
+	// screen and everyone else's lobby screen is non-trivial.
+	if(!started_) {
+		send_server_message("Transferring host in an unstarted game is not yet supported.");
+	}
+
 	const simple_wml::string_span& username = new_host["username"];
 	auto user { find_user(username) };
 

--- a/src/server/wesnothd/game.cpp
+++ b/src/server/wesnothd/game.cpp
@@ -642,8 +642,12 @@ std::unique_ptr<simple_wml::document> game::change_controller_type(const std::si
 	return response.clone();
 }
 
-void game::notify_new_host()
+void game::change_host_and_notify(player_iterator new_host)
 {
+	if(owner_ == new_host) {
+		return;
+	}
+	owner_ = new_host;
 	const std::string owner_name = username(owner_);
 	simple_wml::document cfg;
 	cfg.root().add_child("host_transfer");
@@ -888,6 +892,28 @@ void game::unban_user(const simple_wml::node& unban, player_iterator unbanner)
 	utils::erase(bans_, (*user)->client_ip());
 	utils::erase(name_bans_, username.to_string());
 	send_and_record_server_message(username.to_string() + " has been unbanned.");
+}
+
+void game::transfer_host(const simple_wml::node& new_host, player_iterator requestor) {
+	// TODO: moderators should also have the ability to change the host.
+	if(requestor != owner_) {
+		send_server_message("You cannot transfer host: not the game host.", requestor);
+		return;
+	}
+
+	const simple_wml::string_span& username = new_host["username"];
+	auto user { find_user(username) };
+
+	if(!user || is_player(*user)) {
+		send_server_message("'" + username.to_string() + "' is not a player in this game.", requestor);
+		return;
+	}
+
+	LOG_GAME
+		<< requestor->client_ip() << "\t" << requestor->info().name()
+		<< "\ttransferred hostship to: " << username << " (" << (*user)->client_ip()
+		<< ")\tin game:\t\"" << name_ << "\" (" << id_ << ", " << db_id_ << ")";
+	change_host_and_notify(*user);
 }
 
 void game::process_message(simple_wml::document& data, player_iterator user)
@@ -1500,8 +1526,7 @@ bool game::remove_player(player_iterator player, const bool disconnect, const bo
 
 	// If the player was host choose a new one.
 	if(host) {
-		owner_ = players_.front();
-		notify_new_host();
+		change_host_and_notify(players_.front());
 	}
 
 	bool ai_transfer = false;

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -278,7 +278,7 @@ public:
 	void unban_user(const simple_wml::node& unban, player_iterator unbanner);
 
 	/**
-	 * Transfer host role by name.
+	 * Transfers host role by name.
 	 *
 	 * @param new_host The user to become the new host.
 	 * @param requestor The player initiating the host transfer.
@@ -789,9 +789,13 @@ private:
 
 	/**
 	 * Changes the host to @a new_host, and notify the new host about its status.
+	 *
 	 * No-op if @a new_host is already the host.
+	 *
+	 * @param new_host The player to become the new host.
+	 * @param initiator Optional intiator of the request (for logging).
 	 */
-	void change_host_and_notify(player_iterator new_host);
+	void change_host_and_notify(player_iterator new_host, utils::optional<player_iterator> initiator);
 
 	/**
 	 * Shortcut to a convenience function for finding a user by name.

--- a/src/server/wesnothd/game.hpp
+++ b/src/server/wesnothd/game.hpp
@@ -278,6 +278,14 @@ public:
 	void unban_user(const simple_wml::node& unban, player_iterator unbanner);
 
 	/**
+	 * Transfer host role by name.
+	 *
+	 * @param new_host The user to become the new host.
+	 * @param requestor The player initiating the host transfer.
+	 */
+	void transfer_host(const simple_wml::node& new_host, player_iterator requestor);
+
+	/**
 	 * Add a user to the game.
 	 *
 	 * @todo differentiate between "observers not allowed" and "player already in the game" errors.
@@ -779,8 +787,11 @@ private:
 	void send_history(player_iterator sock) const;
 	void send_chat_history(player_iterator sock) const;
 
-	/** In case of a host transfer, notify the new host about its status. */
-	void notify_new_host();
+	/**
+	 * Changes the host to @a new_host, and notify the new host about its status.
+	 * No-op if @a new_host is already the host.
+	 */
+	void change_host_and_notify(player_iterator new_host);
 
 	/**
 	 * Shortcut to a convenience function for finding a user by name.

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -3261,14 +3261,6 @@ void server::set_game_host_handler(const std::string& issuer_name,
 	assert(out != nullptr);
 
 	const auto issuer = player_connections_.project<0>(player_connections_.get<name_t>().find(issuer_name));
-	// Shouldn't happen, but should check just in case.
-	if(issuer == player_connections_.get<0>().end()) {
-		*out << issuer_name << " does not exist?";
-	} else if(!issuer->info().is_moderator()) {
-		*out << issuer_name << " is not a moderator?";
-		return;
-	}
-
 	const std::string nick = parameters.substr(0, parameters.find(' '));
 	const std::string reason = parameters.length() > nick.length() + 1 ? parameters.substr(nick.length() + 1) : "";
 	const auto player = player_connections_.project<0>(player_connections_.get<name_t>().find(nick));

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -411,6 +411,7 @@ void server::setup_handlers()
 	SETUP_HANDLER("deny_unregistered_login", &server::dul_handler);
 	SETUP_HANDLER("stopgame", &server::stopgame_handler);
 	SETUP_HANDLER("reset_queues", &server::reset_queues_handler);
+	SETUP_HANDLER("setgamehost", &server::set_game_host_handler);
 
 #undef SETUP_HANDLER
 }
@@ -2158,10 +2159,11 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 	} else if(const simple_wml::node* unban = data.child("unban")) {
 		g.unban_user(*unban, p);
 		return;
-		// If info is being provided about the game state.
+		// If host should be transferred to another player.
 	} else if(const simple_wml::node* transfer_host = data.child("transfer_host")) {
 		g.transfer_host(*transfer_host, p);
 		return;
+		// If info is being provided about the game state.
 	} else if(const simple_wml::node* info = data.child("info")) {
 		if(!g.is_player(p)) {
 			return;
@@ -3248,6 +3250,40 @@ void server::reset_queues_handler(const std::string& /*issuer_name*/,
 	}
 
 	*out << "Reset all queues";
+}
+
+void server::set_game_host_handler(const std::string& issuer_name,
+		const std::string& /*query*/,
+		std::string& parameters,
+		std::ostringstream* out)
+{
+	assert(out != nullptr);
+
+	const auto issuer = player_connections_.get<name_t>().find(issuer_name);
+	// Shouldn't happen, but should check just in case.
+	if(!issuer->info().is_moderator()) {
+		*out << issuer_name << " is not a moderator?";
+		return;
+	}
+
+	const std::string nick = parameters.substr(0, parameters.find(' '));
+	const std::string reason = parameters.length() > nick.length() + 1 ? parameters.substr(nick.length() + 1) : "";
+	const auto player = player_connections_.get<name_t>().find(nick);
+
+	if(player == player_connections_.get<name_t>().end()) {
+		*out << "Player '" << nick << "' is not currently logged in.";
+		return;
+	}
+
+	std::shared_ptr<game> g = player->get_game();
+	if(!g) {
+		*out << "Player '" << nick << "' is not currently in a game.";
+		return;
+	}
+
+	*out << "Player '" << nick << "' is in game with id '" << g->id() << ", " << g->db_id()
+		 << "' named '" << g->name() << "'. Setting host to " << nick;
+	g->change_host_and_notify(player, issuer);
 }
 
 void server::delete_game(int gameid, const std::string& reason)

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -2159,6 +2159,9 @@ void server::handle_player_in_game(player_iterator p, simple_wml::document& data
 		g.unban_user(*unban, p);
 		return;
 		// If info is being provided about the game state.
+	} else if(const simple_wml::node* transfer_host = data.child("transfer_host")) {
+		g.transfer_host(*transfer_host, p);
+		return;
 	} else if(const simple_wml::node* info = data.child("info")) {
 		if(!g.is_player(p)) {
 			return;

--- a/src/server/wesnothd/server.hpp
+++ b/src/server/wesnothd/server.hpp
@@ -289,6 +289,7 @@ private:
 	void dul_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
 	void stopgame_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
 	void reset_queues_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
+	void set_game_host_handler(const std::string &, const std::string &, std::string &, std::ostringstream *);
 
 #ifndef _WIN32
 	void handle_sighup(const boost::system::error_code& error, int signal_number);


### PR DESCRIPTION
Fixes https://github.com/wesnoth/wesnoth/issues/2536.

The host of the game can use `/transferhost <nick>` to transfer the host to `<nick>`, and a moderator can use `/query setashost <nick>` to change the host of the game that `<nick>` is in to `<nick>`.