### PR TITLE
Remove confusing locale dir differences

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -77,7 +77,6 @@ opts.AddVariables(
     PathVariable('desktopdir', 'sets the desktop entry directory to a non-default location', "$datarootdir/applications", PathVariable.PathAccept),
     PathVariable('icondir', 'sets the icons directory to a non-default location', "$datarootdir/icons", PathVariable.PathAccept),
     PathVariable('appdatadir', 'sets the appdata directory to a non-default location', "$datarootdir/metainfo", PathVariable.PathAccept),
-    BoolVariable('internal_data', 'Set to put data in Mac OS X application fork', False),
     PathVariable('localedirname', 'sets the locale data directory to a non-default location', "translations", PathVariable.PathAccept),
     PathVariable('mandir', 'sets the man pages directory to a non-default location', "$datarootdir/man", PathVariable.PathAccept),
     PathVariable('docdir', 'sets the doc directory to a non-default location', "$datarootdir/doc/wesnoth", PathVariable.PathAccept),
@@ -666,9 +665,6 @@ for env in [test_env, client_env, env]:
 # #
 # End setting options for release build
 # #
-
-    if env['internal_data']:
-        env.Append(CPPDEFINES = "USE_INTERNAL_DATA")
 
     if have_X:
         env.Append(CPPDEFINES = "_X11")

--- a/src/filesystem_common.cpp
+++ b/src/filesystem_common.cpp
@@ -236,21 +236,10 @@ std::string get_core_images_dir()
 
 std::string get_intl_dir()
 {
-#ifdef _WIN32
+#if HAS_RELATIVE_LOCALEDIR
 	return game_config::path + "/" LOCALEDIR;
 #else
-
-#ifdef USE_INTERNAL_DATA
-	return get_cwd() + "/" LOCALEDIR;
-#endif
-
-#if HAS_RELATIVE_LOCALEDIR
-	std::string res = game_config::path + "/" LOCALEDIR;
-#else
-	std::string res = LOCALEDIR;
-#endif
-
-	return res;
+	return LOCALEDIR;
 #endif
 }
 


### PR DESCRIPTION
All variants are either relative to the data dir or not. Relative to the current working directory is just what happens naturally if LOCALEDIR is a relative path.

To keep the same behavior on windows make sure HAS_RELATIVE_LOCALEDIR is set. CMake does that on windows but SCons does not.

As far as I can tell USE_INTERNAL_DATA is not used and unless HAS_RELATIVE_LOCALEDIR is also set for some reason the behavior stays the same except for a bug when the CWD cannot be determined. If get_cwd has an error it returns the empty string so in that case a "/" would be prepended which is just wrong.