### PR TITLE
add_overlay extended: animation [LLM assisted]

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2747,7 +2747,7 @@ void display::draw_overlays_at(const map_location& loc)
 				? image::get_lighted_texture(frame, lt)
 				: image::get_texture(frame, image::HEXED);
 		} else { // static image
-			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos 
+			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos
 				? image::get_lighted_texture(ov.image, lt)
 				: image::get_texture(ov.image, image::HEXED);
 		}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -171,7 +171,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 	bool is_anim = false;
 
 	if(items.size() > 1 || ov.image.find(':') != std::string::npos) {
-		// This is an animation string. Reform it into a series of frames, 1 per image. 
+		// This is an animation string. Reform it into a series of frames, 1 per image.
 		is_anim = true;
 		for(const auto& item : items) {
 			auto parts = utils::split(item, ':');

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "halo.hpp"
+#include "display.hpp"
 
 struct overlay
 {
@@ -63,4 +64,7 @@ struct overlay
 	float submerge;
 	float z_order;
 
+	// Other support
+	bool is_animated = false;
+	animated<image::locator> anim; // Manages the sequence of frames and timing for animated overlays.
 };


### PR DESCRIPTION
This PR aims to provide more options for image placements via the overlay system. Such a as [item] or wesnoth.interface.add_hex_overlay()

In order to make it simpler to review I will be remaking the other PR here. https://github.com/wesnoth/wesnoth/pull/10505

I'll try to split the code up in 1 commit per feature. And I'll publish each feature in this PR as I make them.

First of is the adding of animations.

Called like:

```
[item]
	x,y=101,158
	image=data/add-ons/Animated_Weather_and_Scenery/images/scenery/god_game/2/00[14~20].png:80
[/item]
```
		
or

`wesnoth.interface.add_hex_overlay(103, 161, { image = "data/add-ons/Animated_Weather_and_Scenery/images/scenery/god_game/1/[1~6].png"})`


https://github.com/user-attachments/assets/3ecf3830-08e4-49cb-af6e-9b700a4e2035

