### PR TITLE
add assertion when disbanding

### DIFF
--- a/src/synced_commands.cpp
+++ b/src/synced_commands.cpp
@@ -247,10 +247,7 @@ SYNCED_COMMAND_HANDLER_FUNCTION(disband, child, spectator)
 
 	current_team.recall_list().erase_if_matches_id(unit_id);
 
-	if (old_size == current_team.recall_list().size()) {
-		spectator.error("illegal disband\n");
-		return false;
-	}
+	assert(old_size != current_team.recall_list().size());
 	return true;
 }
 


### PR DESCRIPTION
the code already checks above whether a unit with this id exists, so it should be impossible to get an error here. So ercan replace this check with an assert.

pr mostly for CI