### PR TITLE
Remove redundant [resistance] values for the Sand Scuttler line

### DIFF
--- a/data/core/units/monsters/Sand_Scamperer.cfg
+++ b/data/core/units/monsters/Sand_Scamperer.cfg
@@ -12,14 +12,6 @@
     profile="portraits/monsters/scamperer.webp~RIGHT()"
     hitpoints=27
     movement_type=scuttlefoot
-    [resistance]
-        blade=90
-        pierce=90
-        impact=30
-        fire=200
-        cold=120
-        arcane=150
-    [/resistance]
     movement=6
     experience=20
     level=0

--- a/data/core/units/monsters/Sand_Scuttler.cfg
+++ b/data/core/units/monsters/Sand_Scuttler.cfg
@@ -23,14 +23,6 @@
     [/standing_anim]
     hitpoints=40
     movement_type=scuttlefoot
-    [resistance]
-        blade=90
-        pierce=90
-        impact=30
-        fire=200
-        cold=120
-        arcane=150
-    [/resistance]
     movement=8
     experience=50
     level=1


### PR DESCRIPTION
The [resistance] values in the Sand Scuttler unit line are identical to the scuttlefoot movement_type. Therefore, they are redundant and can be removed safely.