### PR TITLE
1.18 Fix missing call to gui2::build in gui.show_dialog implementation

### DIFF
--- a/src/scripting/lua_widget_methods.cpp
+++ b/src/scripting/lua_widget_methods.cpp
@@ -71,7 +71,7 @@ int intf_show_dialog(lua_State* L)
 	std::unique_ptr<gui2::window> wp;
 	try {
 		gui2::builder_window::window_resolution def(def_cfg);
-		wp = std::make_unique<gui2::window>(def);
+		wp = gui2::build(def);
 	} catch (const wml_exception& error) {
 		error.caught();
 		error.show();


### PR DESCRIPTION
A mistake introduced by commit 9ac7e7dc2122ec517207e3e29ca2e011a47a15d0 made it so dialogs have no widgets at all. The reason for the mistake being present in the patch is that it's a backport from master, which itself has a change in commit a96ce07e35efb644038c6a0e5481ddf535eab092 that removed gui2::build. Since 1.18 is supposed to be a stable branch, it does not include this change, resulting in a broken backport.

Closes #10654.