### PR TITLE
Sort terrain entries alphabetically.

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -988,9 +988,16 @@ void generate_terrain_sections(section& sec, int /*level*/)
 		}
 	}
 
-	for (const auto& base : base_map) {
-		sec.add_section(base.second);
-	}
+	std::vector<section> sorted_sections;
+	for (const auto& pair : base_map) {
+        sorted_sections.push_back(pair.second);
+    }
+
+	std::sort(sorted_sections.begin(), sorted_sections.end(), section_less());
+
+    for (const section& s : sorted_sections) {
+        sec.add_section(s);
+    }
 }
 
 void generate_unit_sections(const config* /*help_cfg*/, section& sec, int /*level*/, const bool /*sort_generated*/, const std::string& race)


### PR DESCRIPTION
Fixes #10438 

Implements the suggestion from issue #10438.

The terrain help topics were previously sorted by their internal string ID, which is not user-friendly.

This commit moves the sections from the map into a std::vector and sorts it using std::sort with translation::icompare on the display title (a.title). This provides a correct, user-facing alphabetical sort that respects localization.