### PR TITLE
Make terrain_type_data the source of truth

### DIFF
--- a/src/gui/widgets/unit_preview_pane.cpp
+++ b/src/gui/widgets/unit_preview_pane.cpp
@@ -149,17 +149,14 @@ static inline std::string get_mp_tooltip(int total_movement, const std::function
 	std::ostringstream tooltip;
 	tooltip << markup::tag("big", _("Movement Costs:"));
 
-	std::shared_ptr tdata = terrain_type_data::get();
-	if(!tdata) {
-		return "";
-	}
+	terrain_type_data& tdata = terrain_type_data::get();
 
 	for(t_translation::terrain_code terrain : prefs::get().encountered_terrains()) {
 		if(terrain == t_translation::FOGGED || terrain == t_translation::VOID_TERRAIN || t_translation::terrain_matches(terrain, t_translation::ALL_OFF_MAP)) {
 			continue;
 		}
 
-		const terrain_type& info = tdata->get_terrain_info(terrain);
+		const terrain_type& info = tdata.get_terrain_info(terrain);
 		if(info.is_indivisible() && info.is_nonnull()) {
 			terrain_moves.emplace(info.name(), get(terrain));
 		}

--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -849,19 +849,15 @@ void generate_era_sections(const config& help_cfg, section & sec, int level)
 
 void generate_terrain_sections(section& sec, int /*level*/)
 {
-	std::shared_ptr tdata = terrain_type_data::get();
-	if (!tdata) {
-		WRN_HP << "When building terrain help sections, couldn't acquire terrain types data, aborting.";
-		return;
-	}
+	terrain_type_data& tdata = terrain_type_data::get();
 
 	std::map<std::string, section> base_map;
 
-	const t_translation::ter_list& t_listi = tdata->list();
+	const t_translation::ter_list& t_listi = tdata.list();
 
 	for (const t_translation::terrain_code& t : t_listi) {
 
-		const terrain_type& info = tdata->get_terrain_info(t);
+		const terrain_type& info = tdata.get_terrain_info(t);
 
 		bool hidden = info.hide_help();
 
@@ -875,9 +871,9 @@ void generate_terrain_sections(section& sec, int /*level*/)
 			std::make_shared<terrain_topic_generator>(info)
 		};
 
-		t_translation::ter_list base_terrains = tdata->underlying_union_terrain(t);
+		t_translation::ter_list base_terrains = tdata.underlying_union_terrain(t);
 		if (info.has_default_base()) {
-			for (const auto base : tdata->underlying_union_terrain(info.default_base())) {
+			for (const auto base : tdata.underlying_union_terrain(info.default_base())) {
 				if (!utils::contains(base_terrains, base)) {
 					base_terrains.emplace_back(base);
 				}
@@ -885,7 +881,7 @@ void generate_terrain_sections(section& sec, int /*level*/)
 		}
 		for (const t_translation::terrain_code& base : base_terrains) {
 
-			const terrain_type& base_info = tdata->get_terrain_info(base);
+			const terrain_type& base_info = tdata.get_terrain_info(base);
 
 			if (!base_info.is_nonnull() || base_info.hide_help())
 				continue;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -41,21 +41,21 @@ static lg::log_domain log_config("config");
 /** Gets the list of terrains. */
 const t_translation::ter_list& gamemap::get_terrain_list() const
 {
-	return tdata_->list();
+	return terrain_type_data::get().list();
 }
 
 /** Shortcut to get_terrain_info(get_terrain(loc)). */
 const terrain_type& gamemap::get_terrain_info(const map_location &loc) const
 {
-	return tdata_->get_terrain_info(get_terrain(loc));
+	return terrain_type_data::get().get_terrain_info(get_terrain(loc));
 }
 
 const t_translation::ter_list& gamemap::underlying_mvt_terrain(const map_location& loc) const
-	{ return tdata_->underlying_mvt_terrain(get_terrain(loc)); }
+	{ return terrain_type_data::get().underlying_mvt_terrain(get_terrain(loc)); }
 const t_translation::ter_list& gamemap::underlying_def_terrain(const map_location& loc) const
-	{ return tdata_->underlying_def_terrain(get_terrain(loc)); }
+	{ return terrain_type_data::get().underlying_def_terrain(get_terrain(loc)); }
 const t_translation::ter_list& gamemap::underlying_union_terrain(const map_location& loc) const
-	{ return tdata_->underlying_union_terrain(get_terrain(loc)); }
+	{ return terrain_type_data::get().underlying_union_terrain(get_terrain(loc)); }
 std::string gamemap::get_terrain_string(const map_location& loc) const
 	{ return get_terrain_string(get_terrain(loc)); }
 std::string gamemap::get_terrain_editor_string(const map_location& loc) const
@@ -64,25 +64,25 @@ std::string gamemap::get_underlying_terrain_string(const map_location& loc) cons
 	{ return get_underlying_terrain_string(get_terrain(loc)); }
 
 bool gamemap::is_village(const map_location& loc) const
-	{ return on_board(loc) && tdata_->get_terrain_info((*this)[loc]).is_village(); }
+	{ return on_board(loc) && terrain_type_data::get().get_terrain_info((*this)[loc]).is_village(); }
 int gamemap::gives_healing(const map_location& loc) const
-	{ return on_board(loc) ?  tdata_->get_terrain_info((*this)[loc]).gives_healing() : 0; }
+	{ return on_board(loc) ?  terrain_type_data::get().get_terrain_info((*this)[loc]).gives_healing() : 0; }
 bool gamemap::is_castle(const map_location& loc) const
-	{ return on_board(loc) && tdata_->get_terrain_info((*this)[loc]).is_castle(); }
+	{ return on_board(loc) && terrain_type_data::get().get_terrain_info((*this)[loc]).is_castle(); }
 bool gamemap::is_keep(const map_location& loc) const
-	{ return on_board(loc) && tdata_->get_terrain_info((*this)[loc]).is_keep(); }
+	{ return on_board(loc) && terrain_type_data::get().get_terrain_info((*this)[loc]).is_keep(); }
 
 
-/* Forwarded methods of tdata_ */
+/* Forwarded methods of terrain_type_data */
 std::string gamemap::get_terrain_string(const t_translation::terrain_code & terrain) const
-	{ return tdata_->get_terrain_string(terrain); }
+	{ return terrain_type_data::get().get_terrain_string(terrain); }
 std::string gamemap::get_terrain_editor_string(const t_translation::terrain_code & terrain) const
-	{ return tdata_->get_terrain_editor_string(terrain); }
+	{ return terrain_type_data::get().get_terrain_editor_string(terrain); }
 std::string gamemap::get_underlying_terrain_string(const t_translation::terrain_code& terrain) const
-	{ return tdata_->get_underlying_terrain_string(terrain); }
+	{ return terrain_type_data::get().get_underlying_terrain_string(terrain); }
 
 const terrain_type& gamemap::get_terrain_info(const t_translation::terrain_code & terrain) const
-	{ return tdata_->get_terrain_info(terrain); }
+	{ return terrain_type_data::get().get_terrain_info(terrain); }
 
 void gamemap::write_terrain(const map_location &loc, config& cfg) const
 {
@@ -98,7 +98,6 @@ gamemap::gamemap(std::string_view data)
 
 gamemap::gamemap(int w, int h, const terrain_code& t)
 	: gamemap_base(w, h, t)
-	, tdata_(terrain_type_data::get())
 	, villages_()
 {
 }
@@ -140,7 +139,7 @@ void gamemap::read(std::string_view data, const bool allow_invalid)
 		const t_translation::terrain_code& terrain = (*this)[loc];
 
 		// Is the terrain valid?
-		if(!tdata_->is_known(terrain)) {
+		if(!terrain_type_data::get().is_known(terrain)) {
 			std::stringstream ss;
 			ss << "Unknown tile in map: (" << t_translation::write_terrain_code(terrain) << ") '" << terrain << "'";
 			throw incorrect_map_format_error(ss.str());
@@ -376,7 +375,7 @@ gamemap_base::set_terrain_result gamemap::set_terrain(const map_location& loc,
 		return res;
 	}
 
-	new_terrain = tdata_->merge_terrains(get_terrain(loc), terrain, mode, replace_if_failed);
+	new_terrain = terrain_type_data::get().merge_terrains(get_terrain(loc), terrain, mode, replace_if_failed);
 
 	if(new_terrain == t_translation::NONE_TERRAIN) {
 		return res;
@@ -384,7 +383,7 @@ gamemap_base::set_terrain_result gamemap::set_terrain(const map_location& loc,
 
 	if(on_board(loc)) {
 		const bool old_village = is_village(loc);
-		const bool new_village = tdata_->is_village(new_terrain);
+		const bool new_village = terrain_type_data::get().is_village(new_terrain);
 
 		if(old_village && !new_village) {
 			utils::erase(villages_, loc);

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -249,8 +249,6 @@ private:
 	 */
 	std::string_view strip_legacy_header(std::string_view data) const;
 
-	std::shared_ptr<terrain_type_data> tdata_;
-
 protected:
 	std::vector<map_location> villages_;
 };

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -284,20 +284,19 @@ int movetype::terrain_info::data::calc_value(
 		return params_.default_value;
 	}
 
-	std::shared_ptr tdata = terrain_type_data::get();
-	assert(tdata);
+	terrain_type_data& tdata = terrain_type_data::get();
 
 	// Get a list of underlying terrains.
 	const t_translation::ter_list & underlying = params_.use_move ?
-			tdata->underlying_mvt_terrain(terrain) :
-			tdata->underlying_def_terrain(terrain);
+			tdata.underlying_mvt_terrain(terrain) :
+			tdata.underlying_def_terrain(terrain);
 
 	if (terrain_type::is_indivisible(terrain, underlying))
 	{
 		// This is not an alias; get the value directly.
 		int result = params_.default_value;
 
-		const std::string & id = tdata->get_terrain_info(terrain).id();
+		const std::string & id = tdata.get_terrain_info(terrain).id();
 		if (const config::attribute_value *val = cfg_.get(id)) {
 			// Read the value from our config.
 			result = val->to_int(params_.default_value);

--- a/src/terrain/type_data.cpp
+++ b/src/terrain/type_data.cpp
@@ -25,15 +25,16 @@
 #define LOG_G LOG_STREAM(info, lg::general())
 #define DBG_G LOG_STREAM(debug, lg::general())
 
-std::shared_ptr<terrain_type_data> terrain_type_data::reset(const game_config_view& game_config)
+terrain_type_data& terrain_type_data::reset(const game_config_view& game_config)
 {
 	singleton_.reset(new terrain_type_data(game_config));
-	return singleton_;
+	return *singleton_;
 }
 
-std::shared_ptr<terrain_type_data> terrain_type_data::get()
+terrain_type_data& terrain_type_data::get()
 {
-	return singleton_;
+	assert(singleton_);
+	return *singleton_;
 }
 
 terrain_type_data::terrain_type_data(const game_config_view & game_config)

--- a/src/terrain/type_data.hpp
+++ b/src/terrain/type_data.hpp
@@ -54,12 +54,12 @@ public:
 	 *
 	 * @returns A pointer to the new terrain database.
 	 */
-	static std::shared_ptr<terrain_type_data> reset(const game_config_view& game_config);
+	static terrain_type_data& reset(const game_config_view& game_config);
 
 	/**
 	 * @returns A pointer to the current terrain database instance.
 	 */
-	static std::shared_ptr<terrain_type_data> get();
+	static terrain_type_data& get();
 
 	/**
 	 * On the first call to this function, parse all of the [terrain_type]s
@@ -164,5 +164,5 @@ public:
 private:
 	tcodeToTerrain_t::const_iterator find_or_create(t_translation::terrain_code) const;
 
-	static inline std::shared_ptr<terrain_type_data> singleton_;
+	static inline std::unique_ptr<terrain_type_data> singleton_;
 };


### PR DESCRIPTION
Fixes #10462

terrain_type_data is intended to be a singleton, but is passed around via a shared_ptr.  When terrain_type_data::reset reloads the singleton instance owned by terrain_type_data, anyone else holding a shared pointer obtained from terrain_type_data::get() is left with a pointer to a stale copy, or at least to a version of terrain_type_data different from what terrain_type_data::get() will subsequently hand out.  #10462 is caused by exactly this.  When the user presses F5 in the editor, the terrain.cfg file is re-read and terrain_type_data::singleton_ correctly updated with this new data, but gamemap::tdata_ is a shared pointer that keeps the old instance alive, and the terrain pallette in the editor is (confusingly) populated by calling methods on gamemap, which continues to hand out this stale data.

This change converts terrain_type_data::singleton_ to a unique_ptr, and makes terrain_type_data::get() the source of truth tor terrain_type_data.  I am also making ::get() return a reference rather than a pointer.  terrain_type_data is initialized very early on by the game_config_manager, so the null case is probably not a big concern.  In the longer term, it might be better to make terrain_type_data owned by the gcm, so that it can provide a guarantee that it will always be around when it is asked for.