### PR TITLE
Discover extra_recruits for the in-game help dialog (fixes #10776)

### DIFF
--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1266,6 +1266,14 @@ void unit::set_recruits(const std::vector<std::string>& recruits)
 {
 	unit_types.check_types(recruits);
 	std::set<std::string> recruits_set(recruits.begin(), recruits.end());
+	if(resources::gameboard) {
+		if(resources::gameboard->get_team(side_).is_local_human()) {
+			auto& encountered_units = prefs::get().encountered_units();
+			for(const auto& recruit : recruits_set) {
+				encountered_units.insert(recruit);
+			}
+		}
+	}
 	recruit_list_ = recruits_set;
 }
 


### PR DESCRIPTION
This fixes an issue, where the elemental units in the second scenario in HttT are not discovered in the in-game help.