### PR TITLE
Use the default music playlist for Dark Forecast and Isle of Mists

### DIFF
--- a/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
@@ -12,6 +12,7 @@ Note: You need to use the default map settings for the scenario to work right."
     force_lock_settings=yes
 
     {DEFAULT_SCHEDULE_DAWN}
+    {DEFAULT_MUSIC_PLAYLIST}
 
     mp_village_gold=1
 
@@ -126,20 +127,6 @@ Note: You need to use the default map settings for the scenario to work right."
             [/else]
         [/if]
         {CLEAR_VARIABLE leader}
-        [music]
-            name=wanderer.ogg
-            ms_before=2000
-        [/music]
-        [music]
-            name=battle.ogg
-            ms_before=2000
-            append=yes
-        [/music]
-        [music]
-            name=breaking_the_chains.ogg
-            play_once=yes
-            immediate=yes
-        [/music]
 
         [objectives]
             [objective]

--- a/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
+++ b/data/multiplayer/scenarios/2p_Isle_of_Mists.cfg
@@ -14,6 +14,7 @@
     force_lock_settings=yes
 
     {DEFAULT_SCHEDULE}
+    {DEFAULT_MUSIC_PLAYLIST}
     random_start_time=yes
 
     mp_village_gold=1
@@ -151,21 +152,6 @@
             [/else]
         [/if]
         {CLEAR_VARIABLE leader}
-        [music]
-            name=wanderer.ogg
-            ms_before=2000
-        [/music]
-        [music]
-            name=battle.ogg
-            ms_before=2000
-            append=yes
-        [/music]
-        [music]
-            name=breaking_the_chains.ogg
-            play_once=yes
-            immediate=yes
-        [/music]
-
         [objectives]
             [objective]
                 description= _ "Survive and defeat all enemy waves"


### PR DESCRIPTION
So I played Dark Forecast last time and suddenly noticed that the soundtrack seems never changing. It turns out it's just three tracks. I find the resulting mood pretty dull, especially considering how the gameplay goes. I think it's better to just use DEFAULT_MUSIC_PLAYLIST as all other MP scenarios do.