### PR TITLE
Fix abilities_special_tooltips() so that 'name_affected' is displayed the same way as [specials]

### DIFF
--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -266,6 +266,7 @@ private:
 	bool special_active(const config& special, AFFECTS whom, const std::string& tag_name,
 	                    bool in_abilities_tag = false) const;
 
+	bool special_tooltip_active(const config& special, const std::string& tag_name) const;
 /** weapon_specials_impl_self and weapon_specials_impl_adj : check if special name can be added.
 	 * @param[in,out] temp_string the string modified and returned
 	 * @param[in] self the unit checked.
@@ -311,7 +312,6 @@ private:
 	 * @param whom determine if unit affected or not by special ability.
 	 * @param tag_name The special ability type who is being checked.
 	 * @param leader_bool If true, [leadership] abilities are checked.
-	 * @param just_teaching when true, returns inactive specials, when false the special is required to be active.
 	 */
 	static bool check_self_abilities_impl(
 		const const_attack_ptr& self_attack,
@@ -321,8 +321,7 @@ private:
 		const map_location& loc,
 		AFFECTS whom,
 		const std::string& tag_name,
-		bool leader_bool=false,
-		bool just_teaching = false
+		bool leader_bool=false
 	);
 
 
@@ -340,7 +339,6 @@ private:
 	 * @param whom determine if unit affected or not by special ability.
 	 * @param tag_name The special ability type who is being checked.
 	 * @param leader_bool If true, [leadership] abilities are checked.
-	 * @param just_teaching when true, returns inactive specials, when false the special is required to be active.
 	 */
 	static bool check_adj_abilities_impl(
 		const const_attack_ptr& self_attack,
@@ -354,8 +352,7 @@ private:
 		const map_location& from_loc,
 		AFFECTS whom,
 		const std::string& tag_name,
-		bool leader_bool = false,
-		bool just_teaching = false
+		bool leader_bool = false
 	);
 
 	static bool special_active_impl(
@@ -364,8 +361,7 @@ private:
 		const config& special,
 		AFFECTS whom,
 		const std::string& tag_name,
-		bool in_abilities_tag = false,
-		bool just_teaching = false
+		bool in_abilities_tag = false
 	);
 
 	/** has_ability_impl : return an boolean value for checking of activities of abilities used like weapon


### PR DESCRIPTION
Can resolve https://github.com/wesnoth/wesnoth/issues/10535 issue.

For example, if you have a marksman taught to a distant unit and its side isn't the one currently playing its turn, the 'name_affected' that should appear in its distance attack in the ini sidebar disappears. This PR changes this so that it is displayed inactive like a real special marksman.

The general idea is to do a two-step check, first check that the ability applies to 'self/student', taking into account only the filters used for 'self' [filter_student], but also [filter_attacker/defenser] depending on the circumstances, while ignoring the other filters and the 'active_on' attribute, and if these conditions are met, display 'name_affected', then comes the second more standard check where we look at everything, and if the check succeeds 'name_affected' is displayed as active, otherwise, it will be displayed as inactive