### PR TITLE
Drop attempt to extend lifespan of temporaries in range-for initializer

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -84,12 +84,8 @@ try {
  */
 void parse(const std::string& full_path, bool is_core)
 {
-#if __cpp_range_based_for >= 202211L // lifetime extension of temporaries
-	for(const config& def : read_and_validate(full_path).child_range("gui")) {
-#else
 	config cfg = read_and_validate(full_path);
 	for(const config& def : cfg.child_range("gui")) {
-#endif
 		const bool is_default = def["id"] == "default";
 
 		if(is_default && !is_core) {


### PR DESCRIPTION
This seems to be causing issues with recent versions of MSVC, which do not support C++23 range-for temporaries lifetime extension, but somehow define __cpp_range_based_for = 202211L anyhow. As a consequence, we wind up with the MSVC STL yelling at us for attempting to access invalidated iterators.