### PR TITLE
Add "careen" [defense] ability to ships

### DIFF
--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -159,7 +159,6 @@
         deep_water=90
         shallow_water=80
         flat=-70
-        village=70 # no point making this less than flat. Flat village defense will be the best of flat/village, and we want to keep flat village consistent with sand/frozen/hill/etc
         swamp_water=70
     [/defense]
 #enddef

--- a/data/core/macros/traits.cfg
+++ b/data/core/macros/traits.cfg
@@ -374,3 +374,27 @@ Dim is a trait all too common in goblins and other lesser species. There are rea
         [/effect]
     [/trait]
 #enddef
+
+#define TRAIT_CAREEN_MUSTHAVE
+    # Units with the trait Careen have 0% defense while on land.
+    [trait]
+        id=careen
+        availability=musthave
+        name=_"careen"
+        description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
+        [effect]
+            apply_to=new_ability
+            [abilities]
+                [defense]
+                    value=0
+                    affect_self=yes
+                    [filter_self]
+                        [filter_location]
+                            terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
+                        [/filter_location]
+                    [/filter_self]
+                [/defense]
+            [/abilities]
+        [/effect]
+    [/trait]
+#enddef

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -297,26 +297,7 @@ Saurians live spectacularly short lives by comparison to most of the other races
         num_traits=2
         ignore_global_traits=yes
         {TRAIT_MECHANICAL}
-        [trait]
-            id=careen
-            name=careen
-            description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
-            availability=musthave
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [defense]
-                        value=0
-                        affect_self=yes
-                        [filter_self]
-                            [filter_location]
-                                terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
-                            [/filter_location]
-                        [/filter_self]
-                    [/defense]
-                [/abilities]
-            [/effect]
-        [/trait]
+        {TRAIT_CAREEN_MUSTHAVE}
         # these need to span elf/human/orc, so a little vague for now.  Maybe this "race" can be split up
         {SHIP_NAMES}
     [/race]

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -297,6 +297,26 @@ Saurians live spectacularly short lives by comparison to most of the other races
         num_traits=2
         ignore_global_traits=yes
         {TRAIT_MECHANICAL}
+        [trait]
+            id=careen
+            name=careen
+            description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
+            availability=musthave
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [defense]
+                        value=0
+                        affect_self=yes
+                        [filter_self]
+                            [filter_location]
+                                terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
+                            [/filter_location]
+                        [/filter_self]
+                    [/defense]
+                [/abilities]
+            [/effect]
+        [/trait]
         # these need to span elf/human/orc, so a little vague for now.  Maybe this "race" can be split up
         {SHIP_NAMES}
     [/race]
@@ -950,8 +970,7 @@ The life span of the wose is unknown, although the most ancient members of this 
         [defense]
             deep_water=60
             shallow_water=70
-            flat=-80 # can't make this too different from shallow, because there's no way to give ford a different movement_cost than shallow
-            village=80 # no point making this less than flat. Flat village defense will be the best of flat/village, and we want to keep flat village consistent with sand/frozen/hill/etc
+            flat=-80
             swamp_water=80
             reef=90
         [/defense]


### PR DESCRIPTION
Following up on #10478 and #10504, this PR adds a new "careen" ability to ships that limits them to 0% defense when out of water.