### PR TITLE
HttTC: fix broken tutorial achievement

### DIFF
--- a/data/campaigns/Heir_To_The_Throne_Classic/achievements.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/achievements.cfg
@@ -1,9 +1,9 @@
 #textdomain wesnoth-httt
 [achievement_group]
     display_name=_"Heir to the Throne, Classic"
-    content_for=htttc
+    content_for=tutorial
     [achievement]
-        id="s00"
+        id="completed"
         name=_"Trained for Battle"
         description=_"Complete the old <i>Battle Training</i> tutorial."
         icon="data/core/images/icons/crossed_sword_and_hammer.png"

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/00_Tutorial_part_1.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/00_Tutorial_part_1.cfg
@@ -1238,8 +1238,8 @@
         [/hint_message]
 
         [progress_achievement]
-            content_for=htttc
-            id="s00"
+            content_for=tutorial
+            id="completed"
             amount=1
             limit=1
         [/progress_achievement]

--- a/data/campaigns/Heir_To_The_Throne_Classic/scenarios/00_Tutorial_part_2.cfg
+++ b/data/campaigns/Heir_To_The_Throne_Classic/scenarios/00_Tutorial_part_2.cfg
@@ -1519,8 +1519,8 @@ Rest-healing is an exception to the rule — if a unit doesn’t do anything for
             message= _ "Now, continue onwards to play “Heir to the Throne, Classic”..."
         [/message]
         [progress_achievement]
-            content_for=htttc
-            id="s00"
+            content_for=tutorial
+            id="completed"
             amount=1
             limit=2
         [/progress_achievement]


### PR DESCRIPTION
Thanks to Antro for the report. I've also changed the description of the old achievement to fix a grammar issue and better-explain which campaign this achievement is part of.
