### PR TITLE
Add weather effects to more campaigns

### DIFF
--- a/data/campaigns/Dead_Water/_main.cfg
+++ b/data/campaigns/Dead_Water/_main.cfg
@@ -70,6 +70,7 @@
 [/campaign]
 
 #ifdef CAMPAIGN_DEAD_WATER
+{internal/Weather}
 [binary_path]
     path=data/campaigns/Dead_Water
 [/binary_path]

--- a/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
+++ b/data/campaigns/Dead_Water/scenarios/03_Wolf_Coast.cfg
@@ -200,6 +200,7 @@
             name= _ "Vrunt"
             unrenamable=yes
         [/unit]
+        {ADD_MULTIHEX_WIND x,y=1-20,1-26 ""}
     [/event]
 
     [event]

--- a/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
+++ b/data/campaigns/Dead_Water/scenarios/07_Bilheld.cfg
@@ -93,6 +93,7 @@
 
     [event]
         name=prestart
+        {ADD_MULTIHEX_WIND x,y=1-28,1-28 "~FL()"}
 
         [music]
             name=knalgan_theme.ogg

--- a/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
+++ b/data/campaigns/Dead_Water/scenarios/10_The_Flaming_Sword.cfg
@@ -26,6 +26,7 @@
 
     {DW_TRACK {JOURNEY_10_NEW} }
 
+    {ADD_WEATHER_RAIN}
     {DEFAULT_SCHEDULE}
     {TURNS4 34 31 28 25}
     victory_when_enemies_defeated=no
@@ -280,7 +281,7 @@
 
         [message]
             speaker=Caladon
-            message= _ "Here we are. There’s a castle up ahead in the fog. That’s where Agnovon has the sword."
+            message= _ "Here we are. There’s a castle up ahead, through the rain and fog. That’s where Agnovon has the sword."
         [/message]
         [message]
             speaker=Kai Krellis

--- a/data/campaigns/Descent_Into_Darkness/_main.cfg
+++ b/data/campaigns/Descent_Into_Darkness/_main.cfg
@@ -64,6 +64,7 @@
 [/campaign]
 
 #ifdef CAMPAIGN_DESCENT
+{internal/Weather}
 {campaigns/Descent_Into_Darkness/utils}
 [units]
     {campaigns/Descent_Into_Darkness/units}

--- a/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/02_Peaceful_Valley.cfg
@@ -8,6 +8,7 @@
     {TURNS 19 17 15}
     next_scenario=03_A_Haunting_in_Winter
 
+    {ADD_WEATHER_RAIN}
     {DEFAULT_SCHEDULE_MORNING}
 
     {SCENARIO_MUSIC       nunc_dimittis.ogg}

--- a/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/04_Spring_of_Reprisal.cfg
@@ -120,6 +120,7 @@
 
     [event]
         name=prestart
+        {ADD_MULTIHEX_WIND x,y=1-31,1-26 ""}
 
         {CLEAR_CORPSE_HORDE}
 

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
@@ -481,7 +481,7 @@
 
         [message]
             speaker=Darken Volk
-            message= _ "The stolen book lies within Lady Karae’s manor at the north end of the city. It will be difficult for us to defeat the entire city guard, so we must stay hidden as long as possible. For now, we can make use of this fog. I shall use it to cast a spell to obscure the town guards’ vision."
+            message= _ "The stolen book lies within Lady Karae’s manor at the north end of the city. It will be difficult for us to defeat the entire city guard, so we must stay hidden as long as possible. For now, we can make use of this rain and fog. I shall use it to cast a spell to obscure the town guards’ vision."
         [/message]
 
         [delay]

--- a/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
+++ b/data/campaigns/Descent_Into_Darkness/scenarios/07a_A_Small_Favor.cfg
@@ -7,6 +7,7 @@
     {TURNS 20 18 16}
     next_scenario=07b_A_Small_Favor2
     victory_when_enemies_defeated=no
+    {ADD_WEATHER_RAIN}
 
 #ifdef EASY
     {FIRST_WATCH_HOUR2}

--- a/data/campaigns/Sceptre_of_Fire/_main.cfg
+++ b/data/campaigns/Sceptre_of_Fire/_main.cfg
@@ -116,6 +116,7 @@ Their tale I now relate...</i>
 [/campaign]
 
 #ifdef CAMPAIGN_SCEPTRE_FIRE
+{internal/Weather}
 [binary_path]
     path=data/campaigns/Sceptre_of_Fire/
 [/binary_path]

--- a/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/3_Searching_for_the_Runecrafter.cfg
@@ -10,6 +10,7 @@
     {SCENARIO_MUSIC wanderer.ogg}
     {EXTRA_SCENARIO_MUSIC elvish-theme.ogg}
 
+    {ADD_WEATHER_SNOW}
     {DEFAULT_SCHEDULE}
 
     [side]
@@ -95,6 +96,11 @@
 
     [event]
         name=prestart
+        [time_area]
+            {DEFAULT_SCHEDULE_NOWEATHER}
+            x,y=1,30
+            radius=5
+        [/time_area]
 
         [objectives]
             side=1

--- a/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
+++ b/data/campaigns/Sceptre_of_Fire/scenarios/5_Hills_of_the_Shorbear_Clan.cfg
@@ -161,6 +161,12 @@
 
     [event]
         name=prestart
+        {ADD_MULTIHEX_WIND (
+            [not]
+                x,y=19,17
+                radius=8
+            [/not]
+        ) ""}
         [objectives]
             side=1
             [objective]

--- a/data/campaigns/Secrets_of_the_Ancients/_main.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/_main.cfg
@@ -48,6 +48,7 @@
 [/campaign]
 
 #ifdef CAMPAIGN_SECRETS_OF_THE_ANCIENTS
+{internal/Weather}
 [binary_path]
     path=data/campaigns/Secrets_of_the_Ancients
 [/binary_path]

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/02_Dark_Business.cfg
@@ -28,6 +28,7 @@ I decided to hide in the cemetery. That way I could try my experiment to animate
         {JOURNEY_PART 2}
     [/story]
 
+    {ADD_WEATHER_RAIN}
     {FIRST_WATCH_HOUR3}
     {FIRST_WATCH_HOUR3}
     {FIRST_WATCH_HOUR4}
@@ -749,7 +750,7 @@ of Healing"
         [/remove_shroud]
         [message]
             speaker=Syrillin
-            message= _ "Why are we stuck guarding a cemetery all night?"
+            message= _ "Why are we stuck guarding a cemetery all night in the rain?"
         [/message]
         [message]
             speaker=Veomyr

--- a/data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg
+++ b/data/campaigns/Secrets_of_the_Ancients/scenarios/15_Mountain_Pass.cfg
@@ -27,6 +27,7 @@ We have reached a pass through the mountains that Ras-Tabahn knew of. The air is
         {JOURNEY_PART 15}
     [/story]
 
+    {ADD_WEATHER_SNOW}
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}
     {TURNS 26 25 24}

--- a/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/_main.cfg
@@ -81,6 +81,7 @@
 [/campaign]
 
 #ifdef CAMPAIGN_THE_RISE_OF_WESNOTH
+{internal/Weather}
 [binary_path]
     path=data/campaigns/The_Rise_Of_Wesnoth
 [/binary_path]

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/03_A_Harrowing_Escape.cfg
@@ -81,6 +81,7 @@
 
     [event]
         name=prestart
+        {ADD_MULTIHEX_WIND x,y=1-30,1-40 "~FL()"}
 
         {PLACE_IMAGE (scenery/signpost.png) 23 38}
         {PLACE_IMAGE (scenery/signpost.png) 13 7}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/11_Southbay_in_Winter.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/11_Southbay_in_Winter.cfg
@@ -7,6 +7,7 @@
     turns=1
     theme=Cutscene_Minimal
 
+    {ADD_WEATHER_SNOW}
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC traveling_minstrels.ogg}

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/14_Rough_Landing.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/14_Rough_Landing.cfg
@@ -116,6 +116,7 @@
 
     [event]
         name=prestart
+        {ADD_MULTIHEX_WIND x,y=1-25,1-30 "~FL()"}
         [recall]
             id=Lady Jessene
             x=8

--- a/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17d_Cursed_Isle.cfg
+++ b/data/campaigns/The_Rise_Of_Wesnoth/scenarios/17d_Cursed_Isle.cfg
@@ -7,6 +7,7 @@
     map_file=17d_Cursed_Isle.map
 
     {TURNS 30 27 24}
+    {ADD_WEATHER_RAIN}
     {DEFAULT_SCHEDULE}
 
     {SCENARIO_MUSIC loyalists.ogg}
@@ -326,7 +327,7 @@
         name=start
         [message]
             speaker=narrator
-            message= _ "After a short trip by sea, Haldric arrives on the elves’ cursed Isle of Tears. A fog hangs in the air."
+            message= _ "After a short trip by sea, Haldric arrives on the elves’ cursed Isle of Tears. Rainclouds hang in the air."
             image=wesnoth-icon.png
         [/message]
 


### PR DESCRIPTION
This PR adds weather effects to a handful of scenarios in DiD, DW, SoF, SotA, and TRoW.

I've tried to limit these effects to only occasional use - I don't think we want to fill every campaign with incessant weather.