### PR TITLE
run_wml_tests: these should be instance variables

### DIFF
--- a/run_wml_tests
+++ b/run_wml_tests
@@ -45,12 +45,11 @@ class TestCase:
         return "TestCase<{status}, {name}>".format(status=self.status, name=self.name)
 
 class TestResultAccumulator:
-    passed = []
-    skipped = []
-    failed = []
-    crashed = []
-    
     def __init__(self, total):
+        self.passed = []
+        self.skipped = []
+        self.failed = []
+        self.crashed = []
         self.total = total
     
     def pass_test(self, batch):


### PR DESCRIPTION
A clean up rather than a bugfix; this only makes a difference when more than one instance of TestResultAccumulator is created. Noticed while implementing 28e990d480178d3da117da535ac0bfc24d490c32.