### PR TITLE
add_overlay extended: duration [LLM assisted]

### DIFF
--- a/changelog_entries/add_overlay_extended_duration.md
+++ b/changelog_entries/add_overlay_extended_duration.md
@@ -1,0 +1,5 @@
+### Graphics
+   * Duration option for image overlays added
+		* Images (halos/items) placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be removed automaticlly after a duration run out.
+		* The duration is in milliseconds. duration=2300 means the image will stay up for 2.3 seconds.
+		* Images with a duration are not stored in the save file, they will not persist if you save and reload.

--- a/changelog_entries/add_overlay_extended_multihex.md
+++ b/changelog_entries/add_overlay_extended_multihex.md
@@ -1,0 +1,4 @@
+### Graphics
+   * Multihex option for image overlays added
+		* Larger images placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be multihex by adding "multihex = true" or "multihex = yes".
+		* For removal of a multihex image: simply remove the center piece of it the same way as usual.

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -11,6 +11,12 @@ local function add_overlay(x, y, cfg)
 	end
 
 	wesnoth.interface.add_hex_overlay(x, y, cfg)
+	
+	if cfg.duration and cfg.duration ~= 0 then
+		return --Do not store item if it is on a duration timer.
+		--Avoids having to remove scenario_items from display.cpp when duration expires.
+	end
+	
 	local items = scenario_items:get(x, y)
 	if not items then
 		items = {}
@@ -30,6 +36,7 @@ local function add_overlay(x, y, cfg)
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
+			duration = cfg.duration,
 			wml.tag.variables(wml.get_child(cfg, "variables") or {}),
 		})
 end
@@ -69,6 +76,7 @@ end
 ---@field redraw boolean
 ---@field name string
 ---@field z_order integer
+---@field duration integer
 ---@field variables WMLTable
 
 ---Get items on a given hex
@@ -94,6 +102,7 @@ function wesnoth.interface.get_items(x, y)
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
+			duration = cfg.duration,
 			variables = wml.get_child(cfg, "variables"),
 		})
 	end

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -25,6 +25,7 @@ local function add_overlay(x, y, cfg)
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			submerge = cfg.submerge,
+			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
@@ -62,6 +63,7 @@ end
 ---@field filter_team WML
 ---@field visible_in_fog boolean
 ---@field submerge number
+---@field parallax_mult number
 ---@field redraw boolean
 ---@field name string
 ---@field z_order integer
@@ -85,6 +87,7 @@ function wesnoth.interface.get_items(x, y)
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			submerge = cfg.submerge,
+			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -11,12 +11,12 @@ local function add_overlay(x, y, cfg)
 	end
 
 	wesnoth.interface.add_hex_overlay(x, y, cfg)
-	
+
 	if cfg.duration and cfg.duration ~= 0 then
 		return --Do not store item if it is on a duration timer.
 		--Avoids having to remove scenario_items from display.cpp when duration expires.
 	end
-	
+
 	local items = scenario_items:get(x, y)
 	if not items then
 		items = {}

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -24,6 +24,7 @@ local function add_overlay(x, y, cfg)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
 			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
@@ -62,6 +63,7 @@ end
 ---@field team_name string
 ---@field filter_team WML
 ---@field visible_in_fog boolean
+---@field multihex boolean
 ---@field submerge number
 ---@field parallax_mult number
 ---@field redraw boolean
@@ -86,6 +88,7 @@ function wesnoth.interface.get_items(x, y)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
 			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -153,7 +153,7 @@ namespace
 	// Create a crop string for one hex of a multihex image (72x72 px)
 	static std::string build_child_crop_string(const map_location& anchor, const map_location& hex, int big_width, int big_height)
 	{
-		// Calculate the pixel offset between the anchor hex (the parent's center) and the current child hex. 
+		// Calculate the pixel offset between the anchor hex (the parent's center) and the current child hex.
 		// Columns are 54px wide, rows are 72px tall.
 		int dx_px = (hex.x - anchor.x) * 54; //(HEX_W - HEX_W / 4);
 		int dy_px = (hex.y - anchor.y) * 72; // HEX_H
@@ -170,7 +170,7 @@ namespace
 		int crop_x = (big_width / 2) + dx_px - 36; //(HEX_W / 2)
 		int crop_y = (big_height / 2) + dy_px - 36; //(HEX_H / 2)
 
-		// Return crop string for a 72x72 box. 
+		// Return crop string for a 72x72 box.
 		std::stringstream ss;
 		ss << "~CROP(" << crop_x << "," << crop_y << "," << 72 << "," << 72 << ")"; //HEX_W, HEX_H
 		return ss.str();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -161,7 +161,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 
 		auto inserted = overlays.emplace(pos, std::move(ov));
 		auto [x, y] = get_location_rect(loc).center();
-		inserted->halo_handle = halo_man_.add(x, y, inserted->halo, loc);
+		inserted->halo_handle = halo_man_.add(x, y, inserted->halo, loc, halo::NORMAL, true, inserted->parallax_mult);
 		return;
 	}
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2747,7 +2747,7 @@ void display::draw_overlays_at(const map_location& loc)
 				? image::get_lighted_texture(frame, lt)
 				: image::get_texture(frame, image::HEXED);
 		} else { // static image
-			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos 
+			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos
 				? image::get_lighted_texture(ov.image, lt)
 				: image::get_texture(ov.image, image::HEXED);
 		}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -171,7 +171,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 	bool is_anim = false;
 
 	if(items.size() > 1 || ov.image.find(':') != std::string::npos) {
-		// This is an animation string. Reform it into a series of frames, 1 per image. 
+		// This is an animation string. Reform it into a series of frames, 1 per image.
 		is_anim = true;
 		for(const auto& item : items) {
 			auto parts = utils::split(item, ':');

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -51,7 +51,7 @@ public:
 	 * If it is not attached to an item, the location should be set to -1, -1
 	 */
 	handle add(int x, int y, const std::string& image, const map_location& loc,
-			halo::ORIENTATION orientation=NORMAL, bool infinite=true);
+		halo::ORIENTATION orientation=NORMAL, bool infinite=true, float parallax_mult = 1.0f);
 
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(const handle & h, int x, int y);

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -26,16 +26,18 @@ struct overlay
 			const std::string& overlay_team_name,
 			const std::string& item_id,
 			const bool fogged,
+			const bool multihex,
 			float submerge,
 			float parallax_mult,
 			float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
-		, name()
+		, name() // The relation between id and name is strange, they are often assumed to be the same. Can cause issues for removal.
 		, id(item_id)
 		, halo_handle()
 		, visible_in_fog(fogged)
+		, multihex(multihex)
 		, submerge(submerge)
 		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
@@ -50,6 +52,7 @@ struct overlay
 		, id(cfg["id"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
+		, multihex(cfg["multihex"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
 		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
@@ -64,11 +67,14 @@ struct overlay
 
 	halo::handle halo_handle;
 	bool visible_in_fog;
+	bool multihex;
 	float submerge;
 	float parallax_mult;
 	float z_order;
 
 	// Other support
 	bool is_animated = false;
+	bool is_child = false;         // A child overlay part of an larger multihex image (center part is parent)
+	std::vector<std::pair<std::string, map_location>> child_hexes; // Locations and ids of child hexes if multihex (stored in parents)
 	animated<image::locator> anim; // Manages the sequence of frames and timing for animated overlays.
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "halo.hpp"
+#include "display.hpp"
 
 struct overlay
 {
@@ -63,4 +64,7 @@ struct overlay
 	float submerge;
 	float z_order;
 
+	// Other support
+	bool is_animated = false;
+	animated<image::locator> anim; // Manages the sequence of frames and timing for animated overlays.
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -29,7 +29,8 @@ struct overlay
 			const bool multihex,
 			float submerge,
 			float parallax_mult,
-			float item_z_order = 0)
+			float item_z_order = 0,
+			std::chrono::milliseconds duration = std::chrono::milliseconds(0))
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
@@ -41,6 +42,7 @@ struct overlay
 		, submerge(submerge)
 		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
+		, duration(duration)
 	{}
 
 
@@ -56,6 +58,7 @@ struct overlay
 		, submerge(cfg["submerge"].to_double(0))
 		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
+		, duration(std::chrono::milliseconds(cfg["duration"].to_int(0)))
 	{
 	}
 
@@ -71,6 +74,7 @@ struct overlay
 	float submerge;
 	float parallax_mult;
 	float z_order;
+	std::chrono::milliseconds duration;
 
 	// Other support
 	bool is_animated = false;

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -27,6 +27,7 @@ struct overlay
 			const std::string& item_id,
 			const bool fogged,
 			float submerge,
+			float parallax_mult,
 			float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
@@ -36,6 +37,7 @@ struct overlay
 		, halo_handle()
 		, visible_in_fog(fogged)
 		, submerge(submerge)
+		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
 	{}
 
@@ -49,6 +51,7 @@ struct overlay
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
+		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
 	{
 	}
@@ -62,6 +65,7 @@ struct overlay
 	halo::handle halo_handle;
 	bool visible_in_fog;
 	float submerge;
+	float parallax_mult;
 	float z_order;
 
 	// Other support

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4182,6 +4182,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["name"], // Name is treated as the ID
 			cfg["visible_in_fog"].to_bool(true),
 			cfg["submerge"].to_double(0),
+			cfg["parallax_mult"].to_double(1.0),
 			cfg["z_order"].to_double(0)
 		));
 	}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4181,6 +4181,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			team_name,
 			cfg["name"], // Name is treated as the ID
 			cfg["visible_in_fog"].to_bool(true),
+			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),
 			cfg["parallax_mult"].to_double(1.0),
 			cfg["z_order"].to_double(0)

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4184,7 +4184,8 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),
 			cfg["parallax_mult"].to_double(1.0),
-			cfg["z_order"].to_double(0)
+			cfg["z_order"].to_double(0),
+			std::chrono::milliseconds(cfg["duration"].to_int(0))
 		));
 	}
 	return 0;


### PR DESCRIPTION
Enables a timed duration for images and halos. After the time runs out the image is automatically removed. 

Called in WML like:

```
[item]
	x,y=102,157
	image=data/add-ons/Animated_Weather_and_Scenery/images/great_continent.png
	duration=25000 
[/item]
```

or in Lua like:

`wesnoth.interface.add_hex_overlay(103, 161, { duration=3700, multihex=true, image = "data/add-ons/Animated_Weather_and_Scenery/images/scenery/god_game/1/[1~6].png~O(60%)"})`

Why this is needed: Previous solutions to this problem was to either force a wait and then remove (locking the game while waiting) or to add empty images to the end of an animation that lasts forever. 

When duration is enabled the items will not be stored in Lua or WML or savefile. They are just temporary visual overlays. Should be safe from sync issues.

If you test this code and see that some hexes are dark -- know that this an old bug recently fixed in another PR.

Look at the last commit to see the relevant code for this duration PR, since this is stacked on top of other PRs.

Suggested documentation change.
At https://wiki.wesnoth.org/InterfaceActionsWML#.5Bitem.5D after "z_order" add:
**duration:** (integer,  default: 0) If above 0, this specifies that the overlay is temporary and will be automatically removed after the specified number of milliseconds has passed. "duration=4600" - will be removed after 4.6 seconds. Images with a duration will not be stored in WML/Lua/savefile and can not be used for anything but pure visuals and will not persist over save/load. Works for images and halos. 

https://github.com/user-attachments/assets/dfbbe838-6972-49b3-a153-1df8eed76db5

