### PR TITLE
Don't fail to start if the game_config::path folder is empty

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -1271,6 +1271,18 @@ bool is_directory(const std::string& fname)
 	return is_directory_internal(bfs::path(fname));
 }
 
+bool is_empty_directory(const std::string& path)
+{
+	error_code ec;
+	bool is_empty = bfs::is_empty(bfs::path(path), ec);
+	if(ec) {
+		LOG_FS << "Failed to check if directory " << path << " is empty: " << ec.message();
+		return false;
+	}
+
+	return is_empty;
+}
+
 bool file_exists(const std::string& name)
 {
 	return file_exists(bfs::path(name));

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -269,6 +269,8 @@ bool create_directory_if_missing_recursive(const std::string& dirname);
 /** Returns true if the given file is a directory. */
 bool is_directory(const std::string& fname);
 
+bool is_empty_directory(const std::string& path);
+
 /** Returns true if a file or directory with such name already exists. */
 bool file_exists(const std::string& name);
 

--- a/src/wesnoth.cpp
+++ b/src/wesnoth.cpp
@@ -452,7 +452,7 @@ static int process_command_args(commandline_options& cmdline_opts)
 #endif
 		// if a pre-defined path does not exist this will empty it
 		game_config::path = filesystem::normalize_path(game_config::path, true, true);
-		if(game_config::path.empty()) {
+		if(game_config::path.empty() || filesystem::is_empty_directory(game_config::path)) {
 			if(std::string exe_dir = filesystem::get_exe_dir(); !exe_dir.empty()) {
 				if(std::string auto_dir = filesystem::autodetect_game_data_dir(std::move(exe_dir)); !auto_dir.empty()) {
 					if(!cmdline_opts.nobanner) {


### PR DESCRIPTION
Resolves #9613

If the directory pointed at by game_config::path is empty, Wesnoth fails to start.  It isn't completely clear to me how this state could arise; possibly an incomplete install or uninstall.  At any rate, the game has logic to use the exe dir as the game_config::path if its initial value does not exist at all.  Behaving in the same way when the initial path is empty seems like much better behavior than simply refusing to run.