### PR TITLE
GUI2/Preferences: convert to Tab Container

### DIFF
--- a/data/gui/themes/default/dialogs/preferences.cfg
+++ b/data/gui/themes/default/dialogs/preferences.cfg
@@ -15,62 +15,6 @@
 	[/column]
 #enddef
 
-#define _GUI_PREFS_TAB_BAR _LIST_DATA
-	[horizontal_listbox]
-		id = "tab_selector"
-
-		[list_definition]
-			[row]
-				[column]
-					[toggle_panel]
-						linked_group = "tabs"
-
-						[grid]
-
-							[row]
-
-								{_GUI_INFO_TAB_PADDING}
-
-								[column]
-									grow_factor = 1
-									border = all
-									border_size = 5
-
-									[label]
-										id = "tab_label"
-										wrap = true
-									[/label]
-
-								[/column]
-
-								{_GUI_INFO_TAB_PADDING}
-
-							[/row]
-
-						[/grid]
-
-					[/toggle_panel]
-				[/column]
-			[/row]
-		[/list_definition]
-
-		[list_data]
-			{_LIST_DATA}
-		[/list_data]
-
-	[/horizontal_listbox]
-#enddef
-
-#define _GUI_PREFS_TAB_PAGER _CONTENTS
-	[stacked_widget]
-		id = "tab_pager"
-		definition = "default"
-
-		{_CONTENTS}
-
-	[/stacked_widget]
-#enddef
-
 #define _GUI_PREFERENCES_MAIN_COMPOSITE_SLIDER _LABEL_TEXT _SLIDER_ID _SLIDER_ATTRIBUTES
 	[grid]
 		[row]
@@ -214,220 +158,46 @@
 					[/label]
 				[/column]
 
-				{GUI_FILLER}
-
 			[/row]
 
 			[row]
 				grow_factor = 1
 
 				[column]
-					grow_factor = 0
-					horizontal_grow = true
-					vertical_grow = true
-					border = "all"
-					border_size = 5
-					[listbox]
-						id = "selector"
-						definition = "default"
-						horizontal_scrollbar_mode = "never"
-						[list_definition]
-							[row]
-								[column]
-									vertical_grow = true
-									horizontal_grow = true
-									[toggle_panel]
-										definition = "fancy"
-										[grid]
-											[row]
-												[column]
-													grow_factor = 0
-													horizontal_alignment = "left"
-													border = "all"
-													border_size = 5
-													[image]
-														id = "icon"
-														definition = "default"
-														linked_group = "page_icon"
-													[/image]
-												[/column]
-
-												[column]
-													grow_factor = 1
-													horizontal_grow = true
-													border = "all"
-													border_size = 5
-													[label]
-														id = "label"
-														definition = "default"
-														linked_group = "page_label"
-													[/label]
-												[/column]
-
-												[column]
-													[spacer]
-														width = 15
-													[/spacer]
-												[/column]
-											[/row]
-										[/grid]
-									[/toggle_panel]
-								[/column]
-							[/row]
-						[/list_definition]
-
-						[list_data]
-
-							[row]
-
-								[column]
-
-									[widget]
-										id = "icon"
-										label = "icons/icon-general.png"
-									[/widget]
-
-									[widget]
-										id = "label"
-										label = _ "General"
-									[/widget]
-
-								[/column]
-
-							[/row]
-
-
-							[row]
-
-								[column]
-
-									[widget]
-										id = "icon"
-										label = "icons/icon-hotkeys.png"
-									[/widget]
-
-									[widget]
-										id = "label"
-										label = _ "Hotkeys"
-									[/widget]
-
-								[/column]
-
-							[/row]
-
-							[row]
-
-								[column]
-
-									[widget]
-										id = "icon"
-										label = "icons/icon-display.png"
-									[/widget]
-
-									[widget]
-										id = "label"
-										label = _ "Display"
-									[/widget]
-
-								[/column]
-
-							[/row]
-
-							[row]
-
-								[column]
-
-									[widget]
-										id = "icon"
-										label = "icons/icon-music.png"
-									[/widget]
-
-									[widget]
-										id = "label"
-										label = _ "Sound"
-									[/widget]
-
-								[/column]
-
-							[/row]
-
-							[row]
-
-								[column]
-
-									[widget]
-										id = "icon"
-										label = "icons/icon-multiplayer.png"
-									[/widget]
-
-									[widget]
-										id = "label"
-										label = _ "Multiplayer"
-									[/widget]
-
-								[/column]
-
-							[/row]
-
-							[row]
-
-								[column]
-
-									[widget]
-										id = "icon"
-										label = "icons/icon-advanced.png"
-									[/widget]
-
-									[widget]
-										id = "label"
-										label = _ "Advanced"
-									[/widget]
-
-								[/column]
-
-							[/row]
-						[/list_data]
-					[/listbox]
-				[/column]
-
-				[column]
 					grow_factor = 1
 					horizontal_grow = true
 					vertical_grow = true
 
-					[stacked_widget]
+					[tab_container]
 						id = "pager"
-						definition = "default"
-
 						{./preferences}
-
-					[/stacked_widget]
+					[/tab_container]
 
 				[/column]
-
 			[/row]
 
 			[row]
-
 				[column]
-					horizontal_alignment = "left"
-					border = "all"
-					border_size = 5
-					[button]
-						id = "about"
-						definition = "action_about"
-						tooltip = _ "Display the game version and build information"
-					[/button]
-				[/column]
-
-				[column]
-					horizontal_alignment = "right"
-
+					horizontal_grow = true
 					[grid]
 						[row]
 							[column]
+								horizontal_alignment = "left"
 								border = "all"
 								border_size = 5
+
+								[button]
+									id = "about"
+									definition = "action_about"
+									tooltip = _ "Display the game version and build information"
+								[/button]
+							[/column]
+
+							[column]
+								border = "all"
+								border_size = 5
+								horizontal_alignment = "right"
+
 								[button]
 									id = "ok"
 									definition = "default"
@@ -437,9 +207,7 @@
 						[/row]
 					[/grid]
 				[/column]
-
 			[/row]
-
 		[/grid]
 
 	[/resolution]
@@ -455,4 +223,3 @@
 #undef _GUI_PREFS_PAGE
 #undef _GUI_PREFERENCES_MAIN_COMPOSITE_SLIDER
 #undef _GUI_INFO_TAB_PADDING
-#undef _GUI_PREFS_TAB_BAR

--- a/data/gui/themes/default/dialogs/preferences/01_general.cfg
+++ b/data/gui/themes/default/dialogs/preferences/01_general.cfg
@@ -222,36 +222,39 @@
 	[/row]
 #enddef
 
-[layer]
+[tab]
+	name = _ "Main Stats"
+	image = "icons/icon-general.png"
 
-	[row]
-		grow_factor = 0
+	[data]
+		[row]
+			grow_factor = 0
 
-		[column]
-			horizontal_grow = true
-			vertical_alignment = "top"
-			[grid]
-				{_GUI_PREFERENCES_GENERAL_GRID_1}
-			[/grid]
-		[/column]
-	[/row]
+			[column]
+				horizontal_grow = true
+				vertical_alignment = "top"
+				[grid]
+					{_GUI_PREFERENCES_GENERAL_GRID_1}
+				[/grid]
+			[/column]
+		[/row]
 
-	{_GUI_PREFERENCES_SPACER_ROW}
+		{_GUI_PREFERENCES_SPACER_ROW}
 
-	[row]
-		grow_factor = 1
+		[row]
+			grow_factor = 1
 
-		[column]
-			horizontal_alignment = "left"
-			vertical_alignment = "top"
+			[column]
+				horizontal_alignment = "left"
+				vertical_alignment = "top"
 
-			[grid]
-				{_GUI_PREFERENCES_GENERAL_GRID_2}
-			[/grid]
-		[/column]
-	[/row]
-
-[/layer]
+				[grid]
+					{_GUI_PREFERENCES_GENERAL_GRID_2}
+				[/grid]
+			[/column]
+		[/row]
+	[/data]
+[/tab]
 
 #undef _GUI_PREFERENCES_GENERAL_GRID_1
 #undef _GUI_PREFERENCES_GENERAL_GRID_2

--- a/data/gui/themes/default/dialogs/preferences/02_hotkeys.cfg
+++ b/data/gui/themes/default/dialogs/preferences/02_hotkeys.cfg
@@ -3,301 +3,306 @@
 ### Preferences dialog, Hotkeys page
 ###
 
-[layer]
+[tab]
+	name = _ "Hotkeys"
+	image = "icons/icon-hotkeys.png"
 
-	[row]
-		grow_factor = 0
+	[data]
 
-		[column]
-			horizontal_grow = true
+		[row]
+			grow_factor = 0
 
-			[grid]
+			[column]
+				horizontal_grow = true
 
-				[row]
+				[grid]
 
-					[column]
-						grow_factor = 0
-						border = "all"
-						border_size = 5
-
-						[label]
-							definition = "default"
-							label = _ "Filter:"
-						[/label]
-					[/column]
-
-					[column]
-						grow_factor = 1
-						border = "all"
-						border_size = 5
-						horizontal_grow = true
-
-						[multimenu_button]
-							id = "hotkey_category_menu"
-							definition = "default"
-							maximum_shown = 3
-						[/multimenu_button]
-					[/column]
-
-					[column]
-						border = "all"
-						border_size = 5
-
-						[text_box]
-							id = "filter"
-							definition = "default"
-
-							tooltip = _ "Filters on hotkey description"
-							{FILTER_TEXT_BOX_HINT}
-						[/text_box]
-					[/column]
-
-				[/row]
-
-			[/grid]
-
-		[/column]
-
-	[/row]
-
-	[row]
-		grow_factor = 1
-
-		[column]
-			horizontal_grow = true
-			vertical_alignment = "top"
-			border = "all"
-			border_size = 5
-
-			[listbox]
-				id = "list_hotkeys"
-				definition = "default"
-				[header]
 					[row]
-						## The Icon column
-						[column]
-							grow_factor = 1
-							horizontal_grow = true
-							border = "left,right"
-							border_size = 5
-							[spacer]
-								linked_group = "hotkeys_col_icon"
-							[/spacer]
-						[/column]
-
-						## The description column
-						[column]
-							grow_factor = 1
-							horizontal_grow = true
-							border = "left,right"
-							border_size = 5
-							[toggle_button]
-								id = "sort_0"
-								definition = "listbox_header"
-								linked_group = "hotkeys_col_desc"
-								label = _ "Action"
-							[/toggle_button]
-						[/column]
-
-						## The hotkey column
-						[column]
-							grow_factor = 1
-							horizontal_grow = true
-							border = "left,right"
-							border_size = 5
-							[toggle_button]
-								id = "sort_1"
-								definition = "listbox_header"
-								linked_group = "hotkeys_col_hotkey"
-								label = _ "Hotkey"
-							[/toggle_button]
-						[/column]
 
 						[column]
-							grow_factor = 1
-							horizontal_grow = true
-							border = "left,right"
+							grow_factor = 0
+							border = "all"
 							border_size = 5
-							[toggle_button]
-								id = "sort_2"
-								definition = "listbox_header"
-								linked_group = "hotkeys_col_type"
-								# po: Translate G as the initial letter for Game
-								label = _ "game_hotkeys^G"
-								tooltip = _ "Available in game"
-							[/toggle_button]
-						[/column]
 
-						[column]
-							grow_factor = 1
-							horizontal_grow = true
-							border = "left,right"
-							border_size = 5
-							[toggle_button]
-								id = "sort_3"
-								definition = "listbox_header"
-								linked_group = "hotkeys_col_type"
-								# po: Translate E as the initial letter for Editor
-								label = _ "editor_hotkeys^E"
-								tooltip = _ "Available in editor"
-							[/toggle_button]
-						[/column]
-
-						[column]
-							grow_factor = 1
-							horizontal_grow = true
-							border = "left,right"
-							border_size = 5
-							[toggle_button]
-								id = "sort_4"
-								definition = "listbox_header"
-								linked_group = "hotkeys_col_type"
-								# po: Translate M as the initial letter for Main Menu
-								label = _ "mainmenu_hotkeys^M"
-								tooltip = _ "Available at main menu"
-							[/toggle_button]
-						[/column]
-					[/row]
-				[/header]
-
-				[list_definition]
-					[row]
-						[column]
-							horizontal_grow = true
-							[toggle_panel]
+							[label]
 								definition = "default"
-								[grid]
-									[row]
-										[column]
-											grow_factor = 0
-											border = "all"
-											border_size = 10
-											horizontal_grow = true
-											[image]
-												id = "img_icon"
-												linked_group = "hotkeys_col_icon"
-											[/image]
-										[/column]
+								label = _ "Filter:"
+							[/label]
+						[/column]
 
-										## The description column
-										[column]
-											grow_factor = 1
-											horizontal_grow = true
-											border = "all"
-											border_size = 10
-											## work around 'empty lines have height 0'
-											vertical_grow = true
-											[label]
-												id = "lbl_desc"
-												definition = "gold_small"
-												linked_group = "hotkeys_col_desc"
-												wrap = true
-											[/label]
-										[/column]
+						[column]
+							grow_factor = 1
+							border = "all"
+							border_size = 5
+							horizontal_grow = true
 
-										## The hotkey column
-										[column]
-											grow_factor = 1
-											horizontal_grow = true
-											border = "all"
-											border_size = 10
-											## work around 'empty lines have height 0'
-											vertical_grow = true
-											[label]
-												id = "lbl_hotkey"
-												definition = "default_small"
-												linked_group = "hotkeys_col_hotkey"
-											[/label]
-										[/column]
+							[multimenu_button]
+								id = "hotkey_category_menu"
+								definition = "default"
+								maximum_shown = 3
+							[/multimenu_button]
+						[/column]
 
-										[column]
-											grow_factor = 0
-											border = "all"
-											border_size = 10
-											[label]
-												id = "lbl_is_game"
-												definition = "default_small"
-												linked_group = "hotkeys_col_type"
-												use_markup = true
-											[/label]
-										[/column]
+						[column]
+							border = "all"
+							border_size = 5
 
-										[column]
-											grow_factor = 0
-											border = "all"
-											border_size = 10
-											[label]
-												id = "lbl_is_editor"
-												definition = "default"
-												linked_group = "hotkeys_col_type"
-												use_markup = true
-											[/label]
-										[/column]
+							[text_box]
+								id = "filter"
+								definition = "default"
 
-										[column]
-											grow_factor = 0
-											border = "all"
-											border_size = 10
-											[label]
-												id = "lbl_is_mainmenu"
-												definition = "default"
-												linked_group = "hotkeys_col_type"
-												use_markup = true
-											[/label]
-										[/column]
-									[/row]
-								[/grid]
-							[/toggle_panel]
+								tooltip = _ "Filters on hotkey description"
+								{FILTER_TEXT_BOX_HINT}
+							[/text_box]
+						[/column]
+
+					[/row]
+
+				[/grid]
+
+			[/column]
+
+		[/row]
+
+		[row]
+			grow_factor = 1
+
+			[column]
+				horizontal_grow = true
+				vertical_alignment = "top"
+				border = "all"
+				border_size = 5
+
+				[listbox]
+					id = "list_hotkeys"
+					definition = "default"
+					[header]
+						[row]
+							## The Icon column
+							[column]
+								grow_factor = 1
+								horizontal_grow = true
+								border = "left,right"
+								border_size = 5
+								[spacer]
+									linked_group = "hotkeys_col_icon"
+								[/spacer]
+							[/column]
+
+							## The description column
+							[column]
+								grow_factor = 1
+								horizontal_grow = true
+								border = "left,right"
+								border_size = 5
+								[toggle_button]
+									id = "sort_0"
+									definition = "listbox_header"
+									linked_group = "hotkeys_col_desc"
+									label = _ "Action"
+								[/toggle_button]
+							[/column]
+
+							## The hotkey column
+							[column]
+								grow_factor = 1
+								horizontal_grow = true
+								border = "left,right"
+								border_size = 5
+								[toggle_button]
+									id = "sort_1"
+									definition = "listbox_header"
+									linked_group = "hotkeys_col_hotkey"
+									label = _ "Hotkey"
+								[/toggle_button]
+							[/column]
+
+							[column]
+								grow_factor = 1
+								horizontal_grow = true
+								border = "left,right"
+								border_size = 5
+								[toggle_button]
+									id = "sort_2"
+									definition = "listbox_header"
+									linked_group = "hotkeys_col_type"
+									# po: Translate G as the initial letter for Game
+									label = _ "game_hotkeys^G"
+									tooltip = _ "Available in game"
+								[/toggle_button]
+							[/column]
+
+							[column]
+								grow_factor = 1
+								horizontal_grow = true
+								border = "left,right"
+								border_size = 5
+								[toggle_button]
+									id = "sort_3"
+									definition = "listbox_header"
+									linked_group = "hotkeys_col_type"
+									# po: Translate E as the initial letter for Editor
+									label = _ "editor_hotkeys^E"
+									tooltip = _ "Available in editor"
+								[/toggle_button]
+							[/column]
+
+							[column]
+								grow_factor = 1
+								horizontal_grow = true
+								border = "left,right"
+								border_size = 5
+								[toggle_button]
+									id = "sort_4"
+									definition = "listbox_header"
+									linked_group = "hotkeys_col_type"
+									# po: Translate M as the initial letter for Main Menu
+									label = _ "mainmenu_hotkeys^M"
+									tooltip = _ "Available at main menu"
+								[/toggle_button]
+							[/column]
+						[/row]
+					[/header]
+
+					[list_definition]
+						[row]
+							[column]
+								horizontal_grow = true
+								[toggle_panel]
+									definition = "default"
+									[grid]
+										[row]
+											[column]
+												grow_factor = 0
+												border = "all"
+												border_size = 10
+												horizontal_grow = true
+												[image]
+													id = "img_icon"
+													linked_group = "hotkeys_col_icon"
+												[/image]
+											[/column]
+
+											## The description column
+											[column]
+												grow_factor = 1
+												horizontal_grow = true
+												border = "all"
+												border_size = 10
+												## work around 'empty lines have height 0'
+												vertical_grow = true
+												[label]
+													id = "lbl_desc"
+													definition = "gold_small"
+													linked_group = "hotkeys_col_desc"
+													wrap = true
+												[/label]
+											[/column]
+
+											## The hotkey column
+											[column]
+												grow_factor = 1
+												horizontal_grow = true
+												border = "all"
+												border_size = 10
+												## work around 'empty lines have height 0'
+												vertical_grow = true
+												[label]
+													id = "lbl_hotkey"
+													definition = "default_small"
+													linked_group = "hotkeys_col_hotkey"
+												[/label]
+											[/column]
+
+											[column]
+												grow_factor = 0
+												border = "all"
+												border_size = 10
+												[label]
+													id = "lbl_is_game"
+													definition = "default_small"
+													linked_group = "hotkeys_col_type"
+													use_markup = true
+												[/label]
+											[/column]
+
+											[column]
+												grow_factor = 0
+												border = "all"
+												border_size = 10
+												[label]
+													id = "lbl_is_editor"
+													definition = "default"
+													linked_group = "hotkeys_col_type"
+													use_markup = true
+												[/label]
+											[/column]
+
+											[column]
+												grow_factor = 0
+												border = "all"
+												border_size = 10
+												[label]
+													id = "lbl_is_mainmenu"
+													definition = "default"
+													linked_group = "hotkeys_col_type"
+													use_markup = true
+												[/label]
+											[/column]
+										[/row]
+									[/grid]
+								[/toggle_panel]
+							[/column]
+						[/row]
+					[/list_definition]
+				[/listbox]
+			[/column]
+		[/row]
+
+		[row]
+			grow_factor = 0
+			[column]
+				horizontal_grow = true
+
+				[grid]
+					[row]
+						grow_factor = 1
+						[column]
+							grow_factor = 0
+							border = "all"
+							border_size = 5
+							horizontal_grow = true
+							[button]
+								label = _"Add Hotkey"
+								id = "btn_add_hotkey"
+							[/button]
+						[/column]
+
+						[column]
+							grow_factor = 0
+							border = "all"
+							border_size = 5
+							horizontal_grow = true
+							[button]
+								label = _"Clear Hotkey"
+								id = "btn_clear_hotkey"
+							[/button]
+						[/column]
+
+						[column]
+							grow_factor = 1
+							border = "all"
+							border_size = 5
+							horizontal_alignment = "right"
+							[button]
+								label = _"Defaults"
+								id = "btn_reset_hotkeys"
+							[/button]
 						[/column]
 					[/row]
-				[/list_definition]
-			[/listbox]
-		[/column]
-	[/row]
+				[/grid]
+			[/column]
+		[/row]
 
-	[row]
-		grow_factor = 0
-		[column]
-			horizontal_grow = true
-
-			[grid]
-				[row]
-					grow_factor = 1
-					[column]
-						grow_factor = 0
-						border = "all"
-						border_size = 5
-						horizontal_grow = true
-						[button]
-							label = _"Add Hotkey"
-							id = "btn_add_hotkey"
-						[/button]
-					[/column]
-
-					[column]
-						grow_factor = 0
-						border = "all"
-						border_size = 5
-						horizontal_grow = true
-						[button]
-							label = _"Clear Hotkey"
-							id = "btn_clear_hotkey"
-						[/button]
-					[/column]
-
-					[column]
-						grow_factor = 1
-						border = "all"
-						border_size = 5
-						horizontal_alignment = "right"
-						[button]
-							label = _"Defaults"
-							id = "btn_reset_hotkeys"
-						[/button]
-					[/column]
-				[/row]
-			[/grid]
-		[/column]
-	[/row]
-
-[/layer]
+	[/data]
+[/tab]

--- a/data/gui/themes/default/dialogs/preferences/03_display.cfg
+++ b/data/gui/themes/default/dialogs/preferences/03_display.cfg
@@ -450,22 +450,27 @@
 	#[/row]
 #enddef
 
-[layer]
+[tab]
+	name = _ "Display"
+	image = "icons/icon-display.png"
 
-	[row]
-		grow_factor = 0
+	[data]
 
-		[column]
-			horizontal_grow = true
-			vertical_alignment = "top"
+		[row]
+			grow_factor = 0
 
-			[grid]
-				{_GUI_PREFERENCES_DISPLAY_GRID}
-			[/grid]
-		[/column]
-	[/row]
+			[column]
+				horizontal_grow = true
+				vertical_alignment = "top"
 
-[/layer]
+				[grid]
+					{_GUI_PREFERENCES_DISPLAY_GRID}
+				[/grid]
+			[/column]
+		[/row]
+
+	[/data]
+[/tab]
 
 #undef _GUI_PREFERENCES_DISPLAY_GRID
 #undef _GUI_PREFERENCES_DISPLAY_UI_GRID

--- a/data/gui/themes/default/dialogs/preferences/04_sound.cfg
+++ b/data/gui/themes/default/dialogs/preferences/04_sound.cfg
@@ -139,20 +139,25 @@
 	[/row]
 #enddef
 
-[layer]
+[tab]
+	name = _ "Sound"
+	image = "icons/icon-music.png"
 
-	[row]
-		[column]
-			horizontal_grow = true
-			vertical_alignment = "top"
+	[data]
 
-			[grid]
-				{_GUI_PREFERENCES_SOUND_GRID}
-			[/grid]
-		[/column]
-	[/row]
+		[row]
+			[column]
+				horizontal_grow = true
+				vertical_alignment = "top"
 
-[/layer]
+				[grid]
+					{_GUI_PREFERENCES_SOUND_GRID}
+				[/grid]
+			[/column]
+		[/row]
+
+	[/data]
+[/tab]
 
 #undef _GUI_PREFERENCES_SOUND_GRID
 #under _GUI_AUTO_MUTE_MUSIC_CHECKBOX

--- a/data/gui/themes/default/dialogs/preferences/05_multiplayer.cfg
+++ b/data/gui/themes/default/dialogs/preferences/05_multiplayer.cfg
@@ -227,9 +227,10 @@
 
 #define _GUI_PREFERENCES_MP_PAGE_2
 	[row]
-		grow_factor = 1
+		grow_factor = 0
 		[column]
 			horizontal_grow = true
+			vertical_alignment = "top"
 
 			[grid]
 				[row]
@@ -385,110 +386,54 @@
 	[/row]
 #enddef
 
-#define _GUI_PREFERENCES_MP_SWITCH_ROW
-	[row]
-		[column]
-			border = "all"
-			border_size = 5
-			horizontal_alignment = "left"
+[tab]
+	name = _ "Multiplayer"
+	image = "icons/icon-multiplayer.png"
 
-			{_GUI_PREFS_TAB_BAR (
-				[row]
+	[data]
+		[row]
+			grow_factor = 1
+			[column]
+				horizontal_grow = true
+				vertical_alignment = "top"
 
-					[column]
+				[tab_container]
+					id = "multiplayer_pager"
+					definition = "horizontal_no_image"
 
-						[widget]
-							id = "tab_label"
-							label = _ "General"
-						[/widget]
+					[tab]
+						name = _ "General"
 
-					[/column]
+						[data]
+							{_GUI_PREFERENCES_MP_PAGE_1_GRID_1}
 
-				[/row]
+							{_GUI_PREFERENCES_SPACER_ROW}
 
-				[row]
+							[row]
+								[column]
+									horizontal_alignment = "left"
+									vertical_alignment = "top"
 
-					[column]
+									[grid]
+										{_GUI_PREFERENCES_MP_PAGE_1_GRID_2}
+									[/grid]
+								[/column]
+							[/row]
+						[/data]
+					[/tab]
 
-						[widget]
-							id = "tab_label"
-							label = _ "Friends"
-						[/widget]
+					[tab]
+						name = _ "Friends"
 
-					[/column]
-
-				[/row]
-			)}
-		[/column]
-	[/row]
-#enddef
-
-[layer]
-	[row]
-		[column]
-			horizontal_alignment = "left"
-			vertical_alignment = "top"
-
-			[grid]
-				{_GUI_PREFERENCES_MP_SWITCH_ROW}
-			[/grid]
-		[/column]
-	[/row]
-
-	{_GUI_PREFERENCES_SPACER_ROW}
-
-	[row]
-		grow_factor = 1
-		[column]
-			horizontal_grow = true
-			vertical_alignment = "top"
-
-			{_GUI_PREFS_TAB_PAGER (
-				[layer]
-					[row]
-						grow_factor = 0
-						[column]
-							horizontal_grow = true
-							vertical_alignment = "top"
-
-							[grid]
-								{_GUI_PREFERENCES_MP_PAGE_1_GRID_1}
-							[/grid]
-						[/column]
-					[/row]
-
-					{_GUI_PREFERENCES_SPACER_ROW}
-
-					[row]
-						grow_factor = 1
-						[column]
-							horizontal_alignment = "left"
-							vertical_alignment = "top"
-
-							[grid]
-								{_GUI_PREFERENCES_MP_PAGE_1_GRID_2}
-							[/grid]
-						[/column]
-					[/row]
-				[/layer]
-
-				[layer]
-					[row]
-						[column]
-							horizontal_grow = true
-							vertical_alignment = "top"
-
-							[grid]
-								{_GUI_PREFERENCES_MP_PAGE_2}
-							[/grid]
-						[/column]
-					[/row]
-				[/layer]
-			)}
-
-		[/column]
-	[/row]
-[/layer]
+						[data]
+							{_GUI_PREFERENCES_MP_PAGE_2}
+						[/data]
+					[/tab]
+				[/tab_container]
+			[/column]
+		[/row]
+	[/data]
+[/tab]
 
 #undef _GUI_PREFERENCES_MP_PAGE_1_GRID_1
 #undef _GUI_PREFERENCES_MP_PAGE_1_GRID_2

--- a/data/gui/themes/default/dialogs/preferences/06_advanced.cfg
+++ b/data/gui/themes/default/dialogs/preferences/06_advanced.cfg
@@ -144,35 +144,40 @@
 	[/listbox]
 #enddef
 
-[layer]
+[tab]
+	name = _ "Advanced"
+	image = "icons/icon-advanced.png"
 
-	[row]
+	[data]
 
-		[column]
-			horizontal_grow = true
-			vertical_alignment = "top"
+		[row]
 
-			[grid]
+			[column]
+				horizontal_grow = true
+				vertical_alignment = "top"
 
-				[row]
+				[grid]
 
-					[column]
-						horizontal_grow = true
-						vertical_grow = true
-						border = "all"
-						border_size = 5
+					[row]
 
-						{_GUI_ADVANCED_LIST}
-					[/column]
+						[column]
+							horizontal_grow = true
+							vertical_grow = true
+							border = "all"
+							border_size = 5
 
-				[/row]
+							{_GUI_ADVANCED_LIST}
+						[/column]
 
-			[/grid]
+					[/row]
 
-		[/column]
+				[/grid]
 
-	[/row]
+			[/column]
 
-[/layer]
+		[/row]
+
+	[/data]
+[/tab]
 
 #undef _GUI_ADVANCED_LIST

--- a/data/gui/themes/default/widgets/tab_container_default.cfg
+++ b/data/gui/themes/default/widgets/tab_container_default.cfg
@@ -163,13 +163,13 @@
 						id = "_tab_list"
 						definition = "default"
 						horizontal_scrollbar_mode = "never"
+
 						[list_definition]
 							[row]
 								[column]
 									vertical_grow = true
 									horizontal_grow = true
 									[toggle_panel]
-										definition = "fancy"
 										[grid]
 											[row]
 												[column]
@@ -224,3 +224,129 @@
 	[/resolution]
 
 [/tab_container_definition]
+
+#define _GUI_INFO_TAB_PADDING
+	[column]
+		border = all
+		border_size = 5
+
+		[spacer]
+			width = 10
+		[/spacer]
+
+	[/column]
+#enddef
+
+#define _GUI_PREFS_TAB_BAR
+	[horizontal_listbox]
+		id = "_tab_list"
+		horizontal_scrollbar_mode = "never"
+
+		[list_definition]
+			[row]
+				[column]
+					[toggle_panel]
+						linked_group = "tabs"
+
+						[grid]
+
+							[row]
+
+								{_GUI_INFO_TAB_PADDING}
+
+								[column]
+									grow_factor = 1
+									border = all
+									border_size = 10
+
+									[label]
+										id = "name"
+										linked_group = "page_label"
+										wrap = true
+									[/label]
+
+								[/column]
+
+								{_GUI_INFO_TAB_PADDING}
+
+							[/row]
+
+						[/grid]
+
+					[/toggle_panel]
+				[/column]
+			[/row]
+		[/list_definition]
+	[/horizontal_listbox]
+#enddef
+
+[tab_container_definition]
+	id = "horizontal_no_image"
+	description = "tab container with horizontal textonly tabs."
+
+	[resolution]
+
+		min_width = 0
+		min_height = 0
+
+		default_width = 0
+		default_height = 0
+
+		max_width = 0
+		max_height = 0
+
+		[linked_group]
+			id = "page_label"
+			fixed_width = true
+		[/linked_group]
+
+		[state_enabled]
+
+			[draw]
+			[/draw]
+
+		[/state_enabled]
+
+		[state_disabled]
+
+			[draw]
+			[/draw]
+
+		[/state_disabled]
+
+		[grid]
+			id = "_content_grid"
+
+			[row]
+				[column]
+					horizontal_alignment = "center"
+
+					{_GUI_PREFS_TAB_BAR}
+				[/column]
+			[/row]
+
+			[row]
+				[column]
+					[spacer]
+						height = 10
+					[/spacer]
+				[/column]
+			[/row]
+
+			[row]
+				[column]
+					horizontal_grow = true
+					[grid]
+						id = "_page"
+					[/grid]
+				[/column]
+			[/row]
+
+		[/grid]
+
+	[/resolution]
+
+[/tab_container_definition]
+
+#undef _GUI_PREFS_TAB_BAR
+#undef _GUI_INFO_TAB_PADDING

--- a/src/gui/dialogs/preferences_dialog.hpp
+++ b/src/gui/dialogs/preferences_dialog.hpp
@@ -67,7 +67,6 @@ private:
 
 	/** Initializers */
 	void initialize_callbacks();
-	void initialize_tabs(listbox& selector);
 	void set_resolution_list(menu_button& res_list);
 	void set_theme_list(menu_button& theme_list);
 	void set_gui2_theme_list(menu_button& theme_list);
@@ -86,11 +85,7 @@ private:
 	void on_friends_list_select(listbox& list, text_box& textbox);
 	void update_friends_list_controls(listbox& list);
 
-	void set_visible_page(unsigned int page, const std::string& pager_id);
-
 	/** Callback for selection changes */
-	void on_page_select();
-	void on_tab_select();
 	void on_advanced_prefs_list_select(listbox& tree);
 
 	/** Special callback functions */

--- a/src/gui/widgets/tab_container.cpp
+++ b/src/gui/widgets/tab_container.cpp
@@ -45,11 +45,6 @@ struct tab_container_implementation
 			const std::string_view id,
 			const bool must_be_active)
 	{
-		// Use base method if find-in-all-layer isn't set.
-		// if(!stack.find_in_all_layers_) {
-		// 	return stack.container_base::find(id, must_be_active);
-		// }
-
 		for(unsigned i = 0; i < stack.get_tab_count(); ++i) {
 			auto* tab_grid = stack.get_tab_grid(i);
 			if(!tab_grid) {
@@ -187,8 +182,7 @@ builder_tab_container::builder_tab_container(const config& cfg)
 	: implementation::builder_styled_widget(cfg)
 {
 	if(cfg.has_child("tab")) {
-		for(const config& tab : cfg.child_range("tab"))
-		{
+		for(const config& tab : cfg.child_range("tab")) {
 			list_items.emplace_back(widget_data{
 				{ "image", {{"label", tab["image"].str()}} },
 				{ "name", {{"label", tab["name"].t_str()}} }


### PR DESCRIPTION
One of the major usecases of the widget, it removes a lot of manual calculations and tab controlling in the preferences dialog. The stacked widget + listbox combination inside the multiplayer tab has been replaced with a nested tab container as well.

*Backend only change, appearance unaffected.*