### PR TITLE
Help: Add positioning info to parse errors

### DIFF
--- a/src/gui/dialogs/help_browser.cpp
+++ b/src/gui/dialogs/help_browser.cpp
@@ -240,11 +240,11 @@ void help_browser::show_topic(std::string topic_id, bool add_to_history, bool re
 		find_widget<label>("topic_title").set_label(topic->title);
 		try {
 			find_widget<rich_label>("topic_text").set_dom(topic->text.parsed_text());
-		} catch(const game::error& err) {
+		} catch(const markup::parse_error& e) {
 			find_widget<rich_label>("topic_text").set_label(
 				markup::span_color(font::BAD_COLOR,
 					"Error parsing markup in help page with ID: " + topic->id + "\n"
-					+ font::escape_text(err.message)));
+					+ font::escape_text(e.message)));
 		}
 
 		invalidate_layout();

--- a/src/serialization/markup.cpp
+++ b/src/serialization/markup.cpp
@@ -19,6 +19,7 @@
 #include "game_config.hpp"
 #include "gettext.hpp"
 #include "serialization/string_utils.hpp"
+#include "serialization/unicode.hpp"
 #include "serialization/unicode_cast.hpp"  // for unicode_cast
 
 #include <algorithm>
@@ -97,16 +98,14 @@ static std::string::const_iterator text_start;
 
 static std::string position_info(std::string::const_iterator pos)
 {
-	// line numbers start at 1
+	// line numbers start from 1
 	int lines = std::count(text_start, pos, '\n') + 1;
+	// store error location
+	auto error_pos = pos;
 	// Find the start position of the line where the current position is.
 	// We do this by searching in reverse from cursor_position toward text_start.
-	int chars = 0;
-	while(*pos != '\n' && pos != text_start) {
-		pos--;
-		chars++;
-	}
-	return formatter() << "line " << lines << ", character " << chars;
+	for(;pos != text_start && *pos != '\n'; pos--);
+	return formatter() << "line " << lines << ", character " << utf8::size(pos, error_pos);
 }
 
 static config parse_entity(std::string::const_iterator& beg, std::string::const_iterator end)

--- a/src/serialization/markup.hpp
+++ b/src/serialization/markup.hpp
@@ -211,7 +211,16 @@ std::string make_link(const std::string& text, const std::string& dst);
 /** Thrown when the help system fails to parse something. */
 struct parse_error : public game::error
 {
-	parse_error(const std::string& msg) : game::error(msg) {}
+	parse_error(const std::string::const_iterator& error_loc, const std::string& error_msg)
+		: game::error(error_msg)
+		, error_position_(error_loc)
+	{ }
+
+public:
+	std::string::const_iterator error_location() { return error_position_; }
+
+private:
+	std::string::const_iterator error_position_;
 };
 
 /**

--- a/src/serialization/unicode.cpp
+++ b/src/serialization/unicode.cpp
@@ -85,12 +85,8 @@ std::size_t index(std::string_view str, const std::size_t index)
 std::size_t size(std::string_view str)
 {
 	std::size_t chr, i = 0, len = str.size();
-	try {
-		for (chr = 0; i < len; ++chr) {
-			i += byte_size_from_utf8_first(str[i]);
-		}
-	} catch(const invalid_utf8_exception&) {
-		ERR_GENERAL << "Invalid UTF-8 string.";
+	for (chr = 0; i < len; ++chr) {
+		i += byte_size_from_utf8_first(str[i]);
 	}
 	return chr;
 }
@@ -99,12 +95,8 @@ std::size_t size(const std::string::const_iterator& start, const std::string::co
 {
 	std::size_t count;
 	std::string::const_iterator pos = start;
-	try {
-		for (count = 0; pos < end; ++count) {
-			pos += byte_size_from_utf8_first(*pos);
-		}
-	} catch(const invalid_utf8_exception&) {
-		ERR_GENERAL << "Invalid UTF-8 string.";
+	for (count = 0; pos < end; ++count) {
+		pos += byte_size_from_utf8_first(*pos);
 	}
 	return count;
 }

--- a/src/serialization/unicode.cpp
+++ b/src/serialization/unicode.cpp
@@ -84,15 +84,29 @@ std::size_t index(std::string_view str, const std::size_t index)
 
 std::size_t size(std::string_view str)
 {
-	unsigned int chr, i = 0, len = str.size();
+	std::size_t chr, i = 0, len = str.size();
 	try {
-		for (chr=0; i<len; ++chr) {
+		for (chr = 0; i < len; ++chr) {
 			i += byte_size_from_utf8_first(str[i]);
 		}
 	} catch(const invalid_utf8_exception&) {
 		ERR_GENERAL << "Invalid UTF-8 string.";
 	}
 	return chr;
+}
+
+std::size_t size(const std::string::const_iterator& start, const std::string::const_iterator& end)
+{
+	std::size_t count;
+	std::string::const_iterator pos = start;
+	try {
+		for (count = 0; pos < end; ++count) {
+			pos += byte_size_from_utf8_first(*pos);
+		}
+	} catch(const invalid_utf8_exception&) {
+		ERR_GENERAL << "Invalid UTF-8 string.";
+	}
+	return count;
 }
 
 std::string& insert(std::string& str, const std::size_t pos, const std::string& insert)

--- a/src/serialization/unicode.cpp
+++ b/src/serialization/unicode.cpp
@@ -72,12 +72,8 @@ std::size_t index(std::string_view str, const std::size_t index)
 	// chr counts characters, i is the codepoint index
 	// remark: several functions rely on the fallback to str.length()
 	unsigned int i = 0, len = str.size();
-	try {
-		for (unsigned int chr=0; chr<index && i<len; ++chr) {
-			i += byte_size_from_utf8_first(str[i]);
-		}
-	} catch(const invalid_utf8_exception&) {
-		ERR_GENERAL << "Invalid UTF-8 string.";
+	for(unsigned int chr = 0; chr < index && i < len; ++chr) {
+		i += byte_size_from_utf8_first(str[i]);
 	}
 	return i;
 }
@@ -85,7 +81,7 @@ std::size_t index(std::string_view str, const std::size_t index)
 std::size_t size(std::string_view str)
 {
 	std::size_t chr, i = 0, len = str.size();
-	for (chr = 0; i < len; ++chr) {
+	for(chr = 0; i < len; ++chr) {
 		i += byte_size_from_utf8_first(str[i]);
 	}
 	return chr;
@@ -95,7 +91,7 @@ std::size_t size(const std::string::const_iterator& start, const std::string::co
 {
 	std::size_t count;
 	std::string::const_iterator pos = start;
-	for (count = 0; pos < end; ++count) {
+	for(count = 0; pos < end; ++count) {
 		pos += byte_size_from_utf8_first(*pos);
 	}
 	return count;

--- a/src/serialization/unicode.hpp
+++ b/src/serialization/unicode.hpp
@@ -52,6 +52,7 @@ namespace utf8 {
 
 	/** Length in characters of a UTF-8 string. */
 	std::size_t size(std::string_view str);
+	std::size_t size(const std::string::const_iterator& start, const std::string::const_iterator& end);
 
 	/** Insert a UTF-8 string at the specified position. */
 	std::string& insert(std::string& str, const std::size_t pos, const std::string& insert) ;

--- a/src/serialization/unicode.hpp
+++ b/src/serialization/unicode.hpp
@@ -45,12 +45,19 @@ namespace utf8 {
 
 	/**
 	 * Codepoint index corresponding to the nth character in a UTF-8 string.
-	 *
+	 * @throw invalid_utf8_exception if the string is not a valid UTF-8 string.
+	 * The checking is partial. No matter what is in between, it will iterate from first byte
+	 * of a character to the next first byte of the following character.
 	 * @return str.length() if there are less than @p index characters.
 	 */
 	std::size_t index(std::string_view str, const std::size_t index);
 
-	/** Length in characters of a UTF-8 string. */
+	/**
+	 * Length in characters of a UTF-8 string.
+	 * @throw invalid_utf8_exception if the string is not a valid UTF-8 string.
+	 * The checking is partial. No matter what is in between, it will iterate from first byte
+	 * of a character to the next first byte of the following character.
+	 */
 	std::size_t size(std::string_view str);
 	std::size_t size(const std::string::const_iterator& start, const std::string::const_iterator& end);
 


### PR DESCRIPTION
Resolves #4590 (Help browser can already deal with `&amp;`, and shows error messages in the page if invalid.)

Adds Line/Character position info in Help Markup Parser errors.

<img width="592" height="112" alt="Screenshot from 2025-09-04 18-41-38" src="https://github.com/user-attachments/assets/669fd248-13d9-4252-a9f1-627d3c1cb989" />

Source:
```ini
    [topic]
        id=..introduction
        title= _ "Introduction"
        text="<img src='misc/logo-bg.png~BLIT(misc/logo.png)' float='yes' align='center'/><clear/>" + _ "
<i>Battle for Wesnoth</i> is a turn-based fantasy strategy game somewhat unusual among modern strategy games. While other games strive for complexity, <i>Battle for Wesnoth</i> strives for simplicity of both rules and gameplay. This does not make the game simple, however — from these simple rules arises a wealth of strategy, making the game easy to learn but a challenge to master.

The following pages outline &all you need to know to play Wesnoth. As you play, new information is added to the various categories as you come across new aspects of the game. For more detailed information on special situations and exceptions, follow the included links."
    [/topic]```