### PR TITLE
add a 'base_stat' attribute in specials with value

### DIFF
--- a/changelog_entries/base_stat_specials.md
+++ b/changelog_entries/base_stat_specials.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * add a 'base_stat' attribute to special with value(attacks/chance_to_hit/damage/drains/heal_on_hit) so that the value modified when base_stat=yes is treated as a base value by other special of same type.

--- a/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
+++ b/data/campaigns/Eastern_Invasion/scenarios/13_Spoils_of_War.cfg
@@ -715,7 +715,14 @@
                     id=forced_cth
                     [effect]
                         apply_to=attack
-                        set_accuracy=100
+                        [set_specials]
+                            mode=append
+                            [chance_to_hit]
+                                id=force_cth
+                                value=100
+                                base_stat=yes
+                            [/chance_to_hit]
+                        [/set_specials]
                     [/effect]
                 [/object]
             [/modify_unit]

--- a/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
+++ b/data/campaigns/Sceptre_of_Fire/utils/rune-equip.cfg
@@ -325,7 +325,16 @@
                         [effect]
                             apply_to=attack
                             range=ranged
-                            increase_accuracy=20
+                            [set_specials]
+                                mode=append
+                                [chance_to_hit]
+                                    id=accuracy_20
+                                    name=_"accuracy: +20%"
+                                    description=_"The accuracy of this weapon is increased of 20%"
+                                    add=20
+                                    base_stat=yes
+                                [/chance_to_hit]
+                            [/set_specials]
                         [/effect]
                     )}
                 [/option]
@@ -440,7 +449,16 @@
                 [effect]
                     apply_to=attack
                     range=ranged
-                    increase_accuracy=10
+                    [set_specials]
+                        mode=append
+                        [chance_to_hit]
+                            id=accuracy_10
+                            name=_"accuracy: +10%"
+                            description=_"The accuracy of this weapon is increased of 10%"
+                            add=10
+                            base_stat=yes
+                        [/chance_to_hit]
+                    [/set_specials]
                 [/effect]
             )}
             [+command]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Champion.cfg
@@ -63,9 +63,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 2}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     [attack]
         name=glaive
@@ -78,9 +77,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/champion-defend2.png" "units/quenoth/champion-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Fighter.cfg
@@ -53,9 +53,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/fighter-defend-2.png" "units/quenoth/fighter-defend-1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Flanker.cfg
@@ -68,9 +68,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/flanker-defend2.png" "units/quenoth/flanker-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Ranger.cfg
@@ -69,9 +69,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 20}
         [/specials]
-        parry=20
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/ranger-defend2.png" "units/quenoth/ranger-defend1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Warrior.cfg
@@ -62,9 +62,8 @@
         [specials]
             {WEAPON_SPECIAL_FIRSTSTRIKE}
             {WEAPON_SPECIAL_USES_ATTACKS 2}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     [attack]
         name=glaive
@@ -77,9 +76,8 @@
         attacks_used=1
         [specials]
             {WEAPON_SPECIAL_USES_ATTACKS 1}
+            {WEAPON_SPECIAL_PARRYING 10}
         [/specials]
-        parry=10
-        defense_weight=0
     [/attack]
     {DEFENSE_ANIM "units/quenoth/warrior-defend-2.png" "units/quenoth/warrior-defend-1.png" {SOUND_LIST:ELF_HIT}}
     [attack_anim]

--- a/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/units/quenoth/Youth.cfg
@@ -247,7 +247,10 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         [effect]
             apply_to = attack
             name = bow
-            increase_accuracy = 10
+            [set_specials]
+                mode=append
+                {WEAPON_SPECIAL_ACCURACY}
+            [/set_specials]
         [/effect]
         [effect]
             apply_to = attack
@@ -478,7 +481,10 @@ _"Nym is Kaleh’s childhood friend, a young, rebellious lady with quick wits an
         [effect]
             apply_to = attack
             name = sword
-            increase_accuracy = 10
+            [set_specials]
+                mode=append
+                {WEAPON_SPECIAL_ACCURACY}
+            [/set_specials]
         [/effect]
         [effect]
             apply_to = hitpoints

--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -667,6 +667,34 @@ _ "At the start of the turn this unit increases movement points of surrounding u
     [/dummy]
 #enddef
 
+#define STR_PARRYING_10
+_ "This unit sees its defense reinforced by 10% when this weapon is used in offense"#enddef
+
+#define STR_PARRYING_20
+_ "This unit sees its defense reinforced by 20% when this weapon is used in offense"#enddef
+
+#define WEAPON_SPECIAL_PARRYING VALUE
+    [chance_to_hit]
+        id=parrying{VALUE}
+        name=_"parrying: " + "{VALUE}"
+        description={STR_PARRYING_{VALUE}}
+        sub={VALUE}
+        base_stat=yes
+        apply_to=opponent
+        active_on=offense
+    [/chance_to_hit]
+#enddef
+
+#define WEAPON_SPECIAL_ACCURACY
+    [chance_to_hit]
+        id=accuracy_10
+        name=_"accuracy: +10%"
+        description=_"The accuracy of this weapon is increased of 10%"
+        add=10
+        base_stat=yes
+    [/chance_to_hit]
+#enddef
+
 # These are all direct clones of the mainline healing abilities, except that
 # they are set to exclude units suffering from dehydration. Dehydration is only
 # delayed by healers, so they must not actually heal a dehydrated unit any
@@ -978,32 +1006,10 @@ Marksman attacks are only affected if the chance to hit is greater than 60%."
                     [chance_to_hit]
                         id=self_dazed
                         name_affected="<span color='#DD6F6F'>" + _"accuracy:" + "</span>" + " -10%"
-                        description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
+                        description_affected=_"Because this unit is dazed, its accuracy is decreased by 10%"
                         sub=10
+                        base_stat=yes
                         [filter_student]
-                            [filter_weapon]
-                                [not]
-                                    special_id=magical
-                                [/not]
-                                [not]
-                                    special_id_active=marksman
-                                [/not]
-                            [/filter_weapon]
-                            status=dazed
-                        [/filter_student]
-                    [/chance_to_hit]
-                    [chance_to_hit]
-                        id=self_dazed
-                        name_affected="<span color='#DD6F6F'>" + _"accuracy:" + "</span>" + " -10%"
-                        description_affected=_ "Because this unit is dazed, its accuracy is decreased by 10%"
-                        sub=10
-                        [filter_base_value]
-                            greater_than_equal_to=70
-                        [/filter_base_value]
-                        [filter_student]
-                            [filter_weapon]
-                                special_id_active=marksman
-                            [/filter_weapon]
                             status=dazed
                         [/filter_student]
                     [/chance_to_hit]

--- a/data/core/macros/weapon_specials.cfg
+++ b/data/core/macros/weapon_specials.cfg
@@ -159,6 +159,7 @@
         description= _ "This attack is 10% more accurate than other attacks."
         special_note= _ "This unit’s “honed” attack is slightly more accurate than other attacks."
         add=10
+        base_stat=yes
     [/chance_to_hit]
 #enddef
 

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -56,6 +56,7 @@
 	{SIMPLE_KEY max_value s_f_int}
 	{SIMPLE_KEY min_value s_f_int}
 	{SIMPLE_KEY cumulative bool}
+	{SIMPLE_KEY base_stat bool}
 	{DEPRECATED_KEY backstab bool}
 	{FILTER_TAG "filter_base_value" base_value ()}
 [/tag]

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_base_stat_mixed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_base_stat_mixed.cfg
@@ -1,0 +1,31 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks]base_stat=
+##
+# Actions:
+# Give the leaders a attacks ability with both the base_stat and value attributes and a attacks with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes (10 is ignored)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_base_stat_mixed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 10 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY attacks 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_base_stat_mixed_cumulative.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_base_stat_mixed_cumulative.cfg
@@ -1,0 +1,31 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks]base_stat=
+##
+# Actions:
+# Give the leaders a attacks ability with both the base_stat and value attributes and a attacks with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes (5 is the base value)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_base_stat_mixed_cumulative" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 6 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY attacks 2 () CUMULATIVE=yes SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_base_stat_one.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/attacks/attacks_base_stat_one.cfg
@@ -1,0 +1,30 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [attacks]base_stat=
+##
+# Actions:
+# Give the leaders a attacks ability with both the base_stat and value attributes and a attacks with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 strikes
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "attacks_base_stat_one" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 6 (base_stat=yes) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "6,6" ({SUCCEED})}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_base_stat_mixed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_base_stat_mixed.cfg
@@ -1,0 +1,35 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit]base_stat=
+##
+# Actions:
+# Give the leaders a chance_to_hit ability with both the base_stat and value attributes and a chance_to_hit with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 0 times, because the normal [chance_to_hit]value=0 completely replaces the base value
+# The side 1 leader's second weapon strikes 0 times, because the normal [chance_to_hit]value=0 completely replaces the base value
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_base_stat_mixed" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 100 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY chance_to_hit 0 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "0,0" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_base_stat_mixed_cumulative.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_base_stat_mixed_cumulative.cfg
@@ -1,0 +1,35 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit]base_stat=
+##
+# Actions:
+# Give the leaders a chance_to_hit ability with both the base_stat and value attributes and a chance_to_hit with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 100 times, because other [chance_to_hit] choose higher value between base or own value
+# The side 1 leader's second weapon strikes 100 times, because other [chance_to_hit] choose higher value between base or own value
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_base_stat_mixed_cumulative" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 100 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY chance_to_hit 0 () CUMULATIVE=yes SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "100,100" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_base_stat_one.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/chance_to_hit/chance_to_hit_base_stat_one.cfg
@@ -1,0 +1,34 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [chance_to_hit]base_stat=
+##
+# Actions:
+# Give the leaders a chance_to_hit ability with both the base_stat and value attributes and a chance_to_hit with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader's first weapon strikes 100 times, because not other [chance_to_hit]
+# The side 1 leader's second weapon strikes 100 times, because not other [chance_to_hit]
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "chance_to_hit_base_stat_one" (
+    [event]
+        name = start
+
+        {SET_HP VALUE=1000}
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY attacks 100 () SELF=yes}
+                    {TEST_ABILITY chance_to_hit 100 (base_stat=yes) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {CHECK_STRIKES "100,100" ({SUCCEED}) (CHANCE_TO_HIT=)}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_base_stat_mixed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_base_stat_mixed.cfg
@@ -1,0 +1,31 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]base_stat=
+##
+# Actions:
+# Give the leaders a damage ability with both the base_stat and value attributes and a damage with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 damage (value=10 is ignored)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_base_stat_mixed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 10 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY damage 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_base_stat_mixed_cumulative.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_base_stat_mixed_cumulative.cfg
@@ -1,0 +1,31 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]base_stat=
+##
+# Actions:
+# Give the leaders a damage ability with both the base_stat and value attributes and a damage with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 damage (base_value of 6)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_base_stat_mixed_cumulative" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 6 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY damage 2 () CUMULATIVE=yes SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_base_stat_one.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/damage/damage_base_stat_one.cfg
@@ -1,0 +1,30 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [damage]base_stat=
+##
+# Actions:
+# Give the leaders a damage ability with both the base_stat and value attributes and a damage with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The side 1 leader has 2 weapons each of which now has 6 damage (5+1)
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "damage_base_stat_one" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY damage 6 (base_stat=yes) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 6 (DAMAGE_VALUE=) WEAPON_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_base_stat_mixed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_base_stat_mixed.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains]base_stat=
+##
+# Actions:
+# Give the leaders a drains ability with both the base_stat and value attributes and a drains with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp(value=10 is ignored)
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_base_stat_mixed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 10 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY drains 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_base_stat_mixed_cumulative.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_base_stat_mixed_cumulative.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains]base_stat=
+##
+# Actions:
+# Give the leaders a drains ability with both the base_stat and value attributes and a drains with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp(value=6 is highest value because of cumulative)
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_base_stat_mixed_cumulative" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 6 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY drains 2 () CUMULATIVE=yes SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_base_stat_one.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/drains/drains_base_stat_one.cfg
@@ -1,0 +1,32 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [drains]base_stat=
+##
+# Actions:
+# Give the leaders a drains ability with both the base_stat and value attributes and a drains with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "drains_base_stat_one" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY drains 6 (base_stat=yes) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_base_stat_mixed.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_base_stat_mixed.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit]base_stat=
+##
+# Actions:
+# Give the leaders a heal_on_hit ability with both the base_stat and value attributes and a heal_on_hit with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp(value=10 is ignored)
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_base_stat_mixed" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 10 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY heal_on_hit 6 () SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_base_stat_mixed_cumulative.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_base_stat_mixed_cumulative.cfg
@@ -1,0 +1,33 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit]base_stat=
+##
+# Actions:
+# Give the leaders a heal_on_hit ability with both the base_stat and value attributes and a heal_on_hit with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp(value=6 is highest value because of cumulative)
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_base_stat_mixed_cumulative" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 6 (base_stat=yes) SELF=yes}
+                    {TEST_ABILITY heal_on_hit 2 () CUMULATIVE=yes SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+)}

--- a/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_base_stat_one.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/AbilitiesWML/heal_on_hit/heal_on_hit_base_stat_one.cfg
@@ -1,0 +1,32 @@
+# wmllint: no translatables
+
+#####
+# API(s) being tested: [heal_on_hit]base_stat=
+##
+# Actions:
+# Give the leaders a heal_on_hit ability with both the base_stat and value attributes and a heal_on_hit with value attribute
+# Have the side 1 leader attack the side 2 leader with both its weapons
+##
+# Expected end state:
+# The both leaders have 2 weapons each of which now heals 6 hp
+# The leader of side 1 heals 6 hp total since it has full hp when its first strike is made
+# The leader of side 2 heals 12 hp total since it was damaged when its first strike was made
+#####
+{COMMON_KEEP_A_B_UNIT_TEST "heal_on_hit_base_stat_one" (
+    [event]
+        name = start
+
+        [modify_unit]
+            [filter]
+            [/filter]
+            [effect]
+                apply_to = new_ability
+                [abilities]
+                    {TEST_ABILITY heal_on_hit 6 (base_stat=yes) SELF=yes}
+                [/abilities]
+            [/effect]
+        [/modify_unit]
+    [/event]
+
+    {ATTACK_AND_VALIDATE 194 DAMAGE2=188 STRIKE_COUNT=2}
+)}

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -820,6 +820,9 @@
 0 attacks_affect_self_no
 0 attacks_affect_enemies
 0 attacks_affect_everybody
+0 attacks_base_stat_mixed_cumulative
+0 attacks_base_stat_one
+0 attacks_base_stat_mixed
 0 attacks_divide
 0 attacks_high_fraction
 0 attacks_low_fraction
@@ -894,6 +897,9 @@
 0 chance_to_hit_affect_self_no
 0 chance_to_hit_affect_enemies
 0 chance_to_hit_affect_everybody
+0 chance_to_hit_base_stat_mixed_cumulative
+0 chance_to_hit_base_stat_one
+0 chance_to_hit_base_stat_mixed
 0 chance_to_hit_divide
 0 chance_to_hit_multiply
 0 chance_to_hit_multiply_divide
@@ -930,6 +936,9 @@
 0 damage_affect_self_no
 0 damage_affect_enemies
 0 damage_affect_everybody
+0 damage_base_stat_mixed_cumulative
+0 damage_base_stat_one
+0 damage_base_stat_mixed
 0 damage_divide
 0 damage_high_fraction
 0 damage_low_fraction
@@ -1032,6 +1041,9 @@
 0 drains_affect_self_no
 0 drains_affect_enemies
 0 drains_affect_everybody
+0 drains_base_stat_mixed_cumulative
+0 drains_base_stat_one
+0 drains_base_stat_mixed
 0 drains_divide
 0 drains_high_fraction
 0 drains_low_fraction
@@ -1081,6 +1093,9 @@
 0 heal_on_hit_affect_self_no
 0 heal_on_hit_affect_enemies
 0 heal_on_hit_affect_everybody
+0 heal_on_hit_base_stat_mixed_cumulative
+0 heal_on_hit_base_stat_one
+0 heal_on_base_stat_mixed
 0 heal_on_hit_divide
 0 heal_on_hit_high_fraction
 0 heal_on_hit_low_fraction


### PR DESCRIPTION
This is a generalization of the approach explored with https://github.com/wesnoth/wesnoth/pull/10526 to special weapons using standard value attributes, although I don't see if this will be useful outside of [chance_to_hit]