### PR TITLE
Capitalize “Wild Saurians” in Beast Saurian Unit Description

### DIFF
--- a/data/campaigns/Dusk_of_Dawn/units/Beast_Saurian.cfg
+++ b/data/campaigns/Dusk_of_Dawn/units/Beast_Saurian.cfg
@@ -16,7 +16,7 @@
     experience=100
     cost=28
     usage=fighter
-    description= _ "As they grow older, wild saurians begin to be able to produce the poison with which they coat their sickles. This allows them to weaken their prey, which quickly falls under the strain of time."
+    description= _ "As they grow older, Wild Saurians begin to be able to produce the poison with which they coat their sickles. This allows them to weaken their prey, which quickly falls under the strain of time."
     {DEFENSE_ANIM "units/saurians/beast-defend-2.png" "units/saurians/beast-defend-1.png" hiss-hit.wav }
     die_sound=hiss-die.wav
 


### PR DESCRIPTION
Unit names should be capitalized according to the typography style guide.