### PR TITLE
White Mage/Mage of Light: description improvement

### DIFF
--- a/data/core/units/humans/Mage_White.cfg
+++ b/data/core/units/humans/Mage_White.cfg
@@ -16,7 +16,7 @@
     cost=31
     usage=healer
     abilities_list=heals_8,cures
-    description= _ "Some magi, as they learn about the world around them, and learn the truth of the suffering and squalor in which humanity too often lives, find that they cannot bring themselves to be cloistered into a life of study. These men and women give up the life of a mage, and join monastic orders, dedicating the skills they have been given to the good of all. After their ordination, they often travel the world, ministering to sickness and injury.
+    description= _ "Some magi, as they learn about the world and the truth of the suffering and squalor in which humanity too often lives, find that they cannot bring themselves to be cloistered into a life of theoretical study. Instead, these men and women dedicate their skills to the good of all, studying healing and purification to refine their magic into a tool of lifegiving. They are often seen traveling the world, ministering to the sick and injured. Repeated use of the same spells slowly causes their magic to turn white, earning them the title by which they are known.
 
 Though not trained for combat, they are a potent ally against magical or unnatural things."
     [special_note]

--- a/data/core/units/humans/Mage_of_Light.cfg
+++ b/data/core/units/humans/Mage_of_Light.cfg
@@ -17,7 +17,7 @@
     cost=59
     usage=healer
     abilities_list=illumination,heals_8,cures
-    description= _ "After years of experience, the most devout of white magi develop vast spiritual powers. By strict devotion to the path of the light, they can call upon its aid to chase away the shadows of the night.
+    description= _ "After years of experience, the most devout of white magi develop vast magical powers related to healing and purification. By strict devotion to this path, they can also call upon its aid to chase away the shadows of the night. Their great dedication to the path of good or ‘white’ magic is often visible as an illuminating halo around their bodies; a symbol of hope to which people often flock when all else fails to banish the terrors of life.
 
 Following a strict code of piety and honor, these men and women work tirelessly to bring life and order to the troubled world in which they live."
     [special_note]


### PR DESCRIPTION
* Explains why they are called `white magi` and why their magic is white.
* Explains `illuminates` ability lorewise.
* Removes religious connotations and the fact that "white magi stop studying". The point is that they do study, but focus it on healing and removing evil magic. 
* Obviously, now allows them to "marry", explaining the NR white mage couple, and allows both independently working White Magi that are not part of any order/guilds, and the ones that are parts of monastic orders.

(Grammer checked using https://www.grammarly.com/grammar-check)

I understand this is slightly opinionated, but I shall not be accepting any radical rewrites in this PR. Major rewrites should be proposed in a separate PR to keep this one scoped. I am willing to close this one if needed.