### PR TITLE
Fix #10239: add Bandit leader to Northern Outpost scenario

### DIFF
--- a/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/05_Northern_Outpost.cfg
@@ -165,6 +165,7 @@
     #--------------------
     [side]
         side=4
+        controller=ai
         no_leader=yes
         team_name=bad
         hidden=yes
@@ -174,6 +175,14 @@
             leader_aggression=0.7
             grouping=offensive
         [/ai]
+        
+        [unit]
+            type=Bandit
+            id=Bandit_Leader
+            role=leader
+            x=20
+            y=12
+        [/unit]
     [/side]
 
     {PLACE_IMAGE scenery/rock1.png 15 28}


### PR DESCRIPTION
The game cannot place the bandit leader. Fixed it by editing 05_Northern_Outpost.cfg