### PR TITLE
Add white aura as Illuminates default halo

### DIFF
--- a/data/campaigns/Eastern_Invasion/utils/items.cfg
+++ b/data/campaigns/Eastern_Invasion/utils/items.cfg
@@ -145,7 +145,7 @@ crystal_quiver #enddef
         [effect]
             apply_to=new_ability
             [abilities]
-                {ABILITY_ILLUMINATES HALO="halo/illuminates-aura.png"}
+                {ABILITY_ILLUMINATES}
                 {ABILITY_ARCANE_RANGED}
             [/abilities]
         [/effect]

--- a/data/core/macros/abilities.cfg
+++ b/data/core/macros/abilities.cfg
@@ -233,7 +233,7 @@ All adjacent lower-level units from the same side deal 25% more damage for each 
     # Canned definition of the Illuminates ability to be included in an
     # [abilities] clause.
 #arg HALO
-""#endarg
+"halo/illuminates-aura.png"#endarg
     [illuminates]
         id=illumination
         value=25

--- a/data/core/units/humans/Mage_of_Light.cfg
+++ b/data/core/units/humans/Mage_of_Light.cfg
@@ -25,7 +25,7 @@ Following a strict code of piety and honor, these men and women work tirelessly 
     die_sound={SOUND_LIST:HUMAN_OLD_DIE}
     {DEFENSE_ANIM "units/human-magi/white-cleric-defend.png" "units/human-magi/white-cleric.png" {SOUND_LIST:HUMAN_OLD_HIT} }
     [abilities]
-        {ABILITY_ILLUMINATES HALO="halo/illuminates-aura.png"}
+        {ABILITY_ILLUMINATES}
         {ABILITY_CURES}
     [/abilities]
     [resistance]

--- a/data/core/units/merfolk/Diviner.cfg
+++ b/data/core/units/merfolk/Diviner.cfg
@@ -23,7 +23,7 @@
     die_sound=mermaid-die.ogg
     {DEFENSE_ANIM "units/merfolk/diviner-defend2.png" "units/merfolk/diviner-defend1.png" mermaid-hit.ogg }
     [abilities]
-        {ABILITY_ILLUMINATES HALO="halo/illuminates-aura.png"}
+        {ABILITY_ILLUMINATES}
         {ABILITY_CURES}
     [/abilities]
     [healing_anim]

--- a/data/test/scenarios/manual_tests/scenario-test.cfg
+++ b/data/test/scenarios/manual_tests/scenario-test.cfg
@@ -219,7 +219,7 @@ Xu, Xu, Qxu, Qxu, Ql, Ql, Ql, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Xu, Gg, Gg, Gg, Gg, Gg
             [/modifications]
             [abilities]
                 {ABILITY_SKIRMISHER}
-                {ABILITY_ILLUMINATES HALO="halo/illuminates-aura.png"}
+                {ABILITY_ILLUMINATES}
             [/abilities]
         [/unit]
 


### PR DESCRIPTION
Following up on a17369597c4869938d0a44a70bd9708452c0fd6b, this sets the default halo for Illuminates ability to the white aura (`"halo/illuminates-aura.png"`) instead of "No aura". The former is more useful than a default empty one based on Wesnoth history. If someone needs to set a blank/empty halo, `{ABILITY_ILLUMINATES HALO=""}` makes the intent clear (which I seriously doubt why, but there may be edge cases.)

Based on the user expectation that "Adding an illuminates ability should actually illuminate something".

This means that just adding `{ABILITY_ILLUMINATES}` to an unit/unit type will auto add the white aura, and the halo key on [unit_type] is not needed for that purpose. Without this PR, that will also work but you'll need `{ABILITY_ILLUMINATES HALO="halo/illuminates-aura.png")`  a173695 added support for standalone halo on abilities, but didn't add a default halo.

[Came across this while testing the registry from #10644.]