### PR TITLE
add_overlay extended -- complete -- [LLM assisted]

### DIFF
--- a/changelog_entries/add_overlay_extended.md
+++ b/changelog_entries/add_overlay_extended.md
@@ -1,0 +1,34 @@
+### Graphics
+	* Z_order now works for halos placed with [item] or wesnoth.interface.add_hex_overlay().
+		* Before this the order of halos would only depend on when you placed them, the latest placement ending up on top.
+		* Now you can set it like: z_order = -8
+
+	* Animation for image overlays added
+		* Images placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be animated, just as they can for halos and units.
+		* The animation happens automatically if you supply a recognized animation string. Works the same as any other animation.
+		* (e.g. "img1.png, img2.png:200, img3.png, img[04~08].png")
+
+	* Pixel offset x/y options for image overlays added
+		* Images (halos/items) placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now have their placement adjusted/offset in pixels.
+		* If you offset an image outside the hex locations you need to set multihex=yes / true. Otherwise it will get cropped away.
+		* Commands like: pixel_offset_x = -10	pixel_offset_y = 841
+
+	* Duration option for image overlays added
+		* Images (halos/items) placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be removed automatically after a duration runs out.
+		* The duration is in milliseconds. duration=2300 means the image will stay up for 2.3 seconds.
+		* Images with a duration are not stored in the save file, they will not persist if you save and reload.
+
+	* Layer option for image overlays added
+		* Images (items) placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be assigned a drawing layer offset.
+		* Before all items would be placed at the default terrain_background layer.
+		* The input works the same as it does for units.
+		* Example: layer=50 will cause the image to draw at the terrain_foreground layer (mountain top / tree top).
+
+	* Multihex option for image overlays added
+		* Larger images placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now be multihex by adding "multihex = true" or "multihex = yes".
+		* For removal of a multihex image: simply remove the center piece of it the same way as usual.
+
+	* Parallax option for halo image overlays added
+		* Images (halos only) placed with [item] in WML or wesnoth.interface.add_hex_overlay() in Lua can now have a radial parallax effect.
+		* Parallax is a 3D effect that causes images to move differently as you scroll.
+		* e.g. "parallax_r=1.12" means the image will scroll faster than nearby terrain, making it look like it hovers above the ground.

--- a/data/lua/wml/items.lua
+++ b/data/lua/wml/items.lua
@@ -11,6 +11,14 @@ local function add_overlay(x, y, cfg)
 	end
 
 	wesnoth.interface.add_hex_overlay(x, y, cfg)
+
+	if cfg.duration and cfg.duration ~= 0 then
+		return --Do not store item if it is on a duration timer.
+		--A safeguard against any sync issues that can happen with timers.
+		--Means that any images with duration are purely visual and can't be used for gameplay purposes.
+		--The image is not saved and won't persist over save/load.
+	end
+
 	local items = scenario_items:get(x, y)
 	if not items then
 		items = {}
@@ -24,10 +32,16 @@ local function add_overlay(x, y, cfg)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
+			parallax_r = cfg.parallax_r,
 			redraw = cfg.redraw,
 			name = cfg.name,
+			layer = cfg.layer,
 			z_order = cfg.z_order,
+			duration = cfg.duration,
+			pixel_offset_x = cfg.pixel_offset_x,
+			pixel_offset_y = cfg.pixel_offset_y,
 			wml.tag.variables(wml.get_child(cfg, "variables") or {}),
 		})
 end
@@ -61,10 +75,16 @@ end
 ---@field team_name string
 ---@field filter_team WML
 ---@field visible_in_fog boolean
+---@field multihex boolean
 ---@field submerge number
+---@field parallax_r number
 ---@field redraw boolean
 ---@field name string
+---@field layer integer
 ---@field z_order integer
+---@field duration integer
+---@field pixel_offset_x integer
+---@field pixel_offset_y integer
 ---@field variables WMLTable
 
 ---Get items on a given hex
@@ -84,10 +104,16 @@ function wesnoth.interface.get_items(x, y)
 			team_name = cfg.team_name,
 			filter_team = cfg.filter_team,
 			visible_in_fog = cfg.visible_in_fog,
+			multihex = cfg.multihex,
 			submerge = cfg.submerge,
+			parallax_r = cfg.parallax_r,
 			redraw = cfg.redraw,
 			name = cfg.name,
+			layer = cfg.layer,
 			z_order = cfg.z_order,
+			duration = cfg.duration,
+			pixel_offset_x = cfg.pixel_offset_x,
+			pixel_offset_y = cfg.pixel_offset_y,
 			variables = wml.get_child(cfg, "variables"),
 		})
 	end

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -115,28 +115,262 @@ static int get_zoom_levels_index(unsigned int zoom_level)
 	return std::distance(zoom_levels.begin(), iter);
 }
 
+// overlay helpers anonymous namespace
+namespace
+{
+	// ------------------------ General overlay support. ------------------------
+
+	/** Returns a cropped image locator for any static overlay (still image). */
+	image::locator create_static_image_source(const std::string& base_image, const map_location& rel_loc, int center_x, int center_y)
+	{
+		std::string filename = base_image;
+		std::string mod = "";
+		std::size_t tilde = base_image.find('~'); // Modification example: ../boat.png~BG(50,50,50)
+		if(tilde != std::string::npos) {
+			filename = base_image.substr(0, tilde);
+			mod = base_image.substr(tilde);
+		}
+		return image::locator(filename, rel_loc, center_x, center_y, mod);
+	}
+
+	/** Returns animation frame descriptors (a sequence of timed image locators). */
+	animated<image::locator>::anim_description create_animation_source(const std::vector<std::string>& frames, const map_location& internal_loc, int center_x, int center_y)
+	{
+		animated<image::locator>::anim_description desc;
+		for(const std::string& frame : frames) {
+			const std::vector<std::string> sub_items = utils::split(frame, ':');
+			std::string str = frame;
+			auto time = 100ms;
+			if(sub_items.size() > 1) {
+				str = sub_items.front();
+				try {
+					time = std::chrono::milliseconds{ std::stoi(sub_items.back()) };
+				} catch(const std::logic_error&) {
+					ERR_DP << "Invalid time value found when constructing overlay: " << sub_items.back();
+				}
+			}
+			desc.emplace_back(time, create_static_image_source(str, internal_loc, center_x, center_y));
+		}
+		return desc;
+	}
+
+	/** Sets up image source for an overlay (static or animated).
+	Containing info for both single-hex and multi-hex cropping, positioning and mods.*/
+	void create_overlay_image_source(overlay& ov, const std::vector<std::string>& frames,
+		bool is_anim, const map_location& internal_loc,
+		int center_x, int center_y)
+	{
+		if(!is_anim) {
+			ov.image_static = create_static_image_source(ov.image, internal_loc, center_x, center_y);
+		} else {
+			ov.animation = animated<image::locator>(create_animation_source(frames, internal_loc, center_x, center_y));
+			ov.animation.start_animation(std::chrono::milliseconds{0}, true);
+			ov.is_animated = true;
+		}
+	}
+
+	/** Inserts an overlay into a vector, maintaining z-order. */
+	void insert_overlay_sorted(std::vector<overlay>& overlays, overlay&& ov)
+	{
+		auto pos = std::upper_bound(overlays.begin(), overlays.end(), ov.z_order,
+			[](int new_order, const overlay& existing) {
+				return new_order < existing.z_order;
+			});
+		overlays.emplace(pos, std::move(ov));
+	}
+
+} // overlay helpers anonymous namespace end
+
+void display::set_overlay_duration(const map_location& loc, const std::string& id, std::chrono::milliseconds duration)
+{
+	if(duration.count() > 0) {
+		timed_overlays_.push_back({ std::chrono::steady_clock::now() + duration, id, loc });
+		std::push_heap(timed_overlays_.begin(), timed_overlays_.end(), std::greater<overlay_timer>());
+	}
+}
+
+std::vector<display::overlay_timer> display::extract_expired_overlays()
+{
+	const auto now = std::chrono::steady_clock::now();
+	std::vector<overlay_timer> overlays_to_remove;
+	while(!timed_overlays_.empty() && timed_overlays_.front().end_time <= now) {
+		std::pop_heap(timed_overlays_.begin(), timed_overlays_.end(), std::greater<overlay_timer>());
+		overlays_to_remove.push_back(std::move(timed_overlays_.back()));
+		timed_overlays_.pop_back();
+	}
+	return overlays_to_remove;
+}
+
+void display::add_halo_overlay(const map_location& loc, overlay&& ov)
+{
+	if(ov.duration.count() > 0) {
+		set_overlay_duration(loc, ov.id, ov.duration);
+	}
+
+	// Add to halo handler (halo.cpp) then sort placement layer and add to map.
+	// The halo applies the zoomed pixel offset itself on every update.
+	auto [x, y] = get_location_rect(loc).center();
+	ov.halo_handle = halo_man_.add(x, y,
+		ov.halo, loc, halo::NORMAL, true, ov.parallax_r, ov.z_order, ov.pixel_offset_x, ov.pixel_offset_y);
+	std::vector<overlay>& overlays = get_overlays()[loc];
+	insert_overlay_sorted(overlays, std::move(ov)); // Halos are also ordered in halo.cpp, this is just for reference.
+}
+
+void display::add_single_hex_overlay(const map_location& loc, overlay&& ov)
+{
+	// Get data on animation, offset and duration.
+	const std::vector<std::string> frames = utils::square_parenthetical_split(ov.image, ',');
+	const bool is_anim = frames.size() > 1 || ov.image.find(':') != std::string::npos;
+	const int hex_size = game_config::tile_size;
+	const int center_x_offset = (hex_size / 2) + ov.pixel_offset_x;
+	const int center_y_offset = (hex_size / 2) + ov.pixel_offset_y;
+	if(ov.duration.count() > 0) {
+		set_overlay_duration(loc, ov.id, ov.duration);
+	}
+
+	create_overlay_image_source(ov, frames, is_anim, map_location{0,0}, center_x_offset, center_y_offset);
+
+	// Sort placement layer and add to map.
+	std::vector<overlay>& overlays = get_overlays()[loc];
+	insert_overlay_sorted(overlays, std::move(ov));
+}
+
+void display::add_multihex_overlay(const map_location& loc, overlay&& ov)
+{
+	const double zoom = get_zoom_factor();
+	const int half_tile = game_config::tile_size / 2;
+
+	// Parse animation data
+	const std::vector<std::string> frames = utils::square_parenthetical_split(ov.image, ',');
+	const bool is_anim = frames.size() > 1 || ov.image.find(':') != std::string::npos;
+	const auto image_size = image::get_size(utils::split(frames.front(), ':').front());
+
+	// Calculate where the center of the image is on screen (relative to anchor hex center)
+	const point img_center_screen = get_location_rect(loc).center() + point(
+		static_cast<int>(ov.pixel_offset_x * zoom),
+		static_cast<int>(ov.pixel_offset_y * zoom)
+	);
+
+	// Create the bounding box for the full image on screen
+	const rect bounds(
+		static_cast<int>(img_center_screen.x - (image_size.x * zoom) / 2.0),
+		static_cast<int>(img_center_screen.y - (image_size.y * zoom) / 2.0),
+		static_cast<int>(image_size.x * zoom),
+		static_cast<int>(image_size.y * zoom)
+	);
+
+	// Get all hexes covered by this bounding box. These will be the hexes we create child overlays for.
+	const display::rect_of_hexes hexes = hexes_under_rect(bounds);
+
+	// Calculate center offsets relative to top-left hex
+	const int min_x = hexes.left;
+	const int min_y = hexes.top[1]; // Even columns are higher up
+	const int max_y = hexes.bottom[0]; // Odd columns are lower down
+	const point top_left_hex_center = get_location_rect(map_location(min_x, min_y)).center();
+	const int px_center_x = static_cast<int>(((img_center_screen.x - top_left_hex_center.x) / zoom) + half_tile);
+	const int px_center_y = static_cast<int>(((img_center_screen.y - top_left_hex_center.y) / zoom) + half_tile);
+
+	// Iterate over all covered hexes and create child overlays
+	std::vector<std::pair<std::string, map_location>> children;
+	for(const map_location& hex : hexes) {
+
+		// Child location relative to top left hex corner of the multihex image, used for cropping the children so they fit together correctly
+		const map_location internal_loc(hex.x - min_x, hex.y - min_y);
+
+		// Apply correction for hex column staggering
+		const int corrected_px_center_y = px_center_y + ((hex.x % 2 == 0 && min_x % 2 != 0) ? half_tile * 2 : 0);
+
+		// Create child overlay
+		overlay child = ov;
+		child.id = ov.id + "_part_" + std::to_string(internal_loc.x) + "_" + std::to_string(internal_loc.y);
+		child.is_child = true;
+		child.child_height = (max_y - hex.y);
+		child.parent_location = loc;
+		create_overlay_image_source(child, frames, is_anim, internal_loc, px_center_x, corrected_px_center_y);
+		children.push_back({ child.id, hex });
+
+		// Sort placement layer and add to map.
+		std::vector<overlay>& overlays = get_overlays()[hex];
+		insert_overlay_sorted(overlays, std::move(child));
+	}
+
+	// Create parent overlay and add to map. Parent is not an image, it's just a reference to the children, who are images.
+	ov.child_hexes = std::move(children);
+	if(ov.duration.count() > 0) {
+		set_overlay_duration(loc, ov.id, ov.duration);
+	}
+	if(is_anim) {
+		ov.is_animated = true;
+	}
+	std::vector<overlay>& centre_vec = get_overlays()[loc];
+	insert_overlay_sorted(centre_vec, std::move(ov));
+}
+
 void display::add_overlay(const map_location& loc, overlay&& ov)
 {
-	std::vector<overlay>& overlays = get_overlays()[loc];
-	auto pos = std::find_if(overlays.begin(), overlays.end(),
-		[new_order = ov.z_order](const overlay& existing) { return existing.z_order > new_order; });
+	if(!ov.halo.empty()) {
+		add_halo_overlay(loc, std::move(ov));
+		return;
+	}
 
-	auto inserted = overlays.emplace(pos, std::move(ov));
-	if(const std::string& halo = inserted->halo; !halo.empty()) {
-		auto [x, y] = get_location_rect(loc).center();
-		inserted->halo_handle = halo_man_.add(x, y, halo, loc);
+	if(!ov.multihex) {
+		add_single_hex_overlay(loc, std::move(ov));
+		return;
+	}
+
+	add_multihex_overlay(loc, std::move(ov));
+}
+
+void display::remove_multihex_children(const overlay& ov)
+{
+	if(!ov.multihex || ov.is_child) { // Multihex parent only
+		return;
+	}
+
+	for(const auto& child_pair : ov.child_hexes) {
+		const std::string& child_id = child_pair.first;
+		const map_location& child_loc = child_pair.second;
+		auto child_it = get_overlays().find(child_loc);
+		if(child_it == get_overlays().end()) {
+			continue;
+		}
+		bool child_removed = false;
+
+		utils::erase_if(child_it->second, [&](const overlay& child_hex_ov) {
+			if(child_hex_ov.id == child_id) {
+				child_removed = true;
+				return true;
+			}
+			return false;
+		});
+
+		if(child_removed) {
+			this->invalidate(child_loc);
+		}
 	}
 }
 
 void display::remove_overlay(const map_location& loc)
 {
-	get_overlays().erase(loc);
+	if(get_overlays().count(loc)) {
+		for(const auto& ov : get_overlays().at(loc)) {
+			remove_multihex_children(ov);
+		}
+		get_overlays().erase(loc);
+	}
 }
 
 void display::remove_single_overlay(const map_location& loc, const std::string& toDelete)
 {
-	utils::erase_if(get_overlays()[loc],
-		[&toDelete](const overlay& ov) { return ov.image == toDelete || ov.halo == toDelete || ov.id == toDelete; });
+	auto& overlays = get_overlays()[loc];
+	auto pos = std::find_if(overlays.begin(), overlays.end(), [&toDelete](const overlay& ov) {
+		return ov.id == toDelete || ov.name == toDelete || ov.image == toDelete || ov.halo == toDelete;
+	}); // id and name are usually equal but can differ, so match either.
+
+	if(pos != overlays.end()) {
+		remove_multihex_children(*pos);
+		overlays.erase(pos);
+	}
 }
 
 display::display(const display_context* dc,
@@ -2245,6 +2479,13 @@ void display::draw()
 void display::update()
 {
 	//DBG_DP << "display::update";
+
+	// Remove duration expired overlays.
+	for(const overlay_timer& timer : extract_expired_overlays()) {
+		remove_single_overlay(timer.loc, timer.id);
+		invalidate(timer.loc);
+	}
+
 	// Ensure render textures are correctly sized and up-to-date.
 	update_render_textures();
 
@@ -2664,6 +2905,7 @@ void display::draw_overlays_at(const map_location& loc)
 			continue;
 		}
 
+		// Visible only to specific teams? (lurking units)
 		if(dont_show_all_ && !ov.team_name.empty()) {
 			const auto current_team_names = utils::split_view(viewing_team().team_name());
 			const auto team_names = utils::split_view(ov.team_name);
@@ -2676,37 +2918,71 @@ void display::draw_overlays_at(const map_location& loc)
 			}
 		}
 
-		texture tex = ov.image.find("~NO_TOD_SHIFT()") == std::string::npos
-			? image::get_lighted_texture(ov.image, lt)
-			: image::get_texture(ov.image, image::HEXED);
+		// Skip halos. Also skip parent overlays of multihex images - they have no image data, only children do.
+		if((ov.multihex && !ov.is_child) || (!ov.halo.empty())) {
+			continue;
+		}
 
-		// Base submerge value for the terrain at this location
-		const double ter_sub = context().map().get_terrain_info(loc).unit_submerge();
+		// Apply Time-of-Day lighting to the overlay image and crop it to hex shape
+		texture tex;
+		if(ov.is_animated) {
+			const image::locator& frame = ov.animation.get_current_frame();
+			tex = frame.get_modifications().find("NO_TOD_SHIFT") == std::string::npos
+				? image::get_lighted_texture(frame, lt)
+				: image::get_texture(frame, image::HEXED);
+		} else { // static image
+			const image::locator& locator = ov.image_static;
+			tex = locator.get_modifications().find("NO_TOD_SHIFT") == std::string::npos
+				? image::get_lighted_texture(locator, lt)
+				: image::get_texture(locator, image::HEXED);
+		}
 
-		drawing_buffer_add(
-			drawing_layer::terrain_bg, loc, [tex, ter_sub, ovr_sub = ov.submerge](const rect& dest) mutable {
-				if(ovr_sub > 0.0 && ter_sub > 0.0) {
-					// Adjust submerge appropriately
-					double submerge = ter_sub * ovr_sub;
+		if(!tex) { // Skip fully transparent images, e.g. blank multihex child hexes.
+			continue;
+		}
 
-					submerge_data data
-						= display::get_submerge_data(dest, submerge, tex.draw_size(), ALPHA_OPAQUE, false, false);
+		// Base submerge value for the terrain at this location.
+		const map_location submerge_loc = ov.is_child ? ov.parent_location : loc; // Multihex children defer to parent.
+		const double ter_sub = context().map().get_terrain_info(submerge_loc).unit_submerge();
+		float submerge = ov.submerge * ter_sub;
+		if(ov.is_child && ov.submerge > 0.0) {
+			// Submerge is measured in hex heights, so children a whole hex above the waterline end up dry.
+			submerge -= ov.child_height;
+			const bool parent_is_odd = (ov.parent_location.x % 2 == 0); // Adjust for staggered.
+			const bool child_is_odd = (loc.x % 2 == 0);
+			if(parent_is_odd != child_is_odd) {
+				submerge += 0.5f;
+			}
+			if(!parent_is_odd && !child_is_odd) {
+				submerge += 1.0f;
+			}
+		}
 
-					// set clip for dry part
-					// smooth_shaded doesn't use the clip information so it's fine to set it up front
-					// TODO: do we need to unset this?
-					tex.set_src(data.unsub_src);
+		// Skip fully submerged overlays
+		if(submerge >= 1.0f) {
+			continue;
+		}
 
-					// draw underwater part
-					draw::smooth_shaded(tex, data.alpha_verts);
+		drawing_buffer_add(static_cast<drawing_layer>(static_cast<int>(drawing_layer::terrain_bg) + ov.layer), loc, [tex, submerge](const rect& dest) mutable {
+			if(submerge > 0.0f) {
 
-					// draw dry part
-					draw::blit(tex, data.unsub_dest);
-				} else {
-					// draw whole texture
-					draw::blit(tex, dest);
-				}
-			});
+				submerge_data data = display::get_submerge_data(dest, submerge, tex.draw_size(), ALPHA_OPAQUE, false, false);
+
+				// set clip for dry part
+				// smooth_shaded doesn't use the clip information so it's fine to set it up front
+				// TODO: do we need to unset this?
+				tex.set_src(data.unsub_src);
+
+				// draw underwater part
+				draw::smooth_shaded(tex, data.alpha_verts);
+
+				// draw dry part
+				draw::blit(tex, data.unsub_dest);
+			} else {
+				// draw whole texture
+				draw::blit(tex, dest);
+			}
+		});
 	}
 }
 
@@ -3050,14 +3326,30 @@ void display::invalidate_animations()
 	// There are timing issues with this, but i'm not touching it.
 	new_animation_frame();
 	animate_map_ = prefs::get().animate_map();
-	if(animate_map_) {
-		for(const map_location& loc : get_visible_hexes()) {
-			if(shrouded(loc))
-				continue;
+	for(const map_location& loc : get_visible_hexes()) {
+		if(shrouded(loc))
+			continue;
+
+		// terrain animation
+		if(animate_map_) {
 			if(builder_->update_animation(loc)) {
 				invalidate(loc);
 			} else {
 				invalidate_animations_location(loc);
+			}
+		}
+
+		// overlay animation (not halos)
+		auto it = get_overlays().find(loc);
+		if(it != get_overlays().end()) {
+			for(auto& ov : it->second) {
+				if(ov.is_animated) {
+					bool changed = ov.animation.need_update();
+					ov.animation.update_last_draw_time();
+					if(changed) {
+						invalidate(loc);
+					}
+				}
 			}
 		}
 	}

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -76,7 +76,7 @@ struct submerge_data
 {
 	rect unsub_src;
 	rect unsub_dest;
-	std::array<SDL_Vertex, 4> alpha_verts;
+	std::array<SDL_Vertex, 4> alpha_verts{};
 };
 
 class gamemap;

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -160,18 +160,61 @@ public:
 	bool unit_can_draw_here(const map_location& loc, const unit& unit) const;
 
 	/**
-	 * Functions to add and remove overlays from locations.
-	 *
-	 * An overlay is an image that is displayed on top of the tile.
-	 * One tile may have multiple overlays.
+	 * Adds an overlay to a location.
+	 * An overlay is an image displayed on top of the tile(s).
+	 * One tile may have multiple overlays. And one overlay may spread over multiple tiles.
+	 * Overlays are divided into halos, single-hex and multi-hex. They can be static or animated.
+	 * @param loc The map_location (hex coordinates) where the overlay is anchored.
+	 * @param ov An rvalue reference to the overlay object to be added (takes ownership).
 	 */
 	void add_overlay(const map_location& loc, overlay&& ov);
 
-	/** remove_overlay will remove all overlays on a tile. */
+	/** Handles adding a halo overlay. Routes the overlay to the halo manager. */
+	void add_halo_overlay(const map_location& loc, overlay&& ov);
+
+	/** Handles adding a single-hex overlay (both static and animated). */
+	void add_single_hex_overlay(const map_location& loc, overlay&& ov);
+
+	/**
+	 * Handles adding a multi-hex overlay (both static and animated).
+	 * Splits a larger overlay into multiple single-hex child overlays.
+	 * Some of these child hexes may be empty (fully transparent), but that gets optimized for downstream.
+	 */
+	void add_multihex_overlay(const map_location& loc, overlay&& ov);
+
+	/** remove_overlay will remove all overlays on a tile. Including multihex images based on that tile. */
 	void remove_overlay(const map_location& loc);
 
-	/** remove_single_overlay will remove a single overlay from a tile */
+	/** remove_single_overlay will remove a single overlay from a tile. Including multihex image based on that tile. */
 	void remove_single_overlay(const map_location& loc, const std::string& toDelete);
+
+private:
+
+	/** Removes all child overlays associated with a multi-hex parent overlay. */
+	void remove_multihex_children(const overlay& ov);
+
+	/** Holds data for an overlay with a limited display duration. */
+	struct overlay_timer
+	{
+		std::chrono::steady_clock::time_point end_time;
+		std::string id;
+		map_location loc;
+		bool operator>(const overlay_timer& other) const
+		{
+			return end_time > other.end_time;
+		}
+	};
+
+	/** Min-heap of overlays with timers, soonest expiry first. */
+	std::vector<overlay_timer> timed_overlays_;
+
+	/** Sets a timer for an overlay to be removed after a specified duration. */
+	void set_overlay_duration(const map_location& loc, const std::string& id, std::chrono::milliseconds duration);
+
+	/** Removes and returns the overlays whose timers have expired. */
+	std::vector<overlay_timer> extract_expired_overlays();
+
+public:
 
 	/**
 	 * Updates internals that cache map size. This should be called when the map

--- a/src/drawing_layer.hpp
+++ b/src/drawing_layer.hpp
@@ -16,6 +16,10 @@
 
 #pragma once
 
+/**
+ * A list of drawing layers that images should be placed on to keep order.
+ * Halos are the exception, they are drawn with a separate system on top of these layers.
+ */
 enum class drawing_layer {
 	/** Terrain drawn behind the unit */
 	terrain_bg,

--- a/src/halo.cpp
+++ b/src/halo.cpp
@@ -48,7 +48,8 @@ class halo_impl
 		effect(
 			int xpos, int ypos,
 			const animated<image::locator>::anim_description& img,
-			const map_location& loc, ORIENTATION, bool infinite
+			const map_location& loc, ORIENTATION, bool infinite, float parallax_r = 1.0f,
+			float z_order = 0.0f, int pixel_offset_x = 0, int pixel_offset_y = 0
 		);
 
 		void set_location(int x, int y);
@@ -65,6 +66,7 @@ class halo_impl
 		bool expired()     const { return !images_.cycles() && images_.animation_finished(); }
 		bool need_update() const { return images_.need_update(); }
 		bool does_change() const { return !images_.does_not_change(); }
+		float get_z_order() const { return z_order_; }
 
 	private:
 
@@ -93,11 +95,24 @@ class halo_impl
 		// The map location the halo is attached to, if any
 		map_location map_loc_ = {-1, -1};
 
+		float parallax_r_ = 1.0f;
+
+		float z_order_ = 0.0f;
+
+		int pixel_offset_x_ = 0;
+
+		int pixel_offset_y_ = 0;
+
 		display* disp = nullptr;
 	};
 
 	std::map<int, effect> haloes;
 	int halo_id{1};
+
+	// Temporary z_order lists for rendering
+	std::vector<effect*> negative_z_halos;
+	std::vector<effect*> default_z_halos;
+	std::vector<effect*> positive_z_halos;
 
 	/**
 	 * Upon unrendering, an invalidation list is send. All haloes in that area and
@@ -120,7 +135,7 @@ class halo_impl
 
 public:
 	int add(int x, int y, const std::string& image, const map_location& loc,
-			ORIENTATION orientation=NORMAL, bool infinite=true);
+			ORIENTATION orientation=NORMAL, bool infinite=true, float parallax_r = 1.0f, float z_order = 0.0f, int pixel_offset_x = 0, int pixel_offset_y = 0);
 
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(int handle, int x, int y);
@@ -130,17 +145,22 @@ public:
 
 	void update();
 
-	/** Render all halos overlapping the given region */
+	/** Render all halos overlapping the given region, respecting the z_order. */
 	void render(const rect&);
 
 }; //end halo_impl
 
 halo_impl::effect::effect(int xpos, int ypos,
 		const animated<image::locator>::anim_description& img,
-		const map_location& loc, ORIENTATION orientation, bool infinite) :
+		const map_location& loc, ORIENTATION orientation, bool infinite,
+		float parallax_r, float z_order, int pixel_offset_x, int pixel_offset_y):
 	images_(img),
 	orientation_(orientation),
 	map_loc_(loc),
+	parallax_r_(parallax_r),
+	z_order_(z_order),
+	pixel_offset_x_(pixel_offset_x),
+	pixel_offset_y_(pixel_offset_y),
 	disp(display::get_singleton())
 {
 	assert(disp != nullptr);
@@ -178,7 +198,7 @@ void halo_impl::effect::update()
 		// If the halo is attached to a particular map location,
 		// make sure it stays attached.
 		auto [x, y] = disp->get_location_rect(map_loc_).center();
-		set_location(x, y);
+		set_location((x + (zf * pixel_offset_x_)), (y + (zf * pixel_offset_y_)));
 	} else {
 		// It would be good to attach to a position within a hex,
 		// or persistently to an item or unit. That's not the case,
@@ -208,8 +228,21 @@ void halo_impl::effect::update()
 
 	const auto [zero_x, zero_y] = disp->get_location(map_location::ZERO());
 
-	const int xpos = zero_x + abs_mid_.x - w/2;
-	const int ypos = zero_y + abs_mid_.y - h/2;
+	int xpos = zero_x + abs_mid_.x - w / 2;
+	int ypos = zero_y + abs_mid_.y - h / 2;
+
+	if(parallax_r_ != 1.0f) {
+
+		// Radial-from-center parallax.
+		// Moves proportionally to distance from the center of the screen. Max offset at screen edges, none at center.
+		const rect& screen_map_box = disp->map_outside_area();
+		const int cx = screen_map_box.x + screen_map_box.w / 2;
+		const int cy = screen_map_box.y + screen_map_box.h / 2;
+		const int dx = xpos - cx;
+		const int dy = ypos - cy;
+		xpos += static_cast<int>(dx * (parallax_r_ - 1.0f) * zf);
+		ypos += static_cast<int>(dy * (parallax_r_ - 1.0f) * zf);
+	}
 
 	screen_loc_ = {xpos, ypos, w, h};
 
@@ -290,7 +323,7 @@ void halo_impl::effect::queue_redraw()
 
 
 int halo_impl::add(int x, int y, const std::string& image, const map_location& loc,
-		ORIENTATION orientation, bool infinite)
+		ORIENTATION orientation, bool infinite, float parallax_r, float z_order, int pixel_offset_x, int pixel_offset_y)
 {
 	const int id = halo_id++;
 	DBG_HL << "adding halo " << id;
@@ -312,7 +345,7 @@ int halo_impl::add(int x, int y, const std::string& image, const map_location& l
 		}
 		image_vector.emplace_back(time, image::locator(str));
 	}
-	haloes.try_emplace(id, x, y, image_vector, loc, orientation, infinite);
+	haloes.try_emplace(id, x, y, image_vector, loc, orientation, infinite, parallax_r, z_order, pixel_offset_x, pixel_offset_y);
 	invalidated_haloes.insert(id);
 	if(haloes.find(id)->second.does_change() || !infinite) {
 		changing_haloes.insert(id);
@@ -386,10 +419,52 @@ void halo_impl::render(const rect& region)
 		return;
 	}
 
+	negative_z_halos.clear();
+	default_z_halos.clear();
+	positive_z_halos.clear();
+
+	// Get halos that overlap the render region
 	for(auto& [id, effect] : haloes) {
 		if(region.overlaps(effect.get_draw_location())) {
 			DBG_HL << "drawing intersected halo " << id;
-			effect.render();
+			float z = effect.get_z_order();
+			if(z == 0.0f) {
+				default_z_halos.push_back(&effect);
+			} else if(z < 0.0f) {
+				negative_z_halos.push_back(&effect);
+			} else {
+				positive_z_halos.push_back(&effect);
+			}
+		}
+	}
+	if(negative_z_halos.empty() && default_z_halos.empty() && positive_z_halos.empty()) {
+		return;
+	}
+
+	// Sort by their z_order and render.
+	if(!negative_z_halos.empty()) {
+		std::stable_sort(negative_z_halos.begin(), negative_z_halos.end(), // stable_sort to not change order of same-z_order halos.
+			[](const effect* a, const effect* b) {
+				return a->get_z_order() < b->get_z_order();
+			});
+		for(effect* effect_to_render : negative_z_halos) {
+			effect_to_render->render();
+		}
+	}
+
+	if(!default_z_halos.empty()) {
+		for(effect* effect_to_render : default_z_halos) {
+			effect_to_render->render();
+		}
+	}
+
+	if(!positive_z_halos.empty()) {
+		std::stable_sort(positive_z_halos.begin(), positive_z_halos.end(),
+			[](const effect* a, const effect* b) {
+				return a->get_z_order() < b->get_z_order();
+			});
+		for(effect* effect_to_render : positive_z_halos) {
+			effect_to_render->render();
 		}
 	}
 }
@@ -404,9 +479,9 @@ manager::manager() : impl_(new halo_impl())
 {}
 
 handle manager::add(int x, int y, const std::string& image, const map_location& loc,
-		ORIENTATION orientation, bool infinite)
+		ORIENTATION orientation, bool infinite, float parallax_r, float z_order, int pixel_offset_x, int pixel_offset_y)
 {
-	int new_halo = impl_->add(x,y,image, loc, orientation, infinite);
+	int new_halo = impl_->add(x,y,image, loc, orientation, infinite, parallax_r, z_order, pixel_offset_x, pixel_offset_y);
 	return handle(new halo_record(new_halo, impl_));
 }
 

--- a/src/halo.hpp
+++ b/src/halo.hpp
@@ -50,8 +50,8 @@ public:
 	 * shroud is active.  (Note it will be shown with the fog active.)
 	 * If it is not attached to an item, the location should be set to -1, -1
 	 */
-	handle add(int x, int y, const std::string& image, const map_location& loc,
-			halo::ORIENTATION orientation=NORMAL, bool infinite=true);
+	handle add(int x, int y, const std::string& image, const map_location& loc, halo::ORIENTATION orientation=NORMAL,
+		bool infinite=true, float parallax = 1.0f, float z_order = 0.0f,  int pixel_offset_x = 0, int pixel_offset_y = 0);
 
 	/** Set the position of an existing haloing effect, according to its handle. */
 	void set_location(const handle & h, int x, int y);

--- a/src/overlay.hpp
+++ b/src/overlay.hpp
@@ -15,7 +15,14 @@
 
 #pragma once
 
+#include "animated.hpp"
+#include "config.hpp"
+#include "drawing_layer.hpp"
 #include "halo.hpp"
+#include "map/location.hpp"
+#include "picture.hpp"
+
+#include <chrono>
 
 struct overlay
 {
@@ -25,8 +32,14 @@ struct overlay
 			const std::string& overlay_team_name,
 			const std::string& item_id,
 			const bool fogged,
+			const bool multihex,
 			float submerge,
-			float item_z_order = 0)
+			float parallax_r,
+			int layer = 0,
+			float item_z_order = 0,
+			std::chrono::milliseconds duration = std::chrono::milliseconds(0),
+			int pixel_offset_x = 0,
+			int pixel_offset_y = 0)
 		: image(img)
 		, halo(halo_img)
 		, team_name(overlay_team_name)
@@ -34,9 +47,20 @@ struct overlay
 		, id(item_id)
 		, halo_handle()
 		, visible_in_fog(fogged)
+		, multihex(multihex)
 		, submerge(submerge)
+		, parallax_r(parallax_r)
+		, layer(layer)
 		, z_order(item_z_order)
-	{}
+		, duration(duration)
+		, pixel_offset_x(pixel_offset_x)
+		, pixel_offset_y(pixel_offset_y)
+	{
+		if(this->layer != 0) { // Offset layer to match unit layer. So that they behave the same way. (Gap between "terrain_bg" and "unit_first")
+			constexpr int layer_offset = static_cast<int>(drawing_layer::unit_first) - static_cast<int>(drawing_layer::terrain_bg);
+			this->layer += layer_offset;
+		}
+	}
 
 
 	overlay(const config& cfg)
@@ -47,8 +71,14 @@ struct overlay
 		, id(cfg["id"])
 		, halo_handle()
 		, visible_in_fog(cfg["visible_in_fog"].to_bool())
+		, multihex(cfg["multihex"].to_bool())
 		, submerge(cfg["submerge"].to_double(0))
+		, parallax_r(cfg["parallax_r"].to_double(1.0))
+		, layer(cfg["layer"].to_int(0))
 		, z_order(cfg["z_order"].to_double(0))
+		, duration(std::chrono::milliseconds(cfg["duration"].to_int(0)))
+		, pixel_offset_x(cfg["pixel_offset_x"].to_int(0))
+		, pixel_offset_y(cfg["pixel_offset_y"].to_int(0))
 	{
 	}
 
@@ -60,7 +90,21 @@ struct overlay
 
 	halo::handle halo_handle;
 	bool visible_in_fog;
-	float submerge;
-	float z_order;
+	bool multihex; // True if this overlay is part of a multihex overlay.
+	float submerge; // How deep the overlay is submerged on water hexes (0.0 = not submerged).
+	float parallax_r; // Radial parallax factor for the overlay, (How fast it moves during scrolling, 1.0 = normal, <1.0 = slower, >1.0 = faster).
+	int layer; // Layer offset for the overlay, higher values are drawn on top of lower values. Halos are always on top.
+	float z_order; // Layer offset for the overlay within a layer. Images are sorted by layer and then z_order within each layer.
+	std::chrono::milliseconds duration; // Duration before the overlay is removed in ms, 0 means infinite.
+	int pixel_offset_x;
+	int pixel_offset_y;
 
+	// Other support
+	bool is_animated = false;
+	bool is_child = false;         // A child overlay part of an larger multihex image (center part is parent)
+	map_location parent_location;  // Location of parent hex for multihex children (used for submerge calculation)
+	int child_height = 0;        // Height of child hex (used for submerge calculation)
+	std::vector<std::pair<std::string, map_location>> child_hexes; // Locations and ids of child hexes if multihex (stored in parents)
+	animated<image::locator> animation; // Manages the sequence of frames and timing for animated overlays.
+	image::locator image_static; // Locator for static (non-animated) overlays.
 };

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -4184,8 +4184,14 @@ int game_lua_kernel::intf_add_tile_overlay(lua_State *L)
 			team_name,
 			cfg["name"], // Name is treated as the ID
 			cfg["visible_in_fog"].to_bool(true),
+			cfg["multihex"].to_bool(false),
 			cfg["submerge"].to_double(0),
-			cfg["z_order"].to_double(0)
+			cfg["parallax_r"].to_double(1.0),
+			cfg["layer"].to_int(0),
+			cfg["z_order"].to_double(0),
+			std::chrono::milliseconds(cfg["duration"].to_int(0)),
+			cfg["pixel_offset_x"].to_int(0),
+			cfg["pixel_offset_y"].to_int(0)
 		));
 	}
 	return 0;


### PR DESCRIPTION
A completed collection of my add_overlay PRs.

The purpose of these additions is to give more options when placing images and animations on the map. I myself need this to further develop weather and scenery effects. There are plenty of other use cases as well.

Cleaned up into commits that should be easy for review.

Contains new image options: animation, multihex, parallax, pixel_offset_x, pixel_offset_y, layer and duration. See the "change entry" commit for more details.

Called in WML like:

```
[item]
	x,y=102,157
	halo=data/add-ons/Animated_Weather_and_Scenery/images/great_continent.png
	duration=25000
	parallax_r=1.03
	pixel_offset_x=12
	pixel_offset_y=-49
[/item]
```

or in Lua like:

`wesnoth.interface.add_hex_overlay(103, 161, { layer=-20, duration=3700, multihex=true, pixel_offset_y=99, image = "data/add-ons/Animated_Weather_and_Scenery/images/scenery/god_game/1/[1~6].png~O(60%)"})`

Edit: I have write access to the wiki so I would take care of the documentation. Also, have a look at any of the closed PRs linked below in order to see how these features appear in game. I got images and videos.