### PR TITLE
[Units] Great Horse impact RIPLIB fix

### DIFF
--- a/data/core/units/monsters/Horse_Great.cfg
+++ b/data/core/units/monsters/Horse_Great.cfg
@@ -26,7 +26,7 @@
     [resistance]
         blade=100
         pierce=120
-        impact=110
+        impact=90
     [/resistance]
     {DEFENSE_ANIM "units/monsters/horse/horse-larger-defend-2.png" "units/monsters/horse/horse-larger-defend-1.png" {SOUND_LIST:HORSE_HIT} }
     [attack]


### PR DESCRIPTION
Currently, Bay Horse has 10% impact resistance, and most cavalry units have positive impact resistance, but Great Horse (which levels up from Bay Horse) currently has -10% impact resistance. It is a RIPLIB violation, and seems like an accident rather than intentional design, so this PR fixes this oversight.