### PR TITLE
Change rich_label::signal_handler_left_button_click to break out of the iteration over links_ as soon as it finds the click target.

### DIFF
--- a/src/gui/widgets/rich_label.cpp
+++ b/src/gui/widgets/rich_label.cpp
@@ -863,18 +863,23 @@ void rich_label::signal_handler_left_button_click(bool& handled)
 	DBG_GUI_RL << "(mouse) " << mouse;
 	DBG_GUI_RL << "link count :" << links_.size();
 
+	std::optional<std::string> click_target;
 	for(const auto& entry : links_) {
-		DBG_GUI_RL << "link " << entry.first;
+		DBG_GUI_RL << "link " << entry.second;
 
 		if(entry.first.contains(mouse)) {
-			DBG_GUI_RL << "Clicked link! dst = " << entry.second;
-			sound::play_UI_sound(settings::sound_button_click);
-			if(link_handler_) {
-				link_handler_(entry.second);
-			} else {
-				DBG_GUI_RL << "No registered link handler found";
-			}
+			click_target = entry.second;
+			break;
+		}
+	}
 
+	if (click_target) {
+		DBG_GUI_RL << "Clicked link! dst = " << *click_target;
+		sound::play_UI_sound(settings::sound_button_click);
+		if(link_handler_) {
+			link_handler_(*click_target);
+		} else {
+			DBG_GUI_RL << "No registered link handler found";
 		}
 	}
 


### PR DESCRIPTION
Change rich_label::signal_handler_left_button_click to break out of the iteration over links_ as soon as it finds the click target.

The loop over links_ in rich_label::signal_handler_left_button_click, on finding a click target, can result in a callstack like this:

gui2::rich_label::add_link (rich_label.cpp:212)
gui2::rich_label::get_parsed_text (rich_label.cpp:582) gui2::rich_label::set_dom (rich_label.cpp:252)
gui2::dialogs::help_browser::show_topic (help_browser.cpp:241) ...std::function standard library garbage...
gui2::rich_label::signal_handler_left_button_click (rich_label.cpp:873) ...

At the bottom, signal_handler_left_button_click has found a click target and is calling link_handler_(entry->second).  At the top, the same rich_label object is adding new entries to the links_ vector.  If this addition of new entries causes the vector to reallocate, signal_handler_left_button_click will access deleted memory when this callstack returns and the iteration over links_ continues.

The most straightforward way out of this issue is, if a click target is found while iterating  over links_, to save a copy of the corresponding links_ entry, and then break out of the loop before passing it in to the handler.  This approach is also clearer, since it doesn't make sense for multiple links in a rich_label to have the same coordinates and handle the same click anyway.  Once you have found the target you are done; breaking out of the loop early is the right thing to do when there should only be one handler.