### PR TITLE
Update tests for the warning about too few traits

### DIFF
--- a/data/test/scenarios/wml_tests/UnitsWML/traits_exclude_include.cfg
+++ b/data/test/scenarios/wml_tests/UnitsWML/traits_exclude_include.cfg
@@ -5,10 +5,12 @@
 ##
 # Actions:
 # Bob is told to generate special random traits.
+# Bob's unit type expects two traits from a pool of two traits.
+# One of the two special traits excludes the other one trait.
 ##
 # Expected end state:
-# One of the two special traits excludes another trait to be already had by Bob.
 # Bob should either not have the trait or have only the excluded one.
+# This triggers a warning that too few traits were generated (a BROKE_STRICT_PASS result).
 #####
 {GENERIC_UNIT_TEST "trait_exclusion_test" (
     [event]
@@ -47,10 +49,11 @@
 ##
 # Actions:
 # Bob is told to generate special random traits.
+# Bob's unit type expects two traits from a pool of two traits.
+# One of the two special traits needs another trait to be already had by Bob.
 ##
 # Expected end state:
-# One of the two special traits needs another trait to be already had by Bob.
-# Bob only have the trait if it also has the one it requires one.
+# Bob has both traits, and they're ordered by the dependency.
 #####
 {GENERIC_UNIT_TEST "trait_requirement_test" (
     [event]

--- a/wml_test_schedule
+++ b/wml_test_schedule
@@ -406,7 +406,7 @@
 0 unpetrifiable_status_test
 0 test_force_chance_to_hit_macro_nested
 0 test_force_chance_to_hit_macro_toplevel
-0 trait_exclusion_test
+9 trait_exclusion_test
 0 trait_requirement_test
 0 test_remove_ability_by_filter
 0 test_overwrite_specials_filter


### PR DESCRIPTION
One triggers a warning added in 291b28567bd2f40a0098ec0cea91299808a9e21b, as it should. Change the expected status and docs to match.