### PR TITLE
Weapon Specials registry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
 ### Translations
    * Updated translations: Bengali, British English, Finnish, Galician, Hungarian, Italian, Polish, Spanish
 ### Units
-   * A registry for abilities has been added as `[units][abilities]`. Any ability defined there can be added to a `[unit_type]` by just specifying their `unique_id` in the new key `[unit_type]abilities`, like this: `abilities=heals_8,cures`. The unique id for an ability is the value of its new `unique_id` key which falls back to `id` if unspecified. The `abilities` key is also supported under `[effect]apply_to=new_ability`.
+   * A registry for abilities has been added as `[units][abilities]`. Any ability defined there can be added to a `[unit_type]` by just specifying their `unique_id` in the new key `[unit_type]abilities_list`, like this: `abilities_list=heals_8,cures`. The unique id for an ability is the value of its new `unique_id` key which falls back to `id` if unspecified. The `abilities` key is also supported under `[effect]apply_to=new_ability`.
+   * A similar registry for weapon specials has also been added as `[units][weapon_specials]`. The corresponding key is `specials_list` and is supported inside `[unit_type][attack]` as well as in EffectWML `apply_to=new_attack` and `apply_to=attack`'s `[set_specials]`. `unique_id` is also supported inside weapon special definitions.
 ### User interface
    * New key `title_position` added to `[part]` that allows changing the position of the title text.
 ### WML Engine

--- a/data/core/units.cfg
+++ b/data/core/units.cfg
@@ -1808,4 +1808,23 @@ The life span of the wose is unknown, although the most ancient members of this 
         {ABILITY_SWAMP_LURK}
         {ABILITY_FEEDING}
     [/abilities]
+    [weapon_specials]
+        {WEAPON_SPECIAL_UNWIELDY}
+        {WEAPON_SPECIAL_BERSERK}
+        {WEAPON_SPECIAL_BACKSTAB}
+        {WEAPON_SPECIAL_PLAGUE}
+        {WEAPON_SPECIAL_SLOW}
+        {WEAPON_SPECIAL_PETRIFY}
+        {WEAPON_SPECIAL_MARKSMAN}
+        {WEAPON_SPECIAL_MAGICAL}
+        {WEAPON_SPECIAL_HONED}
+        {WEAPON_SPECIAL_SWARM}
+        {WEAPON_SPECIAL_CHARGE}
+        {WEAPON_SPECIAL_GUARD}
+        {WEAPON_SPECIAL_DRAIN}
+        {WEAPON_SPECIAL_FIRSTSTRIKE}
+        {WEAPON_SPECIAL_POISON}
+        {WEAPON_SPECIAL_STUN}
+        {WEAPON_SPECIAL_ARCANE}
+    [/weapon_specials]
 [/units]

--- a/data/schema/units/_main.cfg
+++ b/data/schema/units/_main.cfg
@@ -16,6 +16,11 @@
 	{./types.cfg}
 	
 	{LINK_TAG "units/unit_type/abilities"}
+	[tag]
+		name="weapon_specials"
+		max=infinite
+		super="units/unit_type/attack/specials"
+	[/tag]
 
 	[tag]
 		name="hide_help"

--- a/data/schema/units/modifications.cfg
+++ b/data/schema/units/modifications.cfg
@@ -50,6 +50,7 @@
 				[tag]
 					name="set_specials"
 					super="units/unit_type~core/attack/specials"
+					{SIMPLE_KEY specials_list string_list}
 					{DEFAULT_KEY mode effect_set_special_mode replace}
 				[/tag]
 				[tag]

--- a/data/schema/units/specials.cfg
+++ b/data/schema/units/specials.cfg
@@ -9,6 +9,7 @@
 	{SIMPLE_KEY description_inactive t_string}
 	{SIMPLE_KEY special_note t_string}
 	{SIMPLE_KEY id string}
+	{SIMPLE_KEY unique_id string}
 	{DEFAULT_KEY active_on ability_context both}
 	{DEFAULT_KEY apply_to ability_apply self}
 	

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -1,7 +1,7 @@
 [tag]
 	name="unit_type~core"
 	max=0
-	{SIMPLE_KEY abilities string_list}
+	{SIMPLE_KEY abilities_list string_list}
 	{SIMPLE_KEY advances_to string_list}
 	{SIMPLE_KEY alignment alignment}
 	{SIMPLE_KEY attacks int}
@@ -61,6 +61,7 @@
 		{SIMPLE_KEY attacks_used int}
 		{SIMPLE_KEY accuracy int}
 		{SIMPLE_KEY parry int}
+		{SIMPLE_KEY specials_list string_list}
 		[tag]
 			name="specials"
 			{./specials.cfg}

--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "units/attack_type.hpp"
+#include "units/types.hpp"
 #include "units/unit.hpp"
 #include "formula/callable_objects.hpp"
 #include "formula/formula.hpp"
@@ -180,7 +181,8 @@ attack_type::attack_type(const config& cfg)
 	, specials_()
 	, changed_(true)
 {
-	unit_ability_t::parse_vector(cfg.child_or_empty("specials"), specials_, true);
+	config specials_cfg = unit_type_data::add_registry_entries(cfg, "specials", unit_types.specials());
+	unit_ability_t::parse_vector(specials_cfg, specials_, true);
 
 	if (description_.empty())
 		description_ = translation::egettext(id_.c_str());
@@ -465,6 +467,13 @@ void attack_type::apply_effect(const config& cfg)
 		if(mode != "append") {
 			specials_.clear();
 		}
+		// expand and add registry weapon specials
+		config registry_specials = unit_type_data::add_registry_entries(
+					config{"specials_list", set_specials["specials_list"]}, "specials", unit_types.specials());
+		for(const auto [key, cfg] : registry_specials.all_children_view()) {
+			specials_.push_back(unit_ability_t::create(key, cfg, true));
+		}
+
 		for(const auto [key, cfg] : set_specials->all_children_view()) {
 			specials_.push_back(unit_ability_t::create(key, cfg, true));
 		}

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -1063,9 +1063,9 @@ config unit_type_data::add_registry_entries(
 	const std::map<std::string, config>& registry
 )
 {
-	config to_append = base_cfg.child_or_empty("abilities");
-	if(base_cfg.has_attribute(registry_name)) {
-		std::vector<std::string> abil_ids_list = utils::split(base_cfg[registry_name].str());
+	config to_append = base_cfg.child_or_empty(registry_name);
+	if(base_cfg.has_attribute(registry_name + "_list")) {
+		std::vector<std::string> abil_ids_list = utils::split(base_cfg[registry_name + "_list"].str());
 		for(const std::string& id : abil_ids_list) {
 			auto registry_entry = registry.find(id);
 			if(registry_entry != registry.end()) {
@@ -1107,9 +1107,22 @@ void unit_type_data::set_config(const game_config_view& cfg)
 		for(const auto& [key, child_cfg] : abil_cfg.get().all_children_range()) {
 			const std::string& id = child_cfg["unique_id"].str(child_cfg["id"]);
 			if(abilities_registry_.find(id) == abilities_registry_.end()) {
+				DBG_UT << "Adding ability ‘" << id << "’ to registry.";
 				abilities_registry_.try_emplace(id, config(key, child_cfg));
 			} else {
-				WRN_UT << "Ability with id ‘" << id << "’ already exists, not adding.";
+				WRN_UT << "Ability with id ‘" << id << "’ already exists in registry, not adding.";
+			}
+		}
+	}
+
+	for(const auto& sp_cfg : cfg.child_range("weapon_specials")) {
+		for(const auto& [key, child_cfg] : sp_cfg.get().all_children_range()) {
+			const std::string& id = child_cfg["unique_id"].str(child_cfg["id"]);
+			if(specials_registry_.find(id) == specials_registry_.end()) {
+				DBG_UT << "Adding weapon special ‘" << id << "’ to registry.";
+				specials_registry_.try_emplace(id, config(key, child_cfg));
+			} else {
+				WRN_UT << "Weapon special with id ‘" << id << "’ already exists in registry, not adding.";
 			}
 		}
 	}
@@ -1292,6 +1305,7 @@ void unit_type_data::clear()
 	movement_types_.clear();
 	races_.clear();
 	abilities_registry_.clear();
+	specials_registry_.clear();
 	build_status_ = unit_type::NOT_BUILT;
 
 	hide_help_all_ = false;

--- a/src/units/types.hpp
+++ b/src/units/types.hpp
@@ -406,6 +406,7 @@ public:
 	const race_map& races() const { return races_; }
 	const movement_type_map& movement_types() const { return movement_types_; }
 	const std::map<std::string, config>& abilities() const { return abilities_registry_; }
+	const std::map<std::string, config>& specials() const { return specials_registry_; }
 	config_array_view traits() const { return units_cfg().child_range("trait"); }
 
 	static config add_registry_entries(
@@ -444,6 +445,7 @@ private:
 	race_map races_;
 
 	std::map<std::string, config> abilities_registry_;
+	std::map<std::string, config> specials_registry_;
 
 	/** True if [hide_help] contains a 'all=yes' at its root. */
 	bool hide_help_all_;


### PR DESCRIPTION
Follow up to #10644 and #10660, this extends the registry system to Weapon Specials.
Adds `[units][weapon_specials]` and `[unit_type][attack]specials_list=`, as well as corresponding EffectWML support under `apply_to=attack[set_specials]` and `apply_to=new_attack`.