### PR TITLE
continue ability refactors

### DIFF
--- a/src/units/abilities.hpp
+++ b/src/units/abilities.hpp
@@ -97,6 +97,16 @@ public:
 	static ability_vector filter_tag(const ability_vector& vec, const std::string& tag);
 	static ability_vector clone(const ability_vector& vec);
 
+	/**
+	 * Substitute gettext variables in name and description of abilities and specials
+	 * @param str                  The string in which the substitution is to be done
+	 *
+	 * @return The string `str` with all gettext variables substitutes with corresponding special properties
+	 */
+	std::string substitute_variables(const std::string& str) const;
+
+
+
 	class recursion_guard
 	{
 	public:
@@ -246,15 +256,6 @@ bool filter_base_matches(const config& cfg, int def);
 enum value_modifier {NOT_USED,SET,ADD,MUL,DIV};
 
 enum EFFECTS { EFFECT_DEFAULT=1, EFFECT_CUMULABLE=2, EFFECT_WITHOUT_CLAMP_MIN_MAX=3 };
-
-/**
- * Substitute gettext variables in name and description of abilities and specials
- * @param str                  The string in which the substitution is to be done
- * @param ab                   The special (for example  [plague][/plague] etc.)
- *
- * @return The string `str` with all gettext variables substitutes with corresponding special properties
- */
-std::string substitute_variables(const std::string& str, const unit_ability_t& ab);
 
 struct individual_effect
 {

--- a/src/units/types.cpp
+++ b/src/units/types.cpp
@@ -260,12 +260,12 @@ void unit_type::build_help_index(
 		auto p_ab = unit_ability_t::create(key, cfg, false);
 		abilities_.emplace_back(p_ab);
 		config subst_cfg(cfg);
-		subst_cfg["name"] = unit_abilities::substitute_variables(cfg["name"], *p_ab);
-		subst_cfg["female_name"] = unit_abilities::substitute_variables(cfg["female_name"], *p_ab);
-		subst_cfg["description"] = unit_abilities::substitute_variables(cfg["description"], *p_ab);
-		subst_cfg["name_inactive"] = unit_abilities::substitute_variables(cfg["name_inactive"], *p_ab);
-		subst_cfg["female_name_inactive"] = unit_abilities::substitute_variables(cfg["female_name_inactive"], *p_ab);
-		subst_cfg["description_inactive"] = unit_abilities::substitute_variables(cfg["description_inactive"], *p_ab);
+		subst_cfg["name"] = p_ab->substitute_variables(cfg["name"]);
+		subst_cfg["female_name"] = p_ab->substitute_variables(cfg["female_name"]);
+		subst_cfg["description"] = p_ab->substitute_variables(cfg["description"]);
+		subst_cfg["name_inactive"] = p_ab->substitute_variables(cfg["name_inactive"]);
+		subst_cfg["female_name_inactive"] = p_ab->substitute_variables(cfg["female_name_inactive"]);
+		subst_cfg["description_inactive"] = p_ab->substitute_variables(cfg["description_inactive"]);
 		abilities_infos_.emplace_back(subst_cfg);
 	}
 


### PR DESCRIPTION
we now cache the unit_filter objects of abilities, not recreating unit filters everytime should also increase performance a bit.

wip, might not compile yet.

EDIT: that part was removed form this pr for now, now this pr is only about moveing more atributes to unit_ability_t