### PR TITLE
Test scenario: Give the Shyde a new slows that only works in forest

### DIFF
--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -314,6 +314,34 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             type="Elvish Shyde"
             profile="portraits/elves/shyde.webp~BLIT(items/gold-coins-large.png)"
             generate_name=yes
+            [modifications]
+                [object]
+                    [effect]
+                        apply_to=new_attack
+                        name=forest_entanglement
+                        description=_"Forest Entanglement"
+                        type=impact
+                        [specials]
+                            [slow]
+                                id=slow
+                                name= _ "slows"
+                                description=_"An entanglement attack that gets lots of chances to take effect, but the special only works in forests."
+                                special_note={INTERNAL:SPECIAL_NOTES_SLOW}
+
+                                [filter_self]
+                                    [filter_location]
+                                        terrain="*^F*"
+                                    [/filter_location]
+                                [/filter_self]
+                            [/slow]
+                        [/specials]
+                        damage=6
+                        number=6
+                        range=ranged
+                        icon=attacks/entangle.png
+                    [/effect]
+                [/object]
+            [/modifications]
         [/unit]
         [unit]
             # A unit whose portrait is only shown on the right side.


### PR DESCRIPTION
Weapon specials can have location filters, even if they're applied directly to the weapon rather than being used like abilities. This gives the Shyde a special which should be shown as inactive except when moving to or attacking from a forest hex.

Currently (commit ee7f4c047a4) the sidebar always shows it as active, because the sidebar uses a weapon context that doesn't know which hex it should be used in.