### PR TITLE
Fix a translation hint in the campaign selection dialog

### DIFF
--- a/data/gui/themes/default/dialogs/campaign_dialog.cfg
+++ b/data/gui/themes/default/dialogs/campaign_dialog.cfg
@@ -203,8 +203,8 @@
 					vertical_grow = true
 
 					[label]
-						# TRANSLATORS: "more than 15" gives a little leeway to add or remove one without changing the translatable text.
-						# It's already ambiguous, 1.18 has 19 campaigns, if you include the tutorial and multiplayer-only World Conquest.
+						#po: "more than 15" gives a little leeway to add or remove one without changing the translatable text.
+						#po: It's already ambiguous, 1.18 has 19 campaigns, if you include the tutorial and multiplayer-only World Conquest.
 						label = _ "Wesnoth normally includes more than 15 mainline campaigns, even before installing any from the add-ons server. If you’ve installed the game via a package manager, there’s probably a separate package to install the complete game data."
 						wrap = true
 					[/label]


### PR DESCRIPTION
Possibly excessive to CI this, but I like the routine of checking every change.