### PR TITLE
SotBE-S10: move back unit to adjacent hex

### DIFF
--- a/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
+++ b/data/campaigns/Son_Of_The_Black_Eye/scenarios/10_Saving_Inarix.cfg
@@ -551,6 +551,9 @@
                                         speaker=unit
                                         message= _ "<i>Phew!</i>"
                                     [/message]
+
+                                    # move unit back to safety
+                                    {MOVE_UNIT (x,y=21,13) 20 12}
                                 [/command]
                             [/option]
                         [/message]


### PR DESCRIPTION
Addresses the **SotBE** example in comments of issue #10411 ([source](https://github.com/wesnoth/wesnoth/issues/10411#issuecomment-3181839903))