### PR TITLE
data/tools: Speed up cross-referencing by pre-filtering

### DIFF
--- a/data/core/about.cfg
+++ b/data/core/about.cfg
@@ -1777,6 +1777,10 @@
         name = "starius"
     [/entry]
     [entry]
+        name = "Stefan Fuhrmann (stefan2, stefeff)"
+        comment = "Performance tuning (Python WML tools)"
+    [/entry]
+    [entry]
         name = "Stéphane Gimenez (gim)"
     [/entry]
     [entry]

--- a/data/tools/wesnoth/wmltools3.py
+++ b/data/tools/wesnoth/wmltools3.py
@@ -10,6 +10,7 @@ import collections
 import sys, os, re, sre_constants, hashlib, glob, gzip
 import string
 import enum
+import bisect
 
 # Extensions
 # Ordering is important, see default extensions below
@@ -647,9 +648,33 @@ class CrossRef:
     macro_reference = re.compile(r"\{([A-Z_][A-Za-z0-9_:]*)(?!\.)\b")
     file_reference = re.compile(r"([A-Za-z0-9{}.][A-Za-z0-9_/+{}.@\-\[\],~\*]*?\.(" + "|".join(resource_extensions) + r"))((~[A-Z]+\(.*\))*)(:([0-9]+|\[[0-9,*~]*\]))?")
     tag_parse = re.compile(r"\s*([a-z_]+)\s*=(.*)")
+    postfix_parse = re.compile(r"[a-zA-Z0-9/\+\-\.]*$")
+    regex_to_escape = re.compile(r"([\+\*\.\?\$\{\}\[\]\(\)])")
+    def postfix_files_range(self, postfix):
+        "Get the range of strings and definitions to consider for the given postfix"
+        if postfix:
+            postfix = postfix[::-1]
+            next_postfix = postfix[:-1]
+            next_postfix += chr(ord(postfix[-1]) + 1)
+            first = bisect.bisect_left(self.fileref_reversed, (postfix, "", None))
+            last = bisect.bisect_left(self.fileref_reversed, (next_postfix, "", None))
+            return self.fileref_reversed[first:last]
+        else:
+            return self.fileref_reversed
     def mark_matching_resources(self, pattern, fn, n):
         "Mark all definitions matching a specified pattern with a reference."
-        pattern = pattern.replace("+", r"\+")
+        # repetitions of .* are pointless but potentially expensive
+        while ".*.*" in pattern:
+            pattern = pattern.replace(".*.*", ".*")
+        # we'll use the literal tail (if any) as a quick pre-filter
+        postfix = CrossRef.postfix_parse.search(pattern).group(0)
+        # insert necessary escape sequences and markers
+        # Note:
+        # We use regex simply as a convenient way to implement wildcard matching.
+        # The only regex operator that is actually used intentionally is ".*".
+        # Everything else shall be treated as a literal.
+        pattern = CrossRef.regex_to_escape.sub(r"\\\1", pattern)
+        pattern = pattern.replace(r"\.\*", ".*") # the one pattern we allow
         pattern = os.sep + pattern + "$"
         if os.sep == "\\":
             pattern = pattern.replace("\\", "\\\\")
@@ -658,12 +683,11 @@ class CrossRef:
         except sre_constants.error:
             print("wmlscope: confused by %s" % pattern, file=sys.stderr)
             return None
-        key = None
-        for trial in self.fileref:
+        # only examine the strings whose last few characters match
+        # the postfix required by the pattern
+        for _, trial, defn in self.postfix_files_range(postfix):
             if pattern.search(trial) and self.visible_from(trial, fn, n):
-                key = trial
-                self.fileref[key].append(fn, n)
-        return key
+                defn.append(fn, n)
     def visible_from(self, defn, fn, n):
         "Is specified definition visible from the specified file and line?"
         if isinstance(defn, str):
@@ -900,10 +924,11 @@ class CrossRef:
             # All specified files share the same namespace
             self.filelist = [("src", filename) for filename in filelist]
             self.dirpath = ["src"]
-            
+
         self.warnlevel = warnlevel
         self.xref = {}
         self.fileref = {}
+        self.fileref_reversed = []
         self.noxref = False
         self.properties = {}
         self.unit_ids = {}
@@ -927,6 +952,9 @@ class CrossRef:
                 with open(filename, "r", encoding="utf8") as dfp:
                     for line in dfp:
                         self.xref[line.strip()] = True
+        # Index fileref by tail / postfix
+        # Elements are ( reversed(name), name, defn )
+        self.fileref_reversed = sorted([ (name[::-1], name, self.fileref[name]) for name in self.fileref ])
         # Next, decorate definitions with all references from the filelist.
         self.unresolved = []
         self.missing = []
@@ -1009,7 +1037,7 @@ class CrossRef:
                                             if defn.deprecated:
                                                 self.deprecated.append((name,Reference(ns,fn,n+1)))
                                     if len(candidates) > 1:
-                                        print("%s: more than one definition of %s is visible here (%s)." % (Reference(ns, fn, n), name, "; ".join(candidates)))
+                                        print("%s: more than one definition of %s is visible here (%s)." % (Reference(ns, fn, n), name, "; ".join(sorted(candidates))))
                                 if len(candidates) == 0:
                                     self.unresolved.append((name,Reference(ns,fn,n+1)))
                             # Don't be fooled by HTML image references in help strings.
@@ -1037,18 +1065,17 @@ class CrossRef:
                                         # could potentially match.
                                         elif '{' in name or '@' in name:
                                             pattern = re.sub(r"(\{[^}]*\}|@R[0-5]|@V)", '.*', name)
-                                            key = self.mark_matching_resources(pattern, fn,n+1)
-                                            if key:
-                                                self.fileref[key].append(fn, n+1)
+                                            self.mark_matching_resources(pattern, fn,n+1)
                                         else:
                                             candidates = []
-                                            for trial in self.fileref:
-                                                if trial.endswith(os.sep + name) and self.visible_from(trial, fn, n):
+                                            postfix = os.sep + name
+                                            for _, trial, defn in self.postfix_files_range(postfix):
+                                                if self.visible_from(defn, fn, n):
                                                     key = trial
-                                                    self.fileref[trial].append(fn, n+1)
+                                                    defn.append(fn, n+1)
                                                     candidates.append(trial)
                                             if len(candidates) > 1:
-                                                print("%s: more than one resource matching %s is visible here (%s)." % (Reference(ns,fn, n), name, ", ".join(candidates)))
+                                                print("%s: more than one resource matching %s is visible here (%s)." % (Reference(ns,fn, n), name, ", ".join(sorted(candidates))))
                                         if not key:
                                             self.missing.append((name, Reference(ns,fn,n+1)))
                             # Notice implicit references through attacks
@@ -1066,13 +1093,14 @@ class CrossRef:
                                     if attack_name and not have_icon:
                                         candidates = []
                                         key = None
-                                        for trial in self.fileref:
-                                            if trial.endswith(os.sep + default_icon) and self.visible_from(trial, fn, n):
+                                        postfix = os.sep + default_icon
+                                        for _, trial, defn in self.postfix_files_range(postfix):
+                                            if self.visible_from(defn, fn, n):
                                                 key = trial
-                                                self.fileref[trial].append(fn, n+1)
+                                                defn.append(fn, n+1)
                                                 candidates.append(trial)
                                         if len(candidates) > 1:
-                                            print("%s: more than one definition of %s is visible here (%s)." % (Reference(ns,fn, n), name, ", ".join(candidates)))
+                                            print("%s: more than one definition of %s is visible here (%s)." % (Reference(ns,fn, n), name, ", ".join(sorted(candidates))))
                                     if not key:
                                         self.missing.append((default_icon, Reference(ns,fn,n+1)))
                                 elif line.strip().startswith("[/"):


### PR DESCRIPTION
Most cross references use regex with some literal tail. We introduce an index sorted by the reversed names, so we only probe the relevant range.

To keep the output stable, explicitly sort it in case of multiple candidate matches.

Runtime on Linux for `time ./data/tools/wmlscope data/core ` at the 1.19 root goes down from 23s to 2.3s
and runtime for `time ./data/tools/wmlscope -c ` at the 1.19 root goes down from 69s to 7.1s. (measured using `time` on Linux).

Added myself to "misc contributors" list.
