### PR TITLE
[Liberty] Rewritten Liberty village transformation to use actual transformation instead of lossy unit copying

### DIFF
--- a/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
+++ b/data/campaigns/Liberty/scenarios/02_Civil_Disobedience.cfg
@@ -471,7 +471,6 @@ Me and Harper visited Erwen’s grave today. I helped the lass pick her a bunch 
             variable=stored_peasants
         [/store_unit]
 
-
         [foreach]
             array=stored_peasants
             [do]


### PR DESCRIPTION
Right now in the Liberty campaign, when the villagers are converted into equivalent outlaw units, the code simply deleted the old units, created new units, and only selectively copied some stat attributes. This was a very lossy and hacky way to transform a unit, when the correct way to transform a unit is via [transform_unit]

this PR replaces the old hacky code with new code that relies on [transform_unit], and ensures that it still works on recall list units by using [unstore_unit] before applying [transform_unit], then [put_to_recall_list] to ensure the recall-list units remain invisible to the player. In the new PR, unit data is properly preserved, preventing potential rare edge case bugs, making the behavior consistent, and making Liberty more compatible with anything that modifies unit variables.