### PR TITLE
MP: Fix lag during AI turns on 5P The Wilderlands

### DIFF
--- a/changelog_entries/wilderlands_lag.md
+++ b/changelog_entries/wilderlands_lag.md
@@ -1,0 +1,3 @@
+### Multiplayer
+   * 5p - The Wilderlands:
+     * Fixed lag during AI turn (issue #10419)

--- a/data/multiplayer/scenarios/5p_The_Wilderlands.cfg
+++ b/data/multiplayer/scenarios/5p_The_Wilderlands.cfg
@@ -9,7 +9,6 @@
         x={X}
         y={Y}
         random_traits=no
-        upkeep=loyal
         {VARIATION}
     [/unit]
 #enddef
@@ -20,7 +19,6 @@
         side=5
         x={X}
         y={Y}
-        upkeep=loyal
         variation={VARIATION_NAME}
         #random_traits=no
     [/unit]
@@ -32,7 +30,6 @@
         side=5
         x={X}
         y={Y}
-        upkeep=loyal
         variation={VARIATION_NAME}
         #random_traits=no
     [/unit]
@@ -153,12 +150,19 @@
                     recruit=""
                 [/set_recruit]
 
-                # visual change, don't turn the gold counter negative
+                # Visual change, don't turn the gold counter negative.
+                # Although side 5 can't recruit, it can create units via plague,
+                # so this needs an event instead of just a single [modify_unit].
                 [event]
-                    name=unit placed
+                    name=unit placed,post advance
                     first_time_only=no
                     [filter]
                         side=5
+                        [not]
+                            # upkeep=loyal is the same as upkeep=0, so Walking Corpses
+                            # match it as they're level 0, even if they aren't loyal.
+                            upkeep=0
+                        [/not]
                     [/filter]
 
                     [modify_unit]


### PR DESCRIPTION
Opening a PR just for the CI run, this is a simple backport.

The filter on the unit_placed event didn't check if the unit was already loyal, and after 4 turns, the first unit belonging to side 5 had over 600 of these [object]s.

Thanks to gfgtdf for pointing out that the macro's upkeep=loyal will only last until the unit is rebuilt, so even the units created at the start should use an [object].

Any Walking Corpses created via plague won't get the object, but it will be added if they advance to Soulless.

Fixes #10419
Backports #10482