### PR TITLE
Ability/Weapon specials: support more attributes as po variables

### DIFF
--- a/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
+++ b/data/campaigns/Under_the_Burning_Suns/utils/abilities.cfg
@@ -667,20 +667,11 @@ _ "At the start of the turn this unit increases movement points of surrounding u
     [/dummy]
 #enddef
 
-#define STR_PARRYING_10
-_ "This unit sees its defense reinforced by 10% when this weapon is used offensively"#enddef
-
-#define STR_PARRYING_20
-_ "This unit sees its defense reinforced by 20% when this weapon is used offensively"#enddef
-
-#define STR_PARRYING_30
-_ "This unit sees its defense reinforced by 30% when this weapon is used offensively"#enddef
-
 #define WEAPON_SPECIAL_PARRYING VALUE
     [chance_to_hit]
-        id=parrying{VALUE}
-        name=_"parrying: " + "{VALUE}"
-        description={STR_PARRYING_{VALUE}}
+        id="parrying{VALUE}"
+        name= _ "parrying($sub)"
+        description= _ "This unit sees its defense reinforced by $sub% when this weapon is used offensively"
         sub={VALUE}
         priority=-10
         apply_to=opponent


### PR DESCRIPTION
This adds support for "value", "add", "sub", "multiply", "divide", "max_value" and "min_value", in addition to "type" for plague in #10293. They could be accessed inside translatable strings in ability/weapon special definitions as $value, $add and so on.

As an example, UtBS weapon special "parrying" have been refactored to use this system.