### PR TITLE
Timers for halo updates fixed [LLM assisted]

### DIFF
--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -169,6 +169,7 @@ rect halo_impl::effect::get_draw_location()
 /** Update the current location, animation frame, etc. */
 void halo_impl::effect::update()
 {
+	images_.update_last_draw_time(); //name is a bit missleading, it needs to be called on every update to keep the timer on track.
 	double zf = disp->get_zoom_factor();
 
 	if(map_loc_.x != -1 && map_loc_.y != -1) {
@@ -235,9 +236,6 @@ bool halo_impl::effect::render()
 {
 	// This should only be set if we actually draw something
 	last_draw_loc_ = {};
-
-	// Update animation frame, even if we didn't actually draw it
-	images_.update_last_draw_time();
 
 	if(!visible()) {
 		return false;
@@ -361,11 +359,6 @@ void halo_impl::update()
 	}
 	deleted_haloes.clear();
 
-	// Update the location and animation frame of the remaining halos
-	for(auto& [id, halo] : haloes) {
-		halo.update();
-	}
-
 	// Invalidate any animated halos which need updating
 	for(int id : changing_haloes) {
 		auto& halo = haloes.at(id);
@@ -373,6 +366,11 @@ void halo_impl::update()
 			DBG_HL << "invalidating changed halo " << id;
 			halo.queue_redraw();
 		}
+	}
+
+	// Update the location and animation frame of the remaining halos
+	for(auto& [id, halo] : haloes) {
+		halo.update();
 	}
 }
 


### PR DESCRIPTION
This is an issue for larger animations that also change rapidly (cant see the issue if the image isn't quickly changing).

The timers for halo updating where off before, this caused two issues. 
1: The halo would lag behind 1 frame in the animation, sometimes causing it to get stuck on the wrong frame. 
2: Since smaller parts of the halo are also updated by other animation update functions there could be glitches where parts of the halo are 1 frame behind the rest.

The image contains a "fireball" animation, we are here at one of the first frames of the animation, where to fireball quickly emerges. In the image you see that parts of the animation are on a different frame than the rest, this is because they got updated by another update function, and the main update function for halos is constantly out of sync.
<img width="487" height="414" alt="image" src="https://github.com/user-attachments/assets/256381b2-ba9c-4af0-a587-8fba2af03708" />
