### PR TITLE
HttT: reduce difference in scenario count between difficulties

### DIFF
--- a/data/campaigns/Heir_To_The_Throne/_main.cfg
+++ b/data/campaigns/Heir_To_The_Throne/_main.cfg
@@ -68,10 +68,10 @@
 
 " + _"(Intermediate level, 14 scenarios.)"
 
-    {CAMPAIGN_DIFFICULTY EASY      "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-fighter.png~RC(magenta>red)"   ( _ "Easy"  )  ( _ "1x enemies, 16 scenarios")}
+    {CAMPAIGN_DIFFICULTY EASY      "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-fighter.png~RC(magenta>red)"   ( _ "Easy"  )  ( _ "1x enemies, 15 scenarios")}
     {CAMPAIGN_DIFFICULTY NORMAL    "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-captain.png~RC(magenta>red)"   ( _ "Normal")  ( _ "2x enemies, 14 scenarios")} {DEFAULT_DIFFICULTY}
-    {CAMPAIGN_DIFFICULTY HARD      "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-commander.png~RC(magenta>red)" ( _ "Hard"  )  ( _ "3x enemies, 12 scenarios")}
-    {CAMPAIGN_DIFFICULTY NIGHTMARE "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-lord.png~RC(magenta>red)"      ( _ "Deadly")  ( _ "4x enemies, 10 scenarios")}
+    {CAMPAIGN_DIFFICULTY HARD      "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-commander.png~RC(magenta>red)" ( _ "Hard"  )  ( _ "3x enemies, 13 scenarios")}
+    {CAMPAIGN_DIFFICULTY NIGHTMARE "data/campaigns/Heir_To_The_Throne/images/units/konrad/konrad-lord.png~RC(magenta>red)"      ( _ "Deadly")  ( _ "4x enemies, 12 scenarios")}
     #
     # ----Difficulty Notes:
     # on higher difficulties, the player gets fewer scenarios to play with

--- a/data/campaigns/Heir_To_The_Throne/scenarios/00_The_Great_Continent.cfg
+++ b/data/campaigns/Heir_To_The_Throne/scenarios/00_The_Great_Continent.cfg
@@ -436,16 +436,16 @@
 
         # milestone - on which bm_turn (Elves Besieged ends with turn=1) is Elensefar captured?
         # NOTE: if I change this, make sure the the timed campaign completion achievements are still possible
-        {VARIABLE bm_milestone_elensefar {ON_DIFFICULTY4  6  5  4  4}}
+        {VARIABLE bm_milestone_elensefar {ON_DIFFICULTY4  5  5  4  4}}
 
         # milestone - on which bm_turn (Elves Besieged ends with turn=1) must Konrad play "The Sceptre of Fire"?
-        {VARIABLE bm_milestone_scepter   {ON_DIFFICULTY4  9  7  6  5}}
+        {VARIABLE bm_milestone_scepter   {ON_DIFFICULTY4  9  8  7  6}}
 
         # milestone - on which bm_turn (Elves Besieged ends with turn=1) must Konrad fight Asheviere?
-        # NOTE: this timing works out so that if we start in Autumn (which we do), Nightmare's final battle happens in Summer - the strongest season for Asheviere's lawful soldiers.
+        # NOTE: this timing works out so that if we start in Autumn (which we do), Nightmare's final battle happens in Winter - the worst season for Asheviere's lawful soldiers.
         # NOTE: if I ever reduce the gap between the Sceptre and Finale, be sure that the "cup of bitterness" event doesn't overlap with any other events.
         # NOTE: a player might choose to play the Sceptre early, which would give them extra second-half scenarios before $bm_milestone_finale. That's ok.
-        {VARIABLE bm_milestone_finale    {ON_DIFFICULTY4 14 12 10  8}}
+        {VARIABLE bm_milestone_finale    {ON_DIFFICULTY4 13 12 11 10}}
 
         # both $bm_milestone_scepter and $bm_milestone_finale get set to 99 if the player chooses to disable all time limits on the S30 bigmap
     [/event]


### PR DESCRIPTION
Give players more time to complete the campaign on Hard/Deadly, but slightly less on Easy.

1/2/3/4 difficulty scaling is already very extreme. Combined with HttT's scaling number of scenarios per difficulty, I think the existing gap between Easy/Normal and Hard/Deadly may be too vast.