### PR TITLE
Clarify length of Wesnothian months and end of Wesnothian year in encyclopedia

### DIFF
--- a/data/core/encyclopedia/calendar.cfg
+++ b/data/core/encyclopedia/calendar.cfg
@@ -11,7 +11,7 @@
 [topic]
     id=..calendar
     title= _ "Calendar"
-    text= _ "Each year in the Wesnothian calendar is composed of 12 months. These are, in order:
+    text= _ "Each year in the Wesnothian calendar ends on the winter solstice and is composed of 12 months, each 30 days long. These are, in order:
 
 Whitefire
 Bleeding Moon


### PR DESCRIPTION
All months being exactly 30 days is simpler than months of varying lengths like those of the Gregorian calendar. A Wesnothian year is 360 days, which is fairly close to a year on Earth, so whenever years are mentioned in the game they mean approximately the same length of time that the player expects. No mention of these months elsewhere in the game implies that any months have to be longer than 27 days, so this shouldn’t contradict other content. The Winter Solstice in the Northern Hemisphere on Earth occurs on the 21st or 22nd of December, close to the New Year in the Gregorian Calendar. This means players can easily think of “Whitefire” as equivalent to January, “Bleeding Moon” as equivalent to February, “Scatterseed” as equivalent to March and so on.