### PR TITLE
Cleanup Walking Corpse code

### DIFF
--- a/data/core/units/undead/Corpse_Walking.cfg
+++ b/data/core/units/undead/Corpse_Walking.cfg
@@ -26,11 +26,9 @@
 # Variant animations for the Walking Corpse
 #define UNIT_BODY_WALKING_CORPSE_GRAPHICS BASE_NAME
 #arg IPF
-NOP#endarg
-#arg ARG
 #endarg
     image="units/undead/{BASE_NAME}.png"
-    {DEFENSE_ANIM "units/undead/{BASE_NAME}-defend.png~{IPF}({ARG})" "units/undead/{BASE_NAME}.png~{IPF}({ARG})" {SOUND_LIST:ZOMBIE_WEAK_HIT} }
+    {DEFENSE_ANIM "units/undead/{BASE_NAME}-defend.png{IPF}" "units/undead/{BASE_NAME}.png{IPF}" {SOUND_LIST:ZOMBIE_WEAK_HIT} }
     # This standing animation only exists for the base unit and variation="mounted" for now. As variations are added, the two filters should be updated.
     [standing_anim]
         [filter]
@@ -41,24 +39,24 @@ NOP#endarg
         [/filter]
         start_time=0
         [frame]
-            image="units/undead/{BASE_NAME}-standing-[1~7,2].png~{IPF}({ARG}):[580,980,600,430,350*2,420,720]"
+            image="units/undead/{BASE_NAME}-standing-[1~7,2].png{IPF}:[580,980,600,430,350*2,420,720]"
         [/frame]
     [/standing_anim]
     [standing_anim]
-        #excluded are the base unit and variation="mounted" and "cat" (animation directly above) and variation="bat,falcon" (animation further down)
         [filter]
+            #excluded are the base unit and variation="mounted" and "cat" (animation directly above) and variation="bat,falcon" (animation further down)
             variation="ant,beast_rider,boar,bug,drake,dwarf,fish,goblin,gryphon,horse,rat,sand_scorpion,saurian,scorpion,serpent,spider,swimmer,troll,wolf,wose"
         [/filter]
         start_time=0
         [frame]
-            image="units/undead/{BASE_NAME}.png~{IPF}({ARG}):150"
+            image="units/undead/{BASE_NAME}.png{IPF}:150"
         [/frame]
     [/standing_anim]
     #
     [death]
         start_time=0
         [frame]
-            image="units/undead/{BASE_NAME}-die-[1~4].png~{IPF}({ARG}):150,units/undead/soulless-die-[5~10].png~{IPF}({ARG}):150"
+            image="units/undead/{BASE_NAME}-die-[1~4].png{IPF}:150,units/undead/soulless-die-[5~10].png{IPF}:150"
         [/frame]
     [/death]
     [attack_anim]
@@ -68,7 +66,7 @@ NOP#endarg
         direction=s
         start_time=-200
         [frame]
-            image="units/undead/{BASE_NAME}-attack-s.png~{IPF}({ARG}):400"
+            image="units/undead/{BASE_NAME}-attack-s.png{IPF}:400"
             sound=zombie-attack.wav
         [/frame]
     [/attack_anim]
@@ -79,7 +77,7 @@ NOP#endarg
         direction=n
         start_time=-200
         [frame]
-            image="units/undead/{BASE_NAME}-attack-n.png~{IPF}({ARG}):400"
+            image="units/undead/{BASE_NAME}-attack-n.png{IPF}:400"
             sound=zombie-attack.wav
         [/frame]
     [/attack_anim]
@@ -90,7 +88,7 @@ NOP#endarg
         direction=se,sw,ne,nw
         start_time=-200
         [frame]
-            image="units/undead/{BASE_NAME}-attack.png~{IPF}({ARG}):400"
+            image="units/undead/{BASE_NAME}-attack.png{IPF}:400"
             sound=zombie-attack.wav
         [/frame]
     [/attack_anim]
@@ -378,7 +376,7 @@ NOP#endarg
         inherit=yes
         profile=portraits/undead/zombie-scorpion.webp~CS(7,-8,-51)
         {UNIT_BODY_WALKING_CORPSE_STATS    scuttlefoot 4 21}
-        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-scorpion IPF=CS ARG=10,-12,-77}
+        {UNIT_BODY_WALKING_CORPSE_GRAPHICS zombie-scorpion IPF="~CS(10,-12,-77)"}
     [/variation]
 
     [variation]


### PR DESCRIPTION
This cleans up a macro in Walking Corpse I modified when I added the sand_scorpion variant and removes the unneccessary call of the ~NOP IPF function, as already done for the Soulless by @soliton- in commit 1dd72e709af9ef51f2f467c9e8083a299e934858. I also relocated a comment, so that the code of Walking Corpse and Soulless are more unified.