### PR TITLE
update village name macro CFG ruleset

### DIFF
--- a/data/core/macros/names.cfg
+++ b/data/core/macros/names.cfg
@@ -289,9 +289,13 @@ suffix=men|drum|tor|num|lad|de|ak|lol|dum|tam|nur|dium|deum|bil|rook|relm|dium|n
     base_names= _ "Bal,Cam,Corn,Del,Earl,El,Fox,Fren,Gel,Hel,Hex,Hol,Hox,Il,Kin,Nam,Nes,New,Ol,Old,Olf,Oul,Ox,Rock,Rook,Sal,Sam,Sed,Sel,Sen,Sil,Tal,Water,Wet,York"
     # po: Generator for the base names of features assigned by the random map generator; see <https://wiki.wesnoth.org/Context-free_grammar> for syntax
     base_name_generator= _ <<
-main={prefix}{middle}{suffix}
-prefix=B|C|D|E|F|Fr|Wat|G|H|K|N|O|R|S|T|W|Y|Ro
-middle=a|e|o|u|i
+main={c_prefix}{c_middle}{suffix}|{f_prefix}{f_middle}{suffix}|{other_prefix}{middle}{suffix}
+c_prefix=C
+c_middle=a|e|o|i
+f_prefix=F
+f_middle=a|e|o|i
+other_prefix=B|D|E|Fr|Wat|G|H|K|N|O|R|S|T|W|Y|Ro
+middle=a|e|o|i|u
 suffix=l|m|rn|x|w|ld|ck|k|rk
 >>
 #enddef


### PR DESCRIPTION
Essentially prevents names like "`C*m`" and "`F*ck`" from being added as part of village names.