### PR TITLE
Bump min CMake version to 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # set minimum version
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.21)
 
 project(wesnoth)
 


### PR DESCRIPTION
3.21 is needed to use CMakePresets.json v3, which I recently migrated to, discarding the old, VS-specific CMakeSettings.json file.