### PR TITLE
Use a 'priority' attribute in weapon specials with value

### DIFF
--- a/changelog_entries/priority_chance_to_hit.md
+++ b/changelog_entries/priority_chance_to_hit.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * Add a 'priority' to specials with value of zero by default so that values returned by lower priority specials are considered as a basis for higher priority specials.

--- a/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
@@ -715,7 +715,14 @@
                     id=forced_cth
                     [effect]
                         apply_to=attack
-                        set_accuracy=100
+                        [set_specials]
+                            mode=append
+                            [chance_to_hit]
+                                id=force_cth
+                                value=100
+                                priority=-10
+                            [/chance_to_hit]
+                        [/set_specials]
                     [/effect]
                 [/object]
             [/modify_unit]

--- a/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
@@ -325,7 +325,16 @@
                         [effect]
                             apply_to=attack
                             range=ranged
-                            increase_accuracy=20
+                            [set_specials]
+                                mode=append
+                                [chance_to_hit]
+                                    id=accuracy_20
+                                    name=_"accuracy: +20%"
+                                    description=_"The accuracy of this weapon is increased of 20%"
+                                    add=20
+                                    priority=-10
+                                [/chance_to_hit]
+                            [/set_specials]
                         [/effect]
                     )}
                 [/option]
@@ -440,7 +449,16 @@
                 [effect]
                     apply_to=attack
                     range=ranged
-                    increase_accuracy=10
+                    [set_specials]
+                        mode=append
+                        [chance_to_hit]
+                            id=accuracy_10
+                            name=_"accuracy: +10%"
+                            description=_"The accuracy of this weapon is increased of 10%"
+                            add=10
+                            priority=-10
+                        [/chance_to_hit]
+                    [/set_specials]
                 [/effect]
             )}
             [+command]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
@@ -63,9 +63,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 2}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     [attack]
         name=glaive
@@ -78,9 +77,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/champion-defend2.png" "units/quenoth/champion-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
@@ -53,9 +53,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/fighter-defend-2.png" "units/quenoth/fighter-defend-1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
@@ -68,9 +68,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/flanker-defend2.png" "units/quenoth/flanker-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
@@ -69,9 +69,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 20}
         [/specials]
-        parry=20
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/ranger-defend2.png" "units/quenoth/ranger-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
@@ -62,9 +62,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 2}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     [attack]
         name=glaive
@@ -77,9 +76,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/warrior-defend-2.png" "units/quenoth/warrior-defend-1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -164,9 +164,8 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
             [specials]
                 {WEAPON_SPECIAL_USES_ATTACKS 2}
                 {WEAPON_SPECIAL_TAUNT}
+                {WEAPON_SPECIAL_PARRYING 30}
             [/specials]
-            parry = 30
-            defense_weight = 0
         [/effect]
         [effect]
             apply_to = attack

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -667,6 +667,27 @@ _ "At the start of the turn this unit increases movement points of surrounding u
     [/dummy]
 #enddef
 
+#define STR_PARRYING_10
+_ "This unit sees its defense reinforced by 10% when this weapon is used in offense"#enddef
+
+#define STR_PARRYING_20
+_ "This unit sees its defense reinforced by 20% when this weapon is used in offense"#enddef
+
+#define STR_PARRYING_30
+_ "This unit sees its defense reinforced by 30% when this weapon is used in offense"#enddef
+
+#define WEAPON_SPECIAL_PARRYING VALUE
+    [chance_to_hit]
+        id=parrying{VALUE}
+        name=_"parrying: " + "{VALUE}"
+        description={STR_PARRYING_{VALUE}}
+        sub={VALUE}
+        priority=-10
+        apply_to=opponent
+        active_on=offense
+    [/chance_to_hit]
+#enddef
+
 # These are all direct clones of the mainline healing abilities, except that
 # they are set to exclude units suffering from dehydration. Dehydration is only
 # delayed by healers, so they must not actually heal a dehydrated unit any
@@ -978,32 +999,10 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
                     [chance_to_hit]
                         id=self_dazed
                         name_affected="<span color='#DD6F6F'>" + _"accuracy:" + "</span>" + " -10%"
-                        description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
+                        description_affected=_"Because this unit is dazed, its accuracy is decreased by 10%"
                         sub=10
+                        priority=-10
                         [filter_student]
-                            [filter_weapon]
-                                [not]
-                                    special_id=magical
-                                [/not]
-                                [not]
-                                    special_id_active=marksman
-                                [/not]
-                            [/filter_weapon]
-                            status=dazed
-                        [/filter_student]
-                    [/chance_to_hit]
-                    [chance_to_hit]
-                        id=self_dazed
-                        name_affected="<span color='#DD6F6F'>" + _"accuracy:" + "</span>" + " -10%"
-                        description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
-                        sub=10
-                        [filter_base_value]
-                            greater_than_equal_to=70
-                        [/filter_base_value]
-                        [filter_student]
-                            [filter_weapon]
-                                special_id_active=marksman
-                            [/filter_weapon]
                             status=dazed
                         [/filter_student]
                     [/chance_to_hit]

--- a/data/core/macros/utils.cfg
+++ b/data/core/macros/utils.cfg
@@ -555,6 +555,7 @@
                         [overwrite]
                             priority=1000
                         [/overwrite]
+                        priority=1000
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]
@@ -611,6 +612,7 @@
                         [overwrite]
                             priority=1000
                         [/overwrite]
+                        priority=1000
                         [filter_opponent]
                             {SECOND_FILTER}
                         [/filter_opponent]

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -159,6 +159,7 @@
         description= _ "This attack is 10% more accurate than other attacks."
         special_note= _ "This unit’s “honed” attack is slightly more accurate than other attacks."
         add=10
+        priority=-10
     [/chance_to_hit]
 #enddef
 

--- a/data/schema/filters/abilities.cfg
+++ b/data/schema/filters/abilities.cfg
@@ -15,6 +15,7 @@
 	{SIMPLE_KEY sub s_int_range_list_default}
 	{SIMPLE_KEY multiply s_real_range_list_default}
 	{SIMPLE_KEY divide s_real_range_list_default}
+	{SIMPLE_KEY priority s_real_range_list_default}
 	{SIMPLE_KEY cumulative s_bool}
 	{SIMPLE_KEY affect_adjacent s_bool}
 	{SIMPLE_KEY affect_self s_bool}

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -56,6 +56,7 @@
 	{SIMPLE_KEY divide f_real}
 	{SIMPLE_KEY max_value s_f_int}
 	{SIMPLE_KEY min_value s_f_int}
+	{SIMPLE_KEY priority real}
 	{SIMPLE_KEY cumulative bool}
 	{DEPRECATED_KEY backstab bool}
 	{FILTER_TAG "filter_base_value" base_value ()}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_priority_high.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_priority_high.cfg
@@ -1,0 +1,31 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks]priority=
+##
+# Actions:
+# Give the leaders a attacks ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_priority_high" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 6 (priority=10) SELF=yes}
+                    {TEST_ABILITY attacks 10 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_priority_low.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_priority_low.cfg
@@ -1,0 +1,31 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks]priority=
+##
+# Actions:
+# Give the leaders a attacks ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_priority_low" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 10 (priority=-10) SELF=yes}
+                    {TEST_ABILITY attacks 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_priority_high.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_priority_high.cfg
@@ -1,0 +1,35 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit]priority=
+##
+# Actions:
+# Give the leaders a chance_to_hit ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 0 times, because [chance_to_hit]value=100 has lower priority than [chance_to_hit]value=0
+# The side 1 leader's second weapon strikes 0 times, because [chance_to_hit]value=100 has lower priority than [chance_to_hit]value=0
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_priority_high" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 0 (priority=10) SELF=yes}
+                    {TEST_ABILITY chance_to_hit 100 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "0,0" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_priority_low.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_priority_low.cfg
@@ -1,0 +1,35 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit]priority=
+##
+# Actions:
+# Give the leaders a chance_to_hit ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 0 times, because [chance_to_hit]value=100 has lower priority than [chance_to_hit]value=0
+# The side 1 leader's second weapon strikes 0 times, because [chance_to_hit]value=100 has lower priority than [chance_to_hit]value=0
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_priority_low" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 100 (priority=-10) SELF=yes}
+                    {TEST_ABILITY chance_to_hit 0 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "0,0" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_priority_high.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_priority_high.cfg
@@ -1,0 +1,32 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]priority=
+##
+# Actions:
+# Give the leaders a damage ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+## The side 1 leader has 2 weapons each of which now has 6 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_priority_high" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 6 (priority=10) SELF=yes}
+                    {TEST_ABILITY damage 10 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_priority_low.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_priority_low.cfg
@@ -1,0 +1,32 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]priority=
+##
+# Actions:
+# Give the leaders a damage ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 damage
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_priority_low" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 10 (priority=-10) SELF=yes}
+                    {TEST_ABILITY damage 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_priority_high.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_priority_high.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains]priority=
+##
+# Actions:
+# Give the leaders a drains ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was drainsd when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_priority_high" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 6 (priority=10) SELF=yes}
+                    {TEST_ABILITY drains 10 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_priority_low.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_priority_low.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains]priority=
+##
+# Actions:
+# Give the leaders a drains ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was drainsd when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_priority_low" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 6 () SELF=yes}
+                    {TEST_ABILITY drains 10 (priority=-10) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_priority_high.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_priority_high.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit]priority=
+##
+# Actions:
+# Give the leaders a heal_on_hit ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was heal_on_hitd when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_priority_high" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 6 (priority=10) SELF=yes}
+                    {TEST_ABILITY heal_on_hit 10 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_priority_low.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_priority_low.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit]priority=
+##
+# Actions:
+# Give the leaders a heal_on_hit ability with both the priority and value attributes
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was heal_on_hitd when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_priority_low" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 6 () SELF=yes}
+                    {TEST_ABILITY heal_on_hit 10 (priority=-10) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+
+        {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+        {SUCCEED}
+    [/event]
+) SIDE2_LEADER="Elvish Archer"}

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -1239,7 +1239,6 @@ attack_type::specials_context_t::specials_context_t(attack_type::specials_contex
 }
 
 
-
 namespace { // Helpers for attack_type::special_active()
 
 	/**
@@ -1793,7 +1792,7 @@ namespace
 		bool no_value_weapon_abilities_check =  abilities_list::no_weapon_number_tags().count(tag_name) != 0 || abilities_list::ability_no_value_tags().count(tag_name) != 0;
 		if(filter.has_attribute("cumulative") && no_value_weapon_abilities_check)
 			return false;
-		if(filter.has_attribute("value") && no_value_weapon_abilities_check)
+		if(filter.has_attribute("value") && no_value_weapon_abilities_check && tag_name != "berserk")
 			return false;
 		if(filter.has_attribute("add") && no_value_weapon_abilities_check)
 			return false;
@@ -1802,6 +1801,8 @@ namespace
 		if(filter.has_attribute("multiply") && no_value_weapon_abilities_check)
 			return false;
 		if(filter.has_attribute("divide") && no_value_weapon_abilities_check)
+			return false;
+		if(filter.has_attribute("priority") && no_value_weapon_abilities_check)
 			return false;
 
 		bool all_engine =  abilities_list::no_weapon_number_tags().count(tag_name) != 0 || abilities_list::weapon_number_tags().count(tag_name) != 0 || abilities_list::ability_value_tags().count(tag_name) != 0 || abilities_list::ability_no_value_tags().count(tag_name) != 0;
@@ -1864,6 +1865,9 @@ namespace
 			return false;
 
 		if(!string_matches_if_present(filter, cfg, "active_on", "both"))
+			return false;
+
+		if(!double_matches_if_present(filter, cfg, "priority"))
 			return false;
 
 		//value, add, sub multiply and divide check values of attribute used in engines abilities(default value of 'value' can be checked when not specified)

--- a/src/units/ability_tags.hpp
+++ b/src/units/ability_tags.hpp
@@ -49,13 +49,13 @@ struct ability_list_defines
 
 	static const std::set<std::string>& weapon_number_tags()
 	{
-		static std::set<std::string> tags{attacks, damage, chance_to_hit, berserk, swarm, drains, heal_on_hit};
+		static std::set<std::string> tags{attacks, damage, chance_to_hit, drains, heal_on_hit};
 		return tags;
 	}
 
 	static const std::set<std::string>& no_weapon_number_tags()
 	{
-		static std::set<std::string> tags{disable, plague, slow, petrifies, firststrike, poison, damage_type};
+		static std::set<std::string> tags{berserk, disable, plague, slow, petrifies, firststrike, swarm, poison, damage_type};
 		return tags;
 	}
 

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -275,6 +275,12 @@ private:
 	 * @param ab the ability/special checked
 	 */
 	bool overwrite_special_checking(active_ability_list& overwriters, const unit_ability_t& ab) const;
+	/** Return the special weapon values, considering specials.
+	 * @param abil_list The list of special checked.
+	 * @param base_value The value modified or not by function.
+	 * @param is_cth if true, value must be between 0 and 100.
+	 */
+	std::pair<int, double> get_composites_values(const active_ability_list& abil_list, double base_value, bool is_cth = false) const;
 
 	bool special_active(const unit_ability_t& ab, AFFECTS whom) const;
 

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -807,6 +807,8 @@
 0 tunnel_source_teleport_unit_fail
 0 tunnel_source_teleport_unit_succeed
 # attacks ability tests
+0 attacks_priority_high
+0 attacks_priority_low
 9 attacks_negative_value
 0 attacks_zero
 0 attacks_add
@@ -882,6 +884,8 @@
 0 berserk_overwrite_specials_mixed
 0 berserk_different_values
 # chance_to_hit ability tests
+0 chance_to_hit_priority_high
+0 chance_to_hit_priority_low
 0 chance_to_hit_negative_value
 0 chance_to_hit_add
 0 chance_to_hit_add_cumulative
@@ -917,6 +921,8 @@
 0 chance_to_hit_overwrite_specials_two_one_side
 0 chance_to_hit_overwrite_specials_mixed
 # damage ability tests
+0 damage_priority_high
+0 damage_priority_low
 0 damage_negative_value
 0 damage_zero
 0 damage_add
@@ -1019,6 +1025,8 @@
 0 disable_affect_enemies
 0 disable_affect_everybody
 # drains ability tests
+0 drains_priority_high
+0 drains_priority_low
 0 drains_negative_value
 0 drains_zero
 0 drains_add
@@ -1068,6 +1076,8 @@
 0 firststrike_affect_enemies
 0 firststrike_affect_everybody
 # heal_on_hit ability tests
+0 heal_on_hit_priority_high
+0 heal_on_hit_priority_low
 0 heal_on_hit_negative_value
 0 heal_on_hit_zero
 0 heal_on_hit_add


### PR DESCRIPTION
Use a 'priority' attribute in specials with value
 I implemented a priority system in the special weapons to improve on the concept of https://github.com/wesnoth/wesnoth/pull/10526.

The idea is that calculations are prioritized from lowest priority to highest, with the result of the previous step serving as the basis for the next step.