### PR TITLE
add_overlay extended: drawing_layer [LLM assisted] (last one)

### DIFF
--- a/changelog_entries/add_overlay_extended_drawing_layer.md
+++ b/changelog_entries/add_overlay_extended_drawing_layer.md
@@ -1,0 +1,4 @@
+### Graphics
+   * Drawing layer option for image overlays added
+		* Images placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be assigned to a specific drawing layer.
+		* Example: drawing_layer=arrow will cause the image to be drawn at the arrow layer (above units).

--- a/changelog_entries/add_overlay_extended_duration.md
+++ b/changelog_entries/add_overlay_extended_duration.md
@@ -1,0 +1,5 @@
+### Graphics
+   * Duration option for image overlays added
+		* Images (halos/items) placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be removed automaticlly after a duration run out.
+		* The duration is in milliseconds. duration=2300 means the image will stay up for 2.3 seconds.
+		* Images with a duration are not stored in the save file, they will not persist if you save and reload.

--- a/changelog_entries/add_overlay_extended_multihex.md
+++ b/changelog_entries/add_overlay_extended_multihex.md
@@ -1,0 +1,4 @@
+### Graphics
+   * Multihex option for image overlays added
+		* Larger images placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be multihex by adding "multihex = true" or "multihex = yes".
+		* For removal of a multihex image: simply remove the center piece of it the same way as usual.

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -11,6 +11,12 @@ local function add_overlay(x, y, cfg)
 	end
 
 	wesnoth.interface.add_hex_overlay(x, y, cfg)
+	
+	if cfg.duration and cfg.duration ~= 0 then
+		return --Do not store item if it is on a duration timer.
+		--Avoids having to remove scenario_items from display.cpp when duration expires.
+	end
+	
 	local items = scenario_items:get(x, y)
 	if not items then
 		items = {}
@@ -30,6 +36,7 @@ local function add_overlay(x, y, cfg)
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
+			duration = cfg.duration,
 			wml.tag.variables(wml.get_child(cfg, "variables") or {}),
 		})
 end
@@ -69,6 +76,7 @@ end
 ---@field redraw boolean
 ---@field name string
 ---@field z_order integer
+---@field duration integer
 ---@field variables WMLTable
 
 ---Get items on a given hex
@@ -94,6 +102,7 @@ function wesnoth.interface.get_items(x, y)
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
+			duration = cfg.duration,
 			variables = wml.get_child(cfg, "variables"),
 		})
 	end

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -25,6 +25,7 @@ local function add_overlay(x, y, cfg)
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			submerge = cfg.submerge,
+			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,
@@ -62,6 +63,7 @@ end
 ---@field filter_team WML
 ---@field visible_in_fog boolean
 ---@field submerge number
+---@field parallax_mult number
 ---@field redraw boolean
 ---@field name string
 ---@field z_order integer
@@ -85,6 +87,7 @@ function wesnoth.interface.get_items(x, y)
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
 			submerge = cfg.submerge,
+			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
 			name = cfg.name,
 			z_order = cfg.z_order,

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -29,6 +29,7 @@ local function add_overlay(x, y, cfg)
 			halo = cfg.halo,
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
+			drawing_layer = cfg.drawing_layer,
 			visible_in_fog = cfg.visible_in_fog,
 			multihex = cfg.multihex,
 			submerge = cfg.submerge,
@@ -69,6 +70,7 @@ end
 ---@field halo string
 ---@field team_name string
 ---@field filter_team WML
+---@field drawing_layer string
 ---@field visible_in_fog boolean
 ---@field multihex boolean
 ---@field submerge number
@@ -95,6 +97,7 @@ function wesnoth.interface.get_items(x, y)
 			halo = cfg.halo,
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
+			drawing_layer = cfg.drawing_layer,
 			visible_in_fog = cfg.visible_in_fog,
 			multihex = cfg.multihex,
 			submerge = cfg.submerge,

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -11,12 +11,12 @@ local function add_overlay(x, y, cfg)
 	end
 
 	wesnoth.interface.add_hex_overlay(x, y, cfg)
-	
+
 	if cfg.duration and cfg.duration ~= 0 then
 		return --Do not store item if it is on a duration timer.
 		--Avoids having to remove scenario_items from display.cpp when duration expires.
 	end
-	
+
 	local items = scenario_items:get(x, y)
 	if not items then
 		items = {}

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -24,6 +24,7 @@ local function add_overlay(x, y, cfg)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
 			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,
@@ -62,6 +63,7 @@ end
 ---@field team_name string
 ---@field filter_team WML
 ---@field visible_in_fog boolean
+---@field multihex boolean
 ---@field submerge number
 ---@field parallax_mult number
 ---@field redraw boolean
@@ -86,6 +88,7 @@ function wesnoth.interface.get_items(x, y)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
 			parallax_mult = cfg.parallax_mult,
 			redraw = cfg.redraw,

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -153,7 +153,7 @@ namespace
 	// Create a crop string for one hex of a multihex image (72x72 px)
 	static std::string build_child_crop_string(const map_location& anchor, const map_location& hex, int big_width, int big_height)
 	{
-		// Calculate the pixel offset between the anchor hex (the parent's center) and the current child hex. 
+		// Calculate the pixel offset between the anchor hex (the parent's center) and the current child hex.
 		// Columns are 54px wide, rows are 72px tall.
 		int dx_px = (hex.x - anchor.x) * 54; //(HEX_W - HEX_W / 4);
 		int dy_px = (hex.y - anchor.y) * 72; // HEX_H
@@ -170,7 +170,7 @@ namespace
 		int crop_x = (big_width / 2) + dx_px - 36; //(HEX_W / 2)
 		int crop_y = (big_height / 2) + dy_px - 36; //(HEX_H / 2)
 
-		// Return crop string for a 72x72 box. 
+		// Return crop string for a 72x72 box.
 		std::stringstream ss;
 		ss << "~CROP(" << crop_x << "," << crop_y << "," << 72 << "," << 72 << ")"; //HEX_W, HEX_H
 		return ss.str();

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -206,6 +206,53 @@ namespace
 		return overlays_to_remove;
 	}
 
+	// Drawing_layer overlay support
+	static const std::map<std::string, drawing_layer> layer_map = {
+		{"terrain_bg", drawing_layer::terrain_bg},
+		{"reachmap_highlight", drawing_layer::reachmap_highlight},
+		{"grid_top", drawing_layer::grid_top},
+		{"mouseover_overlay", drawing_layer::mouseover_overlay},
+		{"footsteps", drawing_layer::footsteps},
+		{"mouseover_top", drawing_layer::mouseover_top},
+		{"unit_bg", drawing_layer::unit_bg},
+		{"unit_default", drawing_layer::unit_default},
+		{"terrain_fg", drawing_layer::terrain_fg},
+		{"reachmap_border", drawing_layer::reachmap_border},
+		{"grid_bottom", drawing_layer::grid_bottom},
+		{"unit_move_default", drawing_layer::unit_move_default},
+		{"unit_fg", drawing_layer::unit_fg},
+		{"unit_missile_default", drawing_layer::unit_missile_default},
+		{"mouseover_bottom", drawing_layer::mouseover_bottom},
+		{"fog_shroud", drawing_layer::fog_shroud},
+		{"arrows", drawing_layer::arrows},
+		{"actions_numbering", drawing_layer::actions_numbering},
+		{"selected_hex", drawing_layer::selected_hex},
+		{"attack_indicator", drawing_layer::attack_indicator},
+		{"unit_bar", drawing_layer::unit_bar},
+		{"move_info", drawing_layer::move_info},
+		{"linger_overlay", drawing_layer::linger_overlay},
+		{"border", drawing_layer::border},
+	};
+
+	// Convert string to drawing_layer enum.
+	drawing_layer resolve_drawing_layer(const std::string& name)
+	{
+		if(name.empty()) { // Default to terrain_bg.
+			return drawing_layer::terrain_bg;
+		}
+
+		// Find the name in the map.
+		auto it = layer_map.find(name);
+
+		// If found, return the corresponding enum value.
+		if(it != layer_map.end()) {
+			return it->second;
+		}
+
+		// Unknown string → default
+		return drawing_layer::terrain_bg;
+	}
+
 } // namespace
 
 void display::add_overlay(const map_location& loc, overlay&& ov)
@@ -292,7 +339,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 				}
 
 				// Create a new 'overlay' and animation objects for this single hex part.
-				overlay part_overlay(part_image_string, "", ov.team_name, child_id, ov.visible_in_fog, ov.multihex, ov.submerge, ov.z_order);
+				overlay part_overlay(part_image_string, "", ov.team_name, child_id, ov.drawing_layer, ov.visible_in_fog, ov.multihex, ov.submerge, ov.z_order);
 				part_overlay.is_child = true;
 				children.push_back({child_id, hex}); // Record child location and id.
 				if(is_anim) {
@@ -2951,8 +2998,7 @@ void display::draw_overlays_at(const map_location& loc)
 		// Base submerge value for the terrain at this location
 		const double ter_sub = context().map().get_terrain_info(loc).unit_submerge();
 
-		drawing_buffer_add(
-			drawing_layer::terrain_bg, loc, [tex, ter_sub, ovr_sub = ov.submerge](const rect& dest) mutable {
+		drawing_buffer_add(resolve_drawing_layer(ov.drawing_layer), loc, [tex, ter_sub, ovr_sub = ov.submerge](const rect& dest) mutable {
 				if(ovr_sub > 0.0 && ter_sub > 0.0) {
 					// Adjust submerge appropriately
 					double submerge = ter_sub * ovr_sub;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -161,7 +161,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 
 		auto inserted = overlays.emplace(pos, std::move(ov));
 		auto [x, y] = get_location_rect(loc).center();
-		inserted->halo_handle = halo_man_.add(x, y, inserted->halo, loc);
+		inserted->halo_handle = halo_man_.add(x, y, inserted->halo, loc, halo::NORMAL, true, inserted->parallax_mult);
 		return;
 	}
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2747,7 +2747,7 @@ void display::draw_overlays_at(const map_location& loc)
 				? image::get_lighted_texture(frame, lt)
 				: image::get_texture(frame, image::HEXED);
 		} else { // static image
-			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos 
+			tex = ov.image.find("~NO_TOD_SHIFT") == std::string::npos
 				? image::get_lighted_texture(ov.image, lt)
 				: image::get_texture(ov.image, image::HEXED);
 		}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -171,7 +171,7 @@ void display::add_overlay(const map_location& loc, overlay&& ov)
 	bool is_anim = false;
 
 	if(items.size() > 1 || ov.image.find(':') != std::string::npos) {
-		// This is an animation string. Reform it into a series of frames, 1 per image. 
+		// This is an animation string. Reform it into a series of frames, 1 per image.
 		is_anim = true;
 		for(const auto& item : items) {
 			auto parts = utils::split(item, ':');

--- a/src/drawing_layer.hpp
+++ b/src/drawing_layer.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// Changes to this enum need to be copied to the list in display.cpp at "Drawing_layer overlay support".
+// These layers are exposed to WML/Lua via display.cpp, so changing existing names may break existing content, but you can add more.
+
 enum class drawing_layer {
 	/** Terrain drawn behind the unit */
 	terrain_bg,

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -51,7 +51,7 @@ public:
 	 * If it is not attached to an item, the location should be set to -1, -1
 	 */
 	handle add(int x, int y, const std::string& image, const map_location& loc,
-			halo::ORIENTATION orientation=NORMAL, bool infinite=true);
+		halo::ORIENTATION orientation=NORMAL, bool infinite=true, float parallax_mult = 1.0f);
 
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(const handle & h, int x, int y);

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -26,16 +26,18 @@ struct overlay
 			const std::string& overlay_team_name,
 			const std::string& item_id,
 			const bool fogged,
+			const bool multihex,
 			float submerge,
 			float parallax_mult,
 			float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
-		, name()
+		, name() // The relation between id and name is strange, they are often assumed to be the same. Can cause issues for removal.
 		, id(item_id)
 		, halo_handle()
 		, visible_in_fog(fogged)
+		, multihex(multihex)
 		, submerge(submerge)
 		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
@@ -50,6 +52,7 @@ struct overlay
 		, id(cfg["id"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
+		, multihex(cfg["multihex"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
 		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
@@ -64,11 +67,14 @@ struct overlay
 
 	halo::handle halo_handle;
 	bool visible_in_fog;
+	bool multihex;
 	float submerge;
 	float parallax_mult;
 	float z_order;
 
 	// Other support
 	bool is_animated = false;
+	bool is_child = false;         // A child overlay part of an larger multihex image (center part is parent)
+	std::vector<std::pair<std::string, map_location>> child_hexes; // Locations and ids of child hexes if multihex (stored in parents)
 	animated<image::locator> anim; // Manages the sequence of frames and timing for animated overlays.
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "halo.hpp"
+#include "display.hpp"
 
 struct overlay
 {
@@ -63,4 +64,7 @@ struct overlay
 	float submerge;
 	float z_order;
 
+	// Other support
+	bool is_animated = false;
+	animated<image::locator> anim; // Manages the sequence of frames and timing for animated overlays.
 };

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -29,7 +29,8 @@ struct overlay
 			const bool multihex,
 			float submerge,
 			float parallax_mult,
-			float item_z_order = 0)
+			float item_z_order = 0,
+			std::chrono::milliseconds duration = std::chrono::milliseconds(0))
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
@@ -41,6 +42,7 @@ struct overlay
 		, submerge(submerge)
 		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
+		, duration(duration)
 	{}
 
 
@@ -56,6 +58,7 @@ struct overlay
 		, submerge(cfg["submerge"].to_double(0))
 		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
+		, duration(std::chrono::milliseconds(cfg["duration"].to_int(0)))
 	{
 	}
 
@@ -71,6 +74,7 @@ struct overlay
 	float submerge;
 	float parallax_mult;
 	float z_order;
+	std::chrono::milliseconds duration;
 
 	// Other support
 	bool is_animated = false;

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -27,6 +27,7 @@ struct overlay
 			const std::string& item_id,
 			const bool fogged,
 			float submerge,
+			float parallax_mult,
 			float item_z_order = 0)
 		: image(img)
 		, halo(halo_img)
@@ -36,6 +37,7 @@ struct overlay
 		, halo_handle()
 		, visible_in_fog(fogged)
 		, submerge(submerge)
+		, parallax_mult(parallax_mult)
 		, z_order(item_z_order)
 	{}
 
@@ -49,6 +51,7 @@ struct overlay
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
+		, parallax_mult(cfg["parallax_mult"].to_double(1.0))
 		, z_order(cfg["z_order"].to_double(0))
 	{
 	}
@@ -62,6 +65,7 @@ struct overlay
 	halo::handle halo_handle;
 	bool visible_in_fog;
 	float submerge;
+	float parallax_mult;
 	float z_order;
 
 	// Other support

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -25,6 +25,7 @@ struct overlay
 			const std::string& halo_img,
 			const std::string& overlay_team_name,
 			const std::string& item_id,
+			const std::string& drawing_layer,
 			const bool fogged,
 			const bool multihex,
 			float submerge,
@@ -36,6 +37,7 @@ struct overlay
 		, team_name(overlay_team_name)
 		, name() // The relation between id and name is strange, they are often assumed to be the same. Can cause issues for removal.
 		, id(item_id)
+		, drawing_layer(drawing_layer)
 		, halo_handle()
 		, visible_in_fog(fogged)
 		, multihex(multihex)
@@ -52,6 +54,7 @@ struct overlay
 		, team_name(cfg["team_name"])
 		, name(cfg["name"].t_str())
 		, id(cfg["id"])
+		, drawing_layer(cfg["drawing_layer"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
 		, multihex(cfg["multihex"].to_bool())
@@ -67,6 +70,7 @@ struct overlay
 	std::string team_name;
 	t_string name;
 	std::string id;
+	std::string drawing_layer; // List of input based on drawing_layer.hpp
 
 	halo::handle halo_handle;
 	bool visible_in_fog;

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4180,6 +4180,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["halo"],
 			team_name,
 			cfg["name"], // Name is treated as the ID
+			cfg["drawing_layer"],
 			cfg["visible_in_fog"].to_bool(true),
 			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4182,6 +4182,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["name"], // Name is treated as the ID
 			cfg["visible_in_fog"].to_bool(true),
 			cfg["submerge"].to_double(0),
+			cfg["parallax_mult"].to_double(1.0),
 			cfg["z_order"].to_double(0)
 		));
 	}

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4181,6 +4181,7 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			team_name,
 			cfg["name"], // Name is treated as the ID
 			cfg["visible_in_fog"].to_bool(true),
+			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),
 			cfg["parallax_mult"].to_double(1.0),
 			cfg["z_order"].to_double(0)

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4184,7 +4184,8 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),
 			cfg["parallax_mult"].to_double(1.0),
-			cfg["z_order"].to_double(0)
+			cfg["z_order"].to_double(0),
+			std::chrono::milliseconds(cfg["duration"].to_int(0))
 		));
 	}
 	return 0;


### PR DESCRIPTION
Enables images (items not halos) to be placed at any of the existing drawing layers, not just the default "terrain_bg".
Not to be confused with z_order input, which controls how images are layered within a drawing_layer.

Called in WML like:

```
[item]
	x,y=93,161
	image=data/core/images/items/armor.png
	drawing_layer=arrows
[/item]
```

or in Lua like:

`wesnoth.interface.add_hex_overlay(103, 161, { drawing_layer="grid_bottom", multihex=true, image = "data/add-ons/Animated_Weather_and_Scenery/images/scenery/god_game/1/[1~6].png~O(60%)"})`

The input names are gathered form drawing_layer.hpp, here is a list of them:
`terrain_bg,grid_top,mouseover_overlay,footsteps,mouseover_top,unit_bg,unit_default,terrain_fg,grid_bottom,unit_move_default,unit_fg,unit_missile_default,mouseover_bottom,fog_shroud,arrows,actions_numbering,selected_hex,attack_indicator,unit_bar,move_info,linger_overlay,border,reachmap_highlight,reachmap_border`

I am unsure of the best way to handle this input list, a discussion of further changes is needed.

If you test this code and see that the center hex is dark -- know that this an old bug recently fixed in another PR.

Look at the last commit to see the relevant code for this drawing_overlay PR, since this is stacked on top of other PRs

Suggested documentation change.
At https://wiki.wesnoth.org/InterfaceActionsWML#.5Bitem.5D after "team_name" add:
"drawing_layer: (string, default: terrain_bg) This specifies in what layer an overlay is drawn. It accepts a string name that maps to a specific layer, such as unit_fg (in front of units) or terrain_bg. Using an invalid string will cause the overlay to default to the terrain_bg layer. Valid layers are:"

follow that with either a link to github drawing_layer.hpp or make a hidden/spoiler list like:
"
```
terrain_bg: The base layer for drawing terrain.

reachmap_highlight: An alias for terrain_bg, used for highlighting reachable tiles.

grid_top: The top half of the grid image.

mouseover_overlay: A special overlay used by the editor.

footsteps: An overlay for showing a unit's path.

mouseover_top: The top part of an image following the mouse cursor.

unit_bg: The layer for the ellipse drawn behind a unit.

unit_default: The default layer for drawing most units.

terrain_fg: The layer for terrain drawn in front of a unit.

reachmap_border: An alias for terrain_fg, used for the border of a reachable area.

grid_bottom: The bottom half of the grid image, drawn under moving units.

unit_move_default: The default layer for drawing moving units.

unit_fg: The layer for the ellipse drawn in front of a unit.

unit_missile_default: The default layer for missile animations.

mouseover_bottom: The bottom part of an image following the mouse cursor.

fog_shroud: The layer for fog and shroud effects.

arrows: The layer for drawing arrows from the arrows framework.

actions_numbering: The layer for movement numbering.

selected_hex: The layer for drawing the selected hex indicator.

attack_indicator: The layer for drawing the attack indicator.

unit_bar: The layer for unit health and experience bars.

move_info: The layer for displaying information about movement, like defense percentage.

linger_overlay: The overlay used for "linger mode."

border: The layer for the border of the map.
```
"


<img width="774" height="539" alt="bild" src="https://github.com/user-attachments/assets/cf7e987e-c714-4c3a-a92f-930ae0ca0830" />
