### PR TITLE
Test scenario: put a sensible filter on the shroud change

### DIFF
--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -2754,7 +2754,9 @@ For game purposes, the races group into factions; for example, orcs often cooper
 
     [event]
         name=moveto
+        first_time_only=no
         [filter]
+            x,y=6,2
             side=1
         [/filter]
 
@@ -2800,6 +2802,10 @@ For game purposes, the races group into factions; for example, orcs often cooper
 "
         [/modify_side]
     [/event]
+    [label]
+        x,y=6,2
+        text=_"Side 1 shroud"
+    [/label]
 
     [item]
         x,y=8,16


### PR DESCRIPTION
It's not been annoying enough to fix until now, but it always triggered on the first moveto event.