### PR TITLE
Remove most uses of atoi

### DIFF
--- a/src/scripting/lua_terrainfilter.cpp
+++ b/src/scripting/lua_terrainfilter.cpp
@@ -24,6 +24,7 @@
 #include "scripting/lua_formula_bridge.hpp"
 #include "scripting/push_check.hpp"
 #include "serialization/string_utils.hpp"
+#include "utils/from_chars.hpp"
 
 #include "formula/callable_objects.hpp"
 #include "formula/formula.hpp"
@@ -56,29 +57,18 @@ LOG_LMG << #NAME << ":matches(" << l << ") line:" << __LINE__;
 
 //helper functions for parsing
 namespace {
-	int atoi(std::string_view s)
-	{
-		if(s.empty()) {
-			return 0;
-		}
-
-		char** end = nullptr;
-		int res = strtol(&s[0], end, 10);
-		return res;
-	}
-
 	std::pair<int, int> parse_single_range(std::string_view s)
 	{
-		int dash_pos = s.find('-');
-		if(dash_pos == int(std::string_view::npos)) {
-			int res = atoi(s);
+		std::size_t dash_pos = s.find('-');
+		if(dash_pos == std::string_view::npos) {
+			int res = utils::from_chars<int>(s).value_or(0);
 			return {res, res};
 		}
-		else {
-			std::string_view first = s.substr(0, dash_pos);
-			std::string_view second = s.substr(dash_pos + 1);
-			return {atoi(first), atoi(second)};
-		}
+
+		return {
+			utils::from_chars<int>(s.substr(0, dash_pos)).value_or(0),
+			utils::from_chars<int>(s.substr(dash_pos + 1)).value_or(0)
+		};
 	}
 
 	dynamic_bitset parse_range(std::string_view s)

--- a/src/server/wesnothd/server.cpp
+++ b/src/server/wesnothd/server.cpp
@@ -29,6 +29,7 @@
 #include "serialization/preprocessor.hpp"
 #include "serialization/string_utils.hpp"
 #include "serialization/unicode.hpp"
+#include "utils/from_chars.hpp"
 #include "utils/iterable_pair.hpp"
 #include "game_version.hpp"
 
@@ -2469,7 +2470,7 @@ void server::sample_handler(
 		return;
 	}
 
-	request_sample_frequency = atoi(parameters.c_str());
+	request_sample_frequency = utils::from_chars<int>(parameters).value_or(0);
 	if(request_sample_frequency <= 0) {
 		*out << "Sampling turned off.";
 	} else {
@@ -3367,7 +3368,7 @@ int main(int argc, char** argv)
 				p = q;
 			}
 		} else if((val == "--port" || val == "-p") && arg + 1 != argc) {
-			port = atoi(argv[++arg]);
+			port = utils::from_chars<int>(argv[++arg]).value_or(0);
 		} else if(val == "--keepalive") {
 			keep_alive = true;
 		} else if(val == "--help" || val == "-h") {
@@ -3406,7 +3407,7 @@ int main(int argc, char** argv)
 			setsid();
 #endif
 		} else if(val == "--request_sample_frequency" && arg + 1 != argc) {
-			wesnothd::request_sample_frequency = atoi(argv[++arg]);
+			wesnothd::request_sample_frequency = utils::from_chars<int>(argv[++arg]).value_or(0);
 		} else {
 			ERR_SERVER << "unknown option: " << val;
 			return 2;

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -22,8 +22,10 @@
 #include "log.hpp"
 #include "sdl/rect.hpp"
 #include "serialization/string_utils.hpp"
+#include "utils/from_chars.hpp"
 #include "wml_exception.hpp"
 #include "game_config_view.hpp"
+
 #include <sstream>
 #include <utility>
 
@@ -51,7 +53,7 @@ static std::size_t compute(std::string expr, std::size_t ref1, std::size_t ref2 
 		ref = ref2;
 	}
 
-	return ref + atoi(expr.c_str());
+	return ref + utils::from_chars<int>(expr).value_or(0);
 }
 
 // If x2 or y2 are not specified, use x1 and y1 values
@@ -60,18 +62,18 @@ static _rect read_rect(const config& cfg)
 	_rect rect {0, 0, 0, 0};
 	std::vector<std::string> items = utils::split(cfg["rect"].str());
 	if(items.size() >= 1)
-		rect.x1 = atoi(items[0].c_str());
+		rect.x1 = utils::from_chars<int>(items[0]).value_or(0);
 
 	if(items.size() >= 2)
-		rect.y1 = atoi(items[1].c_str());
+		rect.y1 = utils::from_chars<int>(items[1]).value_or(0);
 
 	if(items.size() >= 3)
-		rect.x2 = atoi(items[2].c_str());
+		rect.x2 = utils::from_chars<int>(items[2]).value_or(0);
 	else
 		rect.x2 = rect.x1;
 
 	if(items.size() >= 4)
-		rect.y2 = atoi(items[3].c_str());
+		rect.y2 = utils::from_chars<int>(items[3]).value_or(0);
 	else
 		rect.y2 = rect.y1;
 

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -26,6 +26,7 @@
 #include "units/animation_component.hpp"
 #include "units/filter.hpp"
 #include "units/unit.hpp"
+#include "utils/from_chars.hpp"
 #include "utils/general.hpp"
 #include "variable.hpp"
 
@@ -342,8 +343,8 @@ unit_animation::unit_animation(const config& cfg,const std::string& frame_string
 		secondary_unit_filter_.push_back(filter);
 	}
 
-	for(const auto& v : utils::split(cfg["value"])) {
-		value_.push_back(utils::stoi(v));
+	for(const std::string& v : utils::split(cfg["value"])) {
+		value_.push_back(utils::from_chars<int>(v).value_or(0));
 	}
 
 	for(const auto& h : utils::split(cfg["hits"])) {
@@ -360,8 +361,8 @@ unit_animation::unit_animation(const config& cfg,const std::string& frame_string
 		}
 	}
 
-	for(const auto& v2 : utils::split(cfg["value_second"])) {
-		value2_.push_back(utils::stoi(v2));
+	for(const std::string& v2 : utils::split(cfg["value_second"])) {
+		value2_.push_back(utils::from_chars<int>(v2).value_or(0));
 	}
 
 	for(const config& filter : cfg.child_range("filter_attack")) {

--- a/src/units/animation.cpp
+++ b/src/units/animation.cpp
@@ -343,7 +343,7 @@ unit_animation::unit_animation(const config& cfg,const std::string& frame_string
 	}
 
 	for(const auto& v : utils::split(cfg["value"])) {
-		value_.push_back(atoi(v.c_str()));
+		value_.push_back(utils::stoi(v));
 	}
 
 	for(const auto& h : utils::split(cfg["hits"])) {
@@ -361,7 +361,7 @@ unit_animation::unit_animation(const config& cfg,const std::string& frame_string
 	}
 
 	for(const auto& v2 : utils::split(cfg["value_second"])) {
-		value2_.push_back(atoi(v2.c_str()));
+		value2_.push_back(utils::stoi(v2));
 	}
 
 	for(const config& filter : cfg.child_range("filter_attack")) {


### PR DESCRIPTION
Toward #10427. I decided to go with utils::from_chars as a replacement and keep the same fallback to 0 in case of errors (`atoi` returns 0 on error). I left the instances in attack_prediction.cpp (commented out ancient benchmarking code, should really just be removed) and `simple_wml::string_span::to_int()` (already full of C-isms, makes sense to keep for now).