### PR TITLE
Use terrain_type accessors directly

### DIFF
--- a/src/help/help_impl.cpp
+++ b/src/help/help_impl.cpp
@@ -875,9 +875,10 @@ void generate_terrain_sections(section& sec, int /*level*/)
 			std::make_shared<terrain_topic_generator>(info)
 		};
 
-		t_translation::ter_list base_terrains = tdata->underlying_union_terrain(t);
+		t_translation::ter_list base_terrains = info.union_type();
+
 		if (info.has_default_base()) {
-			for (const auto base : tdata->underlying_union_terrain(info.default_base())) {
+			for (const auto& base : tdata->get_terrain_info(info.default_base()).union_type()) {
 				if (!utils::contains(base_terrains, base)) {
 					base_terrains.emplace_back(base);
 				}

--- a/src/help/help_topic_generators.cpp
+++ b/src/help/help_topic_generators.cpp
@@ -316,15 +316,13 @@ std::string terrain_topic_generator::operator()() const {
 		ss << (type_.editor_image().empty() ? "Empty" : type_.editor_image());
 		ss << "\n";
 
-		const t_translation::ter_list& underlying_mvt_terrains = tdata->underlying_mvt_terrain(type_.number());
 		ss << "\nDebug Mvt Description String:";
-		for(const t_translation::terrain_code& t : underlying_mvt_terrains) {
+		for(const t_translation::terrain_code& t : type_.mvt_type()) {
 			ss << " " << t;
 		}
 
-		const t_translation::ter_list& underlying_def_terrains = tdata->underlying_def_terrain(type_.number());
 		ss << "\nDebug Def Description String:";
-		for(const t_translation::terrain_code& t : underlying_def_terrains) {
+		for(const t_translation::terrain_code& t : type_.def_type()) {
 			ss << " " << t;
 		}
 

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -50,12 +50,6 @@ const terrain_type& gamemap::get_terrain_info(const map_location &loc) const
 	return tdata_->get_terrain_info(get_terrain(loc));
 }
 
-const t_translation::ter_list& gamemap::underlying_mvt_terrain(const map_location& loc) const
-	{ return tdata_->underlying_mvt_terrain(get_terrain(loc)); }
-const t_translation::ter_list& gamemap::underlying_def_terrain(const map_location& loc) const
-	{ return tdata_->underlying_def_terrain(get_terrain(loc)); }
-const t_translation::ter_list& gamemap::underlying_union_terrain(const map_location& loc) const
-	{ return tdata_->underlying_union_terrain(get_terrain(loc)); }
 std::string gamemap::get_terrain_string(const map_location& loc) const
 	{ return get_terrain_string(get_terrain(loc)); }
 std::string gamemap::get_terrain_editor_string(const map_location& loc) const

--- a/src/map/map.hpp
+++ b/src/map/map.hpp
@@ -177,9 +177,6 @@ class gamemap : public gamemap_base
 public:
 
 	/* Get info from the terrain_type_data object about the terrain at a location */
-	const t_translation::ter_list& underlying_mvt_terrain(const map_location& loc) const;
-	const t_translation::ter_list& underlying_def_terrain(const map_location& loc) const;
-	const t_translation::ter_list& underlying_union_terrain(const map_location& loc) const;
 	std::string get_terrain_string(const map_location& loc) const;
 	std::string get_terrain_editor_string(const map_location& loc) const;
 	std::string get_underlying_terrain_string(const map_location& loc) const;

--- a/src/movetype.cpp
+++ b/src/movetype.cpp
@@ -284,21 +284,19 @@ int movetype::terrain_info::data::calc_value(
 		return params_.default_value;
 	}
 
-	std::shared_ptr tdata = terrain_type_data::get();
-	assert(tdata);
+	const terrain_type& ter_info = terrain_type_data::get()->get_terrain_info(terrain);
 
 	// Get a list of underlying terrains.
-	const t_translation::ter_list & underlying = params_.use_move ?
-			tdata->underlying_mvt_terrain(terrain) :
-			tdata->underlying_def_terrain(terrain);
+	const t_translation::ter_list& underlying = params_.use_move
+		? ter_info.mvt_type()
+		: ter_info.def_type();
 
 	if (terrain_type::is_indivisible(terrain, underlying))
 	{
 		// This is not an alias; get the value directly.
 		int result = params_.default_value;
 
-		const std::string & id = tdata->get_terrain_info(terrain).id();
-		if (const config::attribute_value *val = cfg_.get(id)) {
+		if (const config::attribute_value *val = cfg_.get(ter_info.id())) {
 			// Read the value from our config.
 			result = val->to_int(params_.default_value);
 			if ( params_.eval != nullptr )

--- a/src/reports.cpp
+++ b/src/reports.cpp
@@ -581,14 +581,14 @@ static config unit_defense(const reports::context& rc, const unit* u, const map_
 		return config();
 	}
 
-	const t_translation::terrain_code &terrain = map[displayed_unit_hex];
-	int def = 100 - u->defense_modifier(terrain, displayed_unit_hex);
+	const terrain_type& terrain = map.get_terrain_info(displayed_unit_hex);
+	int def = 100 - u->defense_modifier(terrain.number(), displayed_unit_hex);
 	color_t color = game_config::red_to_green(def);
 	str << span_color(color, def, '%');
-	tooltip << _("Terrain:") << " " << markup::bold(map.get_terrain_info(terrain).description()) << "\n";
+	tooltip << _("Terrain:") << " " << markup::bold(terrain.description()) << "\n";
 
-	const t_translation::ter_list &underlyings = map.underlying_def_terrain(displayed_unit_hex);
-	if (underlyings.size() != 1 || underlyings.front() != terrain)
+	const t_translation::ter_list& underlyings = terrain.def_type();
+	if (underlyings.size() != 1 || underlyings.front() != terrain.number())
 	{
 		bool revert = false;
 		for (const t_translation::terrain_code &t : underlyings)
@@ -1457,7 +1457,7 @@ static config unit_box_at(const reports::context& rc, const map_location& mouseo
 
 	std::string bg_terrain_image;
 
-	for (const t_translation::terrain_code& underlying_terrain : map.underlying_union_terrain(mouseover_hex)) {
+	for(const t_translation::terrain_code& underlying_terrain : map.get_terrain_info(mouseover_hex).union_type()) {
 		const std::string& terrain_id = map.get_terrain_info(underlying_terrain).id();
 		bg_terrain_image = "~BLIT(unit_env/terrain/terrain-" + terrain_id + ".png)" + bg_terrain_image;
 	}
@@ -1603,8 +1603,8 @@ REPORT_GENERATOR(terrain_info, rc)
 		return config();
 	}
 
-	t_translation::terrain_code terrain = map.get_terrain(mouseover_hex);
-	if(t_translation::terrain_matches(terrain, t_translation::ALL_OFF_MAP)) {
+	const terrain_type& terrain = map.get_terrain_info(mouseover_hex);
+	if(t_translation::terrain_matches(terrain.number(), t_translation::ALL_OFF_MAP)) {
 		return config();
 	}
 
@@ -1624,7 +1624,7 @@ REPORT_GENERATOR(terrain_info, rc)
 //		blit_tced_icon(cfg, "keep", high_res);
 //	}
 
-	for(const t_translation::terrain_code& underlying_terrain : map.underlying_union_terrain(mouseover_hex)) {
+	for(const t_translation::terrain_code& underlying_terrain : terrain.union_type()) {
 		if(t_translation::terrain_matches(underlying_terrain, t_translation::ALL_OFF_MAP)) {
 			continue;
 		}

--- a/src/terrain/terrain.hpp
+++ b/src/terrain/terrain.hpp
@@ -66,11 +66,21 @@ public:
 	t_translation::terrain_code number() const { return number_; }
 
 	/**
-	 * The underlying type of the terrain.
+	 * The underlying movement type of the terrain.
+	 *
+	 * The underlying terrain is the name of the terrain for game-logic purposes.
+	 * I.e. if the terrain is simply an alias, the underlying terrain name
+	 * is the name of the terrain(s) that it's aliased to.
 	 *
 	 * Whether "underlying" means "only the types used in [movetype]" is determined
 	 * by the terrain.cfg file, rather than the .cpp code - in 1.14, the terrain.cfg
 	 * file uses only the [movetype] terrains in its alias lists.
+	 *
+	 * This may start with a t_translation::PLUS or t_translation::MINUS to
+	 * indicate whether the movement should be calculated as a best-of or
+	 * worst-of combination. These may also occur later in the list, however if
+	 * both PLUS and MINUS appear in the list then the values calculated are
+	 * implementation defined behavior.
 	 */
 	const t_translation::ter_list& mvt_type() const { return mvt_type_; }
 	const t_translation::ter_list& def_type() const { return def_type_; }

--- a/src/terrain/type_data.cpp
+++ b/src/terrain/type_data.cpp
@@ -122,50 +122,6 @@ const terrain_type& terrain_type_data::get_terrain_info(const t_translation::ter
 	}
 }
 
-const t_translation::ter_list& terrain_type_data::underlying_mvt_terrain(const t_translation::terrain_code & terrain) const
-{
-	auto i = find_or_create(terrain);
-
-	if(i == tcodeToTerrain_.end()) {
-		// TODO: At least in some cases (for example when this is called from lua) it
-		// seems to make more sense to throw an exception here, same goes for get_terrain_info
-		// and underlying_def_terrain
-		static t_translation::ter_list result(1);
-		result[0] = terrain;
-		return result;
-	} else {
-		return i->second.mvt_type();
-	}
-}
-
-const t_translation::ter_list& terrain_type_data::underlying_def_terrain(const t_translation::terrain_code & terrain) const
-{
-	auto i = find_or_create(terrain);
-
-	if(i == tcodeToTerrain_.end()) {
-		static t_translation::ter_list result(1);
-		result[0] = terrain;
-		return result;
-	} else {
-		return i->second.def_type();
-	}
-}
-
-const t_translation::ter_list& terrain_type_data::underlying_union_terrain(const t_translation::terrain_code & terrain) const
-{
-	auto i = find_or_create(terrain);
-
-	if(i == tcodeToTerrain_.end()) {
-		static t_translation::ter_list result(1);
-		result[0] = terrain;
-		return result;
-	} else {
-		return i->second.union_type();
-	}
-}
-
-
-
 t_string terrain_type_data::get_terrain_string(const t_translation::terrain_code& terrain) const
 {
 	t_string str =
@@ -195,10 +151,9 @@ t_string terrain_type_data::get_terrain_editor_string(const t_translation::terra
 
 t_string terrain_type_data::get_underlying_terrain_string(const t_translation::terrain_code& terrain) const
 {
-	// lazy_initialization() is handled in underlying_union_terrain
 	std::string str;
 
-	const t_translation::ter_list& underlying = underlying_union_terrain(terrain);
+	const t_translation::ter_list& underlying = get_terrain_info(terrain).union_type();
 	assert(!underlying.empty());
 
 	if(underlying.size() > 1 || underlying[0] != terrain) {

--- a/src/terrain/type_data.hpp
+++ b/src/terrain/type_data.hpp
@@ -83,37 +83,6 @@ public:
 	const terrain_type& get_terrain_info(const t_translation::terrain_code & terrain) const;
 
 	/**
-	 * The underlying movement type of the terrain.
-	 *
-	 * The underlying terrain is the name of the terrain for game-logic purposes.
-	 * I.e. if the terrain is simply an alias, the underlying terrain name
-	 * is the name of the terrain(s) that it's aliased to.
-	 *
-	 * Whether "underlying" means "only the types used in [movetype]" is determined
-	 * by the terrain.cfg file, rather than the .cpp code - in 1.14, the terrain.cfg
-	 * file uses only the [movetype] terrains in its alias lists.
-	 *
-	 * This may start with a t_translation::PLUS or t_translation::MINUS to
-	 * indicate whether the movement should be calculated as a best-of or
-	 * worst-of combination. These may also occur later in the list, however if
-	 * both PLUS and MINUS appear in the list then the values calculated are
-	 * implementation defined behavior.
-	 */
-	const t_translation::ter_list& underlying_mvt_terrain(const t_translation::terrain_code & terrain) const;
-	/**
-	 * The underlying defense type of the terrain. See the notes for underlying_mvt_terrain.
-	 */
-	const t_translation::ter_list& underlying_def_terrain(const t_translation::terrain_code & terrain) const;
-	/**
-	 * Unordered set of all terrains used in either underlying_mvt_terrain or
-	 * underlying_def_terrain. This does not include any PLUSes or MINUSes.
-	 *
-	 * May also include the aliasof and vision_alias terrains, however
-	 * vision_alias is deprecated and aliasof should probably match the
-	 * movement and defense terrains.
-	 */
-	const t_translation::ter_list& underlying_union_terrain(const t_translation::terrain_code & terrain) const;
-	/**
 	 * Get a formatted terrain name -- terrain (underlying terrains)
 	 */
 	t_string get_terrain_string(const t_translation::terrain_code& terrain) const;


### PR DESCRIPTION
This removes underlying_mvt_terrain, underlying_def_terrain, and underlying_union_terrain from terrain_type_data as well as their corresponding wrappers in gamemap. Instead, we simply use the appropriates methods in terrain_type. Much tidier.