### PR TITLE
optimized square_parenthetical_split() [LLM assisted]

### DIFF
--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -113,14 +113,36 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 		const std::string& right,const int flags)
 {
 	std::vector< std::string > res;
+	std::string lp=left;
+
+	//Early returns -->
+	if ((flags & REMOVE_EMPTY) && val.empty()) {
+		return res;
+	}
+	if (!separator) {
+		ERR_GENERAL << "Separator must be specified for square bracket split function.";
+		return res;
+	}
+	if (left.size() != right.size()) {
+		ERR_GENERAL << "Left and Right Parenthesis lists not same length";
+		return res;
+	}
+
+	// If the string contains no complex markers and no white spaces, return the string immediately.
+	// Added since many static images are treated as animations and run through here.
+	const std::string complex_markers = left + separator + "*~" + " \t\n\r\f\v";
+	if (val.find_first_of(complex_markers) == std::string::npos)
+	{
+		return { val };
+	}
+	//Early returns <--
+
+	std::string rp = right;
 	std::vector<char> part;
 	bool in_parenthesis = false;
 	std::vector<std::string::const_iterator> square_left;
 	std::vector<std::string::const_iterator> square_right;
 	std::vector< std::string > square_expansion;
-
-	std::string lp=left;
-	std::string rp=right;
 
 	std::string::const_iterator i1 = val.begin();
 	std::string::const_iterator i2;
@@ -129,20 +151,9 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 		while (i1 != val.end() && portable_isspace(*i1))
 			++i1;
 	}
+	if (i1 == val.end()) return res; //Early return
 	i2=i1;
 	j1=i1;
-
-	if (i1 == val.end()) return res;
-
-	if (!separator) {
-		ERR_GENERAL << "Separator must be specified for square bracket split function.";
-		return res;
-	}
-
-	if(left.size()!=right.size()){
-		ERR_GENERAL << "Left and Right Parenthesis lists not same length";
-		return res;
-	}
 
 	while (true) {
 		if(i2 == val.end() || (!in_parenthesis && *i2 == separator)) {

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -114,7 +114,7 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 {
 	std::vector< std::string > res;
 
-	if ((flags & REMOVE_EMPTY) && val.empty()) {
+	if (val.empty()) {
 		return res;
 	}
 	if (!separator) {
@@ -147,7 +147,7 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 
 	// If the string contains no animation markers, return the string immediately.
 	// Added since many static images are treated as animations and run through here.
-	const std::string complex_markers = separator + "[";
+	const std::string complex_markers = separator + std::string("[");
 	if (val.find_first_of(complex_markers) == std::string::npos)
 	{
 		std::string mutable_val(i1, val.end());

--- a/src/serialization/string_utils.cpp
+++ b/src/serialization/string_utils.cpp
@@ -113,9 +113,7 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 		const std::string& right,const int flags)
 {
 	std::vector< std::string > res;
-	std::string lp=left;
 
-	//Early returns -->
 	if ((flags & REMOVE_EMPTY) && val.empty()) {
 		return res;
 	}
@@ -128,15 +126,7 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 		return res;
 	}
 
-	// If the string contains no complex markers and no white spaces, return the string immediately.
-	// Added since many static images are treated as animations and run through here.
-	const std::string complex_markers = left + separator + "*~" + " \t\n\r\f\v";
-	if (val.find_first_of(complex_markers) == std::string::npos)
-	{
-		return { val };
-	}
-	//Early returns <--
-
+	std::string lp = left;
 	std::string rp = right;
 	std::vector<char> part;
 	bool in_parenthesis = false;
@@ -151,9 +141,21 @@ std::vector<std::string> square_parenthetical_split(const std::string& val,
 		while (i1 != val.end() && portable_isspace(*i1))
 			++i1;
 	}
-	if (i1 == val.end()) return res; //Early return
+	if (i1 == val.end()) return res;
 	i2=i1;
 	j1=i1;
+
+	// If the string contains no animation markers, return the string immediately.
+	// Added since many static images are treated as animations and run through here.
+	const std::string complex_markers = separator + "[";
+	if (val.find_first_of(complex_markers) == std::string::npos)
+	{
+		std::string mutable_val(i1, val.end());
+		if (flags & STRIP_SPACES) {
+			boost::trim_right(mutable_val);
+		}
+		return { mutable_val };
+	}
 
 	while (true) {
 		if(i2 == val.end() || (!in_parenthesis && *i2 == separator)) {


### PR DESCRIPTION
Added and reworked early returns for square_parenthetical_split() in string_utils.ccp, a heavy parsing function. Early returns are now 85% of all calls, was 30% before this change. No errors detected in an in-game quick test.

Image is the in-game test. First for the "complex_markers" early return and second for the total of all early returns.
<img width="456" height="41" alt="image" src="https://github.com/user-attachments/assets/fe0fc511-17f7-4bc0-a9cd-02f8a7a60a46" />

This function is called when loading new terrain or revealing shrouded areas.
