### PR TITLE
add_overlay extended: parallax [LLM assisted]

### DIFF
--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -25,6 +25,7 @@ local function add_overlay(x, y, cfg)
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			submerge = cfg.submerge,
+			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
@@ -62,6 +63,7 @@ end
 ---@field filter_team WML
 ---@field visible_in_fog boolean
 ---@field submerge number
+---@field parallax_mult number
 ---@field redraw boolean
 ---@field name string
 ---@field z_order integer
@@ -85,6 +87,7 @@ function wesnoth.interface.get_items(x, y)
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			submerge = cfg.submerge,
+			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -161,7 +161,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 
 		auto inserted = overlays.emplace(pos, std::move(ov));
 		auto [x, y] = get_location_rect(loc).center();
-		inserted->halo_handle = halo_man_.add(x, y, inserted->halo, loc);
+		inserted->halo_handle = halo_man_.add(x, y, inserted->halo, loc, halo::NORMAL, true, inserted->parallax_mult);
 		return;
 	}
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2747,7 +2747,7 @@ void display::draw_overlays_at(const map_location& loc)
 				? image::get_lighted_texture(frame, lt)
 				: image::get_texture(frame, image::HEXED);
 		} else { // static image
-			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos 
+			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos
 				? image::get_lighted_texture(ov.image, lt)
 				: image::get_texture(ov.image, image::HEXED);
 		}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -171,7 +171,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 	bool is_anim = false;
 
 	if(items.size() > 1 || ov.image.find(':') != std::string::npos) {
-		// This is an animation string. Reform it into a series of frames, 1 per image. 
+		// This is an animation string. Reform it into a series of frames, 1 per image.
 		is_anim = true;
 		for(const auto& item : items) {
 			auto parts = utils::split(item, ':');

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -51,7 +51,7 @@ public:
 	 * If it is not attached to an item, the location should be set to -1, -1
 	 */
 	handle add(int x, int y, const std::string& image, const map_location& loc,
-			halo::ORIENTATION orientation=NORMAL, bool infinite=true);
+		halo::ORIENTATION orientation=NORMAL, bool infinite=true, float parallax_mult = 1.0f);
 
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(const handle & h, int x, int y);

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "halo.hpp"
+#include "display.hpp"
 
 struct overlay
 {
@@ -63,4 +64,7 @@ struct overlay
 	float submerge;
 	float z_order;
 
+	// Other support
+	bool is_animated = false;
+	animated<image::locator> anim; // Manages the sequence of frames and timing for animated overlays.
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -27,6 +27,7 @@ struct overlay
 			const std::string& item_id,
 			const bool fogged,
 			float submerge,
+			float parallax_mult,
 			float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
@@ -36,6 +37,7 @@ struct overlay
 		, halo_handle()
 		, visible_in_fog(fogged)
 		, submerge(submerge)
+		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
 	{}
 
@@ -49,6 +51,7 @@ struct overlay
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
+		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
 	{
 	}
@@ -62,6 +65,7 @@ struct overlay
 	halo::handle halo_handle;
 	bool visible_in_fog;
 	float submerge;
+	float parallax_mult;
 	float z_order;
 
 	// Other support

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4182,6 +4182,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["name"], // Name is treated as the ID
 			cfg["visible_in_fog"].to_bool(true),
 			cfg["submerge"].to_double(0),
+			cfg["parallax_mult"].to_double(1.0),
 			cfg["z_order"].to_double(0)
 		));
 	}


### PR DESCRIPTION
This PR adds optional input for parallax effect on halos. 

Called like:

```
[item]
	x,y=93,161
	halo=data/core/images/items/armor.png
	parallax_mult=1.1
[/item]
```
or

`wesnoth.interface.add_hex_overlay(93, 161, { parallax_mult=1.1, halo = "data/core/images/items/armor.png"})`

https://github.com/user-attachments/assets/8784d4b9-548c-4f17-8ba5-6a82c3530c33


