### PR TITLE
deprecate accuracy and parry attributes

### DIFF
--- a/changelog_entries/deprecate_accuracy_parry.md
+++ b/changelog_entries/deprecate_accuracy_parry.md
@@ -1,0 +1,2 @@
+### WML Engine
+   * The use of 'accuracy' and 'parry' in [attack] are now deprecated.

--- a/data/schema/units/types.cfg
+++ b/data/schema/units/types.cfg
@@ -59,8 +59,8 @@
 		{SIMPLE_KEY attack_weight real}
 		{SIMPLE_KEY movement_used int}
 		{SIMPLE_KEY attacks_used int}
-		{SIMPLE_KEY accuracy int}
-		{SIMPLE_KEY parry int}
+		{DEPRECATED_KEY accuracy int}
+		{DEPRECATED_KEY parry int}
 		{SIMPLE_KEY min_range int}
 		{SIMPLE_KEY max_range int}
 		{SIMPLE_KEY specials_list string_list}

--- a/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_pre_attack.cfg
+++ b/data/test/scenarios/wml_tests/ScenarioWML/EventWML/events-test_pre_attack.cfg
@@ -130,7 +130,14 @@
             [/filter]
             [effect]
                 apply_to=attack
-                set_accuracy=100
+                [set_specials]
+                    mode=append
+                    [chance_to_hit]
+                        id=pre_attack_cth
+                        add=100
+                        priority=-10
+                    [/chance_to_hit]
+                [/set_specials]
                 set_damage=1
             [/effect]
         [/modify_unit]

--- a/src/units/attack_type.hpp
+++ b/src/units/attack_type.hpp
@@ -242,6 +242,7 @@ private:
 	int parry_;
 	ability_vector specials_;
 	bool changed_;
+	mutable bool accuracy_parry_checked_;
 };
 
 using attack_list = std::vector<attack_ptr>;


### PR DESCRIPTION
Now what [chance_to_hit] can use negative priority for calculation sort, 'accuracy' and 'parry' can be deprecated.