### PR TITLE
New IPF: PAD [LLM assisted]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 ### Units
 ### User interface
 ### WML Engine
+   * ~PAD() added as an IPF (image path function). It allows the sides of an image to be padded with transparent pixels. Can be used to artificially offset images.
 ### Miscellaneous and Bug Fixes
 
 ## Version 1.19.16

--- a/src/image_modifications.cpp
+++ b/src/image_modifications.cpp
@@ -448,6 +448,36 @@ void xbrz_modification::operator()(surface& src) const
 	}
 }
 
+void pad_modification::operator()(surface& src) const
+{
+	// Calculate the new dimensions of the padded surface
+	const int new_w = src->w + left_ + right_;
+	const int new_h = src->h + top_ + bottom_;
+
+	// Create a new transparent surface with the calculated dimensions
+	surface padded(new_w, new_h);
+
+	// Define the destination rectangle for the original image
+	rect dstrect{
+		left_,
+		top_,
+		0, // These two values are ignored by SDL_BlitSurface, so we set them to 0.
+		0  // The function always blits the entire source surface.
+	};
+
+	SDL_BlendMode original_blend_mode;
+	SDL_GetSurfaceBlendMode(src, &original_blend_mode);
+	// Set blend mode to none to prevent blending
+	SDL_SetSurfaceBlendMode(src, SDL_BLENDMODE_NONE);
+
+	// Blit the original surface onto the new, padded surface
+	SDL_BlitSurface(src, nullptr, padded, &dstrect);
+
+	SDL_SetSurfaceBlendMode(padded, original_blend_mode);
+
+	src = padded;
+}
+
 /*
  * The Opacity IPF doesn't seem to work with surface-wide alpha and instead needs per-pixel alpha.
  * If this is needed anywhere else it can be moved back to sdl/utils.*pp.
@@ -1065,6 +1095,66 @@ REGISTER_MOD_PARSER(XBRZ, args)
 {
 	const int factor = std::clamp(utils::from_chars<int>(args).value_or(1), 1, 6);
 	return std::make_unique<xbrz_modification>(factor);
+}
+
+// Pad
+REGISTER_MOD_PARSER(PAD, args)
+{
+	int top = 0;
+	int right = 0;
+	int bottom = 0;
+	int left = 0;
+
+	// Check for the presence of an '=' sign to determine the parsing mode.
+	if(args.find('=') != std::string_view::npos) {
+		// --- Keyword-Argument Mode ---
+		const auto params = utils::map_split(std::string{args}, ',', '='); // map_split needs a std::string
+
+		// Map valid input strings to the corresponding integer reference
+		const std::map<std::string, int*> alias_map = {
+			{"top", &top},
+			{"t", &top},
+			{"right", &right},
+			{"r", &right},
+			{"bottom", &bottom},
+			{"b", &bottom},
+			{"left", &left},
+			{"l", &left},
+		};
+
+		// Parse and assign values if keywords are valid
+		for(const auto& [key, value] : params) {
+			auto it = alias_map.find(key);
+			if(it != alias_map.end()) {
+				if(utils::optional padding = utils::from_chars<int>(value)) {
+					*it->second = padding.value();
+				} else {
+					ERR_DP << "~PAD() keyword argument '" << key << "' requires a valid integer value. Received: '" << value << "'.";
+					return nullptr;
+				}
+			} else {
+				ERR_DP << "~PAD() found an unknown keyword: '" << key << "'. Valid keywords: top, t, right, r, bottom, b, left, l.";
+				return nullptr;
+			}
+		}
+	} else {
+		// --- Numeric-Argument Mode ---
+		const auto params = utils::split_view(args, ',');
+		if(params.size() != 1) {
+			ERR_DP << "~PAD() takes either 1 numeric argument for the padding on all sides or a comma separated list of '<keyword>=<number>' pairs with available keywords: top, t, right, r, bottom, b, left, l.";
+			return nullptr;
+		}
+
+		// Single integer argument: apply to all sides
+		if(utils::optional padding = utils::from_chars<int>(params[0])) {
+			top = right = bottom = left = padding.value();
+		} else {
+			ERR_DP << "~PAD() numeric argument (pad all sides) requires a single valid integer. Received: '" << params[0] << "'.";
+			return nullptr;
+		}
+	}
+
+	return std::make_unique<pad_modification>(top, right, bottom, left);
 }
 
 // Gaussian-like blur

--- a/src/image_modifications.hpp
+++ b/src/image_modifications.hpp
@@ -489,6 +489,30 @@ private:
 };
 
 /**
+ * PAD modification.
+ * Expands the image by adding transparent pixels to its top, right, bottom, and left sides.
+ */
+class pad_modification : public modification
+{
+public:
+	pad_modification(int top, int right, int bottom, int left)
+		: top_{top}
+		, right_{right}
+		, bottom_{bottom}
+		, left_{left}
+	{
+	}
+
+	virtual void operator()(surface& src) const override;
+
+private:
+	int top_;
+	int right_;
+	int bottom_;
+	int left_;
+};
+
+/**
  * Opacity (O) modification
  */
 class o_modification : public modification


### PR DESCRIPTION
Adds a new image path function "OFFSET", that offsets an image by an amount of pixels.

Used like:

```
[item]
	x,y=98,157
	image=data/core/images/items/armor.png~SCALE(50, 50)~OFFSET(-8,18)
[/item]
```
The armour in the image was shifted by this.
<img width="1011" height="359" alt="image" src="https://github.com/user-attachments/assets/f01beaf1-fe90-4f5e-88ea-23f806913bcf" />

Documentation will have to be added too, I will look into that if this is accepted.

