### PR TITLE
Correct the schema validation disable in the wrong test macro.

### DIFF
--- a/data/test/macros/unit_setup.cfg
+++ b/data/test/macros/unit_setup.cfg
@@ -42,9 +42,7 @@ no#endarg
         affect_allies = {ALLIES}
         affect_enemies = {ENEMIES}
         value = {VALUE}
-#ifndef SCHEMA_VALIDATION
         cumulative = {CUMULATIVE}
-#endif
         {OTHER}
     [/{ABIL}]
 #enddef


### PR DESCRIPTION
Since the 'value' attribute is encoded by default in the TEST_ABILITY macro, using cumulative will still be legal in this case.