### PR TITLE
Bugfix Large units and terrain foreground #10685 [LLM assisted]

### DIFF
--- a/src/drawing_layer.hpp
+++ b/src/drawing_layer.hpp
@@ -44,6 +44,9 @@ enum class drawing_layer {
 	/** Terrain drawn in front of the unit */
 	terrain_fg = unit_first + 50,
 
+	/** Minimal layer for drawing huge units (units that are visable on hexes beneath the unit location) */
+	unit_huge_minimal = terrain_fg,
+
 	/** Overlay on reachable hexes */
 	reachmap_highlight = terrain_bg,
 

--- a/src/units/frame.cpp
+++ b/src/units/frame.cpp
@@ -717,8 +717,22 @@ void unit_frame::redraw(const std::chrono::milliseconds& frame_time, bool on_sta
 		}
 
 		if(alpha != 0) {
+
+			//Some huge units (multihex) needs to be drawn above some terrain features, on a higher drawing layer.
+			constexpr int huge_unit_drawing_layer = get_abs_frame_layer(drawing_layer::unit_huge_minimal);
+			int adjusted_drawing_layer = current_data.drawing_layer;
+			int hex_height = game_config::tile_size;
+			// The 50 value below is an arbitrary value, if we replace the transparent padding underneath unit images with y offset we can remove it.
+			if (image_size.y > (hex_height + 50)) { // Minimal height to be considered a huge unit.
+				if ((hex_height / 2) < (image_size.y / 2 + current_data.y)) { // Account for y offset. If the unit is offset upwards enough then we don't need huge_unit_layer.
+					if (adjusted_drawing_layer <= huge_unit_drawing_layer){
+						adjusted_drawing_layer = huge_unit_drawing_layer;
+					}
+				}
+			}
+
 			render_unit_image(my_x, my_y,
-				drawing_layer { int(drawing_layer::unit_first) + current_data.drawing_layer },
+				drawing_layer{ int(drawing_layer::unit_first) + adjusted_drawing_layer },
 				src,
 				image_loc,
 				facing_west,


### PR DESCRIPTION
Pushed up the drawing_layer for units with large image sizes, so that their centre is drawn on top of foreground terrain.

Bugfix for: https://github.com/wesnoth/wesnoth/issues/10685

Probably also fixes: https://github.com/wesnoth/wesnoth/issues/6203
Edit: no, it is the same type of issue but that one is better solved by using y offset to move the image up by 5 pixels or so.

Before fix:

<img width="1325" height="638" alt="512447265-bb8a5601-8378-485b-b1d9-9f51ba35f347" src="https://github.com/user-attachments/assets/f64b7440-aa02-41a5-99fb-56768a097eba" />
<img width="741" height="492" alt="512449782-e666611c-83e0-41da-b369-9c0a940d12bf" src="https://github.com/user-attachments/assets/431b5951-9be2-4a8d-aed8-4b15ed325413" />

After fix:

<img width="1138" height="322" alt="bild" src="https://github.com/user-attachments/assets/9131d8fd-6f42-43be-9b62-2d1998319671" />

There are still imperfections that can be seen in how the jungle trees gets cut, but I deem this good enough.

I have also tested moving the units around and engaging in combat with them. No changes detected other that what is seen above.
