### PR TITLE
unit bar UI rework [LLM assisted] 

### DIFF
--- a/changelog_entries/unit_UI_bars_reworked.md
+++ b/changelog_entries/unit_UI_bars_reworked.md
@@ -1,0 +1,7 @@
+### UI
+  * Reworked how the health bar, xp bar, movement orb and leadership crown will appear with units ingame.
+    * The UI now scales more as you zoom. (Making it bigger when zoomed out and smaller when zoomed in relative to the unit)
+    * The UI is wider and uses stronger border contrasts to make it more readable. Also fades the left/right borders.
+    * The health bar of full hp units have a more muted green, to more easily see what units are damaged.
+    * The UI now fully highlights as you hover or select the unit.
+    * A divider line between the filled and unfilled area of the bar has been added to improve clarity.

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -1195,9 +1195,9 @@ static color_t hp_color_impl(int hitpoints, int max_hitpoints)
 		: 0.0;
 
 	if(1.0 == unit_energy) {
-		return {33, 225, 0};
+		return {33, 255, 100};
 	} else if(unit_energy > 1.0) {
-		return {100, 255, 100};
+		return {140, 255, 140};
 	} else if(unit_energy >= 0.75) {
 		return {170, 255, 0};
 	} else if(unit_energy >= 0.5) {


### PR DESCRIPTION
Changes how "health bar", "xp bar", "movement orb"  and  "leadership crown" are displayed next to the unit in game. 

Resolves: https://github.com/wesnoth/wesnoth/issues/10106 and https://github.com/wesnoth/wesnoth/issues/10847

* The UI now scales some as you zoom.
* The UI is smaller but uses stronger border contrasts to make it more readable
* The health bar of full hp units have a more muted green, to easily see what units are damaged.
* The UI now fully highlights as you hover or select a unit.

<img width="751" height="436" alt="bild" src="https://github.com/user-attachments/assets/6ef507a6-95e0-4706-a44b-ffe2349713c7" />

The goal here is to reach the middle-ground for users in terms of clarity(readability), usefulness, immersion and beauty. All of which is subjective.

Further changes will be done based on feedback.
