### PR TITLE
Add tests for reversed-order config heterogenous comparison

### DIFF
--- a/src/config_attribute_value.hpp
+++ b/src/config_attribute_value.hpp
@@ -197,22 +197,36 @@ public:
 #else
 	template<typename T>
 	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
-	operator==(const T& comp) const
+	friend operator==(const config_attribute_value& attribute, const T& comp)
 	{
-		return apply_visitor([this, &comp](const auto& value) {
+		return attribute.apply_visitor([&](const auto& value) {
 			if constexpr(std::is_constructible_v<std::string, std::decay_t<decltype(value)>>) {
 				return value == comp;
 			} else {
-				return *this == create(comp);
+				return attribute == config_attribute_value::create(comp);
 			}
 		});
 	}
 
 	template<typename T>
 	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
-	operator!=(const T& comp) const
+	friend operator==(const T& comp, const config_attribute_value& val)
 	{
-		return !operator==(comp);
+		return val == comp;
+	}
+
+	template<typename T>
+	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
+	friend operator!=(const config_attribute_value& val, const T& comp)
+	{
+		return !(val == comp);
+	}
+
+	template<typename T>
+	std::enable_if_t<std::is_constructible_v<std::string, T>, bool>
+	friend operator!=(const T& comp, const config_attribute_value& val)
+	{
+		return !(val == comp);
 	}
 #endif
 

--- a/src/tests/test_config.cpp
+++ b/src/tests/test_config.cpp
@@ -238,6 +238,15 @@ BOOST_AUTO_TEST_CASE(test_config_attribute_value)
 	BOOST_CHECK_EQUAL(c["x"], t_string{"sfvsdgdsfg"});
 	BOOST_CHECK_NE(c["x"], "a random string");
 
+	// reversed order heterogenous comparison
+	c["x"] = 9.87654321;
+	BOOST_CHECK_EQUAL("9.87654321", c["x"]);
+	BOOST_CHECK_EQUAL(t_string{"9.87654321"}, c["x"]);
+	BOOST_CHECK_EQUAL(config_attribute_value::create("9.87654321"), c["x"]);
+	BOOST_CHECK_NE("1.23456789", c["x"]);
+	BOOST_CHECK_NE("1.23456789"s, c["x"]);
+	BOOST_CHECK_NE("1.23456789"sv, c["x"]);
+
 	// blank != "" test.
 	c.clear();
 	BOOST_CHECK(cc["x"] != "");


### PR DESCRIPTION
Expecting these to initially fail on C++17.