### PR TITLE
Remove SPECIAL_NOTES_ARCANE and move the [language] tag out of data/core/macros

### DIFF
--- a/changelog_entries/remove_special_notes_arcane_macro.md
+++ b/changelog_entries/remove_special_notes_arcane_macro.md
@@ -1,0 +1,2 @@
+### Miscellaneous and Bug Fixes
+   * Removed the `SPECIAL_NOTES_ARCANE` macro, the note is automatically added to any unit with an arcane attack.

--- a/data/core/macros/special-notes.cfg
+++ b/data/core/macros/special-notes.cfg
@@ -1,19 +1,12 @@
 #textdomain wesnoth-help
 
 # The SPECIAL_NOTES macro and ability-specific SPECIAL_NOTES_* macros are deprecated, they are strings that were historically included directly in [unit_type]description.
-# Since 1.16 these special notes are found in the abilities, movetypes and weapon specials themselves, and in [language]special_note_damage_type_arcane.
+# Since 1.16 these special notes are found in the abilities, movetypes and weapon specials themselves.
 #
 # The INTERNAL:SPECIAL_NOTES_* macros contain the strings shared by the deprecated macros and the non-deprecated uses. They aren't intended to be reused outside mainline.
 
 #define INTERNAL:SPECIAL_NOTES_SPIRIT
 _"Spirits have very unusual resistances to damage, and move quite slowly over open water."#enddef
-
-#define INTERNAL:SPECIAL_NOTES_ARCANE
-_"This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures."#enddef
-
-[language]
-    special_note_damage_type_arcane={INTERNAL:SPECIAL_NOTES_ARCANE}
-[/language]
 
 #define INTERNAL:SPECIAL_NOTES_HEALS
 _"This unit is capable of basic healing."#enddef
@@ -125,10 +118,6 @@ _"This unit has a defense cap on certain terrain types — it cannot achieve a h
 #define SPECIAL_NOTES_SPIRIT
 #deprecated 2 1.19 This note is now added automatically.
 {INTERNAL:SPECIAL_NOTES_SPIRIT}#enddef
-
-#define SPECIAL_NOTES_ARCANE
-#deprecated 2 1.19 This note is now added automatically.
-{INTERNAL:SPECIAL_NOTES_ARCANE}#enddef
 
 #define SPECIAL_NOTES_HEALS
 #deprecated 2 1.19 This note is now added automatically.

--- a/data/english.cfg
+++ b/data/english.cfg
@@ -29,6 +29,10 @@ Twilight: +25% Damage"
     type_fire= _ "fire"
     type_cold= _ "cold"
     type_arcane= _ "arcane"
+
+    #textdomain wesnoth-help
+    special_note_damage_type_arcane= _ "This unit’s arcane attack deals tremendous damage to magical creatures, and even some to mundane creatures."
+    #textdomain wesnoth
 [/language]
 
 #default naming of terrain features


### PR DESCRIPTION
Fixes the expectation that including core/macros does nothing other than defining macros.

This removes the deprecated (since 1.16) SPECIAL_NOTES_ARCANE and INTERNAL:SPECIAL_NOTES_ARCANE macros, but leaves many other deprecated macros untouched. Despite being similarly documented as "automatically added", those should more accurately be documented as "used in a [movetype], [ability] or [special] instead of individual unit type's .cfg files". Mainline is still using those other macros in multiple places, which means those ones are likely to still be used in custom movetypes or custom specials. Notes based on attack types don't need to be replicated in UMCs, because they only need to appear in a single [language] tag, which is why I'm removing just the ARCANE macros.

Fixes #10738