### PR TITLE
Help: keep the manager implementation private

### DIFF
--- a/src/help/help.hpp
+++ b/src/help/help.hpp
@@ -19,15 +19,13 @@ class terrain_type;
 class unit;
 class unit_type;
 
-#include "help/help_impl.hpp"
-
-#include <boost/logic/tribool.hpp>
-
 #include <memory>
 #include <string>
 
 namespace help
 {
+struct section;
+
 /**
  * The help implementation caches data parsed from the game_config. This class
  * is used to control the lifecycle of that cache, so that the cache will be
@@ -45,16 +43,17 @@ public:
 	help_manager(const help_manager&) = delete;
 	help_manager& operator=(const help_manager&) = delete;
 
+	~help_manager();
+
 	/** Returns the existing help_manager instance, or a newly allocated object otherwise. */
 	static std::shared_ptr<help_manager> get_instance();
 
-	/** Regenerates the cached help topics if necessary. */
-	void verify_cache();
-
-	const section& toplevel_section() const
-	{
-		return default_toplevel_;
-	}
+	/**
+	 * Regenerates the cached help topics if necessary.
+	 *
+	 * @returns the toplevel section.
+	 */
+	const section& regenerate();
 
 private:
 	/**
@@ -62,18 +61,12 @@ private:
 	 *
 	 * Use @ref get_instance to get a managed instance instead.
 	 */
-	help_manager() = default;
+	help_manager();
 
-	int last_num_encountered_units_{-1};
-	int last_num_encountered_terrains_{-1};
+	class implementation;
 
-	boost::tribool last_debug_state_{boost::indeterminate};
-
-	/** The default toplevel. */
-	section default_toplevel_;
-
-	/** All sections and topics not referenced from the default toplevel. */
-	section hidden_sections_;
+	/** Pointer-to-implementation to reduce include dependencies. */
+	std::unique_ptr<implementation> impl_;
 
 	static inline std::shared_ptr<help_manager> singleton_;
 };


### PR DESCRIPTION
Prevents excessive recompilation if you change help_impl.hpp. Said include was only needed in help.hpp because help_manager owns its own sections.