### PR TITLE
random recruit MAI: AH.split -> stringx.split

### DIFF
--- a/data/ai/micro_ais/cas/ca_recruit_random.lua
+++ b/data/ai/micro_ais/cas/ca_recruit_random.lua
@@ -55,7 +55,7 @@ function ca_recruit_random:evaluation(cfg)
 
     -- Go through all the types listed in [probability] tags (which can be comma-separated lists)
     for prob in wml.child_range(cfg, "probability") do
-        local types = AH.split(prob.type, ",")
+        local types = stringx.split(prob.type, ",")
         for _,typ in ipairs(types) do  -- 'type' is a reserved keyword in Lua
             -- If this type is in the recruit list, add it
             for _,recruit in ipairs(wesnoth.sides[wesnoth.current.side].recruit) do


### PR DESCRIPTION
solves:
```
20251121 17:27:04 error deprecation: ai_helper.split has been deprecated and will be removed in version 1.20.0.;  (Note: You should use stringx.split instead in new code)
```