### PR TITLE
Add "oceangoing" and "push-poles" [defense] abilities to ships

### DIFF
--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -139,16 +139,19 @@
 
 #define COASTAL_SHIP_MOVES_AND_DEFENSE
     # Movement costs and defense values for coastal ships
+    # These ships are also expected to use {TRAIT_PUSH_POLES_MUSTHAVE}
     [movement_costs]
         shallow_water=1
     [/movement_costs]
     [defense]
-        deep_water=70
+        shallow_water=60
+        deep_water=80
     [/defense]
 #enddef
 
 #define BARGE_MOVES_AND_DEFENSE
     # Movement costs and defense values for shallow-water barges
+    # These ships are also expected to use {TRAIT_PUSH_POLES_MUSTHAVE}
     [movement_costs]
         deep_water=2
         shallow_water=1
@@ -158,7 +161,6 @@
     [defense]
         deep_water=90
         shallow_water=80
-        flat=-70
         swamp_water=70
     [/defense]
 #enddef

--- a/data/core/macros/movetypes.cfg
+++ b/data/core/macros/movetypes.cfg
@@ -159,7 +159,6 @@
         deep_water=90
         shallow_water=80
         flat=-70
-        village=70 # no point making this less than flat. Flat village defense will be the best of flat/village, and we want to keep flat village consistent with sand/frozen/hill/etc
         swamp_water=70
     [/defense]
 #enddef

--- a/data/core/macros/traits.cfg
+++ b/data/core/macros/traits.cfg
@@ -375,22 +375,56 @@ Dim is a trait all too common in goblins and other lesser species. There are rea
     [/trait]
 #enddef
 
-#define TRAIT_CAREEN_MUSTHAVE
-    # Units with the trait Careen have 0% defense while on land.
+#define TRAIT_OCEANGOING_MUSTHAVE
+    # Units with the Oceangoing trait have altered defense while on certain mixed terrains
+    #
+    # I've implemented this as a trait instead of an ability because our UI makes it hard to read names when units have more than 2 traits/abilities.
+    # Some ships will have 2 abilities (heals & cures), but by default they all only have the "mechanical" trait, so there'll be plenty of room in the UI to display this.
+    # Explaining terrain defense in a trait also follows the precedent set by the Feral trait.
     [trait]
-        id=careen
+        id=oceangoing
+        name=_"oceangoing"
+        #po: this is a defense reduction - without this ability most oceangoing ships would have 30% defense on these terrains
+        description=_"This unit is limited to 20% defense while in Ford, Bridge, Oasis, Merfolk Village, or aquatic Castle terrain."
         availability=musthave
-        name=_"careen"
-        description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
         [effect]
             apply_to=new_ability
             [abilities]
                 [defense]
-                    value=0
+                    value=20
                     affect_self=yes
                     [filter_self]
                         [filter_location]
-                            terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
+                            terrain=Wwf*^*,*^B*,*^Do*,*^Vm*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
+                        [/filter_location]
+                    [/filter_self]
+                [/defense]
+            [/abilities]
+        [/effect]
+    [/trait]
+#enddef
+
+#define TRAIT_PUSH_POLES_MUSTHAVE
+    # Units with the Push-Poles trait have altered defense while on certain mixed terrains
+    #
+    # I've implemented this as a trait instead of an ability because our UI makes it hard to read names when units have more than 2 traits/abilities.
+    # Some ships will have 2 abilities (heals & cures), but by default they all only have the "mechanical" trait, so there'll be plenty of room in the UI to display this.
+    # Explaining terrain defense in a trait also follows the precedent set by the Feral trait.
+    [trait]
+        id=push_poles
+        #po: https://en.wikipedia.org/wiki/Setting_pole
+        name=_"push-poles"
+        description=_"This unit has 30% defense while in Ford, Bridge, Oasis, Merfolk Village, or aquatic Castle terrain."
+        availability=musthave
+        [effect]
+            apply_to=new_ability
+            [abilities]
+                [defense]
+                    value=30
+                    affect_self=yes
+                    [filter_self]
+                        [filter_location]
+                            terrain=Wwf*^*,*^B*,*^Do*,*^Vm*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
                         [/filter_location]
                     [/filter_self]
                 [/defense]

--- a/data/core/macros/traits.cfg
+++ b/data/core/macros/traits.cfg
@@ -374,3 +374,27 @@ Dim is a trait all too common in goblins and other lesser species. There are rea
         [/effect]
     [/trait]
 #enddef
+
+#define TRAIT_CAREEN_MUSTHAVE
+    # Units with the trait Careen have 0% defense while on land.
+    [trait]
+        id=careen
+        availability=musthave
+        name=_"careen"
+        description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
+        [effect]
+            apply_to=new_ability
+            [abilities]
+                [defense]
+                    value=0
+                    affect_self=yes
+                    [filter_self]
+                        [filter_location]
+                            terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
+                        [/filter_location]
+                    [/filter_self]
+                [/defense]
+            [/abilities]
+        [/effect]
+    [/trait]
+#enddef

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -297,26 +297,7 @@ Saurians live spectacularly short lives by comparison to most of the other races
         num_traits=2
         ignore_global_traits=yes
         {TRAIT_MECHANICAL}
-        [trait]
-            id=careen
-            name=careen
-            description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
-            availability=musthave
-            [effect]
-                apply_to=new_ability
-                [abilities]
-                    [defense]
-                        value=0
-                        affect_self=yes
-                        [filter_self]
-                            [filter_location]
-                                terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
-                            [/filter_location]
-                        [/filter_self]
-                    [/defense]
-                [/abilities]
-            [/effect]
-        [/trait]
+        {TRAIT_CAREEN_MUSTHAVE}
         # these need to span elf/human/orc, so a little vague for now.  Maybe this "race" can be split up
         {SHIP_NAMES}
     [/race]

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -297,6 +297,26 @@ Saurians live spectacularly short lives by comparison to most of the other races
         num_traits=2
         ignore_global_traits=yes
         {TRAIT_MECHANICAL}
+        [trait]
+            id=careen
+            name=careen
+            description=_"This unit can beach itself at coastal villages to repair, but will have 0% defense while on land."
+            availability=musthave
+            [effect]
+                apply_to=new_ability
+                [abilities]
+                    [defense]
+                        value=0
+                        affect_self=yes
+                        [filter_self]
+                            [filter_location]
+                                terrain=!,W*^*,S*^*,Khw*^*,Khs*^*,Km*^*,Chw*^*,Chs*^*,Cm*^*
+                            [/filter_location]
+                        [/filter_self]
+                    [/defense]
+                [/abilities]
+            [/effect]
+        [/trait]
         # these need to span elf/human/orc, so a little vague for now.  Maybe this "race" can be split up
         {SHIP_NAMES}
     [/race]
@@ -950,8 +970,7 @@ The life span of the wose is unknown, although the most ancient members of this 
         [defense]
             deep_water=60
             shallow_water=70
-            flat=-80 # can't make this too different from shallow, because there's no way to give ford a different movement_cost than shallow
-            village=80 # no point making this less than flat. Flat village defense will be the best of flat/village, and we want to keep flat village consistent with sand/frozen/hill/etc
+            flat=-80
             swamp_water=80
             reef=90
         [/defense]

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -297,7 +297,6 @@ Saurians live spectacularly short lives by comparison to most of the other races
         num_traits=2
         ignore_global_traits=yes
         {TRAIT_MECHANICAL}
-        {TRAIT_CAREEN_MUSTHAVE}
         # these need to span elf/human/orc, so a little vague for now.  Maybe this "race" can be split up
         {SHIP_NAMES}
     [/race]
@@ -951,7 +950,6 @@ The life span of the wose is unknown, although the most ancient members of this 
         [defense]
             deep_water=60
             shallow_water=70
-            flat=-80
             swamp_water=80
             reef=90
         [/defense]

--- a/data/core/units/boats/Carrack_Merchant.cfg
+++ b/data/core/units/boats/Carrack_Merchant.cfg
@@ -10,6 +10,7 @@
     profile="portraits/transport/crew-transport_galleon.webp"
     hitpoints=130
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=8
     experience=150
     level=3

--- a/data/core/units/boats/Carrack_Pirate.cfg
+++ b/data/core/units/boats/Carrack_Pirate.cfg
@@ -10,6 +10,7 @@
     profile="portraits/transport/crew-pirate_galleon.webp"
     hitpoints=130
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=8
     experience=150
     level=3

--- a/data/core/units/boats/Derelict_Ship.cfg
+++ b/data/core/units/boats/Derelict_Ship.cfg
@@ -7,6 +7,7 @@
     image="units/transport/derelict-galleon.png"
     hitpoints=95
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=6
     experience=55
     level=2

--- a/data/core/units/boats/Elf_Cutter.cfg
+++ b/data/core/units/boats/Elf_Cutter.cfg
@@ -8,6 +8,7 @@
     profile="portraits/transport/elf-ship.webp"
     hitpoints=110
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=10
     experience=105
     level=3

--- a/data/core/units/boats/Elf_Sloop.cfg
+++ b/data/core/units/boats/Elf_Sloop.cfg
@@ -8,6 +8,7 @@
     profile="portraits/transport/elf-ship.webp"
     hitpoints=150
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=10
     experience=200
     level=4

--- a/data/core/units/boats/Fireship.cfg
+++ b/data/core/units/boats/Fireship.cfg
@@ -10,6 +10,7 @@
     [resistance]
         fire=50
     [/resistance]
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=6
     experience=100
     level=2

--- a/data/core/units/boats/Ghost_Ship.cfg
+++ b/data/core/units/boats/Ghost_Ship.cfg
@@ -23,6 +23,7 @@
         cold=40
         arcane=110
     [/resistance]
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=6
     experience=150
     level=3

--- a/data/core/units/boats/Orc_Barge.cfg
+++ b/data/core/units/boats/Orc_Barge.cfg
@@ -15,6 +15,7 @@
         impact=80
     [/resistance]
     {BARGE_MOVES_AND_DEFENSE}
+    {TRAIT_PUSH_POLES_MUSTHAVE}
     movement=4
     experience=90
     level=3

--- a/data/core/units/boats/Orc_Battle-Barge.cfg
+++ b/data/core/units/boats/Orc_Battle-Barge.cfg
@@ -15,6 +15,7 @@
         impact=80
     [/resistance]
     {BARGE_MOVES_AND_DEFENSE}
+    {TRAIT_PUSH_POLES_MUSTHAVE}
     movement=4
     experience=200
     level=4

--- a/data/core/units/boats/Orc_Rigship.cfg
+++ b/data/core/units/boats/Orc_Rigship.cfg
@@ -8,6 +8,7 @@
     profile="portraits/transport/rigship.webp"
     hitpoints=135
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=8
     experience=110
     level=3

--- a/data/core/units/boats/Orc_Warship.cfg
+++ b/data/core/units/boats/Orc_Warship.cfg
@@ -8,6 +8,7 @@
     profile="portraits/transport/rigship.webp"
     hitpoints=170
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=8
     experience=200
     level=4

--- a/data/core/units/boats/Raft.cfg
+++ b/data/core/units/boats/Raft.cfg
@@ -9,6 +9,7 @@
     hitpoints=55
     movement_type=ship
     {BARGE_MOVES_AND_DEFENSE}
+    {TRAIT_PUSH_POLES_MUSTHAVE}
     movement=4
     experience=50
     level=1

--- a/data/core/units/boats/Raider_Coastal.cfg
+++ b/data/core/units/boats/Raider_Coastal.cfg
@@ -11,6 +11,7 @@
     hitpoints=90
     movement_type=ship
     {COASTAL_SHIP_MOVES_AND_DEFENSE}
+    {TRAIT_PUSH_POLES_MUSTHAVE}
     [resistance]
         impact=80
     [/resistance]

--- a/data/core/units/boats/Raider_Iron.cfg
+++ b/data/core/units/boats/Raider_Iron.cfg
@@ -11,6 +11,7 @@
     hitpoints=125
     movement_type=ship
     {COASTAL_SHIP_MOVES_AND_DEFENSE}
+    {TRAIT_PUSH_POLES_MUSTHAVE}
     [resistance]
         impact=80
     [/resistance]

--- a/data/core/units/boats/Skiff.cfg
+++ b/data/core/units/boats/Skiff.cfg
@@ -11,6 +11,7 @@
     profile="portraits/transport/crew-boat.webp"
     hitpoints=90
     movement_type=ship
+    {TRAIT_OCEANGOING_MUSTHAVE}
     movement=8
     experience=70
     level=2


### PR DESCRIPTION
Following up on #10576, this PR adds two new abilities for different archetypes of ships, altering their defense on certain mixed aquatic terrains.

Closes #10504.