### PR TITLE
Enable 5th variant of wind weather

### DIFF
--- a/data/internal/Weather/_main.cfg
+++ b/data/internal/Weather/_main.cfg
@@ -126,7 +126,15 @@ dawn_noweather,morning_noweather,midday_noweather,afternoon_noweather,dusk_nowea
         [command]
             {VARIABLE_OP weatherWind__delay  rand {RANDOM_DELAY}}
             {VARIABLE_OP weatherWind__speed  rand "fast,slow"}
-            {VARIABLE_OP weatherWind__variant rand "1,2,3,4"} # "fast" has a 5th variant, but ignore that to simplify the WML
+            [if]
+                {VARIABLE_CONDITIONAL weatherWind__speed equals fast}
+                [then]
+                    {VARIABLE_OP weatherWind__variant rand "1,2,3,4,5"}
+                [/then]
+                [else]
+                    {VARIABLE_OP weatherWind__variant rand "1,2,3,4"}
+                [/else]
+            [/if]
             [item]
                 name=weather_wind
                 x,y=$hex.x,$hex.y


### PR DESCRIPTION
This commits enables an unused variant of the fast wind weather found at /data/internal/Weather/images/terrain/wind/ne/fast/5/
