### PR TITLE
Clean out [advancefrom] and extra_defines deprecation warnings

### DIFF
--- a/src/game_config_manager.cpp
+++ b/src/game_config_manager.cpp
@@ -389,62 +389,6 @@ void game_config_manager::load_game_config(bool reload_everything, const game_cl
 	// Set new binary paths.
 	paths_manager_.set_paths(game_config());
 }
-static void show_deprecated_warnings(config& umc_cfg)
-{
-	for(auto& units : umc_cfg.child_range("units")) {
-		for(auto& unit_type : units.child_range("unit_type")) {
-			for(const auto& advancefrom : unit_type.child_range("advancefrom")) {
-				auto symbols = utils::string_map {
-					{"lower_level", advancefrom["unit"].str()},
-					{"higher_level", unit_type["id"].str()}
-				};
-				auto message = VGETTEXT(
-					// TRANSLATORS: For example, 'Cuttle Fish' units will not be able to advance to 'Kraken'.
-					// The substituted strings are unit ids, not translated names; hopefully any add-ons
-					// that trigger this will be quickly fixed and stop triggering the warning.
-					"Error: [advancefrom] no longer works. ‘$lower_level’ units will not be able to advance to ‘$higher_level’; please ask the add-on author to use [modify_unit_type] instead.",
-					symbols);
-				deprecated_message("[advancefrom]", DEP_LEVEL::REMOVED, {1, 15, 4}, message);
-			}
-			unit_type.remove_children("advancefrom");
-		}
-	}
-
-
-	// hardcoded list of 1.14 advancement macros, just used for the error mesage below.
-	static const std::set<std::string> deprecated_defines {
-		"ENABLE_PARAGON",
-		"DISABLE_GRAND_MARSHAL",
-		"ENABLE_ARMAGEDDON_DRAKE",
-		"ENABLE_DWARVISH_ARCANISTER",
-		"ENABLE_DWARVISH_RUNESMITH",
-		"ENABLE_WOLF_ADVANCEMENT",
-		"ENABLE_NIGHTBLADE",
-		"ENABLE_TROLL_SHAMAN",
-		"ENABLE_ANCIENT_LICH",
-		"ENABLE_DEATH_KNIGHT",
-		"ENABLE_WOSE_SHAMAN"
-	};
-
-	for(auto& campaign : umc_cfg.child_range("campaign")) {
-		for(auto str : utils::split(campaign["extra_defines"])) {
-			if(deprecated_defines.count(str) > 0) {
-				//TODO: we could try to implement a compatibility path by
-				//      somehow getting the content of that macro from the
-				//      cache_ object, but considering that 1) the breakage
-				//      isn't that bad (just one disabled unit) and 2)
-				//      it before also didn't work in all cases (see #4402)
-				//      i don't think it is worth it.
-				deprecated_message(
-					"campaign id='" + campaign["id"].str() + "' has extra_defines=" + str,
-					DEP_LEVEL::REMOVED,
-					{1, 15, 4},
-					_("instead, use the macro with the same name in the [campaign] tag")
-				);
-			}
-		}
-	}
-}
 
 void game_config_manager::load_addons_cfg()
 {
@@ -574,10 +518,6 @@ void game_config_manager::load_addons_cfg()
 					cfg["addon_version"] = addon_version.str();
 				}
 			}
-
-			loading_screen::spin();
-
-			show_deprecated_warnings(umc_cfg);
 
 			loading_screen::spin();
 


### PR DESCRIPTION
It's been two stable cycles with these. Anything using them should have been updated already.