### PR TITLE
Fix some capitalization issues in new boat unit descriptions

### DIFF
--- a/data/core/units/boats/Canoe.cfg
+++ b/data/core/units/boats/Canoe.cfg
@@ -30,7 +30,7 @@
     {AMLA_DEFAULT}
     cost=11
     usage=null
-    description= _"A Canoe is a small, open-top water vessel commonly used for transportation or hunting. Their light-weight construction allows them to be carried around barriers or between unconnected bodies of water. Almost every intelligent race has some form of canoe."
+    description= _"A Canoe is a small, open-top water vessel commonly used for transportation or hunting. Their light-weight construction allows them to be carried around barriers or between unconnected bodies of water. Almost every intelligent race has some form of Canoe."
     [abilities]
         {ABILITY_SKIRMISHER}
     [/abilities]

--- a/data/core/units/boats/Orc_Barge.cfg
+++ b/data/core/units/boats/Orc_Barge.cfg
@@ -23,7 +23,7 @@
     {AMLA_DEFAULT}
     cost=70
     usage=null
-    description= _"Orcish barges are crude constructions, devoid of any of the craftsmanship seen in almost any other ship. But what they lack in speed and grace, they make up for with their rugged durability and utility in navigating rivers and swamps. Their primary means of movement comes from a large, symmetric sail held at three points for downwind propulsion. When currents and winds lead to the wrong direction, the crew must use poles and anchors to move the barge in the intended direction.
+    description= _"Orcish Barges are crude constructions, devoid of any of the craftsmanship seen in almost any other ship. But what they lack in speed and grace, they make up for with their rugged durability and utility in navigating rivers and swamps. Their primary means of movement comes from a large, symmetric sail held at three points for downwind propulsion. When currents and winds lead to the wrong direction, the crew must use poles and anchors to move the barge in the intended direction.
 
 Barges serve as transports for either supplies or troops, and when stocked with medicines can provide a safe space — akin to a village — for wounded fighters to rest. They lack any specific weaponry and cannot ram, but the crew is equipped with enough crude orcish bows to provide deterrent.
 

--- a/data/core/units/boats/Raft.cfg
+++ b/data/core/units/boats/Raft.cfg
@@ -19,7 +19,7 @@
     usage=null
     description= _"Rafts can be an efficient means of downriver transport, but they can also be an improvised vessel of desperation, patched together from the wreck of a larger ship.
 
-These rafts are very ineffective in the high seas; little better than a floating wreck."
+These Rafts are very ineffective in the high seas; little better than a floating wreck."
     [standing_anim]
         start_time=0
         terrain_type=W*^*

--- a/data/core/units/boats/Skiff.cfg
+++ b/data/core/units/boats/Skiff.cfg
@@ -18,7 +18,7 @@
     advances_to=Merchant Carrack,Pirate Carrack
     cost=35
     usage=null
-    description= _"Propelled by oars or small sails, skiffs are used to travel short distances and in shallows where large ships cannot navigate."
+    description= _"Propelled by oars or small sails, Skiffs are used to travel short distances and in shallows where large ships cannot navigate."
 
     [attack]
         name=ram


### PR DESCRIPTION
Some of these new boat descriptions aren't following the typography style guide's convention of capitalizing unit names.