### PR TITLE
Gamemap: clean up legacy header parsing

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -168,7 +168,7 @@ void gamemap::read(const std::string& data, const bool allow_invalid)
 	}
 }
 
-std::string_view gamemap::strip_legacy_header(std::string_view data)
+std::string_view gamemap::strip_legacy_header(std::string_view data) const
 {
 	// Test whether there is a header section
 	std::size_t header_offset = data.find("\n\n");

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -249,7 +249,7 @@ private:
 	 *
 	 * @param data		          The mapdata to load.
 	 */
-	std::string_view strip_legacy_header(std::string_view data);
+	std::string_view strip_legacy_header(std::string_view data) const;
 
 	std::shared_ptr<terrain_type_data> tdata_;
 


### PR DESCRIPTION
Since we decided it's worth more trouble than it's worth to remove the parsing entirely, we can at least avoid copying the map string unnecessarily and parsing the header for data we won't use.