### PR TITLE
Change terrain_builder::set_terrain_rules_cfg() to clear building_rules_ by calling clear()

### DIFF
--- a/src/terrain/builder.cpp
+++ b/src/terrain/builder.cpp
@@ -279,10 +279,7 @@ void terrain_builder::flush_local_rules()
 void terrain_builder::set_terrain_rules_cfg(const game_config_view& cfg)
 {
 	rules_cfg_ = &cfg;
-	// use the swap trick to clear the rules cache and get a fresh one.
-	// because simple clear() seems to cause some progressive memory degradation.
-	building_ruleset empty;
-	std::swap(building_rules_, empty);
+	building_rules_.clear();
 }
 
 void terrain_builder::reload_map()


### PR DESCRIPTION
Change terrain_builder::set_terrain_rules_cfg() to clear building_rules_ by calling clear() rather than by swapping it with an empty container.

set_terrain_rules_cfg, among other things, clears the contents of building_rules_,  a std::multiset.  It does this by swapping it with an empty multiset created on the stack, which is then destroyed when the method returns.  There is a confusing comment justifying this approach in the interest of avoiding "progressive memory degradation".  The author of the comment and the code likely had in mind containers like std::vector, for which clear() will set the size to 0 but will not actually release the memory, leaving the capacity() of the container unchanged.  std::multiset does not have the concept of capacity, and clear() will release the memory, so this confusing swap approach is not necessary.

Fixes #10183