### PR TITLE
Use tuples instead of an out parameter for specials' tooltips

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -281,12 +281,12 @@ void unit_preview_pane::print_attack_details(
 			);
 		}
 
-		for(const auto& pair : a.special_tooltips()) {
+		for(const auto& tip : a.special_tooltips()) {
 			add_name_tree_node(
 				subsection,
 				"item",
-				markup::span_color(font::weapon_details_color, pair.first),
-				markup::span_size("x-large", pair.first) + "\n" + pair.second
+				markup::span_color(font::weapon_details_color, tip.name),
+				markup::span_size("x-large", tip.name) + "\n" + tip.description
 			);
 		}
 	}

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -441,7 +441,7 @@ std::vector<topic> generate_weapon_special_topics(const bool sort_generated)
 			continue;
 
 		for(const attack_type& atk : type.attacks()) {
-			for(const auto& [name, description] : atk.special_tooltips()) {
+			for(const auto& [name, description, active] : atk.special_tooltips()) {
 				special_description.emplace(name, description);
 
 				if (!type.hide_help()) {

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -743,15 +743,15 @@ std::string unit_topic_generator::operator()() const {
 
 			// special
 			if(has_special) {
-				std::vector<std::pair<t_string, t_string>> specials = attack.special_tooltips();
+				const auto specials = attack.special_tooltips();
 				if(!specials.empty()) {
 					std::stringstream specials_ss;
 					std::string lang_special = "";
 					const std::size_t specials_size = specials.size();
 					for(std::size_t i = 0; i != specials_size; ++i) {
 						const std::string ref_id = std::string("weaponspecial_")
-							+ specials[i].first.base_str();
-						lang_special = (specials[i].first);
+							+ specials[i].name.base_str();
+						lang_special = (specials[i].name);
 						specials_ss << markup::make_link(lang_special, ref_id);
 						if(i+1 != specials_size) {
 							specials_ss << ", "; //comma placed before next special

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -992,29 +992,26 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 		auto ctx = (sec_u == nullptr) ? at.specials_context_for_listing(attacking) :
 						at.specials_context(u.shared_from_this(), sec_u->shared_from_this(), hex, sec_u->get_location(), attacking, std::move(sec_u_weapon));
 
-		boost::dynamic_bitset<> active;
-		const std::vector<std::pair<t_string, t_string>> &specials = at.special_tooltips(&active);
-		const std::size_t specials_size = specials.size();
-		for ( std::size_t i = 0; i != specials_size; ++i )
+		bool has_specials = false;
+		for(const auto& tip : at.special_tooltips(false))
 		{
-			// Aliases for readability:
-			const t_string &name = specials[i].first;
-			const t_string &description = specials[i].second;
-			const color_t &details_color =
-				active[i] ? font::weapon_details_color : font::INACTIVE_COLOR;
+			has_specials = true;
 
-			str << span_color(details_color, "  ", "  ", name) << '\n';
-			std::string help_page = "weaponspecial_" + name.base_str();
-			tooltip << _("Weapon special:") << " " << markup::bold(name);
-			if (!active[i]) {
+			const color_t &details_color =
+				tip.active ? font::weapon_details_color : font::INACTIVE_COLOR;
+
+			str << span_color(details_color, "  ", "  ", tip.name) << '\n';
+			std::string help_page = "weaponspecial_" + tip.name.base_str();
+			tooltip << _("Weapon special:") << " " << markup::bold(tip.name);
+			if (!tip.active) {
 				tooltip << markup::italic(_(" (inactive)"));
 			}
-			tooltip << '\n' << description;
+			tooltip << '\n' << tip.description;
 
 			add_text(res, flush(str), flush(tooltip), help_page);
 		}
 
-		if(!specials.empty()) {
+		if(has_specials) {
 			// Add some padding so the end of the specials list
 			// isn't too close vertically to the attack icons of
 			// the next attack. Also for symmetry with the padding
@@ -1033,28 +1030,26 @@ static int attack_info(const reports::context& rc, const attack_type &at, config
 	? at.specials_context(u.shared_from_this(), hex, attacking)
 	: at.specials_context(u.shared_from_this(), sec_u->shared_from_this(), hex, sec_u->get_location(), attacking, std::move(sec_u_weapon));
 
-		boost::dynamic_bitset<> active;
-		const std::vector<std::pair<t_string, t_string>>& specials = at.abilities_special_tooltips(&active);
-		const std::size_t specials_size = specials.size();
-		for ( std::size_t i = 0; i != specials_size; ++i )
+		bool has_specials = false;
+		for(const auto& tip : at.abilities_special_tooltips())
 		{
-			// Aliases for readability:
-			const auto& [name, description] = specials[i];
-			const color_t& details_color =
-				active[i] ? font::weapon_details_color : font::INACTIVE_COLOR;
+			has_specials = true;
 
-			str << span_color(details_color, "  ", "  ", name) << '\n';
-			const std::string help_page = "weaponspecial_" + name.base_str();
-			tooltip << _("Weapon special:") << " " << markup::bold(name);
-			if (!active[i]) {
+			const color_t& details_color =
+				tip.active ? font::weapon_details_color : font::INACTIVE_COLOR;
+
+			str << span_color(details_color, "  ", "  ", tip.name) << '\n';
+			const std::string help_page = "weaponspecial_" + tip.name.base_str();
+			tooltip << _("Weapon special:") << " " << markup::bold(tip.name);
+			if (!tip.active) {
 				tooltip << markup::italic(_(" (inactive)"));
 			}
-			tooltip << '\n' << description;
+			tooltip << '\n' << tip.description;
 
 			add_text(res, flush(str), flush(tooltip), help_page);
 		}
 
-		if(!specials.empty()) {
+		if(has_specials) {
 			// Add some padding so the end of the specials list
 			// isn't too close vertically to the attack icons of
 			// the next attack. Also for symmetry with the padding

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -82,8 +82,31 @@ public:
 	 */
 	bool has_special(const std::string& special, bool simple_check = false) const;
 	unit_ability_list get_specials(const std::string& special) const;
-	std::vector<std::pair<t_string, t_string>> special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
-	std::vector<std::pair<t_string, t_string>> abilities_special_tooltips(boost::dynamic_bitset<>* active_list = nullptr) const;
+
+	/**
+	 * Return value for special_tooltips() and abilities_special_tooltips().
+	 *
+	 * Those functions are responsible for choosing whether to use
+	 * name_inactive, name_affected, etc.
+	 */
+	struct attack_tooltip_metadata
+	{
+		// constructor because emplace_back() doesn't use aggregate initialization
+		explicit attack_tooltip_metadata(t_string&& n, t_string&& d, bool a)
+			: name(std::move(n))
+			, description(std::move(d))
+			, active(a)
+		{
+		}
+
+		t_string name;
+		t_string description;
+		bool active;
+	};
+
+	std::vector<attack_tooltip_metadata> special_tooltips(bool assume_active=true) const;
+	std::vector<attack_tooltip_metadata> abilities_special_tooltips() const;
+
 	std::string weapon_specials() const;
 	std::string weapon_specials_value(const std::set<std::string>& checking_tags) const;
 


### PR DESCRIPTION
There was only one caller for attack_type::abilities_special_tooltips(), so this can hardcode that it always wants inactive specials to be included in the list.

@newfrenchy83 I was thinking of this sort of thing might be good before #10538. Currently barely tested, but opening a PR to share it with you.