### PR TITLE
LUA: 5x speedup for lua_push_namedtuple

### DIFF
--- a/src/scripting/application_lua_kernel.cpp
+++ b/src/scripting/application_lua_kernel.cpp
@@ -468,7 +468,7 @@ bool luaW_copy_upvalues(lua_State* L, const config& cfg)
 					for(const auto& cfg : children) {
 						names.push_back(cfg["name"]);
 					}
-					luaW_push_namedtuple(L, names);
+					lua_named_tuple_builder{ names }.push(L);
 					for(const auto& cfg : children) {
 						luaW_pushscalar(L, cfg["value"]);
 						lua_rawseti(L, -2, lua_rawlen(L, -2) + 1);

--- a/src/scripting/game_lua_kernel.cpp
+++ b/src/scripting/game_lua_kernel.cpp
@@ -2210,12 +2210,14 @@ int game_lua_kernel::intf_find_reach(lua_State *L)
 	pathfind::paths res(*u, ignore_units, !ignore_teleport,
 		viewing_team, additional_turns, see_all, ignore_units);
 
+	static const lua_named_tuple_builder tuple_builder{ {"x", "y", "moves_left"} };
+
 	int nb = res.destinations.size();
 	lua_createtable(L, nb, 0);
 	for (int i = 0; i < nb; ++i)
 	{
 		pathfind::paths::step &s = res.destinations[i];
-		luaW_push_namedtuple(L, {"x", "y", "moves_left"});
+		tuple_builder.push(L);
 		lua_pushinteger(L, s.curr.wml_x());
 		lua_rawseti(L, -2, 1);
 		lua_pushinteger(L, s.curr.wml_y());
@@ -2263,9 +2265,11 @@ int game_lua_kernel::intf_find_vision_range(lua_State *L)
 	actions::create_jamming_map(jamming_map, resources::gameboard->get_team(u->side()));
 	pathfind::vision_path res(*u, u->get_location(), jamming_map);
 
+	static const lua_named_tuple_builder tuple_builder{ {"x", "y", "vision_left"} };
+
 	lua_createtable(L, res.destinations.size() + res.edges.size(), 0);
 	for(const auto& d : res.destinations) {
-		luaW_push_namedtuple(L, {"x", "y", "vision_left"});
+		tuple_builder.push(L);
 		lua_pushinteger(L, d.curr.wml_x());
 		lua_rawseti(L, -2, 1);
 		lua_pushinteger(L, d.curr.wml_y());
@@ -2275,7 +2279,7 @@ int game_lua_kernel::intf_find_vision_range(lua_State *L)
 		lua_rawseti(L, -2, lua_rawlen(L, -2) + 1);
 	}
 	for(const auto& e : res.edges) {
-		luaW_push_namedtuple(L, {"x", "y", "vision_left"});
+		tuple_builder.push(L);
 		lua_pushinteger(L, e.wml_x());
 		lua_rawseti(L, -2, 1);
 		lua_pushinteger(L, e.wml_y());
@@ -2482,11 +2486,13 @@ int game_lua_kernel::intf_find_cost_map(lua_State *L)
 	}
 
 	// create return value
+	static const lua_named_tuple_builder tuple_builder{ {"x", "y", "cost", "reach"} };
+
 	lua_createtable(L, location_set.size(), 0);
 	int counter = 1;
 	for (const map_location& loc : location_set)
 	{
-		luaW_push_namedtuple(L, {"x", "y", "cost", "reach"});
+		tuple_builder.push(L);
 
 		lua_pushinteger(L, loc.wml_x());
 		lua_rawseti(L, -2, 1);

--- a/src/scripting/lua_kernel_base.cpp
+++ b/src/scripting/lua_kernel_base.cpp
@@ -475,7 +475,7 @@ static int intf_named_tuple(lua_State* L)
 	auto names = lua_check<std::vector<std::string>>(L, 2);
 	lua_len(L, 1);
 	int len = luaL_checkinteger(L, -1);
-	luaW_push_namedtuple(L, names);
+	lua_named_tuple_builder{ names }.push(L);
 	for(int i = 1; i <= std::max<int>(len, names.size()); i++) {
 		lua_geti(L, 1, i);
 		lua_seti(L, -2, i);
@@ -1412,11 +1412,13 @@ int lua_kernel_base::intf_kernel_type(lua_State* L)
 	return 1;
 }
 static void push_color_palette(lua_State* L, const std::vector<color_t>& palette) {
+	static const lua_named_tuple_builder tuple_builder{ {"r", "g", "b", "a"} };
+
 	lua_createtable(L, palette.size(), 1);
 	lua_rotate(L, -2, 1); // swap new table with previous element on stack
 	lua_setfield(L, -2, "name");
 	for(std::size_t i = 0; i < palette.size(); i++) {
-		luaW_push_namedtuple(L, {"r", "g", "b", "a"});
+		tuple_builder.push(L);
 		lua_pushinteger(L, palette[i].r);
 		lua_rawseti(L, -2, 1);
 		lua_pushinteger(L, palette[i].g);

--- a/src/scripting/lua_map_location_ops.cpp
+++ b/src/scripting/lua_map_location_ops.cpp
@@ -56,7 +56,8 @@ static cubic_location luaW_checkcubeloc(lua_State* L, int idx) {
 }
 
 static void luaW_pushcubeloc(lua_State* L, cubic_location loc) {
-	luaW_push_namedtuple(L, {"q", "r", "s"});
+	static const lua_named_tuple_builder tuple_builder{ {"q", "r", "s"} };
+	tuple_builder.push(L);
 	lua_pushinteger(L, loc.q);
 	lua_rawseti(L, -2, 1);
 	lua_pushinteger(L, loc.r);


### PR DESCRIPTION
Since we are using only a few different tuple configurations, we can just store the respective meta tables in the LUA registry.

Introduce a builder class that allows for convenient declaration of reusable tuple types. Move static callback functions into the builder class as it provides a natural namespace.

Overall runtime savings is ~5% (estimated by valgrind profiling). Measurements were taken with the "The Wilderlands" map, all players set to AI. 