### PR TITLE
Ability refactor part 2

### DIFF
--- a/src/formula/callable_objects.cpp
+++ b/src/formula/callable_objects.cpp
@@ -119,9 +119,9 @@ variant attack_type_callable::get_value(const std::string& key) const
 	} else if(key == "specials" || key == "special") {
 		std::vector<variant> res;
 
-		for(const auto [_, special_cfg] : att_->specials().all_children_view()) {
-			if(!special_cfg["id"].empty()) {
-				res.emplace_back(special_cfg["id"].str());
+		for(const auto& p_ab : att_->specials()) {
+			if(!p_ab->cfg()["id"].empty()) {
+				res.emplace_back(p_ab->cfg()["id"].str());
 			}
 		}
 		return variant(res);
@@ -183,14 +183,14 @@ int attack_type_callable::do_compare(const formula_callable* callable) const
 		return att_->alignment_str().compare(att_callable->att_->alignment_str());
 	}
 
-	const auto self_specials = att_->specials().all_children_range();
-	const auto other_specials = att_callable->att_->specials().all_children_range();
+	const auto& self_specials = att_->specials();
+	const auto& other_specials = att_callable->att_->specials();
 	if(self_specials.size() != other_specials.size()) {
 		return self_specials.size() < other_specials.size() ? -1 : 1;
 	}
 	for(std::size_t i = 0; i < self_specials.size(); ++i) {
-		const auto& s = self_specials[i].cfg["id"];
-		const auto& o = other_specials[i].cfg["id"];
+		const auto& s = self_specials[i]->cfg()["id"];
+		const auto& o = other_specials[i]->cfg()["id"];
 		if(s != o) {
 			return s.str().compare(o.str());
 		}

--- a/src/scripting/lua_unit_attacks.cpp
+++ b/src/scripting/lua_unit_attacks.cpp
@@ -269,7 +269,7 @@ static int impl_unit_attack_get(lua_State *L)
 	return_int_attrib("parry", attack.parry());
 	return_int_attrib("max_range", attack.max_range());
 	return_int_attrib("min_range", attack.min_range());
-	return_cfgref_attrib("specials", attack.specials());
+	return_cfgref_attrib("specials", attack.specials_cfg());
 	return_cfgref_attrib("__cfg", attack.to_config());
 	if(luaW_getmetafield(L, 1, m)) {
 		return 1;
@@ -307,7 +307,7 @@ static int impl_unit_attack_set(lua_State *L)
 	modify_int_attrib("min_range", attack.set_min_range(value));
 
 	if(strcmp(m, "specials") == 0) {
-		attack.set_specials(luaW_checkconfig(L, 3));
+		attack.set_specials_cfg(luaW_checkconfig(L, 3));
 		return 0;
 	}
 

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -169,16 +169,16 @@ const team& get_team(std::size_t side)
  * for the question "is this unit next to an ally that has a 'camoflages adjacent allies' ability";
  * not the question "is this unit next to an enemy, therefore visible".
  */
-bool affects_side(const config& cfg, std::size_t side, std::size_t other_side)
+bool affects_side(const unit_ability_t& ab, std::size_t side, std::size_t other_side)
 {
 	const team& side_team = get_team(side);
 
 	if(side == other_side)
-		return cfg["affect_allies"].to_bool(true);
+		return ab.cfg()["affect_allies"].to_bool(true);
 	if(side_team.is_enemy(other_side))
-		return cfg["affect_enemies"].to_bool();
+		return ab.cfg()["affect_enemies"].to_bool();
 	else
-		return cfg["affect_allies"].to_bool();
+		return ab.cfg()["affect_allies"].to_bool();
 }
 
 /**
@@ -203,8 +203,8 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 {
 	// Check that the unit has an ability of tag_name type which meets the conditions to be active.
 	// If so, return true.
-	for (const config &i : this->abilities_.child_range(tag_name)) {
-		if (get_self_ability_bool(i, tag_name, loc))
+	for (const auto& p_ab : this->abilities(tag_name)) {
+		if (get_self_ability_bool(*p_ab, loc))
 		{
 			return true;
 		}
@@ -228,8 +228,8 @@ bool unit::get_ability_bool(const std::string& tag_name, const map_location& loc
 			continue;
 		}
 		int dir = find_direction(loc, from_loc, distance);
-		for(const config& i : u.abilities_.child_range(tag_name)) {
-			if(get_adj_ability_bool(i, tag_name, distance, dir, loc, u, from_loc)) {
+		for(const auto& p_ab : u.abilities(tag_name)) {
+			if(get_adj_ability_bool(*p_ab, distance, dir, loc, u, from_loc)) {
 				return true;
 			}
 		}
@@ -245,10 +245,10 @@ active_ability_list unit::get_abilities(const std::string& tag_name, const map_l
 
 	// Check that the unit has an ability of tag_name type which meets the conditions to be active.
 	// If so, add to active_ability_list.
-	for(const config& i : this->abilities_.child_range(tag_name)) {
-		if (get_self_ability_bool(i, tag_name, loc))
+	for(const auto& p_ab : this->abilities(tag_name)) {
+		if (get_self_ability_bool(*p_ab, loc))
 		{
-			res.emplace_back(&i, loc, loc);
+			res.emplace_back(p_ab, loc, loc);
 		}
 	}
 
@@ -270,9 +270,9 @@ active_ability_list unit::get_abilities(const std::string& tag_name, const map_l
 			continue;
 		}
 		int dir = find_direction(loc, from_loc, distance);
-		for(const config& i : u.abilities_.child_range(tag_name)) {
-			if(get_adj_ability_bool(i, tag_name, distance, dir, loc, u, from_loc)) {
-				res.emplace_back(&i, loc, from_loc);
+		for(const auto& p_ab : u.abilities(tag_name)) {
+			if(get_adj_ability_bool(*p_ab, distance, dir, loc, u, from_loc)) {
+				res.emplace_back(p_ab, loc, from_loc);
 			}
 		}
 	}
@@ -285,7 +285,7 @@ active_ability_list unit::get_abilities_weapons(const std::string& tag_name, con
 {
 	active_ability_list res = get_abilities(tag_name, loc);
 	utils::erase_if(res, [&](const active_ability& i) {
-		return !ability_affects_weapon(i.ability_cfg(), weapon, false) || !ability_affects_weapon(i.ability_cfg(), opp_weapon, true);
+		return !ability_affects_weapon(i.ability(), weapon, false) || !ability_affects_weapon(i.ability(), opp_weapon, true);
 	});
 	return res;
 }
@@ -294,8 +294,8 @@ std::vector<std::string> unit::get_ability_list() const
 {
 	std::vector<std::string> res;
 
-	for(const auto [key, cfg] : this->abilities_.all_children_view()) {
-		std::string id = cfg["id"];
+	for(const auto& p_ab : this->abilities()) {
+		std::string id = p_ab->cfg()["id"];
 		if (!id.empty())
 			res.push_back(std::move(id));
 	}
@@ -310,34 +310,34 @@ namespace {
 	 *
 	 * @returns Whether name was resolved and quadruple added.
 	 */
-	bool add_ability_tooltip(const config& ab, const std::string& tag_name, unit_race::GENDER gender, std::vector<std::tuple<std::string, t_string,t_string,t_string>>& res, bool active)
+	bool add_ability_tooltip(const unit_ability_t& ab, unit_race::GENDER gender, std::vector<std::tuple<std::string, t_string,t_string,t_string>>& res, bool active)
 	{
 		if(active) {
-			const t_string& name = gender_value(ab, gender, "name", "female_name", "name").t_str();
+			const t_string& name = gender_value(ab.cfg(), gender, "name", "female_name", "name").t_str();
 
 			if(!name.empty()) {
 				res.emplace_back(
-						ab["id"],
-						ab["name"].t_str(),
-						unit_abilities::substitute_variables(name, tag_name, ab),
-						unit_abilities::substitute_variables(ab["description"].t_str(), tag_name, ab));
+					ab.cfg()["id"],
+					ab.cfg()["name"].t_str(),
+						unit_abilities::substitute_variables(name, ab),
+						unit_abilities::substitute_variables(ab.cfg()["description"].t_str(), ab));
 				return true;
 			}
 		} else {
 			// See if an inactive name was specified.
 			const config::attribute_value& inactive_value =
-				gender_value(ab, gender, "name_inactive",
+				gender_value(ab.cfg(), gender, "name_inactive",
 						"female_name_inactive", "name_inactive");
 			const t_string& name = !inactive_value.blank() ? inactive_value.t_str() :
-				gender_value(ab, gender, "name", "female_name", "name").t_str();
-			const t_string& desc = ab.get_or("description_inactive", "description").t_str();
+				gender_value(ab.cfg(), gender, "name", "female_name", "name").t_str();
+			const t_string& desc = ab.cfg().get_or("description_inactive", "description").t_str();
 
 			if(!name.empty()) {
 				res.emplace_back(
-						ab["id"],
-						ab.get_or("name_inactive", "name").t_str(),
-						unit_abilities::substitute_variables(name, tag_name, ab),
-						unit_abilities::substitute_variables(desc, tag_name, ab));
+					ab.cfg()["id"],
+					ab.cfg().get_or("name_inactive", "name").t_str(),
+						unit_abilities::substitute_variables(name, ab),
+						unit_abilities::substitute_variables(desc, ab));
 				return true;
 			}
 		}
@@ -350,9 +350,9 @@ std::vector<std::tuple<std::string, t_string, t_string, t_string>> unit::ability
 {
 	std::vector<std::tuple<std::string, t_string,t_string,t_string>> res;
 
-	for(const auto [tag_name, cfg] : abilities_.all_children_view())
+	for(const auto& p_ab : abilities())
 	{
-		add_ability_tooltip(cfg, tag_name, gender_, res, true);
+		add_ability_tooltip(*p_ab, gender_, res, true);
 	}
 
 	return res;
@@ -363,10 +363,10 @@ std::vector<std::tuple<std::string, t_string, t_string, t_string>> unit::ability
 	std::vector<std::tuple<std::string, t_string,t_string,t_string>> res;
 	active_list.clear();
 
-	for(const auto [tag_name, cfg] : abilities_.all_children_view())
+	for(const auto& p_ab : abilities())
 	{
-		bool active = ability_active(tag_name, cfg, loc);
-		if(add_ability_tooltip(cfg, tag_name, gender_, res, active))
+		bool active = ability_active(*p_ab, loc);
+		if(add_ability_tooltip(*p_ab, gender_, res, active))
 		{
 			active_list.push_back(active);
 		}
@@ -447,17 +447,17 @@ unit::recursion_guard::~recursion_guard()
 	}
 }
 
-bool unit::ability_active(const std::string& ability,const config& cfg,const map_location& loc) const
+bool unit::ability_active(const unit_ability_t& ab, const map_location& loc) const
 {
-	auto filter_lock = update_variables_recursion(cfg);
+	auto filter_lock = update_variables_recursion(ab.cfg());
 	if(!filter_lock) {
-		show_recursion_warning(*this, cfg);
+		show_recursion_warning(*this, ab.cfg());
 		return false;
 	}
-	return ability_active_impl(ability, cfg, loc);
+	return ability_active_impl(ab, loc);
 }
 
-static bool ability_active_adjacent_helper(const unit& self, bool illuminates, const config& cfg, const map_location& loc, bool in_abilities_tag)
+static bool ability_active_adjacent_helper(const unit& self, bool illuminates, const unit_ability_t& ab, const map_location& loc, bool in_abilities_tag)
 {
 	const auto adjacent = get_adjacent_tiles(loc);
 
@@ -467,7 +467,7 @@ static bool ability_active_adjacent_helper(const unit& self, bool illuminates, c
 	const std::string& filter_adjacent = in_abilities_tag ? "filter_adjacent_student" : "filter_adjacent";
 	const std::string& filter_adjacent_location = in_abilities_tag ? "filter_adjacent_student_location" : "filter_adjacent_location";
 
-	for(const config &i : cfg.child_range(filter_adjacent)) {
+	for(const config &i : ab.cfg().child_range(filter_adjacent)) {
 		std::size_t radius = i["radius"].to_int(1);
 		std::size_t count = 0;
 		unit_filter ufilt{ vconfig(i) };
@@ -510,7 +510,7 @@ static bool ability_active_adjacent_helper(const unit& self, bool illuminates, c
 		}
 	}
 
-	for(const config &i : cfg.child_range(filter_adjacent_location)) {
+	for(const config &i : ab.cfg().child_range(filter_adjacent_location)) {
 		std::size_t count = 0;
 		terrain_filter adj_filter(vconfig(i), resources::filter_con, false);
 		adj_filter.flatten(illuminates);
@@ -532,33 +532,33 @@ static bool ability_active_adjacent_helper(const unit& self, bool illuminates, c
 	return true;
 }
 
-bool unit::ability_active_impl(const std::string& ability,const config& cfg,const map_location& loc) const
+bool unit::ability_active_impl(const unit_ability_t& ab,const map_location& loc) const
 {
-	bool illuminates = ability == "illuminates";
+	bool illuminates = ab.tag() == "illuminates";
 
-	if (auto afilter = cfg.optional_child("filter"))
+	if (auto afilter = ab.cfg().optional_child("filter"))
 		if ( !unit_filter(vconfig(*afilter)).set_use_flat_tod(illuminates).matches(*this, loc) )
 			return false;
 
-	if(!ability_active_adjacent_helper(*this, illuminates, cfg, loc, false)) {
+	if(!ability_active_adjacent_helper(*this, illuminates, ab, loc, false)) {
 		return false;
 	}
 
 	return true;
 }
 
-bool unit::ability_affects_adjacent(const std::string& ability, const config& cfg, std::size_t dist, int dir, const map_location& loc, const unit& from) const
+bool unit::ability_affects_adjacent(const unit_ability_t& ab, std::size_t dist, int dir, const map_location& loc, const unit& from) const
 {
-	if(!cfg.has_child("affect_adjacent")) {
+	if(!ab.cfg().has_child("affect_adjacent")) {
 		return false;
 	}
-	bool illuminates = ability == "illuminates";
+	bool illuminates = ab.tag() == "illuminates";
 
 	assert(dir >=0 && dir <= 5);
 	map_location::direction direction{ dir };
 	std::size_t radius = 1;
 
-	for (const config &i : cfg.child_range("affect_adjacent"))
+	for (const config &i : ab.cfg().child_range("affect_adjacent"))
 	{
 		if(i["radius"] != "all_map") {
 			radius = i["radius"].to_int(1);
@@ -583,28 +583,28 @@ bool unit::ability_affects_adjacent(const std::string& ability, const config& cf
 	return false;
 }
 
-bool unit::ability_affects_self(const std::string& ability,const config& cfg,const map_location& loc) const
+bool unit::ability_affects_self(const unit_ability_t& ab, const map_location& loc) const
 {
-	auto filter = cfg.optional_child("filter_self");
-	bool affect_self = cfg["affect_self"].to_bool(true);
+	auto filter = ab.cfg().optional_child("filter_self");
+	bool affect_self = ab.cfg()["affect_self"].to_bool(true);
 	if (!filter || !affect_self) return affect_self;
-	return unit_filter(vconfig(*filter)).set_use_flat_tod(ability == "illuminates").matches(*this, loc);
+	return unit_filter(vconfig(*filter)).set_use_flat_tod(ab.tag() == "illuminates").matches(*this, loc);
 }
 
-bool unit::ability_affects_weapon(const config& cfg, const const_attack_ptr& weapon, bool is_opp) const
+bool unit::ability_affects_weapon(const unit_ability_t& ab, const const_attack_ptr& weapon, bool is_opp) const
 {
 	const std::string filter_tag_name = is_opp ? "filter_second_weapon" : "filter_weapon";
-	if(!cfg.has_child(filter_tag_name)) {
+	if(!ab.cfg().has_child(filter_tag_name)) {
 		return true;
 	}
-	const config& filter = cfg.mandatory_child(filter_tag_name);
+	const config& filter = ab.cfg().mandatory_child(filter_tag_name);
 	if(!weapon) {
 		return false;
 	}
 	attack_type::recursion_guard filter_lock;
-	filter_lock  = weapon->update_variables_recursion(cfg);
+	filter_lock  = weapon->update_variables_recursion(ab.cfg());
 	if(!filter_lock) {
-		show_recursion_warning(*this, cfg);
+		show_recursion_warning(*this, ab.cfg());
 		return false;
 	}
 	return weapon->matches_filter(filter);
@@ -612,7 +612,7 @@ bool unit::ability_affects_weapon(const config& cfg, const const_attack_ptr& wea
 
 bool unit::has_ability_type(const std::string& ability) const
 {
-	return !abilities_.child_range(ability).empty();
+	return !abilities(ability).empty();
 }
 
 //these two functions below are used in order to add to the unit
@@ -627,15 +627,15 @@ static void add_string_to_vector(std::vector<std::string>& image_list, const con
 std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_type) const
 {
 	std::vector<std::string> image_list;
-	for(const auto [key, cfg] : abilities_.all_children_view()){
-		bool is_active = ability_active(key, cfg, loc_);
+	for(const auto& p_ab : abilities()){
+		bool is_active = ability_active(*p_ab, loc_);
 		//Add halo/overlay to owner of ability if active and affect_self is true.
-		if( !cfg[image_type + "_image"].str().empty() && is_active && ability_affects_self(key, cfg, loc_)){
-			add_string_to_vector(image_list, cfg,image_type + "_image");
+		if( !p_ab->cfg()[image_type + "_image"].str().empty() && is_active && ability_affects_self(*p_ab, loc_)){
+			add_string_to_vector(image_list, p_ab->cfg(), image_type + "_image");
 		}
 		//Add halo/overlay to owner of ability who affect adjacent only if active.
-		if(!cfg[image_type + "_image_self"].str().empty() && is_active){
-			add_string_to_vector(image_list, cfg, image_type + "_image_self");
+		if(!p_ab->cfg()[image_type + "_image_self"].str().empty() && is_active){
+			add_string_to_vector(image_list, p_ab->cfg(), image_type + "_image_self");
 		}
 	}
 
@@ -651,10 +651,10 @@ std::vector<std::string> unit::halo_or_icon_abilities(const std::string& image_t
 			continue;
 		}
 		int dir = find_direction(loc_, from_loc, distance);
-		for(const auto [key, cfg] : u.abilities_.all_children_view()) {
-			if(!cfg[image_type + "_image"].str().empty() && get_adj_ability_bool(cfg, key, distance, dir, loc_, u, from_loc))
+		for(const auto& p_ab : u.abilities()) {
+			if(!p_ab->cfg()[image_type + "_image"].str().empty() && get_adj_ability_bool(*p_ab, distance, dir, loc_, u, from_loc))
 			{
-				add_string_to_vector(image_list, cfg, image_type + "_image");
+				add_string_to_vector(image_list, p_ab->cfg(), image_type + "_image");
 			}
 		}
 	}
@@ -815,12 +815,12 @@ template std::pair<int, map_location> active_ability_list::get_extremum<std::gre
  */
 bool attack_type::has_special(const std::string& special, bool simple_check) const
 {
-	if(simple_check && specials().has_child(special)) {
+	if(simple_check && !specials(special).empty()) {
 		return true;
 	}
 
-	for(const config &i : specials().child_range(special)) {
-		if(special_active(i, AFFECT_SELF, special)) {
+	for(const ability_ptr& p_ab : specials(special)) {
+		if(special_active(*p_ab, AFFECT_SELF)) {
 			return true;
 		}
 	}
@@ -830,8 +830,8 @@ bool attack_type::has_special(const std::string& special, bool simple_check) con
 		return false;
 	}
 
-	for(const config &i : other_attack_->specials().child_range(special)) {
-		if(other_attack_->special_active(i, AFFECT_OTHER, special)) {
+	for(const ability_ptr& p_ab : other_attack_->specials(special)) {
+		if(other_attack_->special_active(*p_ab, AFFECT_OTHER)) {
 			return true;
 		}
 	}
@@ -848,9 +848,9 @@ active_ability_list attack_type::get_specials(const std::string& special) const
 	const map_location loc = self_ ? self_->get_location() : self_loc_;
 	active_ability_list res(loc);
 
-	for(const config& i : specials_.child_range(special)) {
-		if(special_active(i, AFFECT_SELF, special)) {
-			res.emplace_back(&i, loc, loc);
+	for(const ability_ptr& p_ab : specials(special)) {
+		if(special_active(*p_ab, AFFECT_SELF)) {
+			res.emplace_back(p_ab, loc, loc);
 		}
 	}
 
@@ -858,9 +858,9 @@ active_ability_list attack_type::get_specials(const std::string& special) const
 		return res;
 	}
 
-	for(const config& i : other_attack_->specials_.child_range(special)) {
-		if(other_attack_->special_active(i, AFFECT_OTHER, special)) {
-			res.emplace_back(&i, other_loc_, other_loc_);
+	for(const ability_ptr& p_ab : other_attack_->specials(special)) {
+		if(other_attack_->special_active(*p_ab, AFFECT_OTHER)) {
+			res.emplace_back(p_ab, other_loc_, other_loc_);
 		}
 	}
 	return res;
@@ -884,24 +884,24 @@ std::vector<std::pair<t_string, t_string>> attack_type::special_tooltips(
 		active_list->clear();
 	}
 
-	for(const auto [key, cfg] : specials_.all_children_view()) {
-		bool active = !active_list || special_active(cfg, AFFECT_EITHER, key);
+	for(const auto& p_ab : specials()) {
+		bool active = !active_list || special_active(*p_ab, AFFECT_EITHER);
 
 		std::string name = active
-			? cfg["name"].str()
-			: cfg.get_or("name_inactive", "name").str();
+			? p_ab->cfg()["name"].str()
+			: p_ab->cfg().get_or("name_inactive", "name").str();
 
 		if(name.empty()) {
 			continue;
 		}
 
 		std::string desc = active
-			? cfg["description"].str()
-			: cfg.get_or("description_inactive", "description").str();
+			? p_ab->cfg()["description"].str()
+			: p_ab->cfg().get_or("description_inactive", "description").str();
 
 		res.emplace_back(
-			unit_abilities::substitute_variables(name, key, cfg),
-			unit_abilities::substitute_variables(desc, key, cfg)
+			unit_abilities::substitute_variables(name, *p_ab),
+			unit_abilities::substitute_variables(desc, *p_ab)
 		);
 
 		if(active_list) {
@@ -922,11 +922,11 @@ std::vector<std::pair<t_string, t_string>> attack_type::abilities_special_toolti
 	if(!self_) {
 		return res;
 	}
-	for(const auto [key, cfg] : self_->abilities().all_children_view()) {
-		if(self_->get_self_ability_bool(cfg, key, self_loc_) && special_tooltip_active(cfg, key)) {
-			bool active = !active_list || special_active(cfg, AFFECT_SELF, key);
-			const std::string name = cfg["name_affected"];
-			const std::string desc = cfg["description_affected"];
+	for(const auto& p_ab : self_->abilities()) {
+		if(self_->get_self_ability_bool(*p_ab, self_loc_) && special_tooltip_active(*p_ab)) {
+			bool active = !active_list || special_active(*p_ab, AFFECT_SELF);
+			const std::string name = p_ab->cfg()["name_affected"];
+			const std::string desc = p_ab->cfg()["description_affected"];
 
 			if(name.empty() || checking_name.count(name) != 0) {
 				continue;
@@ -948,11 +948,11 @@ std::vector<std::pair<t_string, t_string>> attack_type::abilities_special_toolti
 			continue;
 		}
 		int dir = find_direction(self_loc_, from_loc, distance);
-		for(const auto [key, cfg] : u.abilities().all_children_view()) {
-			if(self_->get_adj_ability_bool(cfg, key, distance, dir, self_loc_, u, from_loc) && special_tooltip_active(cfg, key)) {
-				bool active = !active_list || special_active(cfg, AFFECT_SELF, key);
-				const std::string name = cfg["name_affected"];
-				const std::string desc = cfg["description_affected"];
+		for(const auto& p_ab : u.abilities()) {
+			if(self_->get_adj_ability_bool(*p_ab, distance, dir, self_loc_, u, from_loc) && special_tooltip_active(*p_ab)) {
+				bool active = !active_list || special_active(*p_ab, AFFECT_SELF);
+				const std::string name = p_ab->cfg()["name_affected"];
+				const std::string desc = p_ab->cfg()["description_affected"];
 
 				if(name.empty() || checking_name.count(name) != 0) {
 					continue;
@@ -995,22 +995,22 @@ static void add_name(std::string& temp_string, bool active, const std::string& n
 std::string attack_type::weapon_specials() const
 {
 	//log_scope("weapon_specials");
-	std::vector<std::string> specials;
+	std::vector<std::string> special_names;
 
-	for(const auto [key, cfg] : specials_.all_children_view()) {
-		const bool active = special_active(cfg, AFFECT_EITHER, key);
+	for(const auto& p_ab : specials()) {
+		const bool active = special_active(*p_ab, AFFECT_EITHER);
 
 		std::string name = active
-			? cfg["name"].str()
-			: cfg.get_or("name_inactive", "name").str();
+			? p_ab->cfg()["name"].str()
+			: p_ab->cfg().get_or("name_inactive", "name").str();
 
 		if(name.empty()) {
 			continue;
 		}
 
-		name = unit_abilities::substitute_variables(name, key, cfg);
+		name = unit_abilities::substitute_variables(name, *p_ab);
 
-		specials.push_back(active ? std::move(name) : markup::span_color(font::INACTIVE_COLOR, name));
+		special_names.push_back(active ? std::move(name) : markup::span_color(font::INACTIVE_COLOR, name));
 	}
 
 	// FIXME: clean this up...
@@ -1020,10 +1020,10 @@ std::string attack_type::weapon_specials() const
 	weapon_specials_impl_adj(temp_string, self_, shared_from_this(), other_attack_, self_loc_, AFFECT_SELF, checking_name, {}, "affect_allies");
 
 	if(!temp_string.empty()) {
-		specials.push_back("\n" + std::move(temp_string));
+		special_names.push_back("\n" + std::move(temp_string));
 	}
 
-	return utils::join(specials, ", ");
+	return utils::join(special_names, ", ");
 }
 
 static void add_name_list(std::string& temp_string, std::string& weapon_abilities, std::set<std::string>& checking_name, const std::string& from_str)
@@ -1042,10 +1042,10 @@ std::string attack_type::weapon_specials_value(const std::set<std::string>& chec
 	//log_scope("weapon_specials_value");
 	std::string temp_string, weapon_abilities;
 	std::set<std::string> checking_name;
-	for(const auto [key, cfg] : specials_.all_children_view()) {
-		if(checking_tags.count(key) != 0) {
-			const bool active = special_active(cfg, AFFECT_SELF, key);
-			add_name(temp_string, active, cfg["name"].str(), checking_name);
+	for(const auto& p_ab : specials()) {
+		if(checking_tags.count(p_ab->tag()) != 0) {
+			const bool active = special_active(*p_ab, AFFECT_SELF);
+			add_name(temp_string, active, p_ab->cfg()["name"].str(), checking_name);
 		}
 	}
 	add_name_list(temp_string, weapon_abilities, checking_name, "");
@@ -1063,10 +1063,10 @@ std::string attack_type::weapon_specials_value(const std::set<std::string>& chec
 
 
 	if(other_attack_) {
-		for(const auto [key, cfg] : other_attack_->specials_.all_children_view()) {
-			if((checking_tags.count(key) != 0)){
-				const bool active = other_attack_->special_active(cfg, AFFECT_OTHER, key);
-				add_name(temp_string, active, cfg["name"].str(), checking_name);
+		for(const auto& p_ab : other_attack_->specials()) {
+			if((checking_tags.count(p_ab->tag()) != 0)){
+				const bool active = other_attack_->special_active(*p_ab, AFFECT_OTHER);
+				add_name(temp_string, active, p_ab->cfg()["name"].str(), checking_name);
 			}
 		}
 	}
@@ -1089,10 +1089,10 @@ void attack_type::weapon_specials_impl_self(
 	bool leader_bool)
 {
 	if(self){
-		for(const auto [key, cfg] : self->abilities().all_children_view()){
-			bool tag_checked = (!checking_tags.empty()) ? (checking_tags.count(key) != 0) : true;
-			const bool active = tag_checked && check_self_abilities_impl(self_attack, other_attack, cfg, self, self_loc, whom, key, leader_bool);
-			add_name(temp_string, active, cfg.get_or("name_affected", "name").str(), checking_name);
+		for(const auto& p_ab : self->abilities()){
+			bool tag_checked = (!checking_tags.empty()) ? (checking_tags.count(p_ab->tag()) != 0) : true;
+			const bool active = tag_checked && check_self_abilities_impl(self_attack, other_attack, *p_ab, self, self_loc, whom, leader_bool);
+			add_name(temp_string, active, p_ab->cfg().get_or("name_affected", "name").str(), checking_name);
 		}
 	}
 }
@@ -1121,12 +1121,12 @@ void attack_type::weapon_specials_impl_adj(
 				continue;
 			}
 			int dir = find_direction(self_loc, from_loc, distance);
-			for(const auto [key, cfg] : u.abilities().all_children_view()) {
-				bool tag_checked = !checking_tags.empty() ? checking_tags.count(key) != 0 : true;
+			for(const auto& p_ab : u.abilities()) {
+				bool tag_checked = !checking_tags.empty() ? checking_tags.count(p_ab->tag()) != 0 : true;
 				bool default_bool = affect_adjacents == "affect_allies" ? true : false;
-				bool affect_allies = !affect_adjacents.empty() ? cfg[affect_adjacents].to_bool(default_bool) : true;
-				const bool active = tag_checked && check_adj_abilities_impl(self_attack, other_attack, cfg, self, u, distance, dir, self_loc, from_loc, whom, key, leader_bool) && affect_allies;
-				add_name(temp_string, active, cfg.get_or("name_affected", "name").str(), checking_name);
+				bool affect_allies = !affect_adjacents.empty() ? p_ab->cfg()[affect_adjacents].to_bool(default_bool) : true;
+				const bool active = tag_checked && check_adj_abilities_impl(self_attack, other_attack, *p_ab, self, u, distance, dir, self_loc, from_loc, whom, leader_bool) && affect_allies;
+				add_name(temp_string, active, p_ab->cfg().get_or("name_affected", "name").str(), checking_name);
 			}
 		}
 	}
@@ -1390,13 +1390,13 @@ namespace { // Helpers for attack_type::special_active()
 	/**
 	 * Returns whether or not the given special affects the opponent of the unit
 	 * with the special.
-	 * @param[in]  special      a weapon special WML structure
+	 * @param ab                the ability/special
 	 * @param[in]  is_attacker  whether or not the unit with the special is the attacker
 	 */
-	bool special_affects_opponent(const config& special, bool is_attacker)
+	bool special_affects_opponent(const unit_ability_t& ab, bool is_attacker)
 	{
 		//log_scope("special_affects_opponent");
-		const std::string& apply_to = special["apply_to"];
+		const std::string& apply_to = ab.cfg()["apply_to"];
 		if ( apply_to.empty() )
 			return false;
 		if ( apply_to == "both" )
@@ -1412,13 +1412,13 @@ namespace { // Helpers for attack_type::special_active()
 
 	/**
 	 * Returns whether or not the given special affects the unit with the special.
-	 * @param[in]  special      a weapon special WML structure
+	 * @param ab                the ability/special
 	 * @param[in]  is_attacker  whether or not the unit with the special is the attacker
 	 */
-	bool special_affects_self(const config& special, bool is_attacker)
+	bool special_affects_self(const unit_ability_t& ab, bool is_attacker)
 	{
 		//log_scope("special_affects_self");
-		const std::string& apply_to = special["apply_to"];
+		const std::string& apply_to = ab.cfg()["apply_to"];
 		if ( apply_to.empty() )
 			return true;
 		if ( apply_to == "both" )
@@ -1560,13 +1560,13 @@ active_ability_list attack_type::get_weapon_ability(const std::string& ability) 
 	active_ability_list abil_list(loc);
 	if(self_) {
 		abil_list.append_if((*self_).get_abilities(ability, self_loc_), [&](const active_ability& i) {
-			return special_active(i.ability_cfg(), AFFECT_SELF, ability, true);
+			return special_active(i.ability(), AFFECT_SELF, true);
 		});
 	}
 
 	if(other_) {
 		abil_list.append_if((*other_).get_abilities(ability, other_loc_), [&](const active_ability& i) {
-			return special_active_impl(other_attack_, shared_from_this(), i.ability_cfg(), AFFECT_OTHER, ability, true);
+			return special_active_impl(other_attack_, shared_from_this(), i.ability(), AFFECT_OTHER, true);
 		});
 	}
 
@@ -1580,11 +1580,11 @@ active_ability_list attack_type::get_specials_and_abilities(const std::string& s
 	// append all such weapon specials as abilities as well
 	abil_list.append(get_weapon_ability(special));
 	// get a list of specials/"specials as abilities" that may potentially overwrite others
-	active_ability_list overwriters = overwrite_special_overwriter(abil_list, special);
+	active_ability_list overwriters = overwrite_special_overwriter(abil_list);
 	if(!abil_list.empty() && !overwriters.empty()){
 		// remove all abilities that would be overwritten
 		utils::erase_if(abil_list, [&](const active_ability& j) {
-			return (overwrite_special_checking(overwriters, j.ability_cfg(), special));
+			return (overwrite_special_checking(overwriters, j.ability()));
 		});
 	}
 	return abil_list;
@@ -1595,17 +1595,17 @@ int attack_type::composite_value(const active_ability_list& abil_list, int base_
 	return unit_abilities::effect(abil_list, base_value, shared_from_this()).get_composite_value();
 }
 
-static bool overwrite_special_affects(const config& special)
+static bool overwrite_special_affects(const unit_ability_t& ab)
 {
-	const std::string& apply_to = special["overwrite_specials"];
+	const std::string& apply_to = ab.cfg()["overwrite_specials"];
 	return (apply_to == "one_side" || apply_to == "both_sides");
 }
 
-active_ability_list attack_type::overwrite_special_overwriter(active_ability_list overwriters, const std::string& tag_name) const
+active_ability_list attack_type::overwrite_special_overwriter(active_ability_list overwriters) const
 {
 	//remove element without overwrite_specials key, if list empty after check return empty list.
 	utils::erase_if(overwriters, [&](const active_ability& i) {
-		return (!overwrite_special_affects(i.ability_cfg()));
+		return (!overwrite_special_affects(i.ability()));
 	});
 
 	// if empty, nothing is doing any overwriting
@@ -1631,13 +1631,13 @@ active_ability_list attack_type::overwrite_special_overwriter(active_ability_lis
 		});
 		// remove any that need to be overwritten
 		utils::erase_if(overwriters, [&](const active_ability& i) {
-			return (overwrite_special_checking(overwriters, i.ability_cfg(), tag_name));
+			return (overwrite_special_checking(overwriters, i.ability()));
 		});
 	}
 	return overwriters;
 }
 
-bool attack_type::overwrite_special_checking(active_ability_list& overwriters, const config& cfg, const std::string& tag_name) const
+bool attack_type::overwrite_special_checking(active_ability_list& overwriters, const unit_ability_t& ab) const
 {
 	if(overwriters.empty()){
 		return false;
@@ -1650,23 +1650,23 @@ bool attack_type::overwrite_special_checking(active_ability_list& overwriters, c
 		auto overwrite_specials = j.ability_cfg().optional_child("overwrite");
 		double priority = overwrite_specials ? overwrite_specials["priority"].to_double(0) : 0.00;
 		// the cfg being checked for whether it will be overwritten
-		auto has_overwrite_specials = cfg.optional_child("overwrite");
+		auto has_overwrite_specials = ab.cfg().optional_child("overwrite");
 		// if the overwriter's priority is greater than 0, then true if the cfg being checked has a higher priority
 		// else true
 		bool prior = (priority > 0) ? (has_overwrite_specials && has_overwrite_specials["priority"].to_double(0) >= priority) : true;
 		// true if the cfg being checked affects one or both sides and doesn't have a higher priority, or if it doesn't affect one or both sides
 		// aka whether the cfg being checked can potentially be overwritten by the current overwriter
-		bool is_overwritable = (overwrite_special_affects(cfg) && !prior) || !overwrite_special_affects(cfg);
+		bool is_overwritable = (overwrite_special_affects(ab) && !prior) || !overwrite_special_affects(ab);
 		bool one_side_overwritable = true;
 
 		// if the current overwriter affects one side and the cfg being checked can be overwritten by this overwriter
 		// then check that the current overwriter and the cfg being checked both affect either this unit or its opponent
 		if(affect_side && is_overwritable){
-			if(special_affects_self(j.ability_cfg(), is_attacker_)){
-				one_side_overwritable = special_affects_self(cfg, is_attacker_);
+			if(special_affects_self(j.ability(), is_attacker_)){
+				one_side_overwritable = special_affects_self(ab, is_attacker_);
 			}
-			else if(special_affects_opponent(j.ability_cfg(), !is_attacker_)){
-				one_side_overwritable = special_affects_opponent(cfg, !is_attacker_);
+			else if(special_affects_opponent(j.ability(), !is_attacker_)){
+				one_side_overwritable = special_affects_opponent(ab, !is_attacker_);
 			}
 		}
 
@@ -1681,7 +1681,7 @@ bool attack_type::overwrite_special_checking(active_ability_list& overwriters, c
 				}
 			}
 			if(overwrite_filter && is_overwritable && one_side_overwritable){
-				special_matches = special_matches_filter(cfg, tag_name, *overwrite_filter);
+				special_matches = special_matches_filter(ab, *overwrite_filter);
 			}
 		}
 
@@ -1695,60 +1695,60 @@ bool attack_type::overwrite_special_checking(active_ability_list& overwriters, c
 	return false;
 }
 
-bool unit::get_self_ability_bool(const config& cfg, const std::string& ability, const map_location& loc) const
+bool unit::get_self_ability_bool(const unit_ability_t& ab, const map_location& loc) const
 {
-	auto filter_lock = update_variables_recursion(cfg);
+	auto filter_lock = update_variables_recursion(ab.cfg());
 	if(!filter_lock) {
-		show_recursion_warning(*this, cfg);
+		show_recursion_warning(*this, ab.cfg());
 		return false;
 	}
-	return (ability_active_impl(ability, cfg, loc) && ability_affects_self(ability, cfg, loc));
+	return (ability_active_impl(ab, loc) && ability_affects_self(ab, loc));
 }
 
-bool unit::get_adj_ability_bool(const config& cfg, const std::string& ability, std::size_t dist, int dir, const map_location& loc, const unit& from, const map_location& from_loc) const
+bool unit::get_adj_ability_bool(const unit_ability_t& ab, std::size_t dist, int dir, const map_location& loc, const unit& from, const map_location& from_loc) const
 {
-	auto filter_lock = from.update_variables_recursion(cfg);
+	auto filter_lock = from.update_variables_recursion(ab.cfg());
 	if(!filter_lock) {
-		show_recursion_warning(from, cfg);
+		show_recursion_warning(from, ab.cfg());
 		return false;
 	}
-	return (affects_side(cfg, side(), from.side()) && from.ability_active_impl(ability, cfg, from_loc) && ability_affects_adjacent(ability, cfg, dist, dir, loc, from));
+	return (affects_side(ab, side(), from.side()) && from.ability_active_impl(ab, from_loc) && ability_affects_adjacent(ab, dist, dir, loc, from));
 }
 
-bool unit::get_self_ability_bool_weapon(const config& special, const std::string& tag_name, const map_location& loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
+bool unit::get_self_ability_bool_weapon(const unit_ability_t& ab, const map_location& loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
 {
-	return (get_self_ability_bool(special, tag_name, loc) && ability_affects_weapon(special, weapon, false) && ability_affects_weapon(special, opp_weapon, true));
+	return (get_self_ability_bool(ab, loc) && ability_affects_weapon(ab, weapon, false) && ability_affects_weapon(ab, opp_weapon, true));
 }
 
-bool unit::get_adj_ability_bool_weapon(const config& special, const std::string& tag_name, std::size_t dist, int dir, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
+bool unit::get_adj_ability_bool_weapon(const unit_ability_t& ab, std::size_t dist, int dir, const map_location& loc, const unit& from, const map_location& from_loc, const const_attack_ptr& weapon, const const_attack_ptr& opp_weapon) const
 {
-	return (get_adj_ability_bool(special, tag_name, dist, dir, loc, from, from_loc) && ability_affects_weapon(special, weapon, false) && ability_affects_weapon(special, opp_weapon, true));
+	return (get_adj_ability_bool(ab, dist, dir, loc, from, from_loc) && ability_affects_weapon(ab, weapon, false) && ability_affects_weapon(ab, opp_weapon, true));
 }
 
-bool attack_type::check_self_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const config& special, const unit_const_ptr& u, const map_location& loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
+bool attack_type::check_self_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const unit_ability_t& ab, const unit_const_ptr& u, const map_location& loc, AFFECTS whom, bool leader_bool)
 {
-	if(tag_name == "leadership" && leader_bool){
-		if(u->get_self_ability_bool_weapon(special, tag_name, loc, self_attack, other_attack)) {
+	if(ab.tag() == "leadership" && leader_bool) {
+		if(u->get_self_ability_bool_weapon(ab, loc, self_attack, other_attack)) {
 			return true;
 		}
 	}
-	if(abilities_list::all_weapon_tags().count(tag_name) != 0){
-		if(u->get_self_ability_bool(special, tag_name, loc) && special_active_impl(self_attack, other_attack, special, whom, tag_name, true)) {
+	if(abilities_list::all_weapon_tags().count(ab.tag()) != 0){
+		if(u->get_self_ability_bool(ab, loc) && special_active_impl(self_attack, other_attack, ab, whom, true)) {
 			return true;
 		}
 	}
 	return false;
 }
 
-bool attack_type::check_adj_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const config& special, const unit_const_ptr& u, const unit& from, std::size_t dist, int dir, const map_location& loc, const map_location& from_loc, AFFECTS whom, const std::string& tag_name, bool leader_bool)
+bool attack_type::check_adj_abilities_impl(const const_attack_ptr& self_attack, const const_attack_ptr& other_attack, const unit_ability_t& ab, const unit_const_ptr& u, const unit& from, std::size_t dist, int dir, const map_location& loc, const map_location& from_loc, AFFECTS whom, bool leader_bool)
 {
-	if(tag_name == "leadership" && leader_bool) {
-		if(u->get_adj_ability_bool_weapon(special, tag_name, dist, dir, loc, from, from_loc, self_attack, other_attack)) {
+	if(ab.tag() == "leadership" && leader_bool) {
+		if(u->get_adj_ability_bool_weapon(ab, dist, dir, loc, from, from_loc, self_attack, other_attack)) {
 			return true;
 		}
 	}
-	if(abilities_list::all_weapon_tags().count(tag_name) != 0) {
-		if(u->get_adj_ability_bool(special, tag_name, dist, dir, loc, from, from_loc) && special_active_impl(self_attack, other_attack, special, whom, tag_name, true)) {
+	if(abilities_list::all_weapon_tags().count(ab.tag()) != 0) {
+		if(u->get_adj_ability_bool(ab, dist, dir, loc, from, from_loc) && special_active_impl(self_attack, other_attack, ab, whom, true)) {
 			return true;
 		}
 	}
@@ -1763,8 +1763,8 @@ bool attack_type::has_ability_impl(
 	AFFECTS whom,
 	const std::string& special)
 {
-	for(const config &i : self->abilities().child_range(special)) {
-		if(check_self_abilities_impl(self_attack, other_attack, i, self, self_loc, whom, special)) {
+	for(const ability_ptr& p_ab : self->abilities(special)) {
+		if(check_self_abilities_impl(self_attack, other_attack, *p_ab, self, self_loc, whom)) {
 			return true;
 		}
 	}
@@ -1779,8 +1779,8 @@ bool attack_type::has_ability_impl(
 			continue;
 		}
 		int dir = find_direction(self_loc, from_loc, distance);
-		for(const config &i : u.abilities().child_range(special)) {
-			if(check_adj_abilities_impl(self_attack, other_attack, i, self, u, distance, dir, self_loc, from_loc, whom, special)) {
+		for(const ability_ptr& p_ab : u.abilities(special)) {
+			if(check_adj_abilities_impl(self_attack, other_attack, *p_ab, self, u, distance, dir, self_loc, from_loc, whom)) {
 				return true;
 			}
 		}
@@ -1849,9 +1849,9 @@ bool attack_type::special_distant_filtering_impl(
 	const std::set<std::string> filter_special_type = utils::split_set(filter["special_type_active"].str());
 	const unit_map& units = get_unit_map();
 	bool check_adjacent = sub_filter ? filter["affect_adjacent"].to_bool(true) : true;
-	for(const auto [key, cfg] : self->abilities().all_children_view()) {
-		bool special_check = sub_filter ? self->ability_matches_filter(cfg, key, filter) : special_checking(cfg["id"].str(), key, filter_special, filter_special_id, filter_special_type);
-		if(special_check && check_self_abilities_impl(self_attack, other_attack, cfg, self, self_loc, whom, key, leader_bool)){
+	for(const auto& p_ab : self->abilities()) {
+		bool special_check = sub_filter ? self->ability_matches_filter(*p_ab, filter) : special_checking(p_ab->cfg()["id"].str(), p_ab->tag(), filter_special, filter_special_id, filter_special_type);
+		if(special_check && check_self_abilities_impl(self_attack, other_attack, *p_ab, self, self_loc, whom, leader_bool)){
 			return true;
 		}
 	}
@@ -1867,9 +1867,9 @@ bool attack_type::special_distant_filtering_impl(
 			}
 			int dir = find_direction(self_loc, from_loc, distance);
 
-			for(const auto [key, cfg] : u.abilities().all_children_view()) {
-				bool special_check = sub_filter ? u.ability_matches_filter(cfg, key, filter) : special_checking(cfg["id"].str(), key, filter_special, filter_special_id, filter_special_type);
-				if(special_check && check_adj_abilities_impl(self_attack, other_attack, cfg, self, u, distance, dir, self_loc, from_loc, whom, key, leader_bool)) {
+			for(const auto& p_ab : u.abilities()) {
+				bool special_check = sub_filter ? u.ability_matches_filter(*p_ab, filter) : special_checking(p_ab->cfg()["id"].str(), p_ab->tag(), filter_special, filter_special_id, filter_special_type);
+				if(special_check && check_adj_abilities_impl(self_attack, other_attack, *p_ab, self, u, distance, dir, self_loc, from_loc, whom, leader_bool)) {
 					return true;
 				}
 			}
@@ -1887,20 +1887,20 @@ bool attack_type::has_filter_special_or_ability(const config& filter, bool simpl
 	const std::set<std::string> filter_special_id = simple_check ? utils::split_set(filter["special_id"].str()) : utils::split_set(filter["special_id_active"].str());
 	const std::set<std::string> filter_special_type = simple_check ? utils::split_set(filter["special_type"].str()) : utils::split_set(filter["special_type_active"].str());
 	using namespace utils::config_filters;
-	for(const auto [key, cfg] : specials().all_children_view()) {
-		if(special_checking(cfg["id"].str(), key, filter_special, filter_special_id, filter_special_type)) {
+	for(const auto& p_ab : specials()) {
+		if(special_checking(p_ab->cfg()["id"].str(), p_ab->tag(), filter_special, filter_special_id, filter_special_type)) {
 			if(simple_check) {
 				return true;
-			} else if(special_active(cfg, AFFECT_SELF, key)) {
+			} else if(special_active(*p_ab, AFFECT_SELF)) {
 				return true;
 			}
 		}
 	}
 
 	if(!simple_check && other_attack_) {
-		for(const auto [key, cfg] : other_attack_->specials().all_children_view()) {
-			if(special_checking(cfg["id"].str(), key, filter_special, filter_special_id, filter_special_type)) {
-				if(other_attack_->special_active(cfg, AFFECT_OTHER, key)) {
+		for(const auto& p_ab : other_attack_->specials()) {
+			if(special_checking(p_ab->cfg()["id"].str(), p_ab->tag(), filter_special, filter_special_id, filter_special_type)) {
+				if(other_attack_->special_active(*p_ab, AFFECT_OTHER)) {
 					return true;
 				}
 			}
@@ -2113,14 +2113,14 @@ namespace
 	}
 }
 
-bool unit::ability_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const
+bool unit::ability_matches_filter(const unit_ability_t& ab, const config & filter) const
 {
-	return common_matches_filter(cfg, tag_name, filter);
+	return common_matches_filter(ab.cfg(), ab.tag(), filter);
 }
 
-bool attack_type::special_matches_filter(const config & cfg, const std::string& tag_name, const config & filter) const
+bool attack_type::special_matches_filter(const unit_ability_t& ab, const config & filter) const
 {
-	return common_matches_filter(cfg, tag_name, filter);
+	return common_matches_filter(ab.cfg(), ab.tag(), filter);
 }
 
 bool attack_type::has_special_or_ability_with_filter(const config & filter) const
@@ -2130,21 +2130,21 @@ bool attack_type::has_special_or_ability_with_filter(const config & filter) cons
 	}
 	using namespace utils::config_filters;
 	bool check_if_active = filter["active"].to_bool();
-	for(const auto [key, cfg] : specials().all_children_view()) {
-		if(special_matches_filter(cfg, key, filter)) {
+	for(const auto& p_ab : specials()) {
+		if(special_matches_filter(*p_ab, filter)) {
 			if(!check_if_active) {
 				return true;
 			}
-			if(special_active(cfg, AFFECT_SELF, key)) {
+			if(special_active(*p_ab, AFFECT_SELF)) {
 				return true;
 			}
 		}
 	}
 
 	if(check_if_active && other_attack_) {
-		for(const auto [key, cfg] : other_attack_->specials().all_children_view()) {
-			if(other_attack_->special_matches_filter(cfg, key, filter)) {
-				if(other_attack_->special_active(cfg, AFFECT_OTHER, key)) {
+		for(const auto& p_ab : other_attack_->specials()) {
+			if(other_attack_->special_matches_filter(*p_ab, filter)) {
+				if(other_attack_->special_active(*p_ab, AFFECT_OTHER)) {
 					return true;
 				}
 			}
@@ -2164,10 +2164,10 @@ bool attack_type::has_special_or_ability_with_filter(const config & filter) cons
 	return false;
 }
 
-bool attack_type::special_active(const config& special, AFFECTS whom, const std::string& tag_name,
+bool attack_type::special_active(const unit_ability_t& ab, AFFECTS whom,
                                  bool in_abilities_tag) const
 {
-	return special_active_impl(shared_from_this(), other_attack_, special, whom, tag_name, in_abilities_tag);
+	return special_active_impl(shared_from_this(), other_attack_, ab, whom, in_abilities_tag);
 }
 
 /**
@@ -2175,17 +2175,15 @@ bool attack_type::special_active(const config& special, AFFECTS whom, const std:
  * based on the current context (see set_specials_context).
  * @param self_attack       this unit's attack
  * @param other_attack      the other unit's attack
- * @param special           a weapon special WML structure
+ * @param ab                the ability
  * @param whom              specifies which combatant we care about
- * @param tag_name          tag name of the special config
  * @param in_abilities_tag  if special coded in [specials] or [abilities] tags
  */
 bool attack_type::special_active_impl(
 	const const_attack_ptr& self_attack,
 	const const_attack_ptr& other_attack,
-	const config& special,
+	const unit_ability_t& ab,
 	AFFECTS whom,
-	const std::string& tag_name,
 	bool in_abilities_tag)
 {
 	assert(self_attack || other_attack);
@@ -2196,16 +2194,16 @@ bool attack_type::special_active_impl(
 
 	// Does this affect the specified unit?
 	if ( whom == AFFECT_SELF ) {
-		if ( !special_affects_self(special, is_attacker) )
+		if ( !special_affects_self(ab, is_attacker) )
 			return false;
 	}
 	if ( whom == AFFECT_OTHER ) {
-		if ( !special_affects_opponent(special, is_attacker) )
+		if ( !special_affects_opponent(ab, is_attacker) )
 			return false;
 	}
 
 	// Is this active on attack/defense?
-	const std::string & active_on = special["active_on"];
+	const std::string & active_on = ab.cfg()["active_on"];
 	if ( !active_on.empty() ) {
 		if ( is_attacker  &&  active_on != "offense" )
 			return false;
@@ -2240,27 +2238,27 @@ bool attack_type::special_active_impl(
 
 	// Filter poison, plague, drain, slow, petrifies
 	// True if "whom" corresponds to "self", false if "whom" is "other"
-	bool whom_is_self = ((whom == AFFECT_SELF) || ((whom == AFFECT_EITHER) && special_affects_self(special, is_attacker)));
+	bool whom_is_self = ((whom == AFFECT_SELF) || ((whom == AFFECT_EITHER) && special_affects_self(ab, is_attacker)));
 	unit_const_ptr them = whom_is_self ? other : self;
 	map_location their_loc = whom_is_self ? other_loc : self_loc;
 
-	if (tag_name == "drains" && them && them->get_state("undrainable")) {
+	if (ab.tag() == "drains" && them && them->get_state("undrainable")) {
 		return false;
 	}
-	if (tag_name == "plague" && them &&
+	if (ab.tag() == "plague" && them &&
 		(them->get_state("unplagueable") ||
 		 resources::gameboard->map().is_village(their_loc))) {
 		return false;
 	}
-	if (tag_name == "poison" && them &&
+	if (ab.tag() == "poison" && them &&
 		(them->get_state("unpoisonable") || them->get_state(unit::STATE_POISONED))) {
 		return false;
 	}
-	if (tag_name == "slow" && them &&
+	if (ab.tag() == "slow" && them &&
 		(them->get_state("unslowable") || them->get_state(unit::STATE_SLOWED))) {
 		return false;
 	}
-	if (tag_name == "petrifies" && them &&
+	if (ab.tag() == "petrifies" && them &&
 		them->get_state("unpetrifiable")) {
 		return false;
 	}
@@ -2276,7 +2274,7 @@ bool attack_type::special_active_impl(
 
 	// Filter firststrike here, if both units have first strike then the effects cancel out. Only check
 	// the opponent if "whom" is the defender, otherwise this leads to infinite recursion.
-	if (tag_name == "firststrike") {
+	if (ab.tag() == "firststrike") {
 		bool whom_is_defender = whom_is_self ? !is_attacker : is_attacker;
 		if (whom_is_defender && att_weapon && att_weapon->has_special_or_ability("firststrike"))
 			return false;
@@ -2286,28 +2284,28 @@ bool attack_type::special_active_impl(
 	//If filter concerns the unit on which special is applied,
 	//then the type of special must be entered to avoid calling
 	//the function of this special in matches_filter()
-	//In apply_to=both case, tag_name must be checked in all filter because special applied to both self and opponent.
-	bool applied_both = special["apply_to"] == "both";
+	//In apply_to=both case, ab.tag() must be checked in all filter because special applied to both self and opponent.
+	bool applied_both = ab.cfg()["apply_to"] == "both";
 	const std::string& filter_self = in_abilities_tag ? "filter_student" : "filter_self";
-	std::string self_check_if_recursion = (applied_both || whom_is_self) ? tag_name : "";
-	if (!special_unit_matches(self, other, self_loc, self_attack, special, is_for_listing, filter_self, self_check_if_recursion))
+	std::string self_check_if_recursion = (applied_both || whom_is_self) ? ab.tag() : "";
+	if (!special_unit_matches(self, other, self_loc, self_attack, ab.cfg(), is_for_listing, filter_self, self_check_if_recursion))
 		return false;
-	std::string opp_check_if_recursion = (applied_both || !whom_is_self) ? tag_name : "";
-	if (!special_unit_matches(other, self, other_loc, other_attack, special, is_for_listing, "filter_opponent", opp_check_if_recursion))
+	std::string opp_check_if_recursion = (applied_both || !whom_is_self) ? ab.tag() : "";
+	if (!special_unit_matches(other, self, other_loc, other_attack, ab.cfg(), is_for_listing, "filter_opponent", opp_check_if_recursion))
 		return false;
 	//in case of apply_to=attacker|defender, if both [filter_attacker] and [filter_defender] are used,
 	//check what is_attacker is true(or false for (filter_defender]) in affect self case only is necessary for what unit affected by special has a tag_name check.
 	bool applied_to_attacker = applied_both || (whom_is_self && is_attacker) || (!whom_is_self && !is_attacker);
-	std::string att_check_if_recursion = applied_to_attacker ? tag_name : "";
-	if (!special_unit_matches(att, def, att_loc, att_weapon, special, is_for_listing, "filter_attacker", att_check_if_recursion))
+	std::string att_check_if_recursion = applied_to_attacker ? ab.tag() : "";
+	if (!special_unit_matches(att, def, att_loc, att_weapon, ab.cfg(), is_for_listing, "filter_attacker", att_check_if_recursion))
 		return false;
 	bool applied_to_defender = applied_both || (whom_is_self && !is_attacker) || (!whom_is_self && is_attacker);
-	std::string def_check_if_recursion= applied_to_defender ? tag_name : "";
-	if (!special_unit_matches(def, att, def_loc, def_weapon, special, is_for_listing, "filter_defender", def_check_if_recursion))
+	std::string def_check_if_recursion= applied_to_defender ? ab.tag() : "";
+	if (!special_unit_matches(def, att, def_loc, def_weapon, ab.cfg(), is_for_listing, "filter_defender", def_check_if_recursion))
 		return false;
 
 	// filter adjacent units or adjacent locations
-	if(self && !ability_active_adjacent_helper(*self, false, special, self_loc, in_abilities_tag))
+	if(self && !ability_active_adjacent_helper(*self, false, ab, self_loc, in_abilities_tag))
 		return false;
 
 
@@ -2317,14 +2315,13 @@ bool attack_type::special_active_impl(
 /**
  * Returns whether or not the given special is active for the specified unit,
  * based on the current context (see set_specials_context).
- * @param special           a weapon special WML structure
- * @param tag_name          tag name of the special config
+ * @param ab                the ability/special
  */
-bool attack_type::special_tooltip_active(const config& special, const std::string& tag_name) const
+bool attack_type::special_tooltip_active(const unit_ability_t& ab) const
 {
 	//log_scope("special_tooltip_active");
 
-	bool whom_is_self = special_affects_self(special, is_attacker_);
+	bool whom_is_self = special_affects_self(ab, is_attacker_);
 	if(!whom_is_self)
 		return false;
 
@@ -2346,17 +2343,17 @@ bool attack_type::special_tooltip_active(const config& special, const std::strin
 		}
 	}
 
-	bool applied_both = special["apply_to"] == "both";
-	std::string self_check_if_recursion = (applied_both || whom_is_self) ? tag_name : "";
-	if (!special_unit_matches(self, other, self_loc_, shared_from_this(), special, is_for_listing_, "filter_student", self_check_if_recursion))
+	bool applied_both = ab.cfg()["apply_to"] == "both";
+	std::string self_check_if_recursion = (applied_both || whom_is_self) ? ab.tag() : "";
+	if (!special_unit_matches(self, other, self_loc_, shared_from_this(), ab.cfg(), is_for_listing_, "filter_student", self_check_if_recursion))
 		return false;
 	bool applied_to_attacker = applied_both || (whom_is_self && is_attacker_);
-	std::string att_check_if_recursion = applied_to_attacker ? tag_name : "";
-	if (is_attacker_ && !special_unit_matches(self, other, self_loc_, shared_from_this(), special, is_for_listing_, "filter_attacker", att_check_if_recursion))
+	std::string att_check_if_recursion = applied_to_attacker ? ab.tag() : "";
+	if (is_attacker_ && !special_unit_matches(self, other, self_loc_, shared_from_this(), ab.cfg(), is_for_listing_, "filter_attacker", att_check_if_recursion))
 		return false;
 	bool applied_to_defender = applied_both || (whom_is_self && !is_attacker_);
-	std::string def_check_if_recursion= applied_to_defender ? tag_name : "";
-	if (!is_attacker_ && !special_unit_matches(self, other, self_loc_, shared_from_this(), special, is_for_listing_, "filter_defender", def_check_if_recursion))
+	std::string def_check_if_recursion= applied_to_defender ? ab.tag() : "";
+	if (!is_attacker_ && !special_unit_matches(self, other, self_loc_, shared_from_this(), ab.cfg(), is_for_listing_, "filter_defender", def_check_if_recursion))
 		return false;
 
 	return true;
@@ -2396,10 +2393,10 @@ bool filter_base_matches(const config& cfg, int def)
 
 // TODO add more [specials] keys
 // Currently supports only [plague]type= -> $type
-std::string substitute_variables(const std::string& str, const std::string& tag_name, const config& ability_or_special) {
-	if(tag_name == "plague") {
+std::string substitute_variables(const std::string& str, const unit_ability_t & ab) {
+	if(ab.tag() == "plague") {
 		// Substitute [plague]type= as $type
-		const auto iter = unit_types.types().find(ability_or_special["type"]);
+		const auto iter = unit_types.types().find(ab.cfg()["type"]);
 
 		// TODO: warn if an invalid type is specified?
 		if(iter == unit_types.types().end()) {

--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -31,12 +31,11 @@ enum EFFECTS { EFFECT_DEFAULT=1, EFFECT_CUMULABLE=2, EFFECT_WITHOUT_CLAMP_MIN_MA
 /**
  * Substitute gettext variables in name and description of abilities and specials
  * @param str                  The string in which the substitution is to be done
- * @param tag_name             Tag name of the special (plague, leadership, chance_to_hit etc.)
- * @param ability_or_special   The config for the special (for example, contents inside [plague][/plague] etc.)
+ * @param ab                   The special (for example  [plague][/plague] etc.)
  *
  * @return The string `str` with all gettext variables substitutes with corresponding special properties
  */
-std::string substitute_variables(const std::string& str, const std::string& tag_name, const config& ability_or_special);
+std::string substitute_variables(const std::string& str, const unit_ability_t& ab);
 
 int individual_value(const config::attribute_value *v, int def, const active_ability & ability, const map_location& loc, const const_attack_ptr& att);
 

--- a/src/units/filter.cpp
+++ b/src/units/filter.cpp
@@ -413,8 +413,8 @@ void unit_filter_compound::fill(const vconfig& cfg)
 			[](const std::set<std::string>& abilities, const unit_filter_args& args)
 			{
 				const unit_map& units = args.context().get_disp_context().units();
-				for(const auto [key, cfg] : args.u.abilities().all_children_view()) {
-					if(abilities.count(cfg["id"]) != 0 && args.u.get_self_ability_bool(cfg, key, args.loc)) {
+				for(const auto& p_ab : args.u.abilities()) {
+					if(abilities.count(p_ab->cfg()["id"]) != 0 && args.u.get_self_ability_bool(*p_ab, args.loc)) {
 						return true;
 					}
 				}
@@ -437,8 +437,8 @@ void unit_filter_compound::fill(const vconfig& cfg)
 							break;
 						}
 					}
-					for(const auto [key, cfg] : unit.abilities().all_children_view()) {
-						if(abilities.count(cfg["id"]) != 0 && args.u.get_adj_ability_bool(cfg, key, distance, *dir, args.loc, unit, from_loc)) {
+					for(const auto& p_ab : unit.abilities()) {
+						if(abilities.count(p_ab->cfg()["id"]) != 0 && args.u.get_adj_ability_bool(*p_ab, distance, *dir, args.loc, unit, from_loc)) {
 							return true;
 						}
 					}
@@ -788,16 +788,16 @@ void unit_filter_compound::fill(const vconfig& cfg)
 				}
 				create_child(child.second, [](const vconfig& c, const unit_filter_args& args) {
 					if(!(c.get_parsed_config())["active"].to_bool()){
-						for(const auto [key, cfg] : args.u.abilities().all_children_view()) {
-							if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
+						for(const ability_ptr& p_ab : args.u.abilities()) {
+							if(args.u.ability_matches_filter(*p_ab, c.get_parsed_config())) {
 								return true;
 							}
 						}
 					} else {
 						const unit_map& units = args.context().get_disp_context().units();
-						for(const auto [key, cfg] : args.u.abilities().all_children_view()) {
-							if(args.u.ability_matches_filter(cfg, key, c.get_parsed_config())) {
-								if (args.u.get_self_ability_bool(cfg, key, args.loc)) {
+						for(const ability_ptr& p_ab : args.u.abilities()) {
+							if(args.u.ability_matches_filter(*p_ab, c.get_parsed_config())) {
+								if (args.u.get_self_ability_bool(*p_ab, args.loc)) {
 									return true;
 								}
 							}
@@ -822,8 +822,8 @@ void unit_filter_compound::fill(const vconfig& cfg)
 										break;
 									}
 								}
-								for(const auto [key, cfg] : unit.abilities().all_children_view()) {
-									if(args.u.get_adj_ability_bool(cfg, key, distance, *dir, args.loc, unit, from_loc)) {
+								for(const ability_ptr& p_ab : unit.abilities()) {
+									if(args.u.get_adj_ability_bool(*p_ab, distance, *dir, args.loc, unit, from_loc)) {
 										return true;
 									}
 								}

--- a/src/units/ptr.hpp
+++ b/src/units/ptr.hpp
@@ -32,3 +32,9 @@ class attack_type;
 
 using attack_ptr = std::shared_ptr<attack_type>;
 using const_attack_ptr = std::shared_ptr<const attack_type>;
+
+class unit_ability_t;
+
+using ability_ptr = std::shared_ptr<unit_ability_t>;
+using const_ability_ptr = std::shared_ptr<const unit_ability_t>;
+

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -114,6 +114,7 @@ public:
 	 */
 	std::set<std::string> advancement_tree() const;
 
+	const ability_vector& abilities() const { return abilities_; }
 	/** A vector of unit_type ids that this unit_type can advance to. */
 	const std::vector<std::string>& advances_to() const { return advances_to_; }
 	/** A vector of unit_type ids that can advance to this unit_type. */
@@ -217,10 +218,10 @@ public:
 		bool cumulative;
 	};
 
-	const std::vector<ability_metadata>& abilities_metadata() const { return abilities_; }
+	const std::vector<ability_metadata>& abilities_metadata() const { return abilities_infos_; }
 
 	/** Some extra abilities that may be gained through AMLA advancements. */
-	const std::vector<ability_metadata>& adv_abilities_metadata() const { return adv_abilities_; }
+	const std::vector<ability_metadata>& adv_abilities_metadata() const { return adv_abilities_infos_; }
 
 	bool can_advance() const { return !advances_to_.empty(); }
 
@@ -355,7 +356,10 @@ private:
 	/** Never nullptr, but may point to the null race. */
 	const unit_race* race_;
 
-	std::vector<ability_metadata> abilities_, adv_abilities_;
+	std::vector<ability_metadata> abilities_infos_;
+	std::vector<ability_metadata> adv_abilities_infos_;
+
+	ability_vector abilities_;
 
 	bool zoc_, hide_help_, do_not_list_;
 


### PR DESCRIPTION
Use a struct + shared_ptr for untis abilities.

Currently the struct is only a plain of tagname+config, bit the idae is to turn it into a more "normal" class at some point. in particular:
- we can store/cache filter objects speeding up ability evaluation 
- we can store/cache theabilitiesproperties speeding up ability evaluation 
- we can share the [event]s removing a lot of dublicate data.

Using shared_ptrs also makes it easier to make a the code more robust against bad wml/lua removing a units ability in a lua filter execution.