### PR TITLE
Fix O(N^2) issue with draw_manager::invalidate_region

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2452,6 +2452,8 @@ void display::draw_invalidated()
 		drawer.emplace(*this);
 	}
 
+	std::vector<rect> to_invalidate;
+	to_invalidate.reserve(invalidated_.size());
 	for(const map_location& loc : invalidated_) {
 		rect hex_rect = get_location_rect(loc);
 		if(!hex_rect.overlaps(clip_rect)) {
@@ -2468,8 +2470,9 @@ void display::draw_invalidated()
 			}
 		}
 
-		draw_manager::invalidate_region(hex_rect.intersect(clip_rect));
+		to_invalidate.push_back(hex_rect.intersect(clip_rect));
 	}
+	draw_manager::invalidate_regions(std::move(to_invalidate));
 
 	invalidated_hexes_ += invalidated_.size();
 }

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -82,7 +82,10 @@ void invalidate_regions(std::vector<rect>&& regions)
 			return lhs.x < rhs.x;
 		});
 
-	// merge adjacent rectangles (mark consumed rects by zero width)
+	// Merge adjacent rectangles (mark consumed rects by zero width).
+	// We only need to consider regions that touch or overlap along the X axis;
+	// all others will have a cover larger than the sum of the individual areas.
+	// Since REGIONS have been sorted by X the relevant range is a sliding window.
 	for (auto dest = regions.begin(), end = regions.end(); dest != end; ++dest) {
 		// skip merged rectangles
 		if (dest->w) {
@@ -91,9 +94,14 @@ void invalidate_regions(std::vector<rect>&& regions)
 				if (source->x > dest->x + dest->w) {
 					break;
 				}
-				if (source->w && source->y <= dest->y + dest->h) {
+				// Quick check:
+				// Only non-empty regions that have no gap along the Y axis might
+				// get merged (otherwise, minimal_cover is larger than SOURCE+DEST)
+				if (   source->w
+					&& source->y <= dest->y + dest->h
+					&& source->y + source->h >= dest->y) {
 					rect m = source->minimal_cover(*dest);
-					// is also covers the case, where one side contains the other
+					// this also covers the case of one side containing the other
 					if (m.area() <= source->area() + dest->area()) {
 						*dest = m;
 						source->w = 0;

--- a/src/draw_manager.cpp
+++ b/src/draw_manager.cpp
@@ -112,12 +112,7 @@ void invalidate_regions(std::vector<rect>&& regions)
 	}
 
 	// eliminate zero-width (merged) rectangles
-	regions.erase(
-		std::copy_if(regions.begin(), regions.end(), regions.begin(),
-			[](const rect& r) {
-				return r.w > 0;
-			}),
-		regions.end());
+	utils::erase_if(regions, [](const rect& r) { return r.w <= 0; });
 
 	// check if we had any non-empty regions to begin with
 	if (!regions.empty()) {

--- a/src/draw_manager.hpp
+++ b/src/draw_manager.hpp
@@ -17,6 +17,7 @@
 #include "sdl/rect.hpp"
 
 #include <chrono>
+#include <vector>
 
 namespace gui2 { class top_level_drawable; }
 
@@ -90,6 +91,22 @@ namespace draw_manager
  * so this may be called for every invalidation without much concern.
  */
 void invalidate_region(const rect& region);
+
+/**
+ * Mark a batch of regions of the screen as requiring redraw.
+ *
+ * This should be called any time an item changes in such a way as to
+ * require redrawing. It is equivalent to but much more efficient than
+ * repeated calls to @ref invalidate_region() (O(N log N) vs. O(N^2)).
+ *
+ * The @a regions vector is modified and consumed by this function.
+ *
+ * This may only be called outside the Draw phase.
+ *
+ * Regions are combined to result in a minimal number of draw calls,
+ * so this may be called for every invalidation without much concern.
+ */
+void invalidate_regions(std::vector<rect>&& regions);
 
 /** Mark the entire screen as requiring redraw. */
 void invalidate_all();


### PR DESCRIPTION
The `display` class would add invalidated regions to the `draw_manager` one at a time. In an attempt to eliminate redundant operations, the latter turns this into an O(N^2) process. 

Introduce and use an alternative "batched" function that runs the optimization in O(N * log N) for typical scenarios.

Runtime savings is ~7% on Wesnoth total CPUI load (estimated by valgrind profiling). Measurements were taken with the "The Wilderlands" map, all players set to AI at 4k resolution.