### PR TITLE
Autostore variables in abilities & specials

### DIFF
--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -776,7 +776,7 @@ bool unit::ability_active_impl(const unit_ability_t& ab,const map_location& loc)
 	bool illuminates = ab.tag() == "illuminates";
 
 	if(auto afilter = ab.cfg().optional_child("filter")) {
-		scoped_ability_info ability("ability", ab);
+		scoped_ability_info ability_info{"ability", ab};
 		if(!unit_filter(vconfig(*afilter)).set_use_flat_tod(illuminates).matches(*this, loc)) {
 			return false;
 		}
@@ -812,7 +812,7 @@ bool unit::ability_affects_adjacent(const unit_ability_t& ab, std::size_t dist, 
 			}
 		}
 		auto filter = i.optional_child("filter");
-		scoped_ability_info ability("ability", ab);
+		scoped_ability_info ability_info{"ability", ab};
 		if (!filter || //filter tag given
 			unit_filter(vconfig(*filter)).set_use_flat_tod(illuminates).matches(*this, loc, from) ) {
 			return true;
@@ -2014,7 +2014,7 @@ bool specials_context_t::is_special_active(const specials_combatant& self, const
 		second_weapon.emplace("second_weapon", *second_weapon_cfg);  // Pass the stored config
 	}
 
-	scoped_ability_info special("special", ab);
+	scoped_ability_info ability_info{"ability", ab}; //through it's in [special], it's named "ability" to avoid confusion, when the special is passed by a leadership-like effect
 
 	bool applied_both = ab.apply_to() == unit_ability_t::apply_to_t::both;
 	const std::string& filter_self = ab.in_specials_tag() ? "filter_self" : "filter_student";

--- a/src/units/abilities.cpp
+++ b/src/units/abilities.cpp
@@ -2015,7 +2015,7 @@ bool specials_context_t::is_special_active(const specials_combatant& self, const
 	}
 
 	scoped_ability_info special("special", ab);
-	
+
 	bool applied_both = ab.apply_to() == unit_ability_t::apply_to_t::both;
 	const std::string& filter_self = ab.in_specials_tag() ? "filter_self" : "filter_student";
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -564,6 +564,11 @@ void scoped_weapon_info::activate()
 	}
 }
 
+void scoped_ability_info::activate()
+{
+	store(cfg_);
+}
+
 void scoped_recall_unit::activate()
 {
 	assert(resources::gameboard);

--- a/src/variable.hpp
+++ b/src/variable.hpp
@@ -16,9 +16,11 @@
 
 #pragma once
 
+#include <boost/dynamic_bitset.hpp>
 #include "config.hpp"
 #include "map/location.hpp"
 #include "variable_info.hpp"
+#include "units/abilities.hpp"
 
 #include <utility>
 
@@ -236,7 +238,7 @@ private:
 	bool activated_;
 };
 
-class scoped_weapon_info : public scoped_wml_variable
+class scoped_weapon_info : public scoped_wml_variable //it might be a good idea to store copy of the data - just like scoped_ability_info does
 {
 public:
 	scoped_weapon_info(const std::string& var_name, optional_const_config data)
@@ -244,6 +246,16 @@ public:
 	void activate();
 private:
 	optional_const_config data_;
+};
+
+class scoped_ability_info : public scoped_wml_variable
+{
+public:
+	scoped_ability_info(const std::string& var_name, const unit_ability_t& ability)
+		: scoped_wml_variable(var_name), cfg_(ability.cfg()) {}
+	void activate();
+private:
+	config cfg_;  // Stores a copy of the config
 };
 
 class scoped_xy_unit : public scoped_wml_variable


### PR DESCRIPTION
Aim is to have stored current ability in [ability] filter and to have stored special and it's weapon in [special] filter.

On top of that I did stored second_weapon for special filters, but since second weapon isn't always there, the variable will be nil part of the time, this shall be handled correctly by add-on creaoters, in order for the tooltip active indicator to work.
- Main aim stays to store the always-relevant variables.

I store ability similarly to how a weapon is stored, except I do store copy of the config (this moves the code that creates the config from the code to the variable declaration)