### PR TITLE
Make vision report smaller so it fits and put it next to movement

### DIFF
--- a/changelog_entries/sidebar-vision.md
+++ b/changelog_entries/sidebar-vision.md
@@ -1,0 +1,2 @@
+### User interface
+   * Abbreviated “vision” and “jamming” in the sidebar, so that the number fits on-screen

--- a/data/themes/default.cfg
+++ b/data/themes/default.cfg
@@ -171,7 +171,7 @@
             id=label-xp
             font_size={DEFAULT_FONT_TINY}
             text= _ "XP"
-            rect="=,+14,+65,+14"
+            rect="=,+14,=,+14"
             xanchor=right
             yanchor=fixed
         [/label]
@@ -187,6 +187,7 @@
             id=label-def
             font_size={DEFAULT_FONT_TINY}
             text= _ "def"
+            ref=label-xp
             rect="+1,=,+25,+14"
             xanchor=right
             yanchor=fixed
@@ -447,14 +448,6 @@
                 xanchor=right
                 yanchor=fixed
             [/unit_traits]
-            [unit_vision]
-                id=unit-vision
-                font_size={DEFAULT_FONT_TINY}
-                ref=label-xp
-                rect="+0,=,=+60,="
-                xanchor=right
-                yanchor=fixed
-            [/unit_vision]
             [unit_hp]
                 id=unit-hp
                 font_size={DEFAULT_FONT_TINY}
@@ -490,6 +483,20 @@
                 xanchor=right
                 yanchor=fixed
             [/unit_defense]
+            [unit_vision]
+                id=unit-vision
+                font_size={DEFAULT_FONT_TINY}
+                rect="=,+0,+30,+14"
+                xanchor=right
+                yanchor=fixed
+            [/unit_vision]
+            [unit_jamming]
+                id=unit-jamming
+                font_size={DEFAULT_FONT_TINY}
+                rect="=,+0,+30,+14"
+                xanchor=right
+                yanchor=fixed
+            [/unit_jamming]
 
             # current position not usable, overlays with the status indication (like slow)
             # please find a better place (yes, I know that this is barely possible...)
@@ -617,7 +624,12 @@
         [change]
             id=unit-vision
             font_size={DEFAULT_FONT_REALLYTINY}
-            rect="+0,=,=+60,+{DEFAULT_FONT_REALLYTINY_HEIGHT_SHORTER}"
+            rect="=,+0,=+30,+{DEFAULT_FONT_REALLYTINY_HEIGHT_SHORTER}"
+        [/change]
+        [change]
+            id=unit-jamming
+            font_size={DEFAULT_FONT_REALLYTINY}
+            rect="=,+0,=+30,+{DEFAULT_FONT_REALLYTINY_HEIGHT_SHORTER}"
         [/change]
         [change]
             id=unit-race

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -639,16 +639,11 @@ static config unit_vision(const unit* u)
 {
 	if (!u) return config();
 
-	// TODO
 	std::ostringstream str, tooltip;
 	if (u->vision() != u->total_movement()) {
-		str << _("vision:") << ' ' << u->vision();
+		// TRANSLATORS: single-letter abbreviation of "vision", fits in a small space on the sidebar
+		str << _("vision^V:") << ' ' << u->vision();
 		tooltip << _("vision:") << ' ' << u->vision() << '\n';
-	}
-	if (u->jamming() != 0) {
-		if (static_cast<std::streamoff>(str.tellp()) == 0)
-			str << _("jamming:") << ' ' << u->jamming();
-		tooltip << _("jamming:") << ' ' << u->jamming() << '\n';
 	}
 	return text_report(str.str(), tooltip.str());
 }
@@ -661,6 +656,24 @@ REPORT_GENERATOR(selected_unit_vision, rc)
 {
 	const unit* u = get_selected_unit(rc);
 	return unit_vision(u);
+}
+
+static config unit_jamming(const unit* u)
+{
+	if(!u) return config();
+
+	std::ostringstream str, tooltip;
+	if(u->jamming() != 0) {
+		// TRANSLATORS: single-letter abbreviation of "jamming", fits in a small space on the sidebar
+		str << _("jamming^J:") << ' ' << u->jamming();
+		tooltip << _("jamming:") << ' ' << u->jamming() << '\n';
+	}
+	return text_report(str.str(), tooltip.str());
+}
+REPORT_GENERATOR(unit_jamming, rc)
+{
+	const unit* u = get_visible_unit(rc);
+	return unit_jamming(u);
 }
 
 static config unit_moves(const reports::context& rc, const unit* u, bool is_visible_unit)


### PR DESCRIPTION
Make jamming its own report instead of appending the info with no separation to vision. Also remove the width difference between HP and XP label. (HP label is still way too wide)

Edit by @stevecotton it doesn't look good, but it provides the information needed (and is only shown for the few units that have different vision values, for example the Dune Falconer). I've used debugging to add jamming to this unit too:
<img width="180" height="202" alt="image" src="https://github.com/user-attachments/assets/f9308216-7b0d-40a1-9244-b6be2e369716" />

For comparison, here's the same unit without this PR:
<img width="180" height="202" alt="image" src="https://github.com/user-attachments/assets/8bcc66a9-8712-4a60-9945-2dd69c28d087" />

Vision 10 or higher still gets an ellipsis, so the Dunefolk Sky Hunter gets "V: ..." in the sidebar, but that's better than the current situation.