### PR TITLE
Test scenario: the Silver Mage teaches marksmanship

### DIFF
--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -1005,7 +1005,30 @@ Adjacent own units of lower level will do more damage in battle. When a unit adj
         [unit]
             x,y=24,7
             type="Silver Mage"
-            name= _ "Hidden Teleporter"
+            name= _ "Projectile Teleporter"
+            [abilities]
+                [chance_to_hit]
+                    id=ranged_precision
+                    description= _ "Gives attacks within 2 hexes increased accuracy."
+                    description_affected= _ "When used offensively, the Projectile Teleporter mage will give 80% accuracy to this weapon."
+                    value=80
+                    cumulative=yes
+                    active_on=offense
+                    name=_"ranged precision"
+                    name_affected=_"ranged precision"
+                    affect_self=no
+                    affect_allies=yes
+                    affect_enemies=yes
+                    [filter_student]
+                        [filter_weapon]
+                            range=ranged
+                        [/filter_weapon]
+                    [/filter_student]
+                    [affect_adjacent]
+                        radius=2
+                    [/affect_adjacent]
+                [/chance_to_hit]
+            [/abilities]
         [/unit]
         [unit]
             x,y=18,10


### PR DESCRIPTION
Any unit within 2 hexes gets 80% chance to hit on their ranged attacks, but only when on offense. This is for testing the sidebar's showing of active and inactive taught weapon specials.

If you move the Dark Adept with the darkness aura north-east, it will get taught a weapon special. While it's on the currently playing team, the weapon special shows on the sidebar.

Changing the Dark Adept to side 2 will make it inactive. PR #10538 will make that special show on the sidebar even when its inactive.