### PR TITLE
Ships: don't bob while beached

### DIFF
--- a/data/core/units/boats/Canoe.cfg
+++ b/data/core/units/boats/Canoe.cfg
@@ -56,7 +56,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -66,6 +66,24 @@
         [/frame]
         [boat_frame]
             image="units/transport/raft/canoe-bob[0,1~3,2,1].png:[300,250*2,300,250*2]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/raft/canoe-flag[1~3,2,1~3,2].png:[200*8]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/raft/canoe-bob0.png:[300,250*2,300,250*2]"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Carrack_Merchant.cfg
+++ b/data/core/units/boats/Carrack_Merchant.cfg
@@ -99,10 +99,29 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*
+        terrain_type=S*^*
         boat_start_time=0
         boat_y=0~2:740,2~0:740
         flag_y=0~2:740,2~0:740
+        [frame]
+            image="misc/blank-hex.png:1480"
+        [/frame]
+        [boat_frame]
+            image="units/transport/transport-galleon-bob-1.png:1480"
+            auto_vflip=no
+            image_mod=~MASK(units/transport/transport-galleon-mask.png)
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/transport-galleon-flag[1~3,2,1~3,2].png:[210*3,130,200*3,120]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
         [frame]
             image="misc/blank-hex.png:1480"
         [/frame]

--- a/data/core/units/boats/Carrack_Pirate.cfg
+++ b/data/core/units/boats/Carrack_Pirate.cfg
@@ -162,7 +162,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*
+        terrain_type=S*^*
         boat_start_time=0
         boat_y=0~2:740,2~0:740
         flag_y=0~2:740,2~0:740
@@ -173,6 +173,24 @@
             image="units/transport/pirate-galleon-bob-1.png:1480"
             auto_vflip=no
             image_mod=~MASK(units/transport/pirate-galleon-mask.png)
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/pirate-galleon-flag[1~3,2,1~3,2].png:[210*3,130,200*3,120]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1480"
+        [/frame]
+        [boat_frame]
+            image="units/transport/pirate-galleon-bob-1.png:1480"
+            auto_vflip=no
             primary=yes
         [/boat_frame]
         [flag_frame]

--- a/data/core/units/boats/Derelict_Ship.cfg
+++ b/data/core/units/boats/Derelict_Ship.cfg
@@ -58,10 +58,28 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*
+        terrain_type=S*^*
         boat_start_time=0
         boat_y=0~2:740,2~0:740
         flag_y=0~2:740,2~0:740
+        [frame]
+            image="misc/blank-hex.png:1480"
+        [/frame]
+        [boat_frame]
+            image="units/transport/derelict-galleon-rock-center.png:1480"
+            auto_vflip=no
+            image_mod=~MASK(units/transport/pirate-galleon-mask.png)
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/pirate-galleon-flag[1~3,2,1~3,2].png:[210*3,130,200*3,120]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
         [frame]
             image="misc/blank-hex.png:1480"
         [/frame]

--- a/data/core/units/boats/Elf_Cutter.cfg
+++ b/data/core/units/boats/Elf_Cutter.cfg
@@ -104,7 +104,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -115,6 +115,24 @@
         [/frame]
         [boat_frame]
             image="units/transport/elven/cutter-bob[1,2].png:[800*2]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/elven/cutter-flag[1~3,2,1~3,2].png:[200*8]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/elven/cutter-bob1.png:1600"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Elf_Sloop.cfg
+++ b/data/core/units/boats/Elf_Sloop.cfg
@@ -105,7 +105,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -116,6 +116,24 @@
         [/frame]
         [boat_frame]
             image="units/transport/elven/sloop-bob[2,3,2,3].png:[400*4]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/skiff/skiff-flag[1~3,2,1~3,2].png:[200*8]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/elven/sloop-bob2.png:1600"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Fireship.cfg
+++ b/data/core/units/boats/Fireship.cfg
@@ -139,7 +139,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*
+        terrain_type=S*^*
         boat_start_time=0
         boat_y=-1:250,-1~0:490,0:250,0~-1:490
         flames_start_time=0
@@ -151,6 +151,33 @@
         [/frame]
         [boat_frame]
             image="units/transport/fireship-[port,mid,starboard,mid].png:[350,390,350,390]"
+            auto_vflip=no
+            image_mod=~MASK(units/transport/pirate-galleon-mask.png)
+            primary=yes
+            layer=40
+        [/boat_frame]
+        [fire_frame]
+            image="units/transport/fireship-back-fire[1,2,1,2,1,2,1,2].png:[185*8]"
+            auto_vflip=no
+            layer=41
+        [/fire_frame]
+        [flames_frame]
+            image="units/transport/flames/fireship-[1~9,1~9].png:[82*10,86,82*7]"
+            auto_vflip=no
+            layer=42
+        [/flames_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flames_start_time=0
+        [frame]
+            image="halo/transport/fireship-back-glow.png:1480"
+            layer=9
+        [/frame]
+        [boat_frame]
+            image="units/transport/fireship-mid.png:1480"
             auto_vflip=no
             image_mod=~MASK(units/transport/pirate-galleon-mask.png)
             primary=yes

--- a/data/core/units/boats/Ghost_Ship.cfg
+++ b/data/core/units/boats/Ghost_Ship.cfg
@@ -188,7 +188,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         boat_y=0~2:740,2~0:740
         flag_start_time=0
@@ -202,6 +202,26 @@
             image="units/transport/ghost-ship-rock-center.png:1480"
             auto_vflip=no
             image_mod=~MASK(units/transport/pirate-galleon-mask.png)
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/ghost-ship-flag[1~3,2,1~3,2].png:[210*3,130,200*3,120]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        fog_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1480"
+        [/frame]
+        {GHOST_SHIP_FOG 370 ()}
+        [boat_frame]
+            image="units/transport/ghost-ship-rock-center.png:1480"
+            auto_vflip=no
             primary=yes
         [/boat_frame]
         [flag_frame]

--- a/data/core/units/boats/Orc_Barge.cfg
+++ b/data/core/units/boats/Orc_Barge.cfg
@@ -63,7 +63,7 @@ These barges are very ineffective in the high seas; little better than a floatin
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -72,6 +72,20 @@ These barges are very ineffective in the high seas; little better than a floatin
         [/frame]
         [boat_frame]
             image="units/transport/orc/barge-bob[1,2,1,2].png:[400*4]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/orc/barge.png:1600"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Orc_Battle-Barge.cfg
+++ b/data/core/units/boats/Orc_Battle-Barge.cfg
@@ -126,7 +126,7 @@ These barges are very ineffective in the high seas; little better than a floatin
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -136,6 +136,24 @@ These barges are very ineffective in the high seas; little better than a floatin
         [/frame]
         [boat_frame]
             image="units/transport/orc/battle-barge-bob[1~3,2].png:[400*4]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/orc/battle-barge-flag[1~3,2,1~3,2,1~3,2].png:[140*3,110,140*3,120,140*3,110]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/orc/battle-barge-bob1.png:1600"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Orc_Rigship.cfg
+++ b/data/core/units/boats/Orc_Rigship.cfg
@@ -81,7 +81,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -99,6 +99,24 @@
             auto_vflip=no
             primary=yes
         [/boat_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/orc/rig-bob2.png:1600"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/orc/rig-flag[1~3,2].png:[400*4]"
+            auto_vflip=no
+        [/flag_frame]
     [/standing_anim]
     [movement_anim]
         start_time=0

--- a/data/core/units/boats/Orc_Warship.cfg
+++ b/data/core/units/boats/Orc_Warship.cfg
@@ -82,7 +82,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -101,6 +101,24 @@
             primary=yes
         [/boat_frame]
     [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/orc/warship.png:1600"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/orc/warship-flag[1~3,2].png:[400*4]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
     [movement_anim]
         start_time=0
         boat_start_time=0
@@ -110,7 +128,7 @@
             image="misc/blank-hex.png:1600"
         [/frame]
         [boat_frame]
-            image="units/transport/orc/warship.png:1600"
+            image="units/transport/orc/warship-bob3.png:1600"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Raft.cfg
+++ b/data/core/units/boats/Raft.cfg
@@ -42,7 +42,7 @@ These Rafts are very ineffective in the high seas; little better than a floating
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -52,6 +52,24 @@ These Rafts are very ineffective in the high seas; little better than a floating
         [/frame]
         [boat_frame]
             image="units/transport/raft/raft-bob[1,2,1,2].png:[400*4]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/raft/raft-flag[1~3,2,1~3,2].png:[200*8]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1680"
+        [/frame]
+        [boat_frame]
+            image="units/transport/raft/raft-bob1.png:1680"
             auto_vflip=no
             primary=yes
         [/boat_frame]

--- a/data/core/units/boats/Raider_Coastal.cfg
+++ b/data/core/units/boats/Raider_Coastal.cfg
@@ -99,7 +99,7 @@ Coastal Raider ships are a very basic warship, protected against ramming and use
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*
+        terrain_type=S*^*
         boat_start_time=0
         flag_start_time=0
         flag_directional_x=-2:640,-1:300,0:390,-1:250
@@ -110,6 +110,24 @@ Coastal Raider ships are a very basic warship, protected against ramming and use
             image="units/transport/raider/bob[1~7,6~2].png:[260,170,80*3,170,260,170,80*3,170]"
             auto_vflip=no
             #image_mod=~MASK(units/transport/raider/mask.png)
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/raider/flag[1~3,2,1~3,2].png:[200*3,110,190*3,100]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1680"
+        [/frame]
+        [boat_frame]
+            image="units/transport/raider/bob1.png:1680"
+            auto_vflip=no
             primary=yes
         [/boat_frame]
         [flag_frame]

--- a/data/core/units/boats/Raider_Iron.cfg
+++ b/data/core/units/boats/Raider_Iron.cfg
@@ -100,7 +100,7 @@ Iron Raiders are veteran Coastal Raiders that have been hardened to become tough
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*
+        terrain_type=S*^*
         boat_start_time=0
         flag_start_time=0
         flag_directional_x=-2:640,-1:300,0:390,-1:250
@@ -111,6 +111,24 @@ Iron Raiders are veteran Coastal Raiders that have been hardened to become tough
             image="units/transport/raider/iron-bob[1~7,6~2].png:[260,170,80*3,170,260,170,80*3,170]"
             auto_vflip=no
             #image_mod=~MASK(units/transport/raider/mask.png)
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/raider/iron-flag[1~3,2,1~3,2].png:[200*3,110,190*3,100]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1680"
+        [/frame]
+        [boat_frame]
+            image="units/transport/raider/iron-bob2.png:1680"
+            auto_vflip=no
             primary=yes
         [/boat_frame]
         [flag_frame]

--- a/data/core/units/boats/Skiff.cfg
+++ b/data/core/units/boats/Skiff.cfg
@@ -93,7 +93,7 @@
     [/standing_anim]
     [standing_anim]
         start_time=0
-        terrain_type=S*^*,*^V*,*^B*
+        terrain_type=S*^*,*^B*
         boat_start_time=0
         flag_start_time=0
         boat_y=-1:300,-1~1:550,1:300,1~-1:550
@@ -104,6 +104,24 @@
         [/frame]
         [boat_frame]
             image="units/transport/skiff/skiff-bob[3,4,3,4].png:[400*4]"
+            auto_vflip=no
+            primary=yes
+        [/boat_frame]
+        [flag_frame]
+            image="units/transport/skiff/skiff-flag[1~3,2,1~3,2].png:[200*8]"
+            auto_vflip=no
+        [/flag_frame]
+    [/standing_anim]
+    [standing_anim]
+        start_time=0
+        terrain_type=!,W*^*,S*^*
+        boat_start_time=0
+        flag_start_time=0
+        [frame]
+            image="misc/blank-hex.png:1600"
+        [/frame]
+        [boat_frame]
+            image="units/transport/skiff/skiff-bob3.png:1600"
             auto_vflip=no
             primary=yes
         [/boat_frame]


### PR DESCRIPTION
Once/if #10576 is merged, ships will have 0% defense on land.

When ships are on land (usually only possible via a coastal village), this PR replaces their usual bobbing [standing_anim] with a more stationary one.