### PR TITLE
fix overwrite_specials cannot diffrentiate self or opponent specials when apply_to=attacker/defender is used

### DIFF
--- a/src/units/attack_type.cpp
+++ b/src/units/attack_type.cpp
@@ -887,7 +887,7 @@ active_ability_list attack_type::get_specials_and_abilities(const std::string& s
 	if (!abil_list.empty() && !overwriters.empty()) {
 		// remove all abilities that would be overwritten
 		utils::erase_if(abil_list, [&](const active_ability& j) {
-			return (overwrite_special_checking(overwriters, j.ability()));
+			return (overwrite_special_checking(overwriters, j));
 			});
 	}
 	return abil_list;

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -199,9 +199,9 @@ public:
 	 *
 	 * @return True if element checked is overwritable.
 	 * @param overwriters list used for check if element is overwritable.
-	 * @param ab the ability/special checked
+	 * @param i the ability/special checked
 	 */
-	bool overwrite_special_checking(active_ability_list& overwriters, const unit_ability_t& ab) const;
+	bool overwrite_special_checking(active_ability_list& overwriters, const active_ability& i) const;
 
 	bool special_active(const unit_ability_t& ab, AFFECTS whom) const;
 


### PR DESCRIPTION
Like anyone let comments on https://github.com/wesnoth/wesnoth/pull/10729, i try to fix overwrite_specials with this PR